### PR TITLE
fix(ai-worker): quota-fallback cache identity follows key provenance (prod incident)

### DIFF
--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -1252,13 +1252,48 @@ describe('ConversationalRAGService', () => {
         model: expect.anything(),
         messages: expect.any(Array),
         modelName: 'test-model',
-        // Tighter than `expect.any(String)`: catches a regression where
-        // `deriveCacheKeyId` silently returns an unexpected string shape
-        // (e.g., the raw API key value) instead of `system` or `user:<snowflake>`.
-        cacheKeyId: expect.stringMatching(/^(user:\d+|system)$/),
+        // Exact, not a union: this call passes no userApiKey and no
+        // isGuestMode, so the identity is deterministically 'system'. The old
+        // (user:|system) union was the blind spot that let a retargeted call
+        // scope as the wrong identity while staying green.
+        cacheKeyId: 'system',
         imageCount: 2,
         audioCount: 1,
       });
+    });
+
+    it('scopes cacheKeyId to the BILLING identity: a system-key retarget (isGuestMode) crosses as system, never user', async () => {
+      // Prod regression (ref mrecl8grjuc): the quota fallback rerouted a
+      // credit-exhausted user to openrouter/free on the SYSTEM key, but the
+      // invocation derived its cache identity from key PRESENCE and scoped as
+      // user:<id> — so the user's own cached 402 short-circuited the very
+      // fallback chosen to dodge it. This asserts what actually crosses the
+      // LLMInvoker seam on a retargeted call.
+      const context = createMockContext();
+      const personality = createMockPersonality();
+
+      await service.generateResponse(personality, 'Test', context, {
+        userApiKey: 'sk-or-system-key-passed-as-string',
+        isGuestMode: true,
+      });
+
+      expect(getLLMInvokerMock().invokeWithRetry).toHaveBeenCalledWith(
+        expect.objectContaining({ cacheKeyId: 'system' })
+      );
+    });
+
+    it('scopes cacheKeyId as user:<id> for a genuine BYOK route (isGuestMode false)', async () => {
+      const context = createMockContext();
+      const personality = createMockPersonality();
+
+      await service.generateResponse(personality, 'Test', context, {
+        userApiKey: 'sk-or-users-own-key',
+        isGuestMode: false,
+      });
+
+      expect(getLLMInvokerMock().invokeWithRetry).toHaveBeenCalledWith(
+        expect.objectContaining({ cacheKeyId: `user:${context.userId}` })
+      );
     });
 
     it('should propagate LLMInvoker errors', async () => {

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -114,6 +114,7 @@ export class ConversationalRAGService {
       context,
       referencedMessagesDescriptions,
       userApiKey,
+      isGuestMode,
       retryConfig,
       maxLlmAttempts,
       diagnosticCollector: diagnosticCollectorRef,
@@ -202,8 +203,11 @@ export class ConversationalRAGService {
       diagnosticCollector.markLlmInvocationStart();
     }
 
-    // cacheKeyId scopes rate-limit cache by user identity (not API key value); see InvokeWithRetryOptions JSDoc.
-    const cacheKeyId = deriveCacheKeyId(userApiKey, context.userId);
+    // cacheKeyId scopes doom caches by BILLING identity: guest/system-key
+    // routes (including quota retargets, which pass the system key as a
+    // string with isGuestMode=true) must scope as 'system', or the user's own
+    // cached 402 vetoes the fallback that was chosen to dodge it.
+    const cacheKeyId = deriveCacheKeyId(userApiKey, context.userId, isGuestMode);
     const response = await this.llmInvoker.invokeWithRetry({
       model,
       messages,
@@ -449,6 +453,7 @@ export class ConversationalRAGService {
         context,
         referencedMessagesDescriptions: inputs.referencedMessagesDescriptions,
         userApiKey,
+        isGuestMode,
         retryConfig,
         maxLlmAttempts: options.maxLlmAttempts,
         diagnosticCollector,

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -334,6 +334,9 @@ export interface ModelInvocationOptions {
   context: ConversationContext;
   referencedMessagesDescriptions: string | undefined;
   userApiKey?: string;
+  /** True when this route bills the SYSTEM key (guests + quota retargets) —
+   * drives cache-identity provenance so a retarget never scopes as the user. */
+  isGuestMode?: boolean;
   /** Retry configuration for escalating duplicate detection retries */
   retryConfig?: DuplicateRetryConfig;
   /** Diagnostic collector for the "flight recorder" system */

--- a/services/ai-worker/src/services/CreditExhaustionCache.test.ts
+++ b/services/ai-worker/src/services/CreditExhaustionCache.test.ts
@@ -37,10 +37,10 @@ describe('CreditExhaustionCache', () => {
       const [key, ttl, value] = mockRedis.setex.mock.calls[0];
       // No model dimension in the key — credits are account-wide.
       expect(key).toBe('nocredits:openrouter:user:278863839632818186');
-      expect(ttl).toBe(3600); // default 1h
+      expect(ttl).toBe(600); // default 10min — the top-up staleness bound
       // JSON value carries timestamp AND original write TTL so reads can
       // compute accurate remaining-time without a second redis.ttl() call.
-      expect(JSON.parse(value)).toEqual({ ts: FIXED_NOW_MS, ttl: 3600 });
+      expect(JSON.parse(value)).toEqual({ ts: FIXED_NOW_MS, ttl: 600 });
     });
 
     it('persists the post-clamp TTL in the JSON value, not the raw caller value', async () => {

--- a/services/ai-worker/src/services/CreditExhaustionCache.ts
+++ b/services/ai-worker/src/services/CreditExhaustionCache.ts
@@ -15,8 +15,12 @@
  * **Distinction from `RateLimitCache`**:
  * - **Scope**: per-account, not per-model. A 402 on one OpenRouter model
  *   means the account has no credits across ALL OpenRouter models.
- * - **TTL**: no provider-supplied reset signal. Default 1h is a "re-check
- *   eventually" — users top up at unpredictable cadence.
+ * - **TTL**: no provider-supplied reset signal, so the TTL is the ONLY path
+ *   by which a credit top-up propagates — a user who tops up stays cached as
+ *   broke until expiry. Default 10min bounds that staleness window; the cost
+ *   of a shorter TTL is just one doomed 402 round-trip per window while the
+ *   account is genuinely empty (the quota fallback serves the turn either
+ *   way).
  * - **Semantics**: 402 is a permanent state for the account until the user
  *   tops up; not a time-bounded transient block like 429.
  *
@@ -40,7 +44,7 @@ const logger = createLogger('CreditExhaustionCache');
 const KEY_PREFIX = CACHE_KEY_PREFIXES.CREDIT_EXHAUSTION_OPENROUTER;
 const MIN_TTL_SECONDS = 60;
 const MAX_TTL_SECONDS = 24 * 60 * 60;
-const DEFAULT_TTL_SECONDS = 60 * 60; // 1 hour
+const DEFAULT_TTL_SECONDS = 10 * 60; // 10 minutes — the top-up staleness bound (see header)
 
 interface MarkOptions {
   /**
@@ -50,7 +54,7 @@ interface MarkOptions {
    */
   cacheKeyId: string;
   /**
-   * Optional TTL override. Defaults to 1 hour. Clamped to [60s, 24h].
+   * Optional TTL override. Defaults to 10 minutes. Clamped to [60s, 24h].
    */
   ttlSeconds?: number;
 }

--- a/services/ai-worker/src/services/RateLimitCache.test.ts
+++ b/services/ai-worker/src/services/RateLimitCache.test.ts
@@ -351,6 +351,13 @@ describe('RateLimitCache', () => {
 });
 
 describe('deriveCacheKeyId', () => {
+  it('returns system when the route is system-key even though a key STRING is present', () => {
+    // Provenance beats presence: a quota retarget passes the system key as a
+    // plain string; deriving user:<id> from it re-attaches the user's doom
+    // marks to a route billing a different account (prod ref mrecl8grjuc).
+    expect(deriveCacheKeyId('sk-or-system-key', '278863839632818186', true)).toBe('system');
+  });
+
   it('returns user:<userId> when BYOK key + userId both present', () => {
     expect(deriveCacheKeyId('any-byok-key-value', '278863839632818186')).toBe(
       'user:278863839632818186'

--- a/services/ai-worker/src/services/RateLimitCache.ts
+++ b/services/ai-worker/src/services/RateLimitCache.ts
@@ -321,8 +321,18 @@ function parseStoredValue(raw: string): StoredValue | null {
  * than risking cross-account false-blocks. The empty-string sentinel is
  * recognized by `LLMInvoker.invokeWithRetry`'s cache-skip guard.
  */
-export function deriveCacheKeyId(userApiKey: string | undefined, userId: string): string {
-  const hasByokKey = userApiKey !== undefined && userApiKey.length > 0;
+export function deriveCacheKeyId(
+  userApiKey: string | undefined,
+  userId: string,
+  // Cache identity must follow the key's PROVENANCE, not its presence: a
+  // quota retarget hands the SYSTEM key to the invocation as a plain string,
+  // and deriving `user:<id>` from it re-attaches the user's own doom marks
+  // (credit exhaustion / rate limit) to a route that bills a different
+  // account — the cached 402 then vetoes the very fallback that was chosen
+  // to dodge it. Callers on a system-key route (guest semantics) pass true.
+  isSystemKeyRoute = false
+): string {
+  const hasByokKey = !isSystemKeyRoute && userApiKey !== undefined && userApiKey.length > 0;
   let result: string;
   if (hasByokKey) {
     result = userId.length > 0 ? `user:${userId}` : '';


### PR DESCRIPTION
## Prod incident fix (ref mrecl8grjuc) — per /tzurot-bug-remediation

A credit-exhausted BYOK user was correctly retargeted to `openrouter/free` on the system key — but the invocation derived its doom-cache identity from key **presence**: the system key arrived as a plain string, `deriveCacheKeyId` saw "a key" and scoped the call as `user:<id>`, and the user's own cached 402 short-circuited the very fallback chosen to dodge it. Every message errored for the full cache TTL; a top-up didn't help because the TTL (1h) is the only propagation path. The footer showed the intended route while the free call never ran.

### Protocol checklist
- **Runtime evidence**: prod logs — repeated `Skipped LLM call — credit-exhaustion cache hit` with `cacheKeyId="user:179362616479711233"` on the retargeted calls, 02:50–03:00Z, matching the user's screenshots.
- **Mechanism, not symptom**: the retarget machinery was already right (`selectQuotaFallbackTarget` forces the system key for CREDIT_EXHAUSTION and its comment explicitly anticipates this veto) — the sink re-introduced it. Fix: `deriveCacheKeyId` gains `isSystemKeyRoute` (provenance beats presence); the RAG invoke site passes `isGuestMode`, which both the proactive (AuthStep→retargetRoute) and reactive (quotaFallbackRunner) paths already set `true` for system-key routes.
- **Class sweep** (exhaustive grep, all `deriveCacheKeyId` call sites): `ConversationalRAGService:206` was the **only invoke-time** derivation → fixed. `AuthStep:136/218`, `promotionDemotion:69`, `autoPromotionFallback:181`, `quotaFallbackRunner:112` all deliberately scope the *user's own pre-retarget route* → verified correct, unchanged.
- **Regression tests at the seam tier, verified failing pre-fix** (2 failed | 107 passed on stashed fix): the LLMInvoker seam test asserts a system-key retarget **crosses the seam** with `cacheKeyId: 'system'`; a unit test pins provenance-beats-presence. Also fixed the blind spot the owner called out: the prior seam assertion accepted `(user:\d+|system)` as a **union** — green regardless of which identity crossed. Now exact.
- **Structural guard**: the exact-identity seam assertions are the recurrence blocker; `deriveCacheKeyId`'s doc comment now names the invariant at the canonical producer.

### Second half: top-up propagation
`CreditExhaustionCache` default TTL **1h → 10min**. The TTL is the only path a top-up propagates (the incident user topped up and stayed "broke" for most of an hour). With the fallback fixed, a genuinely-empty account costs one doomed 402 round-trip per 10-min window — the shorter re-check is nearly free, and the user-facing staleness bound drops 6×.

### User impact after this ships
Credit-exhausted BYOK users degrade to the metered free tier (the #1564 design intent) instead of hard-erroring; top-ups restore their paid model within 10 minutes instead of an hour.

Gates: `pnpm test` (25 pkgs, 3582 ai-worker) + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)