### PR TITLE
fix(ai-worker): surface fact tokens in the /inspect token budget

### DIFF
--- a/packages/common-types/src/types/diagnostic.ts
+++ b/packages/common-types/src/types/diagnostic.ts
@@ -149,6 +149,18 @@ export interface DiagnosticTokenBudget {
   historyTokensUsed: number;
   /** Number of memories dropped due to budget */
   memoriesDropped: number;
+  /**
+   * Tokens consumed by the `<facts>` block (wrapper + statements). Facts take
+   * a reserved slice of the memory budget FIRST (episodes get the remainder)
+   * and render INSIDE the system prompt — so `systemPromptTokens` includes
+   * this number; the UI subtracts it out to attribute facts their own line.
+   * `undefined` on logs written before fact accounting existed.
+   */
+  factTokensUsed?: number;
+  /** Facts included in the prompt. `undefined` on pre-fact-accounting logs. */
+  factsIncluded?: number;
+  /** Facts retrieved but dropped for budget. `undefined` on pre-fact-accounting logs. */
+  factsDropped?: number;
   /** Number of history messages dropped due to budget */
   historyMessagesDropped: number;
   /**

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -93,10 +93,49 @@ vi.mock('./multimodal/visionAuthResolver.js', () => ({
 // Fact-retrieval gate mocked so the wiring (personaId in, facts out) is
 // assertable without the flag/embedding/DB path. Default: no facts (existing
 // tests see facts: []).
-vi.mock('./factRetrievalHelper.js', () => ({
-  retrieveFactsForPrompt: vi.fn().mockResolvedValue([]),
-  createFactRetriever: vi.fn().mockReturnValue(undefined),
-}));
+vi.mock('./factRetrievalHelper.js', () => {
+  const retrieveFactsForPrompt = vi.fn().mockResolvedValue([]);
+  return {
+    retrieveFactsForPrompt,
+    createFactRetriever: vi.fn().mockReturnValue(undefined),
+    // Delegating mock: preserves this suite's two seam assertions (the
+    // MemoryRetriever call args and the fact-gate call args) across the
+    // Step-3 extraction. The REAL retrieveMemoriesAndFacts wiring is
+    // covered directly in factRetrievalHelper.test.ts.
+    retrieveMemoriesAndFacts: vi.fn(
+      async (opts: {
+        memoryRetriever: {
+          retrieveRelevantMemories: (
+            p: unknown,
+            q: string,
+            c: unknown,
+            o: unknown
+          ) => Promise<{ memories: unknown[]; focusModeEnabled: boolean; personaId?: string }>;
+        };
+        factRetriever: unknown;
+        personality: { id: string };
+        searchQuery: string;
+        context: unknown;
+        configOverrides?: { shareLtmAcrossPersonalities?: boolean };
+      }) => {
+        const retrieval = await opts.memoryRetriever.retrieveRelevantMemories(
+          opts.personality,
+          opts.searchQuery,
+          opts.context,
+          opts.configOverrides
+        );
+        const facts = await retrieveFactsForPrompt(
+          opts.factRetriever,
+          opts.personality.id,
+          retrieval.personaId,
+          opts.searchQuery,
+          opts.configOverrides?.shareLtmAcrossPersonalities ?? false
+        );
+        return { ...retrieval, facts };
+      }
+    ),
+  };
+});
 
 // Import mock accessors and fixtures (after vi.mock declarations)
 import {

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -24,7 +24,7 @@ import { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
 import { LLMInvoker } from './LLMInvoker.js';
 import { MemoryRetriever } from './MemoryRetriever.js';
 import type { FactRetriever } from './FactRetriever.js';
-import { retrieveFactsForPrompt, createFactRetriever } from './factRetrievalHelper.js';
+import { retrieveMemoriesAndFacts, createFactRetriever } from './factRetrievalHelper.js';
 import { PromptBuilder } from './PromptBuilder.js';
 import { LongTermMemoryService } from './LongTermMemoryService.js';
 import type { ExtractionTrigger } from './extraction/ExtractionTrigger.js';
@@ -381,35 +381,20 @@ export class ConversationalRAGService {
         context
       );
 
-      // Step 3: Retrieve relevant memories
-      const qPreview = inputs.searchQuery.substring(0, TEXT_LIMITS.LOG_PREVIEW);
-      const qTruncated = inputs.searchQuery.length > TEXT_LIMITS.LOG_PREVIEW;
-      logger.info({ queryPreview: qPreview, truncated: qTruncated }, 'Memory search query');
-      diagnosticCollector?.markMemoryRetrievalStart();
+      // Step 3: Retrieve memories + facts (gate/scope semantics live on the helper)
       const {
         memories: retrievedMemories,
         focusModeEnabled,
-        personaId,
-      } = await this.memoryRetriever.retrieveRelevantMemories(
+        facts,
+      } = await retrieveMemoriesAndFacts({
+        memoryRetriever: this.memoryRetriever,
+        factRetriever: this.factRetriever,
         personality,
-        inputs.searchQuery,
+        searchQuery: inputs.searchQuery,
         context,
-        configOverrides
-      );
-
-      // Retrieve distilled facts for the same scope (Phase 2 slice 4a). Inherits
-      // the retriever's skip decisions: `personaId` is undefined when LTM was
-      // skipped (incognito/focus/no-persona), so facts are skipped too.
-      // `shareLtmAcrossPersonalities` widens facts EXACTLY like episode
-      // retrieval (owner call: one flag, both channels — a character that can
-      // recall another character's episodes must know its facts too).
-      const facts = await retrieveFactsForPrompt(
-        this.factRetriever,
-        personality.id,
-        personaId,
-        inputs.searchQuery,
-        configOverrides?.shareLtmAcrossPersonalities ?? false
-      );
+        configOverrides,
+        diagnosticCollector,
+      });
 
       // Step 4: Allocate token budgets and select content
       // Note: Image descriptions and stored reference hydration are handled by
@@ -439,6 +424,7 @@ export class ConversationalRAGService {
           retrievedMemories,
           focusModeEnabled,
           budgetResult,
+          retrievedFactsCount: facts.length,
           contextWindowSize: effectiveContextWindowTokens,
           countTokens: text => this.promptBuilder.countTokens(text),
         });

--- a/services/ai-worker/src/services/DiagnosticCollector.ts
+++ b/services/ai-worker/src/services/DiagnosticCollector.ts
@@ -194,6 +194,9 @@ export class DiagnosticCollector {
       historyTokensUsed: data.historyTokensUsed,
       memoriesDropped: data.memoriesDropped,
       historyMessagesDropped: data.historyMessagesDropped,
+      ...(data.factTokensUsed !== undefined && { factTokensUsed: data.factTokensUsed }),
+      ...(data.factsIncluded !== undefined && { factsIncluded: data.factsIncluded }),
+      ...(data.factsDropped !== undefined && { factsDropped: data.factsDropped }),
       ...(data.crossChannelMessagesIncluded !== undefined && {
         crossChannelMessagesIncluded: data.crossChannelMessagesIncluded,
       }),

--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -27,7 +27,7 @@ const logger = createLogger('MemoryRetriever');
 /**
  * Result of memory retrieval including metadata
  */
-interface MemoryRetrievalResult {
+export interface MemoryRetrievalResult {
   memories: MemoryDocument[];
   focusModeEnabled: boolean;
   /**

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
@@ -176,6 +176,7 @@ describe('DiagnosticRecorders', () => {
         retrievedMemories: memories,
         focusModeEnabled: true,
         budgetResult,
+        retrievedFactsCount: 0,
         contextWindowSize: 24576,
         countTokens: text => text.length,
       });
@@ -192,8 +193,51 @@ describe('DiagnosticRecorders', () => {
         historyTokensUsed: 200,
         memoriesDropped: 1,
         historyMessagesDropped: 2,
+        factTokensUsed: 0,
+        factsIncluded: 0,
+        factsDropped: 0,
         crossChannelMessagesIncluded: 3,
       });
+    });
+
+    it('forwards fact accounting across the collector seam', () => {
+      // The exact seam that dropped fact tokens before: budgetResult carried
+      // factTokensUsed but the recorder never passed it to the collector, so
+      // /inspect's token budget silently absorbed facts into "System".
+      const mockCollector = {
+        recordMemoryRetrieval: vi.fn(),
+        recordTokenBudget: vi.fn(),
+      } as unknown as DiagnosticCollector;
+      const budgetResult: BudgetAllocationResult = {
+        relevantMemories: [],
+        selectedFacts: [{ statement: 'fact a' }, { statement: 'fact b' }],
+        serializedHistory: '',
+        systemPrompt: new SystemMessage('sys'),
+        memoryTokensUsed: 10,
+        factTokensUsed: 42,
+        historyTokensUsed: 20,
+        memoriesDroppedCount: 0,
+        messagesDropped: 0,
+        contentForStorage: '',
+      };
+
+      recordBudgetDiagnostics({
+        collector: mockCollector,
+        retrievedMemories: [],
+        focusModeEnabled: false,
+        budgetResult,
+        retrievedFactsCount: 5,
+        contextWindowSize: 24576,
+        countTokens: () => 0,
+      });
+
+      expect(mockCollector.recordTokenBudget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          factTokensUsed: 42,
+          factsIncluded: 2,
+          factsDropped: 3,
+        })
+      );
     });
   });
 

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
@@ -143,6 +143,8 @@ interface BudgetDiagnosticOptions {
   retrievedMemories: MemoryDocument[];
   focusModeEnabled: boolean;
   budgetResult: BudgetAllocationResult;
+  /** How many facts retrieval produced BEFORE the budget's fact slice applied */
+  retrievedFactsCount: number;
   /** The effective (model-clamped) context window the budget ran against */
   contextWindowSize: number;
   countTokens: (text: string) => number;
@@ -162,6 +164,9 @@ export function recordBudgetDiagnostics(opts: BudgetDiagnosticOptions): void {
     memoryTokensUsed: budgetResult.memoryTokensUsed,
     historyTokensUsed: budgetResult.historyTokensUsed,
     memoriesDropped: budgetResult.memoriesDroppedCount,
+    factTokensUsed: budgetResult.factTokensUsed,
+    factsIncluded: budgetResult.selectedFacts.length,
+    factsDropped: Math.max(0, opts.retrievedFactsCount - budgetResult.selectedFacts.length),
     historyMessagesDropped: budgetResult.messagesDropped,
     crossChannelMessagesIncluded: budgetResult.crossChannelMessagesIncluded,
   });

--- a/services/ai-worker/src/services/diagnostics/DiagnosticTypes.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticTypes.ts
@@ -58,6 +58,9 @@ export interface TokenBudgetData {
   memoryTokensUsed: number;
   historyTokensUsed: number;
   memoriesDropped: number;
+  factTokensUsed?: number;
+  factsIncluded?: number;
+  factsDropped?: number;
   historyMessagesDropped: number;
   /** Optional — undefined when cross-channel was disabled for this turn. */
   crossChannelMessagesIncluded?: number;

--- a/services/ai-worker/src/services/factRetrievalHelper.test.ts
+++ b/services/ai-worker/src/services/factRetrievalHelper.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getConfig } from '@tzurot/common-types/config/config';
+import type { MemoryRetriever } from './MemoryRetriever.js';
+import type { DiagnosticCollector } from './DiagnosticCollector.js';
+import { retrieveMemoriesAndFacts } from './factRetrievalHelper.js';
 import { retrieveFactsForPrompt } from './factRetrievalHelper.js';
 import type { FactRetriever } from './FactRetriever.js';
 import type { SimilarFact } from './extraction/FactStore.js';
@@ -63,5 +66,73 @@ describe('retrieveFactsForPrompt (flag/scope gate)', () => {
     // null personality = all of the persona's characters, matching
     // MemoryRetriever's widening under the same flag.
     expect(retriever.retrieveFacts).toHaveBeenCalledWith('q', null, 'persona');
+  });
+});
+
+describe('retrieveMemoriesAndFacts (Step-3 wiring)', () => {
+  // Runs the REAL combined function — the RAG service suite mocks it with a
+  // delegating stand-in, so this is where the actual wiring is pinned.
+  it('threads the retriever result personaId into the fact gate and merges facts', async () => {
+    setFlag('true');
+    const memoryRetriever = {
+      retrieveRelevantMemories: vi.fn().mockResolvedValue({
+        memories: [{ pageContent: 'm1', metadata: {} }],
+        focusModeEnabled: true,
+        personaId: 'persona-7',
+      }),
+    } as unknown as MemoryRetriever;
+    const factRetriever = {
+      retrieveFacts: vi.fn().mockResolvedValue([{ statement: 'likes tea' }]),
+    };
+    const diagnosticCollector = {
+      markMemoryRetrievalStart: vi.fn(),
+    } as unknown as DiagnosticCollector;
+
+    const result = await retrieveMemoriesAndFacts({
+      memoryRetriever,
+      factRetriever: factRetriever as never,
+      personality: { id: 'personality-1' } as never,
+      searchQuery: 'tea preferences',
+      context: { userId: 'u1' } as never,
+      configOverrides: { shareLtmAcrossPersonalities: true } as never,
+      diagnosticCollector,
+    });
+
+    expect(diagnosticCollector.markMemoryRetrievalStart).toHaveBeenCalledTimes(1);
+    expect(memoryRetriever.retrieveRelevantMemories).toHaveBeenCalledWith(
+      { id: 'personality-1' },
+      'tea preferences',
+      { userId: 'u1' },
+      { shareLtmAcrossPersonalities: true }
+    );
+    // shared scope → personality filter drops (null), personaId from retrieval
+    expect(factRetriever.retrieveFacts).toHaveBeenCalledWith('tea preferences', null, 'persona-7');
+    expect(result.memories).toHaveLength(1);
+    expect(result.focusModeEnabled).toBe(true);
+    expect(result.facts).toEqual([{ statement: 'likes tea' }]);
+  });
+
+  it('returns empty facts when the retrieval resolved no personaId (LTM skipped)', async () => {
+    setFlag('true');
+    const memoryRetriever = {
+      retrieveRelevantMemories: vi.fn().mockResolvedValue({
+        memories: [],
+        focusModeEnabled: false,
+        // personaId undefined — incognito/focus/no-persona turn
+      }),
+    } as unknown as MemoryRetriever;
+    const factRetriever = { retrieveFacts: vi.fn() };
+
+    const result = await retrieveMemoriesAndFacts({
+      memoryRetriever,
+      factRetriever: factRetriever as never,
+      personality: { id: 'personality-1' } as never,
+      searchQuery: 'q',
+      context: {} as never,
+      configOverrides: undefined,
+    });
+
+    expect(factRetriever.retrieveFacts).not.toHaveBeenCalled();
+    expect(result.facts).toEqual([]);
   });
 });

--- a/services/ai-worker/src/services/factRetrievalHelper.ts
+++ b/services/ai-worker/src/services/factRetrievalHelper.ts
@@ -7,11 +7,14 @@
 
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { getConfig } from '@tzurot/common-types/config/config';
+import { TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { FactRetriever } from './FactRetriever.js';
 import { FactStore } from './extraction/FactStore.js';
 import type { PgvectorMemoryAdapter } from './PgvectorMemoryAdapter.js';
 import type { FactForPrompt } from './ConversationalRAGTypes.js';
+import type { MemoryRetriever, MemoryRetrievalResult } from './MemoryRetriever.js';
+import type { DiagnosticCollector } from './DiagnosticCollector.js';
 
 const logger = createLogger('FactRetrieval');
 
@@ -64,4 +67,47 @@ export async function retrieveFactsForPrompt(
     );
   }
   return facts;
+}
+
+/** Options for {@link retrieveMemoriesAndFacts} — the orchestrator's Step 3. */
+export interface MemoriesAndFactsOptions {
+  memoryRetriever: MemoryRetriever;
+  factRetriever: FactRetriever | undefined;
+  personality: Parameters<MemoryRetriever['retrieveRelevantMemories']>[0];
+  searchQuery: string;
+  context: Parameters<MemoryRetriever['retrieveRelevantMemories']>[2];
+  configOverrides: Parameters<MemoryRetriever['retrieveRelevantMemories']>[3];
+  diagnosticCollector?: DiagnosticCollector;
+}
+
+/**
+ * Retrieve episodic memories and distilled facts for one generation turn —
+ * facts inherit the episode retriever's scope decisions via `personaId`
+ * (see {@link retrieveFactsForPrompt} for the gate semantics).
+ */
+export async function retrieveMemoriesAndFacts(
+  opts: MemoriesAndFactsOptions
+): Promise<MemoryRetrievalResult & { facts: FactForPrompt[] }> {
+  const { searchQuery } = opts;
+  const qPreview = searchQuery.substring(0, TEXT_LIMITS.LOG_PREVIEW);
+  const qTruncated = searchQuery.length > TEXT_LIMITS.LOG_PREVIEW;
+  logger.info({ queryPreview: qPreview, truncated: qTruncated }, 'Memory search query');
+
+  opts.diagnosticCollector?.markMemoryRetrievalStart();
+  const retrieval = await opts.memoryRetriever.retrieveRelevantMemories(
+    opts.personality,
+    searchQuery,
+    opts.context,
+    opts.configOverrides
+  );
+
+  const facts = await retrieveFactsForPrompt(
+    opts.factRetriever,
+    opts.personality.id,
+    retrieval.personaId,
+    searchQuery,
+    opts.configOverrides?.shareLtmAcrossPersonalities ?? false
+  );
+
+  return { ...retrieval, facts };
 }

--- a/services/bot-client/src/commands/inspect/views.test.ts
+++ b/services/bot-client/src/commands/inspect/views.test.ts
@@ -540,6 +540,40 @@ describe('buildTokenBudgetView', () => {
     expect(notesOf(result)).not.toContain('Dropped for budget');
   });
 
+  it('gives facts their own bar, subtracted out of System (no double-count)', () => {
+    const payload = createMockPayload();
+    payload.tokenBudget.factTokensUsed = 1000;
+    payload.tokenBudget.factsIncluded = 4;
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    const desc = result.embeds![0].data.description ?? '';
+    // System renders 4000 - 1000 = 3,000; Facts renders its own 1,000
+    expect(desc).toMatch(/^System.*3,000$/m);
+    expect(desc).toMatch(/^Facts.*1,000$/m);
+    expect(notesOf(result)).toContain('Facts: 4 included in the prompt');
+  });
+
+  it('lists dropped facts alongside the other budget drops', () => {
+    const payload = createMockPayload();
+    payload.tokenBudget.factTokensUsed = 500;
+    payload.tokenBudget.factsIncluded = 2;
+    payload.tokenBudget.factsDropped = 7;
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    expect(notesOf(result)).toContain('7 facts');
+  });
+
+  it('renders the legacy chart (no Facts row) for logs predating fact accounting', () => {
+    const payload = createMockPayload();
+    // factTokensUsed / factsIncluded / factsDropped intentionally undefined
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).not.toMatch(/^Facts/m);
+    expect(desc).toMatch(/^System.*4,000$/m);
+    expect(notesOf(result)).not.toContain('Facts:');
+  });
+
   it('renders the cross-channel line when crossChannelMessagesIncluded is set', () => {
     const payload = createMockPayload();
     payload.tokenBudget.crossChannelMessagesIncluded = 3;

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -377,7 +377,17 @@ export function buildTokenBudgetView(
   const { tokenBudget } = payload;
   const total = tokenBudget.contextWindowSize || 1;
 
-  const systemPct = (tokenBudget.systemPromptTokens / total) * 100;
+  // Facts render INSIDE the system prompt, so systemPromptTokens already
+  // includes them — subtract them out for their own row (older logs predate
+  // fact accounting and render the legacy three-row chart).
+  const factTokens = tokenBudget.factTokensUsed;
+  const systemTokens =
+    factTokens !== undefined
+      ? Math.max(0, tokenBudget.systemPromptTokens - factTokens)
+      : tokenBudget.systemPromptTokens;
+
+  const systemPct = (systemTokens / total) * 100;
+  const factsPct = ((factTokens ?? 0) / total) * 100;
   const memoryPct = (tokenBudget.memoryTokensUsed / total) * 100;
   const historyPct = (tokenBudget.historyTokensUsed / total) * 100;
   const usedTokens =
@@ -391,7 +401,8 @@ export function buildTokenBudgetView(
 
   const chart = [
     '```',
-    row('System', tokenBudget.systemPromptTokens, systemPct),
+    row('System', systemTokens, systemPct),
+    ...(factTokens !== undefined ? [row('Facts', factTokens, factsPct)] : []),
     row('Memory', tokenBudget.memoryTokensUsed, memoryPct),
     row('History', tokenBudget.historyTokensUsed, historyPct),
     row('Free', remaining, remainingPct),
@@ -416,9 +427,15 @@ export function buildTokenBudgetView(
       `Cross-channel: ${tokenBudget.crossChannelMessagesIncluded} msgs included from other channels`
     );
   }
+  if (tokenBudget.factsIncluded !== undefined) {
+    notes.push(`Facts: ${tokenBudget.factsIncluded} included in the prompt`);
+  }
   const dropped: string[] = [];
   if (tokenBudget.memoriesDropped > 0) {
     dropped.push(`${tokenBudget.memoriesDropped} memories`);
+  }
+  if ((tokenBudget.factsDropped ?? 0) > 0) {
+    dropped.push(`${tokenBudget.factsDropped} facts`);
   }
   if (tokenBudget.historyMessagesDropped > 0) {
     dropped.push(`${tokenBudget.historyMessagesDropped} history messages`);


### PR DESCRIPTION
## What

Owner-reported: /inspect's Token Budget showed nothing about facts. Traced the full chain — facts ARE budgeted (`ContentBudgetManager` gives them a reserved slice of the memory budget first; episodes get the remainder) and render inside the system prompt, so their tokens were being counted but silently absorbed into the **System** bar. The seam that dropped them: `recordBudgetDiagnostics` never forwarded `factTokensUsed` off the allocation result, and the payload type had no fact fields.

## Changes

- **Payload** (`DiagnosticTokenBudget`): optional `factTokensUsed` / `factsIncluded` / `factsDropped`, with null-semantics doc comments (undefined = pre-fact-accounting log). The API boundary passes the blob as `z.unknown()`, so no schema-strip risk.
- **Producer**: `recordBudgetDiagnostics` forwards all three (drops computed from the retrieved count, threaded from the caller where `facts` is in scope); `DiagnosticCollector.recordTokenBudget` conditionally spreads them.
- **View**: Facts gets its own bar, subtracted out of System so the sum is unchanged (no double-count); "Facts: N included" note; dropped facts join the drops line. Logs without the fields render the legacy three-row chart (pinned by a back-compat test).
- **Line-cap extraction**: the orchestrator's Step 3 (memories + facts retrieval) moved to `factRetrievalHelper.retrieveMemoriesAndFacts` — the RAG suite uses a delegating mock that preserves its existing seam assertions, and the REAL wiring (personaId threading, shared-scope null filter, LTM-skip fall-through) is pinned directly in the helper's suite.

## Verification

Recorder seam test asserts the three fields cross into the collector (including drops math: 5 retrieved − 2 selected = 3). View tests: Facts bar + System subtraction (`4,000 − 1,000 = 3,000`), drops line, legacy back-compat. Helper wiring tests run the real combined function. Full `pnpm test` + `pnpm quality` green sequentially from root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)