### PR TITLE
fix: stop free-pool 429 storms masking as timeout past the quota retarget

### DIFF
--- a/services/ai-worker/src/services/LLMInvoker.test.ts
+++ b/services/ai-worker/src/services/LLMInvoker.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LLMInvoker } from './LLMInvoker.js';
 import { RetryError } from '../utils/retry.js';
+import { classifyQuotaFailure } from './quotaFallback.js';
 import { type BaseMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { type BaseChatModel } from '@langchain/core/language_models/chat_models';
 import {
@@ -238,6 +239,39 @@ describe('LLMInvoker', () => {
           getErrorContext: expect.any(Function),
         })
       );
+    });
+
+    it('the 429-storm terminal error classifies quota even when the LAST attempt aborted', async () => {
+      // The masked-as-timeout prod shape: an early attempt sees a clean 429
+      // (the CAUSE), the final attempt dies of the per-attempt abort (the
+      // SYMPTOM). The thrown RetryError must carry the 429 as lastError so
+      // classifyQuotaFailure fires the reactive retarget downstream.
+      vi.useFakeTimers();
+
+      const rateLimited = new Error('429 Too Many Requests: rate limit exceeded');
+      const aborted = Object.assign(new Error('Request was aborted.'), { name: 'AbortError' });
+      const mockModel = {
+        invoke: vi
+          .fn()
+          .mockRejectedValueOnce(rateLimited)
+          .mockRejectedValueOnce(aborted)
+          .mockRejectedValueOnce(aborted),
+      } as any as BaseChatModel;
+
+      const promise = invoker.invokeWithRetry({
+        model: mockModel,
+        messages: [new HumanMessage('Hello')],
+        modelName: 'test-model',
+      });
+      const assertion = expect(promise).rejects.toThrow(RetryError);
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      const thrown = (await promise.catch((e: unknown) => e)) as RetryError;
+      expect(thrown.lastError).toBe(rateLimited);
+      expect(classifyQuotaFailure(thrown)).toBe(ApiErrorCategory.RATE_LIMIT);
+
+      vi.useRealTimers();
     });
 
     it('should retry on transient ECONNRESET error', async () => {

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -34,6 +34,7 @@ import {
 } from './ModelFactory.js';
 import { extractAndPopulateOpenRouterReasoning } from './modelFactory/extractOpenRouterReasoning.js';
 import { withRetry, RetryError } from '../utils/retry.js';
+import { classifyQuotaFailure } from './quotaFallback.js';
 import {
   shouldRetryError,
   getErrorLogContext,
@@ -250,6 +251,12 @@ export class LLMInvoker {
           operationName: `LLM invocation (${modelName})`,
           shouldRetry: shouldRetryError,
           getErrorContext: getErrorLogContext,
+          // A quota-class attempt error (429/quota/credit) must survive as the
+          // terminal `lastError` even when a LATER attempt dies of the
+          // per-attempt abort (TIMEOUT) — during a 429 storm the abort is the
+          // symptom, the rate limit is the cause, and the reactive quota
+          // retarget only fires on quota-class classification.
+          preferTerminalError: error => classifyQuotaFailure(error) !== null,
         }
       );
     } catch (err) {

--- a/services/ai-worker/src/services/ModelFactory.test.ts
+++ b/services/ai-worker/src/services/ModelFactory.test.ts
@@ -120,6 +120,15 @@ describe('ModelFactory', () => {
       );
     });
 
+    it('disables SDK-internal retries so 429s surface to the LLMInvoker ladder immediately', () => {
+      // During a free-pool 429 storm the SDK's own retry loop absorbed 429s
+      // inside the per-attempt budget until OUR abort fired — the failure then
+      // classified TIMEOUT and bypassed the quota retarget.
+      createChatModel({ modelName: 'test-model', apiKey: 'k' });
+
+      expect(mockChatOpenAI).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 0 }));
+    });
+
     it('should always set __includeRawResponse:true so the OpenRouter reasoning extractor has access to the raw API response', () => {
       // Required for extractAndPopulateOpenRouterReasoning() in LLMInvoker to read
       // additional_kwargs.__raw_response. If this assertion ever fails, also check
@@ -1055,6 +1064,8 @@ describe('ModelFactory', () => {
           modelName: 'glm-4.7',
           apiKey: 'zai-user-key',
           temperature: 0.7,
+          // SDK-internal retries off here too — retries belong to the ladder.
+          maxRetries: 0,
           configuration: expect.objectContaining({
             baseURL: 'https://api.z.ai/api/coding/paas/v4',
           }),

--- a/services/ai-worker/src/services/ModelFactory.ts
+++ b/services/ai-worker/src/services/ModelFactory.ts
@@ -391,6 +391,14 @@ function buildOpenRouterModel(
       frequencyPenalty: shared.frequencyPenalty,
       presencePenalty: shared.presencePenalty,
       maxTokens: shared.maxTokens,
+      // No SDK-internal retries: during a free-pool 429 storm the SDK's own
+      // retry loop honors Retry-After and silently absorbs 429s inside the
+      // per-attempt timeout budget until OUR abort kills the attempt — the
+      // failure then classifies TIMEOUT, masking the true rate_limit category
+      // and bypassing the quota retarget (runtime-confirmed: a 534s burn of
+      // back-to-back 429s that died as "Request was aborted"). LLMInvoker's
+      // ladder owns retries; a 429 must surface to it immediately.
+      maxRetries: 0,
       modelKwargs: shared.hasModelKwargs ? shared.modelKwargs : undefined,
       configuration: buildOpenRouterClientConfig(extraParams, needsCustomFetch),
       // Surfaces the raw OpenRouter response under additional_kwargs.__raw_response,
@@ -440,6 +448,9 @@ function buildZaiCodingModel(
       apiKey,
       temperature: shared.temperature,
       topP: shared.topP,
+      // Same rationale as the OpenRouter build: retries belong to LLMInvoker's
+      // ladder, not the SDK (429 masking + budget burn).
+      maxRetries: 0,
       // frequencyPenalty / presencePenalty intentionally excluded:
       // z.ai's chat-completion API returns 400 "Invalid API parameter" (code
       // 1210) for both. filterRestrictedParams strips them in `shared` before

--- a/services/ai-worker/src/utils/retry.test.ts
+++ b/services/ai-worker/src/utils/retry.test.ts
@@ -89,6 +89,94 @@ describe('retryService', () => {
       expect(mockLogger.error).toHaveBeenCalled();
     });
 
+    it('carries the PREFERRED attempt error as lastError over the literal last (cause beats symptom)', async () => {
+      // The 429-storm shape: attempt 1 sees the true cause (rate limit),
+      // the final attempt dies of the per-attempt abort (timeout). Downstream
+      // classification keys off lastError — the cause must win or the quota
+      // retarget never fires.
+      const rateLimited = new Error('429 Too Many Requests');
+      const aborted = new Error('Request was aborted.');
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(rateLimited)
+        .mockRejectedValueOnce(aborted)
+        .mockRejectedValueOnce(aborted);
+
+      const promise = withRetry(fn, {
+        maxAttempts: 3,
+        initialDelayMs: 100,
+        logger: mockLogger,
+        preferTerminalError: error => error === rateLimited,
+      });
+      const assertionPromise = expect(promise).rejects.toThrow(RetryError);
+      await vi.runAllTimersAsync();
+      await assertionPromise;
+
+      const thrown = (await promise.catch((e: unknown) => e)) as RetryError;
+      expect(thrown.lastError).toBe(rateLimited);
+    });
+
+    it('logs the PREFERRED error context at exhaustion (observability must not re-mask the cause)', async () => {
+      // The incident was root-caused by reading the exhaustion log's category;
+      // if it still shows the abort's TIMEOUT while the thrown error says
+      // RATE_LIMIT, the next prod debugger is misled the same way.
+      const rateLimited = new Error('429 rate limited');
+      const aborted = new Error('Request was aborted.');
+      const fn = vi.fn().mockRejectedValueOnce(rateLimited).mockRejectedValueOnce(aborted);
+
+      const promise = withRetry(fn, {
+        maxAttempts: 2,
+        initialDelayMs: 100,
+        logger: mockLogger,
+        preferTerminalError: error => error === rateLimited,
+        getErrorContext: error => ({ category: (error as Error).message }),
+      });
+      const assertionPromise = expect(promise).rejects.toThrow(RetryError);
+      await vi.runAllTimersAsync();
+      await assertionPromise;
+
+      // The exhaustion error-level log carries the preferred (cause) context.
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ category: '429 rate limited' }),
+        expect.stringContaining('exhausted all retry attempts')
+      );
+    });
+
+    it('falls back to the literal last error when no attempt matches the preference', async () => {
+      const aborted = new Error('Request was aborted.');
+      const fn = vi.fn().mockRejectedValue(aborted);
+
+      const promise = withRetry(fn, {
+        maxAttempts: 2,
+        initialDelayMs: 100,
+        logger: mockLogger,
+        preferTerminalError: () => false,
+      });
+      const assertionPromise = expect(promise).rejects.toThrow(RetryError);
+      await vi.runAllTimersAsync();
+      await assertionPromise;
+
+      const thrown = (await promise.catch((e: unknown) => e)) as RetryError;
+      expect(thrown.lastError).toBe(aborted);
+    });
+
+    it('a throwing preferTerminalError callback never breaks the retry machinery', async () => {
+      const fn = vi.fn().mockRejectedValue(new Error('boom'));
+
+      const promise = withRetry(fn, {
+        maxAttempts: 2,
+        initialDelayMs: 100,
+        logger: mockLogger,
+        preferTerminalError: () => {
+          throw new Error('classifier exploded');
+        },
+      });
+      const assertionPromise = expect(promise).rejects.toThrow(RetryError);
+      await vi.runAllTimersAsync();
+      await assertionPromise;
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
     it('should include getErrorContext in exhaustion error log', async () => {
       const error = new Error('Persistent failure');
       const fn = vi.fn().mockRejectedValue(error);

--- a/services/ai-worker/src/utils/retry.ts
+++ b/services/ai-worker/src/utils/retry.ts
@@ -46,6 +46,15 @@ interface RetryOptions {
    * `attempts`, and `totalTimeMs` are overridden by the retry infrastructure.
    */
   getErrorContext?: (error: unknown) => Record<string, unknown>;
+  /**
+   * When set, the exhaustion RetryError carries the most recent attempt error
+   * for which this returned true as `lastError`, instead of the literal last.
+   * Why: downstream classification keys off `lastError`, and the LAST attempt
+   * can die of a symptom (a per-attempt abort during a 429 storm classifies
+   * TIMEOUT) while an earlier attempt saw the true cause (RATE_LIMIT) — the
+   * cause must win or the quota retarget never fires. Must not throw.
+   */
+  preferTerminalError?: (error: unknown) => boolean;
 }
 
 /**
@@ -244,13 +253,23 @@ export async function withRetry<T>(
     operationName = 'operation',
     shouldRetry,
     getErrorContext,
+    preferTerminalError,
   } = options;
 
   const startTime = Date.now();
   let lastError: unknown;
+  let preferredError: unknown;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    checkGlobalTimeout({ globalTimeoutMs, startTime, attempt, operationName, lastError, logger });
+    checkGlobalTimeout({
+      globalTimeoutMs,
+      startTime,
+      attempt,
+      operationName,
+      // Same cause-over-symptom preference as the exhaustion path.
+      lastError: preferredError ?? lastError,
+      logger,
+    });
     const attemptStartTime = Date.now();
 
     try {
@@ -270,6 +289,13 @@ export async function withRetry<T>(
       return { value, attempts: attempt, totalTimeMs };
     } catch (error) {
       lastError = error;
+      try {
+        if (preferTerminalError?.(error) === true) {
+          preferredError = error;
+        }
+      } catch {
+        // Classifier callbacks must not break the retry machinery.
+      }
       const durationMs = Date.now() - attemptStartTime;
       checkRetryableError({
         error,
@@ -306,12 +332,19 @@ export async function withRetry<T>(
   }
 
   const totalTimeMs = Date.now() - startTime;
+  // The preferred (cause) error wins over the literal last (symptom) — see
+  // preferTerminalError's doc.
+  const terminalError = preferredError ?? lastError;
   const error = new RetryError(
     `${operationName} failed after ${maxAttempts} attempts`,
     maxAttempts,
-    lastError
+    terminalError
   );
-  const exhaustionContext = safeGetErrorContext(getErrorContext, lastError, logger);
+  // Log the TERMINAL (cause) error's context, not the literal last attempt's —
+  // the exhaustion log's errorCategory/statusCode is exactly the field prod
+  // debugging reads, and a masked-429 must report RATE_LIMIT here, not the
+  // abort's TIMEOUT (the observability half of this fix).
+  const exhaustionContext = safeGetErrorContext(getErrorContext, terminalError, logger);
   logger?.error(
     { ...exhaustionContext, err: error, operationName, attempts: maxAttempts, totalTimeMs },
     `[Retry] ${operationName} exhausted all retry attempts`


### PR DESCRIPTION
## Summary

Owner-reported prod issue ("I thought we fixed request-aborted errors") — runtime-confirmed from prod logs (job `llm-01925d35`, a **534-second** burn, ref `mrbu72xdaps`).

**The abort fix works; the 429s are hiding behind it.** During an OpenRouter free-model 429 storm, the request surfaced to the user as an in-character *timeout* error instead of triggering the reactive quota retarget that would have rescued it onto another free model.

### Mechanism (verified in logs, not inferred)

1. The free qwen pool 429'd continuously for ~9 minutes (`status=429` every ~30s in the logs).
2. The **ChatOpenAI SDK's internal retry loop** absorbed those 429s *inside* our 3-min per-attempt window until **our own abort** fired.
3. The last attempt then classified `TIMEOUT` (AbortError — the retry-storm fix, working as designed), and the terminal `RetryError` carried only *that* attempt's category.
4. `classifyQuotaFailure(TIMEOUT)` = `null` → **the reactive quota retarget never fired** — even though attempt 1 had seen a clean 429 (`RATE_LIMIT`).
5. Proof the machinery is otherwise sound: minutes later the doom cache (populated by the clean 429) *proactively* retargeted a fresh request onto cohere-free with the proper breadcrumb.

So a rate-limited free model masquerades as a timeout **exactly when the storm is bad enough that the SDK never gives up inside the attempt window** — blocking the rescue on precisely the requests that need it.

### Fix (two bounded parts)

- **`retry.ts` — `preferTerminalError` option**: a quota-class attempt error survives as the terminal `lastError` over a later *symptom* (the abort), so the cause wins and the retarget fires. Threaded through both the exhaustion and global-timeout paths. Classifier-callback failures are swallowed (a classifier must never break the retry machinery).
- **`ModelFactory` — `maxRetries: 0`** on both ChatOpenAI builds: 429s surface to *our* ladder (which has the doom cache + retarget the SDK lacks) immediately. Kills the masking at the source **and** the ~9-min burn.

### Verification

- `retry.test.ts`: cause-beats-symptom, fallback-to-literal-last, throwing-callback-safe.
- `ModelFactory.test.ts`: `maxRetries: 0` pinned on the build.
- **`LLMInvoker.test.ts` seam test**: drives the exact `429 → abort → abort` sequence through the real `withRetry` wiring and asserts the thrown `RetryError` classifies `RATE_LIMIT` end to end (the assert-across-the-seam standard — this is what would have caught the original bug).

Full ai-worker suite 3521/3521, quality green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)