### PR TITLE
feat(bot-client): /inspect views aligned to the design system

### DIFF
--- a/services/bot-client/src/commands/inspect/components.test.ts
+++ b/services/bot-client/src/commands/inspect/components.test.ts
@@ -66,7 +66,7 @@ describe('buildInspectComponents', () => {
     const rows = buildInspectComponents('test-req');
     const selectMenu = rows[1].components[0].toJSON();
     // Compact JSON, System Prompt, Memory Inspector, Token Budget,
-    // Voice Attribution, Pipeline Health, Quick Copy
-    expect('options' in selectMenu && selectMenu.options).toHaveLength(7);
+    // Voice Attribution, Pipeline Health (Quick Copy removed — never used)
+    expect('options' in selectMenu && selectMenu.options).toHaveLength(6);
   });
 });

--- a/services/bot-client/src/commands/inspect/components.ts
+++ b/services/bot-client/src/commands/inspect/components.ts
@@ -99,12 +99,6 @@ export function buildInspectComponents(
         description: 'Per-step post-processing outcomes (checklist)',
         value: DebugViewType.PipelineHealth,
         emoji: '🩺',
-      },
-      {
-        label: 'Quick Copy',
-        description: 'Single-line summary for incident threads',
-        value: DebugViewType.QuickCopy,
-        emoji: '📎',
       }
     );
 

--- a/services/bot-client/src/commands/inspect/embed.test.ts
+++ b/services/bot-client/src/commands/inspect/embed.test.ts
@@ -382,6 +382,53 @@ describe('buildDiagnosticEmbed', () => {
     expect(modelField?.value).not.toContain('Provider:** z-ai');
   });
 
+  it('flags model substitution prominently when served differs from requested', () => {
+    // Silent substitution (guest override, fallback retarget) is a diagnosis
+    // blind spot — the Model field must show BOTH models.
+    const payload = createMockPayload();
+    payload.llmConfig.model = 'z-ai/glm-4.5-air';
+    payload.llmResponse.modelUsed = 'openrouter/free';
+
+    const embed = buildDiagnosticEmbed(payload);
+    const modelField = embed.toJSON().fields?.find(f => f.name.includes('Model'));
+    expect(modelField?.value).toContain('**Requested:** z-ai/glm-4.5-air');
+    expect(modelField?.value).toContain('⚠️ **Served:** openrouter/free');
+  });
+
+  it('flags a same-family DIFFERENT model (bare prefix is not a version stamp)', () => {
+    // A fallback retarget from claude-sonnet-4.5 down to claude-sonnet-4 is a
+    // real quality regression — a bare startsWith would silently miss it.
+    const payload = createMockPayload();
+    payload.llmConfig.model = 'anthropic/claude-sonnet-4.5';
+    payload.llmResponse.modelUsed = 'anthropic/claude-sonnet-4';
+
+    const embed = buildDiagnosticEmbed(payload);
+    const modelField = embed.toJSON().fields?.find(f => f.name.includes('Model'));
+    expect(modelField?.value).toContain('⚠️ **Served:** anthropic/claude-sonnet-4');
+  });
+
+  it('does NOT flag a version-suffixed variant of the same model', () => {
+    const payload = createMockPayload();
+    payload.llmConfig.model = 'claude-3-5-sonnet';
+    payload.llmResponse.modelUsed = 'claude-3-5-sonnet-20241022';
+
+    const embed = buildDiagnosticEmbed(payload);
+    const modelField = embed.toJSON().fields?.find(f => f.name.includes('Model'));
+    expect(modelField?.value).toContain('**Model:** claude-3-5-sonnet');
+    expect(modelField?.value).not.toContain('Served');
+  });
+
+  it('does NOT flag a provider-prefix-stripped serve of the same model (z.ai promotion)', () => {
+    const payload = createMockPayload();
+    payload.llmConfig.model = 'z-ai/glm-4.5-air';
+    payload.llmResponse.modelUsed = 'glm-4.5-air';
+
+    const embed = buildDiagnosticEmbed(payload);
+    const modelField = embed.toJSON().fields?.find(f => f.name.includes('Model'));
+    expect(modelField?.value).toContain('**Model:** z-ai/glm-4.5-air');
+    expect(modelField?.value).not.toContain('Served');
+  });
+
   it('shows finish reason with emoji decoration in Response field', () => {
     const payload = createMockPayload();
     payload.llmResponse.finishReason = 'length';

--- a/services/bot-client/src/commands/inspect/embed.ts
+++ b/services/bot-client/src/commands/inspect/embed.ts
@@ -136,6 +136,28 @@ export function buildReasoningField(
   };
 }
 
+/** Strip the provider prefix and lowercase — the comparable model base. */
+function bareModel(id: string): string {
+  const lower = id.toLowerCase();
+  const slash = lower.indexOf('/');
+  return slash >= 0 ? lower.slice(slash + 1) : lower;
+}
+
+/** Same model modulo provider prefix and a date/version STAMP suffix.
+ * Only `-<digits>` counts as a stamp (`claude-3-5-sonnet-20241022`) — dotted
+ * or named suffixes (`-4.5`, `-turbo`, `-air`, `:free`) are DIFFERENT models
+ * and must flag. A false "Served" line is honest info; a false negative
+ * hides exactly the substitution this field exists to surface. */
+function isSameModel(requested: string, served: string): boolean {
+  const a = bareModel(requested);
+  const b = bareModel(served);
+  if (a === b) {
+    return true;
+  }
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  return longer.startsWith(shorter) && /^-\d+$/.test(longer.slice(shorter.length));
+}
+
 /**
  * Build the Model field. "Family" is the namespace prefix from the model name
  * (e.g. "z-ai" from "z-ai/glm-4.7") — this is NOT the actual upstream OpenRouter
@@ -147,7 +169,17 @@ function buildModelField(
   llmConfig: DiagnosticPayload['llmConfig'],
   llmResponse: DiagnosticPayload['llmResponse']
 ): { name: string; value: string; inline: boolean } {
-  const lines: string[] = [`**Model:** ${llmConfig.model}`, `**Family:** ${llmConfig.provider}`];
+  // Silent model substitution is a diagnosis blind spot — when the model
+  // that actually served differs from the requested one (guest overrides,
+  // fallback retargets), show BOTH prominently. Normalized comparison:
+  // provider prefixes ('z-ai/…' → bare) and version-suffixed variants
+  // ('…-sonnet' served as '…-sonnet-20241022') are the SAME model.
+  const served = llmResponse.modelUsed;
+  const substituted = served.length > 0 && !isSameModel(llmConfig.model, served);
+  const lines: string[] = substituted
+    ? [`**Requested:** ${llmConfig.model}`, `⚠️ **Served:** ${served}`]
+    : [`**Model:** ${llmConfig.model}`];
+  lines.push(`**Family:** ${llmConfig.provider}`);
   const upstreamProvider = llmResponse.reasoningDebug?.upstreamProvider;
   if (upstreamProvider !== undefined) {
     lines.push(`**Upstream:** ${upstreamProvider}`);

--- a/services/bot-client/src/commands/inspect/extendedViews.test.ts
+++ b/services/bot-client/src/commands/inspect/extendedViews.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { DiagnosticPayload, PipelineStep } from '@tzurot/common-types/types/diagnostic';
-import { buildPipelineHealthView, buildQuickCopySummaryView } from './extendedViews.js';
+import { buildPipelineHealthView } from './extendedViews.js';
 import type { ViewContext } from './viewContext.js';
 
 const OWNER_CTX: ViewContext = { canViewCharacter: true };
@@ -81,16 +81,18 @@ describe('buildPipelineHealthView', () => {
 
     const result = buildPipelineHealthView(payload, 'req-1', OWNER_CTX);
     expect(result.files).toBeUndefined();
-    const text = result.chunkedText!.text;
+    const text = result.embeds![0].data.description ?? '';
 
-    expect(text).toContain('# Pipeline Health');
-    // Fixed-width rows in a code fence (Discord renders no pipe-tables);
-    // names pad to the longest ('thinking_extraction', 19 chars)
-    expect(text).toContain('```');
-    expect(text).toContain('duplicate_removal    ✅ success removed 6 chars');
-    expect(text).toContain('thinking_extraction  ⏭️ skipped no reasoning content found');
-    expect(text).toContain('artifact_strip       ❌ error   regex failed');
-    expect(text).toContain('## Context');
+    expect(result.embeds![0].data.title).toBe('🩺 Pipeline Health');
+    // Two lines per step: emoji + name, then the reason as a subtext line
+    expect(text).toContain('✅ `duplicate_removal`');
+    expect(text).toContain('-# removed 6 chars');
+    expect(text).toContain('⏭️ `thinking_extraction`');
+    expect(text).toContain('-# no reasoning content found');
+    expect(text).toContain('❌ `artifact_strip`');
+    expect(text).toContain('-# regex failed');
+    const content = result.embeds![0].data.fields?.find(f => f.name === 'Content');
+    expect(content).toBeDefined();
   });
 
   it('neutralizes embedded triple-backticks in step reasons', () => {
@@ -111,10 +113,11 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(payload, 'req-1', OWNER_CTX);
-    const text = result.chunkedText!.text;
+    const text = result.embeds![0].data.description ?? '';
 
-    // Only the table's own fence pair survives as raw triple-backticks
-    expect(text.match(/```/g)).toHaveLength(2);
+    // No fence wraps the steps anymore — a raw ``` in a reason would OPEN a
+    // block mid-description, so the neutralizer must leave zero raw runs
+    expect(text.match(/```/g)).toBeNull();
     expect(text.replace(/\u200b/g, '')).toContain('choked on ```xml block```');
   });
 
@@ -132,7 +135,7 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(payload, 'req-2', OWNER_CTX);
-    const text = result.chunkedText!.text;
+    const text = result.embeds![0].data.description ?? '';
 
     expect(text).toContain('predates structured pipeline step tracking');
     expect(text).toContain('- ✅ `duplicate_removal`');
@@ -142,7 +145,7 @@ describe('buildPipelineHealthView', () => {
   it('reports "No transforms applied" when both pipelineSteps and transformsApplied are empty', () => {
     const payload = createMockPayload(); // default postProcessing has empty arrays
     const result = buildPipelineHealthView(payload, 'req-3', OWNER_CTX);
-    const text = result.chunkedText!.text;
+    const text = result.embeds![0].data.description ?? '';
     expect(text).toContain('No transforms applied');
   });
 
@@ -160,11 +163,10 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(payload, 'req-4', OWNER_CTX);
-    const text = result.chunkedText!.text;
-
-    expect(text).toContain('**Final content:** 2,048 chars');
-    expect(text).toContain('**Thinking content:** 1,063 chars');
-    expect(text).toContain('**Artifacts stripped:** <reasoning>');
+    const content = result.embeds![0].data.fields?.find(f => f.name === 'Content');
+    expect(content?.value).toContain('**Final:** 2,048 chars');
+    expect(content?.value).toContain('**Thinking:** 1,063 chars');
+    expect(content?.value).toContain('**Artifacts stripped:** <reasoning>');
   });
 
   it('distinguishes empty pipelineSteps (new log, no steps) from missing pipelineSteps (legacy log)', () => {
@@ -181,64 +183,10 @@ describe('buildPipelineHealthView', () => {
     });
 
     const result = buildPipelineHealthView(newLogEmpty, 'req-empty', OWNER_CTX);
-    const text = result.chunkedText!.text;
+    const text = result.embeds![0].data.description ?? '';
 
     expect(text).toContain('No pipeline steps recorded');
     // Should NOT show the legacy-log fallback message — this log is new, just empty
     expect(text).not.toContain('predates structured pipeline step tracking');
-  });
-});
-
-describe('buildQuickCopySummaryView', () => {
-  it('formats a single-line summary with provider, duration, tokens, thinking', () => {
-    const payload = createMockPayload({
-      llmResponse: {
-        rawContent: 'Hi',
-        finishReason: 'stop',
-        promptTokens: 100,
-        completionTokens: 47,
-        modelUsed: 'z-ai/glm-4.7',
-        reasoningDebug: {
-          additionalKwargsKeys: [],
-          hasReasoningInKwargs: true,
-          reasoningKwargsLength: 1063,
-          responseMetadataKeys: [],
-          hasReasoningDetails: false,
-          hasReasoningTagsInContent: false,
-          rawContentPreview: 'Hi',
-          upstreamProvider: 'DekaLLM',
-        },
-      },
-      postProcessing: {
-        transformsApplied: [],
-        duplicateDetected: false,
-        thinkingExtracted: true,
-        thinkingContent: 'a'.repeat(1063),
-        artifactsStripped: [],
-        finalContent: 'Hi',
-      },
-      timing: { totalDurationMs: 9600 },
-    });
-
-    const result = buildQuickCopySummaryView(payload, 'req-5', OWNER_CTX);
-    expect(result.content).toBeDefined();
-    expect(result.content).toContain('**Quick copy:**');
-    expect(result.content).toContain('z-ai/glm-4.7 via DekaLLM');
-    expect(result.content).toContain('9.6s');
-    expect(result.content).toContain('47 tok');
-    expect(result.content).toContain('thinking 1,063 chars');
-  });
-
-  it('omits the upstream-provider segment when reasoningDebug is absent', () => {
-    const payload = createMockPayload();
-    const result = buildQuickCopySummaryView(payload, 'req-6', OWNER_CTX);
-    expect(result.content).toContain('z-ai/glm-4.7 ·');
-    expect(result.content).not.toContain('via');
-  });
-
-  it('omits the thinking segment when thinkingContent is empty', () => {
-    const payload = createMockPayload();
-    const result = buildQuickCopySummaryView(payload, 'req-7', OWNER_CTX);
-    expect(result.content).not.toContain('thinking');
   });
 });

--- a/services/bot-client/src/commands/inspect/extendedViews.ts
+++ b/services/bot-client/src/commands/inspect/extendedViews.ts
@@ -1,6 +1,7 @@
 // Extracted from views.ts to stay under the 400-line ESLint limit.
 
-import { MessageFlags } from 'discord.js';
+import { EmbedBuilder, MessageFlags } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import type { DiagnosticPayload, PipelineStep } from '@tzurot/common-types/types/diagnostic';
 import type { ViewContext } from './viewContext.js';
 import type { DebugViewResult } from './views.js';
@@ -16,18 +17,19 @@ const STATUS_ICON: Record<PipelineStep['status'], string> = {
   error: '❌',
 };
 
-/** Fixed-width rows in a code fence — Discord doesn't render markdown
- * pipe-tables inline (same solve as the memory inspector / db-sync stats). */
+/** Two lines per step (emoji-status + indented reason) — no fixed-width
+ * columns means no fence, so emoji glyph-width can't skew alignment on
+ * mobile and step names never truncate. */
 function renderStepRows(steps: readonly PipelineStep[]): string[] {
-  const nameWidth = Math.max(...steps.map(s => s.name.length));
-  const rows = ['```'];
+  const rows: string[] = [];
   for (const step of steps) {
     const icon = STATUS_ICON[step.status];
-    // Reasons can carry model/content-derived text — fence-escape them
+    // Reasons can carry model/content-derived text — a ``` inside one would
+    // open a code block mid-description; keep the neutralizer.
     const reason = escapeFenceBreaks(step.reason ?? '—');
-    rows.push(`${step.name.padEnd(nameWidth)}  ${icon} ${step.status.padEnd(7)} ${reason}`);
+    rows.push(`${icon} \`${step.name}\``);
+    rows.push(`-# ${reason}`);
   }
-  rows.push('```');
   return rows;
 }
 
@@ -46,21 +48,7 @@ function renderLegacyTransforms(transformsApplied: readonly string[]): string[] 
   return rows;
 }
 
-function renderContextSection(payload: DiagnosticPayload): string[] {
-  const { finalContent, thinkingContent, artifactsStripped } = payload.postProcessing;
-  const thinkingLabel =
-    thinkingContent !== null ? `${thinkingContent.length.toLocaleString()} chars` : '_none_';
-  const artifactsLabel = artifactsStripped.length > 0 ? artifactsStripped.join(', ') : '_none_';
-  return [
-    '',
-    '## Context',
-    `- **Final content:** ${finalContent.length.toLocaleString()} chars`,
-    `- **Thinking content:** ${thinkingLabel}`,
-    `- **Artifacts stripped:** ${artifactsLabel}`,
-  ];
-}
-
-/** Markdown checklist of post-processing pipeline outcomes. */
+/** Post-processing pipeline outcomes as an informational embed. */
 export function buildPipelineHealthView(
   payload: DiagnosticPayload,
   _requestId: string,
@@ -68,7 +56,7 @@ export function buildPipelineHealthView(
   _ctx: ViewContext
 ): DebugViewResult {
   const steps = payload.postProcessing.pipelineSteps;
-  const lines: string[] = ['# Pipeline Health', ''];
+  const lines: string[] = [];
 
   if (steps === undefined) {
     lines.push(...renderLegacyTransforms(payload.postProcessing.transformsApplied));
@@ -78,42 +66,23 @@ export function buildPipelineHealthView(
     lines.push(...renderStepRows(steps));
   }
 
-  lines.push(...renderContextSection(payload));
+  const { finalContent, thinkingContent, artifactsStripped } = payload.postProcessing;
+  const thinkingLabel =
+    thinkingContent !== null ? `${thinkingContent.length.toLocaleString()} chars` : '_none_';
+  const artifactsLabel = artifactsStripped.length > 0 ? artifactsStripped.join(', ') : '_none_';
 
-  return {
-    chunkedText: {
-      text: lines.join('\n'),
-      continuedHeader: '_(pipeline health continued)_\n',
-    },
-    flags: MessageFlags.Ephemeral,
-  };
-}
+  // Informational surface: BLURPLE always (design system). The step list has
+  // a hard practical bound (a handful of pipeline stages), so the 4096
+  // description cap is never in play.
+  const embed = new EmbedBuilder()
+    .setTitle('🩺 Pipeline Health')
+    .setColor(DISCORD_COLORS.BLURPLE)
+    .setDescription(lines.join('\n'))
+    .addFields({
+      name: 'Content',
+      value: `**Final:** ${finalContent.length.toLocaleString()} chars · **Thinking:** ${thinkingLabel}\n**Artifacts stripped:** ${artifactsLabel}`,
+      inline: false,
+    });
 
-// ---------------------------------------------------------------------------
-// Quick-copy summary
-// ---------------------------------------------------------------------------
-
-/** One-line summary like `z-ai/glm-4.7 via DekaLLM · 9.6s · 47 tok · thinking 1063 chars`. */
-export function buildQuickCopySummaryView(
-  payload: DiagnosticPayload,
-  _requestId: string,
-  // intentionally unused — uniform VIEW_BUILDERS signature
-  _ctx: ViewContext
-): DebugViewResult {
-  const { llmConfig, llmResponse, timing, postProcessing } = payload;
-
-  const upstreamProvider = llmResponse.reasoningDebug?.upstreamProvider;
-  const modelLine =
-    upstreamProvider !== undefined ? `${llmConfig.model} via ${upstreamProvider}` : llmConfig.model;
-
-  const durationSec = (timing.totalDurationMs / 1000).toFixed(1);
-  const thinkingLen = postProcessing.thinkingContent?.length ?? 0;
-  const thinkingPart = thinkingLen > 0 ? ` · thinking ${thinkingLen.toLocaleString()} chars` : '';
-
-  const summary = `\`${modelLine} · ${durationSec}s · ${llmResponse.completionTokens} tok${thinkingPart}\``;
-
-  return {
-    content: `**Quick copy:**\n${summary}`,
-    flags: MessageFlags.Ephemeral,
-  };
+  return { embeds: [embed], flags: MessageFlags.Ephemeral };
 }

--- a/services/bot-client/src/commands/inspect/index.ts
+++ b/services/bot-client/src/commands/inspect/index.ts
@@ -48,7 +48,7 @@ import {
   type DebugViewResult,
 } from './views.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
-import { buildPipelineHealthView, buildQuickCopySummaryView } from './extendedViews.js';
+import { buildPipelineHealthView } from './extendedViews.js';
 import { computeViewContext } from './viewContext.js';
 
 const logger = createLogger('inspect');
@@ -92,7 +92,6 @@ const VIEW_BUILDERS = {
   [DebugViewType.TokenBudget]: buildTokenBudgetView,
   [DebugViewType.VoiceAttribution]: buildVoiceAttributionView,
   [DebugViewType.PipelineHealth]: buildPipelineHealthView,
-  [DebugViewType.QuickCopy]: buildQuickCopySummaryView,
 } as const;
 
 /**

--- a/services/bot-client/src/commands/inspect/types.ts
+++ b/services/bot-client/src/commands/inspect/types.ts
@@ -49,5 +49,4 @@ export enum DebugViewType {
   TokenBudget = 'token-budget',
   VoiceAttribution = 'voice-attribution',
   PipelineHealth = 'pipeline-health',
-  QuickCopy = 'quick-copy',
 }

--- a/services/bot-client/src/commands/inspect/views.test.ts
+++ b/services/bot-client/src/commands/inspect/views.test.ts
@@ -224,30 +224,33 @@ describe('buildReasoningView', () => {
 });
 
 describe('buildMemoryInspectorView', () => {
-  it('should return inline content with no file attachment', () => {
+  it('should return an embed with no file attachment', () => {
     const payload = createMockPayload();
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
     expect(result.files).toBeUndefined();
-    expect(result.content).toContain('# Memory Inspector');
+    expect(result.embeds![0].data.title).toBe('🧠 Memory Inspector');
+    expect(result.embeds![0].data.color).toBe(DISCORD_COLORS.BLURPLE);
   });
 
   it('should include search query and focus mode status', () => {
     const payload = createMockPayload();
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.content).toContain('"hello"');
-    expect(result.content).toContain('Disabled');
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).toContain('"hello"');
+    expect(desc).toContain('**Focus:** off');
   });
 
   it('should include memory table with scores and status', () => {
     const payload = createMockPayload();
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.content).toContain('0.95');
-    expect(result.content).toContain('✓ in');
-    expect(result.content).toContain('0.52');
-    expect(result.content).toContain('✗ drop');
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).toContain('0.95');
+    expect(desc).toMatch(/0\.95\s+✓/);
+    expect(desc).toContain('0.52');
+    expect(desc).toMatch(/0\.52\s+✗/);
   });
 
   it('should show message when no memories found', () => {
@@ -255,7 +258,7 @@ describe('buildMemoryInspectorView', () => {
     payload.memoryRetrieval.memoriesFound = [];
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.content).toContain('No memories retrieved');
+    expect(result.embeds![0].data.description ?? '').toContain('No memories retrieved');
   });
 
   it('should collapse whitespace and truncate long previews to the row budget', () => {
@@ -270,12 +273,13 @@ describe('buildMemoryInspectorView', () => {
     ];
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
+    const desc = result.embeds![0].data.description ?? '';
     // Newlines/tabs collapse to single spaces so one memory = one table row
-    expect(result.content).toContain('line one line two');
-    expect(result.content).not.toContain('line one\nline');
-    // 60-char row budget with ellipsis
-    expect(result.content).toContain('…');
-    expect(result.content).not.toContain('y'.repeat(80));
+    expect(desc).toContain('line one line');
+    expect(desc).not.toContain('line one\nline');
+    // 26-char row budget with ellipsis (mobile embed width)
+    expect(desc).toContain('…');
+    expect(desc).not.toContain('y'.repeat(80));
   });
 
   it('neutralizes embedded triple-backticks so previews cannot close the fence', () => {
@@ -287,10 +291,11 @@ describe('buildMemoryInspectorView', () => {
     ];
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
+    const desc = result.embeds![0].data.description ?? '';
     // Only the table's own fence pair survives as raw triple-backticks
-    expect(result.content!.match(/```/g)).toHaveLength(2);
-    // Visible backticks still present (zero-width-separated)
-    expect(result.content!.replace(/\u200b/g, '')).toContain('```js x```');
+    expect(desc.match(/```/g)).toHaveLength(2);
+    // Preview truncates to 26 chars, so only the leading backtick run survives
+    expect(desc.replace(/\u200b/g, '')).toContain('```js x``');
   });
 
   it('should show "none" for null search query', () => {
@@ -298,12 +303,12 @@ describe('buildMemoryInspectorView', () => {
     payload.inputProcessing.searchQuery = null;
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.content).toContain('_none_');
+    expect(result.embeds![0].data.description ?? '').toContain('_none_');
   });
 
   it('trims table rows from the tail when content would exceed one message', () => {
     const payload = createMockPayload();
-    payload.memoryRetrieval.memoriesFound = Array.from({ length: 40 }, (_, i) => ({
+    payload.memoryRetrieval.memoriesFound = Array.from({ length: 150 }, (_, i) => ({
       id: `mem-${i}`,
       score: 0.9,
       preview: `row ${i} ` + 'z'.repeat(50),
@@ -311,13 +316,14 @@ describe('buildMemoryInspectorView', () => {
     }));
     const result = buildMemoryInspectorView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.content!.length).toBeLessThanOrEqual(1900);
-    expect(result.content).toContain('rows trimmed to fit');
-    // The token-budget summary after the closing fence survives the trim —
-    // it matters most in exactly this high-memory-count case
-    expect(result.content).toContain('**Token Budget:** 1000 tokens allocated');
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc.length).toBeLessThanOrEqual(3900);
+    expect(desc).toContain('rows trimmed to fit');
+    // The token-budget summary lives in the Retrieved field — immune to the trim
+    const retrieved = result.embeds![0].data.fields?.find(f => f.name === 'Retrieved');
+    expect(retrieved?.value).toContain('1000 tokens allocated');
     // Fence stays balanced (one open, one close)
-    expect(result.content!.match(/```/g)).toHaveLength(2);
+    expect(desc.match(/```/g)).toHaveLength(2);
     // Filter buttons survive the trim — the view stays interactive
     expect(result.components).toHaveLength(1);
   });
@@ -337,12 +343,13 @@ describe('buildMemoryInspectorView', () => {
 
     it('default state matches existing behavior (regression)', () => {
       const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX);
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       // All 5 rows shown
       expect(text).toContain('p1');
       expect(text).toContain('p5');
-      expect(text).toContain('5 total');
-      expect(text).toContain('showing 5');
+      const retrieved = result.embeds![0].data.fields?.find(f => f.name === 'Retrieved');
+      expect(retrieved?.value).toContain('5 total');
+      expect(retrieved?.value).toContain('showing 5');
     });
 
     it('returns 5-button component row', () => {
@@ -355,7 +362,7 @@ describe('buildMemoryInspectorView', () => {
       const payload = memoryPayload();
       payload.memoryRetrieval.memoriesFound = [];
       const result = buildMemoryInspectorView(payload, 'req-1', OWNER_CTX);
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
 
       expect(result.components).toEqual([]);
       // State annotation should not appear — there's nothing to filter
@@ -369,7 +376,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       expect(text).toContain('p1');
       expect(text).not.toContain('p2');
       expect(text).toContain('p3');
@@ -383,7 +390,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       expect(text).not.toContain('p1');
       expect(text).toContain('p2');
       expect(text).not.toContain('p3');
@@ -397,8 +404,8 @@ describe('buildMemoryInspectorView', () => {
         topN: 5,
         sort: 'score-desc',
       });
-      const text = result.content!;
-      expect(text).toContain('showing 5');
+      const retrieved = result.embeds![0].data.fields?.find(f => f.name === 'Retrieved');
+      expect(retrieved?.value).toContain('showing 5');
     });
 
     it('sort=score-asc puts lowest score first', () => {
@@ -407,7 +414,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-asc',
       });
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       // First row index is 1, lowest-scored memory (p5 with 0.50) should be there
       const firstRowMatch = text.match(/^ 1 (\d+\.\d+) /m);
       expect(firstRowMatch?.[1]).toBe('0.50');
@@ -419,7 +426,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'included-first',
       });
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       const p1Idx = text.indexOf('p1'); // included
       const p3Idx = text.indexOf('p3'); // included
       const p5Idx = text.indexOf('p5'); // included
@@ -435,7 +442,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 5,
         sort: 'score-asc',
       });
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       // Included memories sorted by ascending score: p5 (0.5), p3 (0.7), p1 (0.9)
       // topN=5 covers all 3
       const p5Idx = text.indexOf('p5');
@@ -457,7 +464,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       expect(text).toContain('No memories match filter');
     });
 
@@ -467,7 +474,7 @@ describe('buildMemoryInspectorView', () => {
         topN: 0,
         sort: 'score-desc',
       });
-      const text = result.content!;
+      const text = result.embeds![0].data.description ?? '';
       expect(text).toContain('[REDACTED]');
       expect(text).not.toContain('p1');
       expect(text).not.toContain('p3');
@@ -504,13 +511,14 @@ describe('buildTokenBudgetView', () => {
     expect(desc).toContain('\u2588'); // at least one filled bar segment
   });
 
-  it('should warn in Notes and switch to the warning color when history > 70%', () => {
+  it('should warn in Notes when history > 70% — color stays BLURPLE (design system)', () => {
     const payload = createMockPayload();
     // 92000 / 128000 = 71.9%
     const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
 
     expect(notesOf(result)).toContain('over 70%');
-    expect(result.embeds![0].data.color).toBe(DISCORD_COLORS.WARNING);
+    // Color encodes surface kind, never state — the ⚠️ note carries the signal
+    expect(result.embeds![0].data.color).toBe(DISCORD_COLORS.BLURPLE);
   });
 
   it('should use the default color when history is under the warning threshold', () => {
@@ -618,8 +626,8 @@ describe('buildVoiceAttributionView', () => {
     const payload = createMockPayload();
     const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.content).toContain('No voice activity');
-    expect(result.chunkedText).toBeUndefined();
+    expect(result.embeds![0].data.description ?? '').toContain('No voice activity');
+    expect(result.embeds![0].data.title).toBe('🎙️ Voice Attribution');
   });
 
   it('renders the TTS provider without a fallback suffix when no fallback fired', () => {
@@ -628,9 +636,8 @@ describe('buildVoiceAttributionView', () => {
     payload.tokenBudget.ttsUsedFallback = false;
     const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const text = result.chunkedText!.text;
-    expect(text).toContain('**TTS provider:** mistral');
-    expect(text).not.toContain('(via fallback)');
+    const tts = result.embeds![0].data.fields?.find(f => f.name === 'TTS provider');
+    expect(tts?.value).toBe('mistral');
   });
 
   it('annotates "(via fallback)" when the dispatcher fell through', () => {
@@ -642,7 +649,8 @@ describe('buildVoiceAttributionView', () => {
     payload.tokenBudget.ttsUsedFallback = true;
     const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    expect(result.chunkedText!.text).toContain('**TTS provider:** self-hosted _(via fallback)_');
+    const tts = result.embeds![0].data.fields?.find(f => f.name === 'TTS provider');
+    expect(tts?.value).toBe('self-hosted _(via fallback)_');
   });
 
   it('omits the "(via fallback)" suffix when ttsUsedFallback is undefined', () => {
@@ -655,9 +663,8 @@ describe('buildVoiceAttributionView', () => {
     payload.tokenBudget.ttsUsedFallback = undefined;
     const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const text = result.chunkedText!.text;
-    expect(text).toContain('**TTS provider:** mistral');
-    expect(text).not.toContain('(via fallback)');
+    const tts = result.embeds![0].data.fields?.find(f => f.name === 'TTS provider');
+    expect(tts?.value).toBe('mistral');
   });
 
   it('renders the voice transcript as a blockquote', () => {
@@ -665,9 +672,9 @@ describe('buildVoiceAttributionView', () => {
     payload.inputProcessing.voiceTranscript = 'hello from a voice note';
     const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const text = result.chunkedText!.text;
-    expect(text).toContain('**Voice transcript:**');
-    expect(text).toContain('> hello from a voice note');
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).toContain('**Voice transcript:**');
+    expect(desc).toContain('> hello from a voice note');
   });
 
   it('quotes every line of a multi-line transcript', () => {
@@ -676,8 +683,30 @@ describe('buildVoiceAttributionView', () => {
     payload.inputProcessing.voiceTranscript = 'first line\nsecond line';
     const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const text = result.chunkedText!.text;
-    expect(text).toContain('> first line\n> second line');
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).toContain('> first line\n> second line');
+  });
+
+  it('caps the QUOTED transcript length (per-line overhead counts)', () => {
+    // Many short lines: raw text under any naive cap, but '> ' per line
+    // inflates the quoted body past the 4096 embed-description limit.
+    const payload = createMockPayload();
+    payload.inputProcessing.voiceTranscript = Array.from({ length: 1500 }, () => 'a').join('\n');
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
+
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc.length).toBeLessThanOrEqual(4096);
+    expect(desc).toContain('truncated — full transcript in Full JSON');
+  });
+
+  it('neutralizes triple-backticks in the transcript (content-derived text)', () => {
+    const payload = createMockPayload();
+    payload.inputProcessing.voiceTranscript = 'said ```rm -rf``` out loud';
+    const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
+
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc.match(/```/g)).toBeNull();
+    expect(desc.replace(/\u200b/g, '')).toContain('```rm -rf```');
   });
 
   it('renders transcript-only requests (voice input, no TTS reply)', () => {
@@ -686,9 +715,9 @@ describe('buildVoiceAttributionView', () => {
     // ttsProviderUsed intentionally undefined
     const result = buildVoiceAttributionView(payload, 'req-123', OWNER_CTX);
 
-    const text = result.chunkedText!.text;
-    expect(text).toContain('> transcript only');
-    expect(text).not.toContain('**TTS provider:**');
+    const desc = result.embeds![0].data.description ?? '';
+    expect(desc).toContain('> transcript only');
+    expect(result.embeds![0].data.fields ?? []).toHaveLength(0);
   });
 });
 
@@ -786,12 +815,12 @@ describe('non-owner redaction', () => {
     it('redacts memory previews while keeping IDs/scores/inclusion visible', () => {
       const payload = createMockPayload();
       const result = buildMemoryInspectorView(payload, 'req-123', NON_OWNER_CTX);
-      const content = result.content!;
+      const content = result.embeds![0].data.description ?? '';
       // Each memory row contains [REDACTED] in the preview column
       expect(content).toContain('[REDACTED]');
       // Score and status remain
       expect(content).toContain('0.95');
-      expect(content).toContain('✓ in');
+      expect(content).toMatch(/0\.95\s+✓/);
       // Banner explaining the redaction
       expect(content).toContain('🔒');
       expect(content).toContain('redacted');
@@ -800,7 +829,7 @@ describe('non-owner redaction', () => {
     it('does not show memory preview text when canViewCharacter is false', () => {
       const payload = createMockPayload();
       const result = buildMemoryInspectorView(payload, 'req-123', NON_OWNER_CTX);
-      const content = result.content!;
+      const content = result.embeds![0].data.description ?? '';
       expect(content).not.toContain('Memory preview text');
       expect(content).not.toContain('Low score memory');
     });
@@ -836,7 +865,8 @@ describe('non-owner redaction', () => {
       payload.tokenBudget.ttsProviderUsed = 'mistral';
       payload.tokenBudget.ttsUsedFallback = false;
       const result = buildVoiceAttributionView(payload, 'req-123', NON_OWNER_CTX);
-      expect(result.chunkedText!.text).toContain('**TTS provider:** mistral');
+      const tts = result.embeds![0].data.fields?.find(f => f.name === 'TTS provider');
+      expect(tts?.value).toBe('mistral');
     });
   });
 });

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -236,17 +236,17 @@ export function buildReasoningView(
 // Memory Inspector
 // ---------------------------------------------------------------------------
 
-/** Preview budget per row: the whole view must stay one in-place message so
- * the filter buttons keep editing it (chunked follow-ups would go stale on
- * refresh). Full previews live in the JSON views. */
-const MEMORY_PREVIEW_MAX = 60;
+/** Preview budget per row — sized for the narrower monospace width embeds get
+ * on mobile (~38 chars/row incl. the index/score/status prefix). Full
+ * previews live in the JSON views. */
+const MEMORY_PREVIEW_MAX = 26;
 
 function formatMemoryRow(
   m: DiagnosticMemoryEntry,
   index: number,
   canViewCharacter: boolean
 ): string {
-  const status = m.includedInPrompt ? '✓ in' : '✗ drop';
+  const status = m.includedInPrompt ? '✓' : '✗';
   let preview = canViewCharacter ? m.preview.replace(/\s+/g, ' ').trim() : REDACTED_MEMORY_PREVIEW;
   if (preview.length > MEMORY_PREVIEW_MAX) {
     preview = `${preview.slice(0, MEMORY_PREVIEW_MAX - 1)}…`;
@@ -255,53 +255,33 @@ function formatMemoryRow(
   // surviving run still gets neutralized before entering the fence.
   preview = escapeFenceBreaks(preview);
   // Score pads to 5 to align under the 'Score' header label
-  return `${String(index + 1).padStart(2)} ${m.score.toFixed(2).padEnd(5)} ${status.padEnd(6)} ${preview}`;
+  return `${String(index + 1).padStart(2)} ${m.score.toFixed(2).padEnd(5)} ${status} ${preview}`;
 }
 
+/** The fenced score table — fence keeps columns aligned; ✓/✗ marks inclusion. */
 function renderMemoryTable(
   memories: readonly DiagnosticMemoryEntry[],
-  allMemories: readonly DiagnosticMemoryEntry[],
-  tokenBudget: { memoryTokensUsed: number },
   canViewCharacter: boolean
 ): string[] {
-  const includedTotal = allMemories.filter(m => m.includedInPrompt).length;
-  // Budget drops happened over the full unfiltered retrieval, not the filtered view —
-  // hence allMemories rather than memories. Variable name is explicit to avoid
-  // confusion with filter-induced row exclusion.
-  const budgetDropped = allMemories.length - includedTotal;
-  const lines = [
-    `## Retrieved Memories (${allMemories.length} total, ${includedTotal} included, showing ${memories.length})`,
-  ];
-  if (!canViewCharacter) {
-    lines.push('');
-    lines.push('🔒 _Memory previews redacted — this character is owned by another user._');
-  }
-  // Fixed-width rows in a code fence — Discord doesn't render markdown
-  // tables, and the fence keeps columns aligned on mobile.
-  lines.push('', '```', ' # Score Status Preview');
+  const lines = ['```', ' # Score ✓ Preview'];
   for (let i = 0; i < memories.length; i++) {
     lines.push(formatMemoryRow(memories[i], i, canViewCharacter));
   }
-  lines.push('```', '');
-  lines.push(
-    `**Token Budget:** ${tokenBudget.memoryTokensUsed} tokens allocated, ${budgetDropped} memories dropped for budget`
-  );
+  lines.push('```');
   return lines;
 }
 
-/** Trim table rows from the tail until the view fits one Discord message,
- * keeping everything after the closing fence (the token-budget summary line)
- * and appending a notice pointing at Top-N (the existing knob) for narrowing.
- * The view must stay a single in-place message — the filter buttons re-edit
- * it, so spilling into chunked follow-ups would go stale. */
-function trimToSingleMessage(content: string): string {
-  const limit = 1900; // headroom under Discord's 2000 for the trim notice
+/** Trim table rows from the tail until the description fits the embed cap,
+ * keeping the closing fence and appending a notice pointing at Top-N (the
+ * existing knob). The view must stay a single in-place message — the filter
+ * buttons re-edit it, so spilling into follow-ups would go stale. */
+function trimToEmbedDescription(content: string): string {
+  const limit = 3900; // headroom under Discord's 4096 embed-description cap
   if (content.length <= limit) {
     return content;
   }
   const trimNotice = '_…rows trimmed to fit — lower Top-N or filter to narrow._';
   const fenceEnd = content.lastIndexOf('\n```');
-  // Tail = closing fence + the token-budget summary; both must survive the trim.
   const tail = fenceEnd > 0 ? content.slice(fenceEnd) : '';
   let head = fenceEnd > 0 ? content.slice(0, fenceEnd) : content;
   while (head.length + tail.length + trimNotice.length + 1 > limit && head.includes('\n')) {
@@ -323,11 +303,13 @@ export function buildMemoryInspectorView(
   const sorted = applySort(filtered, state.sort);
   const memories = applyTopN(sorted, state.topN);
 
+  const includedTotal = allMemories.filter(m => m.includedInPrompt).length;
+  // Budget drops happened over the full unfiltered retrieval, not the filtered
+  // view — hence allMemories rather than memories.
+  const budgetDropped = allMemories.length - includedTotal;
+
   const lines: string[] = [
-    '# Memory Inspector',
-    '',
-    `**Search Query:** ${inputProcessing.searchQuery !== null ? `"${inputProcessing.searchQuery}"` : '_none_'}`,
-    `**Focus Mode:** ${memoryRetrieval.focusModeEnabled ? 'Enabled' : 'Disabled'}`,
+    `**Search Query:** ${inputProcessing.searchQuery !== null ? `"${inputProcessing.searchQuery}"` : '_none_'} · **Focus:** ${memoryRetrieval.focusModeEnabled ? 'on' : 'off'}`,
   ];
 
   // State annotation and filter buttons only make sense when there's something
@@ -336,19 +318,36 @@ export function buildMemoryInspectorView(
     lines.push('', '_No memories retrieved for this request._');
   } else {
     lines.push(
-      `**Filter:** ${state.filter} · **Sort:** ${state.sort} · **Top-N:** ${state.topN === 0 ? 'all' : state.topN}`,
-      ''
+      `**Filter:** ${state.filter} · **Sort:** ${state.sort} · **Top-N:** ${state.topN === 0 ? 'all' : state.topN}`
     );
-    if (memories.length === 0) {
-      lines.push(`_No memories match filter "${state.filter}"._`);
-    } else {
-      lines.push(...renderMemoryTable(memories, allMemories, tokenBudget, ctx.canViewCharacter));
+    if (!ctx.canViewCharacter) {
+      lines.push('🔒 _Previews redacted — this character is owned by another user._');
     }
+    if (memories.length === 0) {
+      lines.push('', `_No memories match filter "${state.filter}"._`);
+    } else {
+      lines.push('', ...renderMemoryTable(memories, ctx.canViewCharacter));
+    }
+  }
+
+  // Informational surface: BLURPLE always (design system — color encodes
+  // surface kind, never state).
+  const embed = new EmbedBuilder()
+    .setTitle('🧠 Memory Inspector')
+    .setColor(DISCORD_COLORS.BLURPLE)
+    .setDescription(trimToEmbedDescription(lines.join('\n')));
+
+  if (allMemories.length > 0) {
+    embed.addFields({
+      name: 'Retrieved',
+      value: `${allMemories.length} total · ${includedTotal} included · showing ${memories.length}\n${tokenBudget.memoryTokensUsed} tokens allocated · ${budgetDropped} dropped for budget`,
+      inline: false,
+    });
   }
 
   // Single in-place message (owner decision: inline, no file download).
   return {
-    content: trimToSingleMessage(lines.join('\n')),
+    embeds: [embed],
     components: allMemories.length > 0 ? [buildMemoryFilterButtons(requestId, state)] : [],
     flags: MessageFlags.Ephemeral,
   };
@@ -395,7 +394,9 @@ export function buildTokenBudgetView(
   const remaining = Math.max(0, total - usedTokens);
   const remainingPct = (remaining / total) * 100;
 
-  const bar = (pct: number): string => '█'.repeat(Math.round(pct / 4)).padEnd(25, '░');
+  // 15-cell bars: embeds render a narrower monospace column on mobile than
+  // plain messages — the full row must fit ~38 chars.
+  const bar = (pct: number): string => '█'.repeat(Math.round(pct / (100 / 15))).padEnd(15, '░');
   const row = (label: string, tokens: number, pct: number): string =>
     `${label.padEnd(8)}${bar(pct)} ${pct.toFixed(0).padStart(3)}% ${tokens.toLocaleString().padStart(8)}`;
 
@@ -409,9 +410,11 @@ export function buildTokenBudgetView(
     '```',
   ].join('\n');
 
+  // Informational surface: BLURPLE always (design system — color encodes
+  // surface kind, never state; the >70% condition speaks via the ⚠️ note).
   const embed = new EmbedBuilder()
     .setTitle('📊 Token Budget')
-    .setColor(historyPct > 70 ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE)
+    .setColor(DISCORD_COLORS.BLURPLE)
     .setDescription(`**Context window:** ${total.toLocaleString()} tokens\n${chart}`);
 
   const notes: string[] = [];
@@ -469,17 +472,19 @@ export function buildVoiceAttributionView(
   _ctx: ViewContext
 ): DebugViewResult {
   const { tokenBudget, inputProcessing } = payload;
-  const lines: string[] = ['## Voice Attribution', ''];
 
   const hasTts = tokenBudget.ttsProviderUsed !== undefined;
   const hasTranscript =
     inputProcessing.voiceTranscript !== null && inputProcessing.voiceTranscript.length > 0;
 
+  // Informational surface: BLURPLE always (design system).
+  const embed = new EmbedBuilder()
+    .setTitle('🎙️ Voice Attribution')
+    .setColor(DISCORD_COLORS.BLURPLE);
+
   if (!hasTts && !hasTranscript) {
-    return {
-      content: 'No voice activity (TTS or voice-message input) on this request.',
-      flags: MessageFlags.Ephemeral,
-    };
+    embed.setDescription('_No voice activity (TTS or voice-message input) on this request._');
+    return { embeds: [embed], flags: MessageFlags.Ephemeral };
   }
 
   if (hasTts) {
@@ -487,23 +492,30 @@ export function buildVoiceAttributionView(
     // where the configured provider failed and a backup produced the audio —
     // the exact diagnostic gap that hid the Mistral STT misattribution.
     const fallbackSuffix = tokenBudget.ttsUsedFallback === true ? ' _(via fallback)_' : '';
-    lines.push(`**TTS provider:** ${tokenBudget.ttsProviderUsed}${fallbackSuffix}`);
+    embed.addFields({
+      name: 'TTS provider',
+      value: `${tokenBudget.ttsProviderUsed}${fallbackSuffix}`,
+      inline: true,
+    });
   }
   if (hasTranscript) {
     // Discord blockquotes need '> ' on EVERY line — a bare continuation line
-    // drops out of the quote (unlike GitHub markdown).
-    const quoted = (inputProcessing.voiceTranscript ?? '')
+    // drops out of the quote (unlike GitHub markdown). ASR output is
+    // content-derived text: neutralize ``` runs (they'd open a code block
+    // mid-description). The cap measures the QUOTED text — per-line '> '
+    // overhead can outgrow the raw length on many-short-line transcripts —
+    // and the full text lives in Full JSON.
+    const quoted = escapeFenceBreaks(inputProcessing.voiceTranscript ?? '')
       .split('\n')
       .map(line => `> ${line}`)
       .join('\n');
-    lines.push('', '**Voice transcript:**', quoted);
+    const body = `**Voice transcript:**\n${quoted}`;
+    embed.setDescription(
+      body.length > 3900
+        ? `${body.slice(0, 3800)}…\n_(truncated — full transcript in Full JSON)_`
+        : body
+    );
   }
 
-  return {
-    chunkedText: {
-      text: lines.join('\n'),
-      continuedHeader: '_(voice attribution continued)_\n',
-    },
-    flags: MessageFlags.Ephemeral,
-  };
+  return { embeds: [embed], flags: MessageFlags.Ephemeral };
 }


### PR DESCRIPTION
## What

The /inspect view-inventory scrutiny outcome (owner Q&A, all decisions recorded in `backlog/cold/themes/voice-inspect-ux-polish.md` item 6):

- **Quick Copy view removed** — never used. Enum member, dropdown option, builder, and tests all deleted (dropdown: 7 → 6 options).
- **Four views become design-system embeds** (owner picked embeds-for-all-four with the mobile-width trade-off stated): Memory Inspector, Token Budget, Pipeline Health, Voice Attribution — BLURPLE always, `{emoji} {Title}` titles.
- **Design-system violation fixed**: Token Budget's >70% WARNING color flip broke the "embed color encodes surface kind, never state" rule — now BLURPLE with the ⚠️ note carrying the signal.
- **Mobile-safe widths**: bars 25→15 cells; memory previews 60→26 chars with single-glyph ✓/✗ status; pipeline steps switch from fixed-width fence rows to emoji + `-#` subtext line pairs (kills the emoji-glyph-width alignment question entirely — nothing to align).
- **Memory Inspector mechanics preserved**: in-place filter buttons; trim budget rises 1900→3900 (embed description cap); token-budget summary moves to a trim-immune `Retrieved` field.
- **Model-substitution flag** (design-system backlog item): the summary embed shows `Requested` vs `⚠️ Served` when they differ — normalized comparison so version suffixes (`-20241022`) and provider-prefix promotion (`z-ai/x` → `x`) don't false-flag. The real cases it catches: guest overrides and fallback retargets.

`chunkedText` now has exactly one consumer (Reasoning) — the dispatcher path is unchanged.

## Verification

213/213 inspect tests (assertion intent preserved through the embed migration: redaction, fence-neutralization, trim survival, strict `=== true` pins), 3 new substitution-flag tests incl. both no-false-flag cases. Full `pnpm test` + `pnpm test:component` (dropdown snapshot) + `pnpm quality` green sequentially from root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)