### PR TITLE
feat: goldens pooling runner + RRF/recall scoring (retrieval A/B instrument)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ops": "tsx packages/tooling/src/cli.ts",
     "with-env": "pnpm ops run --env",
     "eval:memory": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryRetrieval.eval.test.ts",
+    "eval:pool-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/goldensPooling.eval.test.ts",
     "eval:extraction": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts"
   },
   "devDependencies": {

--- a/services/ai-worker/src/services/eval/goldensPooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/goldensPooling.eval.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Goldens pooling runner (TREC-style pooled judgment).
+ *
+ * NOT a CI gate and NOT portable: it reads the LOCAL-ONLY mined corpus from
+ * `reports/goldens-mining/` (see `pnpm ops memory:mine-goldens`) and skips
+ * itself cleanly when that corpus is absent. Run manually via
+ * `pnpm eval:pool-goldens` from the repo root.
+ *
+ * For each draft query it runs BOTH retrieval arms over the real corpus —
+ * dense (the production PgvectorMemoryAdapter path, real local embeddings)
+ * and Postgres FTS (ts_rank) — and pools the top-K of each into a judgment
+ * sheet. The owner then judges only the pooled candidates (relevant / not),
+ * which is what makes ground-truth labeling tractable on a corpus no human
+ * can hold in their head: you react to candidates, you never search your
+ * memory of 19k exchanges.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { type PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { LocalEmbeddingService } from '@tzurot/embeddings';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PgvectorMemoryAdapter } from '../PgvectorMemoryAdapter.js';
+
+// Resolved from the repo root — the pnpm script guarantees the cwd.
+const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
+const CORPUS_PATH = join(WORK_DIR, 'corpus-raw.json');
+const DRAFTS_PATH = join(WORK_DIR, 'query-drafts.json');
+
+const MAIN_USER = '00000000-0000-0000-0000-00000000f001';
+const MAIN_PERSONA = '00000000-0000-0000-0000-00000000f002';
+const SYSTEM_PROMPT = '00000000-0000-0000-0000-00000000f003';
+/** Pool depth per arm — TREC-style shallow pools judge fine at 10. */
+const POOL_K = 10;
+
+interface CorpusRow {
+  id: string;
+  personalityId: string;
+  createdAt: string;
+  content: string;
+  senders: string[];
+}
+
+interface QueryDraft {
+  id: string;
+  targetMemoryId: string;
+  message: string;
+  style: string;
+}
+
+interface PooledCandidate {
+  corpusId: string;
+  denseRank: number | null;
+  ftsRank: number | null;
+  isDraftTarget: boolean;
+}
+
+const corpusAvailable = existsSync(CORPUS_PATH) && existsSync(DRAFTS_PATH);
+
+describe.skipIf(!corpusAvailable)('goldens pooling (local corpus)', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+  let adapter: PgvectorMemoryAdapter;
+  let embeddings: LocalEmbeddingService;
+  let corpus: CorpusRow[];
+  let drafts: QueryDraft[];
+  const pools: Record<string, { message: string; style: string; candidates: PooledCandidate[] }> =
+    {};
+
+  beforeAll(async () => {
+    corpus = (JSON.parse(readFileSync(CORPUS_PATH, 'utf8')) as CorpusRow[]).filter(
+      row => row.content.length > 0
+    );
+    drafts = (JSON.parse(readFileSync(DRAFTS_PATH, 'utf8')) as { drafts: QueryDraft[] }).drafts;
+
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+
+    await seedUserWithPersona(prisma, {
+      userId: MAIN_USER,
+      personaId: MAIN_PERSONA,
+      discordId: '900000000000000011',
+      username: 'pooluser',
+      personaName: 'Pool Persona',
+      personaPreferredName: 'Pool',
+      personaContent: 'The pooling persona',
+    });
+    await prisma.$executeRaw`
+      INSERT INTO system_prompts (id, name, content, updated_at)
+      VALUES (${SYSTEM_PROMPT}::uuid, 'Pool Prompt', 'You are a pooling bot.', NOW())
+    `;
+    // The corpus rows carry their REAL personality ids — create matching rows
+    // so the FK holds and personality-scoped behavior stays faithful.
+    const personalityIds = [...new Set(corpus.map(row => row.personalityId))];
+    for (const [index, personalityId] of personalityIds.entries()) {
+      await prisma.$executeRaw`
+        INSERT INTO personalities (id, name, display_name, slug, system_prompt_id, character_info, personality_traits, owner_id, updated_at)
+        VALUES (${personalityId}::uuid, ${`PoolChar${index}`}, ${`Pool Character ${index}`}, ${`poolchar-${index}`}, ${SYSTEM_PROMPT}::uuid, 'Pooling character', 'Faithful', ${MAIN_USER}::uuid, NOW())
+      `;
+    }
+
+    embeddings = new LocalEmbeddingService();
+    const ready = await embeddings.initialize();
+    if (!ready) {
+      throw new Error('Local embedding model failed to initialize — pooling cannot run');
+    }
+    adapter = new PgvectorMemoryAdapter(prisma, embeddings);
+
+    // Seed through the production write path (embeds each row for real);
+    // real createdAt preserved for any later recency work. The corpus id
+    // rides metadata.sessionId — long rows CHUNK at the embedding token
+    // limit, so hit content can never be matched back to the source row by
+    // string equality; the carrier column survives per chunk.
+    for (const row of corpus) {
+      await adapter.addMemory({
+        text: row.content,
+        metadata: {
+          personaId: MAIN_PERSONA,
+          personalityId: row.personalityId,
+          canonScope: 'personal',
+          createdAt: new Date(row.createdAt).getTime(),
+          summaryType: 'conversation',
+          contextType: 'channel',
+          sessionId: row.id,
+          messageIds: [],
+        },
+      });
+    }
+  }, 900_000);
+
+  afterAll(async () => {
+    writeFileSync(join(WORK_DIR, 'pool.json'), `${JSON.stringify({ pools }, null, 2)}\n`);
+    writeFileSync(join(WORK_DIR, 'judgment-sheets.md'), buildJudgmentSheets(pools, corpus));
+    console.log(
+      `\n=== pooling complete: ${Object.keys(pools).length} queries → ${WORK_DIR}/judgment-sheets.md ===`
+    );
+    // Null-guard each teardown: an early beforeAll throw (e.g. a truncated
+    // corpus JSON) leaves these undefined, and an unguarded cleanup would bury
+    // the real error under a secondary TypeError.
+    await prisma?.$disconnect();
+    await pglite?.close();
+    await embeddings?.shutdown();
+  });
+
+  it('pools both arms for every draft query', { timeout: 900_000 }, async () => {
+    for (const draft of drafts) {
+      // Dense arm: the production retrieval path, persona-wide (no
+      // personality filter — pooling wants candidate diversity), floor-level
+      // threshold so ranking (not the production cutoff) decides the pool.
+      const denseHits = await adapter.queryMemories(draft.message, {
+        personaId: MAIN_PERSONA,
+        limit: POOL_K,
+        scoreThreshold: 0.01,
+      });
+      // Chunk siblings share a carrier id — dedup keeps the best (first) rank.
+      const denseIds = [
+        ...new Set(
+          denseHits
+            .map(hit => (hit.metadata as { sessionId?: string | null }).sessionId ?? undefined)
+            .filter((id): id is string => id !== undefined)
+        ),
+      ];
+
+      // FTS arm: OR-of-lexemes (the parked hybrid branch's FTS-OR shape) —
+      // plainto_tsquery ANDs every word, and a conversational message never
+      // matches ALL its terms, so AND semantics return zero rows on real
+      // chat queries. ts_rank still rewards multi-term matches.
+      const orQuery = draft.message
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, ' ')
+        .split(/\s+/)
+        .filter(word => word.length > 1)
+        .join(' | ');
+      // Empty after stripping (all single-char / all-stopword) → to_tsquery('')
+      // matches nothing silently; skip so a thin sheet has an obvious cause.
+      const ftsRows =
+        orQuery.length === 0
+          ? []
+          : // Same persona_id + visibility scoping as the dense arm's
+            // buildWhereConditions — a no-op on today's single-persona,
+            // all-normal corpus, but keeps the two arms comparable if a 1c
+            // variant ever seeds a second persona or a soft-deleted row.
+            await prisma.$queryRaw<{ session_id: string | null }[]>`
+              SELECT session_id, MAX(ts_rank(to_tsvector('english', content), to_tsquery('english', ${orQuery}))) AS best_rank
+              FROM memories
+              WHERE persona_id = ${MAIN_PERSONA}::uuid
+                AND visibility = 'normal'
+                AND to_tsvector('english', content) @@ to_tsquery('english', ${orQuery})
+              GROUP BY session_id
+              ORDER BY best_rank DESC
+              LIMIT ${POOL_K}
+            `;
+      const ftsIds = ftsRows
+        .map(row => row.session_id ?? undefined)
+        .filter((id): id is string => id !== undefined);
+
+      const pooled = new Map<string, PooledCandidate>();
+      const ensure = (corpusId: string): PooledCandidate => {
+        const existing = pooled.get(corpusId) ?? {
+          corpusId,
+          denseRank: null,
+          ftsRank: null,
+          isDraftTarget: corpusId === draft.targetMemoryId,
+        };
+        pooled.set(corpusId, existing);
+        return existing;
+      };
+      denseIds.forEach((id, index) => {
+        ensure(id).denseRank = index + 1;
+      });
+      ftsIds.forEach((id, index) => {
+        ensure(id).ftsRank = index + 1;
+      });
+      // The draft target always appears on the sheet, even when BOTH arms
+      // missed it (both ranks stay null) — a missed target is the most
+      // informative judgment row.
+      ensure(draft.targetMemoryId);
+
+      pools[draft.id] = {
+        message: draft.message,
+        style: draft.style,
+        candidates: [...pooled.values()],
+      };
+    }
+    expect(Object.keys(pools)).toHaveLength(drafts.length);
+  });
+});
+
+function buildJudgmentSheets(
+  pools: Record<string, { message: string; style: string; candidates: PooledCandidate[] }>,
+  corpus: { id: string; createdAt: string; content: string }[]
+): string {
+  const byId = new Map(corpus.map(row => [row.id, row]));
+  const lines = [
+    '# Goldens pooled-judgment sheets',
+    '',
+    'For each query: mark every candidate `[R]` relevant, `[S]` sort-of, or leave `[ ]` not',
+    'relevant. You are judging ONLY what is listed — no need to recall anything beyond it.',
+    '`◆ TARGET` marks the memory the query was drafted from (judge it too — if it reads as',
+    'not actually relevant, that is a legitimate verdict and kills that golden).',
+    'A target with no rank in either column means BOTH arms missed it — the interesting case.',
+    '',
+  ];
+  for (const [queryId, pool] of Object.entries(pools)) {
+    lines.push(`---`, ``, `## ${queryId} (${pool.style})`, ``, `> ${pool.message}`, ``);
+    const sorted = [...pool.candidates].sort(
+      (a, b) => (a.denseRank ?? 99) + (a.ftsRank ?? 99) - ((b.denseRank ?? 99) + (b.ftsRank ?? 99))
+    );
+    for (const candidate of sorted) {
+      const row = byId.get(candidate.corpusId);
+      const text =
+        row === undefined ? '(row missing)' : row.content.replace(/\s+/g, ' ').slice(0, 240);
+      const marks = [
+        candidate.isDraftTarget ? '◆ TARGET' : null,
+        candidate.denseRank !== null ? `D#${candidate.denseRank}` : null,
+        candidate.ftsRank !== null ? `F#${candidate.ftsRank}` : null,
+      ]
+        .filter(Boolean)
+        .join(' · ');
+      lines.push(
+        `- [ ] \`${candidate.corpusId.slice(0, 8)}\` ${marks} (${row?.createdAt.slice(0, 10) ?? '?'})`,
+        `      ${text}…`,
+        ``
+      );
+    }
+  }
+  return lines.join('\n');
+}

--- a/services/ai-worker/src/services/eval/poolScoring.test.ts
+++ b/services/ai-worker/src/services/eval/poolScoring.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { scoreArm, scoreAllArms, RRF_K, type ScoredQuery, type Qrels } from './poolScoring.js';
+
+function q(queryId: string, candidates: ScoredQuery['candidates']): ScoredQuery {
+  return { queryId, candidates };
+}
+
+describe('scoreArm', () => {
+  it('recall@K counts relevant in the top-K of the arm ranking', () => {
+    const queries = [
+      q('q1', [
+        { corpusId: 'a', denseRank: 1, ftsRank: null },
+        { corpusId: 'b', denseRank: 2, ftsRank: null },
+        { corpusId: 'c', denseRank: 3, ftsRank: null },
+      ]),
+    ];
+    const qrels: Qrels = { q1: { a: 1, c: 1 } }; // 2 relevant
+    // k=2 → top-2 is [a,b], one hit of two relevant → 0.5
+    expect(scoreArm(queries, qrels, 'dense', 2).recallAtK).toBe(0.5);
+    // k=3 → both a and c in → 1.0
+    expect(scoreArm(queries, qrels, 'dense', 3).recallAtK).toBe(1);
+  });
+
+  it('MRR is the reciprocal rank of the FIRST relevant candidate', () => {
+    const queries = [
+      q('q1', [
+        { corpusId: 'a', denseRank: 1, ftsRank: null }, // not relevant
+        { corpusId: 'b', denseRank: 2, ftsRank: null }, // first relevant → 1/2
+        { corpusId: 'c', denseRank: 3, ftsRank: null },
+      ]),
+    ];
+    expect(scoreArm(queries, { q1: { b: 1 } }, 'dense', 10).mrr).toBe(0.5);
+  });
+
+  it('excludes queries with no relevant candidate from both means', () => {
+    const queries = [
+      q('q1', [{ corpusId: 'a', denseRank: 1, ftsRank: null }]),
+      q('q2', [{ corpusId: 'b', denseRank: 1, ftsRank: null }]),
+    ];
+    const qrels: Qrels = { q1: { a: 1 } }; // q2 has nothing relevant
+    const metrics = scoreArm(queries, qrels, 'dense', 10);
+    expect(metrics.scoredQueries).toBe(1);
+    expect(metrics.recallAtK).toBe(1); // only q1 counts, perfect
+  });
+
+  it('an arm that never surfaced the relevant doc scores zero, not NaN', () => {
+    const queries = [
+      q('q1', [
+        { corpusId: 'a', denseRank: 1, ftsRank: null },
+        { corpusId: 'rel', denseRank: null, ftsRank: 1 }, // only FTS found it
+      ]),
+    ];
+    const qrels: Qrels = { q1: { rel: 1 } };
+    const dense = scoreArm(queries, qrels, 'dense', 10);
+    expect(dense.recallAtK).toBe(0);
+    expect(dense.mrr).toBe(0);
+    const fts = scoreArm(queries, qrels, 'fts', 10);
+    expect(fts.recallAtK).toBe(1);
+  });
+});
+
+describe('RRF fusion', () => {
+  it('fuses ranks so a doc found by BOTH arms outranks a doc found by one', () => {
+    const queries = [
+      q('q1', [
+        { corpusId: 'both', denseRank: 3, ftsRank: 3 }, // in both, mid rank
+        { corpusId: 'denseTop', denseRank: 1, ftsRank: null }, // dense #1 only
+      ]),
+    ];
+    // RRF('both') = 1/(60+3)+1/(60+3) ≈ 0.0317; RRF('denseTop') = 1/(60+1) ≈ 0.0164.
+    // So 'both' ranks first under fusion — the whole point of hybrid.
+    const qrels: Qrels = { q1: { both: 1 } };
+    expect(scoreArm(queries, qrels, 'rrf', 1).recallAtK).toBe(1); // 'both' is rank-1 in RRF
+    // Under dense alone, 'both' is rank 3 → not in top-1.
+    expect(scoreArm(queries, qrels, 'dense', 1).recallAtK).toBe(0);
+  });
+
+  it('RRF surfaces a doc that only ONE arm found (union recall)', () => {
+    const queries = [
+      q('q1', [
+        { corpusId: 'ftsOnly', denseRank: null, ftsRank: 1 },
+        { corpusId: 'denseOnly', denseRank: 1, ftsRank: null },
+      ]),
+    ];
+    const qrels: Qrels = { q1: { ftsOnly: 1 } };
+    // dense alone can't see ftsOnly; RRF can.
+    expect(scoreArm(queries, qrels, 'dense', 5).recallAtK).toBe(0);
+    expect(scoreArm(queries, qrels, 'rrf', 5).recallAtK).toBe(1);
+  });
+
+  it('uses the standard RRF_K constant', () => {
+    expect(RRF_K).toBe(60);
+  });
+});
+
+describe('scoreAllArms', () => {
+  it('returns all three arms scored against one qrels set', () => {
+    const queries = [q('q1', [{ corpusId: 'a', denseRank: 1, ftsRank: 2 }])];
+    const result = scoreAllArms(queries, { q1: { a: 1 } }, 10);
+    expect(result.dense.recallAtK).toBe(1);
+    expect(result.fts.recallAtK).toBe(1);
+    expect(result.rrf.recallAtK).toBe(1);
+  });
+});

--- a/services/ai-worker/src/services/eval/poolScoring.ts
+++ b/services/ai-worker/src/services/eval/poolScoring.ts
@@ -1,0 +1,132 @@
+/**
+ * Pool scoring: turn pooled per-arm rankings + owner/judge relevance labels
+ * (qrels) into the retrieval metrics that decide the dense-vs-hybrid A/B.
+ *
+ * Pure and committed (the pooling RUNNER and the qrels are local-only — the
+ * corpus is sensitive — but the scoring MATH is the reusable, testable
+ * instrument the memory epic's phase gates read).
+ *
+ * Three arms are scored against ONE qrels set:
+ *  - dense  — production pgvector ranking
+ *  - fts    — Postgres FTS-OR ranking (the lexical perspective)
+ *  - rrf    — Reciprocal Rank Fusion of the two (what the parked hybrid branch
+ *             implements in SQL; computed here from the collected ranks so the
+ *             A/B needs no branch checkout).
+ */
+
+/** A pooled candidate with its rank in each arm (null = arm didn't surface it). */
+export interface ScoredCandidate {
+  corpusId: string;
+  denseRank: number | null;
+  ftsRank: number | null;
+}
+
+export interface ScoredQuery {
+  queryId: string;
+  candidates: ScoredCandidate[];
+}
+
+/** query id → (corpus id → relevance grade). Absent = judged not-relevant (0). */
+export type Qrels = Record<string, Record<string, number>>;
+
+export type ArmName = 'dense' | 'fts' | 'rrf';
+
+export interface ArmMetrics {
+  /** Mean recall@K across queries that have ≥1 relevant candidate. */
+  recallAtK: number;
+  /** Mean reciprocal rank of the first relevant candidate. */
+  mrr: number;
+  /** Queries with ≥1 relevant candidate anywhere in the pool (the denominator). */
+  scoredQueries: number;
+}
+
+/** RRF constant — the standard 60; damps the top-rank dominance of raw 1/rank. */
+export const RRF_K = 60;
+
+/** A rank list per arm for one query, ties broken by corpus id for determinism. */
+function rankedIds(candidates: ScoredCandidate[], arm: ArmName): string[] {
+  const keyed = candidates
+    .map(candidate => ({ id: candidate.corpusId, score: armScore(candidate, arm) }))
+    .filter(entry => entry.score !== null) as { id: string; score: number }[];
+  // Higher score = better. dense/fts scores are negative rank (rank 1 → -1),
+  // rrf is the summed reciprocal (higher = better) — both sort descending.
+  keyed.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+  return keyed.map(entry => entry.id);
+}
+
+/** Per-arm comparable score (higher = better), or null if the arm didn't rank it. */
+function armScore(candidate: ScoredCandidate, arm: ArmName): number | null {
+  if (arm === 'dense') {
+    return candidate.denseRank === null ? null : -candidate.denseRank;
+  }
+  if (arm === 'fts') {
+    return candidate.ftsRank === null ? null : -candidate.ftsRank;
+  }
+  // RRF: sum of 1/(K+rank) over the arms that surfaced this candidate.
+  let score = 0;
+  let present = false;
+  if (candidate.denseRank !== null) {
+    score += 1 / (RRF_K + candidate.denseRank);
+    present = true;
+  }
+  if (candidate.ftsRank !== null) {
+    score += 1 / (RRF_K + candidate.ftsRank);
+    present = true;
+  }
+  return present ? score : null;
+}
+
+/**
+ * Score one arm over all queries. recall@K uses the arm's ranked list capped at
+ * `k`; queries with no relevant candidate in the pool are excluded from both
+ * means (they can't distinguish arms).
+ */
+export function scoreArm(
+  queries: ScoredQuery[],
+  qrels: Qrels,
+  arm: ArmName,
+  k: number
+): ArmMetrics {
+  let recallSum = 0;
+  let mrrSum = 0;
+  let scored = 0;
+
+  for (const query of queries) {
+    const relevant = new Set(
+      Object.entries(qrels[query.queryId] ?? {})
+        .filter(([, grade]) => grade > 0)
+        .map(([id]) => id)
+    );
+    if (relevant.size === 0) {
+      continue;
+    }
+    scored += 1;
+
+    const ranked = rankedIds(query.candidates, arm);
+    const topK = ranked.slice(0, k);
+    const hits = topK.filter(id => relevant.has(id)).length;
+    recallSum += hits / relevant.size;
+
+    const firstRelevantIndex = ranked.findIndex(id => relevant.has(id));
+    mrrSum += firstRelevantIndex === -1 ? 0 : 1 / (firstRelevantIndex + 1);
+  }
+
+  return {
+    recallAtK: scored === 0 ? 0 : recallSum / scored,
+    mrr: scored === 0 ? 0 : mrrSum / scored,
+    scoredQueries: scored,
+  };
+}
+
+/** Score all three arms at once — the A/B table. */
+export function scoreAllArms(
+  queries: ScoredQuery[],
+  qrels: Qrels,
+  k: number
+): Record<ArmName, ArmMetrics> {
+  return {
+    dense: scoreArm(queries, qrels, 'dense', k),
+    fts: scoreArm(queries, qrels, 'fts', k),
+    rrf: scoreArm(queries, qrels, 'rrf', k),
+  };
+}


### PR DESCRIPTION
The measurement half of the memory Phase-1a resume gate — the instrument that decides whether the parked `feat/memory-hybrid-retrieval` branch un-parks or gets deleted.

**`pnpm eval:pool-goldens`** (`goldensPooling.eval.test.ts`) — runs BOTH retrieval arms over the LOCAL-ONLY mined corpus and pools the top-K of each into TREC-style judgment sheets. Pooled judgment is what makes relevance labeling tractable on a 19k-exchange corpus no human can hold in their head: you react to ~19 pooled candidates per query, you never search your memory. Skips itself cleanly (`describe.skipIf`) when the gitignored corpus is absent — nothing sensitive is committed or required for CI.

**`poolScoring.ts`** — the committed, unit-tested math (8 tests): recall@K + MRR for three arms (`dense`, `fts`, `rrf`) against one qrels set. **RRF is computed from the collected per-arm ranks**, so the dense-vs-hybrid A/B reproduces the fusion the parked branch does in SQL *without a branch checkout*. The tests pin the two claims hybrid rests on: a both-arms doc outranks a single-arm doc, and RRF surfaces an FTS-only doc dense can't see.

Two faithfulness details worth noting:
- **Corpus id rides `metadata.sessionId`** through the production write path, so chunked rows (long exchanges split at the embedding token limit) map back to their source row per chunk — string-matching hit content would silently fail on chunked memories.
- **FTS uses OR-of-lexemes** (the parked branch's FTS-OR shape) because `plainto_tsquery` ANDs every term and no conversational message matches all of them — AND semantics return zero rows on real chat queries.

**What's committed vs local**: the runner + scorer + script are committed (the reusable instrument, also serves the query-sophistication phase 1c). The corpus, the query drafts, the pooled output, and the relevance judgments (qrels) all stay in the gitignored `reports/` tree — the storage policy from #1608.

Owner delegated the relevance judgment to me (evaluator role) — the A/B verdict follows as a separate analysis (LLM-as-judge, judged on intent-match to counter the dense-favoring bias an embedding-flavored judge would otherwise carry).

Verified: `pnpm test` 25/25, `pnpm quality` 27/27; the runner ran end-to-end against the real 800-row corpus (~2 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)