### PR TITLE
feat(ai-worker): extraction rides the z.ai system key with delay-not-downgrade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ VISION_FALLBACK_MODEL=qwen/qwen3.5-397b-a17b  # For image analysis fallback (pai
 # EXTRACTION_MODEL=anthropic/claude-haiku-4.5  # Fact-extraction engine — re-run `pnpm eval:extraction` before switching (quality gate is model-specific)
 # EXTRACTION_DAILY_LIMIT=100  # Per-personality daily ceiling on extraction model calls (cost tripwire)
 # EXTRACTION_BATCH_THRESHOLD=6  # Stored episodes per (channel, personality) before an extraction batch enqueues
+# EXTRACTION_PROVIDER=openrouter  # 'zai-coding' bills extraction to the system z.ai coding plan (requires ZAI_CODING_API_KEY)
+# ZAI_CODING_API_KEY=  # System z.ai coding-plan key — extraction-only; per-user completions stay BYOK
 # Note: Embeddings are local (Xenova/bge-small-en-v1.5) - no API key needed
 
 # Optional: ElevenLabs for voice synthesis

--- a/packages/common-types/src/config/config.test.ts
+++ b/packages/common-types/src/config/config.test.ts
@@ -143,6 +143,19 @@ describe('config', () => {
       expect(result.LOG_LEVEL).toBe('debug');
     });
 
+    it('should validate EXTRACTION_PROVIDER enum (defaults to openrouter)', () => {
+      expect(() =>
+        envSchema.parse({
+          EXTRACTION_PROVIDER: 'zai', // must be the full 'zai-coding' literal
+        })
+      ).toThrow();
+
+      expect(envSchema.parse({}).EXTRACTION_PROVIDER).toBe('openrouter');
+      expect(envSchema.parse({ EXTRACTION_PROVIDER: 'zai-coding' }).EXTRACTION_PROVIDER).toBe(
+        'zai-coding'
+      );
+    });
+
     it('should validate NODE_ENV enum', () => {
       expect(() =>
         envSchema.parse({

--- a/packages/common-types/src/config/config.ts
+++ b/packages/common-types/src/config/config.ts
@@ -69,6 +69,8 @@ export const envSchema = z.object({
   EXTRACTION_BATCH_THRESHOLD: z.coerce.number().int().min(1).max(50).default(6), // episodes per (channel, personality) before an extraction batch enqueues
   EXTRACTION_MODEL: z.string().default(MODEL_DEFAULTS.FACT_EXTRACTION), // extraction engine — switching models MUST re-run pnpm eval:extraction first (the quality gate is model-specific)
   EXTRACTION_DAILY_LIMIT: z.coerce.number().int().min(1).default(100), // per-personality daily ceiling on extraction model calls (cost tripwire)
+  EXTRACTION_PROVIDER: z.enum(['openrouter', 'zai-coding']).default('openrouter'), // which provider bills extraction; 'zai-coding' requires ZAI_CODING_API_KEY (falls back to openrouter with an error log if absent)
+  ZAI_CODING_API_KEY: optionalNonEmptyString(), // SYSTEM z.ai coding-plan key — extraction-only today (per-user completions stay BYOK); future free-tier piggyback consumer
   // Fair-share quota for the SHARED system OpenRouter free-tier key (guests +
   // credit-exhausted-BYOK fallback). Rolling-window per-user cap that shrinks as
   // concurrent users rise, bounded by a floor/ceiling; a daily global counter is
@@ -246,6 +248,8 @@ export function createTestConfig(overrides: Partial<EnvConfig> = {}): EnvConfig 
     EXTRACTION_BATCH_THRESHOLD: 6,
     EXTRACTION_MODEL: MODEL_DEFAULTS.FACT_EXTRACTION,
     EXTRACTION_DAILY_LIMIT: 100,
+    EXTRACTION_PROVIDER: 'openrouter' as const,
+    ZAI_CODING_API_KEY: undefined,
     FREE_TIER_GLOBAL_DAILY_BUDGET: 1000,
     FREE_TIER_WINDOW_MINUTES: 60,
     FREE_TIER_MIN_PER_WINDOW: 5,

--- a/services/ai-worker/src/jobs/factExtractionSetup.test.ts
+++ b/services/ai-worker/src/jobs/factExtractionSetup.test.ts
@@ -3,29 +3,47 @@ import type { Redis } from 'ioredis';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { LocalEmbeddingService } from '@tzurot/embeddings';
 import { JobType } from '@tzurot/common-types/constants/queue';
+import { ExtractionProviderBusyError } from '../services/extraction/FactExtractionService.js';
 
-const { addMock, queueCloseMock, workerCloseMock, getConfigMock, processBatchMock } = vi.hoisted(
-  () => ({
-    addMock: vi.fn(),
-    queueCloseMock: vi.fn(),
-    workerCloseMock: vi.fn(),
-    getConfigMock: vi.fn(),
-    processBatchMock: vi.fn().mockResolvedValue(2),
-  })
-);
+const {
+  addMock,
+  queueCloseMock,
+  workerCloseMock,
+  getConfigMock,
+  processBatchMock,
+  rateLimitMock,
+  rateLimitErrorSentinel,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  queueCloseMock: vi.fn(),
+  workerCloseMock: vi.fn(),
+  getConfigMock: vi.fn(),
+  processBatchMock: vi.fn().mockResolvedValue(2),
+  rateLimitMock: vi.fn().mockResolvedValue(undefined),
+  rateLimitErrorSentinel: new Error('bullmq-rate-limit'),
+  loggerErrorMock: vi.fn(),
+}));
 let capturedProcessor: ((job: { id: string; data: unknown }) => Promise<unknown>) | undefined;
 
 vi.mock('bullmq', () => ({
   Queue: vi.fn().mockImplementation(function () {
     return { add: addMock, close: queueCloseMock };
   }),
-  Worker: vi.fn().mockImplementation(function (_name: string, processor: typeof capturedProcessor) {
-    capturedProcessor = processor;
-    return { on: vi.fn(), close: workerCloseMock };
-  }),
+  Worker: Object.assign(
+    vi.fn().mockImplementation(function (_name: string, processor: typeof capturedProcessor) {
+      capturedProcessor = processor;
+      return { on: vi.fn(), close: workerCloseMock, rateLimit: rateLimitMock };
+    }),
+    // BullMQ's static sentinel: throwing it after worker.rateLimit() requeues
+    // the job without consuming an attempt.
+    { RateLimitError: () => rateLimitErrorSentinel }
+  ),
 }));
 
-vi.mock('../services/extraction/FactExtractionService.js', () => ({
+vi.mock('../services/extraction/FactExtractionService.js', async importOriginal => ({
+  // Keep the REAL ExtractionProviderBusyError so the worker's instanceof works.
+  ...(await importOriginal<typeof import('../services/extraction/FactExtractionService.js')>()),
   FactExtractionService: vi.fn().mockImplementation(function () {
     return { processBatch: processBatchMock };
   }),
@@ -35,6 +53,15 @@ vi.mock('@tzurot/common-types/config/config', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types/config/config')>();
   return { ...actual, getConfig: (): unknown => getConfigMock() };
 });
+
+vi.mock('@tzurot/common-types/utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: loggerErrorMock,
+    debug: vi.fn(),
+  }),
+}));
 
 import { setupFactExtraction } from './factExtractionSetup.js';
 
@@ -67,6 +94,55 @@ describe('setupFactExtraction', () => {
     expect(capturedProcessor).toBeDefined();
   });
 
+  it('logs loudly (but still boots) when zai-coding is configured without the system key', () => {
+    getConfigMock.mockReturnValue({
+      EXTRACTION_ENABLED: 'true',
+      EXTRACTION_BATCH_THRESHOLD: 6,
+      EXTRACTION_PROVIDER: 'zai-coding',
+      ZAI_CODING_API_KEY: undefined,
+    });
+
+    const assembly = setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+
+    expect(assembly).toBeDefined(); // fail-loud-but-SOFT: misconfig must not kill worker boot
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('falls back to OpenRouter')
+    );
+  });
+
+  it('logs loudly when zai-coding is keyed but EXTRACTION_MODEL is not a coding-plan model', () => {
+    getConfigMock.mockReturnValue({
+      EXTRACTION_ENABLED: 'true',
+      EXTRACTION_BATCH_THRESHOLD: 6,
+      EXTRACTION_PROVIDER: 'zai-coding',
+      ZAI_CODING_API_KEY: 'zai-key',
+      EXTRACTION_MODEL: 'anthropic/claude-haiku-4.5', // not servable by z.ai — would 4xx every call
+    });
+
+    const assembly = setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+
+    expect(assembly).toBeDefined();
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'anthropic/claude-haiku-4.5' }),
+      expect.stringContaining('not on the z.ai coding-plan catalog')
+    );
+  });
+
+  it('stays quiet when zai-coding is keyed with a plan model (prefixed form accepted)', () => {
+    getConfigMock.mockReturnValue({
+      EXTRACTION_ENABLED: 'true',
+      EXTRACTION_BATCH_THRESHOLD: 6,
+      EXTRACTION_PROVIDER: 'zai-coding',
+      ZAI_CODING_API_KEY: 'zai-key',
+      EXTRACTION_MODEL: 'z-ai/glm-5.2',
+    });
+
+    setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+
+    expect(loggerErrorMock).not.toHaveBeenCalled();
+  });
+
   it('worker handler fail-to-skips a malformed payload without calling the service', async () => {
     getConfigMock.mockReturnValue({ EXTRACTION_ENABLED: 'true', EXTRACTION_BATCH_THRESHOLD: 6 });
     setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
@@ -96,5 +172,113 @@ describe('setupFactExtraction', () => {
 
     expect(processBatchMock).toHaveBeenCalledWith(expect.objectContaining({ channelId: 'chan-1' }));
     expect(result).toEqual({ written: 2 });
+  });
+});
+
+describe('delay-not-downgrade (provider busy at the BullMQ seam)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedProcessor = undefined;
+    getConfigMock.mockReturnValue({
+      EXTRACTION_ENABLED: 'true',
+      EXTRACTION_BATCH_THRESHOLD: 6,
+      EXTRACTION_DAILY_LIMIT: 100,
+      EXTRACTION_PROVIDER: 'openrouter',
+      ZAI_CODING_API_KEY: undefined,
+    });
+  });
+
+  const busyJob = {
+    requestId: 'req-busy',
+    jobType: JobType.FactExtraction,
+    responseDestination: { type: 'api' },
+    version: 1,
+    channelId: 'chan-1',
+    personalityId: '4f9b0f66-0000-4000-8000-0000000000aa',
+    sourceMemoryIds: [
+      '4f9b0f66-0000-4000-8000-000000000001',
+      '4f9b0f66-0000-4000-8000-000000000002',
+    ],
+    windowStart: '4f9b0f66-0000-4000-8000-000000000001',
+  };
+
+  it('busy error → shrinks the requeued payload, pauses the queue, throws the no-attempt sentinel', async () => {
+    setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+    const remaining = ['4f9b0f66-0000-4000-8000-000000000002'];
+    processBatchMock.mockRejectedValueOnce(
+      new ExtractionProviderBusyError('rate_limit', new Error('429'), remaining)
+    );
+    const updateData = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      capturedProcessor?.({ id: 'j-busy', data: busyJob, updateData } as never)
+    ).rejects.toBe(rateLimitErrorSentinel);
+
+    // Completed groups never re-run: the requeued job carries ONLY the
+    // unfinished episode ids.
+    expect(updateData).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceMemoryIds: remaining })
+    );
+    expect(rateLimitMock).toHaveBeenCalledWith(30 * 60 * 1000);
+  });
+
+  it('a sustained busy loop escalates to logger.error past the threshold (stuck-key visibility)', async () => {
+    setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+    processBatchMock.mockRejectedValue(
+      new ExtractionProviderBusyError('quota_exceeded', new Error('402'), [])
+    );
+    const updateData = vi.fn();
+
+    for (let cycle = 1; cycle <= 12; cycle++) {
+      await expect(
+        capturedProcessor?.({ id: `j-${cycle}`, data: busyJob, updateData } as never)
+      ).rejects.toBe(rateLimitErrorSentinel);
+      if (cycle < 12) {
+        expect(loggerErrorMock).not.toHaveBeenCalled(); // ordinary peak-window delay stays at info
+      }
+    }
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ consecutiveBusyCycles: 12, category: 'quota_exceeded' }),
+      expect.stringContaining('human attention')
+    );
+  });
+
+  it('a successful batch RESETS the consecutive-busy counter', async () => {
+    setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+    const updateData = vi.fn();
+    const busyOnce = (): void => {
+      processBatchMock.mockRejectedValueOnce(
+        new ExtractionProviderBusyError('rate_limit', new Error('429'), [])
+      );
+    };
+
+    for (let i = 0; i < 11; i++) {
+      busyOnce();
+      await expect(
+        capturedProcessor?.({ id: `j-${i}`, data: busyJob, updateData } as never)
+      ).rejects.toBe(rateLimitErrorSentinel);
+    }
+    processBatchMock.mockResolvedValueOnce(1); // success resets the streak
+    await capturedProcessor?.({ id: 'j-ok', data: busyJob, updateData } as never);
+    busyOnce();
+    await expect(
+      capturedProcessor?.({ id: 'j-after', data: busyJob, updateData } as never)
+    ).rejects.toBe(rateLimitErrorSentinel);
+
+    expect(loggerErrorMock).not.toHaveBeenCalled(); // streak never reached 12 consecutively
+  });
+
+  it('non-busy errors propagate untouched (BullMQ attempt-based retry applies)', async () => {
+    setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+    processBatchMock.mockRejectedValueOnce(new Error('db exploded'));
+    const updateData = vi.fn();
+
+    await expect(
+      capturedProcessor?.({ id: 'j-err', data: busyJob, updateData } as never)
+    ).rejects.toThrow('db exploded');
+
+    expect(rateLimitMock).not.toHaveBeenCalled();
+    expect(updateData).not.toHaveBeenCalled();
   });
 });

--- a/services/ai-worker/src/jobs/factExtractionSetup.ts
+++ b/services/ai-worker/src/jobs/factExtractionSetup.ts
@@ -14,15 +14,65 @@ import type { BullMQRedisConfig } from '@tzurot/common-types/utils/redis';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { LocalEmbeddingService } from '@tzurot/embeddings';
 import { FACT_EXTRACTION_QUEUE_NAME, QUEUE_CONFIG } from '@tzurot/common-types/constants/queue';
+import { getZaiCodingPlanContextLength } from '@tzurot/common-types/constants/ai';
 import { factExtractionJobDataSchema } from '@tzurot/common-types/types/jobs';
 import { getConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { ExtractionBudget } from '../services/extraction/ExtractionBudget.js';
 import { ExtractionTrigger } from '../services/extraction/ExtractionTrigger.js';
 import { FactStore } from '../services/extraction/FactStore.js';
-import { FactExtractionService } from '../services/extraction/FactExtractionService.js';
+import {
+  FactExtractionService,
+  ExtractionProviderBusyError,
+} from '../services/extraction/FactExtractionService.js';
 
 const logger = createLogger('FactExtractionSetup');
+
+/**
+ * Queue pause when the extraction provider is busy (z.ai peak hours,
+ * OpenRouter 429/5xx). Peak windows last hours — the 5s-exponential job
+ * backoff is the wrong scale, so busy conditions pause the whole queue for
+ * this window instead. Requeues consume no retry attempts (Worker.RateLimitError).
+ */
+const EXTRACTION_BUSY_DELAY_MS = 30 * 60 * 1000;
+
+/**
+ * Consecutive busy cycles before the per-cycle info log escalates to error.
+ * 12 cycles × 30 min ≈ 6 hours — past any normal z.ai peak window, so
+ * reaching it signals a stuck state needing a human (drained system key,
+ * account problem) rather than ordinary peak-hours delay. In-process counter:
+ * a restart resets it, which is fine — the loop re-accumulates within hours
+ * if the condition persists.
+ */
+const SUSTAINED_BUSY_ERROR_THRESHOLD = 12;
+
+/**
+ * Boot-time coherence checks for the zai-coding route — both fail-loud-but-
+ * SOFT (log error, keep booting; extraction must never kill worker boot):
+ *
+ * 1. 'zai-coding' without the system key silently bills OpenRouter instead
+ *    (the per-call resolver applies the same fallback).
+ * 2. 'zai-coding' with a model that isn't on the coding plan means every call
+ *    4xxes into the PERMANENT fail-to-skip path — a silent, indefinite
+ *    extraction outage. (The null-context-length lookup is the prefix-tolerant
+ *    catalog membership idiom — see modelValidation's z.ai gate.)
+ */
+function logZaiCoherenceMisconfigurations(config: ReturnType<typeof getConfig>): void {
+  if (config.EXTRACTION_PROVIDER !== 'zai-coding') {
+    return;
+  }
+  if (config.ZAI_CODING_API_KEY === undefined) {
+    logger.error(
+      {},
+      'EXTRACTION_PROVIDER=zai-coding but ZAI_CODING_API_KEY is not set — extraction falls back to OpenRouter (paid)'
+    );
+  } else if (getZaiCodingPlanContextLength(config.EXTRACTION_MODEL) === null) {
+    logger.error(
+      { model: config.EXTRACTION_MODEL },
+      'EXTRACTION_PROVIDER=zai-coding but EXTRACTION_MODEL is not on the z.ai coding-plan catalog — every extraction call will fail until the model is switched'
+    );
+  }
+}
 
 export interface FactExtractionAssembly {
   queue: Queue;
@@ -64,6 +114,14 @@ export function setupFactExtraction(
   const extractionService = new FactExtractionService(prisma, factStore, budget);
   const trigger = new ExtractionTrigger(redis, queue, config.EXTRACTION_BATCH_THRESHOLD);
 
+  logZaiCoherenceMisconfigurations(config);
+
+  // Consecutive-busy tracker (concurrency 1, so no race). Ordinary peak-hours
+  // delay logs at info; a loop past SUSTAINED_BUSY_ERROR_THRESHOLD escalates
+  // to error because busy classification includes human-remedy states
+  // (drained credits, exhausted quota) that never self-resolve.
+  let consecutiveBusyCycles = 0;
+
   const worker = new Worker(
     FACT_EXTRACTION_QUEUE_NAME,
     async job => {
@@ -76,8 +134,47 @@ export function setupFactExtraction(
         );
         return { written: 0 };
       }
-      const written = await extractionService.processBatch(parsed.data);
-      return { written };
+      try {
+        const written = await extractionService.processBatch(parsed.data);
+        consecutiveBusyCycles = 0;
+        return { written };
+      } catch (error) {
+        if (error instanceof ExtractionProviderBusyError) {
+          // Delay, never downgrade: facts aren't time-sensitive, so a busy
+          // provider (z.ai peak hours, OpenRouter 429/5xx) pauses the queue and
+          // requeues WITHOUT consuming a retry attempt. The requeued payload is
+          // shrunk to the UNFINISHED groups' episode ids so completed groups
+          // are never re-billed on retries of a sustained busy window.
+          if (error.remainingMemoryIds.length > 0) {
+            await job.updateData({
+              ...parsed.data,
+              sourceMemoryIds: error.remainingMemoryIds,
+            });
+          }
+          consecutiveBusyCycles += 1;
+          const logFields = {
+            jobId: job.id,
+            category: error.category,
+            delayMs: EXTRACTION_BUSY_DELAY_MS,
+            remaining: error.remainingMemoryIds.length,
+            consecutiveBusyCycles,
+          };
+          if (consecutiveBusyCycles >= SUSTAINED_BUSY_ERROR_THRESHOLD) {
+            logger.error(
+              logFields,
+              'Extraction provider busy far past a normal peak window — the system key may need human attention (credits/quota/account)'
+            );
+          } else {
+            logger.info(
+              logFields,
+              'Extraction provider busy — delaying remaining batch (never downgrading provider)'
+            );
+          }
+          await worker.rateLimit(EXTRACTION_BUSY_DELAY_MS);
+          throw Worker.RateLimitError();
+        }
+        throw error;
+      }
     },
     { connection: bullmqConnection, concurrency: 1 }
   );

--- a/services/ai-worker/src/services/extraction/ExtractionBudget.test.ts
+++ b/services/ai-worker/src/services/extraction/ExtractionBudget.test.ts
@@ -68,4 +68,27 @@ describe('ExtractionBudget', () => {
   it('the config schema default limit stays generous (single source of truth)', () => {
     expect(createTestConfig().EXTRACTION_DAILY_LIMIT).toBeGreaterThanOrEqual(50);
   });
+
+  describe('refund (busy calls are budget-neutral)', () => {
+    it('DECRs the same UTC-day-scoped key tryConsume charged', async () => {
+      const decr = vi.fn().mockResolvedValue(0);
+      const redis = { eval: vi.fn().mockResolvedValue(1), decr } as unknown as Redis;
+      const budget = new ExtractionBudget(redis, 10);
+
+      await budget.refund('personality-1');
+
+      expect(decr).toHaveBeenCalledWith(
+        `${CACHE_KEY_PREFIXES.FACT_EXTRACTION_BUDGET}personality-1:2026-07-06`
+      );
+    });
+
+    it('fails open on Redis errors (never throws into the busy path)', async () => {
+      const redis = {
+        decr: vi.fn().mockRejectedValue(new Error('redis down')),
+      } as unknown as Redis;
+      const budget = new ExtractionBudget(redis, 10);
+
+      await expect(budget.refund('p')).resolves.toBeUndefined();
+    });
+  });
 });

--- a/services/ai-worker/src/services/extraction/ExtractionBudget.ts
+++ b/services/ai-worker/src/services/extraction/ExtractionBudget.ts
@@ -85,6 +85,27 @@ export class ExtractionBudget {
     }
   }
 
+  /**
+   * Return one unit consumed by a call that turned out to spend nothing (the
+   * provider answered BUSY before any tokens were billed). Keeps sustained
+   * busy windows budget-neutral — otherwise 30-minute requeue cycles burn the
+   * daily cap for zero written facts and the tripwire then skips REAL batches
+   * once the provider recovers. Plain DECR, fail-open like the rest of the
+   * class; a refund landing just after UTC rollover decrements the new day's
+   * key to -1, harmlessly granting that day one extra unit.
+   */
+  async refund(personalityId: string): Promise<void> {
+    const key = this.buildKey(personalityId);
+    try {
+      await this.redis.decr(key);
+    } catch (error) {
+      logger.warn(
+        { err: error, personalityId },
+        'Extraction budget refund failed — continuing (fail-open)'
+      );
+    }
+  }
+
   /** Build the per-(personality, UTC-day) counter key. */
   private buildKey(personalityId: string): string {
     const utcDay = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)

--- a/services/ai-worker/src/services/extraction/FactExtractionService.component.test.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.component.test.ts
@@ -23,7 +23,7 @@ import { FactExtractionService } from './FactExtractionService.js';
 
 /** Wrap raw model content in the ExtractionModelResult shape the invoker now returns. */
 const mockInvoker = (content: string) =>
-  vi.fn().mockResolvedValue({ content, tokensIn: 10, tokensOut: 5 });
+  vi.fn().mockResolvedValue({ content, tokensIn: 10, tokensOut: 5, provider: 'openrouter' });
 import { FactStore } from './FactStore.js';
 import { ExtractionBudget } from './ExtractionBudget.js';
 
@@ -77,6 +77,7 @@ describe('FactExtractionService (component, PGLite)', () => {
   beforeEach(async () => {
     await prisma.$executeRaw`DELETE FROM memory_facts`;
     await prisma.$executeRaw`DELETE FROM memories`;
+    await prisma.$executeRaw`DELETE FROM usage_logs`;
   });
 
   function makeBudget(allowed = true): ExtractionBudget {
@@ -138,6 +139,15 @@ describe('FactExtractionService (component, PGLite)', () => {
     expect(rows[0].tier).toBe('observed');
     expect(rows[0].supersededAt).toBeNull();
     expect(rows[0].sourceMemoryIds).toEqual([ep]);
+
+    // The usage row must REALLY insert (logExtractionUsage is fail-soft, so a
+    // shape drift in the invoker result would otherwise no-op silently here —
+    // this assertion is what catches that class of regression).
+    const usage = await prisma.usageLog.findMany({ where: { userId: USER } });
+    expect(usage).toHaveLength(1);
+    expect(usage[0].provider).toBe('openrouter');
+    expect(usage[0].requestType).toBe('fact_extraction');
+    expect(usage[0].tokensIn).toBe(10);
   });
 
   it('supersession end-to-end: an indexed target gets its columns flipped in the same write', async () => {

--- a/services/ai-worker/src/services/extraction/FactExtractionService.provider.test.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.provider.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Provider-routing tests for invokeExtractionModel / resolveExtractionProvider.
+ *
+ * Separate from FactExtractionService.test.ts because these need getConfig
+ * mocked (zai vs openrouter routes), while that file's tests rely on the real
+ * test config. Asserts what crosses the createChatModel seam: provider, key,
+ * and the bare-vs-prefixed model id.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getConfigMock = vi.hoisted(() => vi.fn());
+vi.mock('@tzurot/common-types/config/config', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/config/config')>();
+  return { ...actual, getConfig: (): unknown => getConfigMock() };
+});
+
+const createChatModelMock = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    model: {
+      invoke: vi.fn().mockResolvedValue({
+        content: '{"facts": []}',
+        usage_metadata: { input_tokens: 10, output_tokens: 5 },
+      }),
+    },
+    modelName: 'x',
+  })
+);
+vi.mock('../ModelFactory.js', () => ({
+  createChatModel: createChatModelMock,
+}));
+
+import { invokeExtractionModel, resolveExtractionProvider } from './FactExtractionService.js';
+
+const baseConfig = {
+  EXTRACTION_MODEL: 'z-ai/glm-5.2',
+  EXTRACTION_PROVIDER: 'openrouter',
+  ZAI_CODING_API_KEY: undefined as string | undefined,
+};
+
+describe('resolveExtractionProvider', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes to z.ai with the system key when configured', () => {
+    getConfigMock.mockReturnValue({
+      ...baseConfig,
+      EXTRACTION_PROVIDER: 'zai-coding',
+      ZAI_CODING_API_KEY: 'zai-system-key',
+    });
+    expect(resolveExtractionProvider()).toEqual({
+      provider: 'zai-coding',
+      apiKey: 'zai-system-key',
+    });
+  });
+
+  it('falls back to OpenRouter when zai-coding is set WITHOUT a key (misconfiguration)', () => {
+    getConfigMock.mockReturnValue({ ...baseConfig, EXTRACTION_PROVIDER: 'zai-coding' });
+    expect(resolveExtractionProvider()).toEqual({ provider: 'openrouter' });
+  });
+});
+
+describe('invokeExtractionModel provider seam', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('z.ai route: system key attached and the z-ai/ prefix stripped to the bare model id', async () => {
+    getConfigMock.mockReturnValue({
+      ...baseConfig,
+      EXTRACTION_PROVIDER: 'zai-coding',
+      ZAI_CODING_API_KEY: 'zai-system-key',
+    });
+
+    const result = await invokeExtractionModel('prompt');
+
+    expect(createChatModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelName: 'glm-5.2', // bare — z.ai-direct rejects the OpenRouter prefix
+        provider: 'zai-coding',
+        apiKey: 'zai-system-key',
+      })
+    );
+    expect(result).toEqual({
+      content: '{"facts": []}',
+      tokensIn: 10,
+      tokensOut: 5,
+      provider: 'zai-coding',
+    });
+  });
+
+  it('default route: OpenRouter keeps the prefixed model id and attaches no key', async () => {
+    getConfigMock.mockReturnValue(baseConfig);
+
+    await invokeExtractionModel('prompt');
+
+    const args = createChatModelMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(args.modelName).toBe('z-ai/glm-5.2');
+    expect(args.provider).toBe('openrouter');
+    expect(args).not.toHaveProperty('apiKey');
+    expect(args.appTitleSuffix).toBe('Extraction');
+  });
+});

--- a/services/ai-worker/src/services/extraction/FactExtractionService.test.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { JobType } from '@tzurot/common-types/constants/queue';
 import type { FactExtractionJobData } from '@tzurot/common-types/types/jobs';
-import { FactExtractionService, hasEntityOverlap } from './FactExtractionService.js';
+import {
+  FactExtractionService,
+  hasEntityOverlap,
+  ExtractionProviderBusyError,
+  resolveExtractionProvider,
+} from './FactExtractionService.js';
 import { generateFactExtractionJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import type { FactStore, SimilarFact } from './FactStore.js';
 import type { ExtractionBudget } from './ExtractionBudget.js';
@@ -71,6 +76,7 @@ function makeSetup(options: {
 
   const budget = {
     tryConsume: vi.fn().mockResolvedValue(options.budgetAllowed ?? true),
+    refund: vi.fn().mockResolvedValue(undefined),
   } as unknown as ExtractionBudget;
 
   const invokeModel =
@@ -91,6 +97,7 @@ function makeSetup(options: {
             }),
           tokensIn: 120,
           tokensOut: 40,
+          provider: 'openrouter',
         });
 
   const service = new FactExtractionService(prisma, factStore, budget, invokeModel);
@@ -398,6 +405,25 @@ describe('extraction usage rows (cost visibility)', () => {
     );
   });
 
+  it("carries the invoker's ACTUAL provider into the row (no independent re-resolution)", async () => {
+    const s = makeSetup({});
+    // An injected invoker (eval harness, future routing) may bill a different
+    // provider than a fresh config resolution would claim — the row must
+    // reflect what was billed, not what config says now.
+    s.invokeModel.mockResolvedValue({
+      content: JSON.stringify({ facts: [] }),
+      tokensIn: 10,
+      tokensOut: 2,
+      provider: 'zai-coding',
+    });
+
+    await s.service.processBatch(job);
+
+    expect(s.usageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ provider: 'zai-coding' }) })
+    );
+  });
+
   it('a usage-row failure never costs the extraction batch (fail-soft)', async () => {
     const s = makeSetup({});
     s.usageCreateMock.mockRejectedValue(new Error('db hiccup'));
@@ -425,5 +451,105 @@ describe('extraction usage rows (cost visibility)', () => {
     await s.service.processBatch(job);
 
     expect(s.usageCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('delay-not-downgrade (provider busy)', () => {
+  function rejectingSetup(status: number, message: string) {
+    return makeSetup({
+      modelResponse: Object.assign(new Error(message), { status }),
+    });
+  }
+
+  it('a 429 (rate limit) THROWS ExtractionProviderBusyError instead of skipping', async () => {
+    const s = rejectingSetup(429, 'Too many requests');
+    await expect(s.service.processBatch(job)).rejects.toThrow(ExtractionProviderBusyError);
+    expect(s.writeMock).not.toHaveBeenCalled();
+    expect(s.usageCreateMock).not.toHaveBeenCalled(); // busy batches never count usage
+  });
+
+  it('multi-persona batch: only UNFINISHED groups ride the requeue — completed groups are never re-billed', async () => {
+    // Group A (mem 1-2) succeeds; group B (mem 3) hits the busy provider. The
+    // rethrown error must carry ONLY group B's ids — this is the guarantee
+    // that a sustained busy window can't re-bill already-extracted groups on
+    // every 30-min retry.
+    const s = makeSetup({
+      episodes: [
+        { id: MEM(1), content: '{user}: my cat is Miso', personaId: PERSONA_A, isFiction: false },
+        { id: MEM(2), content: '{user}: I love tea', personaId: PERSONA_A, isFiction: false },
+        {
+          id: MEM(3),
+          content: '{user}: I moved to Berlin',
+          personaId: PERSONA_B,
+          isFiction: false,
+        },
+      ],
+    });
+    s.invokeModel
+      .mockResolvedValueOnce({
+        content: JSON.stringify({ facts: [] }),
+        tokensIn: 50,
+        tokensOut: 5,
+        provider: 'openrouter',
+      })
+      .mockRejectedValueOnce(Object.assign(new Error('Too many requests'), { status: 429 }));
+
+    const multiJob = { ...job, sourceMemoryIds: [MEM(1), MEM(2), MEM(3)] };
+    await expect(s.service.processBatch(multiJob)).rejects.toMatchObject({
+      name: 'ExtractionProviderBusyError',
+      remainingMemoryIds: [MEM(3)],
+    });
+
+    // Group A's completed call billed usage once; group B's busy call did not.
+    expect(s.usageCreateMock).toHaveBeenCalledTimes(1);
+    // Only the busy group's consume is refunded — group A's spend stands.
+    expect(s.budget.tryConsume).toHaveBeenCalledTimes(2);
+    expect(s.budget.refund).toHaveBeenCalledTimes(1);
+  });
+
+  it('busy REFUNDS the consumed budget unit — retries of a sustained window are budget-neutral', async () => {
+    const s = rejectingSetup(429, 'Too many requests');
+    await expect(s.service.processBatch(job)).rejects.toThrow(ExtractionProviderBusyError);
+    // Without the refund, each 30-min requeue burns a unit for zero facts and
+    // the tripwire eventually skips REAL batches after the provider recovers.
+    expect(s.budget.tryConsume).toHaveBeenCalledTimes(1);
+    expect(s.budget.refund).toHaveBeenCalledTimes(1);
+    expect(s.budget.refund).toHaveBeenCalledWith(PERSONALITY);
+  });
+
+  it('a 5xx THROWS busy (transient — the batch delays rather than losing facts)', async () => {
+    const s = rejectingSetup(503, 'Service overloaded');
+    await expect(s.service.processBatch(job)).rejects.toThrow(ExtractionProviderBusyError);
+    expect(s.budget.refund).toHaveBeenCalledTimes(1);
+  });
+
+  it('a 402 (quota) THROWS busy — deliberate divergence from the completions fail-fast', async () => {
+    // Completions fail fast on QUOTA_EXCEEDED (a user is waiting); extraction
+    // delays instead, because fail-to-skip would LOSE the batch's facts on a
+    // state a human fixes by topping up.
+    const s = rejectingSetup(402, 'Payment required');
+    await expect(s.service.processBatch(job)).rejects.toThrow(ExtractionProviderBusyError);
+    expect(s.budget.refund).toHaveBeenCalledTimes(1);
+  });
+
+  it('account-level credit exhaustion (402 sub-classified) also delays — the drained-key shape', async () => {
+    const s = rejectingSetup(402, 'Insufficient credits. Add more using https://openrouter.ai');
+    await expect(s.service.processBatch(job)).rejects.toThrow(ExtractionProviderBusyError);
+    expect(s.usageCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('a permanent 400 keeps fail-to-skip (writes nothing, does not throw)', async () => {
+    const s = rejectingSetup(400, 'Invalid API parameter');
+    const written = await s.service.processBatch(job);
+    expect(written).toBe(0);
+    // Permanent failures spent the attempt legitimately — no refund.
+    expect(s.budget.refund).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveExtractionProvider', () => {
+  it('defaults to OpenRouter with no key attached', () => {
+    const route = resolveExtractionProvider();
+    expect(route).toEqual({ provider: 'openrouter' });
   });
 });

--- a/services/ai-worker/src/services/extraction/FactExtractionService.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.ts
@@ -17,6 +17,9 @@
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { HumanMessage } from '@langchain/core/messages';
 import { getConfig } from '@tzurot/common-types/config/config';
+import { AIProvider, ZAI_MODEL_PREFIX } from '@tzurot/common-types/constants/ai';
+import { ApiErrorCategory } from '@tzurot/common-types/constants/error';
+import { parseApiError } from '../../utils/apiErrorParser.js';
 import type { FactExtractionJobData } from '@tzurot/common-types/types/jobs';
 import {
   generateFactExtractionJobUuid,
@@ -67,6 +70,72 @@ export interface ExtractionModelResult {
   content: string;
   tokensIn: number;
   tokensOut: number;
+  /** The provider the call ACTUALLY billed — carried into the usage row so an
+   * injected invoker (eval harness, tests) can never mislabel provenance. */
+  provider: AIProvider;
+}
+
+/**
+ * The extraction provider is BUSY (rate limit, server error, timeout — any
+ * transient shape). Extraction's response is DELAY, never downgrade: facts are
+ * not time-sensitive, so unlike completions (which fall back to OpenRouter to
+ * keep a waiting user responsive), the batch requeues until the provider
+ * window recovers — extraction never bills a fallback provider. The worker
+ * catches this and pauses the queue (owner directive: z.ai peak hours delay
+ * extraction rather than costing OpenRouter money).
+ */
+export class ExtractionProviderBusyError extends Error {
+  constructor(
+    readonly category: string,
+    cause: unknown,
+    /**
+     * Episode ids for the groups NOT yet completed when the provider went
+     * busy (the busy group + all unprocessed groups). The worker shrinks the
+     * requeued job's sourceMemoryIds to exactly these, so groups that already
+     * succeeded are never re-run — re-running them would re-bill the model
+     * call, re-consume budget, and write duplicate usage rows on every retry
+     * of a sustained busy window.
+     */
+    readonly remainingMemoryIds: string[] = []
+  ) {
+    super(`Extraction provider busy (${category})`);
+    this.name = 'ExtractionProviderBusyError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Error categories that mean "provider busy — delay and retry", not "give up".
+ *
+ * QUOTA_EXCEEDED and CREDIT_EXHAUSTION are DELIBERATE divergences from
+ * `PERMANENT_ERROR_CATEGORIES` (common-types error.ts), where both fail fast —
+ * correct for completions, where a user is waiting and a drained key can't
+ * serve them. Extraction is a background queue with the opposite trade-off:
+ * fail-to-skip LOSES the batch's facts forever, while delaying costs nothing
+ * and resumes automatically once the human remedy lands (credits topped up,
+ * quota window reset). A sustained loop on these categories is escalated to
+ * an error log by the worker (SUSTAINED_BUSY_ERROR_THRESHOLD) so a stuck
+ * system key can't sit unnoticed at info level for days.
+ */
+const BUSY_CATEGORIES = new Set<string>([
+  ApiErrorCategory.RATE_LIMIT,
+  ApiErrorCategory.SERVER_ERROR,
+  ApiErrorCategory.TIMEOUT,
+  ApiErrorCategory.QUOTA_EXCEEDED,
+  ApiErrorCategory.CREDIT_EXHAUSTION,
+]);
+
+/**
+ * Resolve the provider extraction bills to. 'zai-coding' requires the system
+ * coding-plan key — without it we fall back to OpenRouter (the boot-time check
+ * in factExtractionSetup logs the misconfiguration loudly once).
+ */
+export function resolveExtractionProvider(): { provider: AIProvider; apiKey?: string } {
+  const cfg = getConfig();
+  if (cfg.EXTRACTION_PROVIDER === 'zai-coding' && cfg.ZAI_CODING_API_KEY !== undefined) {
+    return { provider: AIProvider.ZaiCoding, apiKey: cfg.ZAI_CODING_API_KEY };
+  }
+  return { provider: AIProvider.OpenRouter };
 }
 
 /** Model invocation seam — injectable for tests/eval (defaults to the real call). */
@@ -74,11 +143,23 @@ export type ExtractionModelInvoker = (prompt: string) => Promise<ExtractionModel
 
 /** The real model call — exported for the eval harness (same code path as prod). */
 export async function invokeExtractionModel(prompt: string): Promise<ExtractionModelResult> {
+  const cfg = getConfig();
+  const route = resolveExtractionProvider();
+  // z.ai-direct takes the bare model id ('z-ai/glm-5.2' → 'glm-5.2'), same
+  // mapping ProviderRouter applies to promoted completions.
+  const modelName =
+    route.provider === AIProvider.ZaiCoding && cfg.EXTRACTION_MODEL.startsWith(ZAI_MODEL_PREFIX)
+      ? cfg.EXTRACTION_MODEL.slice(ZAI_MODEL_PREFIX.length)
+      : cfg.EXTRACTION_MODEL;
   const { model } = createChatModel({
-    modelName: getConfig().EXTRACTION_MODEL,
+    modelName,
     temperature: 0,
     responseFormat: { type: 'json_object' },
+    // OpenRouter-only attribution header; inert on z.ai-direct (no analog —
+    // usage_logs requestType is the insight surface there).
     appTitleSuffix: 'Extraction',
+    provider: route.provider,
+    ...(route.apiKey !== undefined ? { apiKey: route.apiKey } : {}),
   });
   const response = await model.invoke([new HumanMessage(prompt)], {
     timeout: EXTRACTION_TIMEOUT_MS,
@@ -88,6 +169,7 @@ export async function invokeExtractionModel(prompt: string): Promise<ExtractionM
       typeof response.content === 'string' ? response.content : JSON.stringify(response.content),
     tokensIn: response.usage_metadata?.input_tokens ?? 0,
     tokensOut: response.usage_metadata?.output_tokens ?? 0,
+    provider: route.provider,
   };
 }
 
@@ -142,8 +224,21 @@ export class FactExtractionService {
     }
 
     let written = 0;
-    for (const group of groups.values()) {
-      written += await this.processGroup(job, group);
+    const pending = [...groups.values()];
+    for (let i = 0; i < pending.length; i++) {
+      try {
+        written += await this.processGroup(job, pending[i]);
+      } catch (error) {
+        if (error instanceof ExtractionProviderBusyError) {
+          // Provider busy: stop immediately (it's busy for the remaining
+          // groups too) and hand the worker exactly the unfinished work —
+          // the busy group plus everything after it. Completed groups stay
+          // out of the requeue so they can't be re-billed.
+          const remaining = pending.slice(i).flatMap(g => g.ids);
+          throw new ExtractionProviderBusyError(error.category, error.cause, remaining);
+        }
+        throw error;
+      }
     }
     return written;
   }
@@ -170,13 +265,28 @@ export class FactExtractionService {
     try {
       modelResult = await this.invokeModel(prompt);
     } catch (error) {
+      // Transient provider failures (rate limit / 5xx / timeout / quota) mean
+      // BUSY, not broken: propagate so the worker delays the whole batch —
+      // facts aren't time-sensitive, and extraction never downgrades to a
+      // fallback provider (owner directive). Permanent shapes keep
+      // fail-to-skip.
+      const category = parseApiError(error).category;
+      if (BUSY_CATEGORIES.has(category)) {
+        // Busy spent zero tokens — refund the unit so a sustained busy window
+        // (30-min requeue cycles for hours) can't burn the daily cap and make
+        // the tripwire skip real batches once the provider recovers.
+        await this.budget.refund(job.personalityId);
+        throw new ExtractionProviderBusyError(category, error);
+      }
       logger.warn({ err: error, ...scope }, 'Extraction model call failed — skipping group');
       return 0;
     }
 
-    await this.logExtractionUsage(group.personaId, modelResult, scope);
-
     const parsed = this.parseResponse(modelResult.content, scope);
+    // Usage is logged only once the call is known non-busy (the busy path
+    // throws above, before any row) so a delayed-and-requeued batch can't
+    // double-count. Parse failures DO log usage — the tokens were spent.
+    await this.logExtractionUsage(group.personaId, modelResult, scope);
     if (parsed === null || parsed.length === 0) {
       return 0;
     }
@@ -222,12 +332,13 @@ export class FactExtractionService {
         return;
       }
       const model = getConfig().EXTRACTION_MODEL;
+      const provider = modelResult.provider;
       const createdAt = new Date();
       await this.prisma.usageLog.create({
         data: {
           id: generateUsageLogUuid(persona.ownerId, model, createdAt),
           userId: persona.ownerId,
-          provider: 'openrouter',
+          provider,
           model,
           tokensIn: modelResult.tokensIn,
           tokensOut: modelResult.tokensOut,


### PR DESCRIPTION
## z.ai track, slice 1 — the shared foundation

Owner gates (2026-07-10): the fact backfill must run at $0 (no OpenRouter charges), and when the z.ai plan is saturated (China peak hours) extraction must **delay, never downgrade** — facts aren't time-sensitive; completions are. This slice is deliberately the *shared foundation*: the GLM-4.5-Air free-tier piggyback (slice 2) reuses the same system-key config and busy classification.

### What it does
1. **`ZAI_CODING_API_KEY`** (system coding-plan key; owner-provisioned Railway secret) + **`EXTRACTION_PROVIDER`** (`openrouter` default | `zai-coding`). Boot logs an error when `zai-coding` is set without the key; the per-call resolver falls back to OpenRouter (fail-loud-but-soft — extraction never kills worker boot).
2. **Provider threading**: `invokeExtractionModel` routes through the existing `buildZaiCodingModel` branch with the system key, stripping the `z-ai/` prefix via the shared `ZAI_MODEL_PREFIX` constant (same mapping ProviderRouter applies to promoted completions — no re-derivation).
3. **Delay-not-downgrade**: transient failures (RATE_LIMIT / SERVER_ERROR / TIMEOUT / QUOTA_EXCEEDED via `parseApiError`) now throw `ExtractionProviderBusyError` — previously the worker *swallowed* model failures, so the enqueue-time retry config never engaged. The worker catches it: `worker.rateLimit(30 min)` + `Worker.RateLimitError()` requeues **without consuming a retry attempt** and pauses the queue (peak windows last hours; the 5s-exponential backoff was the wrong scale). Content-hash idempotency makes batch re-runs safe. Permanent errors keep fail-to-skip.
4. **Usage-row provider honesty**: rows label `zai-coding` or `openrouter` from the actual resolved route (closes PR #1569's review flag), and usage is logged only past the busy check so delayed batches never double-count.

### Defaults unchanged
`EXTRACTION_PROVIDER=openrouter` → byte-for-byte current behavior until the env flips. No migration.

### After merge (owner steps)
Set `ZAI_CODING_API_KEY` (your coding-plan key) + `EXTRACTION_PROVIDER=zai-coding` on dev ai-worker → burn-in continues on the plan at $0. One free confirmation eval via the z.ai endpoint is recommended (serving-config insurance). Prod at prod-enable.

### Slice 2 heads-up (research just landed)
z.ai exposes a real quota endpoint (`GET /api/monitor/usage/quota/limit` — undocumented in the reference but used by z.ai's own official plugin) with 5-hour/weekly meters + reset times, and numeric 429 codes distinguishing peak-busy (1305/1313) from window-exhausted (1308/1316–21) from account-problems (1309/1113). So quota-scaled free-tier limits are feasible; the code-aware classifier upgrade belongs to slice 2 (today's blanket 429→delay is safe: worst case is a 30-min requeue loop on an account problem, logged loudly).

### Tests
Busy-vs-permanent classification (429/503 throw busy, 400 keeps fail-to-skip), no-usage-row-on-busy, provider resolver default, existing suites green. `pnpm test` (25 pkgs) + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)