### PR TITLE
fix(tooling): release:finalize sweeps stale prerelease flags (pre-stable only)

### DIFF
--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -18,23 +18,25 @@ import { finalizeRelease } from './finalize.js';
  * Individual tests override specific subcommands via a nested map.
  */
 function mockGit(overrides: Record<string, string | (() => string)> = {}): void {
-  mockedExec.mockImplementation(((_cmd: string, args: readonly string[]) => {
-    // The first arg after 'git' identifies the subcommand (e.g. 'status',
-    // 'rev-list', 'rebase'); the second arg disambiguates for subcommands
-    // that share a name across cases.
-    const key = args.slice(0, 2).join(' ');
+  mockedExec.mockImplementation(((cmd: string, args: readonly string[]) => {
+    // The first arg after 'git'/'gh' identifies the subcommand (e.g.
+    // 'status', 'rev-list', 'release'); the second arg disambiguates for
+    // subcommands that share a name across cases. gh keys are prefixed
+    // ('gh release list') so they can't collide with git subcommands.
+    const key = (cmd === 'gh' ? 'gh ' : '') + args.slice(0, 2).join(' ');
     const subKey = args[0];
     if (key in overrides) {
       const v = overrides[key];
       return typeof v === 'function' ? v() : v;
     }
-    if (subKey in overrides) {
+    if (cmd !== 'gh' && subKey in overrides) {
       const v = overrides[subKey];
       return typeof v === 'function' ? v() : v;
     }
-    // Defaults: clean working tree (tracked-only check), zero-commit rev-list.
+    // Defaults: clean working tree, zero-commit rev-list, empty release list.
     if (subKey === 'status') return '';
     if (key === 'rev-list --count') return '0\n';
+    if (key === 'gh release list') return '[]';
     return '';
   }) as unknown as typeof execFileSync);
 }
@@ -88,6 +90,111 @@ describe('finalizeRelease', () => {
       expect(pullDevIdx).toBeGreaterThan(checkoutDevIdx);
       expect(rebaseIdx).toBeGreaterThan(pullDevIdx);
       expect(pushIdx).toBeGreaterThan(rebaseIdx);
+    });
+  });
+
+  describe('prerelease sweep', () => {
+    const RELEASES = JSON.stringify([
+      { tagName: 'v3.0.0-beta.159', isPrerelease: false, isLatest: true },
+      { tagName: 'v3.0.0-beta.158', isPrerelease: false, isLatest: false },
+      { tagName: 'v3.0.0-beta.157', isPrerelease: true, isLatest: false },
+    ]);
+
+    it('flips every non-latest, non-prerelease release (and only those)', async () => {
+      mockGit({ 'gh release list': RELEASES });
+
+      await finalizeRelease({ yes: true });
+
+      const ghEdits = mockedExec.mock.calls
+        .filter(c => c[0] === 'gh' && (c[1] as string[])[1] === 'edit')
+        .map(c => (c[1] as string[]).join(' '));
+      expect(ghEdits).toEqual(['release edit v3.0.0-beta.158 --prerelease']);
+    });
+
+    it('never flips a STABLE release, even when older and unmarked', async () => {
+      // Owner rule: the flip is scoped to alpha/beta/rc streams only —
+      // regular releases keep full-release status regardless of age.
+      mockGit({
+        'gh release list': JSON.stringify([
+          { tagName: 'v3.1.0', isPrerelease: false, isLatest: true },
+          { tagName: 'v3.0.0', isPrerelease: false, isLatest: false },
+          { tagName: 'v3.0.0-rc.2', isPrerelease: false, isLatest: false },
+          { tagName: 'v3.0.0-alpha.1', isPrerelease: false, isLatest: false },
+        ]),
+      });
+
+      await finalizeRelease({ yes: true });
+
+      const ghEdits = mockedExec.mock.calls
+        .filter(c => c[0] === 'gh' && (c[1] as string[])[1] === 'edit')
+        .map(c => (c[1] as string[])[2]);
+      // rc + alpha flip; the stable v3.0.0 does NOT
+      expect(ghEdits.sort()).toEqual(['v3.0.0-alpha.1', 'v3.0.0-rc.2']);
+    });
+
+    it('is a no-op when flags are already in order', async () => {
+      mockGit({
+        'gh release list': JSON.stringify([
+          { tagName: 'v3.0.0-beta.159', isPrerelease: false, isLatest: true },
+          { tagName: 'v3.0.0-beta.158', isPrerelease: true, isLatest: false },
+        ]),
+      });
+
+      await finalizeRelease({ yes: true });
+
+      expect(
+        mockedExec.mock.calls.some(c => c[0] === 'gh' && (c[1] as string[])[1] === 'edit')
+      ).toBe(false);
+    });
+
+    it('previews (never edits) in dry-run', async () => {
+      mockGit({ 'gh release list': RELEASES, 'rev-list --count': '2\n' });
+
+      await finalizeRelease({ dryRun: true });
+
+      expect(
+        mockedExec.mock.calls.some(c => c[0] === 'gh' && (c[1] as string[])[1] === 'edit')
+      ).toBe(false);
+    });
+
+    it('fails SOFT when gh errors — the finalize sequence still completes', async () => {
+      mockGit({
+        'gh release list': () => {
+          throw new Error('gh not authenticated');
+        },
+        'rev-list --count': '3\n',
+      });
+
+      await finalizeRelease({ yes: true });
+
+      const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+      expect(invocations).toContain('push --force-with-lease origin develop');
+    });
+
+    it('fails SOFT on a non-array gh payload (gh error text on stdout with exit 0)', async () => {
+      mockGit({
+        'gh release list': '{"message": "API rate limit exceeded"}',
+        'rev-list --count': '3\n',
+      });
+
+      await finalizeRelease({ yes: true });
+
+      const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+      expect(invocations).toContain('push --force-with-lease origin develop');
+      expect(
+        mockedExec.mock.calls.some(c => c[0] === 'gh' && (c[1] as string[])[1] === 'edit')
+      ).toBe(false);
+    });
+
+    it('runs even on the git no-op path (heals flags on re-runs)', async () => {
+      mockGit({ 'gh release list': RELEASES, 'rev-list --count': '0\n' });
+
+      await finalizeRelease({ yes: true });
+
+      const ghEdits = mockedExec.mock.calls.filter(
+        c => c[0] === 'gh' && (c[1] as string[])[1] === 'edit'
+      );
+      expect(ghEdits).toHaveLength(1);
     });
   });
 

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -8,6 +8,7 @@
 import { execFileSync } from 'node:child_process';
 import { createInterface } from 'node:readline/promises';
 import chalk from 'chalk';
+import { isPrereleaseVersion } from './publish.js';
 
 export interface FinalizeOptions {
   dryRun?: boolean;
@@ -223,6 +224,59 @@ function runCheckoutRebasePushSequence(dryRun: boolean): void {
 }
 
 /**
+ * Flip every non-latest, non-prerelease, PRE-STABLE (alpha/beta/rc) GitHub
+ * release to pre-release. Only pre-stable tags are ever flipped (owner rule):
+ * the flip exists so the alpha/beta/rc stream shows a single "latest" — an
+ * older STABLE release keeps its full-release status regardless of age
+ * (channel membership via `isPrereleaseVersion`, shared with publish's
+ * one-back demote). Fail-soft: a gh error warns and never fails the
+ * finalize — the sweep re-runs on every subsequent release, so a transient
+ * miss self-heals. The window is bounded to the 20 most recent releases;
+ * anything staler stays as-is until fixed by hand.
+ */
+function sweepPrereleaseFlags(dryRun: boolean): void {
+  try {
+    const raw = execFileSync(
+      'gh',
+      ['release', 'list', '--limit', '20', '--json', 'tagName,isPrerelease,isLatest'],
+      { encoding: 'utf-8' }
+    );
+    const parsed: unknown = JSON.parse(raw);
+    // gh can exit 0 while writing an error message to stdout instead of JSON
+    // (see github-prs.ts) — surface the payload instead of a generic warning.
+    if (!Array.isArray(parsed)) {
+      throw new Error(`unexpected gh release list payload: ${raw.slice(0, 200)}`);
+    }
+    const releases = parsed as {
+      tagName: string;
+      isPrerelease: boolean;
+      isLatest: boolean;
+    }[];
+    const stale = releases.filter(
+      r => !r.isLatest && !r.isPrerelease && isPrereleaseVersion(r.tagName)
+    );
+    if (stale.length === 0) {
+      console.log(chalk.dim('Prerelease flags already in order.'));
+      return;
+    }
+    for (const r of stale) {
+      if (dryRun) {
+        console.log(chalk.dim(`[dry-run] gh release edit ${r.tagName} --prerelease`));
+      } else {
+        execFileSync('gh', ['release', 'edit', r.tagName, '--prerelease'], { encoding: 'utf-8' });
+        console.log(chalk.green(`✓ Marked ${r.tagName} as pre-release`));
+      }
+    }
+  } catch (err) {
+    console.log(
+      chalk.yellow(
+        `⚠ Prerelease sweep failed — flip manually with \`gh release edit <tag> --prerelease\`: ${String(err)}`
+      )
+    );
+  }
+}
+
+/**
  * Execute or preview the finalize sequence. When `dryRun` is true, all
  * git commands are printed instead of executed — useful for reviewing
  * what the command will do before committing to the force-push.
@@ -250,12 +304,19 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
   console.log(chalk.dim('Fetching remote refs...'));
   git(['fetch', '--all']);
 
-  // Step 2: detect no-op against the freshly-fetched refs (accurate in dry-run).
+  // Step 2: prerelease sweep. House convention: only the NEWEST release
+  // stays un-marked; every older release is a pre-release. Runs as an
+  // idempotent sweep before the no-op check so a re-run heals flags even
+  // when develop is already aligned, and it self-heals releases missed by
+  // past manual flows (the recurring miss this step exists to kill).
+  sweepPrereleaseFlags(dryRun);
+
+  // Step 3: detect no-op against the freshly-fetched refs (accurate in dry-run).
   if (checkAheadCount() === 'noop') {
     return;
   }
 
-  // Step 3: confirm the force-push branch. Rebase itself is safe (local
+  // Step 4: confirm the force-push branch. Rebase itself is safe (local
   // only, reversible via --abort); the force-push needs explicit sign-off.
   if (!dryRun && !(await shouldProceedWithForcePush(yes))) {
     console.log(chalk.dim('Aborted by user.'));


### PR DESCRIPTION
## What

Structural fix for a recurring manual miss: the previous release's flip to pre-release status wasn't happening consistently (owner corrected by hand across multiple releases). Per the fix-recurring-failures rule, the correction moves into the step that can't be skipped — `release:finalize` runs on every release, so it now carries the sweep.

## Why the existing `demotePreviousRelease` didn't cover this

`release:publish`'s `demotePreviousRelease` only shipped on 2026-07-08 (a1d561e7d) — the manually-corrected misses predate it entirely. It also only looks **one tag back**, so any stale flag that already exists (from a release published before the demote logic, or a publish that errored) never self-heals. This sweep is the backfill + ongoing self-heal for the whole visible window; the publish-time demote remains the fast path. Complementary mechanisms, not duplicates.

## Design

- **Idempotent sweep, not "flip the previous one"**: every non-latest release with `prerelease=false` gets flipped — so it also self-heals any releases missed by past flows, and re-running finalize after a partial sequence heals flags (it runs before the git no-op early-return).
- **Tightly scoped to pre-stable streams (owner directive)**: only tags matching `-(alpha|beta|rc)` are ever flipped. A stable release (`v3.0.0`, `v3.1.0`) keeps its full-release status regardless of age — pinned by a mixed-board test (stable latest + older stable + unmarked rc/alpha → only rc/alpha flip).
- **Fail-soft**: a `gh` error warns with the manual command and never fails the finalize — the sweep re-runs on the next release anyway.
- `execFileSync` array form per the shell-safety rule.

## Tests

21/21 on the file: flip-only-stale, stable-never-flipped, already-in-order no-op, dry-run previews without editing, gh-failure soft-degrade with the git sequence still completing, and the runs-on-noop-path healing case. Full `pnpm test` + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
