### PR TITLE
feat(tooling): mine conversation goldens for retrieval re-baseline

### DIFF
--- a/packages/tooling/src/commands/memory.ts
+++ b/packages/tooling/src/commands/memory.ts
@@ -11,6 +11,25 @@ const ENV_OPTION = '--env <env>';
 const ENV_OPTION_DESC = 'Environment: local, dev, or prod';
 const ENV_OPTION_DEFAULT = { default: 'dev' } as const;
 
+/**
+ * Parse an optional positive-integer CLI flag. Returns the number, `undefined`
+ * if the flag is absent, or `null` if it's present-but-invalid (having already
+ * printed the error + set exitCode — the caller returns on null). Shared by the
+ * mining commands' `--sample` / `--history-window` validation.
+ */
+function parsePositiveIntOption(raw: string | undefined, flag: string): number | undefined | null {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    console.error(`${flag} must be a positive integer (got '${raw}')`);
+    process.exitCode = 1;
+    return null;
+  }
+  return value;
+}
+
 /** Backfill fact extraction over historical memories (memory Phase 2). */
 function registerBackfillFactsCommand(cli: CAC): void {
   cli
@@ -76,10 +95,8 @@ function registerGoldensCommands(cli: CAC): void {
         }
         // Fail loudly on a garbage --sample: NaN comparisons are all false, so
         // it would otherwise degrade into nonsense quota math silently.
-        const sampleSize = options.sample === undefined ? undefined : Number(options.sample);
-        if (sampleSize !== undefined && (!Number.isInteger(sampleSize) || sampleSize < 1)) {
-          console.error(`--sample must be a positive integer (got '${options.sample}')`);
-          process.exitCode = 1;
+        const sampleSize = parsePositiveIntOption(options.sample, '--sample');
+        if (sampleSize === null) {
           return;
         }
         const { mineGoldens } = await import('../memory/mine-goldens.js');
@@ -115,6 +132,51 @@ function registerGoldensCommands(cli: CAC): void {
         outFile: options.out,
       });
     });
+}
+
+/** The conversation-goldens miner — its own registrar so registerGoldensCommands stays under the line cap. */
+function registerConversationGoldensCommand(cli: CAC): void {
+  cli
+    .command(
+      'memory:mine-conversation-goldens',
+      'Mine real user turns + their preceding conversation window (the fold input) for the retrieval re-baseline'
+    )
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
+    .option('--persona-id <uuid>', 'Persona UUID to mine (required)')
+    .option('--sample <n>', 'Target golden count across all styles (default 40)')
+    .option('--history-window <n>', 'Prior turns to capture per golden (default 50)')
+    .option('--out <dir>', 'Output dir (default reports/goldens-mining — gitignored)')
+    .action(
+      async (options: {
+        env?: Environment;
+        personaId?: string;
+        sample?: string;
+        historyWindow?: string;
+        out?: string;
+      }) => {
+        if (options.personaId === undefined) {
+          console.error('--persona-id is required');
+          process.exitCode = 1;
+          return;
+        }
+        const sampleSize = parsePositiveIntOption(options.sample, '--sample');
+        if (sampleSize === null) {
+          return;
+        }
+        const historyWindow = parsePositiveIntOption(options.historyWindow, '--history-window');
+        if (historyWindow === null) {
+          return;
+        }
+        const { mineConversationGoldens } = await import('../memory/mine-conversation-goldens.js');
+        await mineConversationGoldens({
+          env: options.env ?? 'dev',
+          personaId: options.personaId,
+          sampleSize,
+          historyWindow,
+          outDir: options.out,
+        });
+      }
+    );
 }
 
 export function registerMemoryCommands(cli: CAC): void {
@@ -167,6 +229,7 @@ export function registerMemoryCommands(cli: CAC): void {
 
   registerBackfillFactsCommand(cli);
   registerGoldensCommands(cli);
+  registerConversationGoldensCommand(cli);
 
   // Cleanup duplicate memories
   cli

--- a/packages/tooling/src/memory/mine-conversation-goldens.test.ts
+++ b/packages/tooling/src/memory/mine-conversation-goldens.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQueryRaw = vi.fn();
+const mockDisconnect = vi.fn();
+vi.mock('./prisma-env.js', () => ({
+  getPrismaForEnv: vi.fn(async () => ({
+    prisma: { $queryRaw: (...args: unknown[]) => mockQueryRaw(...args) },
+    disconnect: mockDisconnect,
+  })),
+}));
+
+const mockWriteFileSync = vi.fn();
+const mockMkdirSync = vi.fn();
+vi.mock('node:fs', () => ({
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  readFileSync: vi.fn(),
+}));
+
+import {
+  classifyQueryStyle,
+  pickEvenlySpaced,
+  stratifiedStyleSample,
+  mineConversationGoldens,
+  QUERY_STYLES,
+  type StyleCandidate,
+  type QueryStyle,
+} from './mine-conversation-goldens.js';
+
+describe('classifyQueryStyle', () => {
+  it('labels very short messages short-reactive', () => {
+    expect(classifyQueryStyle('lol yeah')).toBe('short-reactive');
+    expect(classifyQueryStyle('wait what')).toBe('short-reactive');
+    expect(classifyQueryStyle('nice')).toBe('short-reactive');
+  });
+
+  it('length wins over the referential lead-in (a bare "it" is reactive, not referential)', () => {
+    // "it" leads with a demonstrative but is 1 word — short-reactive takes priority.
+    expect(classifyQueryStyle('it')).toBe('short-reactive');
+  });
+
+  it('labels demonstrative-led messages referential', () => {
+    expect(classifyQueryStyle('that was a really interesting thing to bring up')).toBe(
+      'referential'
+    );
+    expect(classifyQueryStyle('what about the trip you mentioned to me last week')).toBe(
+      'referential'
+    );
+    expect(classifyQueryStyle('they never actually told you the whole story though')).toBe(
+      'referential'
+    );
+  });
+
+  it('labels multi-clause / multi-sentence messages compound', () => {
+    // Two sentence enders.
+    expect(classifyQueryStyle('Tell me a longer story please. Make it genuinely scary.')).toBe(
+      'compound'
+    );
+    // A coordinating conjunction in a long message.
+    expect(
+      classifyQueryStyle('I went to the store and then I saw a movie later that same evening')
+    ).toBe('compound');
+  });
+
+  it('labels a single self-contained question standalone', () => {
+    expect(classifyQueryStyle('Can you explain how photosynthesis works for a plant')).toBe(
+      'standalone'
+    );
+  });
+
+  it('a short message with a conjunction is not compound (needs length)', () => {
+    // "you and me" — 3 words → short-reactive wins before the compound check.
+    expect(classifyQueryStyle('you and me')).toBe('short-reactive');
+  });
+});
+
+describe('pickEvenlySpaced', () => {
+  it('returns the quota count, evenly spread across the pool', () => {
+    const pool = Array.from({ length: 8 }, (_, i) => i);
+    const picked = pickEvenlySpaced(pool, 4, 4);
+    expect(picked).toHaveLength(4);
+    // Even spacing across 4 buckets of 2 → first element of each bucket.
+    expect(picked).toEqual([0, 2, 4, 6]);
+  });
+
+  it('caps at pool size when quota exceeds it', () => {
+    expect(pickEvenlySpaced([1, 2, 3], 10, 8)).toHaveLength(3);
+  });
+
+  it('returns empty for zero quota or empty pool', () => {
+    expect(pickEvenlySpaced([1, 2, 3], 0, 4)).toEqual([]);
+    expect(pickEvenlySpaced([], 5, 4)).toEqual([]);
+  });
+
+  it('is deterministic (same input → same output)', () => {
+    const pool = Array.from({ length: 20 }, (_, i) => i);
+    expect(pickEvenlySpaced(pool, 5, 8)).toEqual(pickEvenlySpaced(pool, 5, 8));
+  });
+});
+
+describe('stratifiedStyleSample', () => {
+  const mk = (id: string, style: QueryStyle, dayOffset: number): StyleCandidate => ({
+    id,
+    style,
+    createdAt: new Date(2026, 0, 1 + dayOffset),
+  });
+
+  it('samples each style independently up to the quota', () => {
+    const candidates: StyleCandidate[] = [
+      ...Array.from({ length: 10 }, (_, i) => mk(`ref-${i}`, 'referential', i)),
+      ...Array.from({ length: 10 }, (_, i) => mk(`std-${i}`, 'standalone', i)),
+      mk('short-0', 'short-reactive', 0),
+    ];
+    const selected = stratifiedStyleSample(candidates, { perStyleQuota: 3, buckets: 4 });
+    const styleOf = (id: string): QueryStyle => candidates.find(c => c.id === id)!.style;
+    const counts = new Map<QueryStyle, number>();
+    for (const id of selected) {
+      counts.set(styleOf(id), (counts.get(styleOf(id)) ?? 0) + 1);
+    }
+    // referential + standalone each hit the quota of 3; short-reactive has only 1.
+    expect(counts.get('referential')).toBe(3);
+    expect(counts.get('standalone')).toBe(3);
+    expect(counts.get('short-reactive')).toBe(1);
+    // compound had no candidates → absent.
+    expect(counts.get('compound')).toBeUndefined();
+  });
+
+  it('returns ids in a stable style-then-time order', () => {
+    const candidates: StyleCandidate[] = [mk('b', 'standalone', 5), mk('a', 'referential', 2)];
+    const first = stratifiedStyleSample(candidates, { perStyleQuota: 5, buckets: 4 });
+    const second = stratifiedStyleSample(candidates, { perStyleQuota: 5, buckets: 4 });
+    expect(first).toEqual(second);
+    // 'referential' precedes 'standalone' in QUERY_STYLES → 'a' before 'b'.
+    expect(first).toEqual(['a', 'b']);
+  });
+
+  it('covers every declared style in QUERY_STYLES', () => {
+    expect(QUERY_STYLES).toEqual(['short-reactive', 'referential', 'compound', 'standalone']);
+  });
+});
+
+describe('mineConversationGoldens (the Prisma + fs seams)', () => {
+  const candidateRow = (id: string, content: string, channelId = 'chan-1') => ({
+    id,
+    channel_id: channelId,
+    personality_id: 'char-1',
+    content,
+    message_metadata: { note: id },
+    created_at: new Date('2026-01-10T00:00:00Z'),
+  });
+  // 3 turns ≥ MIN_PRIOR_TURNS, so every finalist becomes a golden.
+  const priorTurns = [
+    { role: 'user', content: 'earlier one', created_at: new Date('2026-01-09T00:00:00Z') },
+    { role: 'assistant', content: 'earlier reply', created_at: new Date('2026-01-09T00:01:00Z') },
+    { role: 'user', content: 'earlier two', created_at: new Date('2026-01-09T00:02:00Z') },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDisconnect.mockResolvedValue(undefined);
+    // Call 0 = candidates query; every subsequent call = a finalist's prior-history.
+    // One candidate per style so stratification picks all four deterministically.
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        candidateRow('id-short', 'ok cool'), // short-reactive
+        candidateRow('id-ref', 'that was a genuinely interesting point'), // referential
+        candidateRow('id-comp', 'I went out and then I came back home again later that same day'), // compound
+        candidateRow('id-std', 'Can you help me understand this whole topic'), // standalone
+      ])
+      .mockResolvedValue(priorTurns);
+  });
+
+  it('threads the persona id into the candidates query', async () => {
+    await mineConversationGoldens({ env: 'dev', personaId: 'persona-xyz', historyWindow: 10 });
+    expect(mockQueryRaw.mock.calls[0].slice(1)).toContain('persona-xyz');
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes the prior-history window by CHANNEL only — never by personality (prod parity)', async () => {
+    await mineConversationGoldens({ env: 'dev', personaId: 'persona-xyz', historyWindow: 10 });
+    // Prior-history is call index 1+. Assert the SQL skeleton + the params that crossed.
+    const priorCall = mockQueryRaw.mock.calls[1];
+    const sql = (priorCall[0] as string[]).join(' ');
+    expect(sql).toContain('channel_id');
+    // The finding-#1 regression guard: production's getChannelHistory is channel-only,
+    // so folding this by personality would diverge on multi-persona channels.
+    expect(sql).not.toContain('personality_id');
+    const priorValues = priorCall.slice(1);
+    expect(priorValues).toContain('chan-1'); // channel scope crossed the seam
+    expect(priorValues).toContain(10); // historyWindow → LIMIT
+  });
+
+  it('writes goldens with reconstructed fold windows + metadata, bounded by sampleSize', async () => {
+    await mineConversationGoldens({
+      env: 'dev',
+      personaId: 'persona-xyz',
+      sampleSize: 2,
+      historyWindow: 10,
+    });
+    expect(mockMkdirSync).toHaveBeenCalledWith('reports/goldens-mining', { recursive: true });
+    const write = mockWriteFileSync.mock.calls.find(call =>
+      String(call[0]).endsWith('conversation-goldens.json')
+    );
+    expect(write).toBeDefined();
+    const parsed = JSON.parse(String(write![1])) as {
+      goldens: { priorHistory: unknown[]; messageMetadata: unknown; message: string }[];
+    };
+    expect(parsed.goldens).toHaveLength(2); // sampleSize constrains the output
+    expect(parsed.goldens[0].priorHistory).toHaveLength(3); // reconstructed fold window
+    expect(parsed.goldens[0].messageMetadata).toEqual({ note: expect.any(String) }); // rode along, no N+1
+  });
+
+  it('drops a finalist with too-little prior history and backfills the next of that style', async () => {
+    // The point of 2x oversampling: a candidate whose fold window is too thin is
+    // skipped in favor of the next oversampled candidate of the same style.
+    mockQueryRaw.mockReset();
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        { ...candidateRow('id-short-a', 'ok'), created_at: new Date('2026-01-10T00:00:00Z') },
+        { ...candidateRow('id-short-b', 'yes'), created_at: new Date('2026-01-11T00:00:00Z') },
+      ])
+      .mockResolvedValueOnce([priorTurns[0]]) // id-short-a: 1 prior turn < MIN_PRIOR_TURNS → dropped
+      .mockResolvedValueOnce(priorTurns); // id-short-b: 3 prior turns → golden
+    await mineConversationGoldens({
+      env: 'dev',
+      personaId: 'persona-xyz',
+      sampleSize: 1,
+      historyWindow: 10,
+    });
+    const write = mockWriteFileSync.mock.calls.find(call =>
+      String(call[0]).endsWith('conversation-goldens.json')
+    );
+    const parsed = JSON.parse(String(write![1])) as { goldens: { id: string }[] };
+    expect(parsed.goldens).toHaveLength(1);
+    expect(parsed.goldens[0].id).toBe('id-short-b'); // the backfill, not the dropped 'id-short-a'
+  });
+});

--- a/packages/tooling/src/memory/mine-conversation-goldens.ts
+++ b/packages/tooling/src/memory/mine-conversation-goldens.ts
@@ -1,0 +1,412 @@
+/**
+ * Conversation-goldens mining: pull REAL user turns (with their preceding
+ * conversation window) from `conversation_history` so the retrieval re-baseline
+ * can reproduce the EXACT production folded query offline.
+ *
+ * Why this exists: production folds the last few conversation turns into the
+ * embedded retrieval query (`extractRecentHistoryWindow` + `buildSearchQuery`),
+ * and both retrieval arms consume that folded string. The earlier A/B measured
+ * the BARE message, which production never does — so it never measured real
+ * production retrieval. These goldens carry each target user message PLUS the
+ * turns that preceded it, so the eval can build the true folded query and run a
+ * paired bare-vs-folded A/B.
+ *
+ * The mined output is LOCAL-ONLY (gitignored `reports/goldens-mining/`) — it
+ * holds raw conversation content, strictly more sensitive than an entity swap
+ * can launder. What gets committed is THIS miner (deterministic: same DB state →
+ * same sample), never the goldens.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { Environment } from '../utils/env-runner.js';
+
+/** One prior turn in a target's fold window (the shape `extractRecentHistoryWindow` reads). */
+export interface ConversationTurn {
+  role: string;
+  content: string;
+  createdAt: string;
+}
+
+/** A retrieval golden: a real user message + the conversation that preceded it. */
+export interface ConversationGolden {
+  /** The target user message's id. */
+  id: string;
+  channelId: string;
+  personaId: string;
+  personalityId: string;
+  /** The bare user message (the naive query). */
+  message: string;
+  /** The target's structured metadata (referenced messages / attachments) — for optional refs reconstruction. */
+  messageMetadata: unknown;
+  /** ISO timestamp of the target message. */
+  createdAt: string;
+  /** Coarse stratification label (see {@link classifyQueryStyle}). */
+  style: QueryStyle;
+  /** Up to `historyWindow` turns preceding the target, chronological — the fold input + guard timestamps. */
+  priorHistory: ConversationTurn[];
+}
+
+/**
+ * Coarse query-style buckets. This is a STRATIFICATION AID only — it ensures the
+ * sample covers the shapes where folding should matter (short/reactive,
+ * referential, compound), NOT a ground-truth label. The pooled judgment is the
+ * real arbiter of whether folding helped; style just keeps the sample balanced.
+ */
+export type QueryStyle = 'short-reactive' | 'referential' | 'compound' | 'standalone';
+
+export const QUERY_STYLES: readonly QueryStyle[] = [
+  'short-reactive',
+  'referential',
+  'compound',
+  'standalone',
+] as const;
+
+/** A message this short carries no retrievable meaning on its own — folding is its only hope. */
+const SHORT_REACTIVE_MAX_WORDS = 4;
+
+/** First-token demonstratives/pronouns: the message leans on an antecedent the bare text lacks. */
+const REFERENTIAL_RE =
+  /^(?:what about|how about|that|this|it|those|these|they|them|he|she|him|her)\b/i;
+
+/** Coordinating conjunctions that join independent clauses (a compound signal when the message is long). */
+const COMPOUND_CONJ_RE = /\b(?:and|but|because|so|then|also|plus|while|whereas)\b/i;
+
+/** Minimum words before a conjunction counts as "compound" rather than incidental. */
+const COMPOUND_MIN_WORDS = 12;
+
+/**
+ * Classify a message into a coarse style bucket for stratified sampling.
+ *
+ * Priority order matters: short-reactive (by length) → referential (leads with a
+ * demonstrative) → compound (multi-clause) → standalone. The order puts the
+ * folding-relevant shapes first so a message that qualifies for several lands in
+ * the most interesting bucket.
+ */
+export function classifyQueryStyle(message: string): QueryStyle {
+  const trimmed = message.trim();
+  const words = trimmed.split(/\s+/).filter(word => word.length > 0);
+  if (words.length <= SHORT_REACTIVE_MAX_WORDS) {
+    return 'short-reactive';
+  }
+  if (REFERENTIAL_RE.test(trimmed)) {
+    return 'referential';
+  }
+  const sentenceEnders = (trimmed.match(/[.!?]+/g) ?? []).length;
+  if (
+    sentenceEnders >= 2 ||
+    (COMPOUND_CONJ_RE.test(trimmed) && words.length >= COMPOUND_MIN_WORDS)
+  ) {
+    return 'compound';
+  }
+  return 'standalone';
+}
+
+/** A classified candidate turn (content dropped — only what sampling needs). */
+export interface StyleCandidate {
+  id: string;
+  createdAt: Date;
+  style: QueryStyle;
+}
+
+/**
+ * Pick `quota` items spread evenly across `buckets` equal-count time buckets of a
+ * chronologically-sorted pool, so old and recent turns both survive. Earlier
+ * buckets absorb the remainder; within a bucket, picks are evenly spaced. No RNG
+ * — the same pool always yields the same sample.
+ */
+export function pickEvenlySpaced<T>(sortedPool: T[], quota: number, buckets: number): T[] {
+  if (quota <= 0 || sortedPool.length === 0) {
+    return [];
+  }
+  const target = Math.min(quota, sortedPool.length);
+  const bucketSize = Math.ceil(sortedPool.length / buckets);
+  const bucketList: T[][] = [];
+  for (let start = 0; start < sortedPool.length; start += bucketSize) {
+    bucketList.push(sortedPool.slice(start, start + bucketSize));
+  }
+  const perBucketBase = Math.floor(target / bucketList.length);
+  let remainder = target - perBucketBase * bucketList.length;
+  const picked: T[] = [];
+  for (const bucket of bucketList) {
+    let take = perBucketBase;
+    if (remainder > 0) {
+      take += 1;
+      remainder -= 1;
+    }
+    take = Math.min(take, bucket.length);
+    for (let i = 0; i < take; i++) {
+      picked.push(bucket[Math.floor((i * bucket.length) / take)]);
+    }
+  }
+  return picked.slice(0, target);
+}
+
+/**
+ * Per-style time-stratified sample. Each style is sampled independently up to
+ * `perStyleQuota`, so every style is represented even when one dominates the raw
+ * distribution. Returns selected candidate ids in style-then-time order.
+ */
+export function stratifiedStyleSample(
+  candidates: StyleCandidate[],
+  options: { perStyleQuota: number; buckets: number }
+): string[] {
+  const byStyle = new Map<QueryStyle, StyleCandidate[]>();
+  for (const candidate of candidates) {
+    const list = byStyle.get(candidate.style) ?? [];
+    list.push(candidate);
+    byStyle.set(candidate.style, list);
+  }
+  const selected: string[] = [];
+  for (const style of QUERY_STYLES) {
+    const pool = (byStyle.get(style) ?? [])
+      .slice()
+      // id tie-break keeps the sample deterministic even when createdAt collides
+      // (bulk inserts / db-sync backfills) — the miner advertises a diffable re-mine.
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id));
+    selected.push(
+      ...pickEvenlySpaced(pool, options.perStyleQuota, options.buckets).map(
+        candidate => candidate.id
+      )
+    );
+  }
+  return selected;
+}
+
+export interface MineConversationGoldensOptions {
+  env: Environment;
+  personaId: string;
+  /** Target golden count across all styles (default 40). */
+  sampleSize?: number;
+  /** Prior turns to capture per golden (default 50 — matches production's maxMessages default). */
+  historyWindow?: number;
+  outDir?: string;
+}
+
+const DEFAULT_SAMPLE_SIZE = 40;
+const DEFAULT_HISTORY_WINDOW = 50;
+const DEFAULT_OUT_DIR = 'reports/goldens-mining';
+/** Below this, a message is degenerate noise (a stray keystroke), not a real reactive turn. */
+const MIN_MESSAGE_CHARS = 3;
+/** A golden needs at least this many prior turns for folding to change anything. */
+const MIN_PRIOR_TURNS = 2;
+/** Time buckets within a style — spreads the sample across the persona's history. */
+const STRATA_BUCKETS = 8;
+
+interface RawCandidateRow {
+  id: string;
+  channel_id: string;
+  personality_id: string;
+  content: string;
+  message_metadata: unknown;
+  created_at: Date;
+}
+
+interface RawTurnRow {
+  role: string;
+  content: string;
+  created_at: Date;
+}
+
+/** A classified candidate user turn with the content needed to build a golden. */
+interface Candidate {
+  id: string;
+  channelId: string;
+  personalityId: string;
+  content: string;
+  messageMetadata: unknown;
+  createdAt: Date;
+  style: QueryStyle;
+}
+
+/**
+ * Fetch the turns preceding a target in the same CHANNEL — the exact substrate
+ * production folds. Production's history source (`ConversationHistoryService.
+ * getChannelHistory`) is channel-scoped with NO personalityId filter ("fetch ALL
+ * channel messages across all personalities"), so the fold sees cross-persona
+ * context. Scoping this by personality would silently diverge from prod on
+ * multi-persona channels — exactly the cross-persona pronoun case folding most
+ * helps. `extractRecentHistoryWindow` slices the tail of this window. Returns null
+ * when there is too little history to fold.
+ */
+async function fetchPriorHistory(
+  prisma: PrismaClient,
+  candidate: Candidate,
+  historyWindow: number
+): Promise<ConversationTurn[] | null> {
+  const priorRows = await prisma.$queryRaw<RawTurnRow[]>`
+    SELECT role, content, created_at
+    FROM conversation_history
+    WHERE channel_id = ${candidate.channelId}
+      AND deleted_at IS NULL
+      AND created_at < ${candidate.createdAt}
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${historyWindow}
+  `;
+  if (priorRows.length < MIN_PRIOR_TURNS) {
+    return null;
+  }
+  return priorRows
+    .map(row => ({
+      role: row.role,
+      content: row.content,
+      createdAt: new Date(row.created_at).toISOString(),
+    }))
+    .reverse();
+}
+
+/**
+ * Walk the over-sampled candidate ids, keeping one golden per candidate that has
+ * enough prior history, up to `sampleSize` total and `perStyleQuota` per style.
+ */
+async function collectGoldens(
+  prisma: PrismaClient,
+  orderedIds: string[],
+  candidateById: Map<string, Candidate>,
+  opts: { personaId: string; sampleSize: number; perStyleQuota: number; historyWindow: number }
+): Promise<{ goldens: ConversationGolden[]; droppedNoHistory: number }> {
+  const goldens: ConversationGolden[] = [];
+  const perStyleCount = new Map<QueryStyle, number>();
+  let droppedNoHistory = 0;
+
+  for (const id of orderedIds) {
+    if (goldens.length >= opts.sampleSize) {
+      break;
+    }
+    const candidate = candidateById.get(id);
+    if (candidate === undefined) {
+      continue;
+    }
+    const styleCount = perStyleCount.get(candidate.style) ?? 0;
+    if (styleCount >= opts.perStyleQuota) {
+      continue;
+    }
+    const priorHistory = await fetchPriorHistory(prisma, candidate, opts.historyWindow);
+    if (priorHistory === null) {
+      droppedNoHistory += 1;
+      continue;
+    }
+    goldens.push({
+      id: candidate.id,
+      channelId: candidate.channelId,
+      personaId: opts.personaId,
+      personalityId: candidate.personalityId,
+      message: candidate.content,
+      messageMetadata: candidate.messageMetadata,
+      createdAt: candidate.createdAt.toISOString(),
+      style: candidate.style,
+      priorHistory,
+    });
+    perStyleCount.set(candidate.style, styleCount + 1);
+  }
+
+  return { goldens, droppedNoHistory };
+}
+
+/**
+ * Mine conversation goldens from `conversation_history`. Fetches candidate user
+ * turns, classifies + stratifies by style, then for each finalist pulls the
+ * preceding conversation window (the fold input). Finalists without enough prior
+ * history are dropped; over-sampling per style backfills the loss.
+ */
+export async function mineConversationGoldens(
+  options: MineConversationGoldensOptions
+): Promise<void> {
+  const sampleSize = options.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+  const historyWindow = options.historyWindow ?? DEFAULT_HISTORY_WINDOW;
+  const outDir = options.outDir ?? DEFAULT_OUT_DIR;
+
+  const { getPrismaForEnv } = await import('./prisma-env.js');
+  const { prisma, disconnect } = await getPrismaForEnv(options.env);
+
+  try {
+    // Candidate user turns — the persona_id scope + 30-day retention window is the
+    // bound (≈ a few thousand rows). Deliberately NO LIMIT: stratification needs the
+    // full time range, so a LIMIT would bias the sample toward the DB's return order
+    // (the same sanctioned-unbounded pattern as mine-goldens.ts; revisit if retention
+    // ever grows unbounded). content feeds style classification; message_metadata
+    // rides along here (not a per-finalist round-trip) since it's on the same row.
+    // Chunked/normal all included: the fold operates on whatever the message was.
+    const rawCandidates = await prisma.$queryRaw<RawCandidateRow[]>`
+      SELECT id, channel_id, personality_id, content, message_metadata, created_at
+      FROM conversation_history
+      WHERE persona_id = ${options.personaId}::uuid
+        AND role = 'user'
+        AND deleted_at IS NULL
+        AND length(content) >= ${MIN_MESSAGE_CHARS}
+    `;
+
+    const candidateById = new Map<string, Candidate>(
+      rawCandidates.map(row => [
+        row.id,
+        {
+          id: row.id,
+          channelId: row.channel_id,
+          personalityId: row.personality_id,
+          content: row.content,
+          messageMetadata: row.message_metadata,
+          createdAt: new Date(row.created_at),
+          style: classifyQueryStyle(row.content),
+        },
+      ])
+    );
+    const styleCandidates: StyleCandidate[] = [...candidateById.values()].map(candidate => ({
+      id: candidate.id,
+      createdAt: candidate.createdAt,
+      style: candidate.style,
+    }));
+    console.log(`Candidate user turns: ${styleCandidates.length}`);
+    logStyleDistribution('Candidate style distribution', styleCandidates);
+
+    // Over-sample per style (2×) so prior-history drops don't starve a style below
+    // quota. perStyleQuota distributes sampleSize across the 4 styles; the default 40
+    // is exact (10 each). A sampleSize not divisible by 4 slightly favors earlier
+    // styles in QUERY_STYLES order (the total-cap break in collectGoldens can short
+    // the last style) — acceptable for a sampler where balance beats an exact count.
+    const perStyleQuota = Math.ceil(sampleSize / QUERY_STYLES.length);
+    const overSampleIds = stratifiedStyleSample(styleCandidates, {
+      perStyleQuota: perStyleQuota * 2,
+      buckets: STRATA_BUCKETS,
+    });
+
+    const { goldens, droppedNoHistory } = await collectGoldens(
+      prisma,
+      overSampleIds,
+      candidateById,
+      { personaId: options.personaId, sampleSize, perStyleQuota, historyWindow }
+    );
+
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(
+      join(outDir, 'conversation-goldens.json'),
+      `${JSON.stringify({ goldens }, null, 2)}\n`
+    );
+
+    console.log(
+      `\nWrote ${goldens.length} conversation goldens to ${outDir}/conversation-goldens.json` +
+        ' (LOCAL-ONLY, gitignored)'
+    );
+    console.log(`Dropped ${droppedNoHistory} candidates with < ${MIN_PRIOR_TURNS} prior turns.`);
+    logStyleDistribution(
+      'Golden style distribution',
+      goldens.map(golden => ({
+        id: golden.id,
+        createdAt: new Date(golden.createdAt),
+        style: golden.style,
+      }))
+    );
+  } finally {
+    await disconnect();
+  }
+}
+
+/** Console-only style histogram (no content — safe to print). */
+function logStyleDistribution(label: string, candidates: StyleCandidate[]): void {
+  const counts = new Map<QueryStyle, number>();
+  for (const candidate of candidates) {
+    counts.set(candidate.style, (counts.get(candidate.style) ?? 0) + 1);
+  }
+  const summary = QUERY_STYLES.map(style => `${style}=${counts.get(style) ?? 0}`).join(', ');
+  console.log(`${label}: ${summary}`);
+}


### PR DESCRIPTION
## What

`memory:mine-conversation-goldens` pulls **real user turns + their preceding conversation window** from `conversation_history`, so the retrieval eval can reconstruct the **exact production folded query** offline and run a paired bare-vs-folded A/B.

## Why

Slice 2 of the memory-1c honest re-baseline (plan approved). Production folds the last 3 turns into the embedded query (`extractRecentHistoryWindow` + `buildSearchQuery`); the earlier A/B measured the *bare* message, so it never measured real production retrieval. The old synthetic query-drafts (`#1608`) are LLM-generated and context-free — they can't exercise the fold at all. This miner captures each target message plus the turns that preceded it (the fold input), which is exactly what the fold-aware runner (PR-3) needs.

**Owner-supplied insight**: dev is synced from prod and `ConversationHistory` retains a rolling 30-day window, so real historical Lila queries are minable directly — no instrumentation or fresh chat capture needed.

## How

- Fetches candidate user turns for the persona, classifies each by a coarse **query-style heuristic** (short-reactive / referential / compound / standalone) so the folding-relevant shapes stay represented — the pooled judgment remains the real relevance arbiter, style is only for stratification.
- Over-samples per style (2×) so candidates dropped for too-little prior history don't starve a bucket; time-stratified within each style (no RNG — deterministic re-mine).
- For each finalist, pulls the preceding channel+character window (the substrate `extractRecentHistoryWindow` folds) + the target's `messageMetadata` (for optional refs reconstruction).

## Privacy

Output is **LOCAL-ONLY** (gitignored `reports/goldens-mining/`) — it holds raw conversation content, strictly more sensitive than an entity swap can launder. Committed = the deterministic miner; never the goldens (same policy as `corpus-raw.json`).

## Verification

- `pnpm --filter @tzurot/tooling test` — 1480 pass (incl. 13 new pure-function cases: style classification priority, even-spacing sampler, per-style stratification)
- `pnpm --filter @tzurot/tooling build` (tsc) — clean
- Local tooling only; not a runtime code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)