### PR TITLE
refactor: G2 sweep — shapes/channel/voice families onto ux/catalog (UX P1 PR-D3c)

### DIFF
--- a/.github/baselines/ux-literals-baseline.json
+++ b/.github/baselines/ux-literals-baseline.json
@@ -1,15 +1,15 @@
 {
-  "total": 193,
+  "total": 153,
   "byPattern": {
-    "emoji-prefixed": 134,
-    "try-again": 59
+    "emoji-prefixed": 100,
+    "try-again": 53
   },
   "graceMargin": 10,
   "meta": {
     "toolVersion": "ux-literals-check/1",
     "configHash": "4b12eb65e0c6",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "2f39b56a86169c024e57dbf1fba69af89d7956e4",
-    "generatedAt": "2026-07-08T14:26:03.127Z"
+    "generatedFromSha": "86a59f13349cf536f046c45d12b19d65bb7f4ad2",
+    "generatedAt": "2026-07-08T15:06:16.165Z"
   }
 }

--- a/services/bot-client/src/commands/channel/activate.test.ts
+++ b/services/bot-client/src/commands/channel/activate.test.ts
@@ -215,7 +215,7 @@ describe('/channel activate', () => {
 
     await handleActivate(context);
 
-    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining("don't have access"));
+    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('permission to access'));
   });
 
   it('should handle generic API errors', async () => {
@@ -224,7 +224,9 @@ describe('/channel activate', () => {
 
     await handleActivate(context);
 
-    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('Failed to activate'));
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.stringContaining('Internal server error')
+    );
   });
 
   it('should handle unexpected errors', async () => {
@@ -233,7 +235,7 @@ describe('/channel activate', () => {
 
     await handleActivate(context);
 
-    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('unexpected error'));
+    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('Failed to activate'));
   });
 
   it('rejects the autocomplete-error sentinel before calling the gateway', async () => {

--- a/services/bot-client/src/commands/channel/activate.ts
+++ b/services/bot-client/src/commands/channel/activate.ts
@@ -10,6 +10,9 @@
  */
 
 import { channelActivateOptions } from '@tzurot/common-types/generated/commandOptions';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
@@ -20,6 +23,7 @@ import { clientsFor } from '../../utils/gatewayClients.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
 import { invalidateChannelSettingsCache } from '../../utils/gatewayServiceCalls.js';
 import { getChannelActivationCacheInvalidationService } from '../../services/serviceRegistry.js';
+import { escapeMarkdown } from 'discord.js';
 
 const logger = createLogger('channel-activate');
 
@@ -59,7 +63,9 @@ export async function handleActivate(context: DeferredCommandContext): Promise<v
 
   // Guild ID is required (permission check ensures we're in a guild)
   if (guildId === null) {
-    await context.editReply('❌ This command can only be used in a server.');
+    await context.editReply(
+      renderSpec(CATALOG.error.validation('This command can only be used in a server.'))
+    );
     return;
   }
 
@@ -86,21 +92,32 @@ export async function handleActivate(context: DeferredCommandContext): Promise<v
       // Handle specific error cases
       if (result.status === 404) {
         await context.editReply(
-          `❌ Character **${personalitySlug}** not found.\n\n` +
-            'Use the autocomplete to select a valid character.'
+          renderSpec(
+            CATALOG.error.notFound('Character', {
+              name: escapeMarkdown(personalitySlug),
+              autocomplete: true,
+            })
+          )
         );
         return;
       }
 
       if (result.status === 403) {
         await context.editReply(
-          `❌ You don't have access to **${personalitySlug}**.\n\n` +
-            'You can only activate characters that are public or that you own.'
+          renderSpec(
+            CATALOG.error.permissionDenied(
+              `access **${escapeMarkdown(personalitySlug)}** — you can only activate characters that are public or that you own`
+            )
+          )
         );
         return;
       }
 
-      await context.editReply(`❌ Failed to activate: ${result.error}`);
+      await context.editReply(
+        renderSpec(
+          classifyGatewayFailure(result, 'channel', { failedAction: 'activate the channel' })
+        )
+      );
       return;
     }
 
@@ -136,6 +153,8 @@ export async function handleActivate(context: DeferredCommandContext): Promise<v
       },
       'Activation error'
     );
-    await context.editReply('❌ An unexpected error occurred while activating the channel.');
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'channel', { failedAction: 'activate the channel' }))
+    );
   }
 }

--- a/services/bot-client/src/commands/channel/browse.test.ts
+++ b/services/bot-client/src/commands/channel/browse.test.ts
@@ -258,9 +258,7 @@ describe('handleBrowse', () => {
     const context = createMockContext();
     await handleBrowse(context);
 
-    expect(mockEditReply).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to browse channels')
-    );
+    expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('Internal error'));
   });
 
   it('should handle unexpected errors', async () => {
@@ -269,7 +267,9 @@ describe('handleBrowse', () => {
     const context = createMockContext();
     await handleBrowse(context);
 
-    expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('unexpected error'));
+    expect(mockEditReply).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to load the channels')
+    );
   });
 });
 

--- a/services/bot-client/src/commands/channel/browse.ts
+++ b/services/bot-client/src/commands/channel/browse.ts
@@ -28,6 +28,9 @@ import {
   type BrowseSortType,
 } from '../../utils/browse/index.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { channelBrowseOptions } from '@tzurot/common-types/generated/commandOptions';
 import { type ChannelSettings } from '@tzurot/common-types/schemas/api/channel';
 import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
@@ -408,7 +411,13 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
 
   // Check owner permission for 'all' filter
   if (filter === 'all' && !isBotOwner(context.user.id)) {
-    await context.editReply('❌ The "All Servers" filter is only available to bot owners.');
+    await context.editReply(
+      renderSpec(
+        CATALOG.error.permissionDenied(
+          'use the "All Servers" filter — it is only available to bot owners'
+        )
+      )
+    );
     return;
   }
 
@@ -428,7 +437,9 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
         { userId: context.user.id, error: result.error, status: result.status },
         'Browse failed'
       );
-      await context.editReply(`❌ Failed to browse channels: ${result.error}`);
+      await context.editReply(
+        renderSpec(classifyGatewayFailure(result, 'channels', { operation: 'read' }))
+      );
       return;
     }
 
@@ -471,7 +482,9 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
     );
   } catch (error) {
     logger.error({ err: error, userId: context.user.id }, 'Browse error');
-    await context.editReply('❌ An unexpected error occurred while browsing channels.');
+    await context.editReply(
+      renderSpec(classifyGatewayFailure(error, 'channels', { operation: 'read' }))
+    );
   }
 }
 

--- a/services/bot-client/src/commands/channel/deactivate.test.ts
+++ b/services/bot-client/src/commands/channel/deactivate.test.ts
@@ -171,7 +171,7 @@ describe('/channel deactivate', () => {
 
     await handleDeactivate(context);
 
-    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('Failed to deactivate'));
+    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('Database error'));
   });
 
   it('should handle unexpected errors', async () => {
@@ -180,6 +180,6 @@ describe('/channel deactivate', () => {
 
     await handleDeactivate(context);
 
-    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('unexpected error'));
+    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('Failed to deactivate'));
   });
 });

--- a/services/bot-client/src/commands/channel/deactivate.ts
+++ b/services/bot-client/src/commands/channel/deactivate.ts
@@ -10,6 +10,8 @@
  */
 
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
@@ -46,7 +48,11 @@ export async function handleDeactivate(context: DeferredCommandContext): Promise
         'Deactivation failed'
       );
 
-      await context.editReply(`❌ Failed to deactivate: ${result.error}`);
+      await context.editReply(
+        renderSpec(
+          classifyGatewayFailure(result, 'channel', { failedAction: 'deactivate the channel' })
+        )
+      );
       return;
     }
 
@@ -95,6 +101,10 @@ export async function handleDeactivate(context: DeferredCommandContext): Promise
       },
       'Deactivation error'
     );
-    await context.editReply('❌ An unexpected error occurred while deactivating the channel.');
+    await context.editReply(
+      renderSpec(
+        classifyGatewayFailure(error, 'channel', { failedAction: 'deactivate the channel' })
+      )
+    );
   }
 }

--- a/services/bot-client/src/commands/channel/settings.test.ts
+++ b/services/bot-client/src/commands/channel/settings.test.ts
@@ -369,7 +369,7 @@ describe('Channel Settings Dashboard', () => {
       await handleChannelSettings(context);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: '❌ An error occurred while opening the context settings dashboard.',
+        content: '❌ Failed to open the context settings dashboard. Please try again.',
       });
     });
 

--- a/services/bot-client/src/commands/channel/settings.ts
+++ b/services/bot-client/src/commands/channel/settings.ts
@@ -18,6 +18,9 @@ import {
   PermissionFlagsBits,
 } from 'discord.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { type ResolvedConfigOverrides } from '@tzurot/common-types/schemas/api/configOverrides';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -84,7 +87,11 @@ export async function handleChannelSettings(context: DeferredCommandContext): Pr
   // Check permissions: Manage Messages required
   if (member?.permissions.has(PermissionFlagsBits.ManageMessages) !== true) {
     await context.editReply({
-      content: '❌ You need the **Manage Messages** permission to manage channel context settings.',
+      content: renderSpec(
+        CATALOG.error.permissionDenied(
+          'manage channel context settings — you need the **Manage Messages** permission'
+        )
+      ),
     });
     return;
   }
@@ -126,7 +133,12 @@ export async function handleChannelSettings(context: DeferredCommandContext): Pr
     // Check if already replied via interaction (dashboard may have responded)
     if (!interaction.replied) {
       await context.editReply({
-        content: '❌ An error occurred while opening the context settings dashboard.',
+        content: renderSpec(
+          classifyGatewayFailure(error, 'context settings', {
+            operation: 'read',
+            failedAction: 'open the context settings dashboard',
+          })
+        ),
       });
     }
   }

--- a/services/bot-client/src/commands/shapes/import.test.ts
+++ b/services/bot-client/src/commands/shapes/import.test.ts
@@ -162,7 +162,7 @@ describe('handleImport', () => {
     await handleImport(context);
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('unexpected error'),
+      content: expect.stringContaining('Failed to load the shapes import'),
     });
   });
 

--- a/services/bot-client/src/commands/shapes/import.ts
+++ b/services/bot-client/src/commands/shapes/import.ts
@@ -14,6 +14,8 @@ import {
   type MessageComponentInteraction,
 } from 'discord.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
@@ -171,6 +173,8 @@ export async function handleImport(context: DeferredCommandContext): Promise<voi
     await context.editReply({ embeds: [confirmEmbed], components: [row] });
   } catch (error) {
     logger.error({ err: error, userId, slug }, 'Unexpected error starting import');
-    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+    await context.editReply({
+      content: renderSpec(classifyGatewayFailure(error, 'shapes import', { operation: 'read' })),
+    });
   }
 }

--- a/services/bot-client/src/commands/shapes/interactionHandlers.test.ts
+++ b/services/bot-client/src/commands/shapes/interactionHandlers.test.ts
@@ -401,7 +401,7 @@ describe('handleShapesButton', () => {
 
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: expect.stringContaining('unexpected error'),
+          content: expect.stringContaining('Failed to complete that'),
         })
       );
     });

--- a/services/bot-client/src/commands/shapes/interactionHandlers.ts
+++ b/services/bot-client/src/commands/shapes/interactionHandlers.ts
@@ -23,6 +23,8 @@ import {
   type ActionRowBuilder,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { buildBrowsePage, fetchShapesList, shapesBrowseIds } from './browse.js';
@@ -41,7 +43,7 @@ import {
 const logger = createLogger('shapes-interactions');
 
 const UNEXPECTED_ERROR_PAYLOAD = {
-  content: '❌ An unexpected error occurred.',
+  content: renderSpec(CATALOG.error.operationFailed('complete that')),
   embeds: [],
   components: [],
 } as const;

--- a/services/bot-client/src/commands/shapes/logout.test.ts
+++ b/services/bot-client/src/commands/shapes/logout.test.ts
@@ -99,7 +99,7 @@ describe('handleLogout', () => {
     await handleLogout(context);
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('Failed to remove'),
+      content: expect.stringContaining('Server error'),
     });
   });
 
@@ -110,7 +110,7 @@ describe('handleLogout', () => {
     await handleLogout(context);
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('unexpected error'),
+      content: expect.stringContaining('Failed to remove your credentials'),
     });
   });
 });

--- a/services/bot-client/src/commands/shapes/logout.ts
+++ b/services/bot-client/src/commands/shapes/logout.ts
@@ -5,6 +5,9 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
@@ -26,12 +29,18 @@ export async function handleLogout(context: DeferredCommandContext): Promise<voi
     if (!result.ok) {
       if (result.status === 404) {
         await context.editReply({
-          content: "❌ You don't have any shapes.inc credentials stored.",
+          content: renderSpec(
+            CATALOG.error.validation("You don't have any shapes.inc credentials stored.")
+          ),
         });
         return;
       }
 
-      await context.editReply({ content: `❌ Failed to remove credentials: ${result.error}` });
+      await context.editReply({
+        content: renderSpec(
+          classifyGatewayFailure(result, 'credentials', { failedAction: 'remove your credentials' })
+        ),
+      });
       return;
     }
 
@@ -49,6 +58,10 @@ export async function handleLogout(context: DeferredCommandContext): Promise<voi
     logger.info({ userId }, 'Credentials removed');
   } catch (error) {
     logger.error({ err: error, userId }, 'Unexpected error removing credentials');
-    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+    await context.editReply({
+      content: renderSpec(
+        classifyGatewayFailure(error, 'credentials', { failedAction: 'remove your credentials' })
+      ),
+    });
   }
 }

--- a/services/bot-client/src/commands/shapes/modal.test.ts
+++ b/services/bot-client/src/commands/shapes/modal.test.ts
@@ -195,7 +195,9 @@ describe('handleShapesModalSubmit', () => {
       const interaction = createMockInteraction('shapes::auth');
       await handleShapesModalSubmit(interaction);
 
-      expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('unexpected error'));
+      expect(mockEditReply).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to save your credentials')
+      );
     });
   });
 });

--- a/services/bot-client/src/commands/shapes/modal.ts
+++ b/services/bot-client/src/commands/shapes/modal.ts
@@ -11,6 +11,9 @@
  */
 
 import { type ModalSubmitInteraction, MessageFlags, EmbedBuilder } from 'discord.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { parseShapesSessionCookieInput } from '@tzurot/common-types/types/shapes-import';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -18,6 +21,11 @@ import { clientsFor } from '../../utils/gatewayClients.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 
 const logger = createLogger('shapes-modal');
+
+/** Render a rich validation body through the catalog (❌ glyph from the renderer). */
+function validationReply(body: string): string {
+  return renderSpec(CATALOG.error.validation(body));
+}
 
 /**
  * Handle shapes modal submissions
@@ -27,7 +35,7 @@ export async function handleShapesModalSubmit(interaction: ModalSubmitInteractio
   const parsed = ShapesCustomIds.parse(interaction.customId);
   if (parsed === null) {
     await interaction.reply({
-      content: '❌ Unknown shapes modal submission',
+      content: validationReply('Unknown shapes modal submission.'),
       flags: MessageFlags.Ephemeral,
     });
     return;
@@ -37,7 +45,7 @@ export async function handleShapesModalSubmit(interaction: ModalSubmitInteractio
     await handleAuthSubmit(interaction);
   } else {
     await interaction.reply({
-      content: '❌ Unknown shapes action',
+      content: validationReply('Unknown shapes action.'),
       flags: MessageFlags.Ephemeral,
     });
   }
@@ -53,7 +61,7 @@ async function handleAuthSubmit(interaction: ModalSubmitInteraction): Promise<vo
   const parsed = parseShapesSessionCookieInput(rawInput);
 
   if (!parsed.ok) {
-    await interaction.editReply(getInputValidationMessage(parsed.reason));
+    await interaction.editReply(validationReply(getInputValidationMessage(parsed.reason)));
     return;
   }
 
@@ -68,7 +76,7 @@ async function handleAuthSubmit(interaction: ModalSubmitInteraction): Promise<vo
         { status: result.status, userId: interaction.user.id, error: result.error },
         'Failed to store session cookie'
       );
-      await interaction.editReply(getAuthErrorMessage(result.status));
+      await interaction.editReply(validationReply(getAuthErrorMessage(result.status)));
       return;
     }
 
@@ -97,7 +105,9 @@ async function handleAuthSubmit(interaction: ModalSubmitInteraction): Promise<vo
   } catch (error) {
     logger.error({ err: error, userId: interaction.user.id }, 'Error storing cookie');
     await interaction.editReply(
-      '❌ An unexpected error occurred while saving your credentials.\n' + 'Please try again later.'
+      renderSpec(
+        classifyGatewayFailure(error, 'credentials', { failedAction: 'save your credentials' })
+      )
     );
   }
 }
@@ -106,16 +116,16 @@ function getAuthErrorMessage(status: number): string {
   switch (status) {
     case 400:
       return (
-        '❌ **Invalid Cookie**\n\n' +
+        '**Invalid Cookie**\n\n' +
         'The session cookie format is invalid. Please re-run `/shapes auth` and paste the value ' +
         'of `__Secure-better-auth.session_token` from your browser DevTools.'
       );
     case 500:
     case 502:
     case 503:
-      return '❌ **Server Error**\n\nThe server encountered an error. Please try again in a few minutes.';
+      return '**Server Error**\n\nThe server encountered an error. Please try again in a few minutes.';
     default:
-      return '❌ **Unable to Save Credentials**\n\nAn unexpected error occurred. Please try again later.';
+      return '**Unable to Save Credentials**\n\nAn unexpected error occurred. Please try again later.';
   }
 }
 
@@ -126,10 +136,10 @@ function getAuthErrorMessage(status: number): string {
 function getInputValidationMessage(reason: 'empty' | 'wrong-cookie' | 'malformed-value'): string {
   switch (reason) {
     case 'empty':
-      return '❌ Cookie value is required.';
+      return 'Cookie value is required.';
     case 'wrong-cookie':
       return (
-        "❌ **That doesn't look like the right cookie.**\n\n" +
+        "**That doesn't look like the right cookie.**\n\n" +
         'The input contained cookies, but not `__Secure-better-auth.session_token`. ' +
         'Common mistake: copying the whole `Cookie:` header from the Network tab instead ' +
         'of a single cookie value from the Application tab. ' +
@@ -137,7 +147,7 @@ function getInputValidationMessage(reason: 'empty' | 'wrong-cookie' | 'malformed
       );
     case 'malformed-value':
       return (
-        '❌ **Cookie value looks malformed.**\n\n' +
+        '**Cookie value looks malformed.**\n\n' +
         'Better Auth tokens are opaque strings (typically 32+ characters, no whitespace). ' +
         'Please re-run `/shapes auth` and copy the exact value of ' +
         '`__Secure-better-auth.session_token` from DevTools — make sure you got the ' +

--- a/services/bot-client/src/commands/voice/index.ts
+++ b/services/bot-client/src/commands/voice/index.ts
@@ -17,6 +17,8 @@ import {
   type StringSelectMenuInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { renderSpec } from '../../ux/render/render.js';
 import { defineCommand } from '../../utils/defineCommand.js';
 import { createTypedSubcommandRouter } from '../../utils/subcommandRouter.js';
 import type {
@@ -121,7 +123,9 @@ async function execute(context: SafeCommandContext): Promise<void> {
   }
 
   logger.warn({ group, subcommand }, 'Unknown voice subcommand');
-  await deferredCtx.editReply({ content: '❌ Unknown voice subcommand.' });
+  await deferredCtx.editReply({
+    content: renderSpec(CATALOG.error.validation('Unknown voice subcommand.')),
+  });
 }
 
 async function autocomplete(interaction: AutocompleteInteraction): Promise<void> {

--- a/services/bot-client/src/commands/voice/voices/browse.test.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.test.ts
@@ -261,7 +261,7 @@ describe('handleBrowseVoices', () => {
     await handleBrowseVoices(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ An unexpected error occurred. Please try again.',
+      content: '❌ Failed to load the voices. Please try again.',
     });
   });
 });

--- a/services/bot-client/src/commands/voice/voices/browse.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.ts
@@ -11,6 +11,8 @@ import {
   type ButtonBuilder,
 } from 'discord.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { classifyGatewayFailure } from '../../../ux/catalog/classify.js';
+import { renderSpec } from '../../../ux/render/render.js';
 import { type AudioProviderId } from '@tzurot/common-types/types/audio-provider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
@@ -168,7 +170,9 @@ export async function handleBrowseVoices(context: DeferredCommandContext): Promi
     const result = await userClient.listVoices();
 
     if (!result.ok) {
-      await context.editReply({ content: `❌ ${result.error}` });
+      await context.editReply({
+        content: renderSpec(classifyGatewayFailure(result, 'voices', { operation: 'read' })),
+      });
       return;
     }
 
@@ -178,7 +182,9 @@ export async function handleBrowseVoices(context: DeferredCommandContext): Promi
     logger.info({ userId, voiceCount: result.data.voices.length }, 'Listed voices');
   } catch (error) {
     logger.error({ err: error, userId }, 'Unexpected error');
-    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+    await context.editReply({
+      content: renderSpec(classifyGatewayFailure(error, 'voices', { operation: 'read' })),
+    });
   }
 }
 
@@ -204,7 +210,11 @@ export async function handleVoiceBrowsePagination(interaction: ButtonInteraction
     const result = await userClient.listVoices();
 
     if (!result.ok) {
-      await interaction.editReply({ content: `❌ ${result.error}`, embeds: [], components: [] });
+      await interaction.editReply({
+        content: renderSpec(classifyGatewayFailure(result, 'voices', { operation: 'read' })),
+        embeds: [],
+        components: [],
+      });
       return;
     }
 

--- a/services/bot-client/src/commands/voice/voices/clear.test.ts
+++ b/services/bot-client/src/commands/voice/voices/clear.test.ts
@@ -176,7 +176,7 @@ describe('handleClearVoices', () => {
     await handleClearVoices(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ An unexpected error occurred. Please try again.',
+      content: '❌ Failed to clear your voices. Please try again.',
     });
   });
 });

--- a/services/bot-client/src/commands/voice/voices/clear.ts
+++ b/services/bot-client/src/commands/voice/voices/clear.ts
@@ -10,6 +10,8 @@
  */
 
 import { EmbedBuilder, type ButtonInteraction, type ModalSubmitInteraction } from 'discord.js';
+import { classifyGatewayFailure } from '../../../ux/catalog/classify.js';
+import { renderSpec } from '../../../ux/render/render.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
@@ -26,6 +28,9 @@ import { invalidateVoiceCache } from './voiceCache.js';
 
 const logger = createLogger('voice-voices-clear');
 
+/** Shared failedAction verb for the clear-voices classify paths. */
+const CLEAR_VOICES_ACTION = 'clear your voices';
+
 /** Operation name for destructive confirmation custom IDs */
 export const VOICE_CLEAR_OPERATION = 'voice-clear';
 
@@ -41,7 +46,11 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
     const result = await userClient.listVoices();
 
     if (!result.ok) {
-      await context.editReply({ content: `❌ ${result.error}` });
+      await context.editReply({
+        content: renderSpec(
+          classifyGatewayFailure(result, 'voices', { failedAction: CLEAR_VOICES_ACTION })
+        ),
+      });
       return;
     }
 
@@ -75,7 +84,11 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
     logger.info({ userId, voiceCount: count }, 'Showing confirmation');
   } catch (error) {
     logger.error({ err: error, userId }, 'Unexpected error');
-    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+    await context.editReply({
+      content: renderSpec(
+        classifyGatewayFailure(error, 'voices', { failedAction: CLEAR_VOICES_ACTION })
+      ),
+    });
   }
 }
 
@@ -108,7 +121,12 @@ export async function handleVoiceClearModalSubmit(
     const result = await userClient.clearVoices();
 
     if (!result.ok) {
-      return { success: false, errorMessage: `❌ ${result.error}` };
+      return {
+        success: false,
+        errorMessage: renderSpec(
+          classifyGatewayFailure(result, 'voices', { failedAction: CLEAR_VOICES_ACTION })
+        ),
+      };
     }
 
     const { deleted, total, errors } = result.data;

--- a/services/bot-client/src/commands/voice/voices/delete.test.ts
+++ b/services/bot-client/src/commands/voice/voices/delete.test.ts
@@ -148,7 +148,7 @@ describe('handleDeleteVoice', () => {
     await handleDeleteVoice(createMockContext('elevenlabs:voice-1'));
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ An unexpected error occurred. Please try again.',
+      content: '❌ Failed to delete the voice. Please try again.',
     });
   });
 });

--- a/services/bot-client/src/commands/voice/voices/delete.ts
+++ b/services/bot-client/src/commands/voice/voices/delete.ts
@@ -8,6 +8,9 @@
  */
 
 import { EmbedBuilder, type AutocompleteInteraction } from 'discord.js';
+import { CATALOG } from '../../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../../ux/catalog/classify.js';
+import { renderSpec } from '../../../ux/render/render.js';
 import { DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
 import { isAudioProviderId, type AudioProviderId } from '@tzurot/common-types/types/audio-provider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -45,8 +48,11 @@ export async function handleDeleteVoice(context: DeferredCommandContext): Promis
   const parsed = parseVoiceOption(optionValue);
   if (parsed === null) {
     await context.editReply({
-      content:
-        '❌ Invalid voice selection. Please re-run the command and pick a voice from the autocomplete list.',
+      content: renderSpec(
+        CATALOG.error.validation(
+          'Invalid voice selection. Please re-run the command and pick a voice from the autocomplete list.'
+        )
+      ),
     });
     return;
   }
@@ -56,7 +62,11 @@ export async function handleDeleteVoice(context: DeferredCommandContext): Promis
     const result = await userClient.deleteVoice(parsed.provider, parsed.voiceId);
 
     if (!result.ok) {
-      await context.editReply({ content: `❌ ${result.error}` });
+      await context.editReply({
+        content: renderSpec(
+          classifyGatewayFailure(result, 'voice', { failedAction: 'delete the voice' })
+        ),
+      });
       return;
     }
 
@@ -77,7 +87,11 @@ export async function handleDeleteVoice(context: DeferredCommandContext): Promis
     );
   } catch (error) {
     logger.error({ err: error, userId }, 'Unexpected error');
-    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+    await context.editReply({
+      content: renderSpec(
+        classifyGatewayFailure(error, 'voice', { failedAction: 'delete the voice' })
+      ),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

**UX boulder Phase 1, PR-D3c** — the shapes, channel, and voice command families. Ratchet **193 → 153**.

### Swept (12 files)

- **shapes**: `modal` (rich cookie-auth error blocks via strip-glyph-and-wrap, all ❌-severity so no divergence), `logout`, `import`, `interactionHandlers`
- **channel**: `activate`, `browse`, `settings`, `deactivate`
- **voice**: `index`, `voices/{delete,clear,browse}`

### Read/write catch discipline (audited per file at authoring time)

Every classified catch was checked for scope before pushing:
- **Writes** (`failedAction`): activate, deactivate, voice delete, voice clear, shapes credential-save/remove.
- **Reads** (`operation: 'read'`): channel browse, channel settings dashboard-open, shapes import, voice browse.

notFound gets `escapeMarkdown` on the interpolated slug; the "All Servers" and Manage-Messages guards become `permissionDenied`.

### Deliberate exemption: embed-titled error surfaces

`shapes/import` renders failures as a Discord embed (`.setTitle('❌ Import Failed')` + description), not a content string. The catalog's `renderSpec` produces content strings, not `EmbedBuilder` titles — so these two ❌ literals stay. An embed-spec renderer is a Phase-2+ concern (same shape as the list-collapse exemption).

## Verification

shapes/channel/voice families 346/346, full bot-client 5297/5297, component tier 30/30, quality green (sanctioned baseline refresh).

Train: A–D2 ✅ · D3a ✅ · D3b ✅ · **D3c this** · D3d (admin/models/history/help/inspect/deny) → E remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)