### PR TITLE
fix(ai-worker): treat the z.ai piggyback model as conditionally free for guests

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/guestModeOverrides.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/guestModeOverrides.test.ts
@@ -76,6 +76,102 @@ describe('applyGuestModeOverrides', () => {
     expect(result.personality.visionModel).toBeUndefined();
   });
 
+  describe('z.ai piggyback as the guest PERSONAL selection (conditionally free)', () => {
+    const PERSONAL_ZAI = { ...PAID_PERSONALITY, model: 'z-ai/glm-4.5-air' };
+
+    it('admitted: upgrades WITHOUT consulting the global free default', async () => {
+      const gate = admission(true);
+      const resolver = resolverWith('gemma/other-model:free');
+      const result = await applyGuestModeOverrides(
+        { configResolver: resolver, zaiFreeTierAdmission: gate },
+        PERSONAL_ZAI,
+        'u1',
+        'r1'
+      );
+
+      expect(result.personality.model).toBe(ZAI_FREE_TIER_MODEL);
+      expect(result.personality.provider).toBe(AIProvider.ZaiCoding);
+      expect(result.zaiSystemKey).toBe('sk-plan');
+      // The personal selection drives the chain — the global default is never fetched
+      expect(vi.mocked(resolver.getFreeDefaultConfig)).not.toHaveBeenCalled();
+    });
+
+    it('denied: the model leaves the pool and the cascade continues to the global free default', async () => {
+      const result = await applyGuestModeOverrides(
+        {
+          configResolver: resolverWith('gemma/other-model:free'),
+          zaiFreeTierAdmission: admission(false),
+        },
+        PERSONAL_ZAI,
+        'u1',
+        'r1'
+      );
+
+      expect(result.personality.model).toBe('gemma/other-model:free');
+      expect(result.zaiSystemKey).toBeUndefined();
+    });
+
+    it('denied with the global default ALSO the piggyback model: router, admission evaluated ONCE', async () => {
+      // A denied verdict removes the model for the whole request — no second
+      // admit() call (admission consumes quota when it admits).
+      const gate = admission(false);
+      const result = await applyGuestModeOverrides(
+        { configResolver: resolverWith('z-ai/glm-4.5-air'), zaiFreeTierAdmission: gate },
+        PERSONAL_ZAI,
+        'u1',
+        'r1'
+      );
+
+      expect(result.personality.model).toBe(GUEST_MODE.DEFAULT_MODEL);
+      expect(vi.mocked(gate.admit)).toHaveBeenCalledTimes(1);
+    });
+
+    it('denied with no usable global default: last-resort router', async () => {
+      const result = await applyGuestModeOverrides(
+        { configResolver: resolverWith(null), zaiFreeTierAdmission: admission(false) },
+        PERSONAL_ZAI,
+        'u1',
+        'r1'
+      );
+
+      expect(result.personality.model).toBe(GUEST_MODE.DEFAULT_MODEL);
+    });
+
+    it('no admission gate wired (ships dark): falls through the ladder to the router', async () => {
+      const result = await applyGuestModeOverrides({}, PERSONAL_ZAI, 'u1', 'r1');
+
+      expect(result.personality.model).toBe(GUEST_MODE.DEFAULT_MODEL);
+    });
+
+    it('admitted but key vanished (race with config): leaves the pool like any non-admit outcome', async () => {
+      const gate = {
+        admit: vi.fn().mockResolvedValue({ admitted: true, reason: 'ok' }),
+        systemKey: vi.fn().mockReturnValue(undefined),
+      } as unknown as ZaiFreeTierAdmission;
+      const result = await applyGuestModeOverrides(
+        { configResolver: resolverWith('gemma/other-model:free'), zaiFreeTierAdmission: gate },
+        PERSONAL_ZAI,
+        'u1',
+        'r1'
+      );
+
+      // Fall-through continues the cascade to the global free default
+      expect(result.personality.model).toBe('gemma/other-model:free');
+      expect(result.zaiSystemKey).toBeUndefined();
+    });
+
+    it('clears a non-free vision model on the fall-through override', async () => {
+      const result = await applyGuestModeOverrides(
+        { zaiFreeTierAdmission: admission(false) },
+        PERSONAL_ZAI,
+        'u1',
+        'r1'
+      );
+
+      expect(result.personality.visionModel).toBeUndefined();
+    });
+  });
+
   describe('z.ai piggyback (free default = z-ai/glm-4.5-air)', () => {
     it('admitted: upgrades to the BARE model on zai-coding with the plan key', async () => {
       const gate = admission(true);

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/guestModeOverrides.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/guestModeOverrides.ts
@@ -2,13 +2,15 @@
  * Guest-mode model overrides — extracted from AuthStep.
  *
  * A guest (no BYOK key) never runs a non-free model on the system OpenRouter
- * key. The admin free-default preset may be the z.ai piggyback model
- * (`z-ai/glm-4.5-air` — deliberately selectable, NOT free on OpenRouter):
- * per-request admission decides whether the guest rides it on the system
- * coding-plan key, and every denial degrades SILENTLY to the
- * FREE_ROUTER_MODEL dynamic router. A misconfigured paid free-default gets
- * the same router substitution — the paid-model-on-system-key class is
- * unrepresentable through this path.
+ * key. The z.ai piggyback model (`z-ai/glm-4.5-air` — NOT free on OpenRouter)
+ * is CONDITIONALLY free (owner semantics): while per-request admission holds
+ * (flag + key + kill switch + plan headroom + quota), it behaves like any
+ * free model at every resolution step — personal selection or global
+ * free-default. When admission fails, the model leaves the pool for the
+ * whole request and resolution continues down the normal guest ladder:
+ * personal selection → global free-default → FREE_ROUTER_MODEL last resort.
+ * A misconfigured paid free-default gets the same router substitution — the
+ * paid-model-on-system-key class is unrepresentable through this path.
  */
 
 import {
@@ -63,29 +65,38 @@ export async function applyGuestModeOverrides(
     return { personality };
   }
 
-  // Override to guest default
-  let guestModel: string = GUEST_MODE.DEFAULT_MODEL;
+  // Once admission denies, the piggyback model is out of the pool for the
+  // REST of this request's resolution — and admit() must not run twice
+  // (admission consumes the guest's quota share when it admits).
+  let zaiUnavailable = false;
 
-  // Try to get free default from database
-  if (deps.configResolver) {
-    try {
-      const freeConfig = await deps.configResolver.getFreeDefaultConfig();
-      if (freeConfig !== null) {
-        guestModel = freeConfig.model;
-        logger.debug({ model: guestModel }, 'Using database free default config');
-      }
-    } catch (error) {
-      logger.warn({ err: error }, 'Failed to get free default config, using hardcoded fallback');
-    }
-  }
-
-  // Guests never run a non-free model on the system OpenRouter key. The
-  // piggyback model upgrades to z.ai when admitted; everything else (or a
-  // denial) lands on the dynamic free router.
-  if (isZaiFreeTierModel(guestModel)) {
+  // A personally-selected piggyback model is conditionally free: admitted →
+  // serve it; denied → it leaves the pool and resolution falls through to
+  // the global free-default like any other unavailable model.
+  if (isZaiFreeTierModel(currentModel)) {
     const upgrade = await tryZaiFreeTierUpgrade(deps, personality, userId, requestId);
     if (upgrade !== null) {
       return upgrade;
+    }
+    zaiUnavailable = true;
+    logger.info(
+      { userId, originalModel: currentModel },
+      'Guest-selected piggyback model unavailable — continuing down the free-model ladder'
+    );
+  }
+
+  // Next ladder step: the global free default
+  let guestModel = await fetchFreeDefaultModel(deps.configResolver);
+
+  // Guests never run a non-free model on the system OpenRouter key. The
+  // piggyback model upgrades to z.ai when admitted; a denial (or an earlier
+  // denial this request) removes it from the pool → last-resort router.
+  if (isZaiFreeTierModel(guestModel)) {
+    if (!zaiUnavailable) {
+      const upgrade = await tryZaiFreeTierUpgrade(deps, personality, userId, requestId);
+      if (upgrade !== null) {
+        return upgrade;
+      }
     }
     guestModel = GUEST_MODE.DEFAULT_MODEL;
   } else if (!isFreeModel(guestModel)) {
@@ -114,10 +125,30 @@ export async function applyGuestModeOverrides(
   };
 }
 
+/** The global free-default ladder step; the hardcoded router when the
+ * resolver is absent, `getFreeDefaultConfig()` resolves to null, or the
+ * lookup errors. */
+async function fetchFreeDefaultModel(configResolver?: LlmConfigResolver): Promise<string> {
+  if (!configResolver) {
+    return GUEST_MODE.DEFAULT_MODEL;
+  }
+  try {
+    const freeConfig = await configResolver.getFreeDefaultConfig();
+    if (freeConfig !== null) {
+      logger.debug({ model: freeConfig.model }, 'Using database free default config');
+      return freeConfig.model;
+    }
+  } catch (error) {
+    logger.warn({ err: error }, 'Failed to get free default config, using hardcoded fallback');
+  }
+  return GUEST_MODE.DEFAULT_MODEL;
+}
+
 /**
  * The z.ai free-tier upgrade: admitted guests get the bare piggyback model on
  * the coding-plan key with `provider: zai-coding` so ModelFactory routes
- * z.ai-direct. Null (degrade to the router) on any denial.
+ * z.ai-direct. Null on any denial — the model leaves the pool and the caller
+ * continues down the free-model ladder.
  */
 async function tryZaiFreeTierUpgrade(
   deps: GuestOverrideDeps,
@@ -130,9 +161,11 @@ async function tryZaiFreeTierUpgrade(
   }
   const verdict = await deps.zaiFreeTierAdmission.admit(userId, requestId);
   if (!verdict.admitted) {
+    // Destination is the caller's to log — a personal-selection denial
+    // cascades to the global free-default, not straight to the router.
     logger.info(
       { userId, reason: verdict.reason },
-      'z.ai free-tier denied — guest degrades to the free router'
+      'z.ai free-tier denied — piggyback model leaves the pool for this request'
     );
     return null;
   }


### PR DESCRIPTION
## What

Owner semantics (2026-07-11, refined mid-review): GLM-4.5-Air is **conditionally free**. While per-request admission holds (flag + key + kill switch + plan headroom + quota), it behaves like any free model at every guest resolution step. When admission fails, the model **leaves the pool for the whole request** and resolution continues down the normal guest ladder — it never short-circuits to the last resort:

1. Personal selection (cascade tiers 4/5) — if it's the piggyback model: admitted → serve on the coding plan; denied → step 2
2. Global free-default — free model → use it; piggyback model → admission (skipped if already denied this request); denied/misconfigured/missing → step 3
3. Hardcoded `openrouter/free` router (last resort)

## Invariants held

- **One admission evaluation per request** — a denied verdict removes the model at every later step; `admit()` is never called twice (it consumes the guest's quota share when it admits). Pinned by test: personal-piggyback + global-piggyback + denial → router with `admit` called exactly once.
- **Paid world untouched** — `applyGuestModeOverrides` runs only under `route.isGuestMode` (AuthStep.ts:442; verified). BYOK users' GLM-4.5-Air remains a normal paid OpenRouter model on their own key, with the existing zai-coding keyless-fall-through and runtime quota-fallback behavior unchanged.
- **Paid-model-on-system-key stays unrepresentable** — the admitted output shape is identical to the shipped global-path upgrade; all downstream handling (pool accounting, 429 classification, footer) is the same code.

## Verification

- 14/14 on the file: admitted-without-consulting-global-default, denied→cascade-continues-to-global-default, denied-with-piggyback-global-default→router+single-admission, denied-with-no-default→router, ships-dark→router, paid-vision clear on fall-through.
- Full `pnpm test` + `pnpm quality` sequential from root, green. (`fetchFreeDefaultModel` extracted to stay under the cognitive-complexity cap.)

## Release note

Rides v3.0.0-beta.158 — owner is holding release PR #1589 for this. Feature remains dark behind `ZAI_FREE_TIER_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)