### PR TITLE
fix: announce the first z.ai fallback in the response footer

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.test.ts
@@ -1728,6 +1728,61 @@ describe('GenerationStep', () => {
         expect(secondCallOpts?.userApiKey).toBe('sk-or-user-key');
       });
 
+      it('threads the reactive breadcrumb to result metadata when the swap rescues a quota-class failure (the first-fallback footer gap)', async () => {
+        // The seam this pins: a rate-limited z.ai primary + successful
+        // OpenRouter swap must surface `quotaFallback` in the RESULT metadata
+        // — the info was previously computed nowhere on this path, so the
+        // first fallback response of a doom window rendered no breadcrumb.
+        vi.mocked(mockRAGService.generateResponse)
+          .mockRejectedValueOnce(new Error('429 Too Many Requests: rate limit exceeded'))
+          .mockResolvedValueOnce({
+            content: 'rescued',
+            retrievedMemories: 0,
+            tokensIn: 1,
+            tokensOut: 1,
+            modelUsed: 'z-ai/glm-5.1',
+          } as RAGResponse);
+
+        const result = await step.process({
+          job: createMockJob(),
+          startTime: Date.now(),
+          config: promotedConfig,
+          auth: promotedAuth,
+          preparedContext: basePreparedContext,
+        });
+
+        expect(result.result?.success).toBe(true);
+        expect(result.result?.metadata?.quotaFallback).toEqual({
+          fromModel: 'glm-5.1',
+          toModel: 'z-ai/glm-5.1',
+          category: ApiErrorCategory.RATE_LIMIT,
+          mode: 'reactive',
+        });
+      });
+
+      it('non-quota swap reasons leave quotaFallback absent (catalog drift stays unannotated)', async () => {
+        vi.mocked(mockRAGService.generateResponse)
+          .mockRejectedValueOnce(new Error('z.ai 404: model not found'))
+          .mockResolvedValueOnce({
+            content: 'rescued',
+            retrievedMemories: 0,
+            tokensIn: 1,
+            tokensOut: 1,
+            modelUsed: 'z-ai/glm-5.1',
+          } as RAGResponse);
+
+        const result = await step.process({
+          job: createMockJob(),
+          startTime: Date.now(),
+          config: promotedConfig,
+          auth: promotedAuth,
+          preparedContext: basePreparedContext,
+        });
+
+        expect(result.result?.success).toBe(true);
+        expect(result.result?.metadata?.quotaFallback).toBeUndefined();
+      });
+
       it('propagates the ORIGINAL error enriched with the fallback failure when both fail', async () => {
         // Both z.ai and OpenRouter fail — the root cause leads, but the message
         // carries BOTH halves so the user knows a fallback was attempted and why

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
@@ -340,6 +340,7 @@ export class GenerationStep implements IPipelineStep {
         leakedThinkingRetries,
         effectiveProviderUsed,
         quotaFallback: reactiveQuotaFallback,
+        autoPromotionFallback,
       } = await runWithQuotaFallback({
         primary: () =>
           runWithAutoPromotionFallback(
@@ -352,7 +353,14 @@ export class GenerationStep implements IPipelineStep {
         userId: jobContext.userId,
         deps: this.quotaFallbackDeps,
       });
-      const quotaFallbackInfo = composeQuotaFallbackInfo(reactiveQuotaFallback, auth.quotaFallback);
+      // Three announce sources, pairwise-exclusive with the swap: the proactive
+      // demotion clears `auth.fallback` (so no swap can fire), and a quota
+      // retarget only fires when the whole primary FAILED (so a swap that
+      // served can't coexist with it). The swap breadcrumb is therefore a
+      // fallback of the existing composition, never a conflict.
+      const quotaFallbackInfo =
+        composeQuotaFallbackInfo(reactiveQuotaFallback, auth.quotaFallback) ??
+        autoPromotionFallback;
 
       // Store memory ONCE after retry loop completes with a valid response.
       // This prevents duplicate memories when retries occur (the fix for the

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
@@ -10,6 +10,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { RetryError } from '../../../../utils/retry.js';
+import { ApiErrorCategory, ApiErrorType } from '@tzurot/common-types/constants/error';
+import { ApiError } from '../../../../utils/apiErrorParser.js';
 import {
   runWithAutoPromotionFallback,
   getFallbackFailureSummary,
@@ -157,6 +159,87 @@ describe('runWithAutoPromotionFallback', () => {
     // Result is the fallback's, tagged with the effective provider (OpenRouter)
     // so the response footer links to the OpenRouter model card, not z.ai docs.
     expect(result).toEqual({ ...fallbackResult, effectiveProviderUsed: AIProvider.OpenRouter });
+  });
+
+  it('attaches the reactive footer breadcrumb when the swap rescues a quota-class failure', async () => {
+    // The first-fallback footer gap: the response said "via OpenRouter" but
+    // carried no `from → to (rate limited)` annotation — only SUBSEQUENT
+    // requests (proactive demotion off the doom cache) showed it.
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('429 Too Many Requests: rate limit exceeded'))
+      .mockResolvedValueOnce(successResult);
+
+    const result = await runWithAutoPromotionFallback(attempt, baseOpts, {
+      apiKey: 'sk-or-fallback',
+      provider: 'openrouter',
+      model: 'z-ai/glm-5.1',
+      isGuestMode: false,
+    });
+
+    expect(result.autoPromotionFallback).toEqual({
+      fromModel: 'glm-5.1',
+      toModel: 'z-ai/glm-5.1',
+      category: ApiErrorCategory.RATE_LIMIT,
+      mode: 'reactive',
+    });
+  });
+
+  it('attaches NO breadcrumb for a non-quota swap reason (catalog drift stays unannotated)', async () => {
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('model not found: glm-5.1'))
+      .mockResolvedValueOnce(successResult);
+
+    const result = await runWithAutoPromotionFallback(attempt, baseOpts, {
+      apiKey: 'sk-or-fallback',
+      provider: 'openrouter',
+      model: 'z-ai/glm-5.1',
+      isGuestMode: false,
+    });
+
+    expect(result.autoPromotionFallback).toBeUndefined();
+    expect(result.effectiveProviderUsed).toBe(AIProvider.OpenRouter);
+  });
+
+  it('classifies the UNWRAPPED error for the breadcrumb when the failure is RetryError-wrapped', async () => {
+    const wrapped = new RetryError('LLM invocation failed', 1, new Error('too many requests'));
+    const attempt = vi.fn().mockRejectedValueOnce(wrapped).mockResolvedValueOnce(successResult);
+
+    const result = await runWithAutoPromotionFallback(attempt, baseOpts, {
+      apiKey: 'sk-or-fallback',
+      provider: 'openrouter',
+      model: 'z-ai/glm-5.1',
+      isGuestMode: false,
+    });
+
+    expect(result.autoPromotionFallback?.category).toBe(ApiErrorCategory.RATE_LIMIT);
+    expect(result.autoPromotionFallback?.mode).toBe('reactive');
+  });
+
+  it("honors a synthetic ApiError's authoritative category over its generic message", async () => {
+    // The rate-limit-cache short-circuit throws ApiError('Rate limit cached',
+    // { category: QUOTA_EXCEEDED, ... }) — regex-parsing that message would
+    // mislabel the breadcrumb RATE_LIMIT. classifyQuotaFailure trusts the
+    // instance's own category.
+    const synthetic = new ApiError('Rate limit cached', {
+      type: ApiErrorType.PERMANENT,
+      category: ApiErrorCategory.QUOTA_EXCEEDED,
+      userMessage: 'x',
+      technicalMessage: 'x',
+      referenceId: 'ref',
+      shouldRetry: false,
+    });
+    const attempt = vi.fn().mockRejectedValueOnce(synthetic).mockResolvedValueOnce(successResult);
+
+    const result = await runWithAutoPromotionFallback(attempt, baseOpts, {
+      apiKey: 'sk-or-fallback',
+      provider: 'openrouter',
+      model: 'z-ai/glm-5.1',
+      isGuestMode: false,
+    });
+
+    expect(result.autoPromotionFallback?.category).toBe(ApiErrorCategory.QUOTA_EXCEEDED);
   });
 
   it('propagates the ORIGINAL error untouched with the fallback summary attached separately', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
@@ -25,6 +25,12 @@ import type {
 import type { DiagnosticCollector } from '../../../../services/DiagnosticCollector.js';
 import type { GenerationContext } from '../types.js';
 import { RetryError } from '../../../../utils/retry.js';
+import {
+  classifyQuotaFailure,
+  logQuotaFallbackAudit,
+  type QuotaFallbackInfo,
+} from '../../../../services/quotaFallback.js';
+import { deriveCacheKeyId } from '../../../../services/RateLimitCache.js';
 
 const logger = createLogger('AutoPromotionFallback');
 
@@ -64,6 +70,17 @@ export interface GenerateAttemptResult {
    * OpenRouter model card, not the z.ai docs page.
    */
   effectiveProviderUsed?: AIProvider;
+  /**
+   * Footer announce info for a swap that SERVED the response, set only when
+   * the promoted attempt's failure classifies as a quota-class category (the
+   * three the footer renders). Without this, the FIRST fallback response of
+   * a doom window showed "via OpenRouter" with no `from → to (reason)`
+   * breadcrumb — only subsequent requests (proactive demotion off the doom
+   * cache) carried it. Non-quota swap reasons (catalog drift) stay
+   * unannotated: "via OpenRouter" is accurate and the annotation vocabulary
+   * is quota-shaped.
+   */
+  autoPromotionFallback?: QuotaFallbackInfo;
 }
 
 type GenerateAttempt = (opts: GenerateAttemptOpts) => Promise<GenerateAttemptResult>;
@@ -140,8 +157,34 @@ export async function runWithAutoPromotionFallback(
         effectiveProvider: AIProvider.OpenRouter,
       });
       // OpenRouter actually served this request (the promoted z.ai call failed),
-      // so report it as the effective provider for the footer model-info link.
-      return { ...fallbackResult, effectiveProviderUsed: AIProvider.OpenRouter };
+      // so report it as the effective provider for the footer model-info link —
+      // and, for quota-class failures, the announce breadcrumb (same shape the
+      // proactive demotion attaches from the doom cache). classifyQuotaFailure
+      // (not a hand-rolled parseApiError) because it trusts an ApiError's own
+      // .info.category — the rate-limit-cache short-circuit throws a synthetic
+      // ApiError whose generic message would regex-parse to the WRONG category.
+      const category = classifyQuotaFailure(originalError);
+      if (category === null) {
+        return { ...fallbackResult, effectiveProviderUsed: AIProvider.OpenRouter };
+      }
+      const info: QuotaFallbackInfo = {
+        fromModel: opts.personality.model,
+        toModel: fallback.model,
+        category,
+        mode: 'reactive',
+      };
+      // Audit-log parity with the other two announce sources (module
+      // invariant: every fire is announced AND audit-logged) — the fallback
+      // route's key is the one that actually served the rescued request.
+      logQuotaFallbackAudit(info, {
+        jobId: opts.jobId,
+        cacheKeyId: deriveCacheKeyId(fallback.apiKey, opts.conversationContext.userId),
+      });
+      return {
+        ...fallbackResult,
+        effectiveProviderUsed: AIProvider.OpenRouter,
+        autoPromotionFallback: info,
+      };
     } catch (fallbackError) {
       logger.error(
         { jobId: opts.jobId, err: originalError, fallbackErr: fallbackError },


### PR DESCRIPTION
## Summary

Owner-observed prod bug (screenshots, 2026-07-07): the **first** z.ai→OpenRouter fallback response's footer said `via OpenRouter` with no fallback annotation; subsequent responses correctly showed `glm-5.2 → z-ai/glm-5.2 (rate limited)`.

**Mechanism**: two fallback paths, one gap. The *proactive* demotion (`promotionDemotion.ts`, fires when the doom cache already knows z.ai is rate-limited — request #2 onward) attaches `quotaFallback` announce info. The *reactive* swap (`autoPromotionFallback.ts`, the first mid-request 429) returned only `effectiveProviderUsed` — provider link right, story missing.

**Fix**: the swap-success path classifies the original error (RetryError-unwrapped, same as the failure path) and attaches the same `QuotaFallbackInfo` shape when the category is quota-class — the three categories the footer vocabulary renders. Non-quota swap reasons (catalog drift) stay deliberately unannotated. `GenerationStep` composes it as a `??` fallback of the existing two sources, which are pairwise-exclusive with the swap (reasoning in the comment at the composition site).

Severity: cosmetic/observability — routing itself always worked. Board entry removed on merge.

## Verification

New tests: breadcrumb attached on 429 (plain + RetryError-wrapped), absent for non-quota reasons; full pipeline-steps suite 310/310; full suite 25/25; quality green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)