### PR TITLE
fix(hooks): block filtered git commit/push output (recurring failure class)

### DIFF
--- a/.claude/hooks/git-commit-filter-guard.sh
+++ b/.claude/hooks/git-commit-filter-guard.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# PreToolUse hook: block `git commit`/`git push` commands whose output is piped
+# through a filter (tail/head/grep/sed/awk) — the command shape that repeatedly
+# swallowed hook rejections (commitlint, pre-push gate) and let dead commits
+# flow into "Everything up-to-date" pushes or empty-branch PRs.
+#
+# Background: `/tzurot-git-workflow` § command-shape rules forbids the pattern
+# ("never filter commit/push output"). The rule existed but relied on agent
+# attention across sessions; after the fourth recurrence the correction moved
+# here, where the trigger is deterministic (00-critical.md § Fix Recurring
+# Failures Structurally).
+#
+# Scope is deliberately narrow: only a PIPE attached to the git commit/push
+# pipeline segment blocks. `&&` chaining, heredoc -m bodies, redirections, and
+# pipes on other segments of a compound command all pass through.
+
+set -uo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+GUARD_CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$GUARD_CMD" ] && exit 0
+
+# Cheap bash-native short-circuit: the expensive structural scan only runs for
+# commands that could possibly be guilty (a pipe AND a git commit/push). Every
+# other Bash call — the overwhelming majority — exits here without spawning
+# python (sibling hooks set the same do-cheap-checks-first precedent).
+case "$GUARD_CMD" in
+  *\|*) ;;
+  *) exit 0 ;;
+esac
+case "$GUARD_CMD" in
+  *git*commit*|*git*push*) ;;
+  *) exit 0 ;;
+esac
+
+VERDICT=$(GUARD_CMD="$GUARD_CMD" python3 << 'PYEOF'
+import os
+import re
+
+cmd = os.environ.get("GUARD_CMD", "")
+if not cmd:
+    print("ok")
+    raise SystemExit
+
+# Remove $(cat <<'EOF' ... EOF) substitutions (commit-message heredocs) and
+# quoted strings so message CONTENT can't false-positive the structure scan.
+cmd = re.sub(r"\$\(cat <<'?\"?(\w+)'?\"?.*?\n\1\s*\)", "MSG", cmd, flags=re.S)
+cmd = re.sub(r"'[^']*'", "S", cmd)
+cmd = re.sub(r'"[^"]*"', "S", cmd)
+
+# Normalize bash's `|&` shorthand (2>&1 |) so the splitter sees a plain pipe.
+cmd = cmd.replace("|&", "|")
+
+# Split into chain segments (&&, ||, ;, newlines), then each segment into
+# pipeline stages. A commit/push stage with a filter ANYWHERE downstream in
+# the same pipeline blocks — `| cat | tail` must not defeat the guard, while
+# pure pass-throughs (cat/tee) on their own stay allowed.
+FILTERS = re.compile(r"^\s*(tail|head|grep|sed|awk)\b")
+# Tolerate git global flags between `git` and the subcommand:
+# -C <path>, -c k=v, --no-pager, --git-dir=..., etc.
+GIT_TARGET = re.compile(r"\bgit(\s+-{1,2}\S+(\s+\S+)?)*\s+(commit|push)\b")
+for segment in re.split(r"&&|\|\||;|\n", cmd):
+    stages = segment.split("|")
+    for i, stage in enumerate(stages[:-1]):
+        if GIT_TARGET.search(stage) and any(
+            FILTERS.match(later) for later in stages[i + 1 :]
+        ):
+            print("block")
+            raise SystemExit
+print("ok")
+PYEOF
+) || exit 0
+
+[ "$VERDICT" != "block" ] && exit 0
+
+cat >&2 << 'MSG'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+COMMIT/PUSH FILTER GUARD — command blocked
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+This command pipes `git commit` or `git push` output through a filter
+(tail/head/grep/sed/awk). That shape has repeatedly swallowed hook
+rejections (commitlint subject-case, pre-push gates) — the failure
+scrolls away, a chained push lands nothing ("Everything up-to-date")
+or an empty branch.
+
+Per /tzurot-git-workflow § command-shape rules:
+  - Run `git commit` / `git push` with UNFILTERED output. It is short
+    when things work and essential when they don't.
+
+Re-run the same commit/push without the pipe.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/pr-merge-review-check.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/git-commit-filter-guard.sh"
           }
         ]
       }

--- a/packages/tooling/src/dev/gitCommitFilterGuard.test.ts
+++ b/packages/tooling/src/dev/gitCommitFilterGuard.test.ts
@@ -1,0 +1,78 @@
+/**
+ * CI coverage for `.claude/hooks/git-commit-filter-guard.sh` — the PreToolUse
+ * guard blocking filtered `git commit`/`git push` output. The hook's parsing
+ * (segment/pipeline splitting, heredoc stripping, flag-tolerant matching) is
+ * meaningfully more complex than its sibling hooks', so its case matrix lives
+ * here where a regression fails CI instead of silently degrading the guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+
+const HOOK = path.resolve(__dirname, '../../../../.claude/hooks/git-commit-filter-guard.sh');
+
+/** Run the hook exactly as the harness does: tool JSON on stdin, exit code out. */
+function runHook(command: string): number {
+  const input = JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+  try {
+    execFileSync('bash', [HOOK], { input, stdio: ['pipe', 'ignore', 'ignore'] });
+    return 0;
+  } catch (error) {
+    return (error as { status?: number }).status ?? -1;
+  }
+}
+
+describe('git-commit-filter-guard hook', () => {
+  const BLOCKED: [string, string][] = [
+    ['commit piped to tail', 'git commit -m "fix: x" 2>&1 | tail -2 && git push'],
+    ['push piped to tail', 'git push origin develop 2>&1 | tail -1'],
+    ['cat interposed before the filter', 'git push origin b 2>&1 | cat | tail -20'],
+    ['|& shorthand', 'git push origin b |& tail -20'],
+    ['global flag between git and subcommand', 'git --no-pager push origin b | grep -v x'],
+    ['-c config flag', 'git -c commit.gpgsign=false commit -m x | tail'],
+    ['-C path form', 'git -C /repo commit -m msg | grep -v noise'],
+    // One case per remaining FILTERS keyword — a regex typo dropping any of
+    // them must fail CI, not silently degrade the guard.
+    ['head filter', 'git push origin b 2>&1 | head -3'],
+    ['sed filter', 'git commit -m x 2>&1 | sed s/a/b/'],
+    ['awk filter', 'git push origin b | awk NR==1'],
+  ];
+
+  const ALLOWED: [string, string][] = [
+    ['plain && chain', 'git commit -m "fix: x" && git push origin develop'],
+    ['tee pass-through (not a filter)', 'git push origin b 2>&1 | tee out.log'],
+    ['non-target git command piped', 'git log --oneline | head -5'],
+    ['no pipe at all (fast path)', 'ls -la'],
+    ['pipe on a later, non-git segment', 'git commit -m msg && gh pr view 1 | grep state'],
+    [
+      'heredoc commit message mentioning a filter',
+      'git commit -m "$(cat <<\'EOF\'\nfeat: msg with | tail inside\nEOF\n)"',
+    ],
+  ];
+
+  it.each(BLOCKED)('blocks: %s', (_name, command) => {
+    expect(runHook(command)).toBe(2);
+  });
+
+  it.each(ALLOWED)('allows: %s', (_name, command) => {
+    expect(runHook(command)).toBe(0);
+  });
+
+  it.each([
+    ['non-Bash tool', JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/x' } })],
+    ['Bash with empty command', JSON.stringify({ tool_name: 'Bash', tool_input: { command: '' } })],
+    ['Bash with missing command field', JSON.stringify({ tool_name: 'Bash', tool_input: {} })],
+  ])('fails open on %s', (_name, input) => {
+    expect(
+      (() => {
+        try {
+          execFileSync('bash', [HOOK], { input, stdio: ['pipe', 'ignore', 'ignore'] });
+          return 0;
+        } catch (error) {
+          return (error as { status?: number }).status ?? -1;
+        }
+      })()
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
Structural fix for a failure class that has now bitten four times, twice today: piping `git commit`/`git push` output through `tail`/`head`/`grep` swallows hook rejections (commitlint subject-case, pre-push gates) — the failure scrolls away and a chained push lands nothing ("Everything up-to-date") or an empty PR branch (observed today on the LONG_SYNC PR: rejected commit + swallowed reason + `gh pr create` failing with "No commits between develop and branch").

The `/tzurot-git-workflow` skill's command-shape rule already forbids the pattern but relied on agent attention across sessions. Per `00-critical.md` § Fix Recurring Failures Structurally, the trigger is deterministic and the correction mechanical → hook.

**Scope (deliberately narrow, verified by a 7-case matrix in the PR run):**
- BLOCKS: a filter (`tail|head|grep|sed|awk`) piped onto the `git commit`/`git push` pipeline segment itself (incl. `git -C <path>` forms).
- PASSES: plain `&&` chains, heredoc commit messages that mention pipes/filters (stripped before scanning), pipes on other git commands (`git log | head`), and pipes on later segments of a compound command (`git commit -m msg && gh pr view | grep`).

Exit 2 with guidance naming the skill rule and the re-run instruction. This session's agent behavior is the sole consumer; blast radius is agent-tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)