### PR TITLE
fix(tooling): register facts + avatar-clear in the subcommand vocabulary

### DIFF
--- a/packages/tooling/src/dev/commandsAuditChecks.ts
+++ b/packages/tooling/src/dev/commandsAuditChecks.ts
@@ -71,6 +71,7 @@ const KNOWN_SUBCOMMAND_NAMES = new Set<string>([
   'cleanup',
   'presence',
   'avatar',
+  'avatar-clear',
   'voice',
   'voice-clear',
   'kick',
@@ -81,6 +82,9 @@ const KNOWN_SUBCOMMAND_NAMES = new Set<string>([
   'hard-delete',
   'test',
   'set',
+  // noun subcommands opening a second browsable entity under one command
+  // (/memory browse = episodes, /memory facts = extracted facts)
+  'facts',
   // domain-specific verbs with no canonical CRUD equivalent
   'forget', // memory: retroactive/incognito deletion, distinct from `delete`
   'auth', // shapes: third-party integration sign-in


### PR DESCRIPTION
The 2026-07-11 weekly audit's `commands:audit` flagged two `[subcommand-naming]` warnings. Both names are deliberate, so they join `KNOWN_SUBCOMMAND_NAMES`:

- **`/character avatar-clear`** — follows the established `voice-clear` compound directly above it in the registry.
- **`/memory facts`** — the noun subcommand opening the second browsable entity under `/memory` (episodes already own `browse`); shipped in the beta.156 correction surface and owner-smoked on real data yesterday.

`pnpm ops commands:audit` now reports "No command consistency issues found." The UX design-system Phase-3 grammar sweep remains the holistic naming revisit point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)