### PR TITLE
refactor: migrate messaging substrate onto ux/catalog (UX P1 PR-B)

### DIFF
--- a/.github/baselines/ux-literals-baseline.json
+++ b/.github/baselines/ux-literals-baseline.json
@@ -1,15 +1,15 @@
 {
-  "total": 448,
+  "total": 441,
   "byPattern": {
-    "emoji-prefixed": 319,
-    "try-again": 129
+    "emoji-prefixed": 314,
+    "try-again": 127
   },
   "graceMargin": 10,
   "meta": {
     "toolVersion": "ux-literals-check/1",
     "configHash": "4b12eb65e0c6",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "1478e1bb454acf0f1c38791da9a4f5c047b0a8c7",
-    "generatedAt": "2026-07-08T01:25:50.552Z"
+    "generatedFromSha": "719c818d7c3ff533da74de80b0e19ccb0f8f579e",
+    "generatedAt": "2026-07-08T02:57:28.811Z"
   }
 }

--- a/services/bot-client/src/commands/character/api.ts
+++ b/services/bot-client/src/commands/character/api.ts
@@ -24,8 +24,7 @@
 
 import type { ChatInputCommandInteraction } from 'discord.js';
 import type { EnvConfig } from '@tzurot/common-types/config/config';
-import type { UserClient } from '@tzurot/clients';
-import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
+import { GatewayApiError, type UserClient } from '@tzurot/clients';
 import type { CharacterData } from './characterTypes.js';
 
 /**
@@ -251,7 +250,7 @@ export async function createCharacter(
     // Consistent with updateCharacter: carry the status + kind (so a create flow
     // could surface the honest outcome-uncertain notice) and guard the message
     // against an undefined gateway error.
-    throw new DashboardUpdateError(
+    throw new GatewayApiError(
       `Failed to create character: ${result.status} - ${result.error ?? 'Unknown'}`,
       result.status,
       result.kind
@@ -273,11 +272,11 @@ export async function updateCharacter(
   const result = await userClient.updatePersonality(slug, omitEmptyRequiredText(data));
 
   if (!result.ok) {
-    // DashboardUpdateError carries status + kind so the dashboard can distinguish
+    // GatewayApiError carries status + kind so the dashboard can distinguish
     // an outcome-uncertain abort (timeout/network → "still applying") from a real
-    // HTTP rejection (whose message it surfaces). Message format matches
-    // extractApiErrorMessage.
-    throw new DashboardUpdateError(
+    // HTTP rejection (whose message it surfaces). Message format matches the
+    // classifier's caller-wrapper convention (`: {status} - {message}`).
+    throw new GatewayApiError(
       `Failed to update character: ${result.status} - ${result.error ?? 'Unknown'}`,
       result.status,
       result.kind

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -11,7 +11,7 @@ import {
 } from './dashboard.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import * as api from './api.js';
-import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
+import { GatewayApiError } from '@tzurot/clients';
 import * as createModule from './create.js';
 import * as viewModule from './view.js';
 import * as truncationWarning from './truncationWarning.js';
@@ -254,7 +254,7 @@ describe('Character Dashboard', () => {
       // A 400 validation error is surfaced as the real gateway message, not
       // masked behind a generic retry prompt.
       vi.mocked(api.updateCharacter).mockRejectedValue(
-        new DashboardUpdateError(
+        new GatewayApiError(
           'Failed to update character: 400 - avatarData: Invalid input: expected string, received null',
           400,
           'http'

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -33,11 +33,7 @@ vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: clientsForMock,
 }));
 
-const mockReplyWithError = vi.fn();
-const mockHandleCommandError = vi.fn();
 vi.mock('../../utils/commandHelpers.js', () => ({
-  replyWithError: (...args: unknown[]) => mockReplyWithError(...args),
-  handleCommandError: (...args: unknown[]) => mockHandleCommandError(...args),
   createWarningEmbed: vi.fn((_title: string, _description: string) => ({
     toJSON: () => ({ title: 'Test Warning' }),
   })),

--- a/services/bot-client/src/commands/persona/api.test.ts
+++ b/services/bot-client/src/commands/persona/api.test.ts
@@ -195,7 +195,7 @@ describe('updatePersona', () => {
     expect(result?.name).toBe('Updated Name');
   });
 
-  it('throws DashboardUpdateError carrying the gateway status on failure', async () => {
+  it('throws GatewayApiError carrying the gateway status on failure', async () => {
     stub.updatePersona.mockResolvedValue(makeErr(500, 'Update failed'));
 
     await expect(
@@ -212,7 +212,7 @@ describe('updatePersona', () => {
         TEST_USER_ID
       )
     ).rejects.toMatchObject({
-      name: 'DashboardUpdateError',
+      name: 'GatewayApiError',
       status: 500,
       message: 'Failed to update persona: 500 - Update failed',
     });
@@ -234,7 +234,7 @@ describe('updatePersona', () => {
         asUserClient(stub),
         TEST_USER_ID
       )
-    ).rejects.toMatchObject({ name: 'DashboardUpdateError', status: 0, kind: 'timeout' });
+    ).rejects.toMatchObject({ name: 'GatewayApiError', status: 0, kind: 'timeout' });
   });
 });
 

--- a/services/bot-client/src/commands/persona/api.ts
+++ b/services/bot-client/src/commands/persona/api.ts
@@ -7,8 +7,7 @@
 
 import { type PersonaUpdateInput } from '@tzurot/common-types/schemas/api/persona';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { nullOn404, type UserClient } from '@tzurot/clients';
-import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
+import { GatewayApiError, nullOn404, type UserClient } from '@tzurot/clients';
 import type { PersonaDetails, PersonaSummary } from './types.js';
 
 const logger = createLogger('persona-api');
@@ -76,7 +75,7 @@ export async function updatePersona(
     // Throw (rather than return null) so the dashboard can surface the real
     // gateway message and distinguish an outcome-uncertain abort (timeout/network)
     // from an HTTP rejection — the same contract as updateCharacter / updatePreset.
-    throw new DashboardUpdateError(
+    throw new GatewayApiError(
       `Failed to update persona: ${result.status} - ${result.error ?? 'Unknown'}`,
       result.status,
       result.kind

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -385,7 +385,7 @@ describe('handleModalSubmit', () => {
       data: { name: 'Test Persona', preferredName: 'Tester' },
     });
     mockExtractModalValues.mockReturnValue({ name: 'Updated Name' });
-    // updatePersona throws DashboardUpdateError; the dashboard surfaces the
+    // updatePersona throws GatewayApiError; the dashboard surfaces the
     // extracted gateway message instead of a generic "Please try again".
     stub.updatePersona.mockResolvedValue(makeErr(400, 'pronouns: too long'));
 

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -121,7 +121,7 @@ async function handleSectionModalSubmit(
     const updatePayload = unflattenPersonaData(extracted.merged);
 
     const { userClient } = clientsFor(interaction);
-    // updatePersona throws DashboardUpdateError on failure (caught below);
+    // updatePersona throws GatewayApiError on failure (caught below);
     // a resolved value is always a valid persona.
     const updatedPersona = await updatePersona(
       entityId,

--- a/services/bot-client/src/commands/preset/api.test.ts
+++ b/services/bot-client/src/commands/preset/api.test.ts
@@ -162,7 +162,7 @@ describe('updatePreset', () => {
   it('should throw on error without message', async () => {
     // `as never` intentionally omits the type-required `error` to exercise the
     // throw site's `?? 'Unknown'` defensive fallback; `kind` is set so the thrown
-    // DashboardUpdateError carries a valid kind rather than undefined.
+    // GatewayApiError carries a valid kind rather than undefined.
     stub.updateUserLlmConfig.mockResolvedValue({ ok: false, status: 500, kind: 'http' } as never);
 
     await expect(updatePreset('preset-123', {}, asUserClient(stub))).rejects.toThrow(
@@ -170,13 +170,13 @@ describe('updatePreset', () => {
     );
   });
 
-  it('throws DashboardUpdateError carrying status + kind (0/timeout on client-side timeout)', async () => {
+  it('throws GatewayApiError carrying status + kind (0/timeout on client-side timeout)', async () => {
     stub.updateUserLlmConfig.mockResolvedValue(makeErr(0, 'Request timeout', undefined, 'timeout'));
 
     // kind:'timeout' must survive the throw — isSaveTimeout keys on it, so a
     // dropped result.kind would silently hide the "may still be applying" notice.
     await expect(updatePreset('preset-123', {}, asUserClient(stub))).rejects.toMatchObject({
-      name: 'DashboardUpdateError',
+      name: 'GatewayApiError',
       status: 0,
       kind: 'timeout',
     });
@@ -217,7 +217,7 @@ describe('updateGlobalPreset', () => {
 
   it('throws with Unknown when gateway has no error message', async () => {
     // `as never` omits the type-required `error` to exercise the `?? 'Unknown'`
-    // fallback; `kind` is set so the thrown DashboardUpdateError carries a valid kind.
+    // fallback; `kind` is set so the thrown GatewayApiError carries a valid kind.
     stub.updateGlobalLlmConfig.mockResolvedValue({ ok: false, status: 500, kind: 'http' } as never);
 
     await expect(updateGlobalPreset('preset-123', {}, asOwnerClient(stub))).rejects.toThrow(
@@ -225,13 +225,13 @@ describe('updateGlobalPreset', () => {
     );
   });
 
-  it('throws DashboardUpdateError carrying status + kind (0/timeout on client-side timeout)', async () => {
+  it('throws GatewayApiError carrying status + kind (0/timeout on client-side timeout)', async () => {
     stub.updateGlobalLlmConfig.mockResolvedValue(
       makeErr(0, 'Request timeout', undefined, 'timeout')
     );
 
     await expect(updateGlobalPreset('preset-123', {}, asOwnerClient(stub))).rejects.toMatchObject({
-      name: 'DashboardUpdateError',
+      name: 'GatewayApiError',
       status: 0,
       kind: 'timeout',
     });

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -11,7 +11,6 @@ import {
   type LlmConfigUpdateInput,
 } from '@tzurot/common-types/schemas/api/llm-config';
 import { GatewayApiError, type OwnerClient, type UserClient } from '@tzurot/clients';
-import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import type { PresetData } from './types.js';
 
 /**
@@ -80,7 +79,7 @@ export async function updatePreset(
   const result = await userClient.updateUserLlmConfig(presetId, data);
 
   if (!result.ok) {
-    throw new DashboardUpdateError(
+    throw new GatewayApiError(
       `Failed to update preset: ${result.status} - ${result.error ?? 'Unknown'}`,
       result.status,
       result.kind
@@ -103,7 +102,7 @@ export async function updateGlobalPreset(
   const result = await ownerClient.updateGlobalLlmConfig(presetId, data);
 
   if (!result.ok) {
-    throw new DashboardUpdateError(
+    throw new GatewayApiError(
       `Failed to update global preset: ${result.status} - ${result.error ?? 'Unknown'}`,
       result.status,
       result.kind

--- a/services/bot-client/src/commands/preset/create.test.ts
+++ b/services/bot-client/src/commands/preset/create.test.ts
@@ -292,7 +292,7 @@ describe('Preset Create', () => {
       await handleSeedModalSubmit(mockInteraction);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: '❌ Failed to create preset. Please try again.',
+        content: '❌ Failed to create the preset. Please try again.',
       });
     });
 

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -33,8 +33,9 @@ import {
 } from './config.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createPreset } from './api.js';
-import { extractApiErrorMessage } from '../../utils/dashboard/saveError.js';
-import { replyError } from '../../utils/dashboard/replyError.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { replySpec } from '../../ux/render/reply.js';
 
 const logger = createLogger('preset-create');
 
@@ -81,12 +82,12 @@ export async function handleSeedModalSubmit(interaction: ModalSubmitInteraction)
 
   // Validate required fields
   if (!values.name || values.name.trim().length === 0) {
-    await replyError(interaction, '❌ Preset name is required.');
+    await replySpec(interaction, CATALOG.error.validation('Preset name is required.'));
     return;
   }
 
   if (!values.model || values.model.trim().length === 0) {
-    await replyError(interaction, '❌ Model ID is required.');
+    await replySpec(interaction, CATALOG.error.validation('Model ID is required.'));
     return;
   }
 
@@ -137,17 +138,18 @@ export async function handleSeedModalSubmit(interaction: ModalSubmitInteraction)
 
     // Check for duplicate name error (match structured format to avoid false positives)
     if (error instanceof Error && error.message.includes(': 409 ')) {
-      await replyError(
+      await replySpec(
         interaction,
-        `❌ A preset with name "${values.name}" already exists.\n` +
-          'Please choose a different name.'
+        CATALOG.error.validation(
+          `A preset with name "${values.name}" already exists.\nPlease choose a different name.`
+        )
       );
       return;
     }
 
-    await replyError(
+    await replySpec(
       interaction,
-      `❌ ${extractApiErrorMessage(error) ?? 'Failed to create preset. Please try again.'}`
+      classifyGatewayFailure(error, 'preset', { failedAction: 'create the preset' })
     );
   }
 }

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -13,7 +13,6 @@ import {
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 import type { PresetData } from './config.js';
-import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import { GatewayApiError } from '@tzurot/clients';
 
 // Sentinel passed by the migrated dashboard handler — `clientsFor(interaction)`
@@ -477,11 +476,11 @@ describe('handleModalSubmit', () => {
     mockSessionManagerGet.mockResolvedValue({
       data: { id: 'preset-123', name: 'Test', isGlobal: false, isOwned: true },
     });
-    // A client-side timeout surfaces as a DashboardUpdateError with status 0 — the
+    // A client-side timeout surfaces as a GatewayApiError with status 0 — the
     // write may have committed server-side, so the user gets the honest notice
     // rather than a hard "Failed, try again".
     mockUpdatePreset.mockRejectedValue(
-      new DashboardUpdateError('Failed to update preset: 0 - Request timeout', 0, 'timeout')
+      new GatewayApiError('Failed to update preset: 0 - Request timeout', 0, 'timeout')
     );
 
     await handleModalSubmit(createMockModalInteraction('preset::modal::preset-123::identity'));
@@ -1066,7 +1065,7 @@ describe('handleButton', () => {
       await handleButton(createCloneButtonInteraction('preset::clone::preset-123'));
 
       expect(mockFollowUp).toHaveBeenCalledWith({
-        content: '❌ Failed to clone preset. Please try again.',
+        content: '❌ Failed to clone the preset. Please try again.',
         flags: MessageFlags.Ephemeral,
       });
     });

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -32,7 +32,8 @@ import {
   buildPresetDashboardOptions,
 } from './config.js';
 import { fetchPreset, updatePreset, fetchGlobalPreset } from './api.js';
-import { extractApiErrorMessage } from '../../utils/dashboard/saveError.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { createClonedPreset } from './cloneName.js';
 
 // Re-export for backward compatibility
@@ -439,7 +440,9 @@ export async function handleCloneButton(
     logger.error({ err: error, entityId }, 'Failed to clone preset');
 
     await interaction.followUp({
-      content: `❌ ${extractApiErrorMessage(error) ?? 'Failed to clone preset. Please try again.'}`,
+      content: renderSpec(
+        classifyGatewayFailure(error, 'preset', { failedAction: 'clone the preset' })
+      ),
       flags: MessageFlags.Ephemeral,
     });
   }

--- a/services/bot-client/src/services/PersonalityMessageHandler.test.ts
+++ b/services/bot-client/src/services/PersonalityMessageHandler.test.ts
@@ -86,23 +86,31 @@ describe('PersonalityMessageHandler', () => {
       expect(mockJobTracker.trackJob).not.toHaveBeenCalled();
     });
 
-    it('replies with the error and does not track when the manager throws', async () => {
+    it('replies a classified catalog line (not the raw error) and does not track when the manager throws', async () => {
       const message = createMockMessage();
       mockManager.submitChatJob.mockRejectedValueOnce(new Error('boom'));
 
       await handler.handleMessage(message, createMockPersonality(), 'Hi');
 
-      expect(message.reply).toHaveBeenCalledWith('Error: boom');
+      // The classified catalog line — never the raw error.message (the old
+      // `Error: ${message}` shape leaked internals to users).
+      expect(message.reply).toHaveBeenCalledWith(
+        '❌ Failed to process your message. Please try again.'
+      );
+      expect(message.reply).not.toHaveBeenCalledWith(expect.stringContaining('boom'));
       expect(mockJobTracker.trackJob).not.toHaveBeenCalled();
     });
 
-    it('stringifies non-Error throws when replying', async () => {
+    it('replies the generic catalog line for non-Error throws too (no raw leak)', async () => {
       const message = createMockMessage();
       mockManager.submitChatJob.mockRejectedValueOnce('string-failure');
 
       await handler.handleMessage(message, createMockPersonality(), 'Hi');
 
-      expect(message.reply).toHaveBeenCalledWith('Error: string-failure');
+      expect(message.reply).toHaveBeenCalledWith(
+        '❌ Failed to process your message. Please try again.'
+      );
+      expect(message.reply).not.toHaveBeenCalledWith(expect.stringContaining('string-failure'));
     });
 
     it('does not throw if the error reply itself fails', async () => {

--- a/services/bot-client/src/services/PersonalityMessageHandler.ts
+++ b/services/bot-client/src/services/PersonalityMessageHandler.ts
@@ -14,6 +14,8 @@
 import type { Message } from 'discord.js';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { classifyGatewayFailure } from '../ux/catalog/classify.js';
+import { renderSpec } from '../ux/render/render.js';
 import { type JobTracker } from './JobTracker.js';
 import { type PersonalityChatManager } from './character/PersonalityChatManager.js';
 
@@ -75,8 +77,13 @@ export class PersonalityMessageHandler {
     } catch (error) {
       logger.error({ err: error }, 'Error handling personality message');
 
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      await message.reply(`Error: ${errorMessage}`).catch(replyError => {
+      // Classified catalog line — never the raw error.message (internals like
+      // stack fragments and connection errors must not reach users). The
+      // in-character delivery upgrade for this path is a separate step.
+      const spec = classifyGatewayFailure(error, 'message', {
+        failedAction: 'process your message',
+      });
+      await message.reply(renderSpec(spec)).catch(replyError => {
         logger.warn(
           { err: replyError, messageId: message.id },
           'Failed to send error message to user'

--- a/services/bot-client/src/utils/commandHelpers.test.ts
+++ b/services/bot-client/src/utils/commandHelpers.test.ts
@@ -1,8 +1,10 @@
 /**
- * Tests for commandHelpers utilities
+ * Tests for commandHelpers utilities (the shared embed factories — the
+ * error-reply helpers formerly here were dead code and are gone; error
+ * messaging flows through ux/catalog + replySpec).
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EmbedBuilder } from 'discord.js';
 
 // Mock dependencies
@@ -21,109 +23,15 @@ vi.mock('@tzurot/common-types/constants/discord', async () => {
   };
 });
 
-vi.mock('@tzurot/common-types/utils/logger', async () => {
-  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
-    '@tzurot/common-types/utils/logger'
-  );
-  return {
-    ...actual,
-    createLogger: () => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
-  };
-});
-
-vi.mock('./gatewayClients.js', async () => {
-  const actual = await vi.importActual<typeof import('./gatewayClients.js')>('./gatewayClients.js');
-  return {
-    ...actual,
-    isGatewayConfigured: vi.fn().mockReturnValue(true),
-  };
-});
-
 import {
-  replyWithError,
-  replyConfigError,
-  ensureGatewayConfigured,
-  handleCommandError,
   createSuccessEmbed,
   createInfoEmbed,
   createErrorEmbed,
   createWarningEmbed,
-  createSafeHandler,
+  createDangerEmbed,
 } from './commandHelpers.js';
-import { isGatewayConfigured } from './gatewayClients.js';
-import type { ChatInputCommandInteraction } from 'discord.js';
 
 describe('commandHelpers', () => {
-  let mockInteraction: ChatInputCommandInteraction;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    mockInteraction = {
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      user: { id: 'test-user-id' },
-    } as unknown as ChatInputCommandInteraction;
-  });
-
-  describe('replyWithError', () => {
-    it('should edit reply with error message', async () => {
-      await replyWithError(mockInteraction, 'Test error');
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: '❌ Test error',
-      });
-    });
-  });
-
-  describe('replyConfigError', () => {
-    it('should edit reply with config error message', async () => {
-      await replyConfigError(mockInteraction);
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: '❌ Service configuration error. Please try again later.',
-      });
-    });
-  });
-
-  describe('ensureGatewayConfigured', () => {
-    it('should return true when gateway is configured', async () => {
-      vi.mocked(isGatewayConfigured).mockReturnValue(true);
-
-      const result = await ensureGatewayConfigured(mockInteraction);
-
-      expect(result).toBe(true);
-      expect(mockInteraction.editReply).not.toHaveBeenCalled();
-    });
-
-    it('should return false and send error when gateway is not configured', async () => {
-      vi.mocked(isGatewayConfigured).mockReturnValue(false);
-
-      const result = await ensureGatewayConfigured(mockInteraction);
-
-      expect(result).toBe(false);
-      expect(mockInteraction.editReply).toHaveBeenCalled();
-    });
-  });
-
-  describe('handleCommandError', () => {
-    it('should edit reply with generic error message', async () => {
-      await handleCommandError(mockInteraction, new Error('Test'), {
-        userId: 'test-user',
-        command: 'TestCommand',
-      });
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: '❌ An error occurred. Please try again later.',
-      });
-    });
-  });
-
   describe('embed creators', () => {
     it('createSuccessEmbed should create success colored embed', () => {
       const embed = createSuccessEmbed('Test Title', 'Test Description');
@@ -161,35 +69,12 @@ describe('commandHelpers', () => {
       expect(embed).toBeInstanceOf(EmbedBuilder);
       expect(embed.data.color).toBe(0xfee75c); // WARNING color
     });
-  });
 
-  describe('createSafeHandler', () => {
-    it('should call handler normally when no error', async () => {
-      const mockHandler = vi.fn().mockResolvedValue(undefined);
-      const safeHandler = createSafeHandler(mockHandler, { commandName: 'Test' });
+    it('createDangerEmbed should use the ERROR color (destructive intent)', () => {
+      const embed = createDangerEmbed('Delete Everything?', 'This cannot be undone.');
 
-      await safeHandler(mockInteraction);
-
-      expect(mockHandler).toHaveBeenCalledWith(mockInteraction);
-    });
-
-    it('should catch errors and use editReply (interaction always deferred at top-level)', async () => {
-      const mockHandler = vi.fn().mockRejectedValue(new Error('Handler failed'));
-      const safeHandler = createSafeHandler(mockHandler, { commandName: 'Test' });
-
-      // Interactions are always deferred at top-level interactionCreate handler
-      const deferredInteraction = {
-        ...mockInteraction,
-        deferred: true,
-        replied: false,
-        editReply: vi.fn(),
-      } as unknown as ChatInputCommandInteraction;
-
-      await safeHandler(deferredInteraction);
-
-      expect(deferredInteraction.editReply).toHaveBeenCalledWith({
-        content: '❌ An error occurred. Please try again later.',
-      });
+      expect(embed).toBeInstanceOf(EmbedBuilder);
+      expect(embed.data.color).toBe(0xed4245); // ERROR color, semantically danger
     });
   });
 });

--- a/services/bot-client/src/utils/commandHelpers.ts
+++ b/services/bot-client/src/utils/commandHelpers.ts
@@ -2,65 +2,13 @@
  * Command Helpers
  * Shared utilities for Discord slash command handlers
  *
- * Provides:
- * - Consistent ephemeral reply patterns
- * - Standardized error handling
- * - Common interaction utilities
+ * Provides the shared embed factories (success/info/error/warning/danger)
+ * with consistent DISCORD_COLORS styling. Error-reply helpers formerly here
+ * were dead code; error messaging now flows through ux/catalog + replySpec.
  */
 
-import { EmbedBuilder, type ChatInputCommandInteraction } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
-import { createLogger } from '@tzurot/common-types/utils/logger';
-import { isGatewayConfigured } from './gatewayClients.js';
-
-const logger = createLogger('command-helpers');
-
-/**
- * Reply with a simple error message
- */
-export async function replyWithError(
-  interaction: ChatInputCommandInteraction,
-  message: string
-): Promise<void> {
-  await interaction.editReply({ content: `❌ ${message}` });
-}
-
-/**
- * Reply with a configuration error (gateway not configured)
- */
-export async function replyConfigError(interaction: ChatInputCommandInteraction): Promise<void> {
-  await interaction.editReply({
-    content: '❌ Service configuration error. Please try again later.',
-  });
-}
-
-/**
- * Check if gateway is configured, reply with error if not
- * Returns true if configured, false if error was sent
- */
-export async function ensureGatewayConfigured(
-  interaction: ChatInputCommandInteraction
-): Promise<boolean> {
-  if (!isGatewayConfigured()) {
-    await replyConfigError(interaction);
-    return false;
-  }
-  return true;
-}
-
-/**
- * Handle a generic command error (catch block)
- */
-export async function handleCommandError(
-  interaction: ChatInputCommandInteraction,
-  error: unknown,
-  context: { userId: string; command: string }
-): Promise<void> {
-  logger.error({ err: error, ...context }, `Error`);
-  await interaction.editReply({
-    content: '❌ An error occurred. Please try again later.',
-  });
-}
 
 /**
  * Create a success embed with consistent styling
@@ -119,56 +67,4 @@ export function createDangerEmbed(title: string, description: string): EmbedBuil
     .setColor(DISCORD_COLORS.ERROR)
     .setDescription(description)
     .setTimestamp();
-}
-
-/**
- * Handler function type for safe wrapper
- */
-type CommandHandler<T extends ChatInputCommandInteraction = ChatInputCommandInteraction> = (
-  interaction: T
-) => Promise<void>;
-
-/**
- * Options for createSafeHandler
- */
-interface SafeHandlerOptions {
-  /** Command name for logging (e.g., 'Wallet List') */
-  commandName: string;
-}
-
-/**
- * Wraps a command handler with consistent error handling.
- *
- * This is a higher-order function that:
- * - Catches any errors thrown by the handler
- * - Logs the error with context
- * - Replies to the user with a friendly error message
- *
- * Note: Interactions are always deferred at the top-level interactionCreate handler,
- * so error handling only needs to use editReply().
- *
- * @example
- * ```typescript
- * export const handleListKeys = createSafeHandler(
- *   async (interaction) => {
- *     // ... handler logic (no need to defer, already done)
- *   },
- *   { commandName: 'Wallet List' }
- * );
- * ```
- */
-export function createSafeHandler<
-  T extends ChatInputCommandInteraction = ChatInputCommandInteraction,
->(handler: CommandHandler<T>, options: SafeHandlerOptions): CommandHandler<T> {
-  const { commandName } = options;
-
-  return async (interaction: T): Promise<void> => {
-    try {
-      await handler(interaction);
-    } catch (error) {
-      const userId = interaction.user.id;
-      logger.error({ err: error, userId, command: commandName }, `Error`);
-      await interaction.editReply({ content: '❌ An error occurred. Please try again later.' });
-    }
-  };
 }

--- a/services/bot-client/src/utils/dashboard/messages.ts
+++ b/services/bot-client/src/utils/dashboard/messages.ts
@@ -1,49 +1,59 @@
 /**
  * Dashboard Messages
  *
- * Standard message constants used across dashboard implementations.
- * Ensures consistent user-facing messages for common states.
+ * Standard message constants used across dashboard implementations. The
+ * user-facing MESSAGE keys are rendered views of ux/catalog intents — the
+ * catalog owns the wording and the renderer owns the glyphs; this module is
+ * a convenience surface so dashboard call sites keep working unchanged.
+ * New code should prefer building the intent and calling `replySpec`.
+ *
+ * The component-vocabulary keys (embed titles, button labels) are NOT
+ * messages — they stay literal here until the component phase of the UX
+ * design system gives them a home.
  */
+
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { renderSpec } from '../../ux/render/render.js';
 
 /**
  * Standard dashboard messages
  */
 export const DASHBOARD_MESSAGES = {
   /** Message shown when session has expired */
-  SESSION_EXPIRED: '⏰ Session expired. Please run the command again.',
+  SESSION_EXPIRED: renderSpec(CATALOG.progress.sessionExpired()),
 
   /** Message shown when dashboard is closed */
-  DASHBOARD_CLOSED: '✅ Dashboard closed.',
+  DASHBOARD_CLOSED: renderSpec(CATALOG.success.done('Dashboard closed.')),
 
   /** Message shown when entity is not found */
-  NOT_FOUND: (entityType: string) => `❌ ${entityType} not found.`,
+  NOT_FOUND: (entityType: string): string => renderSpec(CATALOG.error.notFound(entityType)),
 
   /** Message shown when user lacks permission */
-  NO_PERMISSION: (action: string) => `❌ You do not have permission to ${action}.`,
+  NO_PERMISSION: (action: string): string => renderSpec(CATALOG.error.permissionDenied(action)),
 
   /** Message shown when edit permission is denied */
-  CANNOT_EDIT: '❌ You do not have permission to edit this.',
+  CANNOT_EDIT: renderSpec(CATALOG.error.permissionDenied('edit this')),
 
   /** Message shown when delete permission is denied */
-  CANNOT_DELETE: '❌ You do not have permission to delete this.',
+  CANNOT_DELETE: renderSpec(CATALOG.error.permissionDenied('delete this')),
 
   /** Generic failure message */
-  OPERATION_FAILED: (action: string) => `❌ Failed to ${action}. Please try again.`,
+  OPERATION_FAILED: (action: string): string => renderSpec(CATALOG.error.operationFailed(action)),
 
   /** Message shown when unknown section is selected */
-  UNKNOWN_SECTION: '❌ Unknown section.',
+  UNKNOWN_SECTION: renderSpec(CATALOG.error.validation('Unknown section.')),
 
   /** Message shown when unknown form is submitted */
-  UNKNOWN_FORM: '❌ Unknown form submission.',
+  UNKNOWN_FORM: renderSpec(CATALOG.error.validation('Unknown form submission.')),
 
   /** Message shown during loading/processing */
-  LOADING: (action: string) => `🔄 ${action}...`,
+  LOADING: (action: string): string => renderSpec(CATALOG.progress.working(action)),
 
   /** Message shown on successful action */
-  SUCCESS: (action: string) => `✅ ${action}`,
+  SUCCESS: (action: string): string => renderSpec(CATALOG.success.done(action)),
 
   /** Message for delete confirmation title */
-  DELETE_CONFIRM_TITLE: (entityType: string) => `🗑️ Delete ${entityType}?`,
+  DELETE_CONFIRM_TITLE: (entityType: string): string => `🗑️ Delete ${entityType}?`,
 
   /** Warning message for delete action */
   DELETE_WARNING: 'This action cannot be undone.',
@@ -62,17 +72,14 @@ export const DASHBOARD_MESSAGES = {
  * Format a session expired message with command hint
  */
 export function formatSessionExpiredMessage(command: string): string {
-  return `⏰ Session expired. Please run \`${command}\` again.`;
+  return renderSpec(CATALOG.progress.sessionExpired(command));
 }
 
 /**
  * Format a not found message for a specific entity
  */
 export function formatNotFoundMessage(entityType: string, entityName?: string): string {
-  if (entityName !== undefined) {
-    return `❌ ${entityType} "${entityName}" not found.`;
-  }
-  return `❌ ${entityType} not found.`;
+  return renderSpec(CATALOG.error.notFound(entityType, { name: entityName }));
 }
 
 /**
@@ -87,5 +94,5 @@ export function formatNotFoundMessage(entityType: string, entityName?: string): 
  *   formatSuccessBanner('Deleted', 'MyPreset') // '✅ **Deleted** · MyPreset'
  */
 export function formatSuccessBanner(verb: string, entityName: string): string {
-  return `✅ **${verb}** · ${entityName}`;
+  return renderSpec(CATALOG.success.banner(verb, entityName));
 }

--- a/services/bot-client/src/utils/dashboard/replyError.ts
+++ b/services/bot-client/src/utils/dashboard/replyError.ts
@@ -1,59 +1,28 @@
-import {
-  MessageFlags,
-  type ButtonInteraction,
-  type StringSelectMenuInteraction,
-  type ModalSubmitInteraction,
-} from 'discord.js';
-import { createLogger } from '@tzurot/common-types/utils/logger';
+/**
+ * Legacy ephemeral-error reply — now a thin delegate onto the unified
+ * ack-state machinery in `ux/render/reply.ts` (`replyContent`), so there is
+ * exactly ONE implementation of the deferred/replied/fresh ack matrix.
+ *
+ * TRANSITIONAL: new code should build a catalog intent and call `replySpec`
+ * instead of hand-writing an error string for this helper — the remaining
+ * call sites migrate with the outcome-honesty sweep.
+ */
 
-const logger = createLogger('replyError');
+import type {
+  ButtonInteraction,
+  StringSelectMenuInteraction,
+  ModalSubmitInteraction,
+} from 'discord.js';
+import { replyContent } from '../../ux/render/reply.js';
 
 /**
  * Reply with an ephemeral error, adapting to the interaction's ack state.
- *
- * Accepts any component-style interaction that shares the
- * deferred/replied/reply/editReply/followUp surface — button, string
- * select menu, and modal submit (their ack handling is identical).
- *
- * Three states map to three response APIs:
- * - `deferred && !replied` (caller did `deferReply`, hasn't sent the
- *   actual response yet) → `editReply` fills the deferred slot. This
- *   replaces the "Thinking…" loading indicator with the error message
- *   instead of leaving the indicator dangling + spawning a separate
- *   followUp.
- * - `replied` (caller already sent a response) → `followUp` for an
- *   additional ephemeral message.
- * - fresh (neither deferred nor replied) → `reply`.
- *
- * **PRECONDITION (deferred path)**: Callers that take the
- * `deferred && !replied` path must have called `deferReply({ flags:
- * MessageFlags.Ephemeral })`. `editReply` inherits whatever flags were
- * set by `deferReply` — passing flags here has no effect. A caller that
- * defers without ephemeral and then hits this helper would expose the
- * error message publicly; that misuse emits a runtime `warn` (it can't be
- * prevented here — the deferral already happened — but it won't pass silently).
- *
- * The deferred slot's ephemeral flag is what makes the error message
- * private; the other two paths pass `flags: Ephemeral` explicitly.
+ * See `replyContent` for the ack matrix and the ephemeral-deferral
+ * precondition (misuse warns at runtime).
  */
 export async function replyError(
   interaction: ButtonInteraction | StringSelectMenuInteraction | ModalSubmitInteraction,
   content: string
 ): Promise<void> {
-  if (interaction.deferred && !interaction.replied) {
-    // editReply inherits the deferReply slot's flags. If the caller deferred
-    // non-ephemerally, this error content is about to be publicly visible —
-    // surface the precondition violation rather than leak it silently.
-    if (interaction.ephemeral === false) {
-      logger.warn(
-        { interactionId: interaction.id },
-        'replyError took the deferred path on a non-ephemeral interaction; error content will be publicly visible. Defer with MessageFlags.Ephemeral.'
-      );
-    }
-    await interaction.editReply({ content });
-  } else if (interaction.replied) {
-    await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
-  } else {
-    await interaction.reply({ content, flags: MessageFlags.Ephemeral });
-  }
+  await replyContent(interaction, content);
 }

--- a/services/bot-client/src/utils/dashboard/saveError.test.ts
+++ b/services/bot-client/src/utils/dashboard/saveError.test.ts
@@ -6,74 +6,11 @@
 
 import { describe, it, expect } from 'vitest';
 import { GatewayApiError } from '@tzurot/clients';
-import {
-  DashboardUpdateError,
-  extractApiErrorMessage,
-  buildDashboardSaveErrorContent,
-} from './saveError.js';
-
-describe('DashboardUpdateError', () => {
-  it('carries the gateway status + kind and is an Error subclass', () => {
-    const err = new DashboardUpdateError(
-      'Failed to update preset: 0 - Request timeout',
-      0,
-      'timeout'
-    );
-    expect(err).toBeInstanceOf(Error);
-    expect(err.name).toBe('DashboardUpdateError');
-    expect(err.status).toBe(0);
-    expect(err.kind).toBe('timeout');
-    expect(err.message).toContain('Request timeout');
-  });
-
-  it('extends GatewayApiError so the ux/catalog classifier narrows it directly', () => {
-    const err = new DashboardUpdateError('boom', 0, 'timeout');
-    expect(err).toBeInstanceOf(GatewayApiError);
-  });
-});
-
-describe('extractApiErrorMessage', () => {
-  it('extracts the API message from a structured error', () => {
-    const error = new Error('Failed to update preset: 400 - Context window too large');
-    expect(extractApiErrorMessage(error)).toBe('Context window too large');
-  });
-
-  it('returns null for non-Error values', () => {
-    expect(extractApiErrorMessage('string error')).toBeNull();
-    expect(extractApiErrorMessage(null)).toBeNull();
-  });
-
-  it('returns null for errors without the API format', () => {
-    expect(extractApiErrorMessage(new Error('Network error'))).toBeNull();
-  });
-
-  it('returns null for non-API errors that merely contain dashes', () => {
-    expect(extractApiErrorMessage(new Error('Request timed out - after 30s'))).toBeNull();
-    expect(extractApiErrorMessage(new Error('TLS handshake failed - connection reset'))).toBeNull();
-  });
-
-  it('preserves dashes inside the API message portion', () => {
-    const error = new Error('Failed to update preset: 400 - limit is 4096 - not 131072');
-    expect(extractApiErrorMessage(error)).toBe('limit is 4096 - not 131072');
-  });
-
-  it('does not match a single-digit status (status-0 aborts fall through)', () => {
-    expect(extractApiErrorMessage(new Error('Failed to update character: 0 - timeout'))).toBeNull();
-  });
-
-  it('truncates very long API messages', () => {
-    const longMessage = 'A'.repeat(2000);
-    const error = new Error(`Failed to update preset: 400 - ${longMessage}`);
-    const result = extractApiErrorMessage(error);
-    expect(result).not.toBeNull();
-    expect(result!.length).toBeLessThanOrEqual(1801); // 1800 + ellipsis
-    expect(result!.endsWith('…')).toBe(true);
-  });
-});
+import { buildDashboardSaveErrorContent } from './saveError.js';
 
 describe('buildDashboardSaveErrorContent', () => {
   it('shows the honest "may still be applying" notice on a timeout abort', () => {
-    const error = new DashboardUpdateError(
+    const error = new GatewayApiError(
       'Failed to update character: 0 - Request timeout',
       0,
       'timeout'
@@ -89,7 +26,7 @@ describe('buildDashboardSaveErrorContent', () => {
     // status 0 but kind 'schema' → outcome is certain (the write committed; only
     // the read-back body failed to parse). Not "may still be applying" (uncertain)
     // and not "try again" (risks a duplicate write) — the write definitively saved.
-    const error = new DashboardUpdateError(
+    const error = new GatewayApiError(
       'Failed to update character: 0 - Response body is not valid JSON',
       0,
       'schema'
@@ -103,16 +40,12 @@ describe('buildDashboardSaveErrorContent', () => {
   });
 
   it('is outcome-uncertain for a network abort too', () => {
-    const error = new DashboardUpdateError(
-      'Failed to update preset: 0 - fetch failed',
-      0,
-      'network'
-    );
+    const error = new GatewayApiError('Failed to update preset: 0 - fetch failed', 0, 'network');
     expect(buildDashboardSaveErrorContent(error, 'preset')).toContain('may still be applying');
   });
 
   it('surfaces the real gateway message on a genuine HTTP rejection', () => {
-    const error = new DashboardUpdateError(
+    const error = new GatewayApiError(
       'Failed to update character: 400 - avatarData: Invalid input: expected string, received null',
       400,
       'http'

--- a/services/bot-client/src/utils/dashboard/saveError.ts
+++ b/services/bot-client/src/utils/dashboard/saveError.ts
@@ -1,7 +1,6 @@
 /**
- * Shared dashboard save-error handling — now a thin adapter over the ux/catalog
- * outcome-honesty classifier (`classifyGatewayFailure`), which generalizes this
- * module's original dispatcher to every gateway write:
+ * Shared dashboard save-error handling — a thin adapter over the ux/catalog
+ * outcome-honesty classifier (`classifyGatewayFailure`):
  *
  *  - **Outcome-uncertain abort (transport kind `'timeout'`/`'network'`)** — the
  *    write frequently commits server-side a moment later; claiming failure (and
@@ -12,50 +11,13 @@
  *    so the reason is visible instead of masked behind a generic "try again".
  *    The masked-400 failure mode is exactly what hid the `avatarData` null
  *    round-trip bug behind "Failed to update character. Please try again."
+ *
+ * Dashboard writes throw `GatewayApiError` (from `@tzurot/clients`) carrying
+ * the transport `kind` + `status`; the classifier narrows it directly.
  */
 
-import { GatewayApiError, type GatewayFailureKind } from '@tzurot/clients';
-import { classifyGatewayFailure, MAX_SURFACED_LENGTH } from '../../ux/catalog/classify.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { renderSpec } from '../../ux/render/render.js';
-
-/**
- * Error thrown by dashboard writes, carrying the gateway response `status` and
- * the transport `kind` so a genuine rejection (HTTP 4xx/5xx) is distinguishable
- * from an outcome-uncertain client-side abort (`'timeout'`/`'network'`).
- *
- * Extends `GatewayApiError` so the ux/catalog classifier narrows it with zero
- * special-casing. TRANSITIONAL: full retirement onto plain `GatewayApiError`
- * (updating the five dashboard api.ts throw sites) lands with the substrate
- * migration PR; new code should throw `GatewayApiError` directly.
- */
-export class DashboardUpdateError extends GatewayApiError {
-  constructor(message: string, status: number, kind: GatewayFailureKind) {
-    super(message, status, kind);
-    this.name = 'DashboardUpdateError';
-  }
-}
-
-/**
- * Extract the user-facing message from a gateway error.
- *
- * Gateway write errors follow the format "Failed to X <resource>: HTTP_STATUS -
- * api_message". This extracts the api_message portion for display. Returns null
- * for non-HTTP failure modes (timeout/network/schema/config all carry status 0,
- * whose single digit doesn't match the 3-digit pattern) or unexpected formats,
- * signaling callers to use a generic fallback. Truncates to Discord's content
- * limit to avoid silent send failures.
- */
-export function extractApiErrorMessage(error: unknown): string | null {
-  if (!(error instanceof Error)) {
-    return null;
-  }
-  const match = /: \d{3} - (.+)$/.exec(error.message);
-  if (match?.[1] === undefined) {
-    return null;
-  }
-  const msg = match[1];
-  return msg.length > MAX_SURFACED_LENGTH ? msg.slice(0, MAX_SURFACED_LENGTH) + '…' : msg;
-}
 
 /**
  * Build the user-facing content for a failed dashboard save. Delegates to the

--- a/services/bot-client/src/ux/catalog/catalog.test.ts
+++ b/services/bot-client/src/ux/catalog/catalog.test.ts
@@ -41,8 +41,8 @@ describe('CATALOG', () => {
   it('OUTCOME-HONESTY INVARIANT: uncertain/committed-unconfirmed specs never invite a retry', () => {
     // The core rule of the catalog (design §4.2): a write whose outcome is
     // unknown must never render a retry invitation — that's the duplicate-write
-    // bug. The regex covers synonyms (review-caught: "trying again" dodged a
-    // bare /try again/ while carrying the exact same invitation).
+    // bug. The regex covers synonyms: "trying again" carries the exact same
+    // invitation as "try again" and must not dodge on morphology.
     const RETRY_INVITATION = /try(?:ing)?\s+again|retry|re-?submit/i;
     for (const { path, spec } of allSpecs()) {
       if (spec.outcome === 'uncertain' || spec.outcome === 'committed-unconfirmed') {

--- a/services/bot-client/src/ux/catalog/catalog.ts
+++ b/services/bot-client/src/ux/catalog/catalog.ts
@@ -19,6 +19,8 @@ import type { MessageSpec } from './types.js';
 export interface NotFoundOptions {
   /** Append the autocomplete steer (only where the option HAS autocomplete). */
   autocomplete?: boolean;
+  /** Name the specific entity instance: `Character "Luna" not found.` */
+  name?: string;
 }
 
 export const CATALOG = {
@@ -27,7 +29,9 @@ export const CATALOG = {
     notFound: (entity: string, opts: NotFoundOptions = {}): MessageSpec => ({
       severity: 'error',
       outcome: 'failed',
-      text: `${entity} not found.${opts.autocomplete === true ? ' Use autocomplete to select a valid option.' : ''}`,
+      text:
+        `${entity}${opts.name !== undefined ? ` "${opts.name}"` : ''} not found.` +
+        `${opts.autocomplete === true ? ' Use autocomplete to select a valid option.' : ''}`,
     }),
 
     /** The user's input was the problem; an immediate retry is honest. */

--- a/services/bot-client/src/ux/catalog/classify.test.ts
+++ b/services/bot-client/src/ux/catalog/classify.test.ts
@@ -52,7 +52,7 @@ describe('classifyGatewayFailure', () => {
       });
     }
 
-    it('http (5xx via nullOn404) SURFACES the gateway message — review-caught: the prose wrapper matches neither regex', () => {
+    it('http (5xx via nullOn404) SURFACES the gateway message even though the prose wrapper matches neither regex', () => {
       const err = new InfraError({
         ok: false,
         kind: 'http',
@@ -95,6 +95,31 @@ describe('classifyGatewayFailure', () => {
     expect(spec.text).not.toContain('Failed to update preset: 400'); // only the clean suffix
   });
 
+  it('preserves dashes inside the extracted gateway message', () => {
+    const err = new Error('Failed to update preset: 400 - limit is 4096 - not 131072');
+    expect(classifyGatewayFailure(err, 'preset').text).toContain('limit is 4096 - not 131072');
+  });
+
+  it('does not extract from a single-digit status (status-0 abort prose falls to generic)', () => {
+    const spec = classifyGatewayFailure(
+      new Error('Failed to update character: 0 - timeout'),
+      'character'
+    );
+    expect(spec.text).toBe('Failed to update character. Please try again.');
+  });
+
+  it('does not extract from prose that merely contains dashes (no wrapper format)', () => {
+    const spec = classifyGatewayFailure(new Error('Request timed out - after 30s'), 'preset');
+    expect(spec.text).toBe('Failed to update preset. Please try again.');
+  });
+
+  it('the failedAction override rewrites the generic fallback for non-write contexts', () => {
+    const spec = classifyGatewayFailure(new Error('boom'), 'message', {
+      failedAction: 'process your message',
+    });
+    expect(spec.text).toBe('Failed to process your message. Please try again.');
+  });
+
   it('TOTAL: unknown error shapes → generic failure, never leaking the raw message', () => {
     const inputs: unknown[] = [
       new Error('ECONNRESET at internal/stream.js:451 SECRET-INTERNAL'),
@@ -135,7 +160,7 @@ describe('classifyGatewayFailure', () => {
     expect(spec.text.endsWith('…')).toBe(true);
   });
 
-  it('truncates oversize messages on the fail-arm carrier too (review-caught gap)', () => {
+  it('truncates oversize messages on the fail-arm carrier too', () => {
     const spec = classifyGatewayFailure(failArm('http', 'y'.repeat(3000), 400), 'preset');
     expect(spec.text.length).toBeLessThan(2000);
     expect(spec.text.endsWith('…')).toBe(true);

--- a/services/bot-client/src/ux/catalog/classify.ts
+++ b/services/bot-client/src/ux/catalog/classify.ts
@@ -37,6 +37,12 @@ export interface GatewayResultFailure {
 /** Options forwarded to the uncertain/committed shapes (dashboard Refresh hint). */
 export interface ClassifyOptions {
   refreshAffordance?: boolean;
+  /**
+   * Verb phrase for the generic-failure fallback (`Failed to {failedAction}.`).
+   * Defaults to `update {resource}` — override for non-write contexts
+   * ("process your message", "load the character").
+   */
+  failedAction?: string;
 }
 
 function isGatewayResultFailure(input: unknown): input is GatewayResultFailure {
@@ -94,14 +100,14 @@ function specForKind(
     case 'http':
       return gatewayMessage !== null
         ? CATALOG.error.gatewayRejection(gatewayMessage)
-        : CATALOG.error.operationFailed(`update ${resource}`);
+        : CATALOG.error.operationFailed(opts.failedAction ?? `update ${resource}`);
     case 'config':
       return CATALOG.error.transient("Couldn't reach the server right now.");
     default:
       // Unreachable for the typed carriers, but the fail-arm guard only
       // verifies `kind` is a string — a malformed object with an off-union
       // kind must degrade to the generic failure, not return undefined.
-      return CATALOG.error.operationFailed(`update ${resource}`);
+      return CATALOG.error.operationFailed(opts.failedAction ?? `update ${resource}`);
   }
 }
 
@@ -121,8 +127,8 @@ export function classifyGatewayFailure(
 ): MessageSpec {
   if (input instanceof InfraError) {
     // InfraError carries the gateway string as a FIELD — its prose wrapper
-    // format matches neither extraction regex (review-caught: a real 5xx via
-    // nullOn404 would silently lose its gateway detail behind the generic).
+    // format matches neither extraction regex, so scraping `message` would
+    // silently lose a real 5xx's gateway detail behind the generic fallback.
     return specForKind(input.kind, truncateSurfaced(input.gatewayMessage), resource, opts);
   }
 
@@ -136,14 +142,14 @@ export function classifyGatewayFailure(
     const gatewayMessage = extractGatewayMessage(input.message);
     return gatewayMessage !== null
       ? CATALOG.error.gatewayRejection(gatewayMessage)
-      : CATALOG.error.operationFailed(`update ${resource}`);
+      : CATALOG.error.operationFailed(opts.failedAction ?? `update ${resource}`);
   }
 
   if (isGatewayResultFailure(input)) {
     // The fail-arm's `error` IS the gateway message for http kinds (no
     // wrapper prefix to strip) — but it needs the same truncation every other
-    // carrier gets (review-caught: a verbose gateway validation error would
-    // blow Discord's content cap and the reply would fail to send).
+    // carrier gets: a verbose gateway validation error would blow Discord's
+    // content cap and the reply would fail to send.
     const gatewayMessage = input.kind === 'http' ? truncateSurfaced(input.error) : null;
     return specForKind(input.kind, gatewayMessage, resource, opts);
   }
@@ -161,5 +167,5 @@ export function classifyGatewayFailure(
 
   // Unknown error shape: generic definitive failure. Deliberately does NOT
   // surface `error.message` — unrecognized internals never reach users.
-  return CATALOG.error.operationFailed(`update ${resource}`);
+  return CATALOG.error.operationFailed(opts.failedAction ?? `update ${resource}`);
 }

--- a/services/bot-client/src/ux/render/render.test.ts
+++ b/services/bot-client/src/ux/render/render.test.ts
@@ -40,4 +40,14 @@ describe('renderSpec', () => {
       );
     });
   });
+
+  it('worst-case rendered output stays under the Discord content cap', () => {
+    // MAX_SURFACED_LENGTH (1800) caps the classifier text; emoji prefix +
+    // affordance suffixes must not push the final render past 2000.
+    const spec = CATALOG.error.gatewayRejection('x'.repeat(1800) + '…');
+    expect(renderSpec(spec).length).toBeLessThanOrEqual(2000);
+
+    const uncertain = CATALOG.error.uncertainWrite('character', { refreshAffordance: true });
+    expect(renderSpec(uncertain).length).toBeLessThanOrEqual(2000);
+  });
 });

--- a/services/bot-client/src/ux/render/reply.ts
+++ b/services/bot-client/src/ux/render/reply.ts
@@ -53,21 +53,30 @@ export function ackMethodFor(state: { deferred: boolean; replied: boolean }): Ac
 }
 
 /**
- * Deliver a MessageSpec to an interaction, selecting the correct ack method
- * for its current state. followUp/reply branches are always ephemeral;
- * editReply inherits the deferral's visibility (callers of deferred flows own
- * that choice — a public deferral getting a public error is deliberate).
+ * Deliver rendered content to an interaction, selecting the correct ack
+ * method for its current state. followUp/reply branches are always ephemeral;
+ * editReply inherits the deferral's visibility.
+ *
+ * PRECONDITION (deferred path): callers taking `deferred && !replied` must
+ * have deferred ephemerally when the content is an error — `editReply`
+ * inherits the deferral's flags, so a non-ephemeral deferral exposes the
+ * content publicly. That misuse emits a runtime `warn` (it can't be prevented
+ * here — the deferral already happened — but it won't pass silently).
  */
-export async function replySpec(
+export async function replyContent(
   interaction: RepliableInteraction,
-  spec: MessageSpec,
-  opts: RenderOptions = {}
+  content: string
 ): Promise<void> {
-  const content = renderSpec(spec, opts);
   const method = ackMethodFor({ deferred: interaction.deferred, replied: interaction.replied });
 
   switch (method) {
     case 'editReply':
+      if (interaction.ephemeral === false) {
+        logger.warn(
+          { interactionId: interaction.id },
+          'Catalog reply took the deferred path on a non-ephemeral interaction; content will be publicly visible. Defer with MessageFlags.Ephemeral.'
+        );
+      }
       await interaction.editReply({ content });
       return;
     case 'followUp':
@@ -77,6 +86,18 @@ export async function replySpec(
       await interaction.reply({ content, flags: MessageFlags.Ephemeral });
       return;
   }
+}
+
+/**
+ * Deliver a MessageSpec to an interaction (render + ack-state-adaptive send).
+ * THE reply path for catalog messages.
+ */
+export async function replySpec(
+  interaction: RepliableInteraction,
+  spec: MessageSpec,
+  opts: RenderOptions = {}
+): Promise<void> {
+  await replyContent(interaction, renderSpec(spec, opts));
 }
 
 /**


### PR DESCRIPTION
## Summary

**UX boulder Phase 1, PR-B** — the live messaging substrate now sources from the catalog shipped in #1550. Net **-270 lines**; ratchet **448 → 441** (the big drops come with the PR-D sweep).

### What moved onto the catalog

- **`DASHBOARD_MESSAGES`** (15 consumers): the 11 message keys are now rendered views of catalog intents — the catalog owns wording, the renderer owns glyphs, call sites unchanged. Wording verified identical key-by-key. The 5 component-vocabulary keys (embed titles, button labels) stay literal until the component phase gives them a home. The three formatters (`formatSessionExpiredMessage` / `formatNotFoundMessage` / `formatSuccessBanner`) delegate too.
- **`replyError`** (8 consumers): now a thin delegate over the new `ux/render/replyContent`, so exactly ONE implementation of the deferred/replied/fresh ack matrix exists. Its non-ephemeral-deferral leak warning moved INTO the shared path — catalog replies get that guard now too. Consumers migrate to intent-based `replySpec` in the PR-D sweep.

### Retirements

- **`DashboardUpdateError` is gone**: the five throw sites (preset/persona/character `api.ts`) throw `GatewayApiError` directly (same constructor shape, carried `kind`/`status` unchanged — PR-A's `extends` was the transitional step).
- **`extractApiErrorMessage` is gone**: its two legacy call sites (preset create + clone) classify through the catalog — closing the transitional regex duplication the PR-A review flagged. Its edge-case tests (dash preservation, single-digit-status fall-through) ported into the classifier suite.
- **Dead `commandHelpers` deleted**: `replyWithError` / `replyConfigError` / `ensureGatewayConfigured` / `handleCommandError` / `createSafeHandler` had zero production consumers. The embed factories (14 real consumers) stay, and `createDangerEmbed` gained the test it never had.

### Leak fix (user-visible)

`PersonalityMessageHandler` replied `Error: ${error.message}` **raw to users** — connection internals, stack fragments, whatever the throw carried. Now a classified catalog line; tests pin the no-leak invariant (`not.toHaveBeenCalledWith(stringContaining('boom'))`). The in-character delivery upgrade for this path is PR-E's scope.

### Classifier refinement

`ClassifyOptions.failedAction` overrides the generic fallback's hardcoded "update {resource}" verb for non-write contexts ("process your message", "create the preset"). PR-A review follow-ups folded: archaeology comment prefixes dropped, worst-case rendered-length assertion added.

## Verification

Full suite 25/25 (5266 bot-client tests), **component tier 30/30** (message-shape change gate), quality green including gate-parity. Intentional wording deltas are pinned by updated tests: "Failed to create/clone **the** preset" (via failedAction) and the leak-fix line.

Train status: A ✅ merged (#1550) · **B this** · C wrapper conversions · D sweep · E in-character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)