### PR TITLE
feat(ai-worker): extraction cost knobs + usage visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,9 @@ OPENROUTER_APP_TITLE=Tzurot  # Shown in OpenRouter dashboard logs
 # Note: These defaults are also defined in packages/common-types/src/constants/ai.ts
 DEFAULT_AI_MODEL=anthropic/claude-haiku-4.5  # Main generation model
 VISION_FALLBACK_MODEL=qwen/qwen3.5-397b-a17b  # For image analysis fallback (paid, multimodal)
+# EXTRACTION_MODEL=anthropic/claude-haiku-4.5  # Fact-extraction engine — re-run `pnpm eval:extraction` before switching (quality gate is model-specific)
+# EXTRACTION_DAILY_LIMIT=100  # Per-personality daily ceiling on extraction model calls (cost tripwire)
+# EXTRACTION_BATCH_THRESHOLD=6  # Stored episodes per (channel, personality) before an extraction batch enqueues
 # Note: Embeddings are local (Xenova/bge-small-en-v1.5) - no API key needed
 
 # Optional: ElevenLabs for voice synthesis

--- a/packages/common-types/src/config/config.ts
+++ b/packages/common-types/src/config/config.ts
@@ -67,6 +67,8 @@ export const envSchema = z.object({
     .optional()
     .or(z.literal('').transform(() => undefined)), // 'true' injects extracted facts into the generation prompt (memory Phase 2 slice 4a; dev-on/prod-off until the quality gate + correction surface land)
   EXTRACTION_BATCH_THRESHOLD: z.coerce.number().int().min(1).max(50).default(6), // episodes per (channel, personality) before an extraction batch enqueues
+  EXTRACTION_MODEL: z.string().default(MODEL_DEFAULTS.FACT_EXTRACTION), // extraction engine — switching models MUST re-run pnpm eval:extraction first (the quality gate is model-specific)
+  EXTRACTION_DAILY_LIMIT: z.coerce.number().int().min(1).default(100), // per-personality daily ceiling on extraction model calls (cost tripwire)
   // Fair-share quota for the SHARED system OpenRouter free-tier key (guests +
   // credit-exhausted-BYOK fallback). Rolling-window per-user cap that shrinks as
   // concurrent users rise, bounded by a floor/ceiling; a daily global counter is
@@ -242,6 +244,8 @@ export function createTestConfig(overrides: Partial<EnvConfig> = {}): EnvConfig 
     EXTRACTION_ENABLED: undefined,
     FACTS_IN_PROMPT_ENABLED: undefined,
     EXTRACTION_BATCH_THRESHOLD: 6,
+    EXTRACTION_MODEL: MODEL_DEFAULTS.FACT_EXTRACTION,
+    EXTRACTION_DAILY_LIMIT: 100,
     FREE_TIER_GLOBAL_DAILY_BUDGET: 1000,
     FREE_TIER_WINDOW_MINUTES: 60,
     FREE_TIER_MIN_PER_WINDOW: 5,

--- a/services/ai-worker/src/jobs/factExtractionSetup.ts
+++ b/services/ai-worker/src/jobs/factExtractionSetup.ts
@@ -60,7 +60,7 @@ export function setupFactExtraction(
   });
 
   const factStore = new FactStore(prisma, embeddingService);
-  const budget = new ExtractionBudget(redis);
+  const budget = new ExtractionBudget(redis, config.EXTRACTION_DAILY_LIMIT);
   const extractionService = new FactExtractionService(prisma, factStore, budget);
   const trigger = new ExtractionTrigger(redis, queue, config.EXTRACTION_BATCH_THRESHOLD);
 

--- a/services/ai-worker/src/services/ModelFactory.test.ts
+++ b/services/ai-worker/src/services/ModelFactory.test.ts
@@ -967,6 +967,17 @@ describe('ModelFactory', () => {
       expect(callArgs?.configuration?.defaultHeaders).toEqual({ 'X-Title': 'MyBot' });
     });
 
+    it('appends appTitleSuffix so background workloads attribute as a distinct app', () => {
+      mockConfigData.OPENROUTER_APP_TITLE = 'MyBot';
+
+      createChatModel({ modelName: 'test-model', appTitleSuffix: 'Extraction' });
+
+      const callArgs = mockChatOpenAI.mock.calls[0]?.[0] as {
+        configuration?: { defaultHeaders?: Record<string, string> };
+      };
+      expect(callArgs?.configuration?.defaultHeaders).toEqual({ 'X-Title': 'MyBot Extraction' });
+    });
+
     it('should strip non-Latin characters from X-Title header', () => {
       mockConfigData.OPENROUTER_APP_TITLE = 'צורות Bot';
 

--- a/services/ai-worker/src/services/ModelFactory.ts
+++ b/services/ai-worker/src/services/ModelFactory.ts
@@ -290,10 +290,15 @@ function getEffectiveMaxTokens(
 
 /**
  * Build the OpenRouter client configuration (baseURL, headers, custom fetch).
+ *
+ * `appTitleSuffix` appends to the X-Title attribution header so background
+ * workloads (e.g. fact extraction) show as a distinct app in the OpenRouter
+ * dashboard instead of blending into chat-completion traffic.
  */
 function buildOpenRouterClientConfig(
   extraParams: OpenRouterExtraParams,
-  needsCustomFetch: boolean
+  needsCustomFetch: boolean,
+  appTitleSuffix?: string
 ): { baseURL: string; defaultHeaders?: Record<string, string>; fetch?: typeof fetch } {
   const clientConfig: {
     baseURL: string;
@@ -313,9 +318,13 @@ function buildOpenRouterClientConfig(
   }
 
   if (config.OPENROUTER_APP_TITLE !== undefined) {
+    const rawTitle =
+      appTitleSuffix === undefined
+        ? config.OPENROUTER_APP_TITLE
+        : `${config.OPENROUTER_APP_TITLE} ${appTitleSuffix}`;
     // HTTP headers only accept printable ASCII (chars 0x20-0x7E). Strip non-ASCII
     // and control characters to prevent "Cannot convert argument to a ByteString" errors.
-    const safeTitle = config.OPENROUTER_APP_TITLE.replace(/[^\x20-\x7E]/g, '').trim();
+    const safeTitle = rawTitle.replace(/[^\x20-\x7E]/g, '').trim();
     if (safeTitle.length > 0) {
       headers['X-Title'] = safeTitle;
     }
@@ -400,7 +409,11 @@ function buildOpenRouterModel(
       // ladder owns retries; a 429 must surface to it immediately.
       maxRetries: 0,
       modelKwargs: shared.hasModelKwargs ? shared.modelKwargs : undefined,
-      configuration: buildOpenRouterClientConfig(extraParams, needsCustomFetch),
+      configuration: buildOpenRouterClientConfig(
+        extraParams,
+        needsCustomFetch,
+        modelConfig.appTitleSuffix
+      ),
       // Surfaces the raw OpenRouter response under additional_kwargs.__raw_response,
       // which extractAndPopulateOpenRouterReasoning() in LLMInvoker reads to populate
       // additional_kwargs.reasoning + response_metadata.reasoning_details. This

--- a/services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts
+++ b/services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts
@@ -143,7 +143,7 @@ describe('memory extraction eval (real model — manual run only)', () => {
         golden.isFiction === true
       );
 
-      const raw = await invokeExtractionModel(prompt);
+      const { content: raw } = await invokeExtractionModel(prompt);
       const parsed = extractionResponseSchema.safeParse(JSON.parse(extractJsonPayload(raw)));
       // A schema-invalid response is a HARD failure: production would skip the
       // batch entirely, which for a golden means the extractor produced nothing

--- a/services/ai-worker/src/services/extraction/ExtractionBudget.test.ts
+++ b/services/ai-worker/src/services/extraction/ExtractionBudget.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Redis } from 'ioredis';
-import { ExtractionBudget, FACT_EXTRACTION_DAILY_LIMIT } from './ExtractionBudget.js';
+import { createTestConfig } from '@tzurot/common-types/config/config';
+import { ExtractionBudget } from './ExtractionBudget.js';
 import { CACHE_KEY_PREFIXES } from '@tzurot/common-types/constants/redis-keys';
 
 function makeRedis(evalResult: number | Error): Redis {
@@ -53,7 +54,7 @@ describe('ExtractionBudget', () => {
 
   it('scopes keys by UTC day so the count resets at midnight', async () => {
     const redis = makeRedis(1);
-    const budget = new ExtractionBudget(redis);
+    const budget = new ExtractionBudget(redis, 100);
 
     await budget.tryConsume('p');
     vi.setSystemTime(new Date('2026-07-07T00:00:01.000Z'));
@@ -64,7 +65,7 @@ describe('ExtractionBudget', () => {
     expect(keys[1]).toContain('2026-07-07');
   });
 
-  it('exposes a generous default limit', () => {
-    expect(FACT_EXTRACTION_DAILY_LIMIT).toBeGreaterThanOrEqual(50);
+  it('the config schema default limit stays generous (single source of truth)', () => {
+    expect(createTestConfig().EXTRACTION_DAILY_LIMIT).toBeGreaterThanOrEqual(50);
   });
 });

--- a/services/ai-worker/src/services/extraction/ExtractionBudget.ts
+++ b/services/ai-worker/src/services/extraction/ExtractionBudget.ts
@@ -26,14 +26,6 @@ const logger = createLogger('ExtractionBudget');
 
 const KEY_PREFIX = CACHE_KEY_PREFIXES.FACT_EXTRACTION_BUDGET;
 
-/**
- * Default per-personality daily ceiling on extraction model calls. At the
- * default batch threshold (one call per ~6 stored interactions) this allows
- * ~600 interactions/personality/day before throttling — far above organic
- * roleplay volume, low enough to bound a runaway loop or an abuse pattern.
- */
-export const FACT_EXTRACTION_DAILY_LIMIT = 100;
-
 /** TTL for the per-day counter key — 25h gives margin past the UTC rollover. */
 const BUDGET_KEY_TTL_SECONDS = 25 * 60 * 60;
 
@@ -47,9 +39,16 @@ return count
 `;
 
 export class ExtractionBudget {
+  /**
+   * `dailyLimit` is the per-personality daily ceiling on extraction model
+   * calls — single source of truth is config.EXTRACTION_DAILY_LIMIT (default
+   * 100: at the default batch threshold that allows ~600 interactions/
+   * personality/day before throttling — far above organic roleplay volume,
+   * low enough to bound a runaway loop or an abuse pattern).
+   */
   constructor(
     private readonly redis: Redis,
-    private readonly dailyLimit: number = FACT_EXTRACTION_DAILY_LIMIT
+    private readonly dailyLimit: number
   ) {}
 
   /**

--- a/services/ai-worker/src/services/extraction/FactExtractionService.component.test.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.component.test.ts
@@ -20,6 +20,10 @@ import type { FactExtractionJobData } from '@tzurot/common-types/types/jobs';
 import { deterministicMemoryUuid } from '@tzurot/common-types/constants/memory';
 import type { Redis } from 'ioredis';
 import { FactExtractionService } from './FactExtractionService.js';
+
+/** Wrap raw model content in the ExtractionModelResult shape the invoker now returns. */
+const mockInvoker = (content: string) =>
+  vi.fn().mockResolvedValue({ content, tokensIn: 10, tokensOut: 5 });
 import { FactStore } from './FactStore.js';
 import { ExtractionBudget } from './ExtractionBudget.js';
 
@@ -110,7 +114,7 @@ describe('FactExtractionService (component, PGLite)', () => {
 
   it('extracts a fact end-to-end: real episode rows → real memory_facts row', async () => {
     const ep = await seedEpisode('{user}: my cat is named Miso\n{assistant}: Lovely name!');
-    const invoker = vi.fn().mockResolvedValue(
+    const invoker = mockInvoker(
       JSON.stringify({
         facts: [
           {
@@ -155,7 +159,7 @@ describe('FactExtractionService (component, PGLite)', () => {
     );
 
     const ep = await seedEpisode('{user}: I moved to Denver last week!\n{assistant}: Congrats!');
-    const invoker = vi.fn().mockResolvedValue(
+    const invoker = mockInvoker(
       JSON.stringify({
         facts: [
           {
@@ -186,7 +190,7 @@ describe('FactExtractionService (component, PGLite)', () => {
 
   it('re-running the same batch is idempotent (content-hash ids, ON CONFLICT no-op)', async () => {
     const ep = await seedEpisode('{user}: I am a nurse\n{assistant}: A demanding job!');
-    const invoker = vi.fn().mockResolvedValue(
+    const invoker = mockInvoker(
       JSON.stringify({
         facts: [
           {
@@ -243,7 +247,7 @@ describe('FactExtractionService (component, PGLite)', () => {
     // The user moves back: the extractor re-asserts Seattle VERBATIM and
     // names Denver (index 0 of the active-facts context) as superseded.
     const ep = await seedEpisode('{user}: moved back to Seattle!\n{assistant}: Welcome home!');
-    const invoker = vi.fn().mockResolvedValue(
+    const invoker = mockInvoker(
       JSON.stringify({
         facts: [
           {
@@ -295,7 +299,7 @@ describe('FactExtractionService (component, PGLite)', () => {
     });
 
     const ep = await seedEpisode('{user}: I live in Seattle btw\n{assistant}: Noted!');
-    const invoker = vi.fn().mockResolvedValue(
+    const invoker = mockInvoker(
       JSON.stringify({
         facts: [
           {
@@ -330,7 +334,7 @@ describe('FactExtractionService (component, PGLite)', () => {
 
   it('fail-to-skip: a non-JSON model response writes nothing', async () => {
     const ep = await seedEpisode('{user}: hello\n{assistant}: hi');
-    const invoker = vi.fn().mockResolvedValue('I cannot help with that.');
+    const invoker = mockInvoker('I cannot help with that.');
     const service = new FactExtractionService(prisma, factStore, makeBudget(), invoker);
 
     const written = await service.processBatch(makeJob([ep]));

--- a/services/ai-worker/src/services/extraction/FactExtractionService.test.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.test.ts
@@ -30,6 +30,8 @@ interface Setup {
   budget: ExtractionBudget;
   invokeModel: ReturnType<typeof vi.fn>;
   writeMock: ReturnType<typeof vi.fn>;
+  usageCreateMock: ReturnType<typeof vi.fn>;
+  prisma: PrismaClient;
 }
 
 function makeSetup(options: {
@@ -50,8 +52,11 @@ function makeSetup(options: {
     { id: MEM(1), content: '{user}: my cat is Miso', personaId: PERSONA_A, isFiction: false },
     { id: MEM(2), content: '{user}: I love tea', personaId: PERSONA_A, isFiction: false },
   ];
+  const usageCreateMock = vi.fn().mockResolvedValue({});
   const prisma = {
     memory: { findMany: vi.fn().mockResolvedValue(episodes) },
+    persona: { findUnique: vi.fn().mockResolvedValue({ ownerId: 'user-uuid-1' }) },
+    usageLog: { create: usageCreateMock },
   } as unknown as PrismaClient;
 
   const writeMock = vi.fn().mockResolvedValue('new-fact-id');
@@ -71,8 +76,9 @@ function makeSetup(options: {
   const invokeModel =
     options.modelResponse instanceof Error
       ? vi.fn().mockRejectedValue(options.modelResponse)
-      : vi.fn().mockResolvedValue(
-          options.modelResponse ??
+      : vi.fn().mockResolvedValue({
+          content:
+            options.modelResponse ??
             JSON.stringify({
               facts: [
                 {
@@ -82,11 +88,13 @@ function makeSetup(options: {
                   supersedesIndex: null,
                 },
               ],
-            })
-        );
+            }),
+          tokensIn: 120,
+          tokensOut: 40,
+        });
 
   const service = new FactExtractionService(prisma, factStore, budget, invokeModel);
-  return { service, factStore, budget, invokeModel, writeMock };
+  return { service, factStore, budget, invokeModel, writeMock, usageCreateMock, prisma };
 }
 
 describe('FactExtractionService', () => {
@@ -367,5 +375,55 @@ describe('hasEntityOverlap', () => {
     expect(hasEntityOverlap(['user:alice'], ['user:bob'])).toBe(false);
     expect(hasEntityOverlap([], ['user:alice'])).toBe(false);
     expect(hasEntityOverlap(['user:alice'], [])).toBe(false);
+  });
+});
+
+describe('extraction usage rows (cost visibility)', () => {
+  it("writes one usage_logs row per model call, attributed to the persona's owner", async () => {
+    const s = makeSetup({});
+
+    await s.service.processBatch(job);
+
+    expect(s.usageCreateMock).toHaveBeenCalledTimes(1);
+    expect(s.usageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 'user-uuid-1',
+          provider: 'openrouter',
+          requestType: 'fact_extraction',
+          tokensIn: 120,
+          tokensOut: 40,
+        }),
+      })
+    );
+  });
+
+  it('a usage-row failure never costs the extraction batch (fail-soft)', async () => {
+    const s = makeSetup({});
+    s.usageCreateMock.mockRejectedValue(new Error('db hiccup'));
+
+    const written = await s.service.processBatch(job);
+
+    expect(written).toBeGreaterThan(0); // facts still written
+  });
+
+  it('skips the usage row (without failing) when the persona has no owner row', async () => {
+    const s = makeSetup({});
+    (
+      s.prisma as unknown as { persona: { findUnique: ReturnType<typeof vi.fn> } }
+    ).persona.findUnique.mockResolvedValue(null);
+
+    const written = await s.service.processBatch(job);
+
+    expect(s.usageCreateMock).not.toHaveBeenCalled();
+    expect(written).toBeGreaterThan(0);
+  });
+
+  it('writes NO usage row when the model call itself failed', async () => {
+    const s = makeSetup({ modelResponse: new Error('model down') });
+
+    await s.service.processBatch(job);
+
+    expect(s.usageCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/services/ai-worker/src/services/extraction/FactExtractionService.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.ts
@@ -16,9 +16,12 @@
 
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { HumanMessage } from '@langchain/core/messages';
-import { MODEL_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { getConfig } from '@tzurot/common-types/config/config';
 import type { FactExtractionJobData } from '@tzurot/common-types/types/jobs';
-import { generateFactExtractionJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import {
+  generateFactExtractionJobUuid,
+  generateUsageLogUuid,
+} from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { createChatModel } from '../ModelFactory.js';
 import type { ExtractionBudget } from './ExtractionBudget.js';
@@ -59,20 +62,33 @@ interface EpisodeGroup {
   texts: string[];
 }
 
+/** One extraction model call's outcome — content plus token usage for cost rows. */
+export interface ExtractionModelResult {
+  content: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
 /** Model invocation seam — injectable for tests/eval (defaults to the real call). */
-export type ExtractionModelInvoker = (prompt: string) => Promise<string>;
+export type ExtractionModelInvoker = (prompt: string) => Promise<ExtractionModelResult>;
 
 /** The real model call — exported for the eval harness (same code path as prod). */
-export async function invokeExtractionModel(prompt: string): Promise<string> {
+export async function invokeExtractionModel(prompt: string): Promise<ExtractionModelResult> {
   const { model } = createChatModel({
-    modelName: MODEL_DEFAULTS.FACT_EXTRACTION,
+    modelName: getConfig().EXTRACTION_MODEL,
     temperature: 0,
     responseFormat: { type: 'json_object' },
+    appTitleSuffix: 'Extraction',
   });
   const response = await model.invoke([new HumanMessage(prompt)], {
     timeout: EXTRACTION_TIMEOUT_MS,
   });
-  return typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+  return {
+    content:
+      typeof response.content === 'string' ? response.content : JSON.stringify(response.content),
+    tokensIn: response.usage_metadata?.input_tokens ?? 0,
+    tokensOut: response.usage_metadata?.output_tokens ?? 0,
+  };
 }
 
 export class FactExtractionService {
@@ -150,15 +166,17 @@ export class FactExtractionService {
 
     const prompt = buildExtractionPrompt(group.texts, knownFacts, group.isFiction);
 
-    let rawResponse: string;
+    let modelResult: ExtractionModelResult;
     try {
-      rawResponse = await this.invokeModel(prompt);
+      modelResult = await this.invokeModel(prompt);
     } catch (error) {
       logger.warn({ err: error, ...scope }, 'Extraction model call failed — skipping group');
       return 0;
     }
 
-    const parsed = this.parseResponse(rawResponse, scope);
+    await this.logExtractionUsage(group.personaId, modelResult, scope);
+
+    const parsed = this.parseResponse(modelResult.content, scope);
     if (parsed === null || parsed.length === 0) {
       return 0;
     }
@@ -180,6 +198,46 @@ export class FactExtractionService {
       'Extraction group complete'
     );
     return written;
+  }
+
+  /**
+   * Record one usage_logs row per extraction model call, attributed to the
+   * persona's owning user (their conversation generated the batch) — the same
+   * ledger chat completions write to, so extraction spend is queryable
+   * in-system instead of only on the provider dashboard. Fail-soft: a usage
+   * bookkeeping failure must never cost an extraction batch.
+   */
+  private async logExtractionUsage(
+    personaId: string,
+    modelResult: ExtractionModelResult,
+    scope: { personalityId: string; personaId: string }
+  ): Promise<void> {
+    try {
+      const persona = await this.prisma.persona.findUnique({
+        where: { id: personaId },
+        select: { ownerId: true },
+      });
+      if (persona === null) {
+        logger.warn({ ...scope }, 'Extraction usage row skipped — persona row not found');
+        return;
+      }
+      const model = getConfig().EXTRACTION_MODEL;
+      const createdAt = new Date();
+      await this.prisma.usageLog.create({
+        data: {
+          id: generateUsageLogUuid(persona.ownerId, model, createdAt),
+          userId: persona.ownerId,
+          provider: 'openrouter',
+          model,
+          tokensIn: modelResult.tokensIn,
+          tokensOut: modelResult.tokensOut,
+          requestType: 'fact_extraction',
+          createdAt,
+        },
+      });
+    } catch (error) {
+      logger.warn({ err: error, ...scope }, 'Extraction usage row failed — continuing');
+    }
   }
 
   /** JSON.parse + zod safeParse; null on ANY malformation (fail-to-skip). */

--- a/services/ai-worker/src/services/modelFactory/types.ts
+++ b/services/ai-worker/src/services/modelFactory/types.ts
@@ -24,6 +24,13 @@ export interface ModelConfig extends ConvertedLlmParams {
    */
   provider?: AIProvider;
   /**
+   * Appended to the X-Title OpenRouter attribution header so background
+   * workloads (e.g. fact extraction) show as a distinct app in the dashboard
+   * instead of blending into chat-completion traffic. OpenRouter-only; other
+   * providers ignore it.
+   */
+  appTitleSuffix?: string;
+  /**
    * Whether the model supports reasoning parameters.
    * Resolved async by caller via checkModelReasoningSupport().
    * When false, reasoning params are silently skipped with a log warning.


### PR DESCRIPTION
## Extraction cost controls (owner spend concern)

Haiku extraction burned ~$2/2days on the system OpenRouter key with **zero in-system visibility** — the spend was discovered on the provider dashboard, not our own ledger, because extraction's direct model path bypasses the usage-logging seam that chat completions use. Its model and daily ceiling were also hardcoded. This PR adds the knobs + the missing ledger. **No behavior change at the defaults.**

### The four pieces
1. **`EXTRACTION_MODEL`** env config (default unchanged: `anthropic/claude-haiku-4.5`). The seam that lets extraction move to a z.ai GLM on the flat-rate plan — but **any switch must re-run `pnpm eval:extraction` first**; the 10.3%/99.6% quality gate is model-specific (documented on the config entry).
2. **`EXTRACTION_DAILY_LIMIT`** env config (default unchanged: 100/personality/day) — the cost tripwire becomes Railway-tunable.
3. **`usage_logs` rows for every extraction model call** — `requestType: 'fact_extraction'`, attributed to the persona's owner (their conversation generated the batch), real token counts from the model response. Same ledger as chat completions, so extraction spend is now queryable in-system. Fail-soft: a bookkeeping failure logs a warning and never costs the extraction batch (tested).
4. **Distinct dashboard attribution**: new `ModelConfig.appTitleSuffix` appends to the `X-Title` header, so extraction traffic shows as "<app> Extraction" in OpenRouter analytics instead of blending into chat.

### Contract change
The extraction invoker seam returns `{ content, tokensIn, tokensOut }` instead of a bare string (the model call was the only place token usage was visible). Eval harness + unit/component stubs updated; the eval runs the same code path as prod, unchanged semantics.

### Tests
- 4 new usage-row tests (attribution, fail-soft, ownerless-persona skip, no row on model failure) + the X-Title suffix test.
- `pnpm test` (25 pkgs) + `pnpm quality` + `pnpm test:component` (485) green. No migration; `usage_logs` and its `requestType` column already exist.

### Follow-up (not this PR)
Eval `z.ai GLM` + `openrouter/free` as extraction engines via the new knob (`EXTRACTION_MODEL` in the eval env) — if GLM passes the gate, extraction moves to the flat-rate plan and this OpenRouter line →$0. Tracked on the Quick Wins board; gated before prod-enable regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)