### PR TITLE
feat(ai-worker): parameterize fold turn-count for retrieval eval sweep

### DIFF
--- a/services/ai-worker/src/services/RAGUtils.test.ts
+++ b/services/ai-worker/src/services/RAGUtils.test.ts
@@ -6,12 +6,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AttachmentType } from '@tzurot/common-types/constants/media';
 import type { AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import type { StoredReferencedMessage } from '@tzurot/common-types/types/schemas/message';
+import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
 import {
   buildAttachmentDescriptions,
   extractContentDescriptions,
   injectImageDescriptions,
   countMediaAttachments,
   enrichConversationHistory,
+  extractRecentHistoryWindow,
   type RawHistoryEntry,
 } from './RAGUtils.js';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
@@ -631,6 +633,76 @@ describe('RAGUtils', () => {
       await expect(
         enrichConversationHistory(history, undefined, mockPrisma, mockVisionCache)
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('extractRecentHistoryWindow', () => {
+    const mkHistory = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `msg-${i}`,
+      }));
+
+    it('folds the last LTM_SEARCH_HISTORY_TURNS turns by default', () => {
+      const history = mkHistory(20);
+      const expectedCount = AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS * 2;
+      const lines = extractRecentHistoryWindow(history)?.split('\n') ?? [];
+      expect(lines).toHaveLength(expectedCount);
+      expect(lines[0]).toBe(`msg-${20 - expectedCount}`);
+      expect(lines.at(-1)).toBe('msg-19');
+    });
+
+    it('default is byte-identical to passing the production turn count explicitly', () => {
+      const history = mkHistory(20);
+      expect(extractRecentHistoryWindow(history)).toBe(
+        extractRecentHistoryWindow(history, AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS)
+      );
+    });
+
+    it.each([
+      [5, 10],
+      [8, 16],
+    ])('folds the last %i turns (%i messages) when asked', (turns, msgs) => {
+      const history = mkHistory(40);
+      const lines = extractRecentHistoryWindow(history, turns)?.split('\n') ?? [];
+      expect(lines).toHaveLength(msgs);
+      expect(lines[0]).toBe(`msg-${40 - msgs}`);
+      expect(lines.at(-1)).toBe('msg-39');
+    });
+
+    it('returns all messages when history is shorter than the requested window', () => {
+      const lines = extractRecentHistoryWindow(mkHistory(4), 3)?.split('\n') ?? [];
+      expect(lines).toHaveLength(4);
+    });
+
+    it('returns undefined for empty or missing history', () => {
+      expect(extractRecentHistoryWindow(undefined)).toBeUndefined();
+      expect(extractRecentHistoryWindow([])).toBeUndefined();
+    });
+
+    it('treats a zero or negative turn count as "no fold" (not the slice(-0) whole-array footgun)', () => {
+      const history = mkHistory(10);
+      // slice(-0) === slice(0) would return the ENTIRE history; the guard returns undefined.
+      expect(extractRecentHistoryWindow(history, 0)).toBeUndefined();
+      // A negative count would slice from the FRONT; the guard returns undefined.
+      expect(extractRecentHistoryWindow(history, -3)).toBeUndefined();
+    });
+
+    it('truncates long messages to LTM_SEARCH_MESSAGE_PREVIEW with an ellipsis', () => {
+      const long = 'x'.repeat(AI_DEFAULTS.LTM_SEARCH_MESSAGE_PREVIEW + 50);
+      const result = extractRecentHistoryWindow([{ role: 'user', content: long }], 3);
+      expect(result).toBe('x'.repeat(AI_DEFAULTS.LTM_SEARCH_MESSAGE_PREVIEW) + '...');
+    });
+
+    it('formats content only (no role labels), joined by newlines', () => {
+      const result = extractRecentHistoryWindow(
+        [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi there' },
+        ],
+        3
+      );
+      expect(result).toBe('hello\nhi there');
     });
   });
 });

--- a/services/ai-worker/src/services/RAGUtils.ts
+++ b/services/ai-worker/src/services/RAGUtils.ts
@@ -253,17 +253,30 @@ export function injectImageDescriptions(
  * providing recent topic context to the embedding model.
  *
  * @param rawHistory The raw conversation history array
+ * @param turnsToInclude How many turns (user+assistant pairs) to fold in. Defaults to
+ *   AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS — the production value; callers pass nothing and
+ *   get byte-identical behavior. The retrieval eval passes explicit counts to sweep the
+ *   fold depth (3/5/8) without touching the production default.
  * @returns Formatted string of recent history, or undefined if no history
  */
 export function extractRecentHistoryWindow(
-  rawHistory?: { role: string; content: string; tokenCount?: number }[]
+  rawHistory?: { role: string; content: string; tokenCount?: number }[],
+  turnsToInclude: number = AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS
 ): string | undefined {
   if (!rawHistory || rawHistory.length === 0) {
     return undefined;
   }
 
+  // Guard the public contract: turnsToInclude <= 0 means "no fold". Without this,
+  // `slice(-0)` (since -0 === 0) would return the ENTIRE history and a negative
+  // count would slice from the front — both silently the OPPOSITE of the intent,
+  // and a corrupted fold window would poison the retrieval re-baseline this param
+  // exists to serve.
+  if (turnsToInclude <= 0) {
+    return undefined;
+  }
+
   // Get the last N turns (each turn = 2 messages: user + assistant)
-  const turnsToInclude = AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS;
   const messagesToInclude = turnsToInclude * 2;
 
   // Take the last N messages (they're already in chronological order)


### PR DESCRIPTION
## What

`extractRecentHistoryWindow` (`RAGUtils.ts`) gains a defaulted `turnsToInclude` param (default = `AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS`). Production's sole caller (`ConversationInputProcessor.ts:154`) passes nothing → **byte-identical behavior**. The retrieval-eval re-baseline (memory 1c) passes explicit counts to sweep fold depth (3/5/8) without touching the production default.

## Why

Slice 1 of the memory-1c **honest re-baseline** (plan approved). Grounding this session found context-folding already ships in production and feeds both retrieval arms — the earlier A/B measured the *bare* message, so we've never measured the real production baseline. Making the fold depth a param lets the eval sweep it faithfully. This is a defaulted param, **not** the `ConfigOverrides` "field #12" cascade ceremony — that defers until the sweep proves N matters.

## Also

Closes a pre-existing coverage gap: `extractRecentHistoryWindow` had **no** colocated tests. Adds 8 cases — default-equals-explicit (byte-identical proof), turn-count slicing (5/8), short-history, empty/undefined, 500-char truncation, content-only formatting.

## Verification

- `pnpm --filter @tzurot/ai-worker test` — 3765 pass (incl. the 8 new cases, confirmed executing)
- `pnpm quality` — full gate green
- Only prod caller passes no second arg → default path is what runs in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)