### PR TITLE
feat(ai-worker): honor explicitly-set vision-config params per tier

### DIFF
--- a/packages/common-types/src/types/configResolution.ts
+++ b/packages/common-types/src/types/configResolution.ts
@@ -11,6 +11,7 @@
 
 import type { ConvertedLlmParams } from '../schemas/llmAdvancedParams.js';
 import type { ResolvedConfigOverrides } from '../schemas/api/configOverrides.js';
+import type { VisionTierParams } from './schemas/personality.js';
 
 /**
  * Source tier that provided the resolved config.
@@ -93,11 +94,20 @@ export interface LoadedVisionPersonality {
 
 /**
  * Effective resolved VISION config. Vision-description calls consume only the
- * model name (no sampling params apply), so this is minimal — plus the cascade
- * source/name for diagnostics and the BaseConfigResolver source-tracking contract.
+ * model name plus the cascade source/name for diagnostics and the
+ * BaseConfigResolver source-tracking contract — and the row's explicitly-set
+ * vision-callable params (see `params`).
  */
 export interface ResolvedVisionConfig {
   model: string;
   source: ConfigResolutionSource;
   configName?: string;
+  /**
+   * Explicitly-SET vision-callable params of the resolved config row (picked
+   * via `pickVisionTierParams` at resolution time). Absent when the row sets
+   * none — the vision invoke path falls back to system defaults. This is the
+   * carrier the gateway stamp reads into `personality.visionConfigParams`;
+   * without it, dashboard-set vision-preset params are decorative.
+   */
+  params?: VisionTierParams;
 }

--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -22,6 +22,55 @@ import { crossChannelHistoryGroupSchema, referencedMessageSchema } from './messa
 export const customFieldsSchema = z.record(z.string(), z.unknown()).nullable();
 
 /**
+ * Explicitly-SET call params for one vision model tier. Only the numeric
+ * sampling/output knobs a captioning call can honor — reasoning and
+ * contextWindowTokens are text-generation concepts and deliberately absent.
+ * `createChatModel`'s per-model param filtering sanitizes downstream.
+ */
+export const visionTierParamsSchema = z.object({
+  temperature: z.number().optional(),
+  maxTokens: z.number().optional(),
+  topP: z.number().optional(),
+  topK: z.number().optional(),
+  minP: z.number().optional(),
+  topA: z.number().optional(),
+  frequencyPenalty: z.number().optional(),
+  presencePenalty: z.number().optional(),
+  repetitionPenalty: z.number().optional(),
+  /** Determinism knob — applies to captioning (reproducible descriptions) as much as text. */
+  seed: z.number().optional(),
+});
+
+export type VisionTierParams = z.infer<typeof visionTierParamsSchema>;
+
+/** The vision-callable param keys, derived from the schema so the two can't drift. */
+export const VISION_TIER_PARAM_KEYS = Object.keys(
+  visionTierParamsSchema.shape
+) as (keyof VisionTierParams)[];
+
+/**
+ * Pick the explicitly-SET vision-callable params off any params-bearing config
+ * (a mapped LlmConfig row, a resolved config). Undefined when none are set —
+ * no entry beats an empty object. Single shared picker: the vision resolver
+ * uses it at resolution time so `ResolvedVisionConfig.params` is the ONE
+ * carrier the gateway stamp reads.
+ */
+export function pickVisionTierParams(
+  source: Partial<Record<keyof VisionTierParams, number>>
+): VisionTierParams | undefined {
+  const out: VisionTierParams = {};
+  let found = false;
+  for (const key of VISION_TIER_PARAM_KEYS) {
+    const value = source[key];
+    if (value !== undefined) {
+      out[key] = value;
+      found = true;
+    }
+  }
+  return found ? out : undefined;
+}
+
+/**
  * Loaded Personality Schema
  *
  * This is the SINGLE SOURCE OF TRUTH for the LoadedPersonality type.
@@ -56,6 +105,16 @@ export const loadedPersonalitySchema = z.object({
    * chain; this carries only the tiers it can't compute locally.
    */
   visionFallbackModels: z.array(z.string()).optional(),
+  /**
+   * Explicitly-SET call params of the resolved vision config(s), keyed by model
+   * name — covers the primary vision model AND the fallback-tier models (each
+   * tier uses ITS config's params). Gateway-stamped from the vision cascade
+   * (`stampResolvedConfig`); the worker looks up by the tier's resolved model
+   * at invoke time. Absent key / absent map = no explicit params for that
+   * model — the vision call uses system defaults (`AI_DEFAULTS.VISION_TEMPERATURE`).
+   * Without this carrier, dashboard-set vision-preset params are decorative.
+   */
+  visionConfigParams: z.record(z.string(), visionTierParamsSchema).optional(),
   /**
    * Provider routing key (e.g. 'openrouter', 'zai-coding'). Drives
    * provider-tier baseURL selection in ModelFactory and any auto-fallthrough

--- a/packages/config-resolver/src/VisionConfigResolver.test.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.test.ts
@@ -43,13 +43,16 @@ function createMockPrisma(): MockPrisma {
 /**
  * A complete `kind='vision'` LlmConfig row in the shape the shared LLM mapper
  * (`LLM_CONFIG_SELECT_WITH_NAME`) reads. Vision configs ARE LlmConfig rows, so the
- * resolver reuses that mapper — only `model` + `name` end up in the resolved result.
+ * resolver reuses that mapper — `model` + `name` + the row's explicitly-set
+ * vision-callable params end up in the resolved result.
  */
-function visionRow(over: { model?: string; name?: string } = {}): Record<string, unknown> {
+function visionRow(
+  over: { model?: string; name?: string; advancedParameters?: Record<string, unknown> } = {}
+): Record<string, unknown> {
   return {
     model: over.model ?? 'qwen/qwen3-vl-235b-a22b-instruct',
     provider: 'openrouter',
-    advancedParameters: null,
+    advancedParameters: over.advancedParameters ?? null,
     memoryScoreThreshold: null,
     memoryLimit: null,
     contextWindowTokens: 8192,
@@ -98,6 +101,45 @@ describe('VisionConfigResolver', () => {
       expect(result.config.source).toBe('user-personality');
       expect(result.config.model).toBe('user-pers-vision');
       expect(result.configName).toBe('user-pers-override');
+    });
+
+    it("carries the row's explicitly-set params through the REAL mapper (tier 1)", async () => {
+      // The round-1 review of the vision-params feature found the resolver
+      // discarding every sampling field — this pins the real end-to-end path
+      // (DB row JSONB → mapper → ResolvedVisionConfig.params) so contract
+      // drift between the resolver and the gateway stamp can't recur silently.
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'internal-x',
+        defaultVisionConfigId: null,
+        defaultVisionConfig: null,
+      });
+      mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue({
+        visionConfig: visionRow({
+          model: 'user-pers-vision',
+          name: 'user-pers-override',
+          // JSONB is snake_case; the mapper converts to camelCase
+          advancedParameters: { temperature: 0.7, max_tokens: 2048, seed: 42 },
+        }),
+      });
+
+      const result = await resolver.resolveConfig('user-x', 'p-uuid-123', FAKE_PERSONALITY);
+
+      expect(result.config.params).toEqual({ temperature: 0.7, maxTokens: 2048, seed: 42 });
+    });
+
+    it('omits params when the row sets none (no empty-object noise)', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'internal-x',
+        defaultVisionConfigId: null,
+        defaultVisionConfig: null,
+      });
+      mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue({
+        visionConfig: visionRow({ model: 'user-pers-vision', name: 'user-pers-override' }),
+      });
+
+      const result = await resolver.resolveConfig('user-x', 'p-uuid-123', FAKE_PERSONALITY);
+
+      expect(result.config.params).toBeUndefined();
     });
 
     it('returns the user global default when no per-personality override (tier 2)', async () => {

--- a/packages/config-resolver/src/VisionConfigResolver.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.ts
@@ -45,6 +45,7 @@ import {
   type ResolvedVisionConfig,
   type LoadedVisionPersonality,
 } from '@tzurot/common-types/types/configResolution';
+import { pickVisionTierParams } from '@tzurot/common-types/types/schemas/personality';
 import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 
 /**
@@ -152,7 +153,12 @@ export class VisionConfigResolver extends BaseConfigResolver<
       });
       if (personalityDefault?.llmConfig) {
         const mapped = mapLlmConfigFromDbWithName(personalityDefault.llmConfig);
-        return { model: mapped.model, source: 'personality', configName: mapped.name };
+        return {
+          model: mapped.model,
+          source: 'personality',
+          configName: mapped.name,
+          params: pickVisionTierParams(mapped),
+        };
       }
     } catch (error) {
       // ERROR severity: a user-configured personality vision default couldn't be
@@ -178,13 +184,18 @@ export class VisionConfigResolver extends BaseConfigResolver<
     return { ...HARDCODED_FALLBACK };
   }
 
-  /** Tiers 1-2: an override REPLACES (vision has a single dimension — the model). */
+  /** Tiers 1-2: an override REPLACES (model + the row's explicit params — no field merge). */
   protected mergeWithPersonality(
     _personality: LoadedVisionPersonality,
     override: MappedLlmConfigWithName,
     tier: 'user-personality' | 'user-default'
   ): ResolvedVisionConfig {
-    return { model: override.model, source: tier, configName: override.name };
+    return {
+      model: override.model,
+      source: tier,
+      configName: override.name,
+      params: pickVisionTierParams(override),
+    };
   }
 
   /** Surface the actual tier from extractFromPersonality to the outer wrapper. */
@@ -245,6 +256,7 @@ export class VisionConfigResolver extends BaseConfigResolver<
         model: mapped.model,
         source: 'personality',
         configName: mapped.name,
+        params: pickVisionTierParams(mapped),
       };
       this.cache.set(GLOBAL_DEFAULT_CACHE_KEY, {
         config,
@@ -300,6 +312,7 @@ export class VisionConfigResolver extends BaseConfigResolver<
         model: mapped.model,
         source: 'personality',
         configName: mapped.name,
+        params: pickVisionTierParams(mapped),
       };
       this.cache.set(FREE_DEFAULT_CACHE_KEY, {
         config,

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -424,6 +424,54 @@ describe('VisionProcessor', () => {
         );
       });
 
+      it('honors explicitly-set vision-config params for the resolved model (seam assertion)', async () => {
+        // Gateway-stamped visionConfigParams must reach createChatModel — the
+        // decorative-config bug this carrier exists to fix. Explicit temperature
+        // wins over VISION_TEMPERATURE; other set params pass through.
+        mockCheckModelVisionSupport.mockResolvedValue(true);
+
+        const personality = createMockPersonality({
+          model: 'gpt-4o',
+          visionModel: 'custom-vision-model',
+          visionConfigParams: {
+            'custom-vision-model': { temperature: 0.7, maxTokens: 512 },
+          },
+        });
+
+        await describeImage(mockAttachment, personality);
+
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelName: 'custom-vision-model',
+            temperature: 0.7,
+            maxTokens: 512,
+          })
+        );
+      });
+
+      it('falls back to VISION_TEMPERATURE when the resolved model has no params entry', async () => {
+        mockCheckModelVisionSupport.mockResolvedValue(true);
+
+        const personality = createMockPersonality({
+          model: 'gpt-4o',
+          visionModel: 'custom-vision-model',
+          // Params stamped for a DIFFERENT model (e.g. a fallback tier) must not
+          // leak onto this tier's call.
+          visionConfigParams: {
+            'some-other-model': { temperature: 0.9 },
+          },
+        });
+
+        await describeImage(mockAttachment, personality);
+
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelName: 'custom-vision-model',
+            temperature: AI_DEFAULTS.VISION_TEMPERATURE,
+          })
+        );
+      });
+
       it('should pass user API key to createChatModel', async () => {
         mockCheckModelVisionSupport.mockResolvedValue(true);
 

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -20,7 +20,10 @@ import {
 import { ERROR_MESSAGES, ApiErrorCategory } from '@tzurot/common-types/constants/error';
 import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
-import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
+import {
+  type LoadedPersonality,
+  type VisionTierParams,
+} from '@tzurot/common-types/types/schemas/personality';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { createChatModel } from '../ModelFactory.js';
 import { detectVisionProvider } from '../ProviderRouter.js';
@@ -181,6 +184,12 @@ interface InvokeVisionModelOptions {
   systemPrompt?: string;
   userApiKey?: string;
   /**
+   * Explicitly-set call params of the TIER's vision config (gateway-stamped,
+   * looked up by resolved model in describeImage). Absent → system defaults
+   * (`AI_DEFAULTS.VISION_TEMPERATURE`).
+   */
+  visionParams?: VisionTierParams;
+  /**
    * Explicit provider for the vision call. When provided, overrides the
    * `config.AI_PROVIDER` env-default lookup inside `createChatModel`. Required
    * for cross-provider personalities (e.g., main=z.ai-coding, vision=OpenRouter)
@@ -208,7 +217,8 @@ async function invokeVisionModel(
   modelName: string,
   options: InvokeVisionModelOptions
 ): Promise<string> {
-  const { systemPrompt, userApiKey, provider, loggingContext, personalityName } = options;
+  const { systemPrompt, userApiKey, provider, loggingContext, personalityName, visionParams } =
+    options;
 
   // Single-chokepoint silent-fallback signal: every vision call across every
   // upstream path (DependencyStep, ConversationalRAGService, ConversationInput-
@@ -230,11 +240,16 @@ async function invokeVisionModel(
     );
   }
 
+  // Explicitly-set vision-config params win; the low factual-captioning
+  // temperature stays the default for anything unset (descriptions feed
+  // memory + search, where creative sampling harms). createChatModel's
+  // per-model filtering sanitizes any param the model can't take.
   const { model } = createChatModel({
     modelName,
     apiKey: userApiKey,
     provider,
-    temperature: AI_DEFAULTS.VISION_TEMPERATURE,
+    ...visionParams,
+    temperature: visionParams?.temperature ?? AI_DEFAULTS.VISION_TEMPERATURE,
   });
 
   const messages = [];
@@ -746,6 +761,10 @@ export async function describeImage(
       imageUrl,
       loggingContext,
       personalityName: personality.name,
+      // Per-TIER params: the fallback chain re-enters describeImage with each
+      // tier's model forced via options.model, so this lookup naturally gives
+      // every tier ITS OWN config's params.
+      visionParams: personality.visionConfigParams?.[usedModel],
     },
     options.throwOnFailure === true
   );

--- a/services/api-gateway/src/utils/stampResolvedConfig.test.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.test.ts
@@ -20,22 +20,35 @@ const llmResolver = (
     resolveConfig: vi.fn().mockResolvedValue({ config: { model, ...extraConfig }, source }),
   }) as unknown as LlmConfigResolver;
 
+// Mirrors the REAL ResolvedVisionConfig contract: explicit params arrive
+// NESTED on `params` (picked at resolution time by VisionConfigResolver via
+// pickVisionTierParams), never as flat sampling fields — the round-1 review
+// caught the double drifting from the real shape and hiding a dead feature.
 const visionResolver = (
   model: string,
   source: string,
-  fallbacks: { global?: string; free?: string } = {}
+  fallbacks: { global?: string; free?: string } = {},
+  params: {
+    primary?: Record<string, number>;
+    global?: Record<string, number>;
+    free?: Record<string, number>;
+  } = {}
 ): VisionConfigResolver =>
   ({
-    resolveConfig: vi.fn().mockResolvedValue({ config: { model }, source }),
+    resolveConfig: vi.fn().mockResolvedValue({ config: { model, params: params.primary }, source }),
     getGlobalDefaultConfig: vi
       .fn()
       .mockResolvedValue(
-        fallbacks.global !== undefined ? { model: fallbacks.global, source: 'personality' } : null
+        fallbacks.global !== undefined
+          ? { model: fallbacks.global, source: 'personality', params: params.global }
+          : null
       ),
     getFreeDefaultVisionConfig: vi
       .fn()
       .mockResolvedValue(
-        fallbacks.free !== undefined ? { model: fallbacks.free, source: 'personality' } : null
+        fallbacks.free !== undefined
+          ? { model: fallbacks.free, source: 'personality', params: params.free }
+          : null
       ),
   }) as unknown as VisionConfigResolver;
 
@@ -166,6 +179,69 @@ describe('stampResolvedConfig', () => {
         visionResolver('qwen/hardcoded-fallback', 'hardcoded')
       );
       expect(personality.visionModel).toBeUndefined();
+    });
+
+    it('stamps explicitly-set vision-config params keyed by model, per tier', async () => {
+      // Each tier's entry carries ITS config's explicit params — the worker
+      // looks them up by the resolved tier model at invoke time.
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver(
+          'primary-vision',
+          'personality',
+          { global: 'g-default', free: 'f-default' },
+          {
+            primary: { temperature: 0.7, maxTokens: 512 },
+            global: { temperature: 0.2 },
+            // free config sets nothing explicit → no entry
+          }
+        )
+      );
+      expect(personality.visionConfigParams).toEqual({
+        'primary-vision': { temperature: 0.7, maxTokens: 512 },
+        'g-default': { temperature: 0.2 },
+      });
+    });
+
+    it('omits visionConfigParams entirely when no config sets explicit params', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver('primary-vision', 'personality', { global: 'g-default' })
+      );
+      expect(personality.visionConfigParams).toBeUndefined();
+    });
+
+    it('primary config params win a same-model collision with a fallback tier', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver(
+          'shared-model',
+          'personality',
+          { global: 'shared-model' },
+          { primary: { temperature: 0.7 }, global: { temperature: 0.1 } }
+        )
+      );
+      expect(personality.visionConfigParams).toEqual({ 'shared-model': { temperature: 0.7 } });
+    });
+
+    it('does not stamp params from a hardcoded-source primary (bootstrap window)', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver('fallback-model', 'hardcoded', {}, { primary: { temperature: 0.9 } })
+      );
+      expect(personality.visionConfigParams).toBeUndefined();
     });
 
     it('fails open on a vision-resolver throw (seed vision left unstamped)', async () => {

--- a/services/api-gateway/src/utils/stampResolvedConfig.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.ts
@@ -9,12 +9,46 @@
 
 import { LLM_CONFIG_OVERRIDE_KEYS } from '@tzurot/common-types/schemas/llmAdvancedParams';
 import { type ConfigSourceId } from '@tzurot/common-types/types/schemas/generation';
-import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
-import { type ResolvedLlmConfig } from '@tzurot/common-types/types/configResolution';
+import {
+  type LoadedPersonality,
+  type VisionTierParams,
+} from '@tzurot/common-types/types/schemas/personality';
+import {
+  type ResolvedLlmConfig,
+  type ResolvedVisionConfig,
+} from '@tzurot/common-types/types/configResolution';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { LlmConfigResolver, VisionConfigResolver } from '@tzurot/config-resolver';
 
 const logger = createLogger('ConfigStamping');
+
+/**
+ * Build the model-keyed map of explicitly-set vision-config params, one entry
+ * per resolved TIER config — the worker looks these up by the tier's resolved
+ * model at invoke time, so a fallback tier runs with ITS config's params, not
+ * the primary's. The params themselves are picked at RESOLUTION time
+ * (`VisionConfigResolver` via the shared `pickVisionTierParams`) and carried on
+ * `ResolvedVisionConfig.params` — this function only keys them by model.
+ * Without this carrier, dashboard-set vision-preset params are decorative
+ * (the invoke site falls back to `AI_DEFAULTS.VISION_TEMPERATURE`).
+ * Undefined when no config sets any explicit param.
+ */
+function buildVisionConfigParams(
+  configs: (ResolvedVisionConfig | null | undefined)[]
+): Record<string, VisionTierParams> | undefined {
+  const map: Record<string, VisionTierParams> = {};
+  for (const config of configs) {
+    if (config === null || config === undefined || config.model.length === 0) {
+      continue;
+    }
+    // First writer wins on a model collision: the PRIMARY config's params
+    // must not be clobbered by a same-model fallback tier.
+    if (config.params !== undefined && map[config.model] === undefined) {
+      map[config.model] = config.params;
+    }
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+}
 
 /**
  * Apply a resolved (already-merged) LLM config onto the personality — model plus
@@ -108,36 +142,7 @@ export async function stampResolvedConfig(
   // vision failure. The worker has no Prisma, so all DB resolution stays here.
   if (visionConfigResolver !== undefined) {
     try {
-      // resolveConfig picks the effective vision model; the two default readers supply the
-      // fallback tiers. Parallel — each is cache-backed after warmup (job-build, not per-token).
-      const [vision, globalDefault, freeDefault] = await Promise.all([
-        visionConfigResolver.resolveConfig(userId, personality.id, personality),
-        visionConfigResolver.getGlobalDefaultConfig(),
-        visionConfigResolver.getFreeDefaultVisionConfig(),
-      ]);
-      // Skip the hardcoded-fallback tier (source='hardcoded' → MODEL_DEFAULTS.VISION_FALLBACK,
-      // the slow model the resolver only returns before the vision globals are seeded).
-      // Stamping it would make selectVisionModel priority-1 fire and force the fallback even
-      // when the main model has native vision — the exact timeout this epic targets. Leaving
-      // it unstamped lets priority-2 (main-model-vision) win during the bootstrap window.
-      // Symmetric with the text leg, which skips the 'personality' (= seed) source.
-      if (vision.source !== 'hardcoded') {
-        stamped = { ...stamped, visionModel: vision.config.model };
-      }
-      // The DB-resolved fallback tiers (global → free), deduped + non-empty. The worker
-      // composes its local native-main + hardcoded tiers around this; only these DB tiers
-      // must cross the boundary. Stamped independently of visionModel — it's for the
-      // runtime-failure path, not the initial pick.
-      const fallbackModels = [
-        ...new Set(
-          [globalDefault?.model, freeDefault?.model].filter(
-            (m): m is string => m !== undefined && m.length > 0
-          )
-        ),
-      ];
-      if (fallbackModels.length > 0) {
-        stamped = { ...stamped, visionFallbackModels: fallbackModels };
-      }
+      stamped = await stampVisionAxis(stamped, personality, userId, visionConfigResolver);
     } catch (error) {
       logger.warn(
         { err: error, requestId, personalityId: personality.id },
@@ -147,4 +152,59 @@ export async function stampResolvedConfig(
   }
 
   return { personality: stamped, configSource };
+}
+
+/**
+ * The vision-axis stamp: primary vision model, DB-resolved fallback tiers, and
+ * the per-tier explicit params map. Throws propagate to the caller's fail-open
+ * catch — this helper only owns the happy-path branching.
+ */
+async function stampVisionAxis(
+  stamped: LoadedPersonality,
+  personality: LoadedPersonality,
+  userId: string,
+  visionConfigResolver: VisionConfigResolver
+): Promise<LoadedPersonality> {
+  // resolveConfig picks the effective vision model; the two default readers supply the
+  // fallback tiers. Parallel — each is cache-backed after warmup (job-build, not per-token).
+  const [vision, globalDefault, freeDefault] = await Promise.all([
+    visionConfigResolver.resolveConfig(userId, personality.id, personality),
+    visionConfigResolver.getGlobalDefaultConfig(),
+    visionConfigResolver.getFreeDefaultVisionConfig(),
+  ]);
+  let result = stamped;
+  // Skip the hardcoded-fallback tier (source='hardcoded' → MODEL_DEFAULTS.VISION_FALLBACK,
+  // the slow model the resolver only returns before the vision globals are seeded).
+  // Stamping it would make selectVisionModel priority-1 fire and force the fallback even
+  // when the main model has native vision — the exact timeout this epic targets. Leaving
+  // it unstamped lets priority-2 (main-model-vision) win during the bootstrap window.
+  // Symmetric with the text leg, which skips the 'personality' (= seed) source.
+  if (vision.source !== 'hardcoded') {
+    result = { ...result, visionModel: vision.config.model };
+  }
+  // The DB-resolved fallback tiers (global → free), deduped + non-empty. The worker
+  // composes its local native-main + hardcoded tiers around this; only these DB tiers
+  // must cross the boundary. Stamped independently of visionModel — it's for the
+  // runtime-failure path, not the initial pick.
+  const fallbackModels = [
+    ...new Set(
+      [globalDefault?.model, freeDefault?.model].filter(
+        (m): m is string => m !== undefined && m.length > 0
+      )
+    ),
+  ];
+  if (fallbackModels.length > 0) {
+    result = { ...result, visionFallbackModels: fallbackModels };
+  }
+  const visionConfigParams = buildVisionConfigParams([
+    // hardcoded-source primary carries the bootstrap fallback, not a user
+    // config — its params must not stamp (same reasoning as visionModel).
+    vision.source !== 'hardcoded' ? vision.config : null,
+    globalDefault,
+    freeDefault,
+  ]);
+  if (visionConfigParams !== undefined) {
+    result = { ...result, visionConfigParams };
+  }
+  return result;
 }


### PR DESCRIPTION
## What

Owner-queued follow-up to #1600 (the text-side stamp regression): vision presets are ordinary LlmConfig rows whose dashboard accepts Core Sampling values — but nothing honored them. The gateway's vision stamp carried only the `visionModel` **string**, and `VisionProcessor.invokeVisionModel` built its call as `{modelName, apiKey, provider, temperature: AI_DEFAULTS.VISION_TEMPERATURE}` — hardcoded 0.3, nothing else. Config says X, runtime does Y — the same least-surprise class as the text bug, on the vision axis.

**Owner-adjudicated fix shape** (2026-07-12): explicitly-SET vision-config params win; **0.3 stays the unset default** — it's the right captioning default, since descriptions feed memory and search where creative sampling harms.

## How

- **Carrier** (`common-types`): `LoadedPersonality.visionConfigParams` — an optional model-name-keyed map of `visionTierParamsSchema` (the vision-callable numeric knobs: temperature, maxTokens, sampling penalties; `reasoning`/`contextWindowTokens` deliberately excluded as text-generation concepts). Rolling-deploy safe — optional field, old services ignore it.
- **Stamp leg** (`api-gateway`): `buildVisionConfigParams` picks the explicitly-set fields off each resolved vision config — primary, global default, free default — one entry per model, so **each fallback tier carries ITS config's params**. First-writer-wins on a same-model collision (primary beats fallback). Hardcoded-source primary contributes nothing (same bootstrap-window reasoning as the `visionModel` skip). The vision axis moved into a `stampVisionAxis` helper (complexity cap).
- **Invoke** (`ai-worker`): `describeImage` looks the map up by the resolved tier model — the fallback chain re-enters `describeImage` with each tier's model forced, so per-tier resolution falls out naturally with ONE lookup site. `invokeVisionModel` spreads the params into `createChatModel` with `temperature ?? AI_DEFAULTS.VISION_TEMPERATURE`; `createChatModel`'s per-model param filtering sanitizes anything a given model can't take.

## Tests

Stamp side: per-tier keyed entries, no-explicit-params → no map, primary-wins collision, hardcoded-source exclusion. Invoke side (seam assertions on the `createChatModel` mock): explicit params reach the call and beat the default; a different model's entry does NOT leak onto this tier's call; the pre-existing VISION_TEMPERATURE default test still pins the unset path. Full `pnpm test` + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
