### PR TITLE
feat(bot-client): /memory facts browse + correct/forget/lock UI (correction slice, part 2)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,13 +40,14 @@ TTS + STT provider selection and cloned-voice library lifecycle. Per-character T
 
 ## Memory & History
 
-| Command    | Subcommands                                        | Purpose                              |
-| ---------- | -------------------------------------------------- | ------------------------------------ |
-| `/memory`  | `browse` `search` `stats`                          | Browse and search long-term memories |
-|            | `delete` `purge`                                   | Memory management operations         |
-|            | `focus` (`enable` `disable` `status`)              | Temporarily disable LTM retrieval    |
-|            | `incognito` (`enable` `disable` `status` `forget`) | Privacy mode (no LTM writes)         |
-| `/history` | `clear` `stats` `undo` `hard-delete`               | Conversation history management      |
+| Command    | Subcommands                                        | Purpose                                            |
+| ---------- | -------------------------------------------------- | -------------------------------------------------- |
+| `/memory`  | `browse` `search` `stats`                          | Browse and search long-term memories               |
+|            | `facts`                                            | Browse/correct facts a character learned about you |
+|            | `delete` `purge`                                   | Memory management operations                       |
+|            | `focus` (`enable` `disable` `status`)              | Temporarily disable LTM retrieval                  |
+|            | `incognito` (`enable` `disable` `status` `forget`) | Privacy mode (no LTM writes)                       |
+| `/history` | `clear` `stats` `undo` `hard-delete`               | Conversation history management                    |
 
 ## Settings & Tools
 

--- a/packages/common-types/src/generated/commandOptions.ts
+++ b/packages/common-types/src/generated/commandOptions.ts
@@ -354,6 +354,13 @@ export const memoryBrowseOptions = defineTypedOptions({
 });
 
 /**
+ * /memory facts <character>
+ */
+export const memoryFactsOptions = defineTypedOptions({
+  character: { type: 'string', required: true },
+});
+
+/**
  * /memory search <query, character, limit>
  */
 export const memorySearchOptions = defineTypedOptions({

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -997,7 +997,9 @@
         "memory-browse",
         "memory-search",
         "memory-detail",
-        "memory-purge"
+        "memory-purge",
+        "memory-fact-browse",
+        "memory-fact"
       ],
       "data": {
         "options": [
@@ -1026,6 +1028,20 @@
                 "name": "character",
                 "description": "Filter by character (optional)",
                 "required": false
+              }
+            ]
+          },
+          {
+            "type": 1,
+            "name": "facts",
+            "description": "Browse and correct the facts a character has learned about you",
+            "options": [
+              {
+                "autocomplete": true,
+                "type": 3,
+                "name": "character",
+                "description": "The character whose facts to manage",
+                "required": true
               }
             ]
           },

--- a/services/bot-client/src/commands/memory/factsApi.test.ts
+++ b/services/bot-client/src/commands/memory/factsApi.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the Memory Facts API client.
+ *
+ * The contract under test mirrors detailApi: null/false ONLY on a genuine
+ * 404; everything else (including the locked-fact 403) throws so callers
+ * classify honestly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InfraError, GatewayClientError } from '@tzurot/clients';
+import { fetchFacts, fetchFact, correctFact, forgetFact, setFactLock } from './factsApi.js';
+import type { FactItem } from './factsApi.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+interface FactClientStub {
+  listFacts: ReturnType<typeof vi.fn>;
+  getFact: ReturnType<typeof vi.fn>;
+  correctFact: ReturnType<typeof vi.fn>;
+  forgetFact: ReturnType<typeof vi.fn>;
+  setFactLock: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): FactClientStub {
+  return {
+    listFacts: vi.fn(),
+    getFact: vi.fn(),
+    correctFact: vi.fn(),
+    forgetFact: vi.fn(),
+    setFactLock: vi.fn(),
+  };
+}
+
+const createMockFact = (overrides: Partial<FactItem> = {}): FactItem => ({
+  id: 'fact-123',
+  personalityId: 'personality-456',
+  personaId: 'persona-789',
+  statement: 'The user has a cat named Miso',
+  entityTags: ['user'],
+  salience: 0.7,
+  tier: 'observed',
+  isLocked: false,
+  validFrom: '2026-06-15T12:00:00.000Z',
+  supersededAt: null,
+  supersededById: null,
+  forgotten: false,
+  sourceMemoryIds: ['mem-1'],
+  createdAt: '2026-06-15T12:00:00.000Z',
+  ...overrides,
+});
+
+describe('Memory Facts API', () => {
+  let stub: FactClientStub;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = createStub();
+  });
+
+  describe('fetchFacts', () => {
+    it('passes personality scope + stringified pagination to the client', async () => {
+      const response = {
+        facts: [createMockFact()],
+        total: 1,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+      stub.listFacts.mockResolvedValue(makeOk(response));
+
+      const result = await fetchFacts(asUserClient(stub), 'personality-456', 20, 10);
+
+      expect(result).toEqual(response);
+      expect(stub.listFacts).toHaveBeenCalledWith({
+        personalityId: 'personality-456',
+        limit: '10',
+        offset: '20',
+      });
+    });
+
+    it('returns null on failure (browse degrades to a transient message)', async () => {
+      stub.listFacts.mockResolvedValue(makeErr(500, 'boom'));
+
+      expect(await fetchFacts(asUserClient(stub), 'personality-456', 0, 10)).toBeNull();
+    });
+  });
+
+  describe('fetchFact', () => {
+    it('unwraps the fact on success', async () => {
+      const fact = createMockFact();
+      stub.getFact.mockResolvedValue(makeOk({ fact }));
+
+      expect(await fetchFact(asUserClient(stub), 'fact-123', 'user-1')).toEqual(fact);
+      expect(stub.getFact).toHaveBeenCalledWith('fact-123');
+    });
+
+    it('returns null ONLY on a genuine 404', async () => {
+      stub.getFact.mockResolvedValue(makeErr(404, 'Not found'));
+      expect(await fetchFact(asUserClient(stub), 'fact-123')).toBeNull();
+    });
+
+    it('THROWS on an infra failure — a timeout must never read as "not found"', async () => {
+      stub.getFact.mockResolvedValue(makeErr(0, 'timed out', undefined, 'timeout'));
+      await expect(fetchFact(asUserClient(stub), 'fact-123')).rejects.toThrow(InfraError);
+    });
+  });
+
+  describe('correctFact', () => {
+    it('sends the corrected statement and returns the SURVIVOR fact', async () => {
+      // On a statement collision the survivor can be a DIFFERENT row.
+      const survivor = createMockFact({ id: 'other-fact', tier: 'corrected' });
+      stub.correctFact.mockResolvedValue(makeOk({ fact: survivor, supersededFactId: 'fact-123' }));
+
+      const result = await correctFact(
+        asUserClient(stub),
+        'fact-123',
+        'The user has a cat named Mochi',
+        'user-1'
+      );
+
+      expect(result).toEqual(survivor);
+      expect(stub.correctFact).toHaveBeenCalledWith('fact-123', {
+        statement: 'The user has a cat named Mochi',
+      });
+    });
+
+    it('THROWS on the locked-fact 403 (hard freeze surfaces, not silence)', async () => {
+      stub.correctFact.mockResolvedValue(makeErr(403, 'Cannot correct a locked fact'));
+      await expect(correctFact(asUserClient(stub), 'fact-123', 'x')).rejects.toThrow(
+        GatewayClientError
+      );
+    });
+
+    it('returns null ONLY on a genuine 404', async () => {
+      stub.correctFact.mockResolvedValue(makeErr(404, 'Not found'));
+      expect(await correctFact(asUserClient(stub), 'fact-123', 'x')).toBeNull();
+    });
+  });
+
+  describe('forgetFact', () => {
+    it('returns true on success', async () => {
+      stub.forgetFact.mockResolvedValue(makeOk({ id: 'fact-123', forgotten: true }));
+
+      expect(await forgetFact(asUserClient(stub), 'fact-123', 'user-1')).toBe(true);
+      expect(stub.forgetFact).toHaveBeenCalledWith('fact-123');
+    });
+
+    it('returns false ONLY on a genuine 404 (already gone)', async () => {
+      stub.forgetFact.mockResolvedValue(makeErr(404, 'Not found'));
+      expect(await forgetFact(asUserClient(stub), 'fact-123')).toBe(false);
+    });
+
+    it('THROWS on the locked-fact 403', async () => {
+      stub.forgetFact.mockResolvedValue(makeErr(403, 'Cannot forget a locked fact'));
+      await expect(forgetFact(asUserClient(stub), 'fact-123')).rejects.toThrow(GatewayClientError);
+    });
+  });
+
+  describe('setFactLock', () => {
+    it('sets the lock state explicitly with PUT + { locked }', async () => {
+      const fact = createMockFact({ isLocked: true });
+      stub.setFactLock.mockResolvedValue(makeOk({ fact }));
+
+      const result = await setFactLock(asUserClient(stub), 'fact-123', true, 'user-1');
+
+      expect(result).toEqual(fact);
+      expect(stub.setFactLock).toHaveBeenCalledWith('fact-123', { locked: true });
+    });
+
+    it('THROWS on a 5xx so the caller can classify the write honestly', async () => {
+      stub.setFactLock.mockResolvedValue(makeErr(500, 'boom'));
+      await expect(setFactLock(asUserClient(stub), 'fact-123', true)).rejects.toThrow(InfraError);
+    });
+  });
+});

--- a/services/bot-client/src/commands/memory/factsApi.ts
+++ b/services/bot-client/src/commands/memory/factsApi.ts
@@ -1,0 +1,114 @@
+/**
+ * Memory Facts API Client
+ * API functions for the /memory facts surface (memory Phase 2 correction slice).
+ *
+ * CONTRACT (mirrors detailApi.ts): `null` (or `false` for forget) means
+ * DEFINITIVELY absent — a genuine 404. Every other failure THROWS
+ * (`InfraError` for transport/5xx, `GatewayClientError` for a non-404 4xx,
+ * including the 403 a locked fact returns on correct/forget) so callers can
+ * classify honestly via `classifyGatewayFailure`.
+ */
+
+import { type z } from 'zod';
+import {
+  type FactItemSchema,
+  type FactListResponseSchema,
+} from '@tzurot/common-types/schemas/api/fact';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { nullOn404, type GatewayResult, type UserClient } from '@tzurot/clients';
+
+const logger = createLogger('memory-facts-api');
+
+export type FactItem = z.infer<typeof FactItemSchema>;
+export type FactListResponse = z.infer<typeof FactListResponseSchema>;
+
+/** Log non-404 failures before nullOn404 throws (observability parity). */
+function warnNonMiss(
+  result: GatewayResult<unknown>,
+  context: Record<string, unknown>,
+  message: string
+): void {
+  if (!result.ok && result.status !== 404) {
+    logger.warn({ ...context, kind: result.kind, status: result.status }, message);
+  }
+}
+
+/**
+ * Fetch a page of active facts for a personality. `null` = fetch failed
+ * (list is a read; the browse view degrades to a transient-error message
+ * rather than classifying, matching the episode browse contract).
+ */
+export async function fetchFacts(
+  userClient: UserClient,
+  personalityId: string,
+  offset: number,
+  limit: number
+): Promise<FactListResponse | null> {
+  const result = await userClient.listFacts({
+    personalityId,
+    limit: limit.toString(),
+    offset: offset.toString(),
+  });
+  if (!result.ok) {
+    return null;
+  }
+  return result.data;
+}
+
+/** Fetch a single fact. `null` = genuine 404; infra failures throw. */
+export async function fetchFact(
+  userClient: UserClient,
+  factId: string,
+  userId?: string
+): Promise<FactItem | null> {
+  const result = await userClient.getFact(factId);
+  warnNonMiss(result, { userId, factId }, 'Failed to fetch fact');
+  return nullOn404(result)?.fact ?? null;
+}
+
+/**
+ * Correct a fact — the gateway supersedes it with a corrected-tier fact and
+ * returns the SURVIVOR (which can be a different row when the corrected
+ * statement collides with an existing fact: the duplicates converge).
+ * `null` = genuine 404; infra failures and the locked-fact 403 throw.
+ */
+export async function correctFact(
+  userClient: UserClient,
+  factId: string,
+  statement: string,
+  userId?: string
+): Promise<FactItem | null> {
+  const result = await userClient.correctFact(factId, { statement });
+  warnNonMiss(result, { userId, factId }, 'Failed to correct fact');
+  return nullOn404(result)?.fact ?? null;
+}
+
+/**
+ * Forget a fact (terminal; never re-extracted). `false` = genuine 404
+ * (already gone); infra failures and the locked-fact 403 throw.
+ */
+export async function forgetFact(
+  userClient: UserClient,
+  factId: string,
+  userId?: string
+): Promise<boolean> {
+  const result = await userClient.forgetFact(factId);
+  warnNonMiss(result, { userId, factId }, 'Failed to forget fact');
+  return nullOn404(result) === null ? false : true;
+}
+
+/**
+ * Set the fact lock explicitly (idempotent — caller supplies the target state
+ * so a retried request can't flip the wrong way). `null` = genuine 404;
+ * infra failures throw.
+ */
+export async function setFactLock(
+  userClient: UserClient,
+  factId: string,
+  locked: boolean,
+  userId?: string
+): Promise<FactItem | null> {
+  const result = await userClient.setFactLock(factId, { locked });
+  warnNonMiss(result, { userId, factId, locked }, 'Failed to set fact lock');
+  return nullOn404(result)?.fact ?? null;
+}

--- a/services/bot-client/src/commands/memory/factsBrowse.test.ts
+++ b/services/bot-client/src/commands/memory/factsBrowse.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for the Memory Facts browser (/memory facts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ButtonInteraction } from 'discord.js';
+import {
+  FACT_BROWSE_PREFIX,
+  factBrowseHelpers,
+  isFactBrowsePagination,
+  handleFacts,
+  handleFactsPagination,
+  refreshFactsList,
+} from './factsBrowse.js';
+import type { FactItem } from './factsApi.js';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({ clientsFor: clientsForMock }));
+
+const resolveRequiredPersonalityMock = vi.hoisted(() => vi.fn());
+vi.mock('./resolveHelpers.js', () => ({
+  resolveRequiredPersonality: resolveRequiredPersonalityMock,
+}));
+
+const sessionManagerMock = vi.hoisted(() => ({
+  set: vi.fn().mockResolvedValue(undefined),
+  get: vi.fn(),
+  update: vi.fn().mockResolvedValue(undefined),
+  findByMessageId: vi.fn(),
+}));
+vi.mock('../../utils/dashboard/index.js', () => ({
+  getSessionManager: () => sessionManagerMock,
+}));
+
+interface FactClientStub {
+  listFacts: ReturnType<typeof vi.fn>;
+}
+
+const createMockFact = (overrides: Partial<FactItem> = {}): FactItem => ({
+  id: 'fact-123',
+  personalityId: 'personality-456',
+  personaId: 'persona-789',
+  statement: 'The user has a cat named Miso',
+  entityTags: ['user'],
+  salience: 0.7,
+  tier: 'observed',
+  isLocked: false,
+  validFrom: '2026-06-15T12:00:00.000Z',
+  supersededAt: null,
+  supersededById: null,
+  forgotten: false,
+  sourceMemoryIds: [],
+  createdAt: '2026-06-15T12:00:00.000Z',
+  ...overrides,
+});
+
+function listResponse(facts: FactItem[], total = facts.length) {
+  return makeOk({ facts, total, limit: 10, offset: 0, hasMore: false });
+}
+
+describe('fact browse custom IDs', () => {
+  it('matches its own pagination ids and nothing else', () => {
+    expect(isFactBrowsePagination(factBrowseHelpers.build(1, 'all', 'date', null))).toBe(true);
+    expect(isFactBrowsePagination('memory-browse::browse::1::all')).toBe(false);
+    expect(isFactBrowsePagination('memory-fact::select')).toBe(false);
+  });
+
+  it('exports the session entity type as the component prefix', () => {
+    expect(FACT_BROWSE_PREFIX).toBe('memory-fact-browse');
+  });
+});
+
+describe('handleFacts', () => {
+  let stub: FactClientStub;
+  let context: DeferredCommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = { listFacts: vi.fn() };
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+    resolveRequiredPersonalityMock.mockResolvedValue('personality-456');
+    context = {
+      user: { id: 'user-1' },
+      interaction: {
+        options: { getString: vi.fn().mockReturnValue('lilith') },
+      },
+      editReply: vi.fn().mockResolvedValue({ id: 'message-1', channelId: 'channel-1' }),
+    } as unknown as DeferredCommandContext;
+  });
+
+  it('renders the list and persists a session keyed by the reply message', async () => {
+    stub.listFacts.mockResolvedValue(listResponse([createMockFact()]));
+
+    await handleFacts(context);
+
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: [expect.anything()] })
+    );
+    expect(sessionManagerMock.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'memory-fact-browse',
+        entityId: 'message-1',
+        data: { personalityId: 'personality-456', currentPage: 0 },
+      })
+    );
+  });
+
+  it('stops when personality resolution already replied (null contract)', async () => {
+    resolveRequiredPersonalityMock.mockResolvedValue(null);
+
+    await handleFacts(context);
+
+    expect(stub.listFacts).not.toHaveBeenCalled();
+    expect(context.editReply).not.toHaveBeenCalled();
+  });
+
+  it('degrades to a transient error message when the list fetch fails', async () => {
+    stub.listFacts.mockResolvedValue(makeErr(500, 'boom'));
+
+    await handleFacts(context);
+
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.any(String) })
+    );
+    expect(sessionManagerMock.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleFactsPagination', () => {
+  let stub: FactClientStub;
+
+  function createPaginationInteraction(customId: string): ButtonInteraction {
+    return {
+      customId,
+      user: { id: 'user-1' },
+      message: { id: 'message-1' },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ButtonInteraction;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = { listFacts: vi.fn() };
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
+  it('acks first, reads the personality scope from the session, and fetches the page', async () => {
+    sessionManagerMock.findByMessageId.mockResolvedValue({
+      data: { personalityId: 'personality-456', currentPage: 0 },
+    });
+    sessionManagerMock.get.mockResolvedValue({
+      data: { personalityId: 'personality-456', currentPage: 0 },
+    });
+    stub.listFacts.mockResolvedValue(listResponse([createMockFact()], 25));
+    const interaction = createPaginationInteraction(
+      factBrowseHelpers.build(2, 'all', 'date', null)
+    );
+
+    await handleFactsPagination(interaction);
+
+    const deferOrder = vi.mocked(interaction.deferUpdate).mock.invocationCallOrder[0];
+    const sessionOrder = sessionManagerMock.findByMessageId.mock.invocationCallOrder[0];
+    expect(deferOrder).toBeLessThan(sessionOrder);
+    expect(stub.listFacts).toHaveBeenCalledWith(
+      expect.objectContaining({ personalityId: 'personality-456', offset: '20' })
+    );
+    expect(interaction.editReply).toHaveBeenCalled();
+  });
+
+  it('reports expiry when the session is gone', async () => {
+    sessionManagerMock.findByMessageId.mockResolvedValue(null);
+    const interaction = createPaginationInteraction(
+      factBrowseHelpers.build(1, 'all', 'date', null)
+    );
+
+    await handleFactsPagination(interaction);
+
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('expired') })
+    );
+    expect(stub.listFacts).not.toHaveBeenCalled();
+  });
+});
+
+describe('refreshFactsList', () => {
+  it('steps back a page when a forget empties the current one', async () => {
+    vi.clearAllMocks();
+    const stub: FactClientStub = { listFacts: vi.fn() };
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+    sessionManagerMock.findByMessageId.mockResolvedValue({
+      data: { personalityId: 'personality-456', currentPage: 1 },
+    });
+    sessionManagerMock.get.mockResolvedValue({
+      data: { personalityId: 'personality-456', currentPage: 1 },
+    });
+    // Page 1 now empty; page 0 still has facts.
+    stub.listFacts
+      .mockResolvedValueOnce(
+        makeOk({ facts: [], total: 10, limit: 10, offset: 10, hasMore: false })
+      )
+      .mockResolvedValueOnce(listResponse([createMockFact()], 10));
+
+    const interaction = {
+      user: { id: 'user-1' },
+      message: { id: 'message-1' },
+      editReply: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ButtonInteraction;
+
+    await refreshFactsList(interaction);
+
+    expect(stub.listFacts).toHaveBeenCalledTimes(2);
+    // Session advanced back to page 0.
+    expect(sessionManagerMock.update).toHaveBeenCalledWith(
+      'user-1',
+      'memory-fact-browse',
+      'message-1',
+      expect.objectContaining({ currentPage: 0 })
+    );
+    expect(interaction.editReply).toHaveBeenCalled();
+  });
+});
+
+describe('error branches', () => {
+  let stub: FactClientStub;
+
+  function createPaginationInteraction(customId: string): ButtonInteraction {
+    return {
+      customId,
+      user: { id: 'user-1' },
+      message: { id: 'message-1' },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ButtonInteraction;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = { listFacts: vi.fn() };
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
+  it('pagination: surfaces a transient error when the page fetch fails', async () => {
+    sessionManagerMock.findByMessageId.mockResolvedValue({
+      data: { personalityId: 'personality-456', currentPage: 0 },
+    });
+    stub.listFacts.mockResolvedValue(makeErr(500, 'boom'));
+    const interaction = createPaginationInteraction(
+      factBrowseHelpers.build(1, 'all', 'date', null)
+    );
+
+    await handleFactsPagination(interaction);
+
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.any(String) })
+    );
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('pagination: ignores a customId its parser rejects', async () => {
+    const interaction = createPaginationInteraction('something-else::entirely');
+
+    await handleFactsPagination(interaction);
+
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
+  });
+
+  it('handleFacts: a thrown gateway failure is classified into the reply', async () => {
+    resolveRequiredPersonalityMock.mockRejectedValue(new Error('gateway exploded'));
+    const context = {
+      user: { id: 'user-1' },
+      interaction: { options: { getString: vi.fn().mockReturnValue('lilith') } },
+      editReply: vi.fn().mockResolvedValue({ id: 'message-1', channelId: 'channel-1' }),
+    } as unknown as DeferredCommandContext;
+
+    await handleFacts(context);
+
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.any(String) })
+    );
+  });
+
+  it('refreshFactsList: no-ops when the session is gone or the fetch fails', async () => {
+    const interaction = {
+      user: { id: 'user-1' },
+      message: { id: 'message-1' },
+      editReply: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ButtonInteraction;
+
+    sessionManagerMock.findByMessageId.mockResolvedValue(null);
+    await refreshFactsList(interaction);
+    expect(interaction.editReply).not.toHaveBeenCalled();
+
+    sessionManagerMock.findByMessageId.mockResolvedValue({
+      data: { personalityId: 'personality-456', currentPage: 0 },
+    });
+    stub.listFacts.mockResolvedValue(makeErr(500, 'boom'));
+    await refreshFactsList(interaction);
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/commands/memory/factsBrowse.ts
+++ b/services/bot-client/src/commands/memory/factsBrowse.ts
@@ -1,0 +1,305 @@
+/**
+ * Memory Facts Browser (memory Phase 2 correction slice)
+ *
+ * /memory facts <character> — paginated list of the durable facts a character
+ * has auto-learned about the user, with a select menu into the detail view
+ * (Correct / Forget / Lock). Mirrors the episode browse router pattern:
+ * state lives in a messageId-keyed dashboard session, no inline collectors.
+ */
+
+import { EmbedBuilder, escapeMarkdown, MessageFlags, type ButtonInteraction } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { memoryFactsOptions } from '@tzurot/common-types/generated/commandOptions';
+import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
+import { getSessionManager } from '../../utils/dashboard/index.js';
+import type { DashboardSession } from '../../utils/dashboard/types.js';
+import {
+  createBrowseCustomIdHelpers,
+  buildBrowseButtons,
+  buildBrowseSelectMenu,
+  calculatePaginationState,
+  joinFooter,
+  pluralize,
+  formatPageIndicator,
+  type BrowseActionRow,
+} from '../../utils/browse/index.js';
+import { resolveRequiredPersonality } from './resolveHelpers.js';
+import { truncateContent } from './formatters.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
+import { fetchPageWithEmptyFallback } from './browseSession.js';
+import { buildFactActionId } from './factsDetail.js';
+import { fetchFacts, type FactItem } from './factsApi.js';
+
+const logger = createLogger('memory-facts-browse');
+
+/** Items per page */
+const FACTS_PER_PAGE = 10;
+
+/**
+ * One string, two roles: the customId prefix (componentPrefixes registration,
+ * pagination ids) AND the dashboard-session entity type — the browse message
+ * is the session's entity, so sharing the identifier keeps them in lockstep.
+ */
+export const FACT_BROWSE_PREFIX = 'memory-fact-browse';
+
+/** Facts session — personality scope lives here (UUIDs don't fit customIds). */
+export interface FactBrowseSession {
+  personalityId: string;
+  currentPage: number;
+}
+
+/** Browse customId helpers — filter slot unused (personality lives in session). */
+export const factBrowseHelpers = createBrowseCustomIdHelpers<'all'>({
+  prefix: FACT_BROWSE_PREFIX,
+  validFilters: ['all'],
+  includeSort: false,
+});
+
+/** Guard for pagination buttons (memory-fact-browse::browse::...). */
+export function isFactBrowsePagination(customId: string): boolean {
+  return factBrowseHelpers.isBrowse(customId);
+}
+
+async function findFactBrowseSession(
+  messageId: string
+): Promise<DashboardSession<FactBrowseSession> | null> {
+  return getSessionManager().findByMessageId<FactBrowseSession>(messageId);
+}
+
+function buildFactsEmbed(options: {
+  facts: FactItem[];
+  total: number;
+  page: number;
+  totalPages: number;
+}): EmbedBuilder {
+  const { facts, total, page, totalPages } = options;
+  const embed = new EmbedBuilder().setTitle('📋 Known Facts').setColor(DISCORD_COLORS.BLURPLE);
+
+  if (facts.length === 0) {
+    embed.setDescription(
+      "This character hasn't learned any facts about you yet.\n\n" +
+        'Facts are distilled automatically from your conversations.'
+    );
+    return embed;
+  }
+
+  const lines: string[] = [];
+  facts.forEach((fact, index) => {
+    const num = page * FACTS_PER_PAGE + index + 1;
+    const badges = `${fact.isLocked ? ' 🔒' : ''}${fact.tier === 'corrected' ? ' ✏️' : ''}`;
+    lines.push(`**${num}.** ${truncateContent(escapeMarkdown(fact.statement))}${badges}`);
+    lines.push(`   _${formatDateShort(fact.validFrom)}_`);
+    lines.push('');
+  });
+  embed.setDescription(lines.join('\n').trim());
+
+  embed.setFooter({
+    text: joinFooter(
+      pluralize(total, { singular: 'fact', plural: 'facts' }),
+      formatPageIndicator(page + 1, totalPages)
+    ),
+  });
+  return embed;
+}
+
+function buildFactsComponents(
+  facts: FactItem[],
+  page: number,
+  totalPages: number
+): BrowseActionRow[] {
+  const selectRow = buildBrowseSelectMenu<FactItem>({
+    items: facts,
+    customId: buildFactActionId('select'),
+    placeholder: 'Select a fact to manage...',
+    startIndex: page * FACTS_PER_PAGE,
+    formatItem: fact => ({
+      label: `${fact.isLocked ? '🔒 ' : ''}${fact.statement}`,
+      value: fact.id,
+      description: formatDateShort(fact.validFrom),
+    }),
+  });
+  if (selectRow === null) {
+    return [];
+  }
+
+  return [
+    selectRow,
+    buildBrowseButtons({
+      currentPage: page,
+      totalPages,
+      filter: 'all',
+      currentSort: 'date',
+      query: null,
+      buildCustomId: factBrowseHelpers.build,
+      buildInfoId: factBrowseHelpers.buildInfo,
+    }),
+  ];
+}
+
+/** Handle /memory facts <character> */
+export async function handleFacts(context: DeferredCommandContext): Promise<void> {
+  const userId = context.user.id;
+  const { userClient } = clientsFor(context.interaction);
+  const options = memoryFactsOptions(context.interaction);
+  const personalityInput = options.character();
+
+  try {
+    // Contract: null means the helper already sent the error reply.
+    const personalityId = await resolveRequiredPersonality(context, userClient, personalityInput);
+    if (personalityId === null) {
+      return;
+    }
+
+    const data = await fetchFacts(userClient, personalityId, 0, FACTS_PER_PAGE);
+    if (data === null) {
+      logger.warn({ userId }, 'Facts browse failed');
+      await context.editReply({
+        content: renderSpec(CATALOG.error.transient("Couldn't load the facts right now.")),
+      });
+      return;
+    }
+
+    const { totalPages } = calculatePaginationState(data.total, FACTS_PER_PAGE, 0);
+    const embed = buildFactsEmbed({ facts: data.facts, total: data.total, page: 0, totalPages });
+    const components = buildFactsComponents(data.facts, 0, totalPages);
+
+    const response = await context.editReply({ embeds: [embed], components });
+
+    await getSessionManager().set<FactBrowseSession>({
+      userId,
+      entityType: FACT_BROWSE_PREFIX,
+      entityId: response.id,
+      data: { personalityId, currentPage: 0 },
+      messageId: response.id,
+      channelId: response.channelId,
+    });
+
+    logger.info({ userId, total: data.total, personalityId }, 'Facts browse displayed');
+  } catch (error) {
+    logger.error({ err: error, userId }, 'Facts browse error');
+    await context.editReply({
+      content: renderSpec(classifyGatewayFailure(error, 'facts', { operation: 'read' })),
+    });
+  }
+}
+
+/** Pagination button handler. Ack-first; session carries the personality scope. */
+export async function handleFactsPagination(interaction: ButtonInteraction): Promise<void> {
+  const parsed = factBrowseHelpers.parse(interaction.customId);
+  if (parsed === null) {
+    return;
+  }
+
+  // Ephemeral deferral means only the invoker can click — no user check needed
+  // (same reasoning as episode browse; revisit if deferral mode ever changes).
+  await interaction.deferUpdate();
+
+  const messageId = interaction.message.id;
+  const session = await findFactBrowseSession(messageId);
+  if (session === null) {
+    await interaction.followUp({
+      content: '⏰ This interaction has expired. Please run `/memory facts` again.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const { personalityId } = session.data;
+  const { userClient } = clientsFor(interaction);
+  const data = await fetchFacts(
+    userClient,
+    personalityId,
+    parsed.page * FACTS_PER_PAGE,
+    FACTS_PER_PAGE
+  );
+  if (data === null) {
+    await interaction.followUp({
+      content: renderSpec(CATALOG.error.transient("Couldn't load that page right now.")),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const { totalPages, safePage } = calculatePaginationState(
+    data.total,
+    FACTS_PER_PAGE,
+    parsed.page
+  );
+  const embed = buildFactsEmbed({
+    facts: data.facts,
+    total: data.total,
+    page: safePage,
+    totalPages,
+  });
+  await interaction.editReply({
+    embeds: [embed],
+    components: buildFactsComponents(data.facts, safePage, totalPages),
+  });
+
+  await updateFactSessionPage(interaction.user.id, messageId, safePage);
+}
+
+async function updateFactSessionPage(
+  userId: string,
+  messageId: string,
+  newPage: number
+): Promise<void> {
+  const sessionManager = getSessionManager();
+  const existing = await sessionManager.get<FactBrowseSession>(
+    userId,
+    FACT_BROWSE_PREFIX,
+    messageId
+  );
+  if (existing === null) {
+    return;
+  }
+  await sessionManager.update<FactBrowseSession>(userId, FACT_BROWSE_PREFIX, messageId, {
+    ...existing.data,
+    currentPage: newPage,
+  });
+}
+
+/**
+ * Refresh the list view — called after "back" from detail and after a forget.
+ * Steps back a page when a forget empties the current one.
+ */
+export async function refreshFactsList(interaction: ButtonInteraction): Promise<void> {
+  const messageId = interaction.message.id;
+  const session = await findFactBrowseSession(messageId);
+  if (session === null) {
+    return;
+  }
+
+  const { personalityId } = session.data;
+  const { userClient } = clientsFor(interaction);
+
+  const result = await fetchPageWithEmptyFallback({
+    currentPage: session.data.currentPage,
+    fetchPage: page => fetchFacts(userClient, personalityId, page * FACTS_PER_PAGE, FACTS_PER_PAGE),
+    isEmpty: d => d.facts.length === 0,
+  });
+  if (result === null) {
+    return;
+  }
+
+  if (result.steppedBack) {
+    await updateFactSessionPage(interaction.user.id, messageId, result.page);
+  }
+
+  const { totalPages } = calculatePaginationState(result.data.total, FACTS_PER_PAGE, result.page);
+  const embed = buildFactsEmbed({
+    facts: result.data.facts,
+    total: result.data.total,
+    page: result.page,
+    totalPages,
+  });
+  await interaction.editReply({
+    embeds: [embed],
+    components: buildFactsComponents(result.data.facts, result.page, totalPages),
+  });
+}

--- a/services/bot-client/src/commands/memory/factsDetail.test.ts
+++ b/services/bot-client/src/commands/memory/factsDetail.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for the Memory Facts detail view (correction verbs).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  ButtonInteraction,
+  ModalSubmitInteraction,
+  StringSelectMenuInteraction,
+} from 'discord.js';
+import {
+  FACT_DETAIL_PREFIX,
+  buildFactActionId,
+  parseFactActionId,
+  buildFactDetailEmbed,
+  buildFactDetailButtons,
+  handleFactSelect,
+  handleCorrectButton,
+  handleCorrectModalSubmit,
+  handleFactLockButton,
+  handleForgetButton,
+  handleForgetConfirm,
+} from './factsDetail.js';
+import type { FactItem } from './factsApi.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({ clientsFor: clientsForMock }));
+
+const showModalMock = vi.hoisted(() => vi.fn());
+const ackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/dashboard/showModalWithTimeoutCatch.js', () => ({
+  showModalWithTimeoutCatch: showModalMock,
+}));
+vi.mock('../../utils/dashboard/ackWithTimeoutCatch.js', () => ({
+  ackWithTimeoutCatch: ackMock,
+}));
+
+interface FactClientStub {
+  getFact: ReturnType<typeof vi.fn>;
+  correctFact: ReturnType<typeof vi.fn>;
+  forgetFact: ReturnType<typeof vi.fn>;
+  setFactLock: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): FactClientStub {
+  return { getFact: vi.fn(), correctFact: vi.fn(), forgetFact: vi.fn(), setFactLock: vi.fn() };
+}
+
+const createMockFact = (overrides: Partial<FactItem> = {}): FactItem => ({
+  id: 'fact-123',
+  personalityId: 'personality-456',
+  personaId: 'persona-789',
+  statement: 'The user has a cat named Miso',
+  entityTags: ['user'],
+  salience: 0.7,
+  tier: 'observed',
+  isLocked: false,
+  validFrom: '2026-06-15T12:00:00.000Z',
+  supersededAt: null,
+  supersededById: null,
+  forgotten: false,
+  sourceMemoryIds: ['mem-1'],
+  createdAt: '2026-06-15T12:00:00.000Z',
+  ...overrides,
+});
+
+function createButtonInteraction(): ButtonInteraction {
+  return {
+    user: { id: 'user-1' },
+    deferred: false,
+    replied: false,
+    deferUpdate: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ButtonInteraction;
+}
+
+describe('fact custom IDs', () => {
+  it('round-trips action, factId, and extra', () => {
+    const id = buildFactActionId('lock', 'fact-123', '1');
+    expect(id).toBe(`${FACT_DETAIL_PREFIX}::lock::fact-123::1`);
+    expect(parseFactActionId(id)).toEqual({ action: 'lock', factId: 'fact-123', extra: '1' });
+  });
+
+  it('does NOT match the fact-browse pagination prefix (shared stem)', () => {
+    // memory-fact-browse::... must never parse as a memory-fact:: action.
+    expect(parseFactActionId('memory-fact-browse::browse::1::all')).toBeNull();
+  });
+
+  it('returns null for foreign prefixes', () => {
+    expect(parseFactActionId('memory-detail::edit::x')).toBeNull();
+  });
+});
+
+describe('buildFactDetailEmbed', () => {
+  it('shows the statement, origin tier, and lock status', () => {
+    const embed = buildFactDetailEmbed(createMockFact()).toJSON();
+    expect(embed.description).toContain('The user has a cat named Miso');
+    expect(embed.fields?.find(f => f.name === 'Origin')?.value).toContain('Learned');
+    expect(embed.fields?.find(f => f.name === 'Status')?.value).toContain('Unlocked');
+  });
+
+  it('marks a corrected fact and a locked fact distinctly', () => {
+    const corrected = buildFactDetailEmbed(
+      createMockFact({ tier: 'corrected', isLocked: true })
+    ).toJSON();
+    expect(corrected.title).toContain('🔒');
+    expect(corrected.fields?.find(f => f.name === 'Origin')?.value).toContain('Corrected');
+  });
+});
+
+describe('buildFactDetailButtons', () => {
+  it('disables Correct and Forget on a locked fact (hard freeze)', () => {
+    const row = buildFactDetailButtons(createMockFact({ isLocked: true })).toJSON();
+    const byLabel = new Map(row.components.map(c => ['label' in c ? c.label : '', c]));
+    expect(byLabel.get('Correct')?.disabled).toBe(true);
+    expect(byLabel.get('Forget')?.disabled).toBe(true);
+    expect(byLabel.get('Unlock')?.disabled).toBeFalsy();
+  });
+
+  it('encodes the lock TARGET state in the customId', () => {
+    const unlockedRow = buildFactDetailButtons(createMockFact({ isLocked: false })).toJSON();
+    const lockButton = unlockedRow.components.find(c => 'label' in c && c.label === 'Lock');
+    expect(lockButton !== undefined && 'custom_id' in lockButton && lockButton.custom_id).toBe(
+      buildFactActionId('lock', 'fact-123', '1')
+    );
+  });
+});
+
+describe('handlers', () => {
+  let stub: FactClientStub;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
+  it('handleFactSelect acks FIRST, then fetches and renders the detail view', async () => {
+    const fact = createMockFact();
+    stub.getFact.mockResolvedValue(makeOk({ fact }));
+    const interaction = {
+      ...createButtonInteraction(),
+      values: ['fact-123'],
+    } as unknown as StringSelectMenuInteraction;
+
+    await handleFactSelect(interaction);
+
+    // Ack-first: deferUpdate must have been called before the gateway fetch.
+    const deferOrder = vi.mocked(interaction.deferUpdate).mock.invocationCallOrder[0];
+    const fetchOrder = stub.getFact.mock.invocationCallOrder[0];
+    expect(deferOrder).toBeLessThan(fetchOrder);
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: [expect.anything()], components: [expect.anything()] })
+    );
+  });
+
+  it('handleCorrectModalSubmit sends the new statement and renders the SURVIVOR', async () => {
+    const survivor = createMockFact({ id: 'other-fact', tier: 'corrected' });
+    stub.correctFact.mockResolvedValue(makeOk({ fact: survivor, supersededFactId: 'fact-123' }));
+    const interaction = {
+      user: { id: 'user-1' },
+      fields: { getTextInputValue: vi.fn().mockReturnValue('The user has a dog named Rex') },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ModalSubmitInteraction;
+
+    await handleCorrectModalSubmit(interaction, 'fact-123');
+
+    expect(stub.correctFact).toHaveBeenCalledWith('fact-123', {
+      statement: 'The user has a dog named Rex',
+    });
+    expect(interaction.editReply).toHaveBeenCalled();
+  });
+
+  it('handleCorrectModalSubmit surfaces a classified error via followUp (e.g. stale-view 403)', async () => {
+    stub.correctFact.mockResolvedValue(makeErr(403, 'Cannot correct a locked fact'));
+    const interaction = {
+      user: { id: 'user-1' },
+      fields: { getTextInputValue: vi.fn().mockReturnValue('x') },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ModalSubmitInteraction;
+
+    await handleCorrectModalSubmit(interaction, 'fact-123');
+
+    expect(interaction.followUp).toHaveBeenCalled();
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('handleFactLockButton passes the desired target state through', async () => {
+    stub.setFactLock.mockResolvedValue(makeOk({ fact: createMockFact({ isLocked: true }) }));
+    const interaction = createButtonInteraction();
+
+    await handleFactLockButton(interaction, 'fact-123', true);
+
+    expect(stub.setFactLock).toHaveBeenCalledWith('fact-123', { locked: true });
+    expect(interaction.editReply).toHaveBeenCalled();
+  });
+
+  it('handleForgetButton renders the confirmation with a danger confirm id', async () => {
+    stub.getFact.mockResolvedValue(makeOk({ fact: createMockFact() }));
+    const interaction = createButtonInteraction();
+
+    await handleForgetButton(interaction, 'fact-123');
+
+    const call = vi.mocked(interaction.editReply).mock.calls[0]?.[0] as unknown as {
+      components: { toJSON(): { components: { custom_id?: string }[] } }[];
+    };
+    const ids = call.components[0].toJSON().components.map(c => c.custom_id);
+    expect(ids).toContain(buildFactActionId('confirm-forget', 'fact-123'));
+  });
+
+  it('handleForgetConfirm forgets and reports true; false on a genuine 404', async () => {
+    stub.forgetFact.mockResolvedValue(makeOk({ id: 'fact-123', forgotten: true }));
+    expect(await handleForgetConfirm(createButtonInteraction(), 'fact-123')).toBe(true);
+
+    stub.forgetFact.mockResolvedValue(makeErr(404, 'gone'));
+    expect(await handleForgetConfirm(createButtonInteraction(), 'fact-123')).toBe(false);
+  });
+});
+
+describe('handleCorrectButton (pre-modal fetch path)', () => {
+  let stub: FactClientStub;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
+  it('shows the modal prefilled with the current statement', async () => {
+    stub.getFact.mockResolvedValue(makeOk({ fact: createMockFact() }));
+    const interaction = createButtonInteraction();
+
+    await handleCorrectButton(interaction, 'fact-123');
+
+    expect(showModalMock).toHaveBeenCalled();
+    const modal = showModalMock.mock.calls[0][1] as { toJSON(): unknown };
+    const json = JSON.stringify(modal.toJSON());
+    expect(json).toContain('The user has a cat named Miso'); // prefill
+    expect(json).toContain(buildFactActionId('correct', 'fact-123'));
+    // showModal must be the first response — no defer/reply on this path.
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
+  });
+
+  it('delivers a not-found error through the timeout-catch ack (no modal)', async () => {
+    stub.getFact.mockResolvedValue(makeErr(404, 'Not found'));
+    const interaction = createButtonInteraction();
+
+    await handleCorrectButton(interaction, 'fact-123');
+
+    expect(showModalMock).not.toHaveBeenCalled();
+    expect(ackMock).toHaveBeenCalled();
+  });
+
+  it('delivers a classified infra error through the timeout-catch ack', async () => {
+    stub.getFact.mockResolvedValue(makeErr(0, 'timed out', undefined, 'timeout'));
+    const interaction = createButtonInteraction();
+
+    await handleCorrectButton(interaction, 'fact-123');
+
+    expect(showModalMock).not.toHaveBeenCalled();
+    expect(ackMock).toHaveBeenCalled();
+  });
+});
+
+describe('handler error branches', () => {
+  let stub: FactClientStub;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
+  it('handleFactSelect: infra failure and genuine 404 both surface via followUp', async () => {
+    const throwing = {
+      ...createButtonInteraction(),
+      values: ['fact-123'],
+    } as unknown as StringSelectMenuInteraction;
+    stub.getFact.mockResolvedValue(makeErr(500, 'boom'));
+    await handleFactSelect(throwing);
+    expect(throwing.followUp).toHaveBeenCalled();
+    expect(throwing.editReply).not.toHaveBeenCalled();
+
+    const missing = {
+      ...createButtonInteraction(),
+      values: ['fact-123'],
+    } as unknown as StringSelectMenuInteraction;
+    stub.getFact.mockResolvedValue(makeErr(404, 'gone'));
+    await handleFactSelect(missing);
+    expect(missing.followUp).toHaveBeenCalled();
+  });
+
+  it('handleCorrectModalSubmit: genuine 404 surfaces as not-found via followUp', async () => {
+    stub.correctFact.mockResolvedValue(makeErr(404, 'gone'));
+    const interaction = {
+      user: { id: 'user-1' },
+      fields: { getTextInputValue: vi.fn().mockReturnValue('x') },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ModalSubmitInteraction;
+
+    await handleCorrectModalSubmit(interaction, 'fact-123');
+
+    expect(interaction.followUp).toHaveBeenCalled();
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('handleFactLockButton: 404 and infra failure surface via followUp', async () => {
+    const gone = createButtonInteraction();
+    stub.setFactLock.mockResolvedValue(makeErr(404, 'gone'));
+    await handleFactLockButton(gone, 'fact-123', true);
+    expect(gone.followUp).toHaveBeenCalled();
+
+    const broken = createButtonInteraction();
+    stub.setFactLock.mockResolvedValue(makeErr(500, 'boom'));
+    await handleFactLockButton(broken, 'fact-123', true);
+    expect(broken.followUp).toHaveBeenCalled();
+  });
+
+  it('handleForgetButton: 404 and infra failure surface via followUp (no confirm view)', async () => {
+    const gone = createButtonInteraction();
+    stub.getFact.mockResolvedValue(makeErr(404, 'gone'));
+    await handleForgetButton(gone, 'fact-123');
+    expect(gone.followUp).toHaveBeenCalled();
+    expect(gone.editReply).not.toHaveBeenCalled();
+
+    const broken = createButtonInteraction();
+    stub.getFact.mockResolvedValue(makeErr(500, 'boom'));
+    await handleForgetButton(broken, 'fact-123');
+    expect(broken.followUp).toHaveBeenCalled();
+  });
+
+  it('handleForgetConfirm: a thrown failure surfaces via followUp and reports false', async () => {
+    stub.forgetFact.mockResolvedValue(makeErr(500, 'boom'));
+    const interaction = createButtonInteraction();
+
+    expect(await handleForgetConfirm(interaction, 'fact-123')).toBe(false);
+    expect(interaction.followUp).toHaveBeenCalled();
+  });
+
+  it('handleForgetConfirm: skips the defer when already deferred (router pre-ack)', async () => {
+    stub.forgetFact.mockResolvedValue(makeOk({ id: 'fact-123', forgotten: true }));
+    const interaction = {
+      ...createButtonInteraction(),
+      deferred: true,
+    } as unknown as ButtonInteraction;
+
+    expect(await handleForgetConfirm(interaction, 'fact-123')).toBe(true);
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/commands/memory/factsDetail.ts
+++ b/services/bot-client/src/commands/memory/factsDetail.ts
@@ -1,0 +1,370 @@
+/**
+ * Memory Facts Detail View (memory Phase 2 correction slice)
+ *
+ * Detail embed + the correction verbs for a single extracted fact:
+ * Correct (modal → PATCH), Forget (confirm → DELETE, terminal), Lock toggle.
+ *
+ * Lock is a hard freeze with the SAME semantics as episode-memory locks:
+ * a locked fact rejects correct/forget (the buttons render disabled) and is
+ * never auto-superseded by extraction. Corrections don't need the lock —
+ * their `corrected` tier already shields them from extraction.
+ */
+
+import {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  MessageFlags,
+  escapeMarkdown,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { formatDateTimeCompact } from '@tzurot/common-types/utils/dateFormatting';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
+import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
+import { ackWithTimeoutCatch } from '../../utils/dashboard/ackWithTimeoutCatch.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
+import { followUpSpec } from '../../ux/render/reply.js';
+import { fetchFact, correctFact, forgetFact, setFactLock, type FactItem } from './factsApi.js';
+
+const logger = createLogger('memory-facts-detail');
+
+/** Custom ID prefix for fact detail actions */
+export const FACT_DETAIL_PREFIX = 'memory-fact';
+
+/**
+ * Statement cap for the correct modal — matches the API's
+ * CorrectFactRequestSchema max (Discord requires prefill ≤ max_length).
+ */
+export const MAX_FACT_STATEMENT_LENGTH = 1000;
+
+/** Human labels for the fact tier (how the fact came to exist). */
+const TIER_LABELS: Record<string, string> = {
+  observed: '🔍 Learned from conversation',
+  inferred: '🔮 Inferred',
+  corrected: '✏️ Corrected by you',
+};
+
+type FactAction = 'select' | 'correct' | 'lock' | 'back' | 'forget' | 'confirm-forget';
+
+/** Build a fact-action custom ID: memory-fact::{action}[::factId[::extra]] */
+export function buildFactActionId(action: FactAction, factId?: string, extra?: string): string {
+  const parts: string[] = [FACT_DETAIL_PREFIX, action];
+  if (factId !== undefined) {
+    parts.push(factId);
+  }
+  if (extra !== undefined) {
+    parts.push(extra);
+  }
+  return parts.join(CUSTOM_ID_DELIMITER);
+}
+
+/** Parse a fact-action custom ID (null if it isn't one). */
+export function parseFactActionId(
+  customId: string
+): { action: string; factId?: string; extra?: string } | null {
+  if (!customId.startsWith(`${FACT_DETAIL_PREFIX}${CUSTOM_ID_DELIMITER}`)) {
+    return null;
+  }
+  const parts = customId.split(CUSTOM_ID_DELIMITER);
+  return { action: parts[1], factId: parts[2], extra: parts[3] };
+}
+
+/** Build the detail embed for a single fact. */
+export function buildFactDetailEmbed(fact: FactItem): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle(`${fact.isLocked ? '🔒 ' : ''}Fact Details`)
+    .setColor(fact.isLocked ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE)
+    .setDescription(escapeMarkdown(fact.statement));
+
+  embed.addFields(
+    { name: 'Origin', value: TIER_LABELS[fact.tier] ?? fact.tier, inline: true },
+    { name: 'Status', value: fact.isLocked ? '🔒 Locked' : '🔓 Unlocked', inline: true },
+    { name: 'Learned', value: formatDateTimeCompact(fact.validFrom), inline: true }
+  );
+
+  if (fact.sourceMemoryIds.length > 0) {
+    embed.addFields({
+      name: 'Sources',
+      value: `${fact.sourceMemoryIds.length} conversation ${fact.sourceMemoryIds.length === 1 ? 'memory' : 'memories'}`,
+      inline: true,
+    });
+  }
+
+  embed.setFooter({ text: `Fact ID: ${fact.id.substring(0, 8)}...` });
+  return embed;
+}
+
+/**
+ * Build the action buttons. Correct and Forget render DISABLED on a locked
+ * fact — the lock is a hard freeze (same contract as episode locks), so the
+ * UI communicates "unlock first" visually instead of letting the click 403.
+ */
+export function buildFactDetailButtons(fact: FactItem): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildFactActionId('correct', fact.id))
+      .setLabel('Correct')
+      .setEmoji('✏️')
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(fact.isLocked),
+    new ButtonBuilder()
+      // Encode desired final state so a retried request can't flip the wrong way.
+      .setCustomId(buildFactActionId('lock', fact.id, fact.isLocked ? '0' : '1'))
+      .setLabel(fact.isLocked ? 'Unlock' : 'Lock')
+      .setEmoji(fact.isLocked ? '🔓' : '🔒')
+      .setStyle(fact.isLocked ? ButtonStyle.Secondary : ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(buildFactActionId('back'))
+      .setLabel('Back to List')
+      .setEmoji('◀️')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(buildFactActionId('forget', fact.id))
+      .setLabel('Forget')
+      .setEmoji('🗑️')
+      .setStyle(ButtonStyle.Danger)
+      .setDisabled(fact.isLocked)
+  );
+}
+
+/** Render the detail view onto the (already-acked) interaction's message. */
+async function showDetailView(
+  interaction: ButtonInteraction | StringSelectMenuInteraction | ModalSubmitInteraction,
+  fact: FactItem
+): Promise<void> {
+  await interaction.editReply({
+    embeds: [buildFactDetailEmbed(fact)],
+    components: [buildFactDetailButtons(fact)],
+  });
+}
+
+/** Select-menu handler — user picked a fact from the browse list. */
+export async function handleFactSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+  const factId = interaction.values[0];
+  await interaction.deferUpdate();
+
+  const { userClient } = clientsFor(interaction);
+  let fact: FactItem | null;
+  try {
+    fact = await fetchFact(userClient, factId, interaction.user.id);
+  } catch (error) {
+    await followUpSpec(interaction, classifyGatewayFailure(error, 'fact', { operation: 'read' }));
+    return;
+  }
+  if (fact === null) {
+    await followUpSpec(interaction, CATALOG.error.notFound('Fact'));
+    return;
+  }
+  await showDetailView(interaction, fact);
+}
+
+/**
+ * Correct button — fetch the fact (prefill) then show the modal. The fetch
+ * happens BEFORE the ack (showModal must be the first response), so both the
+ * error ack and the modal route through timeout-catch wrappers per the
+ * 3-second-budget rule.
+ */
+export async function handleCorrectButton(
+  interaction: ButtonInteraction,
+  factId: string
+): Promise<void> {
+  const { userClient } = clientsFor(interaction);
+  let fact: FactItem | null;
+  let errorContent: string | null = null;
+  try {
+    fact = await fetchFact(userClient, factId, interaction.user.id);
+    if (fact === null) {
+      errorContent = renderSpec(CATALOG.error.notFound('Fact'));
+    }
+  } catch (error) {
+    fact = null;
+    errorContent = renderSpec(classifyGatewayFailure(error, 'fact', { operation: 'read' }));
+  }
+
+  if (fact === null) {
+    const content = errorContent ?? renderSpec(CATALOG.error.notFound('Fact'));
+    await ackWithTimeoutCatch(
+      interaction,
+      () => interaction.reply({ content, flags: MessageFlags.Ephemeral }),
+      {
+        source: 'handleCorrectButton',
+        userId: interaction.user.id,
+        entityId: factId,
+        sectionId: 'correct',
+      },
+      content
+    );
+    return;
+  }
+
+  const modal = new ModalBuilder()
+    .setCustomId(buildFactActionId('correct', fact.id))
+    .setTitle('Correct Fact');
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(
+      new TextInputBuilder()
+        .setCustomId('statement')
+        .setLabel('What should this fact say?')
+        .setStyle(TextInputStyle.Paragraph)
+        .setValue(fact.statement)
+        .setMaxLength(MAX_FACT_STATEMENT_LENGTH)
+        .setRequired(true)
+    )
+  );
+
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    {
+      source: 'handleCorrectButton',
+      userId: interaction.user.id,
+      entityId: factId,
+      sectionId: 'correct',
+    },
+    '⏰ Took too long to open the editor. Please click Correct again.'
+  );
+}
+
+/** Correct modal submit — supersede via the gateway, show the surviving fact. */
+export async function handleCorrectModalSubmit(
+  interaction: ModalSubmitInteraction,
+  factId: string
+): Promise<void> {
+  const userId = interaction.user.id;
+  const statement = interaction.fields.getTextInputValue('statement');
+
+  await interaction.deferUpdate();
+
+  const { userClient } = clientsFor(interaction);
+  let survivor: FactItem | null;
+  try {
+    survivor = await correctFact(userClient, factId, statement, userId);
+  } catch (error) {
+    // Includes the identical-statement 400 and (stale-view) locked 403 —
+    // classified rather than swallowed; a timeout is outcome-uncertain.
+    await followUpSpec(interaction, classifyGatewayFailure(error, 'fact'));
+    return;
+  }
+  if (survivor === null) {
+    await followUpSpec(interaction, CATALOG.error.notFound('Fact'));
+    return;
+  }
+
+  await showDetailView(interaction, survivor);
+  logger.info({ userId, factId, survivorId: survivor.id }, 'Fact corrected');
+}
+
+/** Lock toggle — target state encoded in the customId. */
+export async function handleFactLockButton(
+  interaction: ButtonInteraction,
+  factId: string,
+  desiredState: boolean
+): Promise<void> {
+  await interaction.deferUpdate();
+
+  const { userClient } = clientsFor(interaction);
+  let updated: FactItem | null;
+  try {
+    updated = await setFactLock(userClient, factId, desiredState, interaction.user.id);
+  } catch (error) {
+    await followUpSpec(interaction, classifyGatewayFailure(error, 'fact lock'));
+    return;
+  }
+  if (updated === null) {
+    await followUpSpec(interaction, CATALOG.error.notFound('Fact'));
+    return;
+  }
+
+  await showDetailView(interaction, updated);
+  logger.info(
+    { userId: interaction.user.id, factId, action: updated.isLocked ? 'locked' : 'unlocked' },
+    'Fact lock set'
+  );
+}
+
+/** Forget button — show the confirmation view. */
+export async function handleForgetButton(
+  interaction: ButtonInteraction,
+  factId: string
+): Promise<void> {
+  await interaction.deferUpdate();
+
+  const { userClient } = clientsFor(interaction);
+  let fact: FactItem | null;
+  try {
+    fact = await fetchFact(userClient, factId, interaction.user.id);
+  } catch (error) {
+    await followUpSpec(interaction, classifyGatewayFailure(error, 'fact', { operation: 'read' }));
+    return;
+  }
+  if (fact === null) {
+    await followUpSpec(interaction, CATALOG.error.notFound('Fact'));
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle('⚠️ Forget This Fact?')
+    .setColor(DISCORD_COLORS.ERROR)
+    .setDescription(
+      `> ${escapeMarkdown(fact.statement)}\n\n` +
+        `The character will permanently forget this, and it will **never be re-learned** ` +
+        `from past conversations.\n\n**This cannot be undone.**`
+    );
+
+  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildFactActionId('back'))
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(buildFactActionId('confirm-forget', factId))
+      .setLabel('Yes, Forget')
+      .setStyle(ButtonStyle.Danger)
+  );
+
+  await interaction.editReply({ embeds: [embed], components: [buttons] });
+}
+
+/**
+ * Forget confirmation — terminal removal, then the caller refreshes the list.
+ * Guards the defer so it stays safe both standalone and pre-deferred.
+ * @returns true when the fact was forgotten (caller should refresh the list)
+ */
+export async function handleForgetConfirm(
+  interaction: ButtonInteraction,
+  factId: string
+): Promise<boolean> {
+  if (!interaction.deferred && !interaction.replied) {
+    await interaction.deferUpdate();
+  }
+
+  const { userClient } = clientsFor(interaction);
+  let success: boolean;
+  try {
+    success = await forgetFact(userClient, factId, interaction.user.id);
+  } catch (error) {
+    await followUpSpec(
+      interaction,
+      classifyGatewayFailure(error, 'fact', { failedAction: 'forget the fact' })
+    );
+    return false;
+  }
+  if (!success) {
+    await followUpSpec(interaction, CATALOG.error.notFound('Fact'));
+    return false;
+  }
+
+  logger.info({ userId: interaction.user.id, factId }, 'Fact forgotten');
+  return true;
+}

--- a/services/bot-client/src/commands/memory/index.ts
+++ b/services/bot-client/src/commands/memory/index.ts
@@ -39,6 +39,8 @@ import { handleBatchDelete } from './batchDelete.js';
 import { handlePurge, MEMORY_PURGE_PREFIX } from './purge.js';
 import { handlePersonalityAutocomplete } from './autocomplete.js';
 import { MEMORY_DETAIL_PREFIX } from './detail.js';
+import { handleFacts, FACT_BROWSE_PREFIX } from './factsBrowse.js';
+import { FACT_DETAIL_PREFIX } from './factsDetail.js';
 import { handleButton, handleModal, handleSelectMenu } from './interactionHandlers.js';
 
 const logger = createLogger('memory-command');
@@ -88,6 +90,8 @@ async function execute(ctx: SafeCommandContext): Promise<void> {
     await handleStats(context);
   } else if (subcommand === 'browse') {
     await handleBrowse(context);
+  } else if (subcommand === 'facts') {
+    await handleFacts(context);
   } else if (subcommand === 'search') {
     await handleSearch(context);
   } else if (subcommand === 'delete') {
@@ -144,6 +148,18 @@ export default defineCommand({
             .setName('character')
             .setDescription('Filter by character (optional)')
             .setRequired(false)
+            .setAutocomplete(true)
+        )
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('facts')
+        .setDescription('Browse and correct the facts a character has learned about you')
+        .addStringOption(option =>
+          option
+            .setName('character')
+            .setDescription('The character whose facts to manage')
+            .setRequired(true)
             .setAutocomplete(true)
         )
     )
@@ -328,5 +344,7 @@ export default defineCommand({
     MEMORY_SEARCH_PREFIX,
     MEMORY_DETAIL_PREFIX,
     MEMORY_PURGE_PREFIX,
+    FACT_BROWSE_PREFIX,
+    FACT_DETAIL_PREFIX,
   ],
 });

--- a/services/bot-client/src/commands/memory/interactionHandlers.test.ts
+++ b/services/bot-client/src/commands/memory/interactionHandlers.test.ts
@@ -27,6 +27,17 @@ const {
   mockHandleMemorySelect,
   mockHandleEditModalSubmit,
   mockFindMemoryListSessionByMessage,
+  mockIsFactBrowsePagination,
+  mockFactBrowseHelpers,
+  mockHandleFactsPagination,
+  mockRefreshFactsList,
+  mockParseFactActionId,
+  mockHandleFactSelect,
+  mockHandleCorrectButton,
+  mockHandleCorrectModalSubmit,
+  mockHandleFactLockButton,
+  mockHandleForgetButton,
+  mockHandleForgetConfirm,
 } = vi.hoisted(() => ({
   mockHandleBrowsePagination: vi.fn(),
   mockHandleBrowseSelect: vi.fn(),
@@ -46,6 +57,17 @@ const {
   mockHandleMemorySelect: vi.fn(),
   mockHandleEditModalSubmit: vi.fn(),
   mockFindMemoryListSessionByMessage: vi.fn(),
+  mockIsFactBrowsePagination: vi.fn(),
+  mockFactBrowseHelpers: { isBrowseSelect: vi.fn() },
+  mockHandleFactsPagination: vi.fn(),
+  mockRefreshFactsList: vi.fn(),
+  mockParseFactActionId: vi.fn(),
+  mockHandleFactSelect: vi.fn(),
+  mockHandleCorrectButton: vi.fn(),
+  mockHandleCorrectModalSubmit: vi.fn(),
+  mockHandleFactLockButton: vi.fn(),
+  mockHandleForgetButton: vi.fn(),
+  mockHandleForgetConfirm: vi.fn(),
 }));
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -86,6 +108,23 @@ vi.mock('./search.js', () => ({
   handleSearchSelect: (...args: unknown[]) => mockHandleSearchSelect(...args),
   handleSearchDetailAction: (...args: unknown[]) => mockHandleSearchDetailAction(...args),
   isMemorySearchPagination: (...args: unknown[]) => mockIsMemorySearchPagination(...args),
+}));
+
+vi.mock('./factsBrowse.js', () => ({
+  factBrowseHelpers: mockFactBrowseHelpers,
+  isFactBrowsePagination: (...args: unknown[]) => mockIsFactBrowsePagination(...args),
+  handleFactsPagination: (...args: unknown[]) => mockHandleFactsPagination(...args),
+  refreshFactsList: (...args: unknown[]) => mockRefreshFactsList(...args),
+}));
+
+vi.mock('./factsDetail.js', () => ({
+  parseFactActionId: (...args: unknown[]) => mockParseFactActionId(...args),
+  handleFactSelect: (...args: unknown[]) => mockHandleFactSelect(...args),
+  handleCorrectButton: (...args: unknown[]) => mockHandleCorrectButton(...args),
+  handleCorrectModalSubmit: (...args: unknown[]) => mockHandleCorrectModalSubmit(...args),
+  handleFactLockButton: (...args: unknown[]) => mockHandleFactLockButton(...args),
+  handleForgetButton: (...args: unknown[]) => mockHandleForgetButton(...args),
+  handleForgetConfirm: (...args: unknown[]) => mockHandleForgetConfirm(...args),
 }));
 
 import { handleButton, handleModal, handleSelectMenu } from './interactionHandlers.js';
@@ -147,6 +186,9 @@ describe('handleButton', () => {
     mockIsMemoryBrowsePagination.mockReturnValue(false);
     mockIsMemorySearchPagination.mockReturnValue(false);
     mockParseMemoryActionId.mockReturnValue(null);
+    mockParseFactActionId.mockReturnValue(null);
+    mockIsFactBrowsePagination.mockReturnValue(false);
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(false);
   });
 
   it('routes to browse pagination when custom ID matches', async () => {
@@ -280,6 +322,9 @@ describe('handleButton', () => {
 
   it('shows error for unknown button interactions', async () => {
     mockParseMemoryActionId.mockReturnValue(null);
+    mockParseFactActionId.mockReturnValue(null);
+    mockIsFactBrowsePagination.mockReturnValue(false);
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(false);
     const interaction = createButtonInteraction('unrelated::button');
 
     await handleButton(interaction as never);
@@ -336,6 +381,9 @@ describe('handleModal', () => {
 
   it('acknowledges modal submissions with no parseable custom ID', async () => {
     mockParseMemoryActionId.mockReturnValue(null);
+    mockParseFactActionId.mockReturnValue(null);
+    mockIsFactBrowsePagination.mockReturnValue(false);
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(false);
     const interaction = createModalInteraction('unparseable');
 
     await handleModal(interaction as never);
@@ -365,6 +413,9 @@ describe('handleSelectMenu', () => {
     mockBrowseHelpers.isBrowseSelect.mockReturnValue(false);
     mockSearchHelpers.isBrowseSelect.mockReturnValue(false);
     mockParseMemoryActionId.mockReturnValue(null);
+    mockParseFactActionId.mockReturnValue(null);
+    mockIsFactBrowsePagination.mockReturnValue(false);
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(false);
   });
 
   it('routes browse select custom IDs to browse handler', async () => {
@@ -409,6 +460,9 @@ describe('handleSelectMenu', () => {
 
   it('shows "unknown" message for unknown select custom IDs', async () => {
     mockParseMemoryActionId.mockReturnValue(null);
+    mockParseFactActionId.mockReturnValue(null);
+    mockIsFactBrowsePagination.mockReturnValue(false);
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(false);
     const interaction = createSelectInteraction('unknown::select');
 
     await handleSelectMenu(interaction as never);
@@ -418,5 +472,119 @@ describe('handleSelectMenu', () => {
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Unknown') })
     );
+  });
+});
+
+describe('fact routing (correction slice)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockIsMemoryBrowsePagination.mockReturnValue(false);
+    mockIsMemorySearchPagination.mockReturnValue(false);
+    mockParseMemoryActionId.mockReturnValue(null);
+    mockParseFactActionId.mockReturnValue(null);
+    mockIsFactBrowsePagination.mockReturnValue(false);
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(false);
+    mockBrowseHelpers.isBrowseSelect.mockReturnValue(false);
+    mockSearchHelpers.isBrowseSelect.mockReturnValue(false);
+  });
+
+  it('routes fact pagination buttons to handleFactsPagination', async () => {
+    mockIsFactBrowsePagination.mockReturnValue(true);
+    const interaction = createButtonInteraction('memory-fact-browse::browse::1::all');
+
+    await handleButton(interaction as never);
+
+    expect(mockHandleFactsPagination).toHaveBeenCalledWith(interaction);
+    expect(mockParseFactActionId).not.toHaveBeenCalled();
+  });
+
+  it('routes the correct button WITHOUT deferring (showModal must be first response)', async () => {
+    mockParseFactActionId.mockReturnValue({ action: 'correct', factId: 'fact-1' });
+    const interaction = createButtonInteraction('memory-fact::correct::fact-1');
+
+    await handleButton(interaction as never);
+
+    expect(mockHandleCorrectButton).toHaveBeenCalledWith(interaction, 'fact-1');
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
+  });
+
+  it('routes lock with the decoded TARGET state from the extra slot', async () => {
+    mockParseFactActionId.mockReturnValue({ action: 'lock', factId: 'fact-1', extra: '1' });
+    const interaction = createButtonInteraction('memory-fact::lock::fact-1::1');
+
+    await handleButton(interaction as never);
+
+    expect(mockHandleFactLockButton).toHaveBeenCalledWith(interaction, 'fact-1', true);
+  });
+
+  it('routes forget to the confirmation view', async () => {
+    mockParseFactActionId.mockReturnValue({ action: 'forget', factId: 'fact-1' });
+    const interaction = createButtonInteraction('memory-fact::forget::fact-1');
+
+    await handleButton(interaction as never);
+
+    expect(mockHandleForgetButton).toHaveBeenCalledWith(interaction, 'fact-1');
+  });
+
+  it('back defers then refreshes the facts list', async () => {
+    mockParseFactActionId.mockReturnValue({ action: 'back' });
+    const interaction = createButtonInteraction('memory-fact::back');
+
+    await handleButton(interaction as never);
+
+    expect(interaction.deferUpdate).toHaveBeenCalled();
+    expect(mockRefreshFactsList).toHaveBeenCalledWith(interaction);
+  });
+
+  it('confirm-forget refreshes the list ONLY when the forget succeeded', async () => {
+    mockParseFactActionId.mockReturnValue({ action: 'confirm-forget', factId: 'fact-1' });
+    mockHandleForgetConfirm.mockResolvedValue(true);
+    const interaction = createButtonInteraction('memory-fact::confirm-forget::fact-1');
+
+    await handleButton(interaction as never);
+
+    expect(mockHandleForgetConfirm).toHaveBeenCalledWith(interaction, 'fact-1');
+    expect(mockRefreshFactsList).toHaveBeenCalledWith(interaction);
+
+    // Failure path: no refresh (the error was already surfaced via followUp).
+    mockRefreshFactsList.mockClear();
+    mockHandleForgetConfirm.mockResolvedValue(false);
+    await handleButton(createButtonInteraction('memory-fact::confirm-forget::fact-1') as never);
+    expect(mockRefreshFactsList).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown fact action with a validation reply', async () => {
+    mockParseFactActionId.mockReturnValue({ action: 'mystery', factId: 'fact-1' });
+    const interaction = createButtonInteraction('memory-fact::mystery::fact-1');
+
+    await handleButton(interaction as never);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.any(String) })
+    );
+  });
+
+  it('routes the correct MODAL submit by fact customId', async () => {
+    mockParseFactActionId.mockReturnValue({ action: 'correct', factId: 'fact-1' });
+    const interaction = createModalInteraction('memory-fact::correct::fact-1');
+
+    await handleModal(interaction as never);
+
+    expect(mockHandleCorrectModalSubmit).toHaveBeenCalledWith(interaction, 'fact-1');
+    expect(mockHandleEditModalSubmit).not.toHaveBeenCalled();
+  });
+
+  it('routes fact select menus (both the browse-select and detail select ids)', async () => {
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(true);
+    const browseSelect = createSelectInteraction('memory-fact-browse::browse-select');
+    await handleSelectMenu(browseSelect as never);
+    expect(mockHandleFactSelect).toHaveBeenCalledWith(browseSelect);
+
+    mockHandleFactSelect.mockClear();
+    mockFactBrowseHelpers.isBrowseSelect.mockReturnValue(false);
+    mockParseFactActionId.mockReturnValue({ action: 'select' });
+    const detailSelect = createSelectInteraction('memory-fact::select');
+    await handleSelectMenu(detailSelect as never);
+    expect(mockHandleFactSelect).toHaveBeenCalledWith(detailSelect);
   });
 });

--- a/services/bot-client/src/commands/memory/interactionHandlers.ts
+++ b/services/bot-client/src/commands/memory/interactionHandlers.ts
@@ -36,6 +36,21 @@ import {
   isMemorySearchPagination,
 } from './search.js';
 import { MEMORY_PURGE_PREFIX, handlePurgeButton, handlePurgeModal } from './purge.js';
+import {
+  factBrowseHelpers,
+  isFactBrowsePagination,
+  handleFactsPagination,
+  refreshFactsList,
+} from './factsBrowse.js';
+import {
+  parseFactActionId,
+  handleFactSelect,
+  handleCorrectButton,
+  handleCorrectModalSubmit,
+  handleFactLockButton,
+  handleForgetButton,
+  handleForgetConfirm,
+} from './factsDetail.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { renderSpec } from '../../ux/render/render.js';
 
@@ -81,6 +96,20 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
   // Purge confirmation buttons (memory-purge::proceed::... or memory-purge::cancel)
   if (customId.startsWith(`${MEMORY_PURGE_PREFIX}::`)) {
     await handlePurgeButton(interaction);
+    return;
+  }
+
+  // Fact browse pagination (memory-fact-browse::browse::...) — checked before
+  // the fact detail parse because the prefixes share the 'memory-fact' stem.
+  if (isFactBrowsePagination(customId)) {
+    await handleFactsPagination(interaction);
+    return;
+  }
+
+  // Fact detail buttons (memory-fact::...)
+  const factAction = parseFactActionId(customId);
+  if (factAction !== null) {
+    await routeFactButton(interaction, factAction);
     return;
   }
 
@@ -150,6 +179,53 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
 }
 
 /**
+ * Route a parsed fact-detail button to its handler.
+ *
+ * Ack discipline: 'correct' must NOT be deferred here — it opens a modal, and
+ * showModal must be the interaction's first response. 'lock' and 'forget'
+ * self-defer. 'back' and 'confirm-forget' are deferred here because they
+ * refresh the list view (their handlers guard against double-acking).
+ */
+async function routeFactButton(
+  interaction: ButtonInteraction,
+  parsed: { action: string; factId?: string; extra?: string }
+): Promise<void> {
+  const { action, factId, extra } = parsed;
+
+  if (action === 'correct' && factId !== undefined) {
+    await handleCorrectButton(interaction, factId);
+    return;
+  }
+  if (action === 'lock' && factId !== undefined) {
+    await handleFactLockButton(interaction, factId, extra === '1');
+    return;
+  }
+  if (action === 'forget' && factId !== undefined) {
+    await handleForgetButton(interaction, factId);
+    return;
+  }
+  if (action === 'back') {
+    await interaction.deferUpdate();
+    await refreshFactsList(interaction);
+    return;
+  }
+  if (action === 'confirm-forget' && factId !== undefined) {
+    await interaction.deferUpdate();
+    const forgotten = await handleForgetConfirm(interaction, factId);
+    if (forgotten) {
+      await refreshFactsList(interaction);
+    }
+    return;
+  }
+
+  logger.warn({ customId: interaction.customId }, 'Unhandled fact action');
+  await interaction.reply({
+    content: renderSpec(CATALOG.error.validation('Unknown action.')),
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+/**
  * Handle modal submit interactions for memory editing.
  *
  * Every path must acknowledge the interaction (reply or defer) — unacknowledged
@@ -162,6 +238,13 @@ export async function handleModal(interaction: ModalSubmitInteraction): Promise<
   // Purge confirmation modal (memory-purge::confirm::<personalityId>)
   if (customId.startsWith(`${MEMORY_PURGE_PREFIX}::`)) {
     await handlePurgeModal(interaction);
+    return;
+  }
+
+  // Fact correction modal (memory-fact::correct::<factId>)
+  const factParsed = parseFactActionId(customId);
+  if (factParsed?.action === 'correct' && factParsed.factId !== undefined) {
+    await handleCorrectModalSubmit(interaction, factParsed.factId);
     return;
   }
 
@@ -204,6 +287,16 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
   // Search select (memory-search::browse-select::...)
   if (searchHelpers.isBrowseSelect(customId)) {
     await handleSearchSelect(interaction);
+    return;
+  }
+
+  // Fact browse select (memory-fact-browse::browse-select) or the detail
+  // select id (memory-fact::select) — both open the fact detail view.
+  if (
+    factBrowseHelpers.isBrowseSelect(customId) ||
+    parseFactActionId(customId)?.action === 'select'
+  ) {
+    await handleFactSelect(interaction);
     return;
   }
 

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
@@ -1271,6 +1271,27 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
     "type": 1,
   },
   {
+    "description": "Browse and correct the facts a character has learned about you",
+    "description_localizations": undefined,
+    "name": "facts",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character whose facts to manage",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
     "description": "Search your memories semantically",
     "description_localizations": undefined,
     "name": "search",


### PR DESCRIPTION
## Memory Phase 2 — correction slice, UI half

The user-facing half of the correction slice (backend: #1567). `/memory facts <character>` lists the durable facts a character has auto-learned about you; selecting one opens a detail view with the correction verbs. This closes the "auto-write death spiral" end-to-end: users can now see and fix what extraction learned.

### The surface
- **`/memory facts <character>`** — ephemeral paginated list (statement + learned-date, 🔒/✏️ badges), select menu → detail view. Mirrors the episode browse router pattern exactly: messageId-keyed dashboard session carries the personality scope, no inline collectors, restart-safe.
- **Detail view** — statement, origin tier ("Learned from conversation" / "Corrected by you"), lock status, learned date, source count. Buttons: Correct ✏️ / Lock 🔒 / Back ◀️ / Forget 🗑️.
- **Correct** — modal prefilled with the current statement (max 1000, matching the API schema) → `PATCH /user/fact/:id` → renders the **survivor** fact (which can be a different row when the corrected statement collides with an existing fact and they converge — the backend's documented merge semantics).
- **Forget** — danger confirm → terminal removal ("never be re-learned"); the list refreshes and steps back a page when the last fact on a page is forgotten (reuses `fetchPageWithEmptyFallback`).
- **Lock** — explicit-target-state toggle (state encoded in the customId so retries can't flip the wrong way). **A locked fact renders Correct/Forget disabled** — the hard freeze is visible, same contract and same button behavior as episode memory locks (the owner's one-word-one-meaning consistency decision).

### Ack discipline (04-discord)
Every handler acks first; the one exception is the Correct button, which must fetch the fact before `showModal` (prefill) — that path routes through `showModalWithTimeoutCatch`/`ackWithTimeoutCatch` per the rule's sanctioned pattern (same as the episode edit modal).

### Reuse
`createBrowseCustomIdHelpers`, `buildBrowseButtons`, `buildBrowseSelectMenu`, `calculatePaginationState`, `fetchPageWithEmptyFallback`, `resolveRequiredPersonality`, the shared personality autocomplete, and the detailApi error contract (null/false ONLY on genuine 404; infra + the locked-403 throw for honest classification via `classifyGatewayFailure`).

### Tests
34 new (13 API contract, 13 detail incl. ack-ordering + disabled-buttons-when-locked + survivor rendering, 8 browse incl. session persistence + step-back). Command manifest + generated option types + CommandHandler snapshot regenerated (snapshot diff = exactly the new subcommand). `pnpm test` (25 pkgs) + `pnpm quality` + `pnpm test:component` (485) green.

### After merge
Dev smoke (owner): `/memory facts` on a character with extracted facts → correct one → verify the corrected fact shows "Corrected by you" and survives further chatting (extraction can't supersede corrected-tier). This completes the correction slice; prod-enable remains gated on the extraction-cost quick win + burn-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)