### PR TITLE
fix: main-pool idle-in-transaction timeout (wedged-tx reaper)

### DIFF
--- a/packages/common-types/src/services/poolConfig.test.ts
+++ b/packages/common-types/src/services/poolConfig.test.ts
@@ -11,6 +11,7 @@ import {
   resolveConnectionTimeoutMs,
   resolvePoolStatsIntervalMs,
   resolveMainLockTimeoutMs,
+  resolveMainIdleInTxTimeoutMs,
   mainPoolConnectionOptions,
   resolveFastPoolMax,
   resolveFastLockTimeoutMs,
@@ -75,12 +76,14 @@ describe('transientPoolOptions', () => {
 });
 
 describe('mainPoolConnectionOptions', () => {
-  it('builds keepAlive + explicit idle eviction + the lock_timeout GUC with defaults', () => {
+  it('builds keepAlive + explicit idle eviction + the GUC pair with defaults', () => {
     expect(mainPoolConnectionOptions({})).toEqual({
       keepAlive: true,
       keepAliveInitialDelayMillis: MAIN_POOL_DEFAULTS.KEEPALIVE_INITIAL_DELAY_MS,
       idleTimeoutMillis: MAIN_POOL_DEFAULTS.IDLE_TIMEOUT_MS,
-      options: `-c lock_timeout=${MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS}`,
+      options:
+        `-c lock_timeout=${MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS} ` +
+        `-c idle_in_transaction_session_timeout=${MAIN_POOL_DEFAULTS.IDLE_IN_TX_TIMEOUT_MS}`,
     });
   });
 
@@ -92,7 +95,7 @@ describe('mainPoolConnectionOptions', () => {
   });
 
   it('honors a DB_MAIN_LOCK_TIMEOUT_MS override and falls back on garbage', () => {
-    expect(mainPoolConnectionOptions({ DB_MAIN_LOCK_TIMEOUT_MS: '5000' }).options).toBe(
+    expect(mainPoolConnectionOptions({ DB_MAIN_LOCK_TIMEOUT_MS: '5000' }).options).toContain(
       '-c lock_timeout=5000'
     );
     expect(resolveMainLockTimeoutMs({ DB_MAIN_LOCK_TIMEOUT_MS: 'nope' })).toBe(
@@ -101,6 +104,22 @@ describe('mainPoolConnectionOptions', () => {
     expect(resolveMainLockTimeoutMs({ DB_MAIN_LOCK_TIMEOUT_MS: '0' })).toBe(
       MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS
     );
+  });
+
+  it('reaps wedged transactions: idle_in_transaction GUC rides the startup options', () => {
+    expect(mainPoolConnectionOptions({ DB_MAIN_IDLE_IN_TX_TIMEOUT_MS: '30000' }).options).toContain(
+      '-c idle_in_transaction_session_timeout=30000'
+    );
+    expect(resolveMainIdleInTxTimeoutMs({})).toBe(MAIN_POOL_DEFAULTS.IDLE_IN_TX_TIMEOUT_MS);
+    expect(resolveMainIdleInTxTimeoutMs({ DB_MAIN_IDLE_IN_TX_TIMEOUT_MS: 'nope' })).toBe(
+      MAIN_POOL_DEFAULTS.IDLE_IN_TX_TIMEOUT_MS
+    );
+  });
+
+  it('0 disables the idle-in-transaction reaper (GUC omitted, lock_timeout intact)', () => {
+    const options = mainPoolConnectionOptions({ DB_MAIN_IDLE_IN_TX_TIMEOUT_MS: '0' }).options;
+    expect(options).not.toContain('idle_in_transaction_session_timeout');
+    expect(options).toBe(`-c lock_timeout=${MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS}`);
   });
 });
 

--- a/packages/common-types/src/services/poolConfig.ts
+++ b/packages/common-types/src/services/poolConfig.ts
@@ -100,6 +100,16 @@ export const MAIN_POOL_DEFAULTS = {
   /** Server GUC. Safe pool-wide: legit ops don't wait seconds on locks; a 55P03
    *  names the cause instead of an unbounded invisible queue. */
   LOCK_TIMEOUT_MS: 3_000,
+  /** Server GUC. A wedged transaction (opened, then the app code hangs or leaks
+   *  without commit/rollback) holds its row locks INDEFINITELY at the server
+   *  (`idle_in_transaction_session_timeout=0` server-side), starving every
+   *  writer that needs those rows — observed as an hour-plus prod lock storm
+   *  where only the victims' lock_timeouts contained the damage. 60s is far
+   *  beyond any legitimate idle-between-statements gap (Prisma's interactive
+   *  transactions default to a ~5s client-side ceiling), so this only ever
+   *  reaps genuinely wedged sessions. Transient clients (db-sync, CLI) carry
+   *  no GUC string and are deliberately unaffected. */
+  IDLE_IN_TX_TIMEOUT_MS: 60_000,
   /** Evict idle connections on our schedule (pg-pool's own default, made
    *  explicit) — paired with keepAlive so a retained idle socket is genuinely
    *  alive, not a middlebox-reaped husk waiting to hang the next query. */
@@ -152,6 +162,19 @@ export function resolveMainLockTimeoutMs(env: NodeJS.ProcessEnv = process.env): 
 }
 
 /**
+ * Resolve the main-pool server-side `idle_in_transaction_session_timeout` in
+ * ms. 0 = disabled (the GUC is omitted from the startup options) — the escape
+ * hatch if the reaper ever bites a legitimate flow; tune via env, no redeploy.
+ */
+export function resolveMainIdleInTxTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  return parseIntEnv(
+    env.DB_MAIN_IDLE_IN_TX_TIMEOUT_MS,
+    MAIN_POOL_DEFAULTS.IDLE_IN_TX_TIMEOUT_MS,
+    0
+  );
+}
+
+/**
  * Main-pool hardening options, applied as the BASE pool config for every
  * `createPrismaClient` pool (fast-pool `poolOverrides` spread after this, so
  * its tighter ladder — including its own `options` string — fully wins there).
@@ -168,11 +191,16 @@ export function mainPoolConnectionOptions(env: NodeJS.ProcessEnv = process.env):
   idleTimeoutMillis: number;
   options: string;
 } {
+  const idleInTxMs = resolveMainIdleInTxTimeoutMs(env);
+  const gucs = [`-c lock_timeout=${resolveMainLockTimeoutMs(env)}`];
+  if (idleInTxMs > 0) {
+    gucs.push(`-c idle_in_transaction_session_timeout=${idleInTxMs}`);
+  }
   return {
     keepAlive: true,
     keepAliveInitialDelayMillis: MAIN_POOL_DEFAULTS.KEEPALIVE_INITIAL_DELAY_MS,
     idleTimeoutMillis: MAIN_POOL_DEFAULTS.IDLE_TIMEOUT_MS,
-    options: `-c lock_timeout=${resolveMainLockTimeoutMs(env)}`,
+    options: gucs.join(' '),
   };
 }
 


### PR DESCRIPTION
The structural guard from today's prod lock storm (15:24–16:32 UTC: recurring `canceling statement due to lock timeout` on gateway writes; a character import timed out mid-window; the holder released before the owner-approved `pg_stat_activity` probe ran and is unidentifiable post-hoc).

**Root condition (probe-verified)**: server-level `idle_in_transaction_session_timeout = 0` — a transaction whose app code wedges without commit/rollback holds row locks indefinitely; only the victims' existing `lock_timeout`s bounded the damage.

**The guard**: the main pool's startup GUC string gains `-c idle_in_transaction_session_timeout=60000` next to its existing `lock_timeout`. 60s is far beyond any legitimate idle-between-statements gap (Prisma's interactive transactions carry a ~5s client-side ceiling), so only genuinely wedged sessions get reaped. Env-tunable via `DB_MAIN_IDLE_IN_TX_TIMEOUT_MS`; `0` disables (GUC omitted) as the escape hatch.

**Deliberately untouched**: the fast pool (already carries its own 5s guard in its GUC ladder) and transient clients (db-sync, CLI — no GUC string by design, so long sync batches can't be reaped by this).

**Known limit, flagged for the owner**: this reaps *app-held* transactions. An external wedged session (e.g. a DB console left mid-transaction) is only reachable by a DB-level `ALTER DATABASE … SET idle_in_transaction_session_timeout` — deliberately not included here since it would also govern transient clients; separate call if wanted.

Verified: `pnpm test` 25/25 packages, `pnpm quality` 27/27 checks; new tests pin the GUC in the options string, the env override, and the 0-disables path (lock_timeout intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)