### PR TITLE
refactor: G2 sweep — settings family onto ux/catalog (UX P1 PR-D3b)

### DIFF
--- a/.github/baselines/ux-literals-baseline.json
+++ b/.github/baselines/ux-literals-baseline.json
@@ -1,15 +1,15 @@
 {
-  "total": 208,
+  "total": 193,
   "byPattern": {
-    "emoji-prefixed": 148,
-    "try-again": 60
+    "emoji-prefixed": 134,
+    "try-again": 59
   },
   "graceMargin": 10,
   "meta": {
     "toolVersion": "ux-literals-check/1",
     "configHash": "4b12eb65e0c6",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "3ccd60cf89af6782b331fd1096d05544493bee86",
-    "generatedAt": "2026-07-08T13:03:38.449Z"
+    "generatedFromSha": "2f39b56a86169c024e57dbf1fba69af89d7956e4",
+    "generatedAt": "2026-07-08T14:26:03.127Z"
   }
 }

--- a/services/bot-client/src/commands/settings/apikey/modal.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.test.ts
@@ -93,7 +93,7 @@ describe('handleApikeyModalSubmit', () => {
       await handleApikeyModalSubmit(interaction);
 
       expect(mockReply).toHaveBeenCalledWith({
-        content: '❌ Unknown apikey modal submission',
+        content: '❌ Unknown apikey modal submission.',
         flags: MessageFlags.Ephemeral,
       });
     });
@@ -104,7 +104,7 @@ describe('handleApikeyModalSubmit', () => {
       await handleApikeyModalSubmit(interaction);
 
       expect(mockReply).toHaveBeenCalledWith({
-        content: '❌ Unknown apikey modal submission',
+        content: '❌ Unknown apikey modal submission.',
         flags: MessageFlags.Ephemeral,
       });
     });
@@ -114,7 +114,7 @@ describe('handleApikeyModalSubmit', () => {
       await handleApikeyModalSubmit(interaction);
 
       expect(mockReply).toHaveBeenCalledWith({
-        content: '❌ Unknown apikey action',
+        content: '❌ Unknown apikey action.',
         flags: MessageFlags.Ephemeral,
       });
     });
@@ -126,7 +126,7 @@ describe('handleApikeyModalSubmit', () => {
       await handleApikeyModalSubmit(interaction);
 
       expect(mockDeferReply).toHaveBeenCalled();
-      expect(mockEditReply).toHaveBeenCalledWith({ content: '❌ API key cannot be empty' });
+      expect(mockEditReply).toHaveBeenCalledWith({ content: '❌ API key cannot be empty.' });
     });
 
     it('should reject OpenRouter key with wrong format', async () => {
@@ -274,9 +274,29 @@ describe('handleApikeyModalSubmit', () => {
       );
       await handleApikeyModalSubmit(interaction);
 
-      expect(mockEditReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Request Timed Out'),
-      });
+      // Outcome-uncertain (⏳), single glyph — never a doubled ❌ ⏳, and never
+      // an ❌ that would frame a possibly-saved key as a definitive failure.
+      const timeoutReply = (mockEditReply as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as {
+        content: string;
+      };
+      expect(timeoutReply.content).toContain('⏳ **Request Timed Out**');
+      expect(timeoutReply.content).not.toContain('❌');
+    });
+
+    it('should handle a rate-limit (429) as a transient warning, single glyph', async () => {
+      stub.setWalletKey.mockResolvedValue(makeErr(429, 'Too many requests'));
+
+      const interaction = createMockInteraction(
+        'settings::apikey::set::openrouter',
+        'sk-or-v1-ratelimited'
+      );
+      await handleApikeyModalSubmit(interaction);
+
+      const reply = (mockEditReply as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as {
+        content: string;
+      };
+      expect(reply.content).toContain('⚠️ **Too Many Requests**');
+      expect(reply.content).not.toContain('❌');
     });
 
     it('should handle generic gateway error', async () => {

--- a/services/bot-client/src/commands/settings/apikey/modal.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.ts
@@ -18,6 +18,14 @@ import { getProviderDisplayName } from '../../../utils/providers.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
 import { ApikeyCustomIds } from '../../../utils/customIds.js';
 import { replyError } from '../../../utils/dashboard/replyError.js';
+import { CATALOG } from '../../../ux/catalog/catalog.js';
+import type { MessageSpec } from '../../../ux/catalog/types.js';
+import { renderSpec } from '../../../ux/render/render.js';
+
+/** Render a rich validation body through the catalog (❌ glyph from the renderer). */
+function validationReply(body: string): string {
+  return renderSpec(CATALOG.error.validation(body));
+}
 
 const logger = createLogger('settings-apikey-modal');
 
@@ -29,7 +37,7 @@ export async function handleApikeyModalSubmit(interaction: ModalSubmitInteractio
   // Parse customId using centralized utilities
   const parsed = ApikeyCustomIds.parse(interaction.customId);
   if (parsed?.provider === undefined) {
-    await replyError(interaction, '❌ Unknown apikey modal submission');
+    await replyError(interaction, validationReply('Unknown apikey modal submission.'));
     return;
   }
 
@@ -38,7 +46,7 @@ export async function handleApikeyModalSubmit(interaction: ModalSubmitInteractio
   if (parsed.action === 'set') {
     await handleSetKeySubmit(interaction, provider);
   } else {
-    await replyError(interaction, '❌ Unknown apikey action');
+    await replyError(interaction, validationReply('Unknown apikey action.'));
   }
 }
 
@@ -56,14 +64,14 @@ async function handleSetKeySubmit(
 
   // Basic validation
   if (apiKey.length === 0) {
-    await replyError(interaction, '❌ API key cannot be empty');
+    await replyError(interaction, validationReply('API key cannot be empty.'));
     return;
   }
 
   // Validate key format based on provider
   const formatError = validateKeyFormat(apiKey, provider);
   if (formatError !== null) {
-    await replyError(interaction, formatError);
+    await replyError(interaction, validationReply(formatError));
     return;
   }
 
@@ -123,8 +131,10 @@ async function handleSetKeySubmit(
 
     await replyError(
       interaction,
-      '❌ An unexpected error occurred while saving your API key.\n' +
-        'Please try again later or contact support if the issue persists.'
+      validationReply(
+        'An unexpected error occurred while saving your API key.\n' +
+          'Please try again later or contact support if the issue persists.'
+      )
     );
   }
 }
@@ -142,49 +152,53 @@ function getErrorMessage(
   switch (status) {
     case 400:
       // Validation error (includes scoped-key permission errors)
-      return (
-        '❌ **Validation Error**\n\n' +
-        (errorData.message ?? errorData.error ?? 'The request was invalid.') +
-        '\n\nPlease check your API key and try again.'
+      return validationReply(
+        '**Validation Error**\n\n' +
+          (errorData.message ?? errorData.error ?? 'The request was invalid.') +
+          '\n\nPlease check your API key and try again.'
       );
 
     case 401:
     case 403:
       // Invalid/unauthorized key
-      return (
-        '❌ **Invalid API Key**\n\n' +
-        'The API key you provided is not valid. Please check:\n' +
-        '• The key is copied correctly (no extra spaces)\n' +
-        '• The key has not expired or been revoked\n' +
-        `• You're using a key for ${providerName}`
+      return validationReply(
+        '**Invalid API Key**\n\n' +
+          'The API key you provided is not valid. Please check:\n' +
+          '• The key is copied correctly (no extra spaces)\n' +
+          '• The key has not expired or been revoked\n' +
+          `• You're using a key for ${providerName}`
       );
 
     case 402:
       // Insufficient credits
-      return (
-        '❌ **Insufficient Credits**\n\n' +
-        'Your API key is valid but has insufficient credits.\n' +
-        'Please add funds to your account and try again.'
+      return validationReply(
+        '**Insufficient Credits**\n\n' +
+          'Your API key is valid but has insufficient credits.\n' +
+          'Please add funds to your account and try again.'
       );
 
     case 429:
       // Rate limited
-      return (
-        '⏳ **Too Many Requests**\n\n' +
-        'You have made too many API key operations recently.\n' +
-        'Please wait a few minutes and try again.'
-      );
+      // Rate limited — transient (⚠️), not a definitive ❌ rejection.
+      return renderSpec({
+        severity: 'warning',
+        outcome: 'failed',
+        text:
+          '**Too Many Requests**\n\n' +
+          'You have made too many API key operations recently.\n' +
+          'Please wait a few minutes and try again.',
+      } satisfies MessageSpec);
 
     case 500:
     case 502:
     case 503:
     case 504:
       // Server errors
-      return (
-        '❌ **Server Error**\n\n' +
-        'The server encountered an error while processing your request.\n' +
-        'This is usually temporary. Please try again in a few minutes.\n\n' +
-        'If the problem persists, contact support.'
+      return validationReply(
+        '**Server Error**\n\n' +
+          'The server encountered an error while processing your request.\n' +
+          'This is usually temporary. Please try again in a few minutes.\n\n' +
+          'If the problem persists, contact support.'
       );
 
     case 0:
@@ -192,21 +206,26 @@ function getErrorMessage(
       // provider validation can outlast the client timeout while the gateway
       // still completes the save, so point the user at browse to confirm rather
       // than blindly retrying and creating churn.
-      return (
-        '⏳ **Request Timed Out**\n\n' +
-        "The request didn't complete in time. Your key may already have been saved —\n" +
-        'check `/settings apikey browse` before trying again.'
-      );
+      // Outcome-uncertain (⏳): the save may have applied — steer to verify,
+      // never invite a blind retry (the write-uncertain shape's whole point).
+      return renderSpec({
+        severity: 'progress',
+        outcome: 'uncertain',
+        text:
+          '**Request Timed Out**\n\n' +
+          "The request didn't complete in time. Your key may already have been saved —\n" +
+          'check `/settings apikey browse` before trying again.',
+      } satisfies MessageSpec);
 
     default:
       // Unknown error - still provide friendly message
-      return (
-        '❌ **Unable to Save API Key**\n\n' +
-        'An unexpected error occurred while saving your API key.\n' +
-        (errorData.message !== undefined && errorData.message.length > 0
-          ? `Details: ${errorData.message}\n\n`
-          : '') +
-        'Please try again later or contact support if the issue persists.'
+      return validationReply(
+        '**Unable to Save API Key**\n\n' +
+          'An unexpected error occurred while saving your API key.\n' +
+          (errorData.message !== undefined && errorData.message.length > 0
+            ? `Details: ${errorData.message}\n\n`
+            : '') +
+          'Please try again later or contact support if the issue persists.'
       );
   }
 }
@@ -220,7 +239,7 @@ function validateKeyFormat(apiKey: string, provider: AIProvider): string | null 
       // OpenRouter keys start with 'sk-or-' or 'sk-or-v1-'
       if (!apiKey.startsWith(API_KEY_FORMATS.OPENROUTER_PREFIX)) {
         return (
-          '❌ **Invalid OpenRouter Key Format**\n\n' +
+          '**Invalid OpenRouter Key Format**\n\n' +
           `OpenRouter API keys should start with \`${API_KEY_FORMATS.OPENROUTER_PREFIX}\`.\n` +
           'Get your key at: https://openrouter.ai/keys'
         );

--- a/services/bot-client/src/commands/settings/apikey/remove.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.test.ts
@@ -124,7 +124,7 @@ describe('handleRemoveKey', () => {
     await handleRemoveKey(context);
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ Failed to remove API key: Internal error',
+      content: '❌ Internal error',
     });
   });
 
@@ -135,7 +135,7 @@ describe('handleRemoveKey', () => {
     await handleRemoveKey(context);
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ An unexpected error occurred. Please try again.',
+      content: '❌ Failed to remove the API key. Please try again.',
     });
   });
 });

--- a/services/bot-client/src/commands/settings/apikey/remove.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.ts
@@ -15,6 +15,9 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
+import { CATALOG } from '../../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../../ux/catalog/classify.js';
+import { renderSpec } from '../../../ux/render/render.js';
 
 const logger = createLogger('settings-apikey-remove');
 
@@ -37,12 +40,20 @@ export async function handleRemoveKey(context: DeferredCommandContext): Promise<
     if (!result.ok) {
       if (result.status === 404) {
         await context.editReply({
-          content: `❌ You don't have an API key configured for **${getProviderDisplayName(provider)}**.`,
+          content: renderSpec(
+            CATALOG.error.validation(
+              `You don't have an API key configured for **${getProviderDisplayName(provider)}**.`
+            )
+          ),
         });
         return;
       }
 
-      await context.editReply({ content: `❌ Failed to remove API key: ${result.error}` });
+      await context.editReply({
+        content: renderSpec(
+          classifyGatewayFailure(result, 'API key', { failedAction: 'remove the API key' })
+        ),
+      });
       return;
     }
 
@@ -61,6 +72,10 @@ export async function handleRemoveKey(context: DeferredCommandContext): Promise<
     logger.info({ provider, userId }, 'API key removed');
   } catch (error) {
     logger.error({ err: error, userId, provider }, 'Unexpected error');
-    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+    await context.editReply({
+      content: renderSpec(
+        classifyGatewayFailure(error, 'API key', { failedAction: 'remove the API key' })
+      ),
+    });
   }
 }

--- a/services/bot-client/src/commands/settings/defaults/edit.test.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.test.ts
@@ -271,7 +271,7 @@ describe('User Default Settings Dashboard', () => {
       await handleDefaultsEdit(context);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: '❌ An error occurred while opening the default settings dashboard.',
+        content: '❌ Failed to open the default settings dashboard. Please try again.',
       });
     });
 

--- a/services/bot-client/src/commands/settings/defaults/edit.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.ts
@@ -22,6 +22,8 @@ import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type UserClient } from '@tzurot/clients';
 import { clientsFor } from '../../../utils/gatewayClients.js';
+import { classifyGatewayFailure } from '../../../ux/catalog/classify.js';
+import { renderSpec } from '../../../ux/render/render.js';
 import {
   type SettingsDashboardConfig,
   type SettingsDashboardSession,
@@ -94,7 +96,12 @@ export async function handleDefaultsEdit(context: DeferredCommandContext): Promi
 
     if (!context.interaction.replied) {
       await context.editReply({
-        content: '❌ An error occurred while opening the default settings dashboard.',
+        content: renderSpec(
+          classifyGatewayFailure(error, 'default settings', {
+            operation: 'read',
+            failedAction: 'open the default settings dashboard',
+          })
+        ),
       });
     }
   }

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -58,6 +58,8 @@ import { handleClearDefault as handlePresetClearDefault } from './preset/clear-d
 import { handleAutocomplete as handlePresetAutocomplete } from './preset/autocomplete.js';
 
 // Defaults handlers (user-default config cascade settings)
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { renderSpec } from '../../ux/render/render.js';
 import {
   handleDefaultsEdit,
   handleUserDefaultsButton,
@@ -127,7 +129,7 @@ async function execute(context: SafeCommandContext): Promise<void> {
   } else {
     logger.warn({ group }, 'Unknown subcommand group');
     await (context as DeferredCommandContext).editReply({
-      content: '❌ Unknown settings group.',
+      content: renderSpec(CATALOG.error.validation('Unknown settings group.')),
     });
   }
 }

--- a/services/bot-client/src/ux/catalog/catalog.ts
+++ b/services/bot-client/src/ux/catalog/catalog.ts
@@ -109,7 +109,12 @@ export const CATALOG = {
       text: `You do not have permission to ${action}.`,
     }),
 
-    /** Input validation failure (pre-gateway). */
+    /**
+     * Definitive-failure error carrying a caller-supplied body verbatim.
+     * Primary use is pre-gateway input validation, but it's also the
+     * passthrough for any rich, hand-formatted `❌` message whose body is too
+     * specific for a dedicated intent (e.g. the apikey save-error guidance).
+     */
     validation: (detail: string): MessageSpec => ({
       severity: 'error',
       outcome: 'failed',


### PR DESCRIPTION
## Summary

**UX boulder Phase 1, PR-D3b** — the settings command family. Ratchet **208 → 193**.

### Swept

`apikey/modal` · `apikey/remove` · `settings/index` · `settings/defaults/edit`

### The apikey rich-error conversion

`apikey/modal.ts`'s `getErrorMessage` (a `switch(status)` returning detailed, status-specific user guidance) and `validateKeyFormat` were **not** flattened — each body is preserved and routed through the correct catalog severity, with the glyph now owned by the renderer.

**Two branches are a deliberate honest-glyph change, not a mechanical passthrough** (round-2 review correctly flagged my original "byte-identical" framing as overbroad):
- **429 → ⚠️** (was ⏳): a rate-limit is *transient*, better modeled as a warning than an in-flight-progress state.
- **status-0 (timeout) → ⏳** kept, but now single-glyph: the body ("your key may already have been saved — check browse before retrying") is literally the **outcome-uncertain write shape**, so it renders progress-severity and never an ❌ that would frame a possibly-saved key as a definitive failure.

The other seven branches (400/401/402/403/500–504/default) **are** byte-identical — glyph stripped, body verbatim, pinned by exact-string tests. The round-1 bug this fixes: those two ⏳ branches were missed by the initial strip pass, so `validationReply` double-prefixed them to `❌ ⏳`; both now have exact-glyph regression tests.

### Read/write catch discipline (the D3a lesson, applied at authoring time)

Both classified catches audited before pushing: `apikey/remove`'s try wraps only the `removeWalletKey` write → write semantics; `defaults/edit`'s wraps the fetch+dashboard read → `operation: 'read'`. No read-classified-as-write in this slice.

## Verification

Settings family 164/164, full bot-client 5297/5297, quality green.

Train: A–D2 ✅ · D3a ✅ · **D3b this** · D3c → E remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)