### PR TITLE
feat(bot-client): inline chunked views for /inspect + db-sync report

### DIFF
--- a/services/bot-client/src/commands/admin/db-sync.test.ts
+++ b/services/bot-client/src/commands/admin/db-sync.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { makeErr } from '../../test/gatewayClientStubs.js';
 import type { GatewayResult, OwnerClient } from '@tzurot/clients';
-import { handleDbSync, buildSyncSummary, buildSyncReportMarkdown } from './db-sync.js';
+import { handleDbSync, buildSyncSummary, buildSyncReportText } from './db-sync.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -121,7 +121,7 @@ describe('handleDbSync', () => {
     expect(stub.dbSync).toHaveBeenCalledWith({ dryRun: true, allowSchemaSkew: false });
   });
 
-  it('replies with a summary embed AND an attached report file', async () => {
+  it('replies with a summary embed AND the full report as chunked follow-ups', async () => {
     stub.dbSync.mockResolvedValue(
       ok({
         success: true,
@@ -136,8 +136,13 @@ describe('handleDbSync', () => {
 
     const payload = replyPayload(context);
     expect(payload.embeds).toHaveLength(1);
-    expect(payload.files).toHaveLength(1);
+    expect(payload.files).toBeUndefined();
     expect(payload.embeds?.[0].data.title).toContain('Database Sync Complete');
+    // The report rides follow-ups, never the embed message — 'followUp' mode
+    // keeps the summary embed untouched.
+    expect(context.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('# Database Sync Report') })
+    );
   });
 
   it('uses the dry-run title and warning framing on dry runs', async () => {
@@ -156,7 +161,7 @@ describe('handleDbSync', () => {
     const payload = replyPayload(context);
     expect(payload.embeds?.[0].data.title).toContain('Dry Run');
     expect(payload.embeds?.[0].data.description).toContain('Dry run — no changes were applied');
-    expect(payload.files).toHaveLength(1);
+    expect(payload.files).toBeUndefined();
   });
 
   it('summarizes totals and shows only tables with activity', async () => {
@@ -180,7 +185,7 @@ describe('handleDbSync', () => {
       '**2 tables** · 10 dev→prod · 5 prod→dev · 1 conflicts · 0 deleted'
     );
     expect(description).toContain('`users`:');
-    // Quiet tables stay out of the embed — they live in the report file.
+    // Quiet tables stay out of the embed — they live in the follow-up report.
     expect(description).not.toContain('`personas`:');
   });
 
@@ -199,7 +204,7 @@ describe('handleDbSync', () => {
     await handleDbSync(context);
 
     const description = replyPayload(context).embeds?.[0].data.description ?? '';
-    expect(description).toContain('⚠️ 2 warning(s) — full list in the attached report');
+    expect(description).toContain('⚠️ 2 warning(s) — full list in the report below');
     // The warning bodies themselves must NOT be in the embed.
     expect(description).not.toContain('Table mismatch detected');
   });
@@ -234,7 +239,61 @@ describe('handleDbSync', () => {
 
     const payload = replyPayload(context);
     expect(payload.embeds).toHaveLength(1);
-    expect(payload.files).toHaveLength(1);
+    expect(context.followUp).toHaveBeenCalled();
+  });
+
+  it('does not report sync failure when only report delivery fails', async () => {
+    // The sync itself succeeded; a follow-up chunk failing must produce the
+    // honest partial-delivery note, never the "Database sync failed" banner.
+    stub.dbSync.mockResolvedValue(
+      ok({
+        success: true,
+        timestamp: 'now',
+        schemaVersion: '1.0.0',
+        stats: { users: { devToProd: 5, prodToDev: 2, conflicts: 0, deleted: 0 } },
+      })
+    );
+
+    const context = createMockContext(false);
+    vi.mocked(context.followUp)
+      .mockRejectedValueOnce(new Error('Discord API hiccup'))
+      .mockResolvedValue(undefined as never);
+
+    await handleDbSync(context);
+
+    // Summary embed reply stays; the outer catch's error editReply never fires
+    expect(context.editReply).toHaveBeenCalledTimes(1);
+    expect(replyPayload(context).embeds).toHaveLength(1);
+    // Second followUp is the honest partial-delivery note
+    expect(context.followUp).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(context.followUp).mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        content: expect.stringContaining('report delivery failed'),
+      })
+    );
+  });
+
+  it('still never reports sync failure when the recovery notice also fails', async () => {
+    // Double Discord API failure: report chunk AND the partial-delivery
+    // notice both throw. The outer catch must still not fire — the sync
+    // succeeded, and the log is the terminal path.
+    stub.dbSync.mockResolvedValue(
+      ok({
+        success: true,
+        timestamp: 'now',
+        schemaVersion: '1.0.0',
+        stats: { users: { devToProd: 5, prodToDev: 2, conflicts: 0, deleted: 0 } },
+      })
+    );
+
+    const context = createMockContext(false);
+    vi.mocked(context.followUp).mockRejectedValue(new Error('Discord API down'));
+
+    await handleDbSync(context);
+
+    // Only the summary-embed editReply — no "Database sync failed" banner
+    expect(context.editReply).toHaveBeenCalledTimes(1);
+    expect(replyPayload(context).embeds).toHaveLength(1);
   });
 
   it('should handle 403 unauthorized response', async () => {
@@ -279,7 +338,7 @@ describe('buildSyncSummary', () => {
   });
 });
 
-describe('buildSyncReportMarkdown', () => {
+describe('buildSyncReportText', () => {
   const baseResult = {
     timestamp: '2026-07-11T00:00:00.000Z',
     schemaVersion: '20260710230428_add_sync_tombstones',
@@ -297,14 +356,16 @@ describe('buildSyncReportMarkdown', () => {
   };
 
   it('includes EVERY table in the stats table, active or not', () => {
-    const report = buildSyncReportMarkdown(baseResult, false);
+    const report = buildSyncReportText(baseResult, false);
 
-    expect(report).toContain('| users | 3 | 1 | 0 | 0 |');
-    expect(report).toContain('| personas | 0 | 0 | 0 | 2 |');
+    // Fixed-width rows in a code fence (Discord renders no pipe-tables)
+    expect(report).toContain('```');
+    expect(report).toMatch(/^users\s+3\s+1\s+0\s+0$/m);
+    expect(report).toMatch(/^personas\s+0\s+0\s+0\s+2$/m);
   });
 
   it('lists each deletion row with its losing side', () => {
-    const report = buildSyncReportMarkdown(baseResult, false);
+    const report = buildSyncReportText(baseResult, false);
 
     expect(report).toContain('## Deletions queued for propagation (2)');
     expect(report).toContain('- `personas` · `aaaa-1111` → prod');
@@ -312,7 +373,7 @@ describe('buildSyncReportMarkdown', () => {
   });
 
   it('uses would-propagate framing under dry run', () => {
-    const report = buildSyncReportMarkdown(baseResult, true);
+    const report = buildSyncReportText(baseResult, true);
 
     expect(report).toContain('# Database Sync Report (dry run)');
     expect(report).toContain('- Mode: DRY RUN — no changes applied');
@@ -320,7 +381,7 @@ describe('buildSyncReportMarkdown', () => {
   });
 
   it('marks a gateway-capped deletion list loudly', () => {
-    const report = buildSyncReportMarkdown({ ...baseResult, deletionsTruncated: true }, false);
+    const report = buildSyncReportText({ ...baseResult, deletionsTruncated: true }, false);
 
     expect(report).toContain('## Deletions queued for propagation (2+)');
     expect(report).toContain('Row detail capped by the gateway');
@@ -328,7 +389,7 @@ describe('buildSyncReportMarkdown', () => {
 
   it('carries full warnings and info without truncation', () => {
     const manyWarnings = Array.from({ length: 60 }, (_, i) => `warning line ${i}`);
-    const report = buildSyncReportMarkdown({ ...baseResult, warnings: manyWarnings }, false);
+    const report = buildSyncReportText({ ...baseResult, warnings: manyWarnings }, false);
 
     expect(report).toContain('## Warnings (60)');
     expect(report).toContain('- warning line 0');
@@ -337,7 +398,7 @@ describe('buildSyncReportMarkdown', () => {
   });
 
   it('renders explicit None sections for an empty result', () => {
-    const report = buildSyncReportMarkdown({}, false);
+    const report = buildSyncReportText({}, false);
 
     expect(report).toContain('_No table stats returned._');
     expect(report).toContain('## Deletions queued for propagation (0)');

--- a/services/bot-client/src/commands/admin/db-sync.ts
+++ b/services/bot-client/src/commands/admin/db-sync.ts
@@ -5,14 +5,15 @@
  * Receives DeferredCommandContext (no deferReply method!)
  * because the parent command uses deferralMode: 'ephemeral'.
  *
- * Output shape: a tight summary embed (totals + tables with activity) plus an
- * attached `db-sync-report.md` carrying the FULL untruncated report — per-table
- * stats, row-level deletion detail, every warning and info line. Discord embed
- * caps forced the old single-embed layout to truncate lists; the report file
- * has no such limit (house pattern: /inspect's view attachments).
+ * Output shape: a tight summary embed (totals + tables with activity) plus the
+ * FULL untruncated report — per-table stats, row-level deletion detail, every
+ * warning and info line — rendered inline as chunked ephemeral follow-ups
+ * (owner decision: readable text never ships as a file download; house
+ * pattern: /inspect's chunked views). Discord embed caps forced the old
+ * single-embed layout to truncate lists; chunking has no such limit.
  */
 
-import { AttachmentBuilder, EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, MessageFlags } from 'discord.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { renderSpec } from '../../ux/render/render.js';
@@ -20,6 +21,7 @@ import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { adminDbSyncOptions } from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { clientsFor } from '../../utils/gatewayClients.js';
+import { sendChunkedReply } from '../../utils/chunkedReply.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 
 const logger = createLogger('admin-db-sync');
@@ -86,8 +88,8 @@ function buildActiveTableLines(stats: Record<string, TableStats>): string[] {
 
 /**
  * The tight embed description: totals line + tables with activity only.
- * Full per-table detail (including quiet tables) lives in the report file,
- * so the embed can never outgrow Discord's description cap.
+ * Full per-table detail (including quiet tables) lives in the chunked
+ * follow-up report, so the embed can never outgrow Discord's description cap.
  */
 export function buildSyncSummary(result: SyncResult, dryRun: boolean): string {
   const lines: string[] = [];
@@ -109,7 +111,7 @@ export function buildSyncSummary(result: SyncResult, dryRun: boolean): string {
 
   const warningCount = result.warnings?.length ?? 0;
   if (warningCount > 0) {
-    lines.push('', `⚠️ ${warningCount} warning(s) — full list in the attached report`);
+    lines.push('', `⚠️ ${warningCount} warning(s) — full list in the report below`);
   }
   if (dryRun) {
     lines.push('', '*Dry run — no changes were applied.*');
@@ -118,7 +120,10 @@ export function buildSyncSummary(result: SyncResult, dryRun: boolean): string {
   return lines.join('\n');
 }
 
-/** The `## Per-table stats` markdown table — every table, active or not. */
+/** The `## Per-table stats` section — every table, active or not. Fixed-width
+ * rows in a code fence: Discord doesn't render markdown pipe-tables, and the
+ * fence keeps columns aligned on mobile (same solve as /inspect's memory
+ * inspector). */
 function buildStatsSection(stats: Record<string, TableStats>): string[] {
   const entries = Object.entries(stats);
   const lines = ['', '## Per-table stats', ''];
@@ -126,13 +131,15 @@ function buildStatsSection(stats: Record<string, TableStats>): string[] {
     lines.push('_No table stats returned._');
     return lines;
   }
-  lines.push('| Table | dev→prod | prod→dev | Conflicts | Deleted |');
-  lines.push('| --- | ---: | ---: | ---: | ---: |');
+  const tableWidth = Math.max(5, ...entries.map(([table]) => table.length));
+  lines.push('```');
+  lines.push(`${'Table'.padEnd(tableWidth)} dev→prod prod→dev conflicts deleted`);
   for (const [table, s] of entries) {
     lines.push(
-      `| ${table} | ${s.devToProd ?? 0} | ${s.prodToDev ?? 0} | ${s.conflicts ?? 0} | ${s.deleted ?? 0} |`
+      `${table.padEnd(tableWidth)} ${String(s.devToProd ?? 0).padStart(8)} ${String(s.prodToDev ?? 0).padStart(8)} ${String(s.conflicts ?? 0).padStart(9)} ${String(s.deleted ?? 0).padStart(7)}`
     );
   }
+  lines.push('```');
   return lines;
 }
 
@@ -178,11 +185,11 @@ function buildListSection(title: string, items: string[]): string[] {
 }
 
 /**
- * The full untruncated report attached as `db-sync-report.md`: every table's
- * stats row, row-level deletion detail, and the complete warnings/info lists.
- * Exported for unit tests.
+ * The full untruncated report sent inline below the summary embed: every
+ * table's stats row, row-level deletion detail, and the complete
+ * warnings/info lists. Exported for unit tests.
  */
-export function buildSyncReportMarkdown(result: SyncResult, dryRun: boolean): string {
+export function buildSyncReportText(result: SyncResult, dryRun: boolean): string {
   const lines: string[] = [`# Database Sync Report${dryRun ? ' (dry run)' : ''}`, ''];
 
   lines.push(`- Run: ${result.timestamp ?? new Date().toISOString()}`);
@@ -234,12 +241,34 @@ export async function handleDbSync(context: DeferredCommandContext): Promise<voi
       .setTimestamp()
       .setDescription(buildSyncSummary(result, dryRun));
 
-    const report = new AttachmentBuilder(Buffer.from(buildSyncReportMarkdown(result, dryRun)), {
-      name: 'db-sync-report.md',
-      description: 'Full untruncated sync report',
-    });
+    await context.editReply({ embeds: [embed] });
 
-    await context.editReply({ embeds: [embed], files: [report] });
+    // Full report flows below the summary as chunked ephemeral follow-ups —
+    // 'followUp' mode leaves the embed message untouched. Report delivery
+    // failing must not reach the outer catch: the sync itself already
+    // succeeded, so "Database sync failed" would be a false claim.
+    try {
+      await sendChunkedReply({
+        interaction: context,
+        content: buildSyncReportText(result, dryRun),
+        header: '',
+        continuedHeader: '_(report continued)_\n',
+        via: 'followUp',
+      });
+    } catch (error) {
+      logger.error({ err: error }, 'Sync succeeded but report delivery failed');
+      // The recovery notice failing too must ALSO not reach the outer catch —
+      // it would report "sync failed" for a sync that succeeded. Nothing is
+      // left to tell the user at that point except the log.
+      await context
+        .followUp({
+          content: '⚠️ Full report delivery failed part-way — the summary above is complete.',
+          flags: MessageFlags.Ephemeral,
+        })
+        .catch((followUpError: unknown) => {
+          logger.error({ err: followUpError }, 'Report-failure notice also failed to send');
+        });
+    }
   } catch (error) {
     logger.error({ err: error }, 'Error during database sync');
     await context.editReply({

--- a/services/bot-client/src/commands/inspect/components.test.ts
+++ b/services/bot-client/src/commands/inspect/components.test.ts
@@ -65,7 +65,8 @@ describe('buildInspectComponents', () => {
   it('exposes the expected number of select-menu options', () => {
     const rows = buildInspectComponents('test-req');
     const selectMenu = rows[1].components[0].toJSON();
-    // Compact JSON, System Prompt, Memory Inspector, Token Budget, Pipeline Health, Quick Copy
-    expect('options' in selectMenu && selectMenu.options).toHaveLength(6);
+    // Compact JSON, System Prompt, Memory Inspector, Token Budget,
+    // Voice Attribution, Pipeline Health, Quick Copy
+    expect('options' in selectMenu && selectMenu.options).toHaveLength(7);
   });
 });

--- a/services/bot-client/src/commands/inspect/components.ts
+++ b/services/bot-client/src/commands/inspect/components.ts
@@ -84,9 +84,15 @@ export function buildInspectComponents(
       },
       {
         label: 'Token Budget',
-        description: 'ASCII breakdown of context window allocation',
+        description: 'Context window allocation breakdown',
         value: DebugViewType.TokenBudget,
         emoji: '📊',
+      },
+      {
+        label: 'Voice Attribution',
+        description: 'TTS provider used (incl. fallbacks) + voice transcript',
+        value: DebugViewType.VoiceAttribution,
+        emoji: '🎙️',
       },
       {
         label: 'Pipeline Health',

--- a/services/bot-client/src/commands/inspect/extendedViews.test.ts
+++ b/services/bot-client/src/commands/inspect/extendedViews.test.ts
@@ -80,16 +80,42 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(payload, 'req-1', OWNER_CTX);
-    expect(result.files).toHaveLength(1);
-    const file = result.files![0];
-    const text = file.attachment.toString();
+    expect(result.files).toBeUndefined();
+    const text = result.chunkedText!.text;
 
     expect(text).toContain('# Pipeline Health');
-    expect(text).toContain('| `duplicate_removal` | ✅ success | removed 6 chars |');
-    expect(text).toContain('| `thinking_extraction` | ⏭️ skipped | no reasoning content found |');
-    expect(text).toContain('| `artifact_strip` | ❌ error | regex failed |');
+    // Fixed-width rows in a code fence (Discord renders no pipe-tables);
+    // names pad to the longest ('thinking_extraction', 19 chars)
+    expect(text).toContain('```');
+    expect(text).toContain('duplicate_removal    ✅ success removed 6 chars');
+    expect(text).toContain('thinking_extraction  ⏭️ skipped no reasoning content found');
+    expect(text).toContain('artifact_strip       ❌ error   regex failed');
     expect(text).toContain('## Context');
-    expect(file.name).toBe('pipeline-health-req-1.md');
+  });
+
+  it('neutralizes embedded triple-backticks in step reasons', () => {
+    // Reasons can carry content-derived text; a ``` inside one must not
+    // close the table fence or mis-pair splitMessage's code-block detection.
+    const payload = createMockPayload({
+      postProcessing: {
+        transformsApplied: [],
+        duplicateDetected: false,
+        thinkingExtracted: false,
+        thinkingContent: null,
+        artifactsStripped: [],
+        finalContent: 'Hi',
+        pipelineSteps: [
+          { name: 'artifact_strip', status: 'error', reason: 'choked on ```xml block```' },
+        ],
+      },
+    });
+
+    const result = buildPipelineHealthView(payload, 'req-1', OWNER_CTX);
+    const text = result.chunkedText!.text;
+
+    // Only the table's own fence pair survives as raw triple-backticks
+    expect(text.match(/```/g)).toHaveLength(2);
+    expect(text.replace(/\u200b/g, '')).toContain('choked on ```xml block```');
   });
 
   it('falls back to transformsApplied when pipelineSteps is missing (legacy log)', () => {
@@ -106,7 +132,7 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(payload, 'req-2', OWNER_CTX);
-    const text = result.files![0].attachment.toString();
+    const text = result.chunkedText!.text;
 
     expect(text).toContain('predates structured pipeline step tracking');
     expect(text).toContain('- ✅ `duplicate_removal`');
@@ -116,7 +142,7 @@ describe('buildPipelineHealthView', () => {
   it('reports "No transforms applied" when both pipelineSteps and transformsApplied are empty', () => {
     const payload = createMockPayload(); // default postProcessing has empty arrays
     const result = buildPipelineHealthView(payload, 'req-3', OWNER_CTX);
-    const text = result.files![0].attachment.toString();
+    const text = result.chunkedText!.text;
     expect(text).toContain('No transforms applied');
   });
 
@@ -134,7 +160,7 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(payload, 'req-4', OWNER_CTX);
-    const text = result.files![0].attachment.toString();
+    const text = result.chunkedText!.text;
 
     expect(text).toContain('**Final content:** 2,048 chars');
     expect(text).toContain('**Thinking content:** 1,063 chars');
@@ -155,7 +181,7 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(newLogEmpty, 'req-empty', OWNER_CTX);
-    const text = result.files![0].attachment.toString();
+    const text = result.chunkedText!.text;
 
     expect(text).toContain('No pipeline steps recorded');
     // Should NOT show the legacy-log fallback message — this log is new, just empty

--- a/services/bot-client/src/commands/inspect/extendedViews.ts
+++ b/services/bot-client/src/commands/inspect/extendedViews.ts
@@ -1,9 +1,10 @@
 // Extracted from views.ts to stay under the 400-line ESLint limit.
 
-import { AttachmentBuilder, MessageFlags } from 'discord.js';
+import { MessageFlags } from 'discord.js';
 import type { DiagnosticPayload, PipelineStep } from '@tzurot/common-types/types/diagnostic';
 import type { ViewContext } from './viewContext.js';
 import type { DebugViewResult } from './views.js';
+import { escapeFenceBreaks } from '../../utils/fenceEscape.js';
 
 // ---------------------------------------------------------------------------
 // Pipeline Health
@@ -15,13 +16,18 @@ const STATUS_ICON: Record<PipelineStep['status'], string> = {
   error: '❌',
 };
 
+/** Fixed-width rows in a code fence — Discord doesn't render markdown
+ * pipe-tables inline (same solve as the memory inspector / db-sync stats). */
 function renderStepRows(steps: readonly PipelineStep[]): string[] {
-  const rows = ['| Step | Status | Detail |', '|---|---|---|'];
+  const nameWidth = Math.max(...steps.map(s => s.name.length));
+  const rows = ['```'];
   for (const step of steps) {
     const icon = STATUS_ICON[step.status];
-    const reason = step.reason ?? '—';
-    rows.push(`| \`${step.name}\` | ${icon} ${step.status} | ${reason} |`);
+    // Reasons can carry model/content-derived text — fence-escape them
+    const reason = escapeFenceBreaks(step.reason ?? '—');
+    rows.push(`${step.name.padEnd(nameWidth)}  ${icon} ${step.status.padEnd(7)} ${reason}`);
   }
+  rows.push('```');
   return rows;
 }
 
@@ -57,7 +63,7 @@ function renderContextSection(payload: DiagnosticPayload): string[] {
 /** Markdown checklist of post-processing pipeline outcomes. */
 export function buildPipelineHealthView(
   payload: DiagnosticPayload,
-  requestId: string,
+  _requestId: string,
   // intentionally unused — uniform VIEW_BUILDERS signature
   _ctx: ViewContext
 ): DebugViewResult {
@@ -74,14 +80,11 @@ export function buildPipelineHealthView(
 
   lines.push(...renderContextSection(payload));
 
-  const content = lines.join('\n');
   return {
-    files: [
-      new AttachmentBuilder(Buffer.from(content), {
-        name: `pipeline-health-${requestId}.md`,
-        description: 'Post-processing pipeline step outcomes',
-      }),
-    ],
+    chunkedText: {
+      text: lines.join('\n'),
+      continuedHeader: '_(pipeline health continued)_\n',
+    },
     flags: MessageFlags.Ephemeral,
   };
 }

--- a/services/bot-client/src/commands/inspect/index.test.ts
+++ b/services/bot-client/src/commands/inspect/index.test.ts
@@ -308,6 +308,7 @@ describe('handleButton', () => {
       deferReply: vi.fn().mockResolvedValue(undefined),
       deferUpdate: vi.fn().mockResolvedValue(undefined),
       editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
     } as unknown as import('discord.js').ButtonInteraction;
   }
 
@@ -336,6 +337,31 @@ describe('handleButton', () => {
       expect.objectContaining({
         files: expect.arrayContaining([expect.any(Object)]),
       })
+    );
+  });
+
+  it('routes chunkedText views through the chunked-reply path (button dispatch)', async () => {
+    // renderViewResult is shared with handleSelectMenu, but this pins the
+    // BUTTON path's wiring through sendChunkedReply — Reasoning is reachable
+    // via the button row, and long reasoning follows up past the first chunk.
+    const mockPayload = createMockDiagnosticPayload();
+    mockPayload.postProcessing.thinkingContent = 'z'.repeat(2500);
+    stub.getDiagnosticByRequestId.mockResolvedValue(
+      createSuccessResponse('test-req-123', mockPayload)
+    );
+
+    const interaction = createMockButtonInteraction(DebugViewType.Reasoning);
+    await inspectCommand.handleButton!(interaction);
+
+    const editArg = vi.mocked(interaction.editReply).mock.calls[0][0] as {
+      content?: string;
+      files?: unknown;
+    };
+    expect(editArg.content).toContain('## Reasoning');
+    expect(editArg.files).toBeUndefined();
+    // 2500 chars splits past one message — the tail arrives as a follow-up
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('reasoning continued') })
     );
   });
 
@@ -442,9 +468,32 @@ describe('handleSelectMenu', () => {
     expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        files: expect.arrayContaining([expect.any(Object)]),
+        embeds: expect.arrayContaining([expect.any(Object)]),
       })
     );
+  });
+
+  it('routes chunkedText views through the chunked-reply path', async () => {
+    const mockPayload = createMockDiagnosticPayload();
+    mockPayload.postProcessing.thinkingContent = 'Short reasoning body';
+    stub.getDiagnosticByRequestId.mockResolvedValue(
+      createSuccessResponse('test-req-123', mockPayload)
+    );
+
+    const interaction = createMockSelectInteraction(DebugViewType.Reasoning);
+    await inspectCommand.handleSelectMenu!(interaction);
+
+    // Single chunk: sendChunkedReply edits the deferred reply with inline text,
+    // never a file attachment.
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Short reasoning body'),
+      })
+    );
+    const editArg = (interaction.editReply as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+      files?: unknown;
+    };
+    expect(editArg.files).toBeUndefined();
   });
 
   it('should reject unknown view types', async () => {

--- a/services/bot-client/src/commands/inspect/index.ts
+++ b/services/bot-client/src/commands/inspect/index.ts
@@ -44,11 +44,43 @@ import {
   buildReasoningView,
   buildMemoryInspectorView,
   buildTokenBudgetView,
+  buildVoiceAttributionView,
+  type DebugViewResult,
 } from './views.js';
+import { sendChunkedReply } from '../../utils/chunkedReply.js';
 import { buildPipelineHealthView, buildQuickCopySummaryView } from './extendedViews.js';
 import { computeViewContext } from './viewContext.js';
 
 const logger = createLogger('inspect');
+
+/**
+ * Render one view result onto an already-acked component interaction.
+ * `chunkedText` goes through the chunked-reply path (inline text, split
+ * across ephemeral follow-ups when long — components ride the first chunk);
+ * everything else is a single editReply. Passing components: [] clears any
+ * prior rows when the user switches views on the same message.
+ */
+async function renderViewResult(
+  interaction: StringSelectMenuInteraction | ButtonInteraction,
+  viewResult: DebugViewResult
+): Promise<void> {
+  if (viewResult.chunkedText !== undefined) {
+    await sendChunkedReply({
+      interaction,
+      content: viewResult.chunkedText.text,
+      header: '',
+      continuedHeader: viewResult.chunkedText.continuedHeader,
+      components: viewResult.components ?? [],
+    });
+    return;
+  }
+  await interaction.editReply({
+    content: viewResult.content,
+    embeds: viewResult.embeds ?? [],
+    files: viewResult.files,
+    components: viewResult.components ?? [],
+  });
+}
 
 /** Map view type to its builder function */
 const VIEW_BUILDERS = {
@@ -58,6 +90,7 @@ const VIEW_BUILDERS = {
   [DebugViewType.Reasoning]: buildReasoningView,
   [DebugViewType.MemoryInspector]: buildMemoryInspectorView,
   [DebugViewType.TokenBudget]: buildTokenBudgetView,
+  [DebugViewType.VoiceAttribution]: buildVoiceAttributionView,
   [DebugViewType.PipelineHealth]: buildPipelineHealthView,
   [DebugViewType.QuickCopy]: buildQuickCopySummaryView,
 } as const;
@@ -153,13 +186,7 @@ async function handleSelectMenu(interaction: StringSelectMenuInteraction): Promi
     // Filter / sort / Top-N state is only preserved when navigating between memory-inspector
     // buttons (handleButton below threads parsed.memoryState through).
     const viewResult = VIEW_BUILDERS[viewType](result.log.data, parsed.requestId, ctx);
-    await interaction.editReply({
-      content: viewResult.content,
-      files: viewResult.files,
-      // Pass [] for views without components so any prior component row is cleared
-      // when the user picks a different view from the same select menu.
-      components: viewResult.components ?? [],
-    });
+    await renderViewResult(interaction, viewResult);
   } catch (error) {
     logger.error(
       { err: error, requestId: parsed.requestId, viewType },
@@ -214,11 +241,7 @@ async function handleButton(interaction: ButtonInteraction): Promise<void> {
       parsed.viewType === DebugViewType.MemoryInspector
         ? buildMemoryInspectorView(result.log.data, parsed.requestId, ctx, parsed.memoryState)
         : VIEW_BUILDERS[parsed.viewType](result.log.data, parsed.requestId, ctx);
-    await interaction.editReply({
-      content: viewResult.content,
-      files: viewResult.files,
-      components: viewResult.components ?? [],
-    });
+    await renderViewResult(interaction, viewResult);
   } catch (error) {
     logger.error(
       { err: error, requestId: parsed.requestId, viewType: parsed.viewType },

--- a/services/bot-client/src/commands/inspect/types.ts
+++ b/services/bot-client/src/commands/inspect/types.ts
@@ -47,6 +47,7 @@ export enum DebugViewType {
   Reasoning = 'reasoning',
   MemoryInspector = 'memory-inspector',
   TokenBudget = 'token-budget',
+  VoiceAttribution = 'voice-attribution',
   PipelineHealth = 'pipeline-health',
   QuickCopy = 'quick-copy',
 }

--- a/services/bot-client/src/commands/inspect/views.test.ts
+++ b/services/bot-client/src/commands/inspect/views.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MessageFlags } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import type { DiagnosticPayload } from '@tzurot/common-types/types/diagnostic';
 import {
   buildFullJsonView,
@@ -8,6 +9,7 @@ import {
   buildReasoningView,
   buildMemoryInspectorView,
   buildTokenBudgetView,
+  buildVoiceAttributionView,
 } from './views.js';
 import type { ViewContext } from './viewContext.js';
 
@@ -200,54 +202,52 @@ describe('buildReasoningView', () => {
     expect(result.content).toContain('No reasoning content captured');
   });
 
-  it('should return inline message for short reasoning', () => {
+  it('should return inline chunked text for short reasoning', () => {
     const payload = createMockPayload();
     payload.postProcessing.thinkingContent = 'The user asked about castles...';
     const result = buildReasoningView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.content).toContain('## Reasoning');
-    expect(result.content).toContain('castles');
+    expect(result.chunkedText!.text).toContain('## Reasoning');
+    expect(result.chunkedText!.text).toContain('castles');
     expect(result.files).toBeUndefined();
   });
 
-  it('should return .md file for long reasoning', () => {
+  it('should return inline chunked text (never a file) for long reasoning', () => {
     const payload = createMockPayload();
     payload.postProcessing.thinkingContent = 'x'.repeat(2500);
     const result = buildReasoningView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.files).toHaveLength(1);
-    expect(result.files![0].name).toContain('.md');
-    expect(result.content).toContain('2,500 chars');
+    expect(result.files).toBeUndefined();
+    expect(result.chunkedText!.text).toContain('x'.repeat(2500));
+    expect(result.chunkedText!.continuedHeader).toContain('reasoning continued');
   });
 });
 
 describe('buildMemoryInspectorView', () => {
-  it('should return a .md file', () => {
+  it('should return inline content with no file attachment', () => {
     const payload = createMockPayload();
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.files).toHaveLength(1);
-    expect(result.files![0].name).toContain('memory-inspector');
+    expect(result.files).toBeUndefined();
+    expect(result.content).toContain('# Memory Inspector');
   });
 
   it('should include search query and focus mode status', () => {
     const payload = createMockPayload();
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('"hello"');
-    expect(content).toContain('Disabled');
+    expect(result.content).toContain('"hello"');
+    expect(result.content).toContain('Disabled');
   });
 
   it('should include memory table with scores and status', () => {
     const payload = createMockPayload();
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('0.95');
-    expect(content).toContain('Included');
-    expect(content).toContain('0.52');
-    expect(content).toContain('Dropped (budget)');
+    expect(result.content).toContain('0.95');
+    expect(result.content).toContain('✓ in');
+    expect(result.content).toContain('0.52');
+    expect(result.content).toContain('✗ drop');
   });
 
   it('should show message when no memories found', () => {
@@ -255,19 +255,42 @@ describe('buildMemoryInspectorView', () => {
     payload.memoryRetrieval.memoriesFound = [];
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('No memories retrieved');
+    expect(result.content).toContain('No memories retrieved');
   });
 
-  it('should escape pipes and backslashes in memory previews', () => {
+  it('should collapse whitespace and truncate long previews to the row budget', () => {
     const payload = createMockPayload();
     payload.memoryRetrieval.memoriesFound = [
-      { id: 'mem-1', score: 0.9, preview: 'has | pipe and \\ backslash', includedInPrompt: true },
+      {
+        id: 'mem-1',
+        score: 0.9,
+        preview: 'line one\nline\ttwo  ' + 'y'.repeat(80),
+        includedInPrompt: true,
+      },
     ];
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('has \\| pipe and \\\\ backslash');
+    // Newlines/tabs collapse to single spaces so one memory = one table row
+    expect(result.content).toContain('line one line two');
+    expect(result.content).not.toContain('line one\nline');
+    // 60-char row budget with ellipsis
+    expect(result.content).toContain('…');
+    expect(result.content).not.toContain('y'.repeat(80));
+  });
+
+  it('neutralizes embedded triple-backticks so previews cannot close the fence', () => {
+    // Discord closes a fence at ANY ``` occurrence (not just line start) —
+    // a pasted code block in a memory must not spill the table out of it.
+    const payload = createMockPayload();
+    payload.memoryRetrieval.memoriesFound = [
+      { id: 'mem-1', score: 0.9, preview: 'pasted ```js x``` code', includedInPrompt: true },
+    ];
+    const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
+
+    // Only the table's own fence pair survives as raw triple-backticks
+    expect(result.content!.match(/```/g)).toHaveLength(2);
+    // Visible backticks still present (zero-width-separated)
+    expect(result.content!.replace(/\u200b/g, '')).toContain('```js x```');
   });
 
   it('should show "none" for null search query', () => {
@@ -275,8 +298,28 @@ describe('buildMemoryInspectorView', () => {
     payload.inputProcessing.searchQuery = null;
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('_none_');
+    expect(result.content).toContain('_none_');
+  });
+
+  it('trims table rows from the tail when content would exceed one message', () => {
+    const payload = createMockPayload();
+    payload.memoryRetrieval.memoriesFound = Array.from({ length: 40 }, (_, i) => ({
+      id: `mem-${i}`,
+      score: 0.9,
+      preview: `row ${i} ` + 'z'.repeat(50),
+      includedInPrompt: true,
+    }));
+    const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
+
+    expect(result.content!.length).toBeLessThanOrEqual(1900);
+    expect(result.content).toContain('rows trimmed to fit');
+    // The token-budget summary after the closing fence survives the trim —
+    // it matters most in exactly this high-memory-count case
+    expect(result.content).toContain('**Token Budget:** 1000 tokens allocated');
+    // Fence stays balanced (one open, one close)
+    expect(result.content!.match(/```/g)).toHaveLength(2);
+    // Filter buttons survive the trim — the view stays interactive
+    expect(result.components).toHaveLength(1);
   });
 
   describe('filter / sort / Top-N state', () => {
@@ -294,7 +337,7 @@ describe('buildMemoryInspectorView', () => {
 
     it('default state matches existing behavior (regression)', () => {
       const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX);
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       // All 5 rows shown
       expect(text).toContain('p1');
       expect(text).toContain('p5');
@@ -312,7 +355,7 @@ describe('buildMemoryInspectorView', () => {
       const payload = memoryPayload();
       payload.memoryRetrieval.memoriesFound = [];
       const result = buildMemoryInspectorView(payload, 'req-1', OWNER_CTX);
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
 
       expect(result.components).toEqual([]);
       // State annotation should not appear — there's nothing to filter
@@ -326,7 +369,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       expect(text).toContain('p1');
       expect(text).not.toContain('p2');
       expect(text).toContain('p3');
@@ -340,7 +383,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       expect(text).not.toContain('p1');
       expect(text).toContain('p2');
       expect(text).not.toContain('p3');
@@ -354,7 +397,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 5,
         sort: 'score-desc',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       expect(text).toContain('showing 5');
     });
 
@@ -364,9 +407,9 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-asc',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       // First row index is 1, lowest-scored memory (p5 with 0.50) should be there
-      const firstRowMatch = text.match(/\| 1 \| (\d+\.\d+) \|/);
+      const firstRowMatch = text.match(/^ 1 (\d+\.\d+) /m);
       expect(firstRowMatch?.[1]).toBe('0.50');
     });
 
@@ -376,7 +419,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'included-first',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       const p1Idx = text.indexOf('p1'); // included
       const p3Idx = text.indexOf('p3'); // included
       const p5Idx = text.indexOf('p5'); // included
@@ -392,7 +435,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 5,
         sort: 'score-asc',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       // Included memories sorted by ascending score: p5 (0.5), p3 (0.7), p1 (0.9)
       // topN=5 covers all 3
       const p5Idx = text.indexOf('p5');
@@ -414,7 +457,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       expect(text).toContain('No memories match filter');
     });
 
@@ -424,7 +467,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.files![0].attachment.toString();
+      const text = result.content!;
       expect(text).toContain('[REDACTED]');
       expect(text).not.toContain('p1');
       expect(text).not.toContain('p3');
@@ -433,49 +476,68 @@ describe('buildMemoryInspectorView', () => {
 });
 
 describe('buildTokenBudgetView', () => {
-  it('should return a .txt file', () => {
+  /** Pull the Notes field value off the embed (empty string when absent) */
+  function notesOf(result: ReturnType<typeof buildTokenBudgetView>): string {
+    const field = result.embeds![0].data.fields?.find(f => f.name === 'Notes');
+    return field?.value ?? '';
+  }
+
+  it('should return an embed with no file attachment', () => {
     const payload = createMockPayload();
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.files).toHaveLength(1);
-    expect(result.files![0].name).toContain('token-budget');
-    expect(result.files![0].name).toContain('.txt');
+    expect(result.files).toBeUndefined();
+    expect(result.embeds).toHaveLength(1);
+    expect(result.embeds![0].data.title).toBe('\u{1F4CA} Token Budget');
   });
 
-  it('should include context window size', () => {
+  it('should include context window size and a bar per allocation', () => {
     const payload = createMockPayload();
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('128,000');
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).toContain('128,000');
+    expect(desc).toContain('System');
+    expect(desc).toContain('Memory');
+    expect(desc).toContain('History');
+    expect(desc).toContain('Free');
+    expect(desc).toContain('\u2588'); // at least one filled bar segment
   });
 
-  it('should show history warning when > 70%', () => {
+  it('should warn in Notes and switch to the warning color when history > 70%', () => {
     const payload = createMockPayload();
     // 92000 / 128000 = 71.9%
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('>70%');
+    expect(notesOf(result)).toContain('over 70%');
+    expect(result.embeds![0].data.color).toBe(DISCORD_COLORS.WARNING);
   });
 
-  it('should show dropped counts', () => {
+  it('should use the default color when history is under the warning threshold', () => {
+    const payload = createMockPayload();
+    payload.tokenBudget.historyTokensUsed = 10000;
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    expect(notesOf(result)).not.toContain('over 70%');
+    expect(result.embeds![0].data.color).toBe(DISCORD_COLORS.BLURPLE);
+  });
+
+  it('should show dropped counts in Notes', () => {
     const payload = createMockPayload();
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('1 memories');
-    expect(content).toContain('5 history messages');
+    const notes = notesOf(result);
+    expect(notes).toContain('1 memories');
+    expect(notes).toContain('5 history messages');
   });
 
-  it('should not show dropped line when nothing dropped', () => {
+  it('should not show the dropped line when nothing was dropped', () => {
     const payload = createMockPayload();
     payload.tokenBudget.memoriesDropped = 0;
     payload.tokenBudget.historyMessagesDropped = 0;
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).not.toContain('Dropped:');
+    expect(notesOf(result)).not.toContain('Dropped for budget');
   });
 
   it('renders the cross-channel line when crossChannelMessagesIncluded is set', () => {
@@ -483,8 +545,7 @@ describe('buildTokenBudgetView', () => {
     payload.tokenBudget.crossChannelMessagesIncluded = 3;
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('Cross-channel: 3 msgs included from other channels');
+    expect(notesOf(result)).toContain('Cross-channel: 3 msgs included from other channels');
   });
 
   it('renders "0 msgs" when cross-channel was enabled but produced no eligible messages', () => {
@@ -495,8 +556,7 @@ describe('buildTokenBudgetView', () => {
     payload.tokenBudget.crossChannelMessagesIncluded = 0;
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('Cross-channel: 0 msgs included from other channels');
+    expect(notesOf(result)).toContain('Cross-channel: 0 msgs included from other channels');
   });
 
   it('omits the cross-channel line when the feature was disabled this turn', () => {
@@ -504,41 +564,51 @@ describe('buildTokenBudgetView', () => {
     // crossChannelMessagesIncluded intentionally undefined
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).not.toContain('Cross-channel:');
+    expect(notesOf(result)).not.toContain('Cross-channel:');
   });
 
-  it('renders the TTS line when ttsProviderUsed is set and no fallback fired', () => {
+  it('does not render voice attribution (moved to its own view)', () => {
+    const payload = createMockPayload();
+    payload.tokenBudget.ttsProviderUsed = 'mistral';
+    payload.tokenBudget.ttsUsedFallback = true;
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).not.toContain('mistral');
+    expect(notesOf(result)).not.toContain('mistral');
+  });
+});
+
+describe('buildVoiceAttributionView', () => {
+  it('reports no voice activity when neither TTS nor a transcript is present', () => {
+    const payload = createMockPayload();
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
+
+    expect(result.content).toContain('No voice activity');
+    expect(result.chunkedText).toBeUndefined();
+  });
+
+  it('renders the TTS provider without a fallback suffix when no fallback fired', () => {
     const payload = createMockPayload();
     payload.tokenBudget.ttsProviderUsed = 'mistral';
     payload.tokenBudget.ttsUsedFallback = false;
-    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('TTS: mistral');
-    expect(content).not.toContain('(via fallback)');
+    const text = result.chunkedText!.text;
+    expect(text).toContain('**TTS provider:** mistral');
+    expect(text).not.toContain('(via fallback)');
   });
 
-  it('annotates the TTS line with "(via fallback)" when the dispatcher fell through', () => {
+  it('annotates "(via fallback)" when the dispatcher fell through', () => {
     // Regression contract for the silent-fallback misattribution class —
     // user configures Mistral, Mistral fails, voice-engine produces audio,
     // diagnostic UI must surface the divergence so the user can tell.
     const payload = createMockPayload();
     payload.tokenBudget.ttsProviderUsed = 'self-hosted';
     payload.tokenBudget.ttsUsedFallback = true;
-    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('TTS: self-hosted (via fallback)');
-  });
-
-  it('omits the TTS line when ttsProviderUsed is undefined (TTS disabled or failed)', () => {
-    const payload = createMockPayload();
-    // ttsProviderUsed intentionally undefined
-    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
-
-    const content = result.files![0].attachment.toString();
-    expect(content).not.toContain('TTS:');
+    expect(result.chunkedText!.text).toContain('**TTS provider:** self-hosted _(via fallback)_');
   });
 
   it('omits the "(via fallback)" suffix when ttsUsedFallback is undefined', () => {
@@ -549,11 +619,42 @@ describe('buildTokenBudgetView', () => {
     const payload = createMockPayload();
     payload.tokenBudget.ttsProviderUsed = 'mistral';
     payload.tokenBudget.ttsUsedFallback = undefined;
-    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const content = result.files![0].attachment.toString();
-    expect(content).toContain('TTS: mistral');
-    expect(content).not.toContain('(via fallback)');
+    const text = result.chunkedText!.text;
+    expect(text).toContain('**TTS provider:** mistral');
+    expect(text).not.toContain('(via fallback)');
+  });
+
+  it('renders the voice transcript as a blockquote', () => {
+    const payload = createMockPayload();
+    payload.inputProcessing.voiceTranscript = 'hello from a voice note';
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
+
+    const text = result.chunkedText!.text;
+    expect(text).toContain('**Voice transcript:**');
+    expect(text).toContain('> hello from a voice note');
+  });
+
+  it('quotes every line of a multi-line transcript', () => {
+    // Discord drops unprefixed continuation lines out of a blockquote
+    const payload = createMockPayload();
+    payload.inputProcessing.voiceTranscript = 'first line\nsecond line';
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
+
+    const text = result.chunkedText!.text;
+    expect(text).toContain('> first line\n> second line');
+  });
+
+  it('renders transcript-only requests (voice input, no TTS reply)', () => {
+    const payload = createMockPayload();
+    payload.inputProcessing.voiceTranscript = 'transcript only';
+    // ttsProviderUsed intentionally undefined
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
+
+    const text = result.chunkedText!.text;
+    expect(text).toContain('> transcript only');
+    expect(text).not.toContain('**TTS provider:**');
   });
 });
 
@@ -651,12 +752,12 @@ describe('non-owner redaction', () => {
     it('redacts memory previews while keeping IDs/scores/inclusion visible', () => {
       const payload = createMockPayload();
       const result = buildMemoryInspectorView(payload, 'req-123', NON_OWNER_CTX);
-      const content = result.files![0].attachment.toString();
+      const content = result.content!;
       // Each memory row contains [REDACTED] in the preview column
       expect(content).toContain('[REDACTED]');
       // Score and status remain
       expect(content).toContain('0.95');
-      expect(content).toContain('Included');
+      expect(content).toContain('✓ in');
       // Banner explaining the redaction
       expect(content).toContain('🔒');
       expect(content).toContain('redacted');
@@ -665,7 +766,7 @@ describe('non-owner redaction', () => {
     it('does not show memory preview text when canViewCharacter is false', () => {
       const payload = createMockPayload();
       const result = buildMemoryInspectorView(payload, 'req-123', NON_OWNER_CTX);
-      const content = result.files![0].attachment.toString();
+      const content = result.content!;
       expect(content).not.toContain('Memory preview text');
       expect(content).not.toContain('Low score memory');
     });
@@ -676,7 +777,7 @@ describe('non-owner redaction', () => {
       const payload = createMockPayload();
       payload.postProcessing.thinkingContent = 'I considered the user request and decided to...';
       const result = buildReasoningView(payload, 'req-123', NON_OWNER_CTX);
-      expect(result.content).toContain('considered the user request');
+      expect(result.chunkedText!.text).toContain('considered the user request');
     });
   });
 
@@ -684,12 +785,14 @@ describe('non-owner redaction', () => {
     it('shows full token-budget breakdown even when canViewCharacter is false (purely numeric)', () => {
       const payload = createMockPayload();
       const result = buildTokenBudgetView(payload, 'req-123', NON_OWNER_CTX);
-      const content = result.files![0].attachment.toString();
-      expect(content).toContain('Context Window');
-      expect(content).toContain('System Prompt:');
+      const desc = result.embeds![0].data.description ?? '';
+      expect(desc).toContain('Context window:');
+      expect(desc).toContain('System');
     });
+  });
 
-    it('renders the TTS attribution line for non-owners as well (no ownership gate)', () => {
+  describe('buildVoiceAttributionView', () => {
+    it('renders TTS attribution for non-owners as well (no ownership gate)', () => {
       // Pins the intentional design: TTS provider attribution is a non-sensitive
       // numeric/categorical field, same class as the other token-budget lines,
       // so non-owners also see it. Without this assertion, a future contributor
@@ -698,9 +801,8 @@ describe('non-owner redaction', () => {
       const payload = createMockPayload();
       payload.tokenBudget.ttsProviderUsed = 'mistral';
       payload.tokenBudget.ttsUsedFallback = false;
-      const result = buildTokenBudgetView(payload, 'req-123', NON_OWNER_CTX);
-      const content = result.files![0].attachment.toString();
-      expect(content).toContain('TTS: mistral');
+      const result = buildVoiceAttributionView(payload, 'req-123', NON_OWNER_CTX);
+      expect(result.chunkedText!.text).toContain('**TTS provider:** mistral');
     });
   });
 });

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -12,14 +12,17 @@
 import {
   type ActionRowBuilder,
   AttachmentBuilder,
+  EmbedBuilder,
   MessageFlags,
   type MessageActionRowComponentBuilder,
 } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import type {
   DiagnosticPayload,
   DiagnosticMemoryEntry,
 } from '@tzurot/common-types/types/diagnostic';
 import type { ViewContext } from './viewContext.js';
+import { escapeFenceBreaks } from '../../utils/fenceEscape.js';
 import {
   DEFAULT_MEMORY_STATE,
   applyMemoryFilter,
@@ -32,6 +35,12 @@ import {
 /** Return type for view builders — content string, file attachments, and optional component rows. */
 export interface DebugViewResult {
   content?: string;
+  /** Long-form TEXT rendered inline via chunked ephemeral replies (owner
+   * decision: no file-download dance for readable content — files are for
+   * structured data like JSON/XML only). The dispatcher hands this to
+   * `sendChunkedReply`; `components` ride the first chunk. */
+  chunkedText?: { text: string; continuedHeader: string };
+  embeds?: EmbedBuilder[];
   files?: AttachmentBuilder[];
   flags?: MessageFlags;
   components?: ActionRowBuilder<MessageActionRowComponentBuilder>[];
@@ -188,11 +197,9 @@ export function buildSystemPromptView(
 // Reasoning
 // ---------------------------------------------------------------------------
 
-/** Discord message content limit; reasoning longer than this is sent as a .md file attachment */
-const REASONING_INLINE_LIMIT = 2000;
-
 /**
- * Reasoning content as either inline markdown or a .md file.
+ * Reasoning content, always inline — chunked across ephemeral messages when
+ * long (owner decision: reading text must never require a file download).
  *
  * Reasoning content is shown to non-owners by design (per project decision —
  * model thinking is genuinely interesting and the user already saw the
@@ -203,7 +210,7 @@ const REASONING_INLINE_LIMIT = 2000;
  */
 export function buildReasoningView(
   payload: DiagnosticPayload,
-  requestId: string,
+  _requestId: string,
   // intentionally unused — uniform VIEW_BUILDERS signature
   _ctx: ViewContext
 ): DebugViewResult {
@@ -216,23 +223,11 @@ export function buildReasoningView(
     };
   }
 
-  const formatted = `## Reasoning\n\n${thinking}`;
-
-  if (formatted.length < REASONING_INLINE_LIMIT) {
-    return {
-      content: formatted,
-      flags: MessageFlags.Ephemeral,
-    };
-  }
-
   return {
-    content: `Reasoning content (${thinking.length.toLocaleString()} chars) attached as file:`,
-    files: [
-      new AttachmentBuilder(Buffer.from(formatted), {
-        name: `reasoning-${requestId}.md`,
-        description: 'LLM reasoning / thinking content',
-      }),
-    ],
+    chunkedText: {
+      text: `## Reasoning\n\n${thinking}`,
+      continuedHeader: '_(reasoning continued)_\n',
+    },
     flags: MessageFlags.Ephemeral,
   };
 }
@@ -241,16 +236,26 @@ export function buildReasoningView(
 // Memory Inspector
 // ---------------------------------------------------------------------------
 
+/** Preview budget per row: the whole view must stay one in-place message so
+ * the filter buttons keep editing it (chunked follow-ups would go stale on
+ * refresh). Full previews live in the JSON views. */
+const MEMORY_PREVIEW_MAX = 60;
+
 function formatMemoryRow(
   m: DiagnosticMemoryEntry,
   index: number,
   canViewCharacter: boolean
 ): string {
-  const status = m.includedInPrompt ? 'Included' : 'Dropped (budget)';
-  const preview = canViewCharacter
-    ? m.preview.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ')
-    : REDACTED_MEMORY_PREVIEW;
-  return `| ${index + 1} | ${m.score.toFixed(2)} | ${status} | ${preview} |`;
+  const status = m.includedInPrompt ? '✓ in' : '✗ drop';
+  let preview = canViewCharacter ? m.preview.replace(/\s+/g, ' ').trim() : REDACTED_MEMORY_PREVIEW;
+  if (preview.length > MEMORY_PREVIEW_MAX) {
+    preview = `${preview.slice(0, MEMORY_PREVIEW_MAX - 1)}…`;
+  }
+  // Escape AFTER truncation: a cut can split ``` into a harmless ``, and any
+  // surviving run still gets neutralized before entering the fence.
+  preview = escapeFenceBreaks(preview);
+  // Score pads to 5 to align under the 'Score' header label
+  return `${String(index + 1).padStart(2)} ${m.score.toFixed(2).padEnd(5)} ${status.padEnd(6)} ${preview}`;
 }
 
 function renderMemoryTable(
@@ -271,15 +276,38 @@ function renderMemoryTable(
     lines.push('');
     lines.push('🔒 _Memory previews redacted — this character is owned by another user._');
   }
-  lines.push('', '| # | Score | Status | Preview |', '|---|-------|--------|---------|');
+  // Fixed-width rows in a code fence — Discord doesn't render markdown
+  // tables, and the fence keeps columns aligned on mobile.
+  lines.push('', '```', ' # Score Status Preview');
   for (let i = 0; i < memories.length; i++) {
     lines.push(formatMemoryRow(memories[i], i, canViewCharacter));
   }
-  lines.push('');
+  lines.push('```', '');
   lines.push(
     `**Token Budget:** ${tokenBudget.memoryTokensUsed} tokens allocated, ${budgetDropped} memories dropped for budget`
   );
   return lines;
+}
+
+/** Trim table rows from the tail until the view fits one Discord message,
+ * keeping everything after the closing fence (the token-budget summary line)
+ * and appending a notice pointing at Top-N (the existing knob) for narrowing.
+ * The view must stay a single in-place message — the filter buttons re-edit
+ * it, so spilling into chunked follow-ups would go stale. */
+function trimToSingleMessage(content: string): string {
+  const limit = 1900; // headroom under Discord's 2000 for the trim notice
+  if (content.length <= limit) {
+    return content;
+  }
+  const trimNotice = '_…rows trimmed to fit — lower Top-N or filter to narrow._';
+  const fenceEnd = content.lastIndexOf('\n```');
+  // Tail = closing fence + the token-budget summary; both must survive the trim.
+  const tail = fenceEnd > 0 ? content.slice(fenceEnd) : '';
+  let head = fenceEnd > 0 ? content.slice(0, fenceEnd) : content;
+  while (head.length + tail.length + trimNotice.length + 1 > limit && head.includes('\n')) {
+    head = head.slice(0, head.lastIndexOf('\n'));
+  }
+  return `${head}${tail}\n${trimNotice}`;
 }
 
 /** Scored memories table with inclusion status. Applies filter → sort → Top-N. */
@@ -318,14 +346,9 @@ export function buildMemoryInspectorView(
     }
   }
 
-  const content = lines.join('\n');
+  // Single in-place message (owner decision: inline, no file download).
   return {
-    files: [
-      new AttachmentBuilder(Buffer.from(content), {
-        name: `memory-inspector-${requestId}.md`,
-        description: 'Memory retrieval details',
-      }),
-    ],
+    content: trimToSingleMessage(lines.join('\n')),
     components: allMemories.length > 0 ? [buildMemoryFilterButtons(requestId, state)] : [],
     flags: MessageFlags.Ephemeral,
   };
@@ -336,7 +359,10 @@ export function buildMemoryInspectorView(
 // ---------------------------------------------------------------------------
 
 /**
- * ASCII breakdown of context window allocation.
+ * Context-window allocation as an embed — bars in a code fence for mobile
+ * alignment, numbers as fields (owner decision: a text view, not a .txt
+ * download). Voice attribution moved to its own view (it was buried here
+ * and is about pipeline routing, not token consumption).
  *
  * Token-budget data is purely numeric and contains no character-internal
  * information; the `_ctx` parameter is kept on the signature for uniformity
@@ -344,7 +370,7 @@ export function buildMemoryInspectorView(
  */
 export function buildTokenBudgetView(
   payload: DiagnosticPayload,
-  requestId: string,
+  _requestId: string,
   // intentionally unused — uniform VIEW_BUILDERS signature
   _ctx: ViewContext
 ): DebugViewResult {
@@ -359,49 +385,37 @@ export function buildTokenBudgetView(
   const remaining = Math.max(0, total - usedTokens);
   const remainingPct = (remaining / total) * 100;
 
-  const bar = (pct: number): string => {
-    const blocks = Math.round(pct / 2.5);
-    return '█'.repeat(blocks);
-  };
+  const bar = (pct: number): string => '█'.repeat(Math.round(pct / 4)).padEnd(25, '░');
+  const row = (label: string, tokens: number, pct: number): string =>
+    `${label.padEnd(8)}${bar(pct)} ${pct.toFixed(0).padStart(3)}% ${tokens.toLocaleString().padStart(8)}`;
 
-  const warn = (pct: number): string => (pct > 70 ? '  ⚠️ >70%' : '');
+  const chart = [
+    '```',
+    row('System', tokenBudget.systemPromptTokens, systemPct),
+    row('Memory', tokenBudget.memoryTokensUsed, memoryPct),
+    row('History', tokenBudget.historyTokensUsed, historyPct),
+    row('Free', remaining, remainingPct),
+    '```',
+  ].join('\n');
 
-  const pad = (label: string): string => label.padEnd(16);
+  const embed = new EmbedBuilder()
+    .setTitle('📊 Token Budget')
+    .setColor(historyPct > 70 ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE)
+    .setDescription(`**Context window:** ${total.toLocaleString()} tokens\n${chart}`);
 
-  const lines = [
-    'Token Budget Breakdown',
-    '═'.repeat(40),
-    `Context Window: ${total.toLocaleString()} tokens`,
-    '',
-    `  ${pad('System Prompt:')}${tokenBudget.systemPromptTokens.toLocaleString().padStart(8)} tokens (${systemPct.toFixed(0).padStart(2)}%)  ${bar(systemPct)}`,
-    `  ${pad('Memory:')}${tokenBudget.memoryTokensUsed.toLocaleString().padStart(8)} tokens (${memoryPct.toFixed(0).padStart(2)}%)  ${bar(memoryPct)}`,
-    `  ${pad('History:')}${tokenBudget.historyTokensUsed.toLocaleString().padStart(8)} tokens (${historyPct.toFixed(0).padStart(2)}%)  ${bar(historyPct)}${warn(historyPct)}`,
-    `  ${'─── Available ───'.padEnd(40, '─')}`,
-    `  ${pad('Remaining:')}${remaining.toLocaleString().padStart(8)} tokens (${remainingPct.toFixed(0).padStart(2)}%)`,
-  ];
-
+  const notes: string[] = [];
+  if (historyPct > 70) {
+    notes.push('⚠️ History is using over 70% of the window.');
+  }
   // Cross-channel disclosure: surfaces "0 cross-channel msgs" when the user
   // has crossChannelHistory enabled but the time-filter / personality-history
   // combination produced nothing. Without this line, the silent-skip case is
-  // indistinguishable from "feature disabled" in the embed.
+  // indistinguishable from "feature disabled".
   if (tokenBudget.crossChannelMessagesIncluded !== undefined) {
-    lines.push('');
-    lines.push(
+    notes.push(
       `Cross-channel: ${tokenBudget.crossChannelMessagesIncluded} msgs included from other channels`
     );
   }
-
-  // TTS provider attribution: reports the provider that ACTUALLY produced
-  // the audio. The "(via fallback)" suffix surfaces silent dispatcher
-  // fall-throughs where the user's configured provider failed and the
-  // dispatcher selected a backup — the exact diagnostic gap that hid the
-  // sister Mistral STT misattribution.
-  if (tokenBudget.ttsProviderUsed !== undefined) {
-    lines.push('');
-    const fallbackSuffix = tokenBudget.ttsUsedFallback === true ? ' (via fallback)' : '';
-    lines.push(`TTS: ${tokenBudget.ttsProviderUsed}${fallbackSuffix}`);
-  }
-
   const dropped: string[] = [];
   if (tokenBudget.memoriesDropped > 0) {
     dropped.push(`${tokenBudget.memoriesDropped} memories`);
@@ -410,18 +424,69 @@ export function buildTokenBudgetView(
     dropped.push(`${tokenBudget.historyMessagesDropped} history messages`);
   }
   if (dropped.length > 0) {
-    lines.push('');
-    lines.push(`Dropped: ${dropped.join(', ')}`);
+    notes.push(`Dropped for budget: ${dropped.join(', ')}`);
+  }
+  if (notes.length > 0) {
+    embed.addFields({ name: 'Notes', value: notes.join('\n'), inline: false });
   }
 
-  const content = lines.join('\n');
+  return { embeds: [embed], flags: MessageFlags.Ephemeral };
+}
+
+// ---------------------------------------------------------------------------
+// Voice Attribution
+// ---------------------------------------------------------------------------
+
+/**
+ * Voice-pipeline routing for this request — extracted from the Token Budget
+ * view where it was buried ("that's very unintuitive"). Renders what the
+ * payload carries today: the TTS provider that ACTUALLY produced audio (with
+ * the silent-fallback annotation) and the voice-message transcript. STT
+ * provider attribution isn't in the payload yet — that gap stays tracked in
+ * the voice-inspect-ux-polish theme.
+ */
+export function buildVoiceAttributionView(
+  payload: DiagnosticPayload,
+  _requestId: string,
+  // intentionally unused — uniform VIEW_BUILDERS signature
+  _ctx: ViewContext
+): DebugViewResult {
+  const { tokenBudget, inputProcessing } = payload;
+  const lines: string[] = ['## Voice Attribution', ''];
+
+  const hasTts = tokenBudget.ttsProviderUsed !== undefined;
+  const hasTranscript =
+    inputProcessing.voiceTranscript !== null && inputProcessing.voiceTranscript.length > 0;
+
+  if (!hasTts && !hasTranscript) {
+    return {
+      content: 'No voice activity (TTS or voice-message input) on this request.',
+      flags: MessageFlags.Ephemeral,
+    };
+  }
+
+  if (hasTts) {
+    // The "(via fallback)" suffix surfaces silent dispatcher fall-throughs
+    // where the configured provider failed and a backup produced the audio —
+    // the exact diagnostic gap that hid the Mistral STT misattribution.
+    const fallbackSuffix = tokenBudget.ttsUsedFallback === true ? ' _(via fallback)_' : '';
+    lines.push(`**TTS provider:** ${tokenBudget.ttsProviderUsed}${fallbackSuffix}`);
+  }
+  if (hasTranscript) {
+    // Discord blockquotes need '> ' on EVERY line — a bare continuation line
+    // drops out of the quote (unlike GitHub markdown).
+    const quoted = (inputProcessing.voiceTranscript ?? '')
+      .split('\n')
+      .map(line => `> ${line}`)
+      .join('\n');
+    lines.push('', '**Voice transcript:**', quoted);
+  }
+
   return {
-    files: [
-      new AttachmentBuilder(Buffer.from(content), {
-        name: `token-budget-${requestId}.txt`,
-        description: 'Token budget breakdown',
-      }),
-    ],
+    chunkedText: {
+      text: lines.join('\n'),
+      continuedHeader: '_(voice attribution continued)_\n',
+    },
     flags: MessageFlags.Ephemeral,
   };
 }

--- a/services/bot-client/src/commands/persona/view.test.ts
+++ b/services/bot-client/src/commands/persona/view.test.ts
@@ -224,7 +224,9 @@ describe('handleExpandContent', () => {
     await handleExpandContent(createMockButtonInteraction(), TEST_PERSONA_ID, 'content');
 
     expect(mockDeferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
-    expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('Short content'));
+    expect(mockEditReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Short content') })
+    );
     expect(mockFollowUp).not.toHaveBeenCalled();
   });
 

--- a/services/bot-client/src/utils/chunkedReply.test.ts
+++ b/services/bot-client/src/utils/chunkedReply.test.ts
@@ -7,6 +7,21 @@ import { sendChunkedReply } from './chunkedReply.js';
 import { MessageFlags } from 'discord.js';
 import { DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
 
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
 vi.mock('@tzurot/common-types/utils/discord', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/discord')>(
     '@tzurot/common-types/utils/discord'
@@ -51,7 +66,10 @@ describe('sendChunkedReply', () => {
       continuedHeader: '## Title (continued)\n\n',
     });
 
-    expect(interaction.editReply).toHaveBeenCalledWith('## Title\n\nShort content');
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '## Title\n\nShort content',
+      components: [],
+    });
     expect(interaction.followUp).not.toHaveBeenCalled();
   });
 
@@ -92,7 +110,8 @@ describe('sendChunkedReply', () => {
     });
 
     // First message should have header
-    const editReplyArg = vi.mocked(interaction.editReply).mock.calls[0][0] as string;
+    const editReplyArg = (vi.mocked(interaction.editReply).mock.calls[0][0] as { content: string })
+      .content;
     expect(editReplyArg).toMatch(/^## Title\n\n/);
 
     // Follow-up should have continued header
@@ -100,6 +119,100 @@ describe('sendChunkedReply', () => {
       content: string;
     };
     expect(followUpArg.content).toMatch(/^## Title \(continued\)\n\n/);
+  });
+
+  it('sends every chunk as a follow-up when via is followUp (single chunk)', async () => {
+    await sendChunkedReply({
+      interaction,
+      content: 'Short report',
+      header: '',
+      continuedHeader: '_(continued)_\n',
+      via: 'followUp',
+    });
+
+    // editReply untouched — the caller's summary embed stays intact
+    expect(interaction.editReply).not.toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      content: 'Short report',
+      components: [],
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('sends every chunk as a follow-up when via is followUp (multi chunk)', async () => {
+    const continuedHeader = '_(continued)_\n';
+    const maxContent = DISCORD_LIMITS.MESSAGE_LENGTH - continuedHeader.length;
+    const longContent = 'x'.repeat(maxContent + 100);
+
+    await sendChunkedReply({
+      interaction,
+      content: longContent,
+      header: '',
+      continuedHeader,
+      via: 'followUp',
+    });
+
+    expect(interaction.editReply).not.toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledTimes(2);
+    const second = vi.mocked(interaction.followUp).mock.calls[1][0] as { content: string };
+    expect(second.content).toMatch(/^_\(continued\)_\n/);
+  });
+
+  it('does not throw when a later chunk fails after the first was delivered', async () => {
+    // Delivery contract: a mid-stream failure must stay inside the utility —
+    // callers' error handlers would clobber/mislabel already-shown content.
+    const continuedHeader = '(cont)\n';
+    const maxContent = DISCORD_LIMITS.MESSAGE_LENGTH - continuedHeader.length;
+    const longContent = 'x'.repeat(maxContent * 2 + 100); // 3 chunks
+
+    vi.mocked(interaction.followUp)
+      .mockRejectedValueOnce(new Error('Discord API hiccup')) // chunk 2 fails
+      .mockResolvedValue(undefined as never); // notice succeeds
+
+    await expect(
+      sendChunkedReply({ interaction, content: longContent, header: '', continuedHeader })
+    ).resolves.toBeUndefined();
+
+    // chunk 1 delivered, chunk 2 failed, then the part-way notice — chunk 3 never attempted
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(interaction.followUp).toHaveBeenCalledTimes(2);
+    const notice = vi.mocked(interaction.followUp).mock.calls[1][0] as { content: string };
+    expect(notice.content).toContain('failed to send');
+  });
+
+  it('does not throw when the part-way notice also fails', async () => {
+    const continuedHeader = '(cont)\n';
+    const maxContent = DISCORD_LIMITS.MESSAGE_LENGTH - continuedHeader.length;
+    const longContent = 'x'.repeat(maxContent + 100);
+
+    vi.mocked(interaction.followUp).mockRejectedValue(new Error('Discord API down'));
+
+    await expect(
+      sendChunkedReply({ interaction, content: longContent, header: '', continuedHeader })
+    ).resolves.toBeUndefined();
+  });
+
+  it('still throws when the FIRST chunk fails (nothing was delivered)', async () => {
+    // Callers rely on this: their catch means "nothing reached the user"
+    vi.mocked(interaction.editReply).mockRejectedValue(new Error('ack lost'));
+
+    await expect(
+      sendChunkedReply({ interaction, content: 'short', header: '', continuedHeader: 'c\n' })
+    ).rejects.toThrow('ack lost');
+  });
+
+  it('still throws when the first chunk fails in followUp mode', async () => {
+    vi.mocked(interaction.followUp).mockRejectedValue(new Error('Discord API down'));
+
+    await expect(
+      sendChunkedReply({
+        interaction,
+        content: 'short report',
+        header: '',
+        continuedHeader: 'c\n',
+        via: 'followUp',
+      })
+    ).rejects.toThrow('Discord API down');
   });
 
   it('should use longer header for calculating max content length', async () => {
@@ -117,7 +230,10 @@ describe('sendChunkedReply', () => {
       continuedHeader,
     });
 
-    expect(interaction.editReply).toHaveBeenCalledWith(`${header}${fittingContent}`);
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: `${header}${fittingContent}`,
+      components: [],
+    });
     expect(interaction.followUp).not.toHaveBeenCalled();
   });
 });

--- a/services/bot-client/src/utils/chunkedReply.ts
+++ b/services/bot-client/src/utils/chunkedReply.ts
@@ -3,17 +3,42 @@
  *
  * Splits long content into Discord-safe chunks with headers,
  * sending the first as an editReply and the rest as follow-ups.
+ *
+ * Delivery contract: throws only if the FIRST chunk fails (nothing was
+ * delivered). Once the first chunk is out, a later-chunk failure is handled
+ * internally — log + best-effort notice — and does NOT throw, because the
+ * caller's error handler would replace or mislabel content the user already
+ * received (an editReply'd "error" banner clobbering a delivered view).
  */
 
-import { MessageFlags, type ButtonInteraction } from 'discord.js';
+import {
+  MessageFlags,
+  type ActionRowBuilder,
+  type ButtonInteraction,
+  type MessageActionRowComponentBuilder,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
 import { DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
 import { splitMessage } from '@tzurot/common-types/utils/discord';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import type { DeferredCommandContext } from './commandContext/types.js';
+
+const logger = createLogger('chunkedReply');
 
 export interface ChunkedReplyOptions {
-  interaction: ButtonInteraction;
+  /** Any already-acked reply surface: a component interaction (button or
+   * select menu) or a deferred slash-command context. */
+  interaction: ButtonInteraction | StringSelectMenuInteraction | DeferredCommandContext;
   content: string;
   header: string;
   continuedHeader: string;
+  /** Component rows attached to the FIRST chunk only (follow-ups are plain). */
+  components?: ActionRowBuilder<MessageActionRowComponentBuilder>[];
+  /** Where the FIRST chunk goes. 'editReply' (default) edits the deferred
+   * reply; 'followUp' leaves the deferred reply untouched — for callers whose
+   * deferred reply already carries a summary (e.g. an embed) and want the
+   * chunked text appended below it as separate messages. */
+  via?: 'editReply' | 'followUp';
 }
 
 /**
@@ -24,14 +49,29 @@ export interface ChunkedReplyOptions {
  * and sends the first chunk as editReply, the rest as follow-ups.
  */
 export async function sendChunkedReply(options: ChunkedReplyOptions): Promise<void> {
-  const { interaction, content, header, continuedHeader } = options;
+  const { interaction, content, header, continuedHeader, components, via = 'editReply' } = options;
+
+  const sendFirst = async (
+    firstContent: string,
+    rows: ActionRowBuilder<MessageActionRowComponentBuilder>[]
+  ): Promise<void> => {
+    if (via === 'followUp') {
+      await interaction.followUp({
+        content: firstContent,
+        components: rows,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    await interaction.editReply({ content: firstContent, components: rows });
+  };
 
   // Use the longer header length to ensure all chunks fit
   const maxHeaderLength = Math.max(header.length, continuedHeader.length);
   const maxContentLength = DISCORD_LIMITS.MESSAGE_LENGTH - maxHeaderLength;
 
   if (content.length <= maxContentLength) {
-    await interaction.editReply(`${header}${content}`);
+    await sendFirst(`${header}${content}`, components ?? []);
     return;
   }
 
@@ -44,14 +84,32 @@ export async function sendChunkedReply(options: ChunkedReplyOptions): Promise<vo
     return chunkHeader + chunk;
   });
 
-  // Send first chunk as reply
-  await interaction.editReply(messages[0]);
+  // Send first chunk (components ride the first chunk only)
+  await sendFirst(messages[0], components ?? []);
 
-  // Send remaining chunks as follow-ups
+  // Send remaining chunks as follow-ups — per the delivery contract above,
+  // failures past this point stay inside this function.
   for (let i = 1; i < messages.length; i++) {
-    await interaction.followUp({
-      content: messages[i],
-      flags: MessageFlags.Ephemeral,
-    });
+    try {
+      await interaction.followUp({
+        content: messages[i],
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      logger.warn(
+        { err: error, deliveredChunks: i, totalChunks: messages.length },
+        'Chunked reply delivery failed part-way'
+      );
+      await interaction
+        .followUp({
+          content: '⚠️ Remaining content failed to send — try the view again.',
+          flags: MessageFlags.Ephemeral,
+        })
+        .catch((noticeError: unknown) => {
+          // Two consecutive follow-up failures: the warn above is the terminal path
+          logger.debug({ err: noticeError }, 'Part-way delivery notice also failed');
+        });
+      return;
+    }
   }
 }

--- a/services/bot-client/src/utils/fenceEscape.test.ts
+++ b/services/bot-client/src/utils/fenceEscape.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { escapeFenceBreaks } from './fenceEscape.js';
+
+describe('escapeFenceBreaks', () => {
+  it('breaks a triple-backtick run so it cannot close a fence', () => {
+    const result = escapeFenceBreaks('pasted ```js const x = 1``` code');
+    expect(result).not.toContain('```');
+    // Visible backticks survive (zero-width separators only)
+    expect(result.replace(/\u200b/g, '')).toBe('pasted ```js const x = 1``` code');
+  });
+
+  it('breaks longer backtick runs too', () => {
+    expect(escapeFenceBreaks('````')).not.toContain('```');
+  });
+
+  it('leaves inline code (single/double backticks) untouched', () => {
+    expect(escapeFenceBreaks('has `inline` and ``double`` code')).toBe(
+      'has `inline` and ``double`` code'
+    );
+  });
+
+  it('passes through text without backticks unchanged', () => {
+    expect(escapeFenceBreaks('plain preview text')).toBe('plain preview text');
+  });
+});

--- a/services/bot-client/src/utils/fenceEscape.ts
+++ b/services/bot-client/src/utils/fenceEscape.ts
@@ -1,0 +1,14 @@
+/**
+ * Neutralize embedded triple-backticks in text interpolated into a code
+ * fence. Discord closes a fence at ANY ``` occurrence — not just line start
+ * like GitHub markdown — so untrusted content (memory previews, pipeline
+ * step reasons) could otherwise terminate the fence early and spill the
+ * rest of a fixed-width table into loose markdown. It also protects
+ * splitMessage's code-block detection from mis-pairing fences.
+ *
+ * A zero-width space between the backticks keeps the visible text intact
+ * (backslash escapes would render literally inside a fence).
+ */
+export function escapeFenceBreaks(text: string): string {
+  return text.replace(/`{3,}/g, run => run.split('').join('\u200b'));
+}


### PR DESCRIPTION
## What

Release-gating /inspect UX fix (owner: "I'm ready for the release except for one thing that is still annoying me - the /inspect UX"), plus the follow-on db-sync report ask.

**Owner-scoped decisions this implements:**
- Readable text never ships as a `.md`/`.txt` file download — reuse the character-view chunking mechanism (`sendChunkedReply`). Files stay for structured data only (Full/Compact JSON, System Prompt XML — unchanged).
- Token Budget becomes a text view and gets redesigned (STT/TTS un-buried).
- Copy-message-ID invocation untouched (owner: best option on mobile).
- db-sync report: "should be expandable too using the same chunking approach. it's not valuable enough to be its own separate exported file."

## Changes

**/inspect views** (`views.ts`, `extendedViews.ts`, `index.ts`, `types.ts`, `components.ts`):
- `DebugViewResult` gains `chunkedText` + `embeds`; new shared `renderViewResult()` dispatches chunked text through `sendChunkedReply` (components ride the first chunk) and everything else through one `editReply` — wired into both select-menu and button paths.
- **Reasoning** + **Pipeline Health**: always inline, chunked across ephemeral follow-ups when long.
- **Memory Inspector**: single in-place message (its filter buttons re-edit it, so it must never spill into follow-ups) — fixed-width code-fenced table (Discord renders no pipe-tables; fence keeps columns aligned on mobile), 60-char previews, tail-trim with a "lower Top-N" notice when over one message.
- **Token Budget**: embed with a code-block bar chart (System/Memory/History/Free), warning color + note when history >70%, cross-channel/dropped notes preserved. TTS lines removed —
- **NEW Voice Attribution view**: TTS provider used (incl. the `(via fallback)` silent-fallback annotation) + voice transcript, formerly buried in Token Budget. STT attribution isn't in the payload yet — stays tracked in the voice-inspect-ux-polish theme.

**db-sync** (`db-sync.ts`): summary embed keeps the deferred reply; the full untruncated report flows below as chunked ephemeral follow-ups. Stats section converted from markdown pipe-table to fixed-width code fence.

**chunkedReply.ts**: accepts select-menu interactions and `DeferredCommandContext`; optional `components` on the first chunk; new `via: 'followUp'` mode for callers whose deferred reply already carries a summary embed.

## Verified

- Full unit tier, component tier, and `pnpm quality` all green locally, run sequentially from root.
- 42 tests migrated to pin the new intentional shapes (assertion intent preserved: redaction, fallback annotation, cross-channel disclosure, strict `=== true` pins all carried over); new coverage for the trim path, `via: 'followUp'` (single+multi chunk), the chunked dispatch seam in `index.ts`, and the new Voice Attribution view (owner + non-owner).
- One consumer pin outside /inspect (`persona/view.test.ts`) updated for the editReply object-form change; swept all `sendChunkedReply` consumers for the same class (character/view.ts asserts shape-agnostically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)