### PR TITLE
fix(ai-worker): bind the facts block to its subject persona by name

### DIFF
--- a/packages/common-types/src/utils/promptSanitizer.ts
+++ b/packages/common-types/src/utils/promptSanitizer.ts
@@ -49,6 +49,10 @@ export const PROTECTED_TAGS = [
   // reaches top-level system scope, same boundary class as memory_archive.
   'facts',
   'fact',
+  // Instruction elements interpolate user-authored names (facts subject
+  // binding, chat_log role legend) — a name containing </instruction> must
+  // not break out of the element it's framing.
+  'instruction',
   // Conversation-history ancestors (a user message must not forge these)
   'prior_conversations',
   'channel_history',

--- a/packages/tooling/src/dev/check-prompt-tags.ts
+++ b/packages/tooling/src/dev/check-prompt-tags.ts
@@ -65,7 +65,8 @@ const PROTOCOL_FIELD =
 
 export const KNOWN_UNPROTECTED_TAGS: Record<string, string> = {
   // Hardcoded system text — no user content ever interpolated.
-  instruction: 'Hardcoded instruction strings (memory/participants/references).',
+  // (`instruction` moved to PROTECTED_TAGS when the facts subject binding and
+  // chat_log role legend began interpolating user-authored names into it.)
   platform_constraints: 'Hardcoded safety constraints (HardcodedConstraints).',
   output_constraints: 'Hardcoded output-format constraints (HardcodedConstraints).',
   context:

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -11,7 +11,11 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { contentToText } from '../utils/baseMessageContent.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ContextWindowManager } from './context/ContextWindowManager.js';
-import { formatSingleFact, getFactsWrapperOverheadText } from './prompt/MemoryFormatter.js';
+import {
+  formatSingleFact,
+  getFactsWrapperOverheadText,
+  type FactRenderNames,
+} from './prompt/MemoryFormatter.js';
 import type {
   BudgetAllocationOptions,
   BudgetAllocationResult,
@@ -195,7 +199,11 @@ export class ContentBudgetManager {
 
     // Facts take their reserved slice FIRST; episodes get the remainder — so a
     // dense cluster of short facts can't starve verbose episodes, and vice versa.
-    const { selectedFacts, factTokensUsed } = this.selectFacts(opts.facts ?? [], memoryBudget);
+    const { selectedFacts, factTokensUsed } = this.selectFacts(opts.facts ?? [], memoryBudget, {
+      subjectName: context.activePersonaName,
+      personalityName: personality.name,
+      discordUsername: context.discordUsername,
+    });
     const episodeBudget = Math.max(0, memoryBudget - factTokensUsed);
 
     const {
@@ -245,7 +253,8 @@ export class ContentBudgetManager {
    */
   private selectFacts(
     facts: FactForPrompt[],
-    memoryBudget: number
+    memoryBudget: number,
+    names?: FactRenderNames
   ): { selectedFacts: FactForPrompt[]; factTokensUsed: number } {
     if (facts.length === 0) {
       return { selectedFacts: [], factTokensUsed: 0 };
@@ -254,11 +263,15 @@ export class ContentBudgetManager {
       FACT_BUDGET_MAX_TOKENS,
       Math.floor(memoryBudget * FACT_BUDGET_MAX_FRACTION)
     );
-    const wrapperOverhead = this.promptBuilder.countTokens(getFactsWrapperOverheadText());
+    // Same names the render path uses — the overhead count and the per-fact
+    // counts must be of the same text the render emits (placeholder-resolved).
+    const wrapperOverhead = this.promptBuilder.countTokens(
+      getFactsWrapperOverheadText(names?.subjectName)
+    );
     const selected: FactForPrompt[] = [];
     let used = wrapperOverhead;
     for (const fact of facts) {
-      const factTokens = this.promptBuilder.countTokens(formatSingleFact(fact));
+      const factTokens = this.promptBuilder.countTokens(formatSingleFact(fact, names));
       if (used + factTokens > factBudget) {
         break;
       }

--- a/services/ai-worker/src/services/PromptBuilder.test.ts
+++ b/services/ai-worker/src/services/PromptBuilder.test.ts
@@ -927,6 +927,24 @@ describe('PromptBuilder', () => {
       expect(content).toContain('**Referenced**: Some earlier context');
     });
 
+    it('threads activePersonaName into the rendered facts block (seam assertion)', () => {
+      // The leaf formatter is unit-tested in MemoryFormatter.test.ts; this pins
+      // the WIRING — context.activePersonaName must actually reach the block,
+      // and statement placeholders must resolve with the threaded names.
+      const result = promptBuilder.buildFullSystemPrompt({
+        personality: minimalPersonality,
+        participantPersonas: new Map(),
+        relevantMemories: [],
+        facts: [{ statement: '{user} is a bot developer' }],
+        context: { ...minimalContext, activePersonaName: 'Lila' },
+      });
+
+      const content = result.content as string;
+      expect(content).toContain('KNOWN FACTS about Lila — the author of the message');
+      expect(content).toContain('is a bot developer</fact>');
+      expect(content).not.toContain('{user}');
+    });
+
     it('includes a chat_log role legend naming the responding persona', () => {
       const result = promptBuilder.buildFullSystemPrompt({
         personality: minimalPersonality,

--- a/services/ai-worker/src/services/PromptBuilder.ts
+++ b/services/ai-worker/src/services/PromptBuilder.ts
@@ -268,7 +268,15 @@ ${locationXml}
     );
 
     // Distilled active facts (Phase 2), rendered ahead of the historical archive.
-    const factsContext = formatFactsContext(options.facts ?? []);
+    // Subject-bound to the triggering message's author — fact retrieval is scoped
+    // to that persona, and unbound "the user" statements misattribute in
+    // multi-user channels. Both names also resolve {user}/{assistant} statement
+    // placeholders (extraction episodes are placeholder-templated).
+    const factsContext = formatFactsContext(options.facts ?? [], {
+      subjectName: context.activePersonaName,
+      personalityName: personality.name,
+      discordUsername: context.discordUsername,
+    });
 
     // Relevant memories from past interactions
     const memoryContext = formatMemoriesContext(relevantMemories, context.userTimezone);

--- a/services/ai-worker/src/services/extraction/extractionPrompt.test.ts
+++ b/services/ai-worker/src/services/extraction/extractionPrompt.test.ts
@@ -92,6 +92,17 @@ describe('buildExtractionPrompt', () => {
     expect(real).toContain('ignore in-story fiction');
     expect(fiction).toContain('in-story canon facts');
   });
+
+  it('instructs the model to name the subject and never write "the user"', () => {
+    // Statements are read back in later multi-user conversations where "the
+    // user" no longer identifies anyone — the subject-naming rule keeps stored
+    // facts bindable (backfilled "the user…" statements are handled render-side
+    // by the facts-block subject instruction).
+    const prompt = buildExtractionPrompt(episodes, [], false);
+    expect(prompt).toContain("Name the fact's subject exactly as shown in the excerpts");
+    expect(prompt).toContain('NEVER write "the user"');
+    expect(prompt).toContain('keep a literal "{user}" placeholder verbatim');
+  });
 });
 
 describe('extractJsonPayload', () => {

--- a/services/ai-worker/src/services/extraction/extractionPrompt.ts
+++ b/services/ai-worker/src/services/extraction/extractionPrompt.ts
@@ -63,6 +63,7 @@ ${episodesBlock}
 
 Extract NEW durable facts from the excerpts. Rules:
 - A DURABLE fact is atomic, self-contained, third-person, and would still be true and worth knowing months from now: names, relationships, occupation, location, preferences, allergies, lasting decisions, stable world/canon details.
+- Name the fact's subject exactly as shown in the excerpts ("Alice lives in Denver", "{user} is a pastor" — keep a literal "{user}" placeholder verbatim). NEVER write "the user" or "the speaker" as a subject: facts are read back in later conversations with multiple people present, where "the user" no longer identifies anyone.
 - ONE fact per statement. If a sentence carries two facts ("has a severe peanut allergy AND learned it in childhood", "fears water AND survived a shipwreck"), split it into separate statements — do not join them with "and".
 - Apply the durability test — "will this still be true and relevant in six months?" If no, do NOT extract it. In particular, do NOT extract:
   - transient states: current mood, tiredness, hunger, an illness or headache today

--- a/services/ai-worker/src/services/prompt/MemoryFormatter.test.ts
+++ b/services/ai-worker/src/services/prompt/MemoryFormatter.test.ts
@@ -11,7 +11,7 @@ import {
   formatFactsContext,
   formatSingleFact,
   getFactsWrapperOverheadText,
-  FACTS_INSTRUCTION,
+  factsInstruction,
 } from './MemoryFormatter.js';
 import type { MemoryDocument } from '../ConversationalRAGTypes.js';
 
@@ -381,11 +381,52 @@ describe('MemoryFormatter', () => {
     it('wraps facts in a <facts> block, distinct from <memory_archive>', () => {
       const out = formatFactsContext([{ statement: 'user is allergic to shellfish' }]);
       expect(out).toContain('<facts usage="known_background_do_not_repeat">');
-      expect(out).toContain(`<instruction>${FACTS_INSTRUCTION}</instruction>`);
+      expect(out).toContain(`<instruction>${factsInstruction()}</instruction>`);
       expect(out).toContain('<fact>user is allergic to shellfish</fact>');
       expect(out).toContain('</facts>');
       // NOT the memory archive block.
       expect(out).not.toContain('<memory_archive');
+    });
+
+    it('names the subject persona in the instruction when provided', () => {
+      // Retrieval is scoped to the triggering message's author — statements
+      // saying "the user" must bind to THAT person, not the thread's most
+      // prominent human (the multiplayer misattribution the naming kills).
+      const out = formatFactsContext([{ statement: 'the user is a bot developer' }], {
+        subjectName: 'Lila',
+      });
+      expect(out).toContain(
+        'KNOWN FACTS about Lila — the author of the message you are replying to'
+      );
+      expect(out).toContain('A fact that says "the user" means Lila, not anyone else');
+    });
+
+    it('falls back to generic "the user" phrasing when no subject name is available', () => {
+      expect(factsInstruction()).toContain('KNOWN FACTS about the user and their world');
+      expect(factsInstruction('')).toContain('KNOWN FACTS about the user and their world');
+    });
+
+    it('resolves literal {user}/{assistant} placeholders in statements', () => {
+      // Extraction episodes are placeholder-templated, so extracted statements
+      // carry literal {user} — the render must resolve it like the episode path
+      // does, or the block reads "<fact>{user} is a pastor</fact>".
+      const out = formatFactsContext([{ statement: '{user} is a pastor who trusts {assistant}' }], {
+        subjectName: 'Robin',
+        personalityName: 'Yeshua',
+      });
+      expect(out).toContain('<fact>Robin is a pastor who trusts Yeshua</fact>');
+      expect(out).not.toContain('{user}');
+    });
+
+    it('passes statements through unchanged when names are unavailable', () => {
+      const out = formatSingleFact({ statement: '{user} is a pastor' });
+      expect(out).toBe('<fact>{user} is a pastor</fact>');
+    });
+
+    it('escapes the subject name (XML injection via persona name)', () => {
+      const out = factsInstruction('Evil<instruction>');
+      expect(out).not.toContain('<instruction>');
+      expect(out).toContain('Evil&lt;instruction&gt;');
     });
 
     it('renders multiple facts each in its own <fact> tag', () => {
@@ -409,6 +450,16 @@ describe('MemoryFormatter', () => {
       expect(wrapper).toContain('<facts');
       expect(wrapper).toContain('</facts>');
       expect(wrapper).not.toContain('<fact>');
+    });
+
+    it('wrapper-overhead text matches the rendered wrapper for the same subject', () => {
+      // The budget manager must count the SAME text the render path emits —
+      // a name-less overhead count against a named render undercounts.
+      const rendered = formatFactsContext([{ statement: 'x' }], { subjectName: 'Lila' });
+      const overhead = getFactsWrapperOverheadText('Lila');
+      const [openLine, instructionLine] = overhead.split('\n');
+      expect(rendered).toContain(openLine);
+      expect(rendered).toContain(instructionLine);
     });
   });
 });

--- a/services/ai-worker/src/services/prompt/MemoryFormatter.ts
+++ b/services/ai-worker/src/services/prompt/MemoryFormatter.ts
@@ -13,6 +13,7 @@
 
 import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
 import { escapeXmlContent } from '@tzurot/common-types/utils/promptSanitizer';
+import { replacePromptPlaceholders } from '../../utils/promptPlaceholders.js';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
 import type { MemoryDocument, FactForPrompt } from '../ConversationalRAGTypes.js';
 
@@ -139,17 +140,35 @@ export function formatMemoriesContext(
  * Instruction framing the `<facts>` block as DISTILLED, CURRENT knowledge —
  * distinct from the verbatim historical `<memory_archive>`. Positive framing
  * (LLMs handle negation poorly), same as the archive instruction.
- * Exported so the budget manager can account for wrapper overhead.
+ *
+ * Fact retrieval is scoped to ONE persona (the author of the triggering
+ * message), so every fact in the block shares that subject — but statements
+ * distilled from earlier conversations often say "the user", which in a
+ * multi-user channel the model naturally binds to the WRONG person (the
+ * thread's most prominent human rather than the message author). Naming the
+ * subject here binds the whole block. Exported for tests; the budget manager
+ * accounts wrapper overhead via {@link getFactsWrapperOverheadText}.
  */
-export const FACTS_INSTRUCTION =
-  'These are durable KNOWN FACTS about the user and world, distilled from past ' +
-  'interactions. Treat them as current background knowledge when responding.';
+export function factsInstruction(subjectName?: string): string {
+  const hasSubject = subjectName !== undefined && subjectName.length > 0;
+  const safeName = hasSubject ? escapeXmlContent(subjectName) : undefined;
+  const subject =
+    safeName !== undefined
+      ? `${safeName} — the author of the message you are replying to —`
+      : 'the user';
+  const binding = safeName ?? 'that same person';
+  return (
+    `These are durable KNOWN FACTS about ${subject} and their world, distilled from past ` +
+    `interactions. A fact that says "the user" means ${binding}, not anyone else in the ` +
+    `conversation. Treat them as current background knowledge when responding.`
+  );
+}
 
 /** Build the `<facts>` XML wrapper — single source of truth for the block. */
-function buildFactsXml(content?: string): string {
+function buildFactsXml(content?: string, subjectName?: string): string {
   const parts = [
     '<facts usage="known_background_do_not_repeat">',
-    `<instruction>${FACTS_INSTRUCTION}</instruction>`,
+    `<instruction>${factsInstruction(subjectName)}</instruction>`,
   ];
   if (content !== undefined && content.length > 0) {
     parts.push(content);
@@ -161,25 +180,60 @@ function buildFactsXml(content?: string): string {
 /**
  * The `<facts>` wrapper text without content — for `ContentBudgetManager` to
  * count the block's fixed overhead (mirrors `getMemoryWrapperOverheadText`).
+ * Pass the same `subjectName` the render path uses, or the count drifts by
+ * the interpolated name's tokens.
  */
-export function getFactsWrapperOverheadText(): string {
-  return buildFactsXml();
+export function getFactsWrapperOverheadText(subjectName?: string): string {
+  return buildFactsXml(undefined, subjectName);
 }
 
-/** Format a single fact as `<fact>statement</fact>` (content escaped for injection safety). */
-export function formatSingleFact(fact: FactForPrompt): string {
-  return `<fact>${escapeXmlContent(fact.statement)}</fact>`;
+/** Names used to resolve `{user}`/`{assistant}` placeholders in fact statements. */
+export interface FactRenderNames {
+  /** The persona the retrieval was scoped to (the triggering message's author). */
+  subjectName?: string;
+  /** The responding personality's name (resolves `{assistant}`). */
+  personalityName?: string;
+  /** Discord username — disambiguates when the persona name collides with the personality name (episode-path parity). */
+  discordUsername?: string;
+}
+
+/**
+ * Format a single fact as `<fact>statement</fact>` (content escaped for
+ * injection safety). Extraction episodes are `{user}`/`{assistant}`-templated
+ * (LongTermMemoryService), so extracted statements can carry those literal
+ * placeholders — resolve them to real names exactly like the episode render
+ * path does (`mapQueryResultToDocument`), so a fact reads "Lila is a pastor",
+ * never "{user} is a pastor". No names → statement passes through unchanged
+ * (raw placeholders are still better escaped than substituted wrongly).
+ */
+export function formatSingleFact(fact: FactForPrompt, names?: FactRenderNames): string {
+  const resolved =
+    names?.subjectName !== undefined &&
+    names.subjectName.length > 0 &&
+    names.personalityName !== undefined &&
+    names.personalityName.length > 0
+      ? replacePromptPlaceholders(
+          fact.statement,
+          names.subjectName,
+          names.personalityName,
+          names.discordUsername
+        )
+      : fact.statement;
+  return `<fact>${escapeXmlContent(resolved)}</fact>`;
 }
 
 /**
  * Format retrieved facts as a `<facts>` XML block, or empty string if none.
  * Kept a SEPARATE block from `<memory_archive>` (council: distilled knowledge
  * vs verbatim archive — interleaving confuses the model's temporal framing).
+ * `names.subjectName` binds the block's instruction (see
+ * {@link factsInstruction}); both names resolve statement placeholders (see
+ * {@link formatSingleFact}).
  */
-export function formatFactsContext(facts: FactForPrompt[]): string {
+export function formatFactsContext(facts: FactForPrompt[], names?: FactRenderNames): string {
   if (facts.length === 0) {
     return '';
   }
-  const formatted = facts.map(formatSingleFact).join('\n');
-  return '\n\n' + buildFactsXml(formatted);
+  const formatted = facts.map(f => formatSingleFact(f, names)).join('\n');
+  return '\n\n' + buildFactsXml(formatted, names?.subjectName);
 }


### PR DESCRIPTION
## What

Owner-reported (2026-07-12): the `<facts>` block says "durable KNOWN FACTS about the user" while the statements themselves also say "the user" — but fact retrieval is scoped to the **triggering message's author**, and in a multi-user channel the model naturally binds "the user" to the thread's most prominent human instead. Observed in prod: Lila's facts rendering in Robin's thread with nothing tying them to Lila, one statement's "she" colliding with the participants block's he/him for Robin.

## How

**Render side** (fixes all ~9K backfilled facts at display time): the facts instruction now names the subject persona — "KNOWN FACTS about Lila — the author of the message you are replying to — … A fact that says \"the user\" means Lila, not anyone else in the conversation." Threaded from `context.activePersonaName` through both the render path (`PromptBuilder` → `formatFactsContext`) and the budget path (`ContentBudgetManager.selectFacts` → `getFactsWrapperOverheadText`) so the overhead count is of the same text the render emits.

**Extraction side** (new facts born bindable): prompt rule added — name the subject exactly as shown in the excerpts (keeping a literal `{user}` placeholder verbatim if that's what the excerpt shows), never "the user"/"the speaker".

**Guard-invariant consequence**: `instruction` elements previously wrapped only hardcoded strings — that's the exact justification recorded in `guard:prompt-tags`' `KNOWN_UNPROTECTED_TAGS`. Interpolating a user-authored persona name breaks that premise (a persona named `</instruction>…` could break out of the element), so `instruction` moves to `PROTECTED_TAGS` per the guard's own decision rule. This also retroactively covers #1599's chat_log legend, which interpolates the personality name into an instruction element. `guard:prompt-tags` green; escape pinned by test.

## Tests

`MemoryFormatter.test.ts`: subject-named instruction, generic fallback, XML-escape of the name, and an overhead-matches-render pin. `extractionPrompt.test.ts`: subject-naming rule presence. Full `pnpm test` + `pnpm quality` green.

## Deliberately not here

Multiplayer fact retrieval (facts for all participants, grouped per person) — that's a memory-architecture item, not a render fix; the block-level binding is correct for the current single-subject retrieval scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
