### PR TITLE
feat(tooling): memory:backfill-facts — extraction backfill over historical memories

### DIFF
--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -46,13 +46,16 @@ pnpm ops run --env <env> <command> [args...]
 
 Commands for analyzing and managing pgvector memories:
 
-| Command                             | Description                           |
-| ----------------------------------- | ------------------------------------- |
-| `pnpm ops memory:analyze --env dev` | Analyze duplicate memories            |
-| `pnpm ops memory:analyze --verbose` | Show detailed breakdown               |
-| `pnpm ops memory:cleanup --env dev` | Remove duplicate memories             |
-| `pnpm ops memory:cleanup --dry-run` | Preview what would be deleted         |
-| `pnpm ops memory:cleanup --force`   | Skip confirmation (required for prod) |
+| Command                                              | Description                                         |
+| ---------------------------------------------------- | --------------------------------------------------- |
+| `pnpm ops memory:analyze --env dev`                  | Analyze duplicate memories                          |
+| `pnpm ops memory:analyze --verbose`                  | Show detailed breakdown                             |
+| `pnpm ops memory:cleanup --env dev`                  | Remove duplicate memories                           |
+| `pnpm ops memory:cleanup --dry-run`                  | Preview what would be deleted                       |
+| `pnpm ops memory:cleanup --force`                    | Skip confirmation (required for prod)               |
+| `pnpm ops memory:backfill-facts --env dev --dry-run` | Report fact-backfill scope (groups/windows)         |
+| `pnpm ops memory:backfill-facts --env dev --limit 5` | Canary: enqueue the first N extraction windows      |
+| `pnpm ops memory:backfill-facts --env dev`           | Enqueue fact extraction over all uncovered memories |
 
 **Use case:** After migrations or data imports, check for and clean up duplicate memory embeddings.
 

--- a/packages/common-types/src/types/jobs.test.ts
+++ b/packages/common-types/src/types/jobs.test.ts
@@ -111,6 +111,30 @@ describe('BullMQ Job Contract Tests', () => {
       expect(result.success).toBe(true);
     });
 
+    it('budgetExempt is optional and survives the parse (backfill jobs set it true)', () => {
+      const base = {
+        requestId: 'req-fact-extract-exempt',
+        jobType: JobType.FactExtraction,
+        responseDestination: DISCORD_DESTINATION,
+        channelId: 'backfill',
+        personalityId: UUID_A,
+        sourceMemoryIds: [UUID_B],
+        windowStart: UUID_B,
+      };
+
+      const without = factExtractionJobDataSchema.safeParse(base);
+      expect(without.success).toBe(true);
+      if (without.success) {
+        expect(without.data.budgetExempt).toBeUndefined();
+      }
+
+      const withFlag = factExtractionJobDataSchema.safeParse({ ...base, budgetExempt: true });
+      expect(withFlag.success).toBe(true);
+      if (withFlag.success) {
+        expect(withFlag.data.budgetExempt).toBe(true); // must not be stripped (strip-mode pin)
+      }
+    });
+
     it('should reject an empty sourceMemoryIds batch', () => {
       const invalidJob = {
         requestId: 'req-fact-extract-2',

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -490,6 +490,11 @@ export const factExtractionJobDataSchema = baseJobDataSchema.extend({
   sourceMemoryIds: z.array(z.string().uuid()).min(1),
   /** First pending episode id — the deterministic-jobId anchor, for traceability. */
   windowStart: z.string().uuid(),
+  /** Owner-initiated backfill jobs skip the per-personality daily budget: the
+   * tripwire bounds MALFUNCTIONS (runaway loops), not deliberate finite work —
+   * a backfill's job set is fixed at enqueue time. The worker gates both
+   * tryConsume and the busy-path refund on this flag. */
+  budgetExempt: z.boolean().optional(),
 });
 
 export type FactExtractionJobData = z.infer<typeof factExtractionJobDataSchema>;

--- a/packages/tooling/src/commands/memory.ts
+++ b/packages/tooling/src/commands/memory.ts
@@ -11,6 +11,44 @@ const ENV_OPTION = '--env <env>';
 const ENV_OPTION_DESC = 'Environment: local, dev, or prod';
 const ENV_OPTION_DEFAULT = { default: 'dev' } as const;
 
+/** Backfill fact extraction over historical memories (memory Phase 2). */
+function registerBackfillFactsCommand(cli: CAC): void {
+  cli
+    .command(
+      'memory:backfill-facts',
+      'Enqueue fact-extraction jobs for memories that predate the live trigger'
+    )
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
+    .option('--dry-run', 'Report scope (groups/windows) without enqueueing')
+    .option('--limit <n>', 'Cap enqueued windows (canary runs)')
+    .option('--personality-id <id>', 'Filter to a specific personality UUID')
+    .option('--window-size <n>', 'Episodes per extraction window (default 6, the live threshold)')
+    .option('--include-covered', 'Also re-enqueue memories already cited by existing facts')
+    .option('--force', 'Skip production confirmation prompt')
+    .action(
+      async (options: {
+        env?: Environment;
+        dryRun?: boolean;
+        limit?: string;
+        personalityId?: string;
+        windowSize?: string;
+        includeCovered?: boolean;
+        force?: boolean;
+      }) => {
+        const { backfillFacts } = await import('../memory/backfill-facts.js');
+        await backfillFacts({
+          env: options.env ?? 'dev',
+          dryRun: options.dryRun,
+          limit: options.limit === undefined ? undefined : Number(options.limit),
+          personalityId: options.personalityId,
+          windowSize: options.windowSize === undefined ? undefined : Number(options.windowSize),
+          includeCovered: options.includeCovered,
+          force: options.force,
+        });
+      }
+    );
+}
+
 export function registerMemoryCommands(cli: CAC): void {
   // Analyze duplicate memories
   cli
@@ -58,6 +96,8 @@ export function registerMemoryCommands(cli: CAC): void {
         });
       }
     );
+
+  registerBackfillFactsCommand(cli);
 
   // Cleanup duplicate memories
   cli

--- a/packages/tooling/src/memory/backfill-facts.test.ts
+++ b/packages/tooling/src/memory/backfill-facts.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateFactExtractionJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { FACT_EXTRACTION_QUEUE_NAME, JobType } from '@tzurot/common-types/constants/queue';
+
+const { queueAddMock, queueCloseMock, queryMock } = vi.hoisted(() => ({
+  queueAddMock: vi.fn().mockResolvedValue({}),
+  queueCloseMock: vi.fn().mockResolvedValue(undefined),
+  queryMock: vi.fn(),
+}));
+
+vi.mock('../utils/env-runner.js', () => ({
+  validateEnvironment: vi.fn(),
+  showEnvironmentBanner: vi.fn(),
+  confirmProductionOperation: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./prisma-env.js', () => ({
+  getPrismaForEnv: vi.fn().mockResolvedValue({
+    prisma: { $queryRawUnsafe: queryMock },
+    disconnect: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('../inspect/bullmqConnection.js', () => ({
+  getRailwayRedisUrl: vi.fn().mockResolvedValue('redis://proxy.example:1234'),
+  createInspectorQueue: vi.fn().mockImplementation((_url: string, name: string) => ({
+    name,
+    add: queueAddMock,
+    close: queueCloseMock,
+  })),
+}));
+
+import { buildWindows, buildJobData, backfillFacts } from './backfill-facts.js';
+import { createInspectorQueue } from '../inspect/bullmqConnection.js';
+import { confirmProductionOperation } from '../utils/env-runner.js';
+
+const P1 = '4f9b0f66-0000-4000-8000-0000000000a1';
+const P2 = '4f9b0f66-0000-4000-8000-0000000000a2';
+const PERSONA_X = '4f9b0f66-0000-4000-8000-0000000000b1';
+const PERSONA_Y = '4f9b0f66-0000-4000-8000-0000000000b2';
+const MEM = (n: number): string =>
+  `4f9b0f66-0000-4000-8000-0000000000${String(n).padStart(2, '0')}`;
+
+const row = (id: string, personality: string, persona: string) => ({
+  id,
+  personality_id: personality,
+  persona_id: persona,
+});
+
+describe('buildWindows', () => {
+  it('groups by (personality, persona) and chunks preserving incoming order', () => {
+    const rows = [
+      row(MEM(1), P1, PERSONA_X),
+      row(MEM(2), P1, PERSONA_X),
+      row(MEM(3), P1, PERSONA_X),
+      row(MEM(4), P1, PERSONA_Y), // different persona → own group
+      row(MEM(5), P2, PERSONA_X), // different personality → own group
+    ];
+
+    const windows = buildWindows(rows, 2);
+
+    expect(windows).toEqual([
+      {
+        personalityId: P1,
+        personaId: PERSONA_X,
+        sourceMemoryIds: [MEM(1), MEM(2)],
+        windowStart: MEM(1),
+      },
+      { personalityId: P1, personaId: PERSONA_X, sourceMemoryIds: [MEM(3)], windowStart: MEM(3) },
+      { personalityId: P1, personaId: PERSONA_Y, sourceMemoryIds: [MEM(4)], windowStart: MEM(4) },
+      { personalityId: P2, personaId: PERSONA_X, sourceMemoryIds: [MEM(5)], windowStart: MEM(5) },
+    ]);
+  });
+
+  it('interleaved group rows still window within their own group in order', () => {
+    const rows = [
+      row(MEM(1), P1, PERSONA_X),
+      row(MEM(2), P1, PERSONA_Y),
+      row(MEM(3), P1, PERSONA_X),
+    ];
+
+    const windows = buildWindows(rows, 6);
+
+    expect(windows).toContainEqual(
+      expect.objectContaining({ personaId: PERSONA_X, sourceMemoryIds: [MEM(1), MEM(3)] })
+    );
+    expect(windows).toContainEqual(
+      expect.objectContaining({ personaId: PERSONA_Y, sourceMemoryIds: [MEM(2)] })
+    );
+  });
+
+  it.each([0, Number.NaN, 2.5, 101])(
+    'rejects invalid window size %s (NaN would silently truncate chunks; >100 exceeds the worker take cap)',
+    bad => {
+      expect(() => buildWindows([], bad)).toThrow('windowSize must be an integer in 1..100');
+    }
+  );
+});
+
+describe('buildJobData', () => {
+  it('produces the exact worker payload: backfill sentinel, budget exemption, deterministic anchor', () => {
+    const { jobId, jobData } = buildJobData({
+      personalityId: P1,
+      personaId: PERSONA_X,
+      sourceMemoryIds: [MEM(1), MEM(2)],
+      windowStart: MEM(1),
+    });
+
+    expect(jobId).toBe(generateFactExtractionJobUuid('backfill', P1, MEM(1)));
+    expect(jobData).toEqual({
+      requestId: `fact-backfill-${generateFactExtractionJobUuid('backfill', P1, MEM(1))}`,
+      jobType: JobType.FactExtraction,
+      responseDestination: { type: 'api' },
+      version: 1,
+      channelId: 'backfill',
+      personalityId: P1,
+      sourceMemoryIds: [MEM(1), MEM(2)],
+      windowStart: MEM(1),
+      budgetExempt: true,
+    });
+  });
+});
+
+describe('backfillFacts (the queue.add seam)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // First query: eligible rows; second query: covered ids.
+    queryMock
+      .mockResolvedValueOnce([
+        row(MEM(1), P1, PERSONA_X),
+        row(MEM(2), P1, PERSONA_X),
+        row(MEM(3), P1, PERSONA_X),
+      ])
+      .mockResolvedValueOnce([{ src: MEM(3) }]); // MEM(3) already covered by a fact
+  });
+
+  it('enqueues windows with live-parity options plus the backfill deltas', async () => {
+    await backfillFacts({ env: 'dev', windowSize: 2 });
+
+    expect(createInspectorQueue).toHaveBeenCalledWith(
+      'redis://proxy.example:1234',
+      FACT_EXTRACTION_QUEUE_NAME
+    );
+    // MEM(3) is covered → one window of [MEM(1), MEM(2)]
+    expect(queueAddMock).toHaveBeenCalledTimes(1);
+    expect(queueAddMock).toHaveBeenCalledWith(
+      JobType.FactExtraction,
+      expect.objectContaining({
+        channelId: 'backfill',
+        budgetExempt: true,
+        sourceMemoryIds: [MEM(1), MEM(2)],
+      }),
+      expect.objectContaining({
+        jobId: generateFactExtractionJobUuid('backfill', P1, MEM(1)),
+        priority: 10, // live (unprioritized) extraction always jumps the backfill
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+      })
+    );
+    expect(queueCloseMock).toHaveBeenCalled();
+  });
+
+  it('dry-run reports scope without touching Redis', async () => {
+    await backfillFacts({ env: 'dev', dryRun: true });
+
+    expect(createInspectorQueue).not.toHaveBeenCalled();
+    expect(queueAddMock).not.toHaveBeenCalled();
+  });
+
+  it('--limit caps the enqueued windows (canary)', async () => {
+    await backfillFacts({ env: 'dev', windowSize: 1, limit: 1 });
+
+    expect(queueAddMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a declined prod confirmation ABORTS the run (the gate is real, not decorative)', async () => {
+    vi.mocked(confirmProductionOperation).mockResolvedValueOnce(false);
+
+    await backfillFacts({ env: 'prod' });
+
+    expect(createInspectorQueue).not.toHaveBeenCalled();
+    expect(queueAddMock).not.toHaveBeenCalled();
+  });
+
+  it('a NaN --limit fails LOUDLY instead of silently uncapping the canary', async () => {
+    // NaN < windows.length is false — without the guard, a mistyped
+    // `--limit 5o` would enqueue the FULL budget-exempt run instead of 5.
+    await expect(backfillFacts({ env: 'dev', limit: Number('5o') })).rejects.toThrow(
+      '--limit must be a positive integer'
+    );
+    expect(queueAddMock).not.toHaveBeenCalled();
+  });
+
+  it('--personality-id threads the parameterized filter into the eligible query', async () => {
+    await backfillFacts({ env: 'dev', windowSize: 3, personalityId: P1, dryRun: true });
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('AND personality_id = $1::uuid'),
+      P1
+    );
+  });
+
+  it('--include-covered skips the covered-set subtraction', async () => {
+    queryMock.mockReset();
+    queryMock.mockResolvedValueOnce([
+      row(MEM(1), P1, PERSONA_X),
+      row(MEM(2), P1, PERSONA_X),
+      row(MEM(3), P1, PERSONA_X),
+    ]);
+
+    await backfillFacts({ env: 'dev', windowSize: 3, includeCovered: true });
+
+    expect(queryMock).toHaveBeenCalledTimes(1); // no covered query
+    expect(queueAddMock).toHaveBeenCalledWith(
+      JobType.FactExtraction,
+      expect.objectContaining({ sourceMemoryIds: [MEM(1), MEM(2), MEM(3)] }),
+      expect.anything()
+    );
+  });
+});

--- a/packages/tooling/src/memory/backfill-facts.ts
+++ b/packages/tooling/src/memory/backfill-facts.ts
@@ -1,0 +1,280 @@
+/**
+ * Fact-extraction backfill (memory Phase 2 — the beta.157 historical run)
+ *
+ * Enqueues FACT_EXTRACTION jobs for memories that predate the live extraction
+ * trigger. No Redis counters involved — the worker reads episode ids from the
+ * job payload, so windows are built here directly from Postgres and enqueued
+ * onto the existing queue. The Railway ai-worker (which holds the z.ai system
+ * key) does all model work; this command only reads memories and enqueues.
+ *
+ * Safety properties:
+ * - Deterministic jobIds (channel sentinel 'backfill') dedup re-enqueues
+ *   within BullMQ retention; fact writes are content-hash idempotent anyway.
+ * - `budgetExempt: true` skips the per-personality daily tripwire (finite,
+ *   owner-initiated job set — the tripwire bounds malfunctions, not backfills).
+ * - `priority: 10` keeps live extraction ahead of the backfill (BullMQ runs
+ *   unprioritized jobs first).
+ * - Skip-covered (default): memories already cited by any fact's
+ *   source_memory_ids are excluded, so re-runs only touch new ground.
+ */
+
+import chalk from 'chalk';
+import { FACT_EXTRACTION_QUEUE_NAME, JobType } from '@tzurot/common-types/constants/queue';
+import { generateFactExtractionJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import type { FactExtractionJobData } from '@tzurot/common-types/types/jobs';
+import {
+  type Environment,
+  validateEnvironment,
+  showEnvironmentBanner,
+  confirmProductionOperation,
+} from '../utils/env-runner.js';
+import { getPrismaForEnv } from './prisma-env.js';
+import { getRailwayRedisUrl, createInspectorQueue } from '../inspect/bullmqConnection.js';
+
+/** channelId sentinel — provenance-only downstream (jobId + fact extractionJobId
+ * namespace); real channel ids are meaningless for cross-channel windows. */
+const BACKFILL_CHANNEL_SENTINEL = 'backfill';
+
+/** BullMQ runs unprioritized (live) jobs before any prioritized job. */
+const BACKFILL_JOB_PRIORITY = 10;
+
+/** Mirrors the live trigger's EXTRACTION_BATCH_THRESHOLD default. */
+const DEFAULT_WINDOW_SIZE = 6;
+
+/** The worker re-queries a window's episodes with `take: 100` — a larger
+ * window would silently truncate its tail (unmarked, resurfacing next run).
+ * Cap here so the operator gets an error instead of a silent partial batch. */
+const MAX_WINDOW_SIZE = 100;
+
+const ENQUEUE_PROGRESS_INTERVAL = 500;
+
+export interface BackfillFactsOptions {
+  env: Environment;
+  dryRun?: boolean;
+  /** Cap on enqueued windows — the canary knob. */
+  limit?: number;
+  personalityId?: string;
+  windowSize?: number;
+  /** Re-enqueue memories already cited by existing facts (default: skip them). */
+  includeCovered?: boolean;
+  force?: boolean;
+}
+
+export interface EligibleMemoryRow {
+  id: string;
+  personality_id: string;
+  persona_id: string;
+}
+
+export interface BackfillWindow {
+  personalityId: string;
+  personaId: string;
+  sourceMemoryIds: string[];
+  windowStart: string;
+}
+
+/**
+ * Group eligible rows per (personality, persona) and chunk each group into
+ * extraction windows, preserving the rows' incoming (created_at ASC) order.
+ * Pure — the unit-testable core of the command.
+ */
+export function buildWindows(rows: EligibleMemoryRow[], windowSize: number): BackfillWindow[] {
+  // Number.isInteger rejects NaN (a mistyped CLI value) — a bare `< 1` check
+  // would let NaN through and crash confusingly in the chunking loop.
+  if (!Number.isInteger(windowSize) || windowSize < 1 || windowSize > MAX_WINDOW_SIZE) {
+    throw new Error(`windowSize must be an integer in 1..${MAX_WINDOW_SIZE} (got ${windowSize})`);
+  }
+  const groups = new Map<string, EligibleMemoryRow[]>();
+  for (const row of rows) {
+    const key = `${row.personality_id}|${row.persona_id}`;
+    const group = groups.get(key) ?? [];
+    group.push(row);
+    groups.set(key, group);
+  }
+
+  const windows: BackfillWindow[] = [];
+  for (const group of groups.values()) {
+    for (let i = 0; i < group.length; i += windowSize) {
+      const chunk = group.slice(i, i + windowSize);
+      windows.push({
+        personalityId: chunk[0].personality_id,
+        personaId: chunk[0].persona_id,
+        sourceMemoryIds: chunk.map(r => r.id),
+        windowStart: chunk[0].id,
+      });
+    }
+  }
+  return windows;
+}
+
+/** Build one window's deterministic BullMQ jobId + the exact worker payload. */
+export function buildJobData(window: BackfillWindow): {
+  jobId: string;
+  jobData: FactExtractionJobData;
+} {
+  const jobId = generateFactExtractionJobUuid(
+    BACKFILL_CHANNEL_SENTINEL,
+    window.personalityId,
+    window.windowStart
+  );
+  return {
+    jobId,
+    jobData: {
+      requestId: `fact-backfill-${jobId}`,
+      jobType: JobType.FactExtraction,
+      responseDestination: { type: 'api' },
+      version: 1,
+      channelId: BACKFILL_CHANNEL_SENTINEL,
+      personalityId: window.personalityId,
+      sourceMemoryIds: window.sourceMemoryIds,
+      windowStart: window.windowStart,
+      budgetExempt: true,
+    },
+  };
+}
+
+interface PrismaLike {
+  $queryRawUnsafe: <T = unknown>(query: string, ...values: unknown[]) => Promise<T>;
+}
+
+/**
+ * Fetch eligible memories in window-build order. Eligibility mirrors the
+ * worker's own re-filter (visibility + non-null persona); the covered-set
+ * subtraction happens in JS (a Set over UNNESTed fact sources) because
+ * source_memory_ids has no index and the id sets are small at this scale.
+ */
+async function queryEligibleRows(
+  prisma: PrismaLike,
+  personalityId: string | undefined,
+  includeCovered: boolean
+): Promise<EligibleMemoryRow[]> {
+  const filter = personalityId === undefined ? '' : `AND personality_id = $1::uuid`;
+  const params = personalityId === undefined ? [] : [personalityId];
+  const rows = await prisma.$queryRawUnsafe<EligibleMemoryRow[]>(
+    `SELECT id, personality_id, persona_id
+     FROM memories
+     WHERE visibility = 'normal' AND persona_id IS NOT NULL ${filter}
+     ORDER BY personality_id, persona_id, created_at ASC`,
+    ...params
+  );
+  if (includeCovered) {
+    return rows;
+  }
+  // Unbounded whole-table scan by design: this is a one-shot ops command and
+  // the covered set fits trivially in memory at current scale. Scope it (or
+  // index source_memory_ids) if this ever becomes a frequent operation.
+  const covered = await prisma.$queryRawUnsafe<{ src: string }[]>(
+    `SELECT DISTINCT UNNEST(source_memory_ids) AS src FROM memory_facts`
+  );
+  const coveredSet = new Set(covered.map(r => r.src));
+  return rows.filter(r => !coveredSet.has(r.id));
+}
+
+function printSummary(
+  rows: EligibleMemoryRow[],
+  totalWindows: number,
+  enqueueingWindows: number
+): void {
+  const perPersonality = new Map<string, number>();
+  for (const row of rows) {
+    perPersonality.set(row.personality_id, (perPersonality.get(row.personality_id) ?? 0) + 1);
+  }
+  console.log(chalk.bold('\nBackfill scope:'));
+  console.log(`  Eligible episodes:  ${rows.length}`);
+  console.log(`  Windows (total):    ${totalWindows}`);
+  console.log(`  Enqueueing now:     ${enqueueingWindows}`);
+  console.log(`  Personalities:      ${perPersonality.size}`);
+  const top = [...perPersonality.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+  console.log(chalk.dim('  Top personalities by episode count:'));
+  for (const [id, count] of top) {
+    console.log(chalk.dim(`    ${id.slice(0, 8)}…  ${count} episodes`));
+  }
+}
+
+/** Entry point for `pnpm ops memory:backfill-facts`. */
+export async function backfillFacts(options: BackfillFactsOptions): Promise<void> {
+  const { env, dryRun = false, force = false, includeCovered = false } = options;
+  const windowSize = options.windowSize ?? DEFAULT_WINDOW_SIZE;
+
+  // Fail loudly on malformed numeric flags: a NaN limit would silently
+  // UNCAP the run (NaN comparisons are false), turning a mistyped 5-window
+  // canary into the full budget-exempt backfill.
+  if (options.limit !== undefined && (!Number.isInteger(options.limit) || options.limit < 1)) {
+    throw new Error(`--limit must be a positive integer (got ${options.limit})`);
+  }
+
+  validateEnvironment(env);
+  showEnvironmentBanner(env);
+  if (env === 'prod' && !dryRun && !force) {
+    const confirmed = await confirmProductionOperation('enqueue fact-extraction backfill jobs');
+    if (!confirmed) {
+      console.log(chalk.yellow('\nOperation cancelled.'));
+      return;
+    }
+  }
+
+  const { prisma, disconnect } = await getPrismaForEnv(env);
+  try {
+    const rows = await queryEligibleRows(prisma, options.personalityId, includeCovered);
+    let windows = buildWindows(rows, windowSize);
+    const totalWindows = windows.length;
+    if (options.limit !== undefined && options.limit < windows.length) {
+      windows = windows.slice(0, options.limit);
+      console.log(
+        chalk.yellow(
+          `--limit ${options.limit}: enqueueing ${windows.length} of ${totalWindows} windows`
+        )
+      );
+    }
+    printSummary(rows, totalWindows, windows.length);
+
+    if (windows.length === 0) {
+      console.log(
+        chalk.green('\nNothing to backfill — every eligible episode is already covered.')
+      );
+      return;
+    }
+    if (dryRun) {
+      console.log(chalk.yellow('\nDry run — no jobs enqueued.'));
+      return;
+    }
+
+    const redisUrl = await getRailwayRedisUrl(env);
+    if (redisUrl === null) {
+      throw new Error(`Could not resolve a Redis URL for ${env}`);
+    }
+    const queue = createInspectorQueue(redisUrl, FACT_EXTRACTION_QUEUE_NAME);
+    try {
+      let enqueued = 0;
+      for (const window of windows) {
+        const { jobId, jobData } = buildJobData(window);
+        // Options mirror the live trigger's (ExtractionTrigger), plus the
+        // backfill deltas: deterministic-jobId dedup + below-live priority.
+        await queue.add(JobType.FactExtraction, jobData, {
+          jobId,
+          priority: BACKFILL_JOB_PRIORITY,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5000 },
+          removeOnComplete: { count: 50, age: 24 * 3600 },
+          removeOnFail: { count: 100, age: 7 * 24 * 3600 },
+        });
+        enqueued += 1;
+        if (enqueued % ENQUEUE_PROGRESS_INTERVAL === 0) {
+          console.log(chalk.dim(`  enqueued ${enqueued}/${windows.length}…`));
+        }
+      }
+      console.log(
+        chalk.green(`\n✅ Enqueued ${enqueued} backfill windows onto ${FACT_EXTRACTION_QUEUE_NAME}`)
+      );
+      console.log(
+        chalk.dim(
+          'The worker paces itself: live jobs take priority, and z.ai busy windows pause the queue (delay-not-downgrade).'
+        )
+      );
+    } finally {
+      await queue.close();
+    }
+  } finally {
+    await disconnect();
+  }
+}

--- a/services/ai-worker/src/services/extraction/FactExtractionService.test.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.test.ts
@@ -144,6 +144,28 @@ describe('FactExtractionService', () => {
     expect(s.writeMock).not.toHaveBeenCalled();
   });
 
+  it('budgetExempt jobs (backfill) bypass the tripwire entirely — even a denied budget', async () => {
+    const s = makeSetup({ budgetAllowed: false }); // would deny if consulted
+
+    const written = await s.service.processBatch({ ...job, budgetExempt: true });
+
+    expect(s.budget.tryConsume).not.toHaveBeenCalled();
+    expect(written).toBe(1); // extraction proceeded
+  });
+
+  it('budgetExempt busy path refunds NOTHING (no unit was consumed)', async () => {
+    const s = makeSetup({
+      modelResponse: Object.assign(new Error('Too many requests'), { status: 429 }),
+    });
+
+    await expect(s.service.processBatch({ ...job, budgetExempt: true })).rejects.toThrow(
+      ExtractionProviderBusyError
+    );
+
+    expect(s.budget.tryConsume).not.toHaveBeenCalled();
+    expect(s.budget.refund).not.toHaveBeenCalled(); // asymmetric refund would corrupt the counter
+  });
+
   it('fail-to-skip: malformed JSON writes nothing', async () => {
     const s = makeSetup({ modelResponse: 'sorry, I cannot do that' });
 

--- a/services/ai-worker/src/services/extraction/FactExtractionService.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.ts
@@ -247,10 +247,14 @@ export class FactExtractionService {
   private async processGroup(job: FactExtractionJobData, group: EpisodeGroup): Promise<number> {
     const scope = { personalityId: job.personalityId, personaId: group.personaId };
 
-    // Cost tripwire FIRST — shadow mode already spends money.
-    const allowed = await this.budget.tryConsume(job.personalityId);
-    if (!allowed) {
-      return 0;
+    // Cost tripwire FIRST — shadow mode already spends money. Owner-initiated
+    // backfill jobs are exempt (finite job set, deliberate consumption); the
+    // busy-path refund below mirrors this gate so the counter stays balanced.
+    if (job.budgetExempt !== true) {
+      const allowed = await this.budget.tryConsume(job.personalityId);
+      if (!allowed) {
+        return 0;
+      }
     }
 
     const knownFacts = await this.factStore.getRecentActiveFacts(
@@ -274,8 +278,12 @@ export class FactExtractionService {
       if (BUSY_CATEGORIES.has(category)) {
         // Busy spent zero tokens — refund the unit so a sustained busy window
         // (30-min requeue cycles for hours) can't burn the daily cap and make
-        // the tripwire skip real batches once the provider recovers.
-        await this.budget.refund(job.personalityId);
+        // the tripwire skip real batches once the provider recovers. Gated on
+        // the same flag as tryConsume: an exempt job never consumed a unit,
+        // so refunding one would corrupt the counter downward.
+        if (job.budgetExempt !== true) {
+          await this.budget.refund(job.personalityId);
+        }
         throw new ExtractionProviderBusyError(category, error);
       }
       logger.warn({ err: error, ...scope }, 'Extraction model call failed — skipping group');


### PR DESCRIPTION
## What

beta.157 chain step 3: `pnpm ops memory:backfill-facts` enqueues fact-extraction jobs for memories that predate the live trigger. Dev sizing: **35,303 eligible episodes → ~5,884 windows** across 611 (personality, persona) groups. Runs once on dev; db-sync (#1573) carries the facts to prod, which never re-bills. This run doubles as the real burn-in of the z.ai + delay-not-downgrade path (dev has 0 fact rows — the live trigger never fired without organic traffic).

- **No Redis counters**: the worker reads `sourceMemoryIds` from the payload, so windows are built straight from Postgres (`visibility='normal' AND persona_id IS NOT NULL`, mirroring the worker's own re-filter) and enqueued via the existing off-platform queue helpers (`getRailwayRedisUrl` + `createInspectorQueue`).
- **`budgetExempt` payload flag** (additive, optional): backfill jobs skip the per-personality daily tripwire — it bounds malfunctions, not deliberate finite work (fixed job set, attempts:3). The worker gates BOTH `tryConsume` and the busy-path `refund` on the flag; asymmetric gating would corrupt the counter downward.
- **Live-parity enqueue options** plus two deltas: deterministic jobId under a `'backfill'` channel sentinel (BullMQ dedup within retention + recognizable `extractionJobId` provenance on backfilled facts; `channelId` is provenance-only downstream), and `priority: 10` (BullMQ runs unprioritized jobs first, so live extraction always jumps the backfill).
- **Skip-covered default**: memories already cited by any fact's `source_memory_ids` are excluded (covered-set built in JS — no index needed on the array column), so re-runs are near-free. Documented caveat: zero-fact batches leave no coverage marker and re-process on re-run (harmless, content-hash idempotent).
- `--dry-run` (scope report), `--limit N` (canary), `--personality-id`, `--window-size` (default 6 = live threshold), `--include-covered`, `--force` (prod gate). Deliberately broader than the live path: summaries + shapes-imports included (dev-first + correction surface + $0 derisk the shape difference; imported history is exactly what the owner wants mined).

## Verified

- Seam tests assert the exact `queue.add` payload + options (jobId determinism, priority, budgetExempt) across the mocked queue; window construction (grouping, interleaved rows, chunking, order preservation) unit-tested pure; service tests prove an exempt job never consults the budget even when it would deny, and the exempt busy path refunds nothing; schema test pins `budgetExempt` surviving the Zod parse (strip-mode).
- Gates: `pnpm test` 25/25 green, `pnpm quality` green.
- Post-merge dev sequence (will report results): `--dry-run` sanity vs the sizing numbers → `--limit 5` canary → inspect `memory_facts` + worker logs → full run → owner smokes `/memory facts` on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)