### PR TITLE
fix(api-gateway): stamp the full resolved config, not just the model

### DIFF
--- a/services/api-gateway/src/utils/stampResolvedConfig.test.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.test.ts
@@ -11,9 +11,13 @@ const basePersonality = {
   // visionModel intentionally unset — an undefined seed vision model.
 } as unknown as LoadedPersonality;
 
-const llmResolver = (model: string, source: string): LlmConfigResolver =>
+const llmResolver = (
+  model: string,
+  source: string,
+  extraConfig: Record<string, unknown> = {}
+): LlmConfigResolver =>
   ({
-    resolveConfig: vi.fn().mockResolvedValue({ config: { model }, source }),
+    resolveConfig: vi.fn().mockResolvedValue({ config: { model, ...extraConfig }, source }),
   }) as unknown as LlmConfigResolver;
 
 const visionResolver = (
@@ -46,6 +50,56 @@ describe('stampResolvedConfig', () => {
       );
       expect(personality.model).toBe('resolved-model');
       expect(configSource).toBe('user-default');
+    });
+
+    it('stamps the FULL merged config, not just the model (regression: preset params ignored)', async () => {
+      // The observed prod bug: a user-default preset with ctx=500K/minP=0.01 ran
+      // against the seed's 100K budget with minP dropped, because only `model`
+      // crossed the stamp. Every LLM_CONFIG_OVERRIDE_KEYS field must cross.
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'user-1',
+        'req-1',
+        llmResolver('resolved-model', 'user-default', {
+          contextWindowTokens: 500000,
+          minP: 0.01,
+          temperature: 0.8,
+          reasoning: { enabled: true, effort: 'medium' },
+        })
+      );
+      expect(personality.contextWindowTokens).toBe(500000);
+      expect(personality.minP).toBe(0.01);
+      expect(personality.temperature).toBe(0.8);
+      expect(personality.reasoning).toEqual({ enabled: true, effort: 'medium' });
+    });
+
+    it('leaves seed fields untouched when the resolved config omits them (undefined)', async () => {
+      const seeded = {
+        ...basePersonality,
+        contextWindowTokens: 131072,
+        temperature: 0.7,
+      } as unknown as LoadedPersonality;
+      const { personality } = await stampResolvedConfig(
+        seeded,
+        'user-1',
+        'req-1',
+        // merged config carries only a model + one field — the rest stay seed
+        llmResolver('resolved-model', 'user-default', { minP: 0.05 })
+      );
+      expect(personality.model).toBe('resolved-model');
+      expect(personality.minP).toBe(0.05);
+      expect(personality.contextWindowTokens).toBe(131072);
+      expect(personality.temperature).toBe(0.7);
+    });
+
+    it('does not stamp provider (ProviderRouter promotes by model prefix)', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'user-1',
+        'req-1',
+        llmResolver('z-ai/glm-5.2', 'user-default', { provider: 'openrouter' })
+      );
+      expect((personality as { provider?: string }).provider).toBeUndefined();
     });
 
     it('leaves the seed model unchanged when the source is personality (already the seed)', async () => {

--- a/services/api-gateway/src/utils/stampResolvedConfig.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.ts
@@ -7,19 +7,48 @@
  * module under the line limit and to give the resolve-and-stamp logic its own test surface.
  */
 
+import { LLM_CONFIG_OVERRIDE_KEYS } from '@tzurot/common-types/schemas/llmAdvancedParams';
 import { type ConfigSourceId } from '@tzurot/common-types/types/schemas/generation';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
+import { type ResolvedLlmConfig } from '@tzurot/common-types/types/configResolution';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { LlmConfigResolver, VisionConfigResolver } from '@tzurot/config-resolver';
 
 const logger = createLogger('ConfigStamping');
 
 /**
- * Resolve the user's effective TEXT model AND vision model ONCE and stamp both onto
+ * Apply a resolved (already-merged) LLM config onto the personality — model plus
+ * EVERY override key (`contextWindowTokens`, sampling, `reasoning`, `maxTokens`,
+ * …). This mirrors the pre-stamp ConfigStep merge: stamping only `model` silently
+ * reverts every other preset field to the SEED personality (personality-bound
+ * config, else the admin global default), which shipped as a real regression —
+ * a user's 500K-context preset generated against the seed's 100K budget with the
+ * preset's minP dropped. ai-worker's ConfigStep deliberately does not re-run the
+ * cascade, so what's stamped here is ALL the job chain ever sees.
+ */
+function applyResolvedConfig(
+  personality: LoadedPersonality,
+  config: ResolvedLlmConfig
+): LoadedPersonality {
+  const result = { ...personality, model: config.model };
+  for (const key of LLM_CONFIG_OVERRIDE_KEYS) {
+    const value = config[key];
+    if (value !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Dynamic key assignment from LLM_CONFIG_OVERRIDE_KEYS requires runtime indexing
+      (result as any)[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolve the user's effective TEXT config AND vision model ONCE and stamp both onto
  * the personality, so every job in the chain (the conversation job AND the
- * image-description child job) shares the same user-cascaded values. Without this,
- * the image-description job would consume the personality SEED values (the load-time
- * defaults) because it never runs ai-worker's `ConfigStep` cascade.
+ * image-description child job) shares the same user-cascaded values. The TEXT stamp
+ * carries the FULL merged config — model plus every `LLM_CONFIG_OVERRIDE_KEYS` field
+ * (contextWindowTokens, sampling, reasoning, …) — because nothing downstream re-runs
+ * the cascade: ai-worker's `ConfigStep` trusts the stamp, and the image-description
+ * job never runs the cascade at all.
  *
  * The TEXT model (`personality.model`) and the VISION model (`personality.visionModel`,
  * the carrier `selectVisionModel` reads at priority 1) resolve through INDEPENDENT
@@ -61,8 +90,9 @@ export async function stampResolvedConfig(
           'LlmConfigResolver returned a TTS-only config source — using personality seed'
         );
       } else if (resolved.source !== 'personality') {
-        // user-personality | user-default → stamp the resolved (already-merged) model.
-        stamped = { ...stamped, model: resolved.config.model };
+        // user-personality | user-default → stamp the FULL resolved (already-merged)
+        // config, not just the model (see applyResolvedConfig).
+        stamped = applyResolvedConfig(stamped, resolved.config);
         configSource = resolved.source;
       }
     } catch (error) {


### PR DESCRIPTION
## What

Production regression fix (board: 🚨 Production Issues). Since the resolve-once refactor (a8bb9b00a, 2026-06-17), `stampResolvedConfig` carried **only `resolved.config.model`** across the user config cascade, while ai-worker's `ConfigStep` deliberately stopped re-running it. Every other field of a user-default / user-personality preset — `contextWindowTokens`, `minP`, `temperature`, sampling, `reasoning`, `maxTokens` — silently reverted to the SEED personality (its bound config, or the admin global default when unbound).

**Runtime evidence** (owner-reported, traced 2026-07-12): a GLM 5.2 preset configured at 500K context generated against the seed's 100,000-token budget (`/inspect` showed "Context window: 100,000" on a 1M-context model) with the preset's `min_p=0.01` absent from the recorded params. Prod DB probe confirmed the preset value (500K), no personality-bound config for the persona, and the admin-default preset carrying the observed 100K. Invisible for ~3.5 weeks because owner presets share house-standard sampling with the seeds.

## How

The stamp now applies the **full merged config** — `model` plus every `LLM_CONFIG_OVERRIDE_KEYS` field — restoring the pre-refactor ConfigStep merge semantics at the stamp site while keeping the resolve-once-share-across-chain design (the image-description child job inherits the same values, as intended by the original refactor).

`provider` is intentionally still NOT stamped — `LLM_CONFIG_OVERRIDE_KEYS` doesn't include it, preserving the documented invariant (ProviderRouter auto-promotes by model-name prefix; the seed provider must survive for AuthStep routing).

## Tests

Regression pins in `stampResolvedConfig.test.ts`: full-config crossing (ctx/minP/temperature/reasoning), undefined resolved fields leaving seed values untouched, and provider exclusion. Existing personality-tier no-op, fail-open, and vision-axis tests unchanged and green. Full `pnpm test` + `pnpm quality` green.

## Verification plan post-merge

Dev deploy → one message with a user-default preset carrying a distinct context window → `/inspect` Token Budget shows the preset's value (clamped to the model cap). The owner's original 100K report is the prod re-verification case after the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
