### PR TITLE
refactor: G2 sweep — character family onto ux/catalog (UX P1 PR-D1)

### DIFF
--- a/.github/baselines/ux-literals-baseline.json
+++ b/.github/baselines/ux-literals-baseline.json
@@ -1,15 +1,15 @@
 {
-  "total": 441,
+  "total": 370,
   "byPattern": {
-    "emoji-prefixed": 314,
-    "try-again": 127
+    "emoji-prefixed": 259,
+    "try-again": 111
   },
   "graceMargin": 10,
   "meta": {
     "toolVersion": "ux-literals-check/1",
     "configHash": "4b12eb65e0c6",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "719c818d7c3ff533da74de80b0e19ccb0f8f579e",
-    "generatedAt": "2026-07-08T02:57:28.811Z"
+    "generatedFromSha": "d4eae6ab23fff1510e8aede72f09087342133833",
+    "generatedAt": "2026-07-08T04:31:30.120Z"
   }
 }

--- a/services/bot-client/src/commands/character/avatar.test.ts
+++ b/services/bot-client/src/commands/character/avatar.test.ts
@@ -190,7 +190,7 @@ describe('Character Avatar Handler', () => {
       await handleAvatar(mockContext, mockConfig);
 
       expect(mockContext.editReply).toHaveBeenCalledWith(
-        expect.stringContaining("don't have permission")
+        expect.stringContaining('do not have permission')
       );
     });
 
@@ -237,7 +237,7 @@ describe('Character Avatar Handler', () => {
       // Not the timeout-specific message — must fall through to outer catch.
       expect(mockContext.editReply).not.toHaveBeenCalledWith(expect.stringContaining('timed out'));
       expect(mockContext.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to update avatar')
+        expect.stringContaining('Failed to update the avatar')
       );
       expect(api.updateCharacter).not.toHaveBeenCalled();
     });
@@ -285,7 +285,7 @@ describe('Character Avatar Handler', () => {
       await handleAvatar(mockContext, mockConfig);
 
       expect(mockContext.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to update avatar')
+        expect.stringContaining('Failed to update the avatar')
       );
     });
   });
@@ -321,7 +321,7 @@ describe('Character Avatar Handler', () => {
 
       expect(api.updateCharacter).not.toHaveBeenCalled();
       expect(mockContext.editReply).toHaveBeenCalledWith(
-        expect.stringContaining("don't have permission")
+        expect.stringContaining('do not have permission')
       );
     });
   });

--- a/services/bot-client/src/commands/character/avatar.test.ts
+++ b/services/bot-client/src/commands/character/avatar.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GatewayApiError } from '@tzurot/clients';
 import { handleAvatar } from './avatar.js';
 import {
   VALID_IMAGE_TYPES,
@@ -288,9 +289,79 @@ describe('Character Avatar Handler', () => {
         expect.stringContaining('Failed to update the avatar')
       );
     });
+
+    it('renders the outcome-uncertain shape on a write timeout (never "try again")', async () => {
+      // Wiring proof for the sweep's headline claim: a typed timeout from
+      // updateCharacter reaches the classifier and renders verify-first copy.
+      const attachment = createMockAttachment();
+      const mockContext = createMockContext('my-char', attachment);
+      vi.mocked(api.fetchCharacter).mockResolvedValue(createMockCharacter({ slug: 'my-char' }));
+      vi.mocked(api.updateCharacter).mockRejectedValue(
+        new GatewayApiError('Failed to update personality: 0 - timed out', 0, 'timeout')
+      );
+
+      await handleAvatar(mockContext, mockConfig);
+
+      const reply = vi.mocked(mockContext.editReply).mock.calls.at(-1)?.[0] as string;
+      expect(reply).toContain('may still be applying');
+      expect(reply).not.toMatch(/try again/i);
+    });
+  });
+
+  it('rejects an unknown avatar subcommand with the catalog validation line', async () => {
+    const mockContext = createMockContext('my-char', createMockAttachment(), 'avatar-nonsense');
+
+    await handleAvatar(mockContext, mockConfig);
+
+    expect(mockContext.editReply).toHaveBeenCalledWith('❌ Unknown avatar command.');
+  });
+
+  it('classifies a READ-phase failure as a load error, never write-uncertain', async () => {
+    // The permission-check fetch failing must not claim "your avatar change
+    // may still be applying" — nothing was submitted yet.
+    const mockContext = createMockContext('my-char', createMockAttachment());
+    vi.mocked(api.fetchCharacter).mockRejectedValue(
+      new GatewayApiError('Failed to fetch character: 0 - timed out', 0, 'timeout')
+    );
+
+    await handleAvatar(mockContext, mockConfig);
+
+    const reply = vi.mocked(mockContext.editReply).mock.calls.at(-1)?.[0] as string;
+    expect(reply).toContain("Couldn't load the character right now");
+    expect(reply).not.toContain('may still be applying');
+    expect(vi.mocked(api.updateCharacter)).not.toHaveBeenCalled();
+  });
+
+  it('renders the retry-honest timeout line when the CDN download aborts', async () => {
+    const attachment = createMockAttachment();
+    const mockContext = createMockContext('my-char', attachment);
+    vi.mocked(api.fetchCharacter).mockResolvedValue(createMockCharacter({ slug: 'my-char' }));
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    mockFetch.mockRejectedValue(abortError);
+
+    await handleAvatar(mockContext, mockConfig);
+
+    expect(mockContext.editReply).toHaveBeenCalledWith(
+      expect.stringContaining('Avatar download timed out')
+    );
   });
 
   describe('avatar-clear', () => {
+    it('classifies a clear-write timeout as outcome-uncertain', async () => {
+      const mockContext = createMockContext('my-char', createMockAttachment(), 'avatar-clear');
+      vi.mocked(api.fetchCharacter).mockResolvedValue(createMockCharacter({ slug: 'my-char' }));
+      vi.mocked(api.updateCharacter).mockRejectedValue(
+        new GatewayApiError('Failed to update personality: 0 - timed out', 0, 'timeout')
+      );
+
+      await handleAvatar(mockContext, mockConfig);
+
+      const reply = vi.mocked(mockContext.editReply).mock.calls.at(-1)?.[0] as string;
+      expect(reply).toContain('may still be applying');
+      expect(reply).not.toMatch(/try again/i);
+    });
+
     it('nulls avatarData and confirms removal on success', async () => {
       const attachment = createMockAttachment();
       const mockContext = createMockContext('my-char', attachment, 'avatar-clear');

--- a/services/bot-client/src/commands/character/avatar.ts
+++ b/services/bot-client/src/commands/character/avatar.ts
@@ -20,6 +20,9 @@ import { clientsFor } from '../../utils/gatewayClients.js';
 import { validateDiscordCdnUrl } from '../../utils/discordCdnGuard.js';
 import { validateImageAttachment } from './mediaValidation.js';
 import { fetchCharacter, updateCharacter, type FetchedCharacter } from './api.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { processAvatarBuffer } from './avatarUtils.js';
 
 const logger = createLogger('character-avatar');
@@ -37,14 +40,17 @@ async function fetchEditableCharacter(
   const character = await fetchCharacter(slug, config, userClient);
   if (!character) {
     await context.editReply(
-      `❌ Character \`${escapeMarkdown(slug)}\` not found or not accessible.`
+      renderSpec(CATALOG.error.notFound('Character', { name: escapeMarkdown(slug) }))
     );
     return null;
   }
   if (!character.canEdit) {
     await context.editReply(
-      `❌ You don't have permission to edit \`${escapeMarkdown(slug)}\`.\n` +
-        'You can only edit characters you own.'
+      renderSpec(
+        CATALOG.error.permissionDenied(
+          `edit \`${escapeMarkdown(slug)}\` — you can only edit characters you own`
+        )
+      )
     );
     return null;
   }
@@ -75,7 +81,7 @@ async function handleAvatarUpload(
 
   const cdnGuard = validateDiscordCdnUrl(attachment.url, logger);
   if (!cdnGuard.ok) {
-    await context.editReply('❌ Invalid attachment URL.');
+    await context.editReply(renderSpec(CATALOG.error.validation('Invalid attachment URL.')));
     return;
   }
 
@@ -96,7 +102,9 @@ async function handleAvatarUpload(
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         await context.editReply(
-          '❌ Avatar download timed out. Discord may be slow — please try again.'
+          renderSpec(
+            CATALOG.error.userRetryable('Avatar download timed out — Discord may be slow.')
+          )
         );
         return;
       }
@@ -105,7 +113,7 @@ async function handleAvatarUpload(
       clearTimeout(timeout);
     }
     if (!imageResponse.ok) {
-      await context.editReply('❌ Failed to download the image. Please try again.');
+      await context.editReply(renderSpec(CATALOG.error.operationFailed('download the image')));
       return;
     }
 
@@ -114,7 +122,7 @@ async function handleAvatarUpload(
     // Process avatar (resize if needed)
     const result = await processAvatarBuffer(rawBuffer, slug);
     if (!result.success) {
-      await context.editReply(`❌ ${result.message}`);
+      await context.editReply(renderSpec(CATALOG.error.validation(result.message)));
       return;
     }
 
@@ -128,7 +136,11 @@ async function handleAvatarUpload(
     logger.info({ slug, userId }, 'Character avatar updated');
   } catch (error) {
     logger.error({ err: error, slug }, 'Failed to update avatar');
-    await context.editReply('❌ Failed to update avatar. Please try again.');
+    // Gateway write — a timeout is outcome-uncertain; the classifier renders
+    // the honest shape instead of a blanket "try again".
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'avatar', { failedAction: 'update the avatar' }))
+    );
   }
 }
 
@@ -166,7 +178,9 @@ async function handleAvatarClear(
     logger.info({ slug, userId }, 'Character avatar cleared');
   } catch (error) {
     logger.error({ err: error, slug }, 'Failed to clear avatar');
-    await context.editReply('❌ Failed to clear avatar. Please try again.');
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'avatar', { failedAction: 'clear the avatar' }))
+    );
   }
 }
 
@@ -186,6 +200,6 @@ export async function handleAvatar(
     await handleAvatarClear(context, config);
   } else {
     logger.warn({ subcommand }, 'Unexpected avatar subcommand');
-    await context.editReply('❌ Unknown avatar command.');
+    await context.editReply(renderSpec(CATALOG.error.validation('Unknown avatar command.')));
   }
 }

--- a/services/bot-client/src/commands/character/avatar.ts
+++ b/services/bot-client/src/commands/character/avatar.ts
@@ -87,12 +87,24 @@ async function handleAvatarUpload(
 
   const { userClient } = clientsFor(context.interaction);
 
+  // Read phase gets its own catch: a transient failure while CHECKING the
+  // character must never render the write-uncertain "may still be applying"
+  // copy — nothing has been submitted yet.
+  let character: FetchedCharacter | null;
   try {
-    const character = await fetchEditableCharacter(slug, config, userClient, context);
-    if (!character) {
-      return;
-    }
+    character = await fetchEditableCharacter(slug, config, userClient, context);
+  } catch (error) {
+    logger.error({ err: error, slug }, 'Failed to load character for avatar upload');
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'character', { operation: 'read' }))
+    );
+    return;
+  }
+  if (!character) {
+    return;
+  }
 
+  try {
     // Download the image with a 30s timeout (pattern matches voice.ts).
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30_000);
@@ -161,12 +173,21 @@ async function handleAvatarClear(
 
   const { userClient } = clientsFor(context.interaction);
 
+  let character: FetchedCharacter | null;
   try {
-    const character = await fetchEditableCharacter(slug, config, userClient, context);
-    if (!character) {
-      return;
-    }
+    character = await fetchEditableCharacter(slug, config, userClient, context);
+  } catch (error) {
+    logger.error({ err: error, slug }, 'Failed to load character for avatar clear');
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'character', { operation: 'read' }))
+    );
+    return;
+  }
+  if (!character) {
+    return;
+  }
 
+  try {
     // `clearAvatar: true` is the explicit clear signal — `avatarData: null`
     // means "no change" (dashboard round-trip), so it would silently no-op.
     await updateCharacter(slug, { clearAvatar: true }, userClient, config);

--- a/services/bot-client/src/commands/character/characterDashboardShared.test.ts
+++ b/services/bot-client/src/commands/character/characterDashboardShared.test.ts
@@ -109,7 +109,7 @@ describe('openCharacterCascadeDashboard', () => {
     });
 
     expect(context.editReply).toHaveBeenCalledWith({
-      content: '❌ An error occurred while opening the settings dashboard.',
+      content: '❌ Failed to open the settings dashboard. Please try again.',
     });
   });
 
@@ -119,17 +119,26 @@ describe('openCharacterCascadeDashboard', () => {
     await openCharacterCascadeDashboard(context, 'ivy', {
       dashboardConfig,
       sourceTier: 'user-personality',
-      resolveCascade: vi.fn().mockResolvedValue({ ok: false, error: 'gateway timeout' }),
+      resolveCascade: vi
+        .fn()
+        .mockResolvedValue({
+          ok: false,
+          kind: 'http',
+          error: 'Cascade resolve broke',
+          status: 500,
+        }),
       noun: 'overrides',
       logger,
     });
 
+    // The real fail-arm carries kind/status — the classifier surfaces the
+    // gateway's own message, not a hand-written generic.
     expect(context.editReply).toHaveBeenCalledWith({
-      content: '❌ Failed to fetch config settings.',
+      content: '❌ Cascade resolve broke',
     });
     expect(mockCreateDashboard).not.toHaveBeenCalled();
     expect(vi.mocked((logger as { warn: unknown }).warn)).toHaveBeenCalledWith(
-      expect.objectContaining({ error: 'gateway timeout' }),
+      expect.objectContaining({ error: 'Cascade resolve broke' }),
       'Cascade resolve failed'
     );
   });

--- a/services/bot-client/src/commands/character/characterDashboardShared.ts
+++ b/services/bot-client/src/commands/character/characterDashboardShared.ts
@@ -16,7 +16,7 @@ import type { UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
-import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { classifyGatewayFailure, type GatewayResultFailure } from '../../ux/catalog/classify.js';
 import { renderSpec } from '../../ux/render/render.js';
 import {
   type SettingsDashboardConfig,
@@ -34,7 +34,7 @@ export interface CharacterDashboardSpec {
   resolveCascade: (
     userClient: UserClient,
     personalityId: string
-  ) => Promise<{ ok: true; data: ResolvedConfigOverrides } | { ok: false; error: string }>;
+  ) => Promise<{ ok: true; data: ResolvedConfigOverrides } | GatewayResultFailure>;
   /** Error-copy noun — narrowed so a future caller can't typo it silently. */
   noun: 'overrides' | 'settings';
   logger: Logger;
@@ -76,8 +76,8 @@ export async function openCharacterCascadeDashboard(
     const cascadeResult = await resolveCascade(userClient, personality.id);
 
     if (!cascadeResult.ok) {
-      // Log before the generic reply so timeout-vs-5xx-vs-validation
-      // failures stay distinguishable in logs (the user copy stays generic).
+      // Log the raw failure detail; the user copy is classified by kind
+      // (transient vs. surfaced gateway message) but stays terse.
       logger.warn(
         { characterSlug, personalityId: personality.id, error: cascadeResult.error },
         'Cascade resolve failed'

--- a/services/bot-client/src/commands/character/characterDashboardShared.ts
+++ b/services/bot-client/src/commands/character/characterDashboardShared.ts
@@ -15,6 +15,9 @@ import type { createLogger } from '@tzurot/common-types/utils/logger';
 import type { UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import {
   type SettingsDashboardConfig,
   createSettingsDashboard,
@@ -56,13 +59,14 @@ export async function openCharacterCascadeDashboard(
     if (!result.ok) {
       if (result.status === 404) {
         await context.editReply({
-          content: `❌ Character "${characterSlug}" not found.`,
+          content: renderSpec(CATALOG.error.notFound('Character', { name: characterSlug })),
         });
         return;
       }
       logger.warn({ error: result.error, characterSlug }, 'Fetch failed');
+      // The fail-arm carries the transport kind — classify it directly.
       await context.editReply({
-        content: '❌ Failed to load character data.',
+        content: renderSpec(classifyGatewayFailure(result, 'character', { operation: 'read' })),
       });
       return;
     }
@@ -79,7 +83,9 @@ export async function openCharacterCascadeDashboard(
         'Cascade resolve failed'
       );
       await context.editReply({
-        content: '❌ Failed to fetch config settings.',
+        content: renderSpec(
+          classifyGatewayFailure(cascadeResult, 'config settings', { operation: 'read' })
+        ),
       });
       return;
     }
@@ -99,7 +105,12 @@ export async function openCharacterCascadeDashboard(
     logger.error({ err: error, characterSlug }, 'Error opening dashboard');
 
     await context.editReply({
-      content: `❌ An error occurred while opening the ${noun} dashboard.`,
+      content: renderSpec(
+        classifyGatewayFailure(error, 'character', {
+          operation: 'read',
+          failedAction: `open the ${noun} dashboard`,
+        })
+      ),
     });
   }
 }

--- a/services/bot-client/src/commands/character/create.test.ts
+++ b/services/bot-client/src/commands/character/create.test.ts
@@ -408,7 +408,7 @@ describe('Character Create', () => {
       await handleSeedModalSubmit(mockInteraction, mockConfig);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        '❌ Failed to create character. Please try again.'
+        '❌ Failed to create the character. Please try again.'
       );
     });
 

--- a/services/bot-client/src/commands/character/create.ts
+++ b/services/bot-client/src/commands/character/create.ts
@@ -40,6 +40,9 @@ import {
   buildCharacterDashboardOptions,
 } from './config.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { createCharacter } from './api.js';
 
 const logger = createLogger('character-create');
@@ -90,15 +93,21 @@ export async function handleSeedModalSubmit(
   // instead of a raw 400 after submit.
   if (!SLUG_PATTERN.test(values.slug)) {
     await interaction.editReply(
-      `❌ Invalid slug format. ${SLUG_REQUIREMENTS_MESSAGE}\n` +
-        `Example: \`${suggestSlugExample(values.name)}\``
+      renderSpec(
+        CATALOG.error.validation(
+          `Invalid slug format. ${SLUG_REQUIREMENTS_MESSAGE}\nExample: \`${suggestSlugExample(values.name)}\``
+        )
+      )
     );
     return;
   }
   if (values.slug.length < SLUG_MIN_LENGTH || values.slug.length > DISCORD_LIMITS.SLUG_MAX_LENGTH) {
     await interaction.editReply(
-      `❌ Slug must be ${SLUG_MIN_LENGTH}–${DISCORD_LIMITS.SLUG_MAX_LENGTH} characters ` +
-        `(yours is ${values.slug.length}).`
+      renderSpec(
+        CATALOG.error.validation(
+          `Slug must be ${SLUG_MIN_LENGTH}–${DISCORD_LIMITS.SLUG_MAX_LENGTH} characters (yours is ${values.slug.length}).`
+        )
+      )
     );
     return;
   }
@@ -162,12 +171,19 @@ export async function handleSeedModalSubmit(
     // Check for duplicate slug error
     if (error instanceof Error && error.message.includes('409')) {
       await interaction.editReply(
-        `❌ A character with slug \`${normalizedSlug}\` already exists.\n` +
-          'Please choose a different slug.'
+        renderSpec(
+          CATALOG.error.validation(
+            `A character with slug \`${normalizedSlug}\` already exists.\nPlease choose a different slug.`
+          )
+        )
       );
       return;
     }
 
-    await interaction.editReply('❌ Failed to create character. Please try again.');
+    await interaction.editReply(
+      renderSpec(
+        classifyGatewayFailure(error, 'character', { failedAction: 'create the character' })
+      )
+    );
   }
 }

--- a/services/bot-client/src/commands/character/export.test.ts
+++ b/services/bot-client/src/commands/character/export.test.ts
@@ -22,6 +22,10 @@ const stub: StubUserClient = {
   getPersonality: vi.fn(),
 };
 
+vi.mock('@tzurot/common-types/utils/ownerMiddleware', () => ({
+  isBotOwner: vi.fn().mockReturnValue(false),
+}));
+
 vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
@@ -112,6 +116,20 @@ describe('Character Export', () => {
   });
 
   describe('handleExport', () => {
+    it('denies export of a non-owned character (system-voice permission line)', async () => {
+      stub.getPersonality.mockResolvedValue({
+        ok: true,
+        data: { personality: mockCharacterData, canEdit: false },
+      });
+
+      const mockContext = createMockContext();
+      await handleExport(mockContext, mockConfig);
+
+      expect(mockContext.editReply).toHaveBeenCalledWith(
+        expect.stringContaining('You do not have permission to export')
+      );
+    });
+
     it('should export character as JSON attachment', async () => {
       stub.getPersonality.mockResolvedValue({
         ok: true,
@@ -287,7 +305,7 @@ describe('Character Export', () => {
       await handleExport(mockContext, mockConfig);
 
       expect(mockContext.editReply).toHaveBeenCalledWith(
-        '❌ Character `test-character` not found.'
+        '❌ Character "test-character" not found.'
       );
     });
 
@@ -302,13 +320,14 @@ describe('Character Export', () => {
       await handleExport(mockContext, mockConfig);
 
       expect(mockContext.editReply).toHaveBeenCalledWith(
-        "❌ You don't have access to character `test-character`."
+        '❌ You do not have permission to access character `test-character`.'
       );
     });
 
     it('should handle API errors gracefully', async () => {
       stub.getPersonality.mockResolvedValue({
         ok: false,
+        kind: 'http',
         status: 500,
         error: 'Internal server error',
       });
@@ -316,9 +335,8 @@ describe('Character Export', () => {
       const mockContext = createMockContext();
       await handleExport(mockContext, mockConfig);
 
-      expect(mockContext.editReply).toHaveBeenCalledWith(
-        '❌ An unexpected error occurred while exporting the character.'
-      );
+      // The fail-arm's gateway message is surfaced, not a hand-written generic.
+      expect(mockContext.editReply).toHaveBeenCalledWith('❌ Internal server error');
     });
 
     it('should handle network errors gracefully', async () => {
@@ -328,7 +346,7 @@ describe('Character Export', () => {
       await handleExport(mockContext, mockConfig);
 
       expect(mockContext.editReply).toHaveBeenCalledWith(
-        '❌ An unexpected error occurred while exporting the character.'
+        '❌ Failed to export the character. Please try again.'
       );
     });
 

--- a/services/bot-client/src/commands/character/export.ts
+++ b/services/bot-client/src/commands/character/export.ts
@@ -11,6 +11,9 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { toCharacterData } from './api.js';
 import type { CharacterData } from './characterTypes.js';
 
@@ -132,14 +135,21 @@ export async function handleExport(
 
     if (!result.ok) {
       if (result.status === 404) {
-        await context.editReply(`❌ Character \`${slug}\` not found.`);
+        await context.editReply(renderSpec(CATALOG.error.notFound('Character', { name: slug })));
         return;
       }
       if (result.status === 403) {
-        await context.editReply(`❌ You don't have access to character \`${slug}\`.`);
+        await context.editReply(
+          renderSpec(CATALOG.error.permissionDenied(`access character \`${slug}\``))
+        );
         return;
       }
-      throw new Error(`API error: ${result.status}`);
+      // Fail-arm carries the transport kind — classify directly (a timeout
+      // must not read as a definitive export failure).
+      await context.editReply(
+        renderSpec(classifyGatewayFailure(result, 'character', { operation: 'read' }))
+      );
+      return;
     }
 
     // Coerce schema-derived `personality` into the `ExportCharacterData` shape
@@ -159,8 +169,11 @@ export async function handleExport(
     // Check ownership - only character owner or bot owner can export
     if (!canEdit && !isBotOwner(userId)) {
       await context.editReply(
-        `❌ You don't have permission to export \`${slug}\`.\n` +
-          'You can only export characters you own.'
+        renderSpec(
+          CATALOG.error.permissionDenied(
+            `export \`${slug}\` — you can only export characters you own`
+          )
+        )
       );
       return;
     }
@@ -203,6 +216,13 @@ export async function handleExport(
     );
   } catch (error) {
     logger.error({ err: error, slug }, 'Error exporting character');
-    await context.editReply('❌ An unexpected error occurred while exporting the character.');
+    await context.editReply(
+      renderSpec(
+        classifyGatewayFailure(error, 'character', {
+          operation: 'read',
+          failedAction: 'export the character',
+        })
+      )
+    );
   }
 }

--- a/services/bot-client/src/commands/character/import.test.ts
+++ b/services/bot-client/src/commands/character/import.test.ts
@@ -181,6 +181,7 @@ function createValidCharacterData(
  */
 function mockCreateScenario(createResponse: {
   ok: boolean;
+  kind?: string;
   data?: unknown;
   error?: string;
   status?: number;
@@ -194,7 +195,7 @@ function mockCreateScenario(createResponse: {
  */
 function mockUpdateScenario(
   canEdit: boolean,
-  updateResponse?: { ok: boolean; data?: unknown; error?: string; status?: number }
+  updateResponse?: { ok: boolean; kind?: string; data?: unknown; error?: string; status?: number }
 ) {
   const getResponse = {
     ok: true,
@@ -683,14 +684,15 @@ describe('handleImport', () => {
       });
       mockCreateScenario({
         ok: false,
+        kind: 'http',
         error: 'Internal server error',
         status: 500,
       });
 
       await handleImport(context, mockConfig);
 
+      // The fail-arm's gateway message is surfaced via the classifier.
       const editReplyArg = (context.editReply as Mock).mock.calls[0][0];
-      expect(editReplyArg).toContain('❌ Failed to import character');
       expect(editReplyArg).toContain('Internal server error');
     });
 
@@ -754,6 +756,42 @@ describe('handleImport', () => {
       expect(stub.createPersonality).toHaveBeenCalledWith(
         expect.objectContaining({ definitionPublic: true })
       );
+    });
+
+    it('surfaces the per-field validation list when the JSON fails the API schema', async () => {
+      const context = createMockContext();
+      // `name` is presence-checked earlier (truthy) but schema-rejected as non-string.
+      const badData = { ...createValidCharacterData(), name: 12345 };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify(badData)),
+      });
+
+      await handleImport(context, mockConfig);
+
+      const editReplyArg = (context.editReply as Mock).mock.calls[0][0] as string;
+      expect(editReplyArg).toContain('Validation errors in import file');
+      expect(editReplyArg).toContain('name');
+      expect(stub.createPersonality).not.toHaveBeenCalled();
+    });
+
+    it('renders the download-failure line when the voice reference download dies', async () => {
+      const context = createMockContext(undefined, null, {}); // voice attachment present
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('voice.wav')) {
+          return Promise.reject(new Error('socket hang up'));
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify(createValidCharacterData())),
+        });
+      });
+
+      await handleImport(context, mockConfig);
+
+      const editReplyArg = (context.editReply as Mock).mock.calls[0][0] as string;
+      expect(editReplyArg).toContain('Failed to download the audio file');
+      expect(stub.createPersonality).not.toHaveBeenCalled();
     });
 
     it('processes an attached voice reference into the create payload as a data URI', async () => {
@@ -1052,6 +1090,29 @@ describe('handleImport', () => {
   });
 
   describe('unexpected errors', () => {
+    it('renders the outcome-uncertain shape when the create times out (fail-arm kind preserved)', async () => {
+      // The saveCharacter fail-arm change's headline: an import timeout is
+      // outcome-uncertain (the character may have been created) — never the
+      // definitive "failed, try again".
+      const context = createMockContext();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify(createValidCharacterData())),
+      });
+      mockCreateScenario({
+        ok: false,
+        kind: 'timeout',
+        error: 'Request timed out',
+        status: 0,
+      });
+
+      await handleImport(context, mockConfig);
+
+      const editReplyArg = (context.editReply as Mock).mock.calls[0][0] as string;
+      expect(editReplyArg).toContain('may still be applying');
+      expect(editReplyArg).not.toMatch(/try again/i);
+    });
+
     it('should handle unexpected exceptions gracefully', async () => {
       const context = createMockContext();
       mockFetch.mockResolvedValue({
@@ -1064,8 +1125,7 @@ describe('handleImport', () => {
       await handleImport(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith(
-        '❌ An unexpected error occurred while importing the character.\n' +
-          'Check bot logs for details.'
+        '❌ Failed to import the character. Please try again.'
       );
     });
   });
@@ -1138,6 +1198,7 @@ describe('handleImport', () => {
       });
       mockUpdateScenario(true, {
         ok: false,
+        kind: 'http',
         error: 'Database error',
         status: 500,
       });
@@ -1145,7 +1206,6 @@ describe('handleImport', () => {
       await handleImport(context, mockConfig);
 
       const editReplyArg = (context.editReply as Mock).mock.calls[0][0];
-      expect(editReplyArg).toContain('❌ Failed to update character');
       expect(editReplyArg).toContain('Database error');
     });
 
@@ -1175,7 +1235,9 @@ describe('handleImport', () => {
       expect(stub.createPersonality).not.toHaveBeenCalled();
       expect(stub.updatePersonality).not.toHaveBeenCalled();
       const editReplyArg = (context.editReply as Mock).mock.calls[0][0];
-      expect(editReplyArg).toContain('unexpected error');
+      // The thrown existence-check error carries the wrapper format, so the
+      // classifier surfaces the gateway's own message — better than a generic.
+      expect(editReplyArg).toContain('Gateway timeout');
     });
   });
 });

--- a/services/bot-client/src/commands/character/import.ts
+++ b/services/bot-client/src/commands/character/import.ts
@@ -18,6 +18,9 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { UserClient } from '@tzurot/clients';
 import { clientsFor } from '../../utils/gatewayClients.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { validateJsonFile, downloadAndParseJson } from '../../utils/jsonFileUtils.js';
 import { validateDiscordCdnUrl } from '../../utils/discordCdnGuard.js';
 import { processAvatarBuffer } from './avatarUtils.js';
@@ -116,7 +119,11 @@ function validateCharacterData(
   const missingFields = getMissingRequiredFields(data, REQUIRED_IMPORT_FIELDS);
   if (missingFields.length > 0) {
     return {
-      error: `❌ Missing required fields: ${missingFields.join(', ')}\n\n` + buildTemplateMessage(),
+      error: renderSpec(
+        CATALOG.error.validation(
+          `Missing required fields: ${missingFields.join(', ')}\n\n` + buildTemplateMessage()
+        )
+      ),
     };
   }
 
@@ -126,16 +133,20 @@ function validateCharacterData(
   // leading-hyphen result.
   if (!SLUG_PATTERN.test(rawSlug)) {
     return {
-      error:
-        `❌ Invalid slug format in JSON. ${SLUG_REQUIREMENTS_MESSAGE}\n` +
-        `Example: \`${suggestSlugExample(rawSlug)}\``,
+      error: renderSpec(
+        CATALOG.error.validation(
+          `Invalid slug format in JSON. ${SLUG_REQUIREMENTS_MESSAGE}\nExample: \`${suggestSlugExample(rawSlug)}\``
+        )
+      ),
     };
   }
   if (rawSlug.length < SLUG_MIN_LENGTH || rawSlug.length > DISCORD_LIMITS.SLUG_MAX_LENGTH) {
     return {
-      error:
-        `❌ Slug must be ${SLUG_MIN_LENGTH}–${DISCORD_LIMITS.SLUG_MAX_LENGTH} characters ` +
-        `(yours is ${rawSlug.length}).`,
+      error: renderSpec(
+        CATALOG.error.validation(
+          `Slug must be ${SLUG_MIN_LENGTH}–${DISCORD_LIMITS.SLUG_MAX_LENGTH} characters (yours is ${rawSlug.length}).`
+        )
+      ),
     };
   }
 
@@ -201,18 +212,18 @@ async function validateAndProcessAvatar(
   }
   const cdnGuard = validateDiscordCdnUrl(avatar.url, logger);
   if (!cdnGuard.ok) {
-    return { error: '❌ Invalid attachment URL.' };
+    return { error: renderSpec(CATALOG.error.validation('Invalid attachment URL.')) };
   }
   try {
     const rawBuffer = await downloadCdnAttachment(avatar.url);
     const result = await processAvatarBuffer(rawBuffer, avatar.name ?? 'import-avatar');
     if (!result.success) {
-      return { error: `❌ ${result.message}` };
+      return { error: renderSpec(CATALOG.error.validation(result.message)) };
     }
     return { data: result.buffer.toString('base64') };
   } catch (error) {
     logger.error({ err: error }, 'Failed to download avatar');
-    return { error: '❌ Failed to download the image. Please try again.' };
+    return { error: renderSpec(CATALOG.error.operationFailed('download the image')) };
   }
 }
 
@@ -230,14 +241,14 @@ async function validateAndProcessVoice(
   }
   const cdnGuard = validateDiscordCdnUrl(audio.url, logger);
   if (!cdnGuard.ok) {
-    return { error: '❌ Invalid attachment URL.' };
+    return { error: renderSpec(CATALOG.error.validation('Invalid attachment URL.')) };
   }
   try {
     const rawBuffer = await downloadCdnAttachment(audio.url);
     return { data: `data:${audio.contentType};base64,${rawBuffer.toString('base64')}` };
   } catch (error) {
     logger.error({ err: error }, 'Failed to download voice reference');
-    return { error: '❌ Failed to download the audio file. Please try again.' };
+    return { error: renderSpec(CATALOG.error.operationFailed('download the audio file')) };
   }
 }
 
@@ -256,7 +267,9 @@ function validatePayloadFields(payload: Record<string, unknown>): string | null 
     return `• **${field}**: ${issue.message}`;
   });
 
-  return `❌ **Validation errors in import file:**\n${fieldErrors.join('\n')}`;
+  return renderSpec(
+    CATALOG.error.validation(`**Validation errors in import file:**\n${fieldErrors.join('\n')}`)
+  );
 }
 
 // ============================================================================
@@ -359,14 +372,16 @@ async function saveCharacter(
   userClient: UserClient,
   payload: Record<string, unknown>,
   isUpdate: boolean
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true } | { ok: false; failure: unknown }> {
   const result = isUpdate
     ? await userClient.updatePersonality(slug, payload)
     : await userClient.createPersonality(payload as Parameters<UserClient['createPersonality']>[0]);
 
   if (!result.ok) {
     logger.error({ error: result.error, isUpdate }, 'Failed to import');
-    return { ok: false, error: result.error };
+    // Return the fail-arm itself so the caller can classify honestly (kind
+    // preserved — an import timeout is outcome-uncertain, not "failed").
+    return { ok: false, failure: result };
   }
   return { ok: true };
 }
@@ -469,8 +484,11 @@ export async function handleImport(
     const existingCheck = await checkExistingCharacter(slug, userClient);
     if (existingCheck.exists && !existingCheck.canEdit) {
       await context.editReply(
-        `❌ A character with the slug \`${slug}\` already exists and you don't own it.\n` +
-          'You can only overwrite characters that you own.'
+        renderSpec(
+          CATALOG.error.validation(
+            `A character with the slug \`${slug}\` already exists and you don't own it.\nYou can only overwrite characters that you own.`
+          )
+        )
       );
       return;
     }
@@ -479,8 +497,11 @@ export async function handleImport(
     const saveResult = await saveCharacter(slug, userClient, payload, existingCheck.exists);
     if (!saveResult.ok) {
       await context.editReply(
-        `❌ Failed to ${existingCheck.exists ? 'update' : 'import'} character:\n` +
-          `\`\`\`\n${saveResult.error.slice(0, 1500)}\n\`\`\``
+        renderSpec(
+          classifyGatewayFailure(saveResult.failure, 'character', {
+            failedAction: existingCheck.exists ? 'update the character' : 'import the character',
+          })
+        )
       );
       return;
     }
@@ -496,8 +517,9 @@ export async function handleImport(
   } catch (error) {
     logger.error({ err: error }, 'Error importing character');
     await context.editReply(
-      '❌ An unexpected error occurred while importing the character.\n' +
-        'Check bot logs for details.'
+      renderSpec(
+        classifyGatewayFailure(error, 'character', { failedAction: 'import the character' })
+      )
     );
   }
 }

--- a/services/bot-client/src/commands/character/overrides.test.ts
+++ b/services/bot-client/src/commands/character/overrides.test.ts
@@ -244,7 +244,7 @@ describe('Character Overrides Dashboard', () => {
       await handleOverrides(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Failed to load character data'),
+        content: expect.stringContaining('Failed to load the character'),
       });
     });
 
@@ -256,7 +256,7 @@ describe('Character Overrides Dashboard', () => {
       await handleOverrides(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: '❌ Failed to fetch config settings.',
+        content: '❌ Failed to load the config settings. Please try again.',
       });
     });
 
@@ -267,7 +267,7 @@ describe('Character Overrides Dashboard', () => {
       await handleOverrides(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: '❌ An error occurred while opening the overrides dashboard.',
+        content: '❌ Failed to open the overrides dashboard. Please try again.',
       });
     });
   });

--- a/services/bot-client/src/commands/character/settings.test.ts
+++ b/services/bot-client/src/commands/character/settings.test.ts
@@ -257,7 +257,7 @@ describe('Character Settings Dashboard', () => {
       await handleSettings(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Failed to load character data'),
+        content: expect.stringContaining('Failed to load the character'),
       });
     });
 
@@ -269,7 +269,7 @@ describe('Character Settings Dashboard', () => {
       await handleSettings(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: '❌ Failed to fetch config settings.',
+        content: '❌ Failed to load the config settings. Please try again.',
       });
     });
 
@@ -280,7 +280,7 @@ describe('Character Settings Dashboard', () => {
       await handleSettings(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: '❌ An error occurred while opening the settings dashboard.',
+        content: '❌ Failed to open the settings dashboard. Please try again.',
       });
     });
 
@@ -291,7 +291,7 @@ describe('Character Settings Dashboard', () => {
       await handleSettings(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: '❌ An error occurred while opening the settings dashboard.',
+        content: '❌ Failed to open the settings dashboard. Please try again.',
       });
     });
   });

--- a/services/bot-client/src/commands/character/view.test.ts
+++ b/services/bot-client/src/commands/character/view.test.ts
@@ -521,7 +521,7 @@ describe('handleView / handleViewPagination', () => {
 
     await handleView(viewContext(), config);
 
-    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('not found or not accessible'));
+    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('not found'));
   });
 
   it('renders the private-definition state with NO components when redacted', async () => {
@@ -560,13 +560,14 @@ describe('handleView / handleViewPagination', () => {
     expect(call.embeds[0].toJSON().description).toContain('definition is private');
   });
 
-  it('shows a generic error when the fetch fails with a non-404 status', async () => {
-    // fetchCharacterForView throws on non-404/403 → handleView's catch fires.
+  it('surfaces the gateway message when the fetch fails with a non-404 status', async () => {
+    // fetchCharacterForView throws typed GatewayApiError on non-404/403 →
+    // handleView's catch classifies and surfaces the gateway's own message.
     stub.getPersonality.mockResolvedValue(makeErr(500, 'boom'));
 
     await handleView(viewContext(), config);
 
-    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('Failed to load character'));
+    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('boom'));
   });
 
   it('paginates: defers, re-fetches, and renders the requested page', async () => {
@@ -683,7 +684,7 @@ describe('handleExpandField', () => {
     await handleExpandField(expandInteraction(), 'test-character', 'characterInfo', config);
 
     expect(editReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('Failed to load field content'),
+      content: expect.stringContaining('boom'),
     });
     expect(sendChunkedReply).not.toHaveBeenCalled();
   });

--- a/services/bot-client/src/commands/character/view.ts
+++ b/services/bot-client/src/commands/character/view.ts
@@ -22,6 +22,9 @@ import { characterViewOptions } from '@tzurot/common-types/generated/commandOpti
 import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { GatewayApiError, type UserClient } from '@tzurot/clients';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { CharacterData } from './characterTypes.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
@@ -31,8 +34,11 @@ import { toCharacterData } from './api.js';
 import { VIEW_TOTAL_PAGES, VIEW_PAGE_TITLES, EXPANDABLE_FIELDS } from './viewTypes.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
 
-// Re-export for backward compatibility
 const logger = createLogger('character-view');
+
+/** Rendered read-failure line for this view's fetch catches. */
+const readFailure = (error: unknown, resource: string): string =>
+  renderSpec(classifyGatewayFailure(error, resource, { operation: 'read' }));
 
 /** Field info for tracking truncation */
 interface FieldInfo {
@@ -418,7 +424,7 @@ export async function handleView(
     const { userClient } = clientsFor(context.interaction);
     const character = await fetchCharacterForView(slug, userClient);
     if (!character) {
-      await context.editReply(`❌ Character \`${slug}\` not found or not accessible.`);
+      await context.editReply(renderSpec(CATALOG.error.notFound('Character', { name: slug })));
       return;
     }
 
@@ -432,7 +438,7 @@ export async function handleView(
     await context.editReply({ embeds: [embed], components });
   } catch (error) {
     logger.error({ err: error, slug }, 'Failed to view character');
-    await context.editReply('❌ Failed to load character. Please try again.');
+    await context.editReply(readFailure(error, 'character'));
   }
 }
 
@@ -452,7 +458,7 @@ export async function handleViewPagination(
     const character = await fetchCharacterForView(slug, userClient);
     if (!character) {
       await interaction.editReply({
-        content: '❌ Character not found.',
+        content: renderSpec(CATALOG.error.notFound('Character')),
         embeds: [],
         components: [],
       });
@@ -488,14 +494,14 @@ export async function handleExpandField(
     const { userClient } = clientsFor(interaction);
     const character = await fetchCharacterForView(slug, userClient);
     if (!character) {
-      await replyError(interaction, '❌ Character not found.');
+      await replyError(interaction, renderSpec(CATALOG.error.notFound('Character')));
       return;
     }
 
     // Get field info
     const fieldInfo = EXPANDABLE_FIELDS[fieldName];
     if (fieldInfo === undefined) {
-      await replyError(interaction, '❌ Unknown field.');
+      await replyError(interaction, renderSpec(CATALOG.error.validation('Unknown field.')));
       return;
     }
 
@@ -523,7 +529,7 @@ export async function handleExpandField(
     logger.info({ slug, fieldName }, 'Expanded field content shown');
   } catch (error) {
     logger.error({ err: error, slug, fieldName }, 'Failed to expand field');
-    await replyError(interaction, '❌ Failed to load field content. Please try again.');
+    await replyError(interaction, readFailure(error, 'field content'));
   }
 }
 

--- a/services/bot-client/src/commands/character/view.ts
+++ b/services/bot-client/src/commands/character/view.ts
@@ -424,7 +424,9 @@ export async function handleView(
     const { userClient } = clientsFor(context.interaction);
     const character = await fetchCharacterForView(slug, userClient);
     if (!character) {
-      await context.editReply(renderSpec(CATALOG.error.notFound('Character', { name: slug })));
+      await context.editReply(
+        renderSpec(CATALOG.error.notFound('Character', { name: escapeMarkdown(slug) }))
+      );
       return;
     }
 

--- a/services/bot-client/src/commands/character/voice.test.ts
+++ b/services/bot-client/src/commands/character/voice.test.ts
@@ -119,7 +119,7 @@ describe('handleVoice', () => {
       await handleVoice(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith(
-        expect.stringContaining("don't have permission")
+        expect.stringContaining('do not have permission')
       );
     });
 
@@ -275,7 +275,7 @@ describe('handleVoice', () => {
       await handleVoice(context, mockConfig);
 
       expect(context.editReply).toHaveBeenCalledWith(
-        expect.stringContaining("don't have permission")
+        expect.stringContaining('do not have permission')
       );
     });
 

--- a/services/bot-client/src/commands/character/voice.test.ts
+++ b/services/bot-client/src/commands/character/voice.test.ts
@@ -31,6 +31,7 @@ vi.mock('./api.js', () => ({
   updateCharacter: vi.fn(),
 }));
 
+import { GatewayApiError } from '@tzurot/clients';
 import { handleVoice } from './voice.js';
 import { fetchCharacter, updateCharacter } from './api.js';
 import type { EnvConfig } from '@tzurot/common-types/config/config';
@@ -166,6 +167,43 @@ describe('handleVoice', () => {
       );
     });
 
+    it('renders the outcome-uncertain shape on an upload timeout (never "try again")', async () => {
+      // Wiring proof: a typed timeout from updateCharacter reaches the
+      // classifier and renders the verify-first copy.
+      const mockAudioBuffer = Buffer.from('fake-audio-data');
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          arrayBuffer: vi.fn().mockResolvedValue(mockAudioBuffer.buffer),
+        })
+      );
+      const context = createMockContext('voice', {
+        character: 'test-char',
+        audio: {
+          contentType: 'audio/wav',
+          size: mockAudioBuffer.length,
+          url: 'https://cdn.discordapp.com/file.wav',
+        },
+      });
+      (fetchCharacter as ReturnType<typeof vi.fn>).mockResolvedValue({
+        name: 'Test',
+        displayName: 'Test Character',
+        canEdit: true,
+      });
+      (updateCharacter as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new GatewayApiError('Failed to update personality: 0 - timed out', 0, 'timeout')
+      );
+
+      await handleVoice(context, mockConfig);
+
+      const reply = (context.editReply as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1
+      )?.[0] as string;
+      expect(reply).toContain('may still be applying');
+      expect(reply).not.toMatch(/try again/i);
+    });
+
     it('should handle download failure', async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
 
@@ -252,7 +290,96 @@ describe('handleVoice', () => {
     });
   });
 
+  it('classifies a READ-phase failure as a load error, never write-uncertain', async () => {
+    const context = createMockContext('voice', {
+      character: 'test-char',
+      audio: {
+        contentType: 'audio/wav',
+        size: 1024,
+        url: 'https://cdn.discordapp.com/file.wav',
+      },
+    });
+    (fetchCharacter as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new GatewayApiError('Failed to fetch character: 0 - timed out', 0, 'timeout')
+    );
+
+    await handleVoice(context, mockConfig);
+
+    const reply = (context.editReply as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as string;
+    expect(reply).toContain("Couldn't load the character right now");
+    expect(reply).not.toContain('may still be applying');
+    expect(updateCharacter).not.toHaveBeenCalled();
+  });
+
+  it('renders the retry-honest timeout line when the CDN download aborts', async () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+    const context = createMockContext('voice', {
+      character: 'test-char',
+      audio: {
+        contentType: 'audio/wav',
+        size: 1024,
+        url: 'https://cdn.discordapp.com/file.wav',
+      },
+    });
+    (fetchCharacter as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'Test',
+      displayName: 'Test Character',
+      canEdit: true,
+    });
+
+    await handleVoice(context, mockConfig);
+
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.stringContaining('Voice download timed out')
+    );
+  });
+
+  it('renders the download-failure line on a non-OK CDN response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 502 }));
+    const context = createMockContext('voice', {
+      character: 'test-char',
+      audio: {
+        contentType: 'audio/wav',
+        size: 1024,
+        url: 'https://cdn.discordapp.com/file.wav',
+      },
+    });
+    (fetchCharacter as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'Test',
+      displayName: 'Test Character',
+      canEdit: true,
+    });
+
+    await handleVoice(context, mockConfig);
+
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to download the audio file')
+    );
+  });
+
   describe('voice-clear', () => {
+    it('classifies a clear-write timeout as outcome-uncertain', async () => {
+      const context = createMockContext('voice-clear', { character: 'test-char' });
+      (fetchCharacter as ReturnType<typeof vi.fn>).mockResolvedValue({
+        name: 'Test',
+        displayName: 'Test Character',
+        canEdit: true,
+      });
+      (updateCharacter as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new GatewayApiError('Failed to update personality: 0 - timed out', 0, 'timeout')
+      );
+
+      await handleVoice(context, mockConfig);
+
+      const reply = (context.editReply as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1
+      )?.[0] as string;
+      expect(reply).toContain('may still be applying');
+      expect(reply).not.toMatch(/try again/i);
+    });
+
     it('should reject if character not found', async () => {
       const context = createMockContext('voice-clear', { character: 'nonexistent' });
 

--- a/services/bot-client/src/commands/character/voice.ts
+++ b/services/bot-client/src/commands/character/voice.ts
@@ -89,13 +89,24 @@ async function handleVoiceUpload(
 
   const { userClient } = clientsFor(context.interaction);
 
+  // Read phase gets its own catch: a transient failure while CHECKING the
+  // character must never render the write-uncertain "may still be applying"
+  // copy — nothing has been submitted yet.
+  let character: FetchedCharacter | null;
   try {
-    // Check permissions
-    const character = await fetchEditableCharacter(slug, config, userClient, context);
-    if (!character) {
-      return;
-    }
+    character = await fetchEditableCharacter(slug, config, userClient, context);
+  } catch (error) {
+    logger.error({ err: error, slug }, 'Failed to load character for voice upload');
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'character', { operation: 'read' }))
+    );
+    return;
+  }
+  if (!character) {
+    return;
+  }
 
+  try {
     // Download audio from Discord CDN (30s timeout to avoid holding the deferred interaction)
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30_000);
@@ -163,13 +174,21 @@ async function handleVoiceClear(context: DeferredCommandContext, config: EnvConf
 
   const { userClient } = clientsFor(context.interaction);
 
+  let character: FetchedCharacter | null;
   try {
-    // Check permissions
-    const character = await fetchEditableCharacter(slug, config, userClient, context);
-    if (!character) {
-      return;
-    }
+    character = await fetchEditableCharacter(slug, config, userClient, context);
+  } catch (error) {
+    logger.error({ err: error, slug }, 'Failed to load character for voice clear');
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'character', { operation: 'read' }))
+    );
+    return;
+  }
+  if (!character) {
+    return;
+  }
 
+  try {
     // Clear voice reference and disable voice
     await updateCharacter(
       slug,

--- a/services/bot-client/src/commands/character/voice.ts
+++ b/services/bot-client/src/commands/character/voice.ts
@@ -21,6 +21,9 @@ import { clientsFor } from '../../utils/gatewayClients.js';
 import { validateDiscordCdnUrl } from '../../utils/discordCdnGuard.js';
 import { validateAudioAttachment } from './mediaValidation.js';
 import { fetchCharacter, updateCharacter, type FetchedCharacter } from './api.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 
 const logger = createLogger('character-voice');
 
@@ -37,14 +40,17 @@ async function fetchEditableCharacter(
   const character = await fetchCharacter(slug, config, userClient);
   if (!character) {
     await context.editReply(
-      `❌ Character \`${escapeMarkdown(slug)}\` not found or not accessible.`
+      renderSpec(CATALOG.error.notFound('Character', { name: escapeMarkdown(slug) }))
     );
     return null;
   }
   if (!character.canEdit) {
     await context.editReply(
-      `❌ You don't have permission to edit \`${escapeMarkdown(slug)}\`.\n` +
-        'You can only edit characters you own.'
+      renderSpec(
+        CATALOG.error.permissionDenied(
+          `edit \`${escapeMarkdown(slug)}\` — you can only edit characters you own`
+        )
+      )
     );
     return null;
   }
@@ -77,7 +83,7 @@ async function handleVoiceUpload(
   // Validate attachment URL is from Discord CDN (SSRF defense-in-depth)
   const cdnGuard = validateDiscordCdnUrl(attachment.url, logger);
   if (!cdnGuard.ok) {
-    await context.editReply('❌ Invalid attachment URL.');
+    await context.editReply(renderSpec(CATALOG.error.validation('Invalid attachment URL.')));
     return;
   }
 
@@ -99,7 +105,7 @@ async function handleVoiceUpload(
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         await context.editReply(
-          '❌ Voice download timed out. Discord may be slow — please try again.'
+          renderSpec(CATALOG.error.userRetryable('Voice download timed out — Discord may be slow.'))
         );
         return;
       }
@@ -108,7 +114,7 @@ async function handleVoiceUpload(
       clearTimeout(timeout);
     }
     if (!audioResponse.ok) {
-      await context.editReply('❌ Failed to download the audio file. Please try again.');
+      await context.editReply(renderSpec(CATALOG.error.operationFailed('download the audio file')));
       return;
     }
 
@@ -133,7 +139,13 @@ async function handleVoiceUpload(
     );
   } catch (error) {
     logger.error({ err: error, slug }, 'Failed to upload voice reference');
-    await context.editReply('❌ Failed to upload voice reference. Please try again.');
+    await context.editReply(
+      renderSpec(
+        classifyGatewayFailure(error, 'voice reference', {
+          failedAction: 'upload the voice reference',
+        })
+      )
+    );
   }
 }
 
@@ -173,7 +185,13 @@ async function handleVoiceClear(context: DeferredCommandContext, config: EnvConf
     logger.info({ slug, userId }, 'Character voice reference cleared');
   } catch (error) {
     logger.error({ err: error, slug }, 'Failed to clear voice reference');
-    await context.editReply('❌ Failed to clear voice reference. Please try again.');
+    await context.editReply(
+      renderSpec(
+        classifyGatewayFailure(error, 'voice reference', {
+          failedAction: 'clear the voice reference',
+        })
+      )
+    );
   }
 }
 
@@ -194,6 +212,6 @@ export async function handleVoice(
     await handleVoiceClear(context, config);
   } else {
     logger.warn({ subcommand }, 'Unexpected voice subcommand');
-    await context.editReply('❌ Unknown voice command.');
+    await context.editReply(renderSpec(CATALOG.error.validation('Unknown voice command.')));
   }
 }


### PR DESCRIPTION
## Summary

**UX boulder Phase 1, PR-D slice 1** — the character command family swept onto the catalog. Ratchet: **441 → 370** (-71), the largest single drop of the train.

### Converted (7 files + their tests)

`avatar.ts` · `voice.ts` · `view.ts` · `export.ts` · `create.ts` · `import.ts` · `characterDashboardShared.ts`

Per the established patterns: validation literals → `CATALOG.error.validation`, not-found/permission → their intents (named-entity variants), CDN download catches → retry-honest generics, **gateway write catches → the classifier** (an avatar/voice/import timeout now renders the outcome-uncertain verify-first shape instead of "try again"), gateway read catches → `operation: 'read'`.

### Two structural upgrades that rode along

- `import.ts`'s `saveCharacter` returned `{ ok: false, error: string }` — a string-form Shape-B collapse that destroyed the transport kind. It now returns the fail-arm itself, so an import timeout is honestly uncertain (the character may have been created).
- `characterDashboardShared.ts` (+ `export.ts`) classify their `GatewayResult` fail-arms directly — the classifier's fail-arm carrier in production use, and 500s now surface the gateway's own message instead of hand-written generics.

### Scope line

Remaining character files (`browse.ts`, `chat.ts`, `dashboard.ts`, `randomPick.ts`, `edit.ts`) carry ~15 more literals and roll into **PR-D2** with the persona/preset family — bounded slices per the plan's split rule.

## Verification

Character family suite 499/499, full bot-client 5277/5277, component tier 30/30, quality green (including the refreshed ratchet baseline — sanctioned `ux:literals:update-baseline`, adoption-driven drop). Intentional wording deltas pinned by updated tests (verb-article shifts from `failedAction` phrases, gateway messages surfaced on 5xx).

Train: A ✅ · B ✅ · C ✅ · **D1 this** · D2 next · E in-character. Side-quest #1553 (footer breadcrumb) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)