### PR TITLE
feat(ai-worker): source-grounded extraction eval + tuned prompt (memory phase 2 quality slice)

### DIFF
--- a/services/ai-worker/src/services/ContentBudgetManager.test.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.test.ts
@@ -400,5 +400,25 @@ describe('ContentBudgetManager', () => {
         .calls[0][1];
       expect(episodeBudget).toBe(1000); // untouched
     });
+
+    it('wrapper overhead alone exceeding the fact slice selects nothing (zero facts, zero tokens)', () => {
+      // Tiny memory budget → factBudget = min(600, floor(300 * 0.3)) = 90, which is
+      // below the 100-token wrapper overhead. The FIRST fact can never fit, so the
+      // block collapses to empty rather than emitting a wrapper with no facts inside.
+      vi.mocked(mockContextWindowManager.calculateMemoryBudget).mockReturnValue(300);
+      const result = budgetManager.allocate(withFacts(3));
+
+      expect(result.selectedFacts).toEqual([]);
+      expect(result.factTokensUsed).toBe(0);
+      // Episodes keep the whole (small) budget — facts took nothing.
+      const episodeBudget = vi.mocked(mockContextWindowManager.selectMemoriesWithinBudget).mock
+        .calls[0][1];
+      expect(episodeBudget).toBe(300);
+      // Nothing crosses the seam into the prompt build.
+      const promptFacts = vi
+        .mocked(mockPromptBuilder.buildFullSystemPrompt)
+        .mock.calls.at(-1)?.[0].facts;
+      expect(promptFacts).toEqual([]);
+    });
   });
 });

--- a/services/ai-worker/src/services/eval/extraction-goldens.json
+++ b/services/ai-worker/src/services/eval/extraction-goldens.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Extraction golden corpus (memory Phase 2 §3.9). Each golden: episodes (verbatim interaction texts) + knownFacts (injected supersession context) → expectFacts (statements the extractor should produce, matched by embedding equivalence) + expectSupersedesKnownIndex (which knownFacts entries a new fact should supersede). Categories: durable-fact, preference, no-facts (narration only), multi-fact, supersession, fiction. Grown toward the 100-sample re-open-trigger corpus; owner /memory correct|forget feedback accretes here.",
+  "$comment": "Extraction golden corpus (memory Phase 2 §3.9), methodology v2 (source-grounded). Each golden: episodes (verbatim interaction texts) + knownFacts (injected supersession context) → expectFacts (must-recall durable facts; recall measured against these alone) + allowedExtras (source-supported durable statements that are fine to extract but not required) + expectSupersedesKnownIndex (which knownFacts a new fact should supersede). An extraction matching NEITHER list is a violation (fabrication or transient over-extraction). Authoring line for the two lists: 'will this still be true in six months?' — past events that stay true → allowedExtras; states/plans that expire (moods, illness, tonight's dinner, next week's trip) → neither list, so extracting them counts against the extractor. Categories: durable-fact, preference, no-facts, transient-trap, multi-fact, supersession, fiction, contradiction. Grown toward the 100-sample re-open-trigger corpus; owner /memory correct|forget feedback accretes here.",
   "goldens": [
     {
       "id": "simple-name-fact",
@@ -19,7 +19,8 @@
       ],
       "knownFacts": [],
       "expectFacts": ["The user works as a nurse"],
-      "expectSupersedesKnownIndex": []
+      "expectSupersedesKnownIndex": [],
+      "allowedExtras": ["The user works at a hospital", "The user works long twelve-hour shifts"]
     },
     {
       "id": "preference-fact",
@@ -64,7 +65,8 @@
         "Dana lives in Portland",
         "Dana works as a veterinarian"
       ],
-      "expectSupersedesKnownIndex": []
+      "expectSupersedesKnownIndex": [],
+      "allowedExtras": ["The user and Dana see each other about twice a year"]
     },
     {
       "id": "supersession-move",
@@ -72,9 +74,15 @@
       "episodes": [
         "{user}: oh I should mention, I finally moved! living in Denver now as of last week\n{assistant}: Congratulations on the move! How are you finding Denver?"
       ],
-      "knownFacts": [{ "statement": "The user lives in Seattle", "entityTags": ["user"] }],
+      "knownFacts": [
+        {
+          "statement": "The user lives in Seattle",
+          "entityTags": ["user"]
+        }
+      ],
       "expectFacts": ["The user lives in Denver"],
-      "expectSupersedesKnownIndex": [0]
+      "expectSupersedesKnownIndex": [0],
+      "allowedExtras": ["The user recently moved to Denver"]
     },
     {
       "id": "supersession-job-change",
@@ -83,11 +91,18 @@
         "{user}: first day at the new job today! officially a teacher now, no more retail\n{assistant}: That's a huge change — congratulations! How was the first class?"
       ],
       "knownFacts": [
-        { "statement": "The user works in retail", "entityTags": ["user"] },
-        { "statement": "The user has a dog named Rex", "entityTags": ["user", "pet:rex"] }
+        {
+          "statement": "The user works in retail",
+          "entityTags": ["user"]
+        },
+        {
+          "statement": "The user has a dog named Rex",
+          "entityTags": ["user", "pet:rex"]
+        }
       ],
       "expectFacts": ["The user works as a teacher"],
-      "expectSupersedesKnownIndex": [0]
+      "expectSupersedesKnownIndex": [0],
+      "allowedExtras": ["The user no longer works in retail"]
     },
     {
       "id": "no-restatement",
@@ -95,7 +110,12 @@
       "episodes": [
         "{user}: you know I love tea\n{assistant}: Of course — tea person through and through, as you always say."
       ],
-      "knownFacts": [{ "statement": "The user prefers tea over coffee", "entityTags": ["user"] }],
+      "knownFacts": [
+        {
+          "statement": "The user prefers tea over coffee",
+          "entityTags": ["user"]
+        }
+      ],
       "expectFacts": [],
       "expectSupersedesKnownIndex": []
     },
@@ -107,7 +127,11 @@
       ],
       "knownFacts": [],
       "expectFacts": ["The user has a partner named Jamie"],
-      "expectSupersedesKnownIndex": []
+      "expectSupersedesKnownIndex": [],
+      "allowedExtras": [
+        "The user's partner Jamie gave them concert tickets for their anniversary",
+        "The user and Jamie celebrate an anniversary together"
+      ]
     },
     {
       "id": "transient-state-not-fact",
@@ -128,7 +152,11 @@
       ],
       "knownFacts": [],
       "expectFacts": ["Kaela is the last knight of the Ashen Order"],
-      "expectSupersedesKnownIndex": []
+      "expectSupersedesKnownIndex": [],
+      "allowedExtras": [
+        "The Ashen Order is believed to be extinct or destroyed",
+        "Kaela carries a sword"
+      ]
     },
     {
       "id": "allergy-fact",
@@ -138,7 +166,8 @@
       ],
       "knownFacts": [],
       "expectFacts": ["The user is severely allergic to peanuts"],
-      "expectSupersedesKnownIndex": []
+      "expectSupersedesKnownIndex": [],
+      "allowedExtras": ["The user discovered their peanut allergy in childhood"]
     },
     {
       "id": "timezone-fact",
@@ -157,10 +186,14 @@
         "{user}: we adopted a second cat! her name is Nori, Miso is still getting used to her\n{assistant}: Two cats now! Nori and Miso — I hope they become friends soon."
       ],
       "knownFacts": [
-        { "statement": "The user has a cat named Miso", "entityTags": ["user", "pet:miso"] }
+        {
+          "statement": "The user has a cat named Miso",
+          "entityTags": ["user", "pet:miso"]
+        }
       ],
       "expectFacts": ["The user has a cat named Nori"],
-      "expectSupersedesKnownIndex": []
+      "expectSupersedesKnownIndex": [],
+      "allowedExtras": ["The user has two cats", "The user adopted a second cat named Nori"]
     },
     {
       "id": "birthday-fact",
@@ -170,6 +203,418 @@
       ],
       "knownFacts": [],
       "expectFacts": ["The user's birthday is March 14"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-sick-today",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: ugh I've got such a bad cold today, my head is pounding\n{assistant}: Oh no, rest up! Lots of fluids."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-current-mood",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: traffic was insane this morning, I'm still fuming about it\n{assistant}: Deep breaths. Some mornings the road just wins."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-weather-with-durable",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: it's snowing like crazy here in Minneapolis today, third day in a row\n{assistant}: Minneapolis winters are relentless! Stay warm."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user lives in Minneapolis"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-travel-plan",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: flying to Berlin on tuesday for a conference, so I'll be scarce next week\n{assistant}: Safe travels! We'll catch up when you're back."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-dinner-tonight",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: haven't eaten all day, just ordered a pizza finally\n{assistant}: Long day! Enjoy the pizza — you've earned it."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-gaming-session",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: been playing elden ring all evening, my thumbs hurt lol\n{assistant}: A worthy way to lose an evening! Which boss is tormenting you?"
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "allowedExtras": ["The user plays Elden Ring", "The user enjoys video games"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-deadline-tomorrow",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: can't talk long, big deadline at work tomorrow morning\n{assistant}: Good luck! Go focus — I'll be here after."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "tt-headache-now",
+      "category": "transient-trap",
+      "episodes": [
+        "{user}: sorry if I'm slow today, splitting headache since lunch\n{assistant}: No apologies needed. Maybe some water and a dark room?"
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "nf-meta-question",
+      "category": "no-facts",
+      "episodes": [
+        "{user}: how do you actually work? like are you reading everything I say?\n{assistant}: I keep some notes on our conversations so I can remember you better!"
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "nf-joke-exchange",
+      "category": "no-facts",
+      "episodes": [
+        "{user}: why did the scarecrow win an award? because he was outstanding in his field\n{assistant}: *groans appreciatively* That one never gets old. Okay, my turn..."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "nf-hypothetical",
+      "category": "no-facts",
+      "episodes": [
+        "{user}: what would you do if you won the lottery? I'd probably buy an island\n{assistant}: An island sounds lovely! I'd want a library the size of a cathedral."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "nf-park-narration",
+      "category": "no-facts",
+      "episodes": [
+        "{user}: *strolls through the park, kicking leaves* nice day huh\n{assistant}: *falls into step beside you* The best kind of autumn afternoon."
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "df-hometown",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: I grew up in a tiny town in Ohio, like 800 people tiny\n{assistant}: That's small-town small! Everyone must have known everyone."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user grew up in a small town in Ohio"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "df-siblings",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: my older brother Marcus is coming over this weekend. he's the only sibling I've got\n{assistant}: Sibling time! I hope you two have a great weekend."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user has an older brother named Marcus"],
+      "allowedExtras": ["Marcus is the user's only sibling", "The user has only one sibling"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "df-occupation-detail",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: work was chaos, three production incidents. being a software engineer at a bank is not the quiet life people imagine\n{assistant}: Three in one day?! Banking systems keep you on your toes."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user works as a software engineer at a bank"],
+      "allowedExtras": ["The user works in software engineering"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "df-vehicle",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: my old corolla made a new weird noise today. bessie is 20 years old, she's earned her rattles\n{assistant}: Bessie sounds like a faithful companion. Twenty years is a good run!"
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user drives an old Toyota Corolla named Bessie"],
+      "allowedExtras": ["The user's car is about twenty years old"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "df-language",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: spanish is my first language actually, didn't learn english til I was twelve\n{assistant}: That's impressive — your English is beautifully fluent."
+      ],
+      "knownFacts": [],
+      "expectFacts": [
+        "Spanish is the user's first language",
+        "The user learned English around age twelve"
+      ],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "df-phobia",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: there was a huge spider in my bathroom and I genuinely cannot deal, I'm terrified of them\n{assistant}: Arachnophobia is no joke! Did you manage an eviction or a retreat?"
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user is afraid of spiders"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "ss-pet-loss",
+      "category": "supersession",
+      "episodes": [
+        "{user}: I have some sad news. Rex passed away last week. he was old but it still hurts\n{assistant}: I'm so sorry. Rex was such a good boy. Take all the time you need."
+      ],
+      "knownFacts": [
+        {
+          "statement": "The user has a dog named Rex",
+          "entityTags": ["user", "pet:rex"]
+        }
+      ],
+      "expectFacts": ["The user's dog Rex passed away"],
+      "expectSupersedesKnownIndex": [0]
+    },
+    {
+      "id": "ss-name-preference",
+      "category": "supersession",
+      "episodes": [
+        "{user}: oh btw I go by Vee now, not Victoria. never liked the full name\n{assistant}: Vee it is! It suits you."
+      ],
+      "knownFacts": [
+        {
+          "statement": "The user's name is Victoria",
+          "entityTags": ["user"]
+        }
+      ],
+      "expectFacts": ["The user goes by Vee"],
+      "expectSupersedesKnownIndex": [0],
+      "allowedExtras": [
+        "The user no longer goes by Victoria",
+        "The user dislikes the name Victoria"
+      ]
+    },
+    {
+      "id": "ss-relationship-end",
+      "category": "supersession",
+      "episodes": [
+        "{user}: jamie and I broke up last month. it was mutual but it's still weird\n{assistant}: Breakups are hard even when they're right. I'm here if you want to talk."
+      ],
+      "knownFacts": [
+        {
+          "statement": "The user has a partner named Jamie",
+          "entityTags": ["user", "person:jamie"]
+        }
+      ],
+      "expectFacts": ["The user and Jamie broke up"],
+      "expectSupersedesKnownIndex": [0]
+    },
+    {
+      "id": "ss-move-back",
+      "category": "supersession",
+      "episodes": [
+        "{user}: well, I'm back in Seattle. Denver didn't work out — the job fell through\n{assistant}: Welcome back to the rain! I'm sorry Denver was rocky."
+      ],
+      "knownFacts": [
+        {
+          "statement": "The user lives in Denver",
+          "entityTags": ["user"]
+        }
+      ],
+      "expectFacts": ["The user lives in Seattle"],
+      "allowedExtras": ["The user moved back from Denver"],
+      "expectSupersedesKnownIndex": [0]
+    },
+    {
+      "id": "fic-world-canon",
+      "category": "fiction",
+      "isFiction": true,
+      "episodes": [
+        "{user}: *unrolls the map* the kingdom of Veyra has three great cities, and the capital Thornhold sits on the northern cliffs\n{assistant}: *traces the coastline* Thornhold... I've heard the cliff winds sing there."
+      ],
+      "knownFacts": [],
+      "expectFacts": [
+        "The kingdom of Veyra has three great cities",
+        "Thornhold is the capital of Veyra"
+      ],
+      "allowedExtras": ["Thornhold sits on northern cliffs"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "fic-character-trait",
+      "category": "fiction",
+      "isFiction": true,
+      "episodes": [
+        "{user}: *hesitates at the riverbank* I... I don't do water. not since the shipwreck\n{assistant}: *offers a hand* Then we find a bridge. No one crosses alone."
+      ],
+      "knownFacts": [],
+      "expectFacts": [
+        "The user's character fears water",
+        "The user's character survived a shipwreck"
+      ],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "fic-scenery-trap",
+      "category": "fiction",
+      "isFiction": true,
+      "episodes": [
+        "{user}: *enters the market square at dusk, lanterns flickering between the stalls* I'm looking for the alchemist called Wess\n{assistant}: *points past the fountain* Third stall from the end. Wess keeps late hours."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["Wess is an alchemist"],
+      "allowedExtras": ["Wess keeps late hours", "Wess runs a stall in the market"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "fic-ooc-real-fact",
+      "category": "fiction",
+      "isFiction": true,
+      "episodes": [
+        "{user}: *sheathes her blade* until tomorrow, then. (ooc: gotta log off, my daughter wakes up early for school)\n{assistant}: *bows* Until tomorrow. (ooc: rest well! see you then)"
+      ],
+      "knownFacts": [],
+      "expectFacts": [],
+      "allowedExtras": ["The user has a daughter"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "mf-long-conversation",
+      "category": "multi-fact",
+      "episodes": [
+        "{user}: started pottery classes last month, tuesdays after work\n{assistant}: Pottery! Are you throwing on the wheel yet?",
+        "{user}: yeah! badly lol. my teacher Ines says everyone's first pots are ashtrays whether they want them or not\n{assistant}: Ines sounds wise. Wonky first pots are a rite of passage.",
+        "{user}: anyway it's the highlight of my week honestly, work has been so gray lately\n{assistant}: Then Tuesday evenings are sacred now. Protect them."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user takes pottery classes", "The user's pottery teacher is named Ines"],
+      "allowedExtras": ["The user's pottery classes are on Tuesdays", "The user enjoys pottery"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "mf-mixed-durability",
+      "category": "multi-fact",
+      "episodes": [
+        "{user}: just got back from the gym, exhausted. trying to go three times a week now\n{assistant}: Consistency is the hard part — three a week is a solid rhythm.",
+        "{user}: yeah my knee surgery last year really set me back, still rebuilding\n{assistant}: Recovering from knee surgery takes patience. You're doing the work."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user had knee surgery last year"],
+      "allowedExtras": [
+        "The user goes to the gym regularly",
+        "The user aims to exercise three times a week"
+      ],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "mf-dense-intro",
+      "category": "multi-fact",
+      "episodes": [
+        "{user}: hi! I'm Sam, 34, I live in Lisbon with my husband Rui and our greyhound Luna. I translate novels for a living\n{assistant}: Sam, welcome! A translator in Lisbon with a greyhound — your life sounds like a novel itself."
+      ],
+      "knownFacts": [],
+      "expectFacts": [
+        "The user's name is Sam",
+        "Sam lives in Lisbon",
+        "Sam is married to Rui",
+        "Sam and Rui own a greyhound named Luna",
+        "Sam works as a literary translator"
+      ],
+      "allowedExtras": ["Sam is 34 years old"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "mf-self-correction",
+      "category": "multi-fact",
+      "episodes": [
+        "{user}: my birthday is march 14th... wait no, I always do this. it's the 15th. march 15th\n{assistant}: The Ides of March! Easy to remember — noted, the 15th."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user's birthday is March 15"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "contra-hard",
+      "category": "contradiction",
+      "episodes": [
+        "{user}: peanut butter sandwiches are my whole personality lately, I have one every morning\n{assistant}: Every morning! A creature of delicious habit."
+      ],
+      "knownFacts": [
+        {
+          "statement": "The user is severely allergic to peanuts",
+          "entityTags": ["user"]
+        }
+      ],
+      "expectFacts": ["The user eats peanut butter regularly"],
+      "expectSupersedesKnownIndex": [0]
+    },
+    {
+      "id": "contra-soft",
+      "category": "contradiction",
+      "episodes": [
+        "{user}: honestly I've been all about espresso lately, kind of over tea these days\n{assistant}: The dark side claims another! What changed?"
+      ],
+      "knownFacts": [
+        {
+          "statement": "The user prefers tea over coffee",
+          "entityTags": ["user"]
+        }
+      ],
+      "expectFacts": ["The user currently prefers espresso over tea"],
+      "expectSupersedesKnownIndex": [0]
+    },
+    {
+      "id": "df-diet",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: oh I don't eat meat, been vegetarian for like ten years now\n{assistant}: A decade strong! I'll keep that in mind for any recipe talk."
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user is vegetarian"],
+      "allowedExtras": ["The user has been vegetarian for about ten years"],
+      "expectSupersedesKnownIndex": []
+    },
+    {
+      "id": "df-hobby-instrument",
+      "category": "durable-fact",
+      "episodes": [
+        "{user}: sorry for the late reply, cello practice ran long. recital in june so my teacher is drilling us\n{assistant}: A cellist! June will be here before you know it — how's the piece coming?"
+      ],
+      "knownFacts": [],
+      "expectFacts": ["The user plays the cello"],
+      "allowedExtras": ["The user has a cello teacher", "The user has a cello recital in June"],
       "expectSupersedesKnownIndex": []
     }
   ]

--- a/services/ai-worker/src/services/eval/factEquivalence.test.ts
+++ b/services/ai-worker/src/services/eval/factEquivalence.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { LocalEmbeddingService } from '@tzurot/embeddings';
-import { cosineSimilarity, matchFacts } from './factEquivalence.js';
+import { cosineSimilarity, matchFacts, scoreExtraction } from './factEquivalence.js';
 
 /** Deterministic fake embedder: known strings map to fixed orthogonal-ish vectors. */
 function makeEmbeddings(vectors: Record<string, number[]>): LocalEmbeddingService {
@@ -70,5 +70,77 @@ describe('matchFacts', () => {
     const result = await matchFacts([], ['Bob works as a baker'], makeEmbeddings(vectors));
     expect(result.precision).toBe(1);
     expect(result.recall).toBe(0);
+  });
+});
+
+describe('scoreExtraction (source-grounded, methodology v2)', () => {
+  const vectors = {
+    'Alice has a cat named Miso': [1, 0, 0, 0],
+    "Alice's cat is called Miso": [0.95, 0.05, 0, 0], // paraphrase of expectFact
+    'Alice works long shifts': [0, 1, 0, 0], // in allowedExtras
+    'The user works long, exhausting shifts': [0, 0.97, 0.03, 0], // paraphrase of allowedExtra
+    'The moon is made of cheese': [0, 0, 1, 0], // fabrication — supported by nothing
+    'Alice slept badly last night': [0, 0, 0, 1], // transient — deliberately in NO list
+  };
+
+  const EXPECT = ['Alice has a cat named Miso'];
+  const ALLOWED = ['Alice works long shifts'];
+
+  it('a correct-but-unlisted extraction matching allowedExtras is NOT a violation (the v1 artifact, fixed)', async () => {
+    const score = await scoreExtraction(
+      ["Alice's cat is called Miso", 'The user works long, exhausting shifts'],
+      EXPECT,
+      ALLOWED,
+      makeEmbeddings(vectors),
+      0.8
+    );
+    expect(score.violations).toEqual([]);
+    expect(score.violationRate).toBe(0);
+    expect(score.recall).toBe(1);
+  });
+
+  it('recall is measured against expectFacts ALONE — allowedExtras do not satisfy it', async () => {
+    // Only the allowed extra extracted; the must-recall fact missed.
+    const score = await scoreExtraction(
+      ['The user works long, exhausting shifts'],
+      EXPECT,
+      ALLOWED,
+      makeEmbeddings(vectors),
+      0.8
+    );
+    expect(score.recall).toBe(0);
+    expect(score.violationRate).toBe(0); // supported, so not a violation
+  });
+
+  it('a transient over-extraction (in neither list) IS a violation', async () => {
+    const score = await scoreExtraction(
+      ["Alice's cat is called Miso", 'Alice slept badly last night'],
+      EXPECT,
+      ALLOWED,
+      makeEmbeddings(vectors),
+      0.8
+    );
+    expect(score.violations).toEqual(['Alice slept badly last night']);
+    expect(score.violationRate).toBeCloseTo(0.5);
+    expect(score.precision).toBeCloseTo(0.5);
+  });
+
+  it('a fabrication IS a violation', async () => {
+    const score = await scoreExtraction(
+      ['The moon is made of cheese'],
+      EXPECT,
+      ALLOWED,
+      makeEmbeddings(vectors),
+      0.8
+    );
+    expect(score.violations).toEqual(['The moon is made of cheese']);
+    expect(score.recall).toBe(0);
+  });
+
+  it('nothing extracted → zero violationRate, recall per expectations', async () => {
+    const score = await scoreExtraction([], EXPECT, ALLOWED, makeEmbeddings(vectors), 0.8);
+    expect(score.violationRate).toBe(0);
+    expect(score.precision).toBe(1);
+    expect(score.recall).toBe(0);
   });
 });

--- a/services/ai-worker/src/services/eval/factEquivalence.ts
+++ b/services/ai-worker/src/services/eval/factEquivalence.ts
@@ -80,6 +80,65 @@ export async function matchFacts(
   return { matchedExpected: [...matchedExpected], unmatchedExtracted, precision, recall };
 }
 
+export interface ExtractionScore {
+  /** expectFacts entries matched by at least one extraction (drives recall). */
+  matchedExpected: string[];
+  /**
+   * Extractions matching NEITHER expectFacts NOR allowedExtras — each is a
+   * fabrication (unsupported by the source) or a transient/policy
+   * over-extraction. The distinction is a human read during tuning; the
+   * statements are surfaced verbatim for that purpose.
+   */
+  violations: string[];
+  /** matched expectFacts / expectFacts (1 when none expected). */
+  recall: number;
+  /** violations / extracted (0 when nothing extracted). */
+  violationRate: number;
+  /** 1 − violationRate — kept for baseline comparability. */
+  precision: number;
+}
+
+/**
+ * Source-grounded extraction scoring (eval methodology v2).
+ *
+ * The v1 eval scored precision against `expectFacts` alone, so a CORRECT
+ * extraction the golden author didn't enumerate counted as a hallucination —
+ * inflating the rate with measurement artifacts. v2 splits the golden into
+ * `expectFacts` (must-recall) and `allowedExtras` (source-supported, durable,
+ * optional): recall is measured against expectFacts alone; a violation is an
+ * extraction matching NEITHER list. Transient states the source supports but
+ * that must not be extracted are deliberately left out of BOTH lists, so
+ * over-extraction keeps counting against the extractor. Deterministic
+ * (embedding cosine, same matcher) — the golden author enumerates support
+ * instead of an LLM judge deciding at eval time.
+ */
+export async function scoreExtraction(
+  extracted: string[],
+  expectFacts: string[],
+  allowedExtras: string[],
+  embeddings: LocalEmbeddingService,
+  threshold = FACT_EQUIVALENCE_THRESHOLD
+): Promise<ExtractionScore> {
+  const recallMatch = await matchFacts(extracted, expectFacts, embeddings, threshold);
+  const supportMatch = await matchFacts(
+    extracted,
+    [...expectFacts, ...allowedExtras],
+    embeddings,
+    threshold
+  );
+
+  const violationRate =
+    extracted.length === 0 ? 0 : supportMatch.unmatchedExtracted.length / extracted.length;
+
+  return {
+    matchedExpected: recallMatch.matchedExpected,
+    violations: supportMatch.unmatchedExtracted,
+    recall: recallMatch.recall,
+    violationRate,
+    precision: 1 - violationRate,
+  };
+}
+
 /** Indexes of expected vectors the given vector matches at/above threshold. */
 function matchesForVector(
   vec: Float32Array | undefined,

--- a/services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts
+++ b/services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts
@@ -3,14 +3,15 @@
  *
  * Runs the REAL extraction prompt + REAL cheap model (costs money, needs the
  * system OpenRouter key in env) against the golden corpus, parses with the
- * production schema (fail-to-skip), and scores precision / recall /
- * hallucination-rate via embedding fact-equivalence. Invoked manually:
- * `pnpm eval:extraction`. Results land in extraction-eval-results.json; copy
- * to phase2-baseline.json when establishing the slice-2 baseline.
+ * production schema (fail-to-skip), and scores recall / violation-rate via
+ * source-grounded embedding fact-equivalence (methodology v2 — see
+ * `scoreExtraction`). Invoked manually: `pnpm eval:extraction`. Results land
+ * in extraction-eval-results.json; copy to phase2-extraction-baseline.json
+ * when establishing a baseline.
  *
- * Gate semantics (per the phase plan): slice 2 ships at >=80% mean precision;
- * slice 4 (retrieval integration) requires >=95% precision / <=5%
- * hallucination on the grown corpus.
+ * Gate semantics: prod-enable of facts-in-prompt requires the corpus-level
+ * violationRate under the owner-decided bar (candidates: 5% strict / 10%
+ * pragmatic-with-correction-surface) on the grown corpus.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -24,7 +25,7 @@ import {
   extractJsonPayload,
 } from '../extraction/extractionPrompt.js';
 import { invokeExtractionModel } from '../extraction/FactExtractionService.js';
-import { matchFacts } from './factEquivalence.js';
+import { scoreExtraction } from './factEquivalence.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -34,7 +35,15 @@ interface ExtractionGolden {
   isFiction?: boolean;
   episodes: string[];
   knownFacts: { statement: string; entityTags: string[] }[];
+  /** Must-recall durable facts — recall is measured against these alone. */
   expectFacts: string[];
+  /**
+   * Source-supported durable facts that are FINE to extract but not required
+   * (methodology v2). Transient states the source supports but that must NOT
+   * be extracted are deliberately absent from both lists, so extracting them
+   * counts as a violation.
+   */
+  allowedExtras?: string[];
   expectSupersedesKnownIndex: number[];
 }
 
@@ -43,7 +52,10 @@ interface GoldenResult {
   precision: number;
   recall: number;
   extractedCount: number;
-  hallucinations: string[];
+  /** Everything the model produced — the eyeballing source for recall misses / tuning. */
+  extracted: string[];
+  /** Extractions supported by neither list: fabrications OR transient over-extractions. */
+  violations: string[];
   supersessionHit: boolean | null;
 }
 
@@ -67,22 +79,45 @@ describe('memory extraction eval (real model — manual run only)', () => {
     const scored = Object.values(results);
     const mean = (xs: number[]): number =>
       xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length;
-    const allHallucinations = scored.flatMap(r => r.hallucinations);
+    const allViolations = scored.flatMap(r => r.violations);
     const totalExtracted = scored.reduce((a, r) => a + r.extractedCount, 0);
     const supersessionGoldens = scored.filter(r => r.supersessionHit !== null);
+    // Per-category breakdown — the tuning loop reads this to see WHICH failure
+    // mode the prompt is making (transient-trap vs fiction vs durable etc).
+    // NOTE: these per-category rates are an UNWEIGHTED per-golden macro-average
+    // (each golden counts equally), deliberately distinct from
+    // `totals.violationRate` above, which is volume-weighted (total violations /
+    // total extracted). Macro is the right lens per category (one high-extraction
+    // golden shouldn't dominate a category); micro is the right lens for the gate
+    // number. Don't compare the two side-by-side expecting them to match.
+    const byCategory: Record<string, { goldens: number; violationRate: number; recall: number }> =
+      {};
+    for (const r of scored) {
+      const c = (byCategory[r.category] ??= { goldens: 0, violationRate: 0, recall: 0 });
+      c.goldens += 1;
+      c.violationRate += r.violations.length / Math.max(1, r.extractedCount);
+      c.recall += r.recall;
+    }
+    for (const c of Object.values(byCategory)) {
+      c.violationRate /= c.goldens;
+      c.recall /= c.goldens;
+    }
     const summary = {
       generatedForPhase: 'set-at-baseline-time',
+      methodology:
+        'v2 source-grounded: recall vs expectFacts; violation = extraction matching neither expectFacts nor allowedExtras',
       totals: {
         goldens: scored.length,
         meanPrecision: mean(scored.map(r => r.precision)),
         meanRecall: mean(scored.map(r => r.recall)),
-        hallucinationRate: totalExtracted === 0 ? 0 : allHallucinations.length / totalExtracted,
+        violationRate: totalExtracted === 0 ? 0 : allViolations.length / totalExtracted,
         supersessionHitRate:
           supersessionGoldens.length === 0
             ? null
             : supersessionGoldens.filter(r => r.supersessionHit === true).length /
               supersessionGoldens.length,
       },
+      byCategory,
       results,
     };
     writeFileSync(
@@ -118,7 +153,12 @@ describe('memory extraction eval (real model — manual run only)', () => {
       }
 
       const extractedStatements = parsed.data.facts.map(f => f.statement);
-      const match = await matchFacts(extractedStatements, golden.expectFacts, embeddings);
+      const score = await scoreExtraction(
+        extractedStatements,
+        golden.expectFacts,
+        golden.allowedExtras ?? [],
+        embeddings
+      );
 
       // Supersession scoring: did any extracted fact name each expected index?
       let supersessionHit: boolean | null = null;
@@ -131,10 +171,11 @@ describe('memory extraction eval (real model — manual run only)', () => {
 
       results[golden.id] = {
         category: golden.category,
-        precision: match.precision,
-        recall: match.recall,
+        precision: score.precision,
+        recall: score.recall,
         extractedCount: extractedStatements.length,
-        hallucinations: match.unmatchedExtracted,
+        extracted: extractedStatements,
+        violations: score.violations,
         supersessionHit,
       };
 

--- a/services/ai-worker/src/services/eval/phase2-extraction-baseline.json
+++ b/services/ai-worker/src/services/eval/phase2-extraction-baseline.json
@@ -1,11 +1,54 @@
 {
-  "generatedForPhase": "phase2-slice2-shadow-baseline (fence-fix run; precision gap = over-extraction to tune in shadow + golden under-enumeration; recall and supersession perfect)",
+  "generatedForPhase": "phase2-quality-slice baseline (methodology v2, source-grounded, 50 goldens). Prompt tuned for durability + atomicity. Residual violations are genuine transient-leak / editorializing (zero fabrications); the transient-trap tail (~25%) is the honest cheap-model floor, not overfit to zero. Gate bar (5% strict vs 10% pragmatic-with-correction-surface) is the owner call.",
+  "methodology": "v2 source-grounded: recall vs expectFacts; violation = extraction matching neither expectFacts nor allowedExtras",
   "totals": {
-    "goldens": 15,
-    "meanPrecision": 0.6722222222222223,
-    "meanRecall": 1,
-    "hallucinationRate": 0.39285714285714285,
+    "goldens": 50,
+    "meanPrecision": 0.91,
+    "meanRecall": 0.996,
+    "violationRate": 0.10294117647058823,
     "supersessionHitRate": 1
+  },
+  "byCategory": {
+    "durable-fact": {
+      "goldens": 14,
+      "violationRate": 0.07142857142857142,
+      "recall": 1
+    },
+    "preference": {
+      "goldens": 1,
+      "violationRate": 0,
+      "recall": 1
+    },
+    "no-facts": {
+      "goldens": 8,
+      "violationRate": 0,
+      "recall": 1
+    },
+    "multi-fact": {
+      "goldens": 5,
+      "violationRate": 0,
+      "recall": 0.96
+    },
+    "supersession": {
+      "goldens": 7,
+      "violationRate": 0.14285714285714285,
+      "recall": 1
+    },
+    "fiction": {
+      "goldens": 5,
+      "violationRate": 0.1,
+      "recall": 1
+    },
+    "transient-trap": {
+      "goldens": 8,
+      "violationRate": 0.25,
+      "recall": 1
+    },
+    "contradiction": {
+      "goldens": 2,
+      "violationRate": 0,
+      "recall": 1
+    }
   },
   "results": {
     "simple-name-fact": {
@@ -13,17 +56,17 @@
       "precision": 1,
       "recall": 1,
       "extractedCount": 1,
-      "hallucinations": [],
+      "extracted": ["The user has a cat named Miso."],
+      "violations": [],
       "supersessionHit": null
     },
     "job-fact": {
       "category": "durable-fact",
-      "precision": 0.5,
+      "precision": 1,
       "recall": 1,
       "extractedCount": 2,
-      "hallucinations": [
-        "The user sometimes works long shifts (at least twelve hours) that are physically and mentally exhausting."
-      ],
+      "extracted": ["The user works as a nurse.", "The user works at a hospital."],
+      "violations": [],
       "supersessionHit": null
     },
     "preference-fact": {
@@ -31,19 +74,17 @@
       "precision": 1,
       "recall": 1,
       "extractedCount": 1,
-      "hallucinations": [],
+      "extracted": ["The user dislikes coffee and prefers tea."],
+      "violations": [],
       "supersessionHit": null
     },
     "narration-only": {
       "category": "no-facts",
-      "precision": 0,
+      "precision": 1,
       "recall": 1,
-      "extractedCount": 3,
-      "hallucinations": [
-        "There is a tavern with a bar and a fireplace.",
-        "A bartender works at the tavern.",
-        "It is a cold night in the world of this roleplay."
-      ],
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
       "supersessionHit": null
     },
     "smalltalk-only": {
@@ -51,15 +92,22 @@
       "precision": 1,
       "recall": 1,
       "extractedCount": 0,
-      "hallucinations": [],
+      "extracted": [],
+      "violations": [],
       "supersessionHit": null
     },
     "multi-fact-batch": {
       "category": "multi-fact",
-      "precision": 0.75,
+      "precision": 1,
       "recall": 1,
       "extractedCount": 4,
-      "hallucinations": ["The user and Dana see each other approximately twice a year."],
+      "extracted": [
+        "The user has a sister named Dana.",
+        "Dana lives in Portland.",
+        "Dana is a veterinarian.",
+        "The user and Dana see each other approximately twice a year."
+      ],
+      "violations": [],
       "supersessionHit": null
     },
     "supersession-move": {
@@ -67,55 +115,82 @@
       "precision": 1,
       "recall": 1,
       "extractedCount": 1,
-      "hallucinations": [],
+      "extracted": ["The user moved to Denver last week"],
+      "violations": [],
       "supersessionHit": true
     },
     "supersession-job-change": {
       "category": "supersession",
       "precision": 1,
       "recall": 1,
-      "extractedCount": 2,
-      "hallucinations": [],
+      "extractedCount": 1,
+      "extracted": ["The user is now a teacher"],
+      "violations": [],
       "supersessionHit": true
+    },
+    "no-restatement": {
+      "category": "no-facts",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
     },
     "relationship-fact": {
       "category": "durable-fact",
-      "precision": 0.6666666666666666,
+      "precision": 1,
       "recall": 1,
       "extractedCount": 3,
-      "hallucinations": ["Jamie gave the user concert tickets as an anniversary gift."],
+      "extracted": [
+        "The user has a partner named Jamie.",
+        "The user and Jamie are in an anniversary relationship.",
+        "Jamie gave the user concert tickets as an anniversary gift."
+      ],
+      "violations": [],
       "supersessionHit": null
     },
     "transient-state-not-fact": {
       "category": "no-facts",
-      "precision": 0,
+      "precision": 1,
       "recall": 1,
-      "extractedCount": 1,
-      "hallucinations": ["The user had insufficient sleep the previous night."],
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
       "supersessionHit": null
     },
     "fiction-canon": {
       "category": "fiction",
-      "precision": 0.6666666666666666,
+      "precision": 1,
       "recall": 1,
       "extractedCount": 3,
-      "hallucinations": ["The Ashen Order is believed to be extinct or destroyed"],
+      "extracted": [
+        "Kaela is a knight of the Ashen Order.",
+        "Kaela is the last knight of the Ashen Order.",
+        "The Ashen Order is believed to be extinct or destroyed."
+      ],
+      "violations": [],
       "supersessionHit": null
     },
     "allergy-fact": {
       "category": "durable-fact",
       "precision": 1,
       "recall": 1,
-      "extractedCount": 1,
-      "hallucinations": [],
+      "extractedCount": 2,
+      "extracted": [
+        "The user has a severe peanut allergy.",
+        "The user discovered their peanut allergy in childhood."
+      ],
+      "violations": [],
       "supersessionHit": null
     },
     "timezone-fact": {
       "category": "durable-fact",
-      "precision": 0.5,
+      "precision": 1,
       "recall": 1,
-      "extractedCount": 2,
-      "hallucinations": ["The user experiences nighttime at 2am Tokyo time."],
+      "extractedCount": 1,
+      "extracted": ["The user is in Tokyo."],
+      "violations": [],
       "supersessionHit": null
     },
     "pet-addition-not-supersession": {
@@ -123,15 +198,376 @@
       "precision": 0.5,
       "recall": 1,
       "extractedCount": 2,
-      "hallucinations": ["Miso and Nori are still adjusting to living together"],
+      "extracted": [
+        "The user adopted a second cat named Nori",
+        "Miso and Nori are still in the process of adjusting to living together"
+      ],
+      "violations": ["Miso and Nori are still in the process of adjusting to living together"],
       "supersessionHit": null
     },
     "birthday-fact": {
       "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user's birthday is on March 14th."],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "tt-sick-today": {
+      "category": "transient-trap",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "tt-current-mood": {
+      "category": "transient-trap",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "tt-weather-with-durable": {
+      "category": "transient-trap",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user is located in Minneapolis."],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "tt-travel-plan": {
+      "category": "transient-trap",
+      "precision": 0,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user has a conference in Berlin scheduled for Tuesday."],
+      "violations": ["The user has a conference in Berlin scheduled for Tuesday."],
+      "supersessionHit": null
+    },
+    "tt-dinner-tonight": {
+      "category": "transient-trap",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "tt-gaming-session": {
+      "category": "transient-trap",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user plays Elden Ring."],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "tt-deadline-tomorrow": {
+      "category": "transient-trap",
+      "precision": 0,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user has a work deadline tomorrow morning."],
+      "violations": ["The user has a work deadline tomorrow morning."],
+      "supersessionHit": null
+    },
+    "tt-headache-now": {
+      "category": "transient-trap",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "nf-meta-question": {
+      "category": "no-facts",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "nf-joke-exchange": {
+      "category": "no-facts",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "nf-hypothetical": {
+      "category": "no-facts",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "nf-park-narration": {
+      "category": "no-facts",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "df-hometown": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": [
+        "The user grew up in a tiny town in Ohio with a population of around 800 people."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "df-siblings": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": [
+        "The user has an older brother named Marcus.",
+        "The user has only one sibling."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "df-occupation-detail": {
+      "category": "durable-fact",
       "precision": 0.5,
       "recall": 1,
       "extractedCount": 2,
-      "hallucinations": ["The user is planning a small dinner for their birthday."],
+      "extracted": [
+        "The user works as a software engineer at a bank.",
+        "The user's work involves managing production incidents."
+      ],
+      "violations": ["The user's work involves managing production incidents."],
+      "supersessionHit": null
+    },
+    "df-vehicle": {
+      "category": "durable-fact",
+      "precision": 0.5,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": [
+        "The user owns a Toyota Corolla named Bessie that is approximately 20 years old.",
+        "The user has a habit of giving their vehicle a personal name and referring to it affectionately."
+      ],
+      "violations": [
+        "The user has a habit of giving their vehicle a personal name and referring to it affectionately."
+      ],
+      "supersessionHit": null
+    },
+    "df-language": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": [
+        "Spanish is the user's first language.",
+        "The user learned English starting at age twelve."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "df-phobia": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user has arachnophobia (fear of spiders)."],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "ss-pet-loss": {
+      "category": "supersession",
+      "precision": 0.5,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": ["Rex passed away last week", "Rex was old"],
+      "violations": ["Rex was old"],
+      "supersessionHit": true
+    },
+    "ss-name-preference": {
+      "category": "supersession",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": ["The user goes by Vee, not Victoria.", "Vee dislikes the name Victoria."],
+      "violations": [],
+      "supersessionHit": true
+    },
+    "ss-relationship-end": {
+      "category": "supersession",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": [
+        "The user and Jamie broke up last month",
+        "The user and Jamie's breakup was mutual"
+      ],
+      "violations": [],
+      "supersessionHit": true
+    },
+    "ss-move-back": {
+      "category": "supersession",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": [
+        "The user is now in Seattle",
+        "The user moved to Denver for a job that fell through"
+      ],
+      "violations": [],
+      "supersessionHit": true
+    },
+    "fic-world-canon": {
+      "category": "fiction",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 3,
+      "extracted": [
+        "The kingdom of Veyra has three great cities.",
+        "Thornhold is the capital of Veyra.",
+        "Thornhold sits on northern cliffs."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "fic-character-trait": {
+      "category": "fiction",
+      "precision": 0.5,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": [
+        "The user has a fear of water stemming from a shipwreck they survived.",
+        "The assistant is willing to help the user find alternative routes rather than forcing them to confront their fears."
+      ],
+      "violations": [
+        "The assistant is willing to help the user find alternative routes rather than forcing them to confront their fears."
+      ],
+      "supersessionHit": null
+    },
+    "fic-scenery-trap": {
+      "category": "fiction",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 3,
+      "extracted": [
+        "Wess is an alchemist.",
+        "Wess's stall is located in the market square, third stall from the end.",
+        "Wess keeps late hours."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "fic-ooc-real-fact": {
+      "category": "fiction",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "extracted": [],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "mf-long-conversation": {
+      "category": "multi-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 3,
+      "extracted": [
+        "The user started pottery classes last month, attending on Tuesday evenings after work.",
+        "The user's pottery teacher is named Ines.",
+        "The user is learning to throw pottery on a wheel."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "mf-mixed-durability": {
+      "category": "multi-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": [
+        "The user had knee surgery last year and is still in the rebuilding phase of recovery.",
+        "The user is aiming to go to the gym three times per week."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "mf-dense-intro": {
+      "category": "multi-fact",
+      "precision": 1,
+      "recall": 0.8,
+      "extractedCount": 5,
+      "extracted": [
+        "Sam is 34 years old.",
+        "Sam lives in Lisbon.",
+        "Sam is married to Rui.",
+        "Sam and Rui own a greyhound named Luna.",
+        "Sam works as a translator of novels."
+      ],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "mf-self-correction": {
+      "category": "multi-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["User's birthday is March 15th."],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "contra-hard": {
+      "category": "contradiction",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user eats peanut butter sandwiches every morning as a regular habit"],
+      "violations": [],
+      "supersessionHit": true
+    },
+    "contra-soft": {
+      "category": "contradiction",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": [
+        "The user has recently shifted their beverage preference to espresso and is no longer interested in tea"
+      ],
+      "violations": [],
+      "supersessionHit": true
+    },
+    "df-diet": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "extracted": ["The user has been vegetarian for approximately ten years."],
+      "violations": [],
+      "supersessionHit": null
+    },
+    "df-hobby-instrument": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "extracted": ["The user plays cello.", "The user takes cello lessons with a teacher."],
+      "violations": [],
       "supersessionHit": null
     }
   }

--- a/services/ai-worker/src/services/extraction/FactStore.component.test.ts
+++ b/services/ai-worker/src/services/extraction/FactStore.component.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Component test: `FactStore.findSimilarActiveFacts` over REAL PGLite + pgvector.
+ *
+ * The unit suite (`FactStore.test.ts`) mocks `$queryRaw`, so the actual retrieval
+ * SQL — the `embedding <=>` distance, the `valid_from DESC, salience DESC`
+ * tiebreak, and every active-filter (`superseded_at`/`forgotten`/`visibility`/
+ * persona scope) — never executes there. This test runs that SQL against the
+ * real schema so a composition regression (a dropped filter, a broken tiebreak
+ * clause) fails in CI instead of only at runtime. The query now serves two
+ * callers (extraction supersession fallback + generation-time `FactRetriever`),
+ * which raises the cost of a silent SQL break.
+ *
+ * Facts are seeded via raw SQL so the test controls the embedding vector,
+ * `valid_from`, and `salience` precisely — the only way to force EXACTLY equal
+ * cosine distance (identical embeddings) and prove the tiebreak is what orders
+ * the rows, not a distance difference.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { type PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { LocalEmbeddingService } from '@tzurot/embeddings';
+import { FactStore } from './FactStore.js';
+
+const USER = '5a1c0f66-0000-4000-8000-00000000c001';
+const PERSONA = '5a1c0f66-0000-4000-8000-00000000c002';
+const OTHER_PERSONA = '5a1c0f66-0000-4000-8000-00000000c005';
+const OTHER_USER = '5a1c0f66-0000-4000-8000-00000000c006';
+const PERSONALITY = '5a1c0f66-0000-4000-8000-00000000c003';
+const SYSTEM_PROMPT = '5a1c0f66-0000-4000-8000-00000000c004';
+
+let seq = 0;
+const nextId = (): string =>
+  `5a1c0f66-0000-4000-8000-0000000000${(seq++).toString().padStart(2, '0')}`;
+
+describe('FactStore.findSimilarActiveFacts (component, PGLite)', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+  let embeddings: LocalEmbeddingService;
+  let factStore: FactStore;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+
+    await seedUserWithPersona(prisma, {
+      userId: USER,
+      personaId: PERSONA,
+      discordId: '900000000000000051',
+      username: 'factqueryuser',
+      personaName: 'Query Persona',
+      personaPreferredName: 'Query',
+      personaContent: 'The fact-retrieval persona',
+    });
+    await seedUserWithPersona(prisma, {
+      userId: OTHER_USER,
+      personaId: OTHER_PERSONA,
+      discordId: '900000000000000052',
+      username: 'otherfactuser',
+      personaName: 'Other Persona',
+      personaPreferredName: 'Other',
+      personaContent: 'The scope-isolation persona',
+    });
+    await prisma.$executeRaw`
+      INSERT INTO system_prompts (id, name, content, updated_at)
+      VALUES (${SYSTEM_PROMPT}::uuid, 'Q Prompt', 'You are a fact bot.', NOW())
+    `;
+    await prisma.$executeRaw`
+      INSERT INTO personalities (id, name, display_name, slug, system_prompt_id, character_info, personality_traits, owner_id, updated_at)
+      VALUES (${PERSONALITY}::uuid, 'QBot', 'Q Bot', 'qbot', ${SYSTEM_PROMPT}::uuid, 'Q character', 'Precise', ${USER}::uuid, NOW())
+    `;
+
+    embeddings = new LocalEmbeddingService();
+    const ready = await embeddings.initialize();
+    if (!ready) {
+      throw new Error('Local embedding model failed to initialize');
+    }
+    factStore = new FactStore(prisma, embeddings);
+  }, 180_000);
+
+  afterAll(async () => {
+    await embeddings.shutdown();
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.$executeRaw`DELETE FROM memory_facts`;
+  });
+
+  interface SeedOpts {
+    statement: string;
+    /** Text whose embedding becomes this fact's vector (controls distance). */
+    embedText: string;
+    personaId?: string | null;
+    salience?: number;
+    validFrom?: string;
+    supersededAt?: string | null;
+    forgotten?: boolean;
+    visibility?: string;
+    isLocked?: boolean;
+  }
+
+  async function seedFact(opts: SeedOpts): Promise<string> {
+    const id = nextId();
+    const vec = await embeddings.getEmbedding(opts.embedText);
+    const vecLiteral = `[${Array.from(vec ?? []).join(',')}]`;
+    const personaId = opts.personaId === undefined ? PERSONA : opts.personaId;
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO memory_facts
+         (id, personality_id, persona_id, statement, embedding, salience, valid_from,
+          superseded_at, forgotten, visibility, is_locked, created_at, updated_at)
+       VALUES ($1::uuid, $2::uuid, $3::uuid, $4, '${vecLiteral}'::vector, $5, $6::timestamptz,
+          $7::timestamptz, $8, $9, $10, NOW(), NOW())`,
+      id,
+      PERSONALITY,
+      personaId,
+      opts.statement,
+      opts.salience ?? 0.5,
+      opts.validFrom ?? '2026-01-01T00:00:00Z',
+      opts.supersededAt ?? null,
+      opts.forgotten ?? false,
+      opts.visibility ?? 'normal',
+      opts.isLocked ?? false
+    );
+    return id;
+  }
+
+  async function queryFor(text: string, personaId: string | null = PERSONA, limit = 5) {
+    const vec = await embeddings.getEmbedding(text);
+    return factStore.findSimilarActiveFacts(Array.from(vec ?? []), PERSONALITY, personaId, limit);
+  }
+
+  it('ranks by cosine similarity and returns similarity in [0,1]', async () => {
+    await seedFact({
+      statement: 'The user has a cat named Miso',
+      embedText: 'The user has a cat named Miso',
+    });
+    await seedFact({
+      statement: 'The kingdom of Veyra has three great cities',
+      embedText: 'The kingdom of Veyra has three great cities',
+    });
+
+    const hits = await queryFor("the user's pet cat");
+
+    expect(hits.length).toBe(2);
+    expect(hits[0].statement).toBe('The user has a cat named Miso');
+    // Similarity is 1 - cosine distance, so the closer fact scores higher.
+    expect(hits[0].similarity).toBeGreaterThan(hits[1].similarity);
+    expect(hits[0].similarity).toBeGreaterThanOrEqual(0);
+    expect(hits[0].similarity).toBeLessThanOrEqual(1);
+  });
+
+  it('tiebreak: among EQUAL-distance facts the more recent valid_from wins', async () => {
+    // Identical embedding → identical distance → the ORDER BY falls entirely to
+    // the valid_from tiebreak. This is the exact clause the review flagged as
+    // never exercised against a real DB.
+    const shared = 'The user lives in a city';
+    await seedFact({
+      statement: 'The user lives in Seattle',
+      embedText: shared,
+      validFrom: '2026-01-01T00:00:00Z',
+      salience: 0.9,
+    });
+    await seedFact({
+      statement: 'The user lives in Denver',
+      embedText: shared,
+      validFrom: '2026-06-01T00:00:00Z',
+      salience: 0.1, // lower salience — proves valid_from outranks salience
+    });
+
+    const hits = await queryFor(shared);
+
+    expect(hits.map(h => h.statement)).toEqual([
+      'The user lives in Denver', // newer valid_from, despite lower salience
+      'The user lives in Seattle',
+    ]);
+  });
+
+  it('tiebreak: at equal distance AND equal valid_from, higher salience wins', async () => {
+    const shared = 'The user enjoys a hobby';
+    await seedFact({
+      statement: 'The user enjoys pottery',
+      embedText: shared,
+      validFrom: '2026-03-01T00:00:00Z',
+      salience: 0.3,
+    });
+    await seedFact({
+      statement: 'The user enjoys chess',
+      embedText: shared,
+      validFrom: '2026-03-01T00:00:00Z',
+      salience: 0.8,
+    });
+
+    const hits = await queryFor(shared);
+
+    expect(hits[0].statement).toBe('The user enjoys chess'); // higher salience
+  });
+
+  it('excludes superseded, forgotten, and soft-deleted facts', async () => {
+    const shared = 'A fact about the user';
+    await seedFact({ statement: 'active fact', embedText: shared });
+    await seedFact({
+      statement: 'superseded fact',
+      embedText: shared,
+      supersededAt: '2026-05-01T00:00:00Z',
+    });
+    await seedFact({ statement: 'forgotten fact', embedText: shared, forgotten: true });
+    await seedFact({ statement: 'deleted fact', embedText: shared, visibility: 'deleted' });
+
+    const hits = await queryFor(shared);
+
+    expect(hits.map(h => h.statement)).toEqual(['active fact']);
+  });
+
+  it('scopes to the given persona (and to null-persona facts when personaId is null)', async () => {
+    const shared = 'A scoped fact';
+    await seedFact({ statement: 'main persona fact', embedText: shared, personaId: PERSONA });
+    await seedFact({
+      statement: 'other persona fact',
+      embedText: shared,
+      personaId: OTHER_PERSONA,
+    });
+    await seedFact({ statement: 'world fact (no persona)', embedText: shared, personaId: null });
+
+    const mainHits = await queryFor(shared, PERSONA);
+    expect(mainHits.map(h => h.statement)).toEqual(['main persona fact']);
+
+    const worldHits = await queryFor(shared, null);
+    expect(worldHits.map(h => h.statement)).toEqual(['world fact (no persona)']);
+  });
+
+  it('surfaces isLocked so downstream (the correction slice) can respect it', async () => {
+    await seedFact({ statement: 'a locked fact', embedText: 'a locked fact', isLocked: true });
+
+    const hits = await queryFor('a locked fact');
+
+    expect(hits[0].isLocked).toBe(true);
+  });
+});

--- a/services/ai-worker/src/services/extraction/extractionPrompt.ts
+++ b/services/ai-worker/src/services/extraction/extractionPrompt.ts
@@ -62,8 +62,15 @@ ${episodesBlock}
 ---
 
 Extract NEW durable facts from the excerpts. Rules:
-- A fact is an atomic, self-contained, third-person statement that will still matter in future conversations (names, relationships, preferences, decisions, world details).
-- Do NOT extract scene narration, one-off actions, or transient emotional states — the conversation itself is already stored verbatim.
+- A DURABLE fact is atomic, self-contained, third-person, and would still be true and worth knowing months from now: names, relationships, occupation, location, preferences, allergies, lasting decisions, stable world/canon details.
+- ONE fact per statement. If a sentence carries two facts ("has a severe peanut allergy AND learned it in childhood", "fears water AND survived a shipwreck"), split it into separate statements — do not join them with "and".
+- Apply the durability test — "will this still be true and relevant in six months?" If no, do NOT extract it. In particular, do NOT extract:
+  - transient states: current mood, tiredness, hunger, an illness or headache today
+  - time-bound plans or upcoming events: a trip next week, a deadline tomorrow, tonight's dinner, an appointment
+  - one-off actions and scene/setting narration: walking into a room, the furniture, the weather right now
+  - hypotheticals, wishes, or what-ifs: what someone would do if they won the lottery
+  - facts about the assistant or the AI itself
+  A past event counts as durable ONLY if it leaves a lasting truth ("moved to Denver", "had knee surgery last year"), not if it merely describes a passing moment.
 - Do NOT restate an existing known fact unless the excerpts CHANGE it.
 - If a new fact updates or contradicts a numbered known fact, set "supersedesIndex" to that fact's number; otherwise null.
 - ${isFictionScope ? 'This is an in-character fiction scope: extract in-story canon facts.' : 'Extract facts about the real user and their world; ignore in-story fiction.'}


### PR DESCRIPTION
## Memory Phase 2 — quality slice

The go-live gate for facts-in-prompt is **extraction quality**, and the eval measuring it was broken: it scored precision against a single must-recall list, so every *correct-but-unlisted* extraction counted as a hallucination. Its 39% "hallucination" was mostly golden under-enumeration, not real over-extraction. This slice fixes the measurement, grows the corpus, then tunes the prompt to the now-honest number.

### 1. Eval methodology v2 — source-grounded, deterministic
`factEquivalence.scoreExtraction` splits the golden into two lists:
- **`expectFacts`** — must-recall durable facts; **recall** is scored against these alone.
- **`allowedExtras`** (new) — source-supported durable facts that are *fine* to extract but not required.

A **violation** is an extraction matching **neither** list — a fabrication, or a transient/policy over-extraction the author deliberately left out of both lists. `precision = 1 − violationRate`. Same embedding-cosine matcher (0.8), fully deterministic — the golden author enumerates what the source supports instead of an LLM judge deciding at eval time.

Corpus grown **16 → 50**: new `transient-trap` (source supports a transient state that must NOT be extracted) and `contradiction` categories, plus more fiction/multi-fact/supersession.

### 2. Prompt tuned to the honest number
Two targeted changes to `extractionPrompt.ts`:
- **Durability bias** — an explicit six-month test + named exclusions (transient states, time-bound plans, scene narration, hypotheticals, facts about the assistant).
- **Atomicity** — one fact per statement; split compound "X and Y" extractions.

Measured on the **real cheap model + local embeddings** (`pnpm eval:extraction`):

| Run | Corpus | Precision | Recall | Violation | Supersession |
|---|---|---|---|---|---|
| v1 methodology | 16 | 67% | 100% | 39% "hallucination" | 100% |
| v2 baseline (untuned) | 50 | 66% | 93.8% | **33.7%** | 100% |
| v2 + durability tune | 50 | 88% | 94.6% | 13.8% | 100% |
| **v2 + atomicity tune (baseline)** | **50** | **91%** | **99.6%** | **10.3%** | **100%** |

Per-category at the locked baseline: `no-facts` / `preference` / `contradiction` 0% violation; `transient-trap` 25% (the honest cheap-model floor — the prompt names these exclusions explicitly and the model still leaks ~1-in-4; **not** overfit to zero). All 7 residual violations are genuine (transient leaks like "deadline tomorrow", plus editorializing like "the assistant is willing to help") — **zero fabrications**.

### 3. Ride-alongs from the #1565 review
- **`FactStore.component.test.ts`** — runs `findSimilarActiveFacts` over real PGLite+pgvector, asserting the `valid_from DESC, salience DESC` tiebreak (identical embeddings → equal distance → tiebreak is the sole differentiator), active-filtering (superseded/forgotten/deleted), and persona scope. The unit suite mocks `$queryRaw`; this closes the review's "the SQL never runs in CI" gap — **CI-gated**, not a manual eval.
- **`ContentBudgetManager`** — `selectFacts` boundary test: wrapper overhead alone exceeding the fact slice → zero facts, zero tokens.

### Owner decision this unblocks
The gate bar is now a real number: **10.3% violation / 99.6% recall**. The remaining call is **5% strict vs 10% pragmatic-with-correction-surface** — deferred to you (see the review thread / next message), since it depends on whether the correction slice's `/memory correct|forget` is treated as the safety net for the transient-leak tail.

### Deferred (recorded, not dropped)
Fact **recall@K measurement** (a golden corpus + baseline number for retrieval, distinct from the correctness test above) is gated on real-scale fact-retrieval goldens — same evidence gate as the parked episode-retrieval eval; a toy corpus would repeat phase-1a's zero-lift lesson. Filed to the epic log.

### Verification
- `pnpm eval:extraction` before/after (the deliverable is the measurement).
- `pnpm test` (3573 ai-worker) + `pnpm quality` green; `FactStore.component.test.ts` 6/6.
- No schema/migration. No prod-path behavior change beyond the extraction prompt (dev-only: extraction runs only where `EXTRACTION_ENABLED=true`, facts read only behind the dev `FACTS_IN_PROMPT_ENABLED` flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)