### PR TITLE
feat(ai-worker): retrieve extracted facts into the prompt (memory phase 2, slice 4a)

### DIFF
--- a/packages/common-types/src/config/config.ts
+++ b/packages/common-types/src/config/config.ts
@@ -62,6 +62,10 @@ export const envSchema = z.object({
     .enum(['true', 'false'])
     .optional()
     .or(z.literal('').transform(() => undefined)), // 'true' enables async fact extraction (memory Phase 2 shadow mode; default off)
+  FACTS_IN_PROMPT_ENABLED: z
+    .enum(['true', 'false'])
+    .optional()
+    .or(z.literal('').transform(() => undefined)), // 'true' injects extracted facts into the generation prompt (memory Phase 2 slice 4a; dev-on/prod-off until the quality gate + correction surface land)
   EXTRACTION_BATCH_THRESHOLD: z.coerce.number().int().min(1).max(50).default(6), // episodes per (channel, personality) before an extraction batch enqueues
   // Fair-share quota for the SHARED system OpenRouter free-tier key (guests +
   // credit-exhausted-BYOK fallback). Rolling-window per-user cap that shrinks as
@@ -236,6 +240,7 @@ export function createTestConfig(overrides: Partial<EnvConfig> = {}): EnvConfig 
     AUTO_DEPLOY_COMMANDS: undefined,
     AUTO_TRANSCRIBE_VOICE: undefined,
     EXTRACTION_ENABLED: undefined,
+    FACTS_IN_PROMPT_ENABLED: undefined,
     EXTRACTION_BATCH_THRESHOLD: 6,
     FREE_TIER_GLOBAL_DAILY_BUDGET: 1000,
     FREE_TIER_WINDOW_MINUTES: 60,

--- a/packages/common-types/src/utils/promptSanitizer.ts
+++ b/packages/common-types/src/utils/promptSanitizer.ts
@@ -45,6 +45,10 @@ export const PROTECTED_TAGS = [
   'character',
   'identity_constraints',
   'constraint',
+  // Distilled-fact block (Phase 2 slice 4a) — a user statement escaping <facts>
+  // reaches top-level system scope, same boundary class as memory_archive.
+  'facts',
+  'fact',
   // Conversation-history ancestors (a user message must not forge these)
   'prior_conversations',
   'channel_history',

--- a/services/ai-worker/src/services/ContentBudgetManager.test.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.test.ts
@@ -354,4 +354,51 @@ describe('ContentBudgetManager', () => {
       expect(call[4]).toBeUndefined(); // 5th arg = undefined when no environment
     });
   });
+
+  // Fixed mocks: calculateMemoryBudget → 1000, countTokens → 100 for every
+  // string. So the fact sub-budget = min(600, floor(1000*0.3)) = 300; wrapper
+  // (100) + fact (100) each → exactly 2 facts fit (100+100+100=300), episodes
+  // get 1000-300 = 700.
+  describe('reserved fact sub-budget (Phase 2 slice 4a)', () => {
+    const withFacts = (n: number): BudgetAllocationOptions => ({
+      personality: mockPersonality,
+      processedPersonality: mockPersonality,
+      participantPersonas: new Map(),
+      retrievedMemories: [],
+      facts: Array.from({ length: n }, (_, i) => ({ statement: `fact ${i}` })),
+      context: { userId: 'u', channelId: 'c' },
+      userMessage: 'hi',
+      processedAttachments: [],
+      referencedMessagesDescriptions: undefined,
+      effectiveContextWindowTokens: 8000,
+    });
+
+    it('selects facts within the reserved slice and reduces the episode budget by exactly that cost', () => {
+      const result = budgetManager.allocate(withFacts(3));
+
+      // 2 of 3 facts fit the 300-token slice; factTokensUsed = 300.
+      expect(result.selectedFacts).toHaveLength(2);
+      expect(result.factTokensUsed).toBe(300);
+      // Episodes got the remainder (1000 - 300 = 700), NOT the full 1000 —
+      // facts don't come for free but also don't starve episodes.
+      const episodeBudget = vi.mocked(mockContextWindowManager.selectMemoriesWithinBudget).mock
+        .calls[0][1];
+      expect(episodeBudget).toBe(700);
+      // The selected facts cross the seam into the prompt build.
+      const promptFacts = vi
+        .mocked(mockPromptBuilder.buildFullSystemPrompt)
+        .mock.calls.at(-1)?.[0].facts;
+      expect(promptFacts).toHaveLength(2);
+    });
+
+    it('no facts → episodes keep the full memory budget, factTokensUsed 0', () => {
+      const result = budgetManager.allocate(withFacts(0));
+
+      expect(result.selectedFacts).toEqual([]);
+      expect(result.factTokensUsed).toBe(0);
+      const episodeBudget = vi.mocked(mockContextWindowManager.selectMemoriesWithinBudget).mock
+        .calls[0][1];
+      expect(episodeBudget).toBe(1000); // untouched
+    });
+  });
 });

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -11,13 +11,25 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { contentToText } from '../utils/baseMessageContent.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ContextWindowManager } from './context/ContextWindowManager.js';
+import { formatSingleFact, getFactsWrapperOverheadText } from './prompt/MemoryFormatter.js';
 import type {
   BudgetAllocationOptions,
   BudgetAllocationResult,
+  FactForPrompt,
   MemoryDocument,
 } from './ConversationalRAGTypes.js';
 
 const logger = createLogger('ContentBudgetManager');
+
+/**
+ * Reserved fact sub-budget (Phase 2 slice 4a). Facts are short/dense and would
+ * otherwise crowd verbose episodes out of the shared memory budget (council).
+ * They get a capped slice — at most `FACT_BUDGET_MAX_TOKENS`, and never more
+ * than `FACT_BUDGET_MAX_FRACTION` of the memory budget — so episodes always
+ * keep the majority; the rest of the memory budget goes to episodes.
+ */
+const FACT_BUDGET_MAX_TOKENS = 600;
+const FACT_BUDGET_MAX_FRACTION = 0.3;
 
 export class ContentBudgetManager {
   constructor(
@@ -48,8 +60,14 @@ export class ContentBudgetManager {
       contentToText(currentMessage.content)
     );
 
-    // Select memories within budget
-    const { relevantMemories, memoryTokensUsed, memoriesDroppedCount } = this.selectMemories(
+    // Select memories + facts within budget (facts get a reserved sub-budget)
+    const {
+      relevantMemories,
+      memoryTokensUsed,
+      memoriesDroppedCount,
+      selectedFacts,
+      factTokensUsed,
+    } = this.selectMemories(
       opts,
       contextWindowTokens,
       systemPromptBaseTokens,
@@ -71,6 +89,7 @@ export class ContentBudgetManager {
       personality: processedPersonality,
       participantPersonas,
       relevantMemories,
+      facts: selectedFacts,
       context,
       referencedMessagesFormatted: opts.referencedMessagesDescriptions,
       serializedHistory,
@@ -91,9 +110,11 @@ export class ContentBudgetManager {
 
     return {
       relevantMemories,
+      selectedFacts,
       serializedHistory,
       systemPrompt,
       memoryTokensUsed,
+      factTokensUsed,
       historyTokensUsed,
       memoriesDroppedCount,
       messagesDropped,
@@ -156,6 +177,8 @@ export class ContentBudgetManager {
     relevantMemories: MemoryDocument[];
     memoryTokensUsed: number;
     memoriesDroppedCount: number;
+    selectedFacts: FactForPrompt[];
+    factTokensUsed: number;
   } {
     const { personality, retrievedMemories, context } = opts;
     const historyTokens = this.contextWindowManager.countHistoryTokens(
@@ -170,6 +193,11 @@ export class ContentBudgetManager {
       historyTokens
     );
 
+    // Facts take their reserved slice FIRST; episodes get the remainder — so a
+    // dense cluster of short facts can't starve verbose episodes, and vice versa.
+    const { selectedFacts, factTokensUsed } = this.selectFacts(opts.facts ?? [], memoryBudget);
+    const episodeBudget = Math.max(0, memoryBudget - factTokensUsed);
+
     const {
       selectedMemories: relevantMemories,
       tokensUsed: memoryTokensUsed,
@@ -177,25 +205,69 @@ export class ContentBudgetManager {
       droppedDueToSize,
     } = this.contextWindowManager.selectMemoriesWithinBudget(
       retrievedMemories,
-      memoryBudget,
+      episodeBudget,
       context.userTimezone
     );
 
-    if (memoriesDroppedCount > 0) {
+    if (memoriesDroppedCount > 0 || selectedFacts.length > 0) {
       logger.info(
         {
           kept: relevantMemories.length,
           total: retrievedMemories.length,
           tokensUsed: memoryTokensUsed,
           budget: memoryBudget,
+          episodeBudget,
           dropped: memoriesDroppedCount,
           oversized: droppedDueToSize,
+          factsKept: selectedFacts.length,
+          factsRetrieved: opts.facts?.length ?? 0,
+          factTokensUsed,
         },
         'Memory budget applied'
       );
     }
 
-    return { relevantMemories, memoryTokensUsed, memoriesDroppedCount };
+    return {
+      relevantMemories,
+      memoryTokensUsed,
+      memoriesDroppedCount,
+      selectedFacts,
+      factTokensUsed,
+    };
+  }
+
+  /**
+   * Select facts within the reserved fact sub-budget (capped fraction of the
+   * memory budget). Greedy by retrieval order (already sorted by
+   * distance→recency→salience), counting the `<facts>` wrapper overhead so the
+   * block never overflows its slice. Zero facts selected → zero tokens (the
+   * empty block renders nothing).
+   */
+  private selectFacts(
+    facts: FactForPrompt[],
+    memoryBudget: number
+  ): { selectedFacts: FactForPrompt[]; factTokensUsed: number } {
+    if (facts.length === 0) {
+      return { selectedFacts: [], factTokensUsed: 0 };
+    }
+    const factBudget = Math.min(
+      FACT_BUDGET_MAX_TOKENS,
+      Math.floor(memoryBudget * FACT_BUDGET_MAX_FRACTION)
+    );
+    const wrapperOverhead = this.promptBuilder.countTokens(getFactsWrapperOverheadText());
+    const selected: FactForPrompt[] = [];
+    let used = wrapperOverhead;
+    for (const fact of facts) {
+      const factTokens = this.promptBuilder.countTokens(formatSingleFact(fact));
+      if (used + factTokens > factBudget) {
+        break;
+      }
+      selected.push(fact);
+      used += factTokens;
+    }
+    return selected.length > 0
+      ? { selectedFacts: selected, factTokensUsed: used }
+      : { selectedFacts: [], factTokensUsed: 0 };
   }
 
   private selectHistory(

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -90,6 +90,13 @@ vi.mock('./storedReferenceHydrator.js', () => ({
 vi.mock('./multimodal/visionAuthResolver.js', () => ({
   resolveVisionConfig: mockResolveVisionConfig,
 }));
+// Fact-retrieval gate mocked so the wiring (personaId in, facts out) is
+// assertable without the flag/embedding/DB path. Default: no facts (existing
+// tests see facts: []).
+vi.mock('./factRetrievalHelper.js', () => ({
+  retrieveFactsForPrompt: vi.fn().mockResolvedValue([]),
+  createFactRetriever: vi.fn().mockReturnValue(undefined),
+}));
 
 // Import mock accessors and fixtures (after vi.mock declarations)
 import {
@@ -107,6 +114,7 @@ import {
   resetAllMocks,
 } from '../test/mocks/index.js';
 import { checkModelContextLength } from '../redis.js';
+import { retrieveFactsForPrompt } from './factRetrievalHelper.js';
 
 // Prisma is injected into the constructor, but every DB-touching child
 // (MemoryRetriever, LongTermMemoryService, UserReferenceResolver) is mocked
@@ -120,6 +128,9 @@ describe('ConversationalRAGService', () => {
     vi.clearAllMocks();
     // Restore default mock implementations after mockReset clears them
     resetAllMocks();
+    // clearAllMocks resets call history but NOT implementations — restore the
+    // no-facts default so a test that opts into facts can't leak into the next.
+    vi.mocked(retrieveFactsForPrompt).mockResolvedValue([]);
     // Create service - this populates the mock instances via constructors
     service = new ConversationalRAGService(mockPrisma);
   });
@@ -322,11 +333,42 @@ describe('ConversationalRAGService', () => {
         personality,
         participantPersonas: expect.any(Map),
         relevantMemories: memories,
+        facts: [],
         context,
         referencedMessagesFormatted: undefined,
         serializedHistory: expect.anything(),
       });
       expect(result.retrievedMemories).toBe(2);
+    });
+
+    it('flag-ON wiring: resolved personaId flows into fact retrieval; returned facts reach the prompt', async () => {
+      // The seam that every other test leaves at facts:[] — a dropped facts
+      // field, a wrong personaId, or an arg-order mismatch would pass them all.
+      const facts = [{ statement: 'user is allergic to shellfish' }];
+      vi.mocked(retrieveFactsForPrompt).mockResolvedValue(facts);
+      getMemoryRetrieverMock().retrieveRelevantMemories.mockResolvedValue({
+        memories: [],
+        focusModeEnabled: false,
+        personaId: 'persona-x',
+      });
+      const personality = createMockPersonality();
+      const context = createMockContext();
+
+      await service.generateResponse(personality, 'what am i allergic to?', context);
+
+      // personality.id + the MemoryRetriever-resolved personaId + the query cross
+      // into the gate in the right order.
+      expect(retrieveFactsForPrompt).toHaveBeenCalledWith(
+        undefined, // factRetriever (createFactRetriever mocked → undefined)
+        personality.id,
+        'persona-x',
+        expect.any(String)
+      );
+      // The non-empty facts flow through the REAL ContentBudgetManager into the
+      // prompt's <facts> block (default budget mocks let one fact fit).
+      expect(getPromptBuilderMock().buildFullSystemPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({ facts })
+      );
     });
 
     it('should include participant personas in system prompt', async () => {
@@ -344,6 +386,7 @@ describe('ConversationalRAGService', () => {
         personality,
         participantPersonas: participantMap,
         relevantMemories: expect.any(Array),
+        facts: [],
         context,
         referencedMessagesFormatted: undefined,
         serializedHistory: expect.anything(),
@@ -745,6 +788,7 @@ describe('ConversationalRAGService', () => {
         personality,
         participantPersonas: expect.any(Map),
         relevantMemories: expect.any(Array),
+        facts: [],
         context,
         referencedMessagesFormatted: 'formatted references',
         serializedHistory: expect.anything(),

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -23,6 +23,8 @@ import { validateAIProvider } from '../utils/providerValidation.js';
 import { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
 import { LLMInvoker } from './LLMInvoker.js';
 import { MemoryRetriever } from './MemoryRetriever.js';
+import type { FactRetriever } from './FactRetriever.js';
+import { retrieveFactsForPrompt, createFactRetriever } from './factRetrievalHelper.js';
 import { PromptBuilder } from './PromptBuilder.js';
 import { LongTermMemoryService } from './LongTermMemoryService.js';
 import type { ExtractionTrigger } from './extraction/ExtractionTrigger.js';
@@ -61,6 +63,7 @@ const logger = createLogger('ConversationalRAGService');
 export class ConversationalRAGService {
   private llmInvoker: LLMInvoker;
   private memoryRetriever: MemoryRetriever;
+  private factRetriever?: FactRetriever;
   private promptBuilder: PromptBuilder;
   private referencedMessageFormatter: ReferencedMessageFormatter;
   private contextWindowManager: ContextWindowManager;
@@ -79,6 +82,9 @@ export class ConversationalRAGService {
   ) {
     this.llmInvoker = new LLMInvoker();
     this.memoryRetriever = new MemoryRetriever(prisma, memoryManager, personaResolver);
+    // Fact retrieval (Phase 2 slice 4a); undefined without a memory manager,
+    // gated at call time by FACTS_IN_PROMPT_ENABLED.
+    this.factRetriever = createFactRetriever(prisma, memoryManager);
     this.promptBuilder = new PromptBuilder();
     const longTermMemory = new LongTermMemoryService(prisma, memoryManager, extractionTrigger);
     this.referencedMessageFormatter = new ReferencedMessageFormatter();
@@ -376,13 +382,30 @@ export class ConversationalRAGService {
       const qTruncated = inputs.searchQuery.length > TEXT_LIMITS.LOG_PREVIEW;
       logger.info({ queryPreview: qPreview, truncated: qTruncated }, 'Memory search query');
       diagnosticCollector?.markMemoryRetrievalStart();
-      const { memories: retrievedMemories, focusModeEnabled } =
-        await this.memoryRetriever.retrieveRelevantMemories(
-          personality,
-          inputs.searchQuery,
-          context,
-          configOverrides
-        );
+      const {
+        memories: retrievedMemories,
+        focusModeEnabled,
+        personaId,
+      } = await this.memoryRetriever.retrieveRelevantMemories(
+        personality,
+        inputs.searchQuery,
+        context,
+        configOverrides
+      );
+
+      // Retrieve distilled facts for the same scope (Phase 2 slice 4a). Inherits
+      // the retriever's skip decisions: `personaId` is undefined when LTM was
+      // skipped (incognito/focus/no-persona), so facts are skipped too.
+      // NOTE: facts always scope to `personality.id`, deliberately NOT widened by
+      // `shareLtmAcrossPersonalities` the way EPISODE retrieval is — facts stay
+      // private persona×personality in Phase 2; cross-personality fact sharing is
+      // a later phase, not a bug to "fix".
+      const facts = await retrieveFactsForPrompt(
+        this.factRetriever,
+        personality.id,
+        personaId,
+        inputs.searchQuery
+      );
 
       // Step 4: Allocate token budgets and select content
       // Note: Image descriptions and stored reference hydration are handled by
@@ -396,6 +419,7 @@ export class ConversationalRAGService {
         processedPersonality,
         participantPersonas,
         retrievedMemories,
+        facts,
         context,
         userMessage: inputs.userMessage,
         processedAttachments: inputs.processedAttachments,

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -245,12 +245,25 @@ export interface PersonaLoadResult {
   processedPersonality: LoadedPersonality;
 }
 
+/**
+ * A distilled fact for prompt rendering — just the atomic statement. Minimal
+ * by design (decoupled from the retrieval-layer `SimilarFact`) so the formatter
+ * and budget manager only depend on what they render. Phase 2 slice 4a.
+ */
+export interface FactForPrompt {
+  statement: string;
+}
+
 /** Result of token budget calculation and content selection */
 export interface BudgetAllocationResult {
   relevantMemories: MemoryDocument[];
+  /** Facts selected within the reserved fact sub-budget (Phase 2 slice 4a). */
+  selectedFacts: FactForPrompt[];
   serializedHistory: string;
   systemPrompt: BaseMessage;
   memoryTokensUsed: number;
+  /** Tokens consumed by the `<facts>` block (wrapper + statements). */
+  factTokensUsed: number;
   historyTokensUsed: number;
   memoriesDroppedCount: number;
   messagesDropped: number;
@@ -280,6 +293,8 @@ export interface BudgetAllocationOptions {
   processedPersonality: LoadedPersonality;
   participantPersonas: Map<string, ParticipantInfo>;
   retrievedMemories: MemoryDocument[];
+  /** Retrieved active facts (Phase 2 slice 4a); the reserved fact sub-budget trims them. */
+  facts?: FactForPrompt[];
   context: ConversationContext;
   userMessage: string;
   processedAttachments: ProcessedAttachment[];

--- a/services/ai-worker/src/services/FactRetriever.test.ts
+++ b/services/ai-worker/src/services/FactRetriever.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FactRetriever, FACT_RETRIEVAL_LIMIT } from './FactRetriever.js';
+import type { FactStore, SimilarFact } from './extraction/FactStore.js';
+
+const EMBEDDING = [0.1, 0.2, 0.3];
+
+function makeFacts(...statements: string[]): SimilarFact[] {
+  return statements.map((statement, i) => ({
+    id: `fact-${i}`,
+    statement,
+    entityTags: [],
+    similarity: 0.9 - i * 0.01,
+    isLocked: false,
+  }));
+}
+
+/** Mock FactStore exposing only the two methods FactRetriever uses. */
+function makeFactStore(
+  overrides: Partial<
+    Record<'embedStatement' | 'findSimilarActiveFacts', ReturnType<typeof vi.fn>>
+  > = {}
+): {
+  factStore: FactStore;
+  embedStatement: ReturnType<typeof vi.fn>;
+  findSimilarActiveFacts: ReturnType<typeof vi.fn>;
+} {
+  const embedStatement = overrides.embedStatement ?? vi.fn().mockResolvedValue(EMBEDDING);
+  const findSimilarActiveFacts =
+    overrides.findSimilarActiveFacts ?? vi.fn().mockResolvedValue(makeFacts('user likes tea'));
+  return {
+    factStore: { embedStatement, findSimilarActiveFacts } as unknown as FactStore,
+    embedStatement,
+    findSimilarActiveFacts,
+  };
+}
+
+describe('FactRetriever', () => {
+  it('embeds the query and queries facts scoped to persona×personality', async () => {
+    const { factStore, embedStatement, findSimilarActiveFacts } = makeFactStore();
+    const retriever = new FactRetriever(factStore);
+
+    const facts = await retriever.retrieveFacts('what does the user like?', 'pers-1', 'persona-1');
+
+    expect(embedStatement).toHaveBeenCalledWith('what does the user like?');
+    // Assert the args crossing the seam — scope + the embedding + default limit.
+    expect(findSimilarActiveFacts).toHaveBeenCalledWith(
+      EMBEDDING,
+      'pers-1',
+      'persona-1',
+      FACT_RETRIEVAL_LIMIT
+    );
+    expect(facts.map(f => f.statement)).toEqual(['user likes tea']);
+  });
+
+  it('passes a null persona through (world/canon facts)', async () => {
+    const { factStore, findSimilarActiveFacts } = makeFactStore();
+    const retriever = new FactRetriever(factStore);
+
+    await retriever.retrieveFacts('q', 'pers-1', null, 3);
+
+    expect(findSimilarActiveFacts).toHaveBeenCalledWith(EMBEDDING, 'pers-1', null, 3);
+  });
+
+  it('fails soft — returns [] when embedding throws (generation must not break)', async () => {
+    const { factStore, findSimilarActiveFacts } = makeFactStore({
+      embedStatement: vi.fn().mockRejectedValue(new Error('embedding service not ready')),
+    });
+    const retriever = new FactRetriever(factStore);
+
+    const facts = await retriever.retrieveFacts('q', 'pers-1', 'persona-1');
+
+    expect(facts).toEqual([]);
+    expect(findSimilarActiveFacts).not.toHaveBeenCalled();
+  });
+
+  it('fails soft — returns [] when the query throws', async () => {
+    const { factStore } = makeFactStore({
+      findSimilarActiveFacts: vi.fn().mockRejectedValue(new Error('db down')),
+    });
+    const retriever = new FactRetriever(factStore);
+
+    expect(await retriever.retrieveFacts('q', 'pers-1', 'persona-1')).toEqual([]);
+  });
+});

--- a/services/ai-worker/src/services/FactRetriever.ts
+++ b/services/ai-worker/src/services/FactRetriever.ts
@@ -1,0 +1,60 @@
+/**
+ * Generation-time fact retrieval (memory-architecture Phase 2, slice 4a).
+ *
+ * Mirrors `MemoryRetriever` but for extracted atomic FACTS: given the search
+ * query, returns the top-K active facts scoped to the current
+ * persona×personality (the private pool — community/canon pool blending is
+ * Phase 3), for injection into the prompt's `<facts>` block.
+ *
+ * Reuses `FactStore.findSimilarActiveFacts` (active-only: superseded/forgotten
+ * facts are filtered in SQL) with its recency/salience tiebreak, so a
+ * stale-but-similar fact can't outrank a recent correction.
+ *
+ * **Config-free by design**: the `FACTS_IN_PROMPT_ENABLED` flag gate lives at
+ * the caller (`ConversationalRAGService`), so this stays a pure retrieval unit.
+ *
+ * **Fail-soft**: facts are additive context, never load-bearing — any error
+ * (embedding not ready, query failure) returns `[]` rather than breaking
+ * generation, matching the rest of the memory pipeline's degrade-don't-crash
+ * posture.
+ */
+
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import type { FactStore, SimilarFact } from './extraction/FactStore.js';
+
+const logger = createLogger('FactRetriever');
+
+/** Top-K active facts to fetch before the reserved fact sub-budget truncates. */
+export const FACT_RETRIEVAL_LIMIT = 10;
+
+export class FactRetriever {
+  constructor(private readonly factStore: FactStore) {}
+
+  /**
+   * Top active facts most similar to `query`, scoped to persona×personality.
+   * Returns `[]` on any failure (fail-soft). `personaId` null = world/canon
+   * facts (no persona).
+   */
+  async retrieveFacts(
+    query: string,
+    personalityId: string,
+    personaId: string | null,
+    limit: number = FACT_RETRIEVAL_LIMIT
+  ): Promise<SimilarFact[]> {
+    try {
+      const embedding = await this.factStore.embedStatement(query);
+      return await this.factStore.findSimilarActiveFacts(
+        embedding,
+        personalityId,
+        personaId,
+        limit
+      );
+    } catch (error) {
+      logger.warn(
+        { err: error, personalityId },
+        'Fact retrieval failed — returning no facts (generation degrades gracefully)'
+      );
+      return [];
+    }
+  }
+}

--- a/services/ai-worker/src/services/MemoryRetriever.test.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.test.ts
@@ -604,7 +604,11 @@ describe('MemoryRetriever', () => {
         context
       );
 
-      expect(result).toEqual({ memories: mockMemories, focusModeEnabled: false });
+      expect(result).toEqual({
+        memories: mockMemories,
+        focusModeEnabled: false,
+        personaId: 'persona-123',
+      });
       // Should query memories when focus mode is off
       expect(mockMemoryManager.queryMemories).toHaveBeenCalled();
     });
@@ -627,7 +631,9 @@ describe('MemoryRetriever', () => {
         context
       );
 
-      expect(result).toEqual({ memories: [], focusModeEnabled: false });
+      // No memory manager → no episodes, but the persona still resolves (facts
+      // path in ConversationalRAGService inherits this personaId).
+      expect(result).toEqual({ memories: [], focusModeEnabled: false, personaId: 'persona-123' });
     });
 
     it('should query memories with correct parameters', async () => {
@@ -663,7 +669,11 @@ describe('MemoryRetriever', () => {
         context
       );
 
-      expect(result).toEqual({ memories: mockMemories, focusModeEnabled: false });
+      expect(result).toEqual({
+        memories: mockMemories,
+        focusModeEnabled: false,
+        personaId: 'persona-123',
+      });
       expect(mockMemoryManager.queryMemories).toHaveBeenCalledWith('What food do I like?', {
         personaId: 'persona-123',
         personalityId: 'personality-123',

--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -30,6 +30,13 @@ const logger = createLogger('MemoryRetriever');
 interface MemoryRetrievalResult {
   memories: MemoryDocument[];
   focusModeEnabled: boolean;
+  /**
+   * The resolved persona for this turn — present ONLY when LTM retrieval
+   * actually ran. Undefined when retrieval was skipped (incognito, focus mode,
+   * or no persona), so the fact-retrieval path (Phase 2 slice 4a) inherits the
+   * exact same scope AND the same skip decisions from one source of truth.
+   */
+  personaId?: string;
 }
 
 export class MemoryRetriever {
@@ -232,7 +239,7 @@ export class MemoryRetriever {
 
     this.logRetrievedMemories(relevantMemories, personality.name);
 
-    return { memories: relevantMemories, focusModeEnabled: false };
+    return { memories: relevantMemories, focusModeEnabled: false, personaId };
   }
 
   /**

--- a/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
+++ b/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
@@ -54,6 +54,15 @@ export class PgvectorMemoryAdapter {
   }
 
   /**
+   * The shared local embedding service, so sibling retrievers (e.g. the
+   * generation-side `FactRetriever`, slice 4a) can reuse the same embedder
+   * without a second instance.
+   */
+  getEmbeddingService(): IEmbeddingService {
+    return this.embeddingService;
+  }
+
+  /**
    * Query memories using vector similarity search
    */
   async queryMemories(

--- a/services/ai-worker/src/services/PromptBuilder.test.ts
+++ b/services/ai-worker/src/services/PromptBuilder.test.ts
@@ -547,6 +547,29 @@ describe('PromptBuilder', () => {
         expect(content).toContain('&lt;/character&gt;&lt;/system_identity&gt;');
       });
 
+      it('renders a <facts> block when facts are provided (Phase 2 slice 4a)', () => {
+        const result = promptBuilder.buildFullSystemPrompt({
+          personality: minimalPersonality,
+          participantPersonas: new Map(),
+          relevantMemories: [],
+          facts: [{ statement: 'user is allergic to shellfish' }],
+          context: minimalContext,
+        });
+        const content = result.content as string;
+        expect(content).toContain('<facts');
+        expect(content).toContain('<fact>user is allergic to shellfish</fact>');
+      });
+
+      it('omits the <facts> block entirely when no facts are provided', () => {
+        const result = promptBuilder.buildFullSystemPrompt({
+          personality: minimalPersonality,
+          participantPersonas: new Map(),
+          relevantMemories: [],
+          context: minimalContext,
+        });
+        expect(result.content as string).not.toContain('<facts');
+      });
+
       it('a malicious personality NAME cannot forge a top-level safety constraint', () => {
         // personality.name was previously interpolated raw into <role> and the
         // identity constraints. <role> is single-pass protected and <constraint>

--- a/services/ai-worker/src/services/PromptBuilder.ts
+++ b/services/ai-worker/src/services/PromptBuilder.ts
@@ -12,10 +12,11 @@ import type {
   MemoryDocument,
   ConversationContext,
   ParticipantInfo,
+  FactForPrompt,
 } from './ConversationalRAGTypes.js';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 import { formatParticipantsContext } from './prompt/ParticipantFormatter.js';
-import { formatMemoriesContext } from './prompt/MemoryFormatter.js';
+import { formatMemoriesContext, formatFactsContext } from './prompt/MemoryFormatter.js';
 import { formatPersonalityFields } from './prompt/PersonalityFieldsFormatter.js';
 import { formatEnvironmentContext } from './prompt/EnvironmentFormatter.js';
 import { extractContentDescriptions } from './RAGUtils.js';
@@ -41,6 +42,8 @@ interface BuildFullSystemPromptOptions {
   personality: LoadedPersonality;
   participantPersonas: Map<string, ParticipantInfo>;
   relevantMemories: MemoryDocument[];
+  /** Distilled active facts for the `<facts>` block (Phase 2 slice 4a; empty/absent = no block). */
+  facts?: FactForPrompt[];
   context: ConversationContext;
   referencedMessagesFormatted?: string;
   serializedHistory?: string;
@@ -245,6 +248,9 @@ ${locationXml}
       context.activePersonaName
     );
 
+    // Distilled active facts (Phase 2), rendered ahead of the historical archive.
+    const factsContext = formatFactsContext(options.facts ?? []);
+
     // Relevant memories from past interactions
     const memoryContext = formatMemoriesContext(relevantMemories, context.userTimezone);
 
@@ -279,7 +285,7 @@ ${serializedHistory}
     const outputConstraintsSection = `\n\n${OUTPUT_CONSTRAINTS}`;
 
     // Assemble in correct order using Sandwich Method
-    const fullSystemPrompt = `${identitySection}\n\n${identityConstraintsSection}\n\n${PLATFORM_CONSTRAINTS}${contextSection}${participantsContext}${memoryContext}${referencesContext}${chatLogSection}${protocolSection}${outputConstraintsSection}`;
+    const fullSystemPrompt = `${identitySection}\n\n${identityConstraintsSection}\n\n${PLATFORM_CONSTRAINTS}${contextSection}${participantsContext}${factsContext}${memoryContext}${referencesContext}${chatLogSection}${protocolSection}${outputConstraintsSection}`;
 
     // Basic prompt composition logging
     const historyLength = serializedHistory?.length ?? 0;

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
@@ -159,9 +159,11 @@ describe('DiagnosticRecorders', () => {
       const memories: MemoryDocument[] = [{ pageContent: 'a memory', metadata: {} }];
       const budgetResult: BudgetAllocationResult = {
         relevantMemories: memories,
+        selectedFacts: [],
         serializedHistory: '',
         systemPrompt: new SystemMessage('system prompt text'),
         memoryTokensUsed: 50,
+        factTokensUsed: 0,
         historyTokensUsed: 200,
         memoriesDroppedCount: 1,
         messagesDropped: 2,

--- a/services/ai-worker/src/services/extraction/FactStore.ts
+++ b/services/ai-worker/src/services/extraction/FactStore.ts
@@ -13,7 +13,7 @@
  */
 
 import { Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { LOCAL_EMBEDDING_DIMENSIONS, type LocalEmbeddingService } from '@tzurot/embeddings';
+import { LOCAL_EMBEDDING_DIMENSIONS, type IEmbeddingService } from '@tzurot/embeddings';
 import { generateMemoryFactUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { countTextTokens } from '@tzurot/common-types/utils/tokenCounter';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -55,7 +55,10 @@ export interface NewFact {
 export class FactStore {
   constructor(
     private readonly prisma: PrismaClient,
-    private readonly embeddingService: LocalEmbeddingService
+    // Interface, not the concrete LocalEmbeddingService — the generation-side
+    // FactRetriever (slice 4a) reuses this store with the shared adapter's
+    // embedder; only isServiceReady/getEmbedding are used.
+    private readonly embeddingService: IEmbeddingService
   ) {}
 
   /**
@@ -95,9 +98,18 @@ export class FactStore {
   }
 
   /**
-   * Top-K active facts by cosine similarity to `embedding` — the always-on
-   * supersession fallback (catches targets that fell outside the injected
-   * context window). Returns similarity as 1 - cosine distance.
+   * Top-K active facts by cosine similarity to `embedding`. Two callers:
+   * (1) the extraction supersession fallback (catches near-dup targets that
+   * fell outside the injected context window); (2) generation-time fact
+   * retrieval (`FactRetriever`, Phase 2 slice 4a). Returns similarity as
+   * 1 - cosine distance.
+   *
+   * Ordered by cosine distance, then `valid_from DESC, salience DESC` as
+   * tiebreakers so that among near-equidistant facts the most RECENT and most
+   * SALIENT wins — a stale-but-similar fact can't beat a recent correction.
+   * (This is a tiebreak, not composite scoring; full type/salience weighting
+   * is a later phase.) The tiebreak only reorders equal-distance rows, so it's
+   * inert for the supersession-fallback caller.
    */
   async findSimilarActiveFacts(
     embedding: number[],
@@ -133,7 +145,7 @@ export class FactStore {
           AND f.embedding IS NOT NULL
         ORDER BY f.embedding <=> `,
           Prisma.raw(`'${embeddingVector}'::vector`),
-          Prisma.sql` ASC
+          Prisma.sql` ASC, f.valid_from DESC, f.salience DESC
         LIMIT ${limit}
       `,
         ],

--- a/services/ai-worker/src/services/factRetrievalHelper.test.ts
+++ b/services/ai-worker/src/services/factRetrievalHelper.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { retrieveFactsForPrompt } from './factRetrievalHelper.js';
+import type { FactRetriever } from './FactRetriever.js';
+import type { SimilarFact } from './extraction/FactStore.js';
+
+vi.mock('@tzurot/common-types/config/config', () => ({ getConfig: vi.fn() }));
+
+function setFlag(value: 'true' | 'false' | undefined): void {
+  vi.mocked(getConfig).mockReturnValue({ FACTS_IN_PROMPT_ENABLED: value } as never);
+}
+
+function mockRetriever(): FactRetriever {
+  const facts: SimilarFact[] = [
+    { id: '1', statement: 'user likes tea', entityTags: [], similarity: 0.9, isLocked: false },
+  ];
+  return { retrieveFacts: vi.fn().mockResolvedValue(facts) } as unknown as FactRetriever;
+}
+
+describe('retrieveFactsForPrompt (flag/scope gate)', () => {
+  beforeEach(() => setFlag('true'));
+
+  it('returns [] and never queries when the flag is off (prod default)', async () => {
+    setFlag(undefined);
+    const retriever = mockRetriever();
+    expect(await retrieveFactsForPrompt(retriever, 'pers', 'persona', 'q')).toEqual([]);
+    expect(retriever.retrieveFacts).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when no retriever is wired (no memory manager)', async () => {
+    expect(await retrieveFactsForPrompt(undefined, 'pers', 'persona', 'q')).toEqual([]);
+  });
+
+  it('returns [] and never queries when personaId is undefined (LTM skipped this turn)', async () => {
+    const retriever = mockRetriever();
+    expect(await retrieveFactsForPrompt(retriever, 'pers', undefined, 'q')).toEqual([]);
+    expect(retriever.retrieveFacts).not.toHaveBeenCalled();
+  });
+
+  it('queries scoped to persona×personality when flag on + retriever + personaId present', async () => {
+    const retriever = mockRetriever();
+    const facts = await retrieveFactsForPrompt(retriever, 'pers', 'persona', 'what do i like?');
+    expect(retriever.retrieveFacts).toHaveBeenCalledWith('what do i like?', 'pers', 'persona');
+    expect(facts.map(f => f.statement)).toEqual(['user likes tea']);
+  });
+});

--- a/services/ai-worker/src/services/factRetrievalHelper.ts
+++ b/services/ai-worker/src/services/factRetrievalHelper.ts
@@ -1,0 +1,57 @@
+/**
+ * Generation-time fact-retrieval gate (Phase 2 slice 4a).
+ *
+ * Extracted from `ConversationalRAGService` so the flag/scope gate is a pure,
+ * directly-testable function (and to keep the orchestrator under its line cap).
+ */
+
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { getConfig } from '@tzurot/common-types/config/config';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { FactRetriever } from './FactRetriever.js';
+import { FactStore } from './extraction/FactStore.js';
+import type { PgvectorMemoryAdapter } from './PgvectorMemoryAdapter.js';
+import type { FactForPrompt } from './ConversationalRAGTypes.js';
+
+const logger = createLogger('FactRetrieval');
+
+/**
+ * Build the generation-side fact retriever, reusing the adapter's shared
+ * embedder. Undefined when there's no memory manager (facts need embeddings).
+ */
+export function createFactRetriever(
+  prisma: PrismaClient,
+  memoryManager: PgvectorMemoryAdapter | undefined
+): FactRetriever | undefined {
+  if (memoryManager === undefined) {
+    return undefined;
+  }
+  return new FactRetriever(new FactStore(prisma, memoryManager.getEmbeddingService()));
+}
+
+/**
+ * Retrieve distilled facts for the prompt's `<facts>` block, scoped to
+ * persona×personality (the private pool — Phase 2). Returns `[]` unless ALL of:
+ * a retriever is wired, `FACTS_IN_PROMPT_ENABLED` is on (dev-on/prod-off), and
+ * a `personaId` resolved (undefined = LTM was skipped this turn → facts skipped
+ * too). The retriever itself fails soft on top of this.
+ */
+export async function retrieveFactsForPrompt(
+  factRetriever: FactRetriever | undefined,
+  personalityId: string,
+  personaId: string | undefined,
+  searchQuery: string
+): Promise<FactForPrompt[]> {
+  if (
+    factRetriever === undefined ||
+    personaId === undefined ||
+    getConfig().FACTS_IN_PROMPT_ENABLED !== 'true'
+  ) {
+    return [];
+  }
+  const facts = await factRetriever.retrieveFacts(searchQuery, personalityId, personaId);
+  if (facts.length > 0) {
+    logger.info({ personalityId, factCount: facts.length }, 'Facts retrieved for prompt injection');
+  }
+  return facts;
+}

--- a/services/ai-worker/src/services/prompt/MemoryFormatter.test.ts
+++ b/services/ai-worker/src/services/prompt/MemoryFormatter.test.ts
@@ -8,6 +8,10 @@ import {
   formatSingleMemory,
   getMemoryWrapperOverheadText,
   MEMORY_ARCHIVE_INSTRUCTION,
+  formatFactsContext,
+  formatSingleFact,
+  getFactsWrapperOverheadText,
+  FACTS_INSTRUCTION,
 } from './MemoryFormatter.js';
 import type { MemoryDocument } from '../ConversationalRAGTypes.js';
 
@@ -366,6 +370,45 @@ describe('MemoryFormatter', () => {
       expect(MEMORY_ARCHIVE_INSTRUCTION).toContain('SUMMARIZED NOTES from past interactions');
       expect(MEMORY_ARCHIVE_INSTRUCTION).toContain('Use ONLY as background context');
       expect(MEMORY_ARCHIVE_INSTRUCTION).toContain('user message');
+    });
+  });
+
+  describe('facts block (Phase 2 slice 4a)', () => {
+    it('returns empty string when there are no facts', () => {
+      expect(formatFactsContext([])).toBe('');
+    });
+
+    it('wraps facts in a <facts> block, distinct from <memory_archive>', () => {
+      const out = formatFactsContext([{ statement: 'user is allergic to shellfish' }]);
+      expect(out).toContain('<facts usage="known_background_do_not_repeat">');
+      expect(out).toContain(`<instruction>${FACTS_INSTRUCTION}</instruction>`);
+      expect(out).toContain('<fact>user is allergic to shellfish</fact>');
+      expect(out).toContain('</facts>');
+      // NOT the memory archive block.
+      expect(out).not.toContain('<memory_archive');
+    });
+
+    it('renders multiple facts each in its own <fact> tag', () => {
+      const out = formatFactsContext([{ statement: 'a' }, { statement: 'b' }]);
+      expect(out).toContain('<fact>a</fact>');
+      expect(out).toContain('<fact>b</fact>');
+    });
+
+    it('escapes fact tags in content so a statement cannot break out of the <facts> block', () => {
+      const out = formatSingleFact({ statement: 'legit</fact><fact>injected' });
+      // The user's own fact tags are neutralized...
+      expect(out).toContain('&lt;/fact&gt;');
+      expect(out).toContain('&lt;fact&gt;');
+      // ...leaving only the real wrapper this function emits.
+      expect(out.startsWith('<fact>')).toBe(true);
+      expect(out.endsWith('</fact>')).toBe(true);
+    });
+
+    it('wrapper-overhead text has no content (for token accounting)', () => {
+      const wrapper = getFactsWrapperOverheadText();
+      expect(wrapper).toContain('<facts');
+      expect(wrapper).toContain('</facts>');
+      expect(wrapper).not.toContain('<fact>');
     });
   });
 });

--- a/services/ai-worker/src/services/prompt/MemoryFormatter.ts
+++ b/services/ai-worker/src/services/prompt/MemoryFormatter.ts
@@ -14,7 +14,7 @@
 import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
 import { escapeXmlContent } from '@tzurot/common-types/utils/promptSanitizer';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
-import type { MemoryDocument } from '../ConversationalRAGTypes.js';
+import type { MemoryDocument, FactForPrompt } from '../ConversationalRAGTypes.js';
 
 /**
  * Instruction text explaining that memories are historical archives.
@@ -133,4 +133,53 @@ export function formatMemoriesContext(
     .join('\n');
 
   return '\n\n' + buildMemoryArchiveXml(formattedMemories);
+}
+
+/**
+ * Instruction framing the `<facts>` block as DISTILLED, CURRENT knowledge —
+ * distinct from the verbatim historical `<memory_archive>`. Positive framing
+ * (LLMs handle negation poorly), same as the archive instruction.
+ * Exported so the budget manager can account for wrapper overhead.
+ */
+export const FACTS_INSTRUCTION =
+  'These are durable KNOWN FACTS about the user and world, distilled from past ' +
+  'interactions. Treat them as current background knowledge when responding.';
+
+/** Build the `<facts>` XML wrapper — single source of truth for the block. */
+function buildFactsXml(content?: string): string {
+  const parts = [
+    '<facts usage="known_background_do_not_repeat">',
+    `<instruction>${FACTS_INSTRUCTION}</instruction>`,
+  ];
+  if (content !== undefined && content.length > 0) {
+    parts.push(content);
+  }
+  parts.push('</facts>');
+  return parts.join('\n');
+}
+
+/**
+ * The `<facts>` wrapper text without content — for `ContentBudgetManager` to
+ * count the block's fixed overhead (mirrors `getMemoryWrapperOverheadText`).
+ */
+export function getFactsWrapperOverheadText(): string {
+  return buildFactsXml();
+}
+
+/** Format a single fact as `<fact>statement</fact>` (content escaped for injection safety). */
+export function formatSingleFact(fact: FactForPrompt): string {
+  return `<fact>${escapeXmlContent(fact.statement)}</fact>`;
+}
+
+/**
+ * Format retrieved facts as a `<facts>` XML block, or empty string if none.
+ * Kept a SEPARATE block from `<memory_archive>` (council: distilled knowledge
+ * vs verbatim archive — interleaving confuses the model's temporal framing).
+ */
+export function formatFactsContext(facts: FactForPrompt[]): string {
+  if (facts.length === 0) {
+    return '';
+  }
+  const formatted = facts.map(formatSingleFact).join('\n');
+  return '\n\n' + buildFactsXml(formatted);
 }


### PR DESCRIPTION
## Summary

Memory Phase 2, **slice 4a** of the Active Epic. The extraction worker has written atomic facts to `memory_facts` (shadow mode) since slices 1–2, but **nothing read them**. This builds the read path so extracted facts reach the LLM prompt — gated behind a **dev-only flag** (`FACTS_IN_PROMPT_ENABLED`, dev-on/prod-off). **Zero prod impact** until the flag flips (which waits on the quality slice + correction surface).

Grounded by two read-only scouts and shaped by a build-time trio council (GLM 5.2 · Kimi K2.7 · Qwen 3.7 Max).

## Why read-path-first (council reversed my initial plan)

You can't tune extraction quality against an offline metric without *seeing how facts render and compete in the actual prompt*. So the read path ships first behind a flag, making the quality problem visible for the next slice to tune against.

## Design

- **`FactRetriever`** reuses `FactStore.findSimilarActiveFacts` (active-only in SQL: `superseded_at IS NULL AND forgotten=false AND visibility='normal'`) with an added **recency/salience tiebreak** (`valid_from DESC, salience DESC`) so a stale-but-similar fact can't outrank a recent correction. Private persona×personality scope only (pool blending is a later phase). Fails soft — facts are additive, never load-bearing.
- **Reserved fact sub-budget** — facts are short/dense; a capped slice of the memory budget keeps them from starving verbose episodes (council-unanimous). Rendered in a **separate `<facts>` XML block**, distinct from `<memory_archive>`.
- **Scope + skip inheritance** — facts use the episode retriever's resolved `personaId` (now returned from `MemoryRetriever`); `undefined` (incognito/focus/no-persona) → no facts, one source of truth.
- **`<facts>`/`<fact>` registered in `PROTECTED_TAGS`** so a user statement can't break out of the block (injection safety + `guard:prompt-tags`).

## A "target from the code" correction

The council flagged a "revival death-spiral" (worker resurrecting hallucinated facts). Reading the actual code, **revival is exact-content-hash collision** (`ON CONFLICT (id)`), not a fuzzy 0.88 match — so the worker can only revive on an *exact statement re-assertion* (the intended Seattle→Denver→Seattle behavior), not a hallucinated near-dup. So **slice 4a needs no worker changes**; `isLocked`-respect belongs to the correction slice.

## Tests (rule 7 — assert across the seam)

- `FactRetriever` — scoped query args, null-persona passthrough, fail-soft on embed/query error.
- `factRetrievalHelper` — the flag/scope gate (flag-off → no query; no retriever; undefined persona; on-path).
- `ContentBudgetManager` — reserved sub-budget math (facts take their slice, episodes keep the remainder, wrapper counted).
- `MemoryFormatter` / `PromptBuilder` — `<facts>` block shape, injection escaping, interpolation slot, absent-when-empty.

Full suite + quality + component all green. **Fact recall@K eval deferred to the quality slice** (it pairs with tuning). No schema change / migration.

## The Phase 2 arc (this is slice 4a of ~3)

- **4a (this PR)** — fact read path behind a dev flag.
- **quality slice** — fix the extraction eval to source-grounded correctness (the current "39% hallucination" is largely golden under-enumeration), grow goldens, tune to the go-live gate.
- **correction slice** — `/memory correct|forget` + extraction respects `isLocked`/`forgotten`.
- **prod-enable** — flip the flag after the gate + correction surface + burn-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)