### PR TITLE
fix(ci): weekly-audit security surface — GH_TOKEN env + informative gh errors

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -25,6 +25,11 @@ on:
 
 permissions:
   contents: read
+  # The security-surface section counts open Dependabot PRs (gh pr list) and
+  # alerts (gh api). Without a token, gh exits with its set-GH_TOKEN hint and
+  # the section degrades to "unavailable".
+  pull-requests: read
+  security-events: read
 
 jobs:
   audit-health:
@@ -55,6 +60,8 @@ jobs:
 
       - name: Run audit-health aggregator
         id: health
+        env:
+          GH_TOKEN: ${{ github.token }}
         # Capture the report for the Discord step; the aggregator's exit code
         # still fails the job so a red run is visible in the Actions UI.
         run: |

--- a/packages/tooling/src/audits/health-extras.test.ts
+++ b/packages/tooling/src/audits/health-extras.test.ts
@@ -99,6 +99,25 @@ describe('collectSecuritySurface', () => {
     });
   });
 
+  it('reports the FIRST stderr line of a multi-line gh hint (not the trailing example)', () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      const error = new Error('Command failed: gh pr list') as Error & { stderr: string };
+      error.stderr =
+        'gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:\n' +
+        '  env:\n' +
+        '    GH_TOKEN: ${{ github.token }}\n';
+      throw error;
+    });
+
+    const result = collectSecuritySurface();
+
+    expect(result.available).toBe(false);
+    if (!result.available) {
+      expect(result.reason).toContain('set the GH_TOKEN environment variable');
+      expect(result.reason).not.toContain('${{ github.token }}');
+    }
+  });
+
   it('degrades to unavailable when gh emits something non-numeric', () => {
     vi.mocked(execFileSync).mockReturnValue('not a count');
 

--- a/packages/tooling/src/audits/health-extras.ts
+++ b/packages/tooling/src/audits/health-extras.ts
@@ -55,13 +55,15 @@ function runGhCount(args: string[]): number {
 /** Compose a one-line degradation reason, preferring gh's own stderr. */
 function describeGhFailure(error: unknown): string {
   const execError = error as { stderr?: string | Buffer };
+  // FIRST non-empty line: gh's multi-line hints lead with the explanation
+  // ("set the GH_TOKEN environment variable") and trail with an example
+  // snippet — .at(-1) once reported the bare snippet as the whole reason.
   const stderrLine =
     typeof execError.stderr === 'string'
       ? execError.stderr
           .trim()
           .split('\n')
-          .filter(l => l.length > 0)
-          .at(-1)
+          .find(l => l.trim().length > 0)
       : undefined;
   if (stderrLine !== undefined && stderrLine.length > 0) {
     return stderrLine;


### PR DESCRIPTION
The 2026-07-11 weekly audit reported `security: unavailable (    GH_TOKEN: ${{ github.token }})` — two stacked problems:

1. **The aggregator step has no `GH_TOKEN`**, so both `gh` calls (Dependabot PR count + alerts count) fail in Actions with gh's canonical "set the GH_TOKEN environment variable" hint. Fixed: `GH_TOKEN: ${{ github.token }}` on the step, plus `pull-requests: read` and `security-events: read` workflow permissions.
2. **`describeGhFailure` reported the LAST stderr line** — for gh's multi-line hint that's the bare yaml example snippet, not the explanation. Fixed to prefer the first informative line, with a test pinning the exact multi-line-hint shape from the incident.

Note for the next audit run: if the Dependabot **alerts** endpoint still 403s under `GITHUB_TOKEN` (its permission model differs from code-scanning's), the section will now degrade with a clear HTTP error naming the endpoint instead of the token hint — that would be the signal to switch that one call to a fine-grained PAT secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)