### PR TITLE
fix(api-gateway): db-sync tolerates not-yet-deferrable constraints (soak window)

### DIFF
--- a/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
@@ -391,6 +391,45 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
   }, 30000);
 
   /**
+   * The migration-soak-window regression: a DEFERRABLE migration reaches dev
+   * before prod on every release cycle, so the sync must NOT name a
+   * constraint the target can't defer (SET CONSTRAINTS throws 42809 and
+   * breaks the whole sync — observed in prod the day the memory_facts
+   * deferral shipped to dev only). Simulate the window by reverting one
+   * side's constraint to NOT DEFERRABLE and assert the sync still completes,
+   * deferring only what that side supports.
+   */
+  it('survives a target whose constraint is not yet deferrable (soak window)', async () => {
+    await prodPrisma.$executeRawUnsafe(
+      `ALTER TABLE "memory_facts" ALTER CONSTRAINT "memory_facts_superseded_by_id_fkey" NOT DEFERRABLE`
+    );
+    try {
+      const discordId = '88888888888888888888';
+      const userId = generateUserUuid(discordId);
+      const personaId = generatePersonaUuid('soak-window-user', userId);
+      await seedUserWithPersona(devPrisma, {
+        userId,
+        personaId,
+        discordId,
+        username: 'soak-window-user',
+        personaName: 'soak-window-user',
+      });
+
+      // Pre-fix this threw 42809 ("constraint ... is not deferrable") before
+      // flushing ANYTHING prod-bound; post-fix the user+persona sync through.
+      await service.sync({ dryRun: false });
+
+      const prodUser = await prodPrisma.user.findUnique({ where: { id: userId } });
+      expect(prodUser).not.toBeNull();
+      expect(prodUser?.defaultPersonaId).toBe(personaId);
+    } finally {
+      await prodPrisma.$executeRawUnsafe(
+        `ALTER TABLE "memory_facts" ALTER CONSTRAINT "memory_facts_superseded_by_id_fkey" DEFERRABLE INITIALLY IMMEDIATE`
+      );
+    }
+  }, 30000);
+
+  /**
    * memory_facts sync: the revive-shaped supersession chain is the
    * adversarial case for the self-FK. After Seattle→Denver→moved-back,
    * the NEWER fact (Denver) carries superseded_by_id → the OLDER fact

--- a/services/api-gateway/src/services/DatabaseSyncService.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.test.ts
@@ -923,6 +923,59 @@ describe('DatabaseSyncService', () => {
       }
     });
 
+    it('defers only the constraints the target reports deferrable (migration-soak window)', async () => {
+      const executedQueries: string[] = [];
+      const userId = '4f9b0f66-0000-4000-8000-0000000000d1';
+      const personaId = '4f9b0f66-0000-4000-8000-0000000000d2';
+
+      devClient.$queryRawUnsafe.mockImplementation(async query => {
+        const queryStr = String(query);
+        if (queryStr.includes('FROM "users"') && !queryStr.includes('UPDATE')) {
+          return [
+            {
+              id: userId,
+              discord_id: '123456789',
+              username: 'soakuser',
+              default_persona_id: personaId,
+              created_at: new Date('2024-01-01'),
+              updated_at: new Date('2024-01-02'),
+            },
+          ];
+        }
+        return [];
+      });
+      // Prod reports every wanted constraint EXCEPT the memory_facts self-FK
+      // as deferrable — the exact shape of a dev-ahead soak window.
+      prodClient.$queryRawUnsafe.mockImplementation(async query => {
+        if (String(query).includes('table_constraints')) {
+          return [
+            { constraint_name: 'users_default_persona_id_fkey' },
+            { constraint_name: 'users_default_llm_config_id_fkey' },
+            { constraint_name: 'users_default_tts_config_id_fkey' },
+            { constraint_name: 'personas_owner_id_fkey' },
+            { constraint_name: 'llm_configs_owner_id_fkey' },
+          ];
+        }
+        return [];
+      });
+      prodClient.$executeRawUnsafe.mockImplementation(async (query: unknown) => {
+        executedQueries.push(String(query));
+        return { count: 1 };
+      });
+
+      await service.sync({ dryRun: false });
+
+      const setConstraints = executedQueries.find(
+        q => q.includes('SET CONSTRAINTS') && q.includes('DEFERRED')
+      );
+      expect(setConstraints, 'expected SET CONSTRAINTS on the prod flush').toBeDefined();
+      // The not-yet-deferrable constraint must be OMITTED — naming it throws
+      // Postgres 42809 and breaks the whole sync for the soak window.
+      expect(setConstraints).not.toContain('memory_facts_superseded_by_id_fkey');
+      expect(setConstraints).toContain('users_default_persona_id_fkey');
+      expect(setConstraints).toContain('llm_configs_owner_id_fkey');
+    });
+
     it('should return stats for all tables in SYNC_TABLE_ORDER', async () => {
       devClient.$queryRawUnsafe.mockResolvedValue([]);
       prodClient.$queryRawUnsafe.mockResolvedValue([]);

--- a/services/api-gateway/src/services/DatabaseSyncService.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.ts
@@ -60,6 +60,24 @@ import {
 const logger = createLogger('db-sync');
 
 /**
+ * Constraints the flush transaction wants deferred. Must stay in sync with
+ * the DEFERRABLE-marking migrations (20260418010642 for the original 4,
+ * 20260504065151 for users_default_tts_config_id_fkey, 20260710183055 for
+ * the memory_facts supersession self-FK — its pointers are not
+ * creation-ordered, so rows upsert in arbitrary order and Postgres validates
+ * the chain at COMMIT). Each flush target defers only the subset it reports
+ * as deferrable (see resolveDeferrableConstraints).
+ */
+const SYNC_DEFERRED_CONSTRAINTS = [
+  'users_default_persona_id_fkey',
+  'users_default_llm_config_id_fkey',
+  'users_default_tts_config_id_fkey',
+  'personas_owner_id_fkey',
+  'llm_configs_owner_id_fkey',
+  'memory_facts_superseded_by_id_fkey',
+] as const;
+
+/**
  * Prisma interactive-transaction timeout in milliseconds. Defaults to 5s,
  * which is not enough for a real dev↔prod sync across all tables. 10 min
  * gives comfortable headroom for large row counts without being so long
@@ -226,28 +244,25 @@ export class DatabaseSyncService {
       return;
     }
     logger.info({ label, count: writes.length }, 'Phase 2: Flushing writes');
+    // Resolve which of the wanted constraints THIS target can actually defer.
+    // A DEFERRABLE-marking migration reaches dev before prod on every release
+    // cycle; naming a not-yet-deferrable constraint makes SET CONSTRAINTS
+    // throw 42809 and break the whole sync for the soak window. Skew-tolerant
+    // instead: defer the intersection, WARN the skips (rows that genuinely
+    // need the skipped deferral fail their own FK check with a clear error;
+    // everything else syncs normally).
+    const deferrable = await this.resolveDeferrableConstraints(client, label);
     await client.$transaction(
       async tx => {
         // Defer exactly the named circular FKs, not ALL deferrable
         // constraints in the transaction — future migrations might add
         // unrelated deferrable constraints (e.g., deferred uniqueness) and
-        // we don't want to silently soften those inside the sync. The names
-        // here must stay in sync with the DEFERRABLE-marking migrations
-        // (20260418010642 for the original 4, 20260504065151 for
-        // users_default_tts_config_id_fkey, 20260710183055 for the
-        // memory_facts supersession self-FK — its pointers are not
-        // creation-ordered, so rows upsert in arbitrary order and Postgres
-        // validates the chain at COMMIT).
-        await tx.$executeRawUnsafe(
-          `SET CONSTRAINTS
-            "users_default_persona_id_fkey",
-            "users_default_llm_config_id_fkey",
-            "users_default_tts_config_id_fkey",
-            "personas_owner_id_fkey",
-            "llm_configs_owner_id_fkey",
-            "memory_facts_superseded_by_id_fkey"
-          DEFERRED`
-        );
+        // we don't want to silently soften those inside the sync.
+        if (deferrable.length > 0) {
+          await tx.$executeRawUnsafe(
+            `SET CONSTRAINTS ${deferrable.map(c => `"${c}"`).join(', ')} DEFERRED`
+          );
+        }
         for (const w of writes) {
           // `tx` structurally satisfies `SyncExecutor` — both the full
           // PrismaClient and Prisma's transaction client expose
@@ -265,6 +280,46 @@ export class DatabaseSyncService {
       },
       { timeout: SYNC_TX_TIMEOUT_MS, maxWait: SYNC_TX_MAX_WAIT_MS }
     );
+  }
+
+  /**
+   * Intersect the wanted deferred-constraint list with what THIS database
+   * reports as deferrable. During a migration-soak window (a DEFERRABLE
+   * migration applied on dev, not yet released to prod) the two sides
+   * genuinely differ; the skipped names are WARNed so the degraded deferral
+   * is visible, mirroring the vector-table column-intersection philosophy.
+   */
+  private async resolveDeferrableConstraints(
+    client: PrismaClient,
+    label: 'dev' | 'prod'
+  ): Promise<string[]> {
+    const wanted = [...SYNC_DEFERRED_CONSTRAINTS];
+    const rows = await client.$queryRawUnsafe<{ constraint_name: string }[]>(
+      `SELECT constraint_name FROM information_schema.table_constraints
+       WHERE is_deferrable = 'YES' AND constraint_name IN (${wanted.map((_, i) => `$${i + 1}`).join(', ')})`,
+      ...wanted
+    );
+    const deferrableSet = new Set(rows.map(r => r.constraint_name));
+    // Fail open on an EMPTY result: every real database has had most of these
+    // deferrable since the original Ouroboros migration, so zero matches means
+    // the introspection itself is suspect — use the full list rather than
+    // silently dropping all deferral (mirrors resolveVectorSyncColumns).
+    if (deferrableSet.size === 0) {
+      logger.warn(
+        { label },
+        'Deferrable-constraint introspection returned nothing — falling back to the full named list'
+      );
+      return wanted;
+    }
+    const usable = wanted.filter(c => deferrableSet.has(c));
+    const skipped = wanted.filter(c => !deferrableSet.has(c));
+    if (skipped.length > 0) {
+      logger.warn(
+        { label, skipped },
+        'Constraints not deferrable on this database — skipping their deferral (expected during a migration-soak window; rows that need it will fail their own FK check instead of breaking the whole sync)'
+      );
+    }
+    return usable;
   }
 
   /**


### PR DESCRIPTION
## What

Fixes the prod-observed db-sync failure (`42809: constraint "memory_facts_superseded_by_id_fkey" is not deferrable`): #1573's named `SET CONSTRAINTS` list assumed both databases carry the DEFERRABLE marking, but every DEFERRABLE migration reaches dev before prod (release soak window) — so the sync broke wholesale the day the migration landed on dev. `--allow-schema-skew` couldn't help; the version check was bypassed but the constraint dependency wasn't skew-tolerant.

- `flushWrites` now resolves the deferrable subset per target via `information_schema.table_constraints` and defers only that, WARNing skipped names. Rows that genuinely need a skipped deferral fail their own FK check (clear, scoped error) instead of every table's sync failing at transaction start.
- Fail-open on an EMPTY introspection result (use the full list) — zero matches means the introspection is suspect, since every real database has had most of these deferrable for months. Mirrors `resolveVectorSyncColumns`' documented fail-open.

## Verified

- **The pre-fix failure is runtime-observed in prod today** (the incident this fixes), not just code-read.
- PGLite component regression: revert one side's constraint to `NOT DEFERRABLE` (the exact soak-window shape), sync completes and lands the user+persona pair on the degraded side.
- Mocked-suite test pins the SQL shape: the not-deferrable constraint is OMITTED from `SET CONSTRAINTS` while the rest remain.
- Gates: `pnpm test` 25/25, `pnpm quality` green.

## Note

The immediate prod unblock is independent of this PR: applying the pending additive migration to prod (`pnpm ops db:migrate --env prod --force`) makes the constraint deferrable there. This PR removes the class — future DEFERRABLE migrations won't break sync during their soak windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)