### PR TITLE
feat(ai-worker): fold-aware retrieval re-baseline runner + non-circularity guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "with-env": "pnpm ops run --env",
     "eval:memory": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryRetrieval.eval.test.ts",
     "eval:pool-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/goldensPooling.eval.test.ts",
+    "eval:fold-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts",
     "eval:extraction": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts"
   },
   "devDependencies": {

--- a/packages/tooling/src/commands/memory.ts
+++ b/packages/tooling/src/commands/memory.ts
@@ -30,6 +30,28 @@ function parsePositiveIntOption(raw: string | undefined, flag: string): number |
   return value;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate a required `--persona-id` UUID. Returns the id, or `null` when it's
+ * absent or malformed (error printed + exitCode set — the caller returns on null).
+ * Catches a bad id before it hits a raw `::uuid` cast, which would otherwise
+ * surface as a raw Postgres error instead of a clean CLI message.
+ */
+function requirePersonaId(raw: string | undefined): string | null {
+  if (raw === undefined) {
+    console.error('--persona-id is required');
+    process.exitCode = 1;
+    return null;
+  }
+  if (!UUID_RE.test(raw)) {
+    console.error(`--persona-id must be a UUID (got '${raw}')`);
+    process.exitCode = 1;
+    return null;
+  }
+  return raw;
+}
+
 /** Backfill fact extraction over historical memories (memory Phase 2). */
 function registerBackfillFactsCommand(cli: CAC): void {
   cli
@@ -88,9 +110,8 @@ function registerGoldensCommands(cli: CAC): void {
         sample?: string;
         out?: string;
       }) => {
-        if (options.personaId === undefined) {
-          console.error('--persona-id is required');
-          process.exitCode = 1;
+        const personaId = requirePersonaId(options.personaId);
+        if (personaId === null) {
           return;
         }
         // Fail loudly on a garbage --sample: NaN comparisons are all false, so
@@ -102,7 +123,7 @@ function registerGoldensCommands(cli: CAC): void {
         const { mineGoldens } = await import('../memory/mine-goldens.js');
         await mineGoldens({
           env: options.env ?? 'dev',
-          personaId: options.personaId,
+          personaId,
           personalityIds: options.personalityIds
             ?.split(',')
             .map(id => id.trim())
@@ -154,9 +175,8 @@ function registerConversationGoldensCommand(cli: CAC): void {
         historyWindow?: string;
         out?: string;
       }) => {
-        if (options.personaId === undefined) {
-          console.error('--persona-id is required');
-          process.exitCode = 1;
+        const personaId = requirePersonaId(options.personaId);
+        if (personaId === null) {
           return;
         }
         const sampleSize = parsePositiveIntOption(options.sample, '--sample');
@@ -170,7 +190,7 @@ function registerConversationGoldensCommand(cli: CAC): void {
         const { mineConversationGoldens } = await import('../memory/mine-conversation-goldens.js');
         await mineConversationGoldens({
           env: options.env ?? 'dev',
-          personaId: options.personaId,
+          personaId,
           sampleSize,
           historyWindow,
           outDir: options.out,

--- a/packages/tooling/src/memory/mine-conversation-goldens.test.ts
+++ b/packages/tooling/src/memory/mine-conversation-goldens.test.ts
@@ -19,7 +19,6 @@ vi.mock('node:fs', () => ({
 
 import {
   classifyQueryStyle,
-  pickEvenlySpaced,
   stratifiedStyleSample,
   mineConversationGoldens,
   QUERY_STYLES,
@@ -71,30 +70,6 @@ describe('classifyQueryStyle', () => {
   it('a short message with a conjunction is not compound (needs length)', () => {
     // "you and me" — 3 words → short-reactive wins before the compound check.
     expect(classifyQueryStyle('you and me')).toBe('short-reactive');
-  });
-});
-
-describe('pickEvenlySpaced', () => {
-  it('returns the quota count, evenly spread across the pool', () => {
-    const pool = Array.from({ length: 8 }, (_, i) => i);
-    const picked = pickEvenlySpaced(pool, 4, 4);
-    expect(picked).toHaveLength(4);
-    // Even spacing across 4 buckets of 2 → first element of each bucket.
-    expect(picked).toEqual([0, 2, 4, 6]);
-  });
-
-  it('caps at pool size when quota exceeds it', () => {
-    expect(pickEvenlySpaced([1, 2, 3], 10, 8)).toHaveLength(3);
-  });
-
-  it('returns empty for zero quota or empty pool', () => {
-    expect(pickEvenlySpaced([1, 2, 3], 0, 4)).toEqual([]);
-    expect(pickEvenlySpaced([], 5, 4)).toEqual([]);
-  });
-
-  it('is deterministic (same input → same output)', () => {
-    const pool = Array.from({ length: 20 }, (_, i) => i);
-    expect(pickEvenlySpaced(pool, 5, 8)).toEqual(pickEvenlySpaced(pool, 5, 8));
   });
 });
 

--- a/packages/tooling/src/memory/mine-conversation-goldens.ts
+++ b/packages/tooling/src/memory/mine-conversation-goldens.ts
@@ -21,6 +21,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { Environment } from '../utils/env-runner.js';
+import { pickEvenlySpaced } from './sampling.js';
 
 /** One prior turn in a target's fold window (the shape `extractRecentHistoryWindow` reads). */
 export interface ConversationTurn {
@@ -111,39 +112,6 @@ export interface StyleCandidate {
 }
 
 /**
- * Pick `quota` items spread evenly across `buckets` equal-count time buckets of a
- * chronologically-sorted pool, so old and recent turns both survive. Earlier
- * buckets absorb the remainder; within a bucket, picks are evenly spaced. No RNG
- * — the same pool always yields the same sample.
- */
-export function pickEvenlySpaced<T>(sortedPool: T[], quota: number, buckets: number): T[] {
-  if (quota <= 0 || sortedPool.length === 0) {
-    return [];
-  }
-  const target = Math.min(quota, sortedPool.length);
-  const bucketSize = Math.ceil(sortedPool.length / buckets);
-  const bucketList: T[][] = [];
-  for (let start = 0; start < sortedPool.length; start += bucketSize) {
-    bucketList.push(sortedPool.slice(start, start + bucketSize));
-  }
-  const perBucketBase = Math.floor(target / bucketList.length);
-  let remainder = target - perBucketBase * bucketList.length;
-  const picked: T[] = [];
-  for (const bucket of bucketList) {
-    let take = perBucketBase;
-    if (remainder > 0) {
-      take += 1;
-      remainder -= 1;
-    }
-    take = Math.min(take, bucket.length);
-    for (let i = 0; i < take; i++) {
-      picked.push(bucket[Math.floor((i * bucket.length) / take)]);
-    }
-  }
-  return picked.slice(0, target);
-}
-
-/**
  * Per-style time-stratified sample. Each style is sampled independently up to
  * `perStyleQuota`, so every style is represented even when one dominates the raw
  * distribution. Returns selected candidate ids in style-then-time order.
@@ -179,7 +147,9 @@ export interface MineConversationGoldensOptions {
   personaId: string;
   /** Target golden count across all styles (default 40). */
   sampleSize?: number;
-  /** Prior turns to capture per golden (default 50 — matches production's maxMessages default). */
+  /** Raw prior-turn POOL captured per golden (default 50 = production's DEFAULT_MAX_MESSAGES
+   * over-fetch bound). The fold slices only its tail (LTM_SEARCH_HISTORY_TURNS=3), so this is
+   * the pool the fold draws from, NOT the fold size itself. */
   historyWindow?: number;
   outDir?: string;
 }
@@ -240,7 +210,7 @@ async function fetchPriorHistory(
     FROM conversation_history
     WHERE channel_id = ${candidate.channelId}
       AND deleted_at IS NULL
-      AND created_at < ${candidate.createdAt}
+      AND (created_at, id) < (${candidate.createdAt}, ${candidate.id}::uuid)
     ORDER BY created_at DESC, id DESC
     LIMIT ${historyWindow}
   `;

--- a/packages/tooling/src/memory/mine-goldens.ts
+++ b/packages/tooling/src/memory/mine-goldens.ts
@@ -26,6 +26,7 @@ import {
   type CorpusRawRow,
   type SwapMap,
 } from './goldens-anonymize.js';
+import { pickEvenlySpaced } from './sampling.js';
 
 /** Metadata row used for stratification (content deliberately absent). */
 export interface MemoryMetaRow {
@@ -79,29 +80,8 @@ export function stratifySample(rows: MemoryMetaRow[], options: StratifyOptions):
       pool.length,
       Math.max(1, Math.round((pool.length / eligible.length) * sampleSize))
     );
-    const bucketSize = Math.ceil(pool.length / STRATA_BUCKETS);
-    const buckets: MemoryMetaRow[][] = [];
-    for (let start = 0; start < pool.length; start += bucketSize) {
-      buckets.push(pool.slice(start, start + bucketSize));
-    }
-
-    // Distribute the quota over buckets (earlier buckets absorb the
-    // remainder), then pick each bucket's k rows at even spacing.
-    const perBucketBase = Math.floor(quota / buckets.length);
-    let remainder = quota - perBucketBase * buckets.length;
-    const picked: string[] = [];
-    for (const bucketRows of buckets) {
-      let k = perBucketBase;
-      if (remainder > 0) {
-        k += 1;
-        remainder -= 1;
-      }
-      k = Math.min(k, bucketRows.length);
-      for (let i = 0; i < k; i++) {
-        picked.push(bucketRows[Math.floor((i * bucketRows.length) / k)].id);
-      }
-    }
-    selected.push(...picked.slice(0, quota));
+    // Even-spaced pick across time buckets (shared with mine-conversation-goldens).
+    selected.push(...pickEvenlySpaced(pool, quota, STRATA_BUCKETS).map(row => row.id));
   }
   return selected.slice(0, sampleSize);
 }

--- a/packages/tooling/src/memory/sampling.test.ts
+++ b/packages/tooling/src/memory/sampling.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { pickEvenlySpaced } from './sampling.js';
+
+describe('pickEvenlySpaced', () => {
+  it('returns the quota count, evenly spread across the pool', () => {
+    const pool = Array.from({ length: 8 }, (_, i) => i);
+    const picked = pickEvenlySpaced(pool, 4, 4);
+    expect(picked).toHaveLength(4);
+    // Even spacing across 4 buckets of 2 → first element of each bucket.
+    expect(picked).toEqual([0, 2, 4, 6]);
+  });
+
+  it('caps at pool size when quota exceeds it', () => {
+    expect(pickEvenlySpaced([1, 2, 3], 10, 8)).toHaveLength(3);
+  });
+
+  it('returns empty for zero quota or empty pool', () => {
+    expect(pickEvenlySpaced([1, 2, 3], 0, 4)).toEqual([]);
+    expect(pickEvenlySpaced([], 5, 4)).toEqual([]);
+  });
+
+  it('is deterministic (same input → same output)', () => {
+    const pool = Array.from({ length: 20 }, (_, i) => i);
+    expect(pickEvenlySpaced(pool, 5, 8)).toEqual(pickEvenlySpaced(pool, 5, 8));
+  });
+});

--- a/packages/tooling/src/memory/sampling.ts
+++ b/packages/tooling/src/memory/sampling.ts
@@ -1,0 +1,40 @@
+/**
+ * Deterministic bucket-based even-spacing sampler, shared by the goldens miners.
+ *
+ * Both `mine-goldens` (memory corpus) and `mine-conversation-goldens` (query
+ * turns) need the same primitive: pick `quota` items spread evenly across a
+ * chronologically-sorted pool so old and recent both survive. Kept in one place
+ * so the two miners can't drift.
+ */
+
+/**
+ * Pick `quota` items spread evenly across `buckets` equal-count buckets of a
+ * (caller-)sorted pool. Earlier buckets absorb the remainder; within a bucket,
+ * picks are evenly spaced. No RNG — the same pool always yields the same sample.
+ */
+export function pickEvenlySpaced<T>(sortedPool: T[], quota: number, buckets: number): T[] {
+  if (quota <= 0 || sortedPool.length === 0) {
+    return [];
+  }
+  const target = Math.min(quota, sortedPool.length);
+  const bucketSize = Math.ceil(sortedPool.length / buckets);
+  const bucketList: T[][] = [];
+  for (let start = 0; start < sortedPool.length; start += bucketSize) {
+    bucketList.push(sortedPool.slice(start, start + bucketSize));
+  }
+  const perBucketBase = Math.floor(target / bucketList.length);
+  let remainder = target - perBucketBase * bucketList.length;
+  const picked: T[] = [];
+  for (const bucket of bucketList) {
+    let take = perBucketBase;
+    if (remainder > 0) {
+      take += 1;
+      remainder -= 1;
+    }
+    take = Math.min(take, bucket.length);
+    for (let i = 0; i < take; i++) {
+      picked.push(bucket[Math.floor((i * bucket.length) / take)]);
+    }
+  }
+  return picked.slice(0, target);
+}

--- a/services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Fold-aware pooling runner (the honest re-baseline).
+ *
+ * Runs the retrieval A/B the way production actually retrieves: with the fold.
+ * For each REAL conversation golden (mined via `memory:mine-conversation-goldens`)
+ * it runs bare-vs-folded arms — dense (pgvector) and FTS — pools the top-K of
+ * each into a judgment sheet, and flags every pooled candidate against the
+ * non-circularity guard so a memory the fold window already contains can't count
+ * as a "win".
+ *
+ * NOT a CI test and NOT hermetic: it queries a LIVE, prod-synced memory store
+ * directly (dev), because the faithful corpus is the persona's FULL ~19k memory
+ * pool with real embeddings — infeasible to re-embed into PGLite. Persona-wide
+ * (no personality filter) matches the owner's shareLtmAcrossPersonalities=ON.
+ *
+ * Run: `EVAL_MEMORY_DATABASE_URL=<dev-url> pnpm eval:fold-goldens`. Skips itself
+ * cleanly when the env var or the local goldens file is absent. Output (pool +
+ * judgment sheet) is LOCAL-ONLY (gitignored `reports/goldens-mining/`).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { LocalEmbeddingService } from '@tzurot/embeddings';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { PgvectorMemoryAdapter } from '../PgvectorMemoryAdapter.js';
+import { buildSearchQuery } from '../prompt/SearchQueryBuilder.js';
+import { extractRecentHistoryWindow } from '../RAGUtils.js';
+import { classifyCandidate, type GuardVerdict } from './nonCircularityGuard.js';
+
+const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
+const GOLDENS_PATH = join(WORK_DIR, 'conversation-goldens.json');
+const DB_URL = process.env.EVAL_MEMORY_DATABASE_URL;
+
+/** Pool depth per arm — TREC-style shallow pools judge fine at 10. */
+const POOL_K = 10;
+/** Over-fetch before chunk-dedup so a deduped arm still fills K distinct candidates. */
+const OVERFETCH = POOL_K * 2;
+/** Floor threshold: let ranking (not the production cutoff) decide the pool. */
+const SCORE_FLOOR = 0.01;
+/** Fold depths swept: production is 3; 5/8 probe whether more context helps. */
+const FOLD_TURN_COUNTS = [3, 5, 8] as const;
+/** The production fold depth — its window text is what the guard checks against.
+ * Sourced from the same constant production uses so it can't drift from a stale literal. */
+const PROD_FOLD_TURNS = AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS;
+
+interface ConversationTurn {
+  role: string;
+  content: string;
+  createdAt: string;
+}
+
+interface ConversationGolden {
+  id: string;
+  channelId: string;
+  personaId: string;
+  personalityId: string;
+  message: string;
+  messageMetadata: unknown;
+  createdAt: string;
+  style: string;
+  priorHistory: ConversationTurn[];
+}
+
+/** A persisted pooled candidate: its rank in each arm + the guard verdict. */
+interface PooledCandidate {
+  corpusId: string;
+  createdAtMs: number;
+  contentPreview: string;
+  ranks: Record<string, number>;
+  verdict: GuardVerdict;
+}
+
+/**
+ * Transient during pooling — carries the FULL memory content the guard must see.
+ * A truncated preview would let a verbatim fold-window overlap past the cutoff
+ * slip through as `eligible`, flattering the folded arm; only the preview is
+ * persisted (below), never the full content.
+ */
+interface PoolingCandidate {
+  corpusId: string;
+  createdAtMs: number;
+  content: string;
+  ranks: Record<string, number>;
+}
+
+interface GoldenPool {
+  goldenId: string;
+  message: string;
+  style: string;
+  oldestHistoryMs: number;
+  arms: string[];
+  candidates: PooledCandidate[];
+}
+
+const ready = DB_URL !== undefined && DB_URL.length > 0 && existsSync(GOLDENS_PATH);
+
+describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
+  let prisma: PrismaClient;
+  let embeddings: LocalEmbeddingService;
+  let adapter: PgvectorMemoryAdapter;
+  let goldens: ConversationGolden[];
+  const pools: GoldenPool[] = [];
+
+  beforeAll(async () => {
+    goldens = (JSON.parse(readFileSync(GOLDENS_PATH, 'utf8')) as { goldens: ConversationGolden[] })
+      .goldens;
+
+    prisma = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: DB_URL }),
+    }) as PrismaClient;
+
+    embeddings = new LocalEmbeddingService();
+    const initialized = await embeddings.initialize();
+    if (!initialized) {
+      throw new Error('Local embedding model failed to initialize — pooling cannot run');
+    }
+    adapter = new PgvectorMemoryAdapter(prisma, embeddings);
+  }, 900_000);
+
+  afterAll(async () => {
+    if (pools.length > 0) {
+      writeFileSync(join(WORK_DIR, 'fold-pool.json'), `${JSON.stringify({ pools }, null, 2)}\n`);
+      writeFileSync(join(WORK_DIR, 'fold-judgment-sheets.md'), buildJudgmentSheets(pools));
+      console.log(
+        `\n=== fold-aware pooling: ${pools.length} goldens → ${WORK_DIR}/fold-judgment-sheets.md ===`
+      );
+    }
+    await prisma?.$disconnect();
+    await embeddings?.shutdown();
+  });
+
+  it('pools bare-vs-folded arms for every golden', { timeout: 1_800_000 }, async () => {
+    for (const golden of goldens) {
+      const turns = golden.priorHistory.map(turn => ({ role: turn.role, content: turn.content }));
+      // Approximation of production's oldestHistoryTimestamp: computed from the mined
+      // channel-scoped priorHistory (capped at historyWindow). Production can also fold
+      // cross-channel timestamps in, which would push this slightly older — acceptable
+      // for the temporal guard (a looser cutoff only makes the folded arm's bar HIGHER).
+      const oldestHistoryMs = Math.min(
+        ...golden.priorHistory.map(turn => new Date(turn.createdAt).getTime())
+      );
+      const foldWindowText = extractRecentHistoryWindow(turns, PROD_FOLD_TURNS) ?? '';
+
+      // Build the arm → query map. Dense arms embed + pgvector; FTS arms lexical.
+      const denseQueries: Record<string, string> = { 'bare-dense': golden.message };
+      for (const n of FOLD_TURN_COUNTS) {
+        denseQueries[`fold${n}-dense`] = buildSearchQuery(
+          golden.message,
+          [],
+          undefined,
+          extractRecentHistoryWindow(turns, n)
+        );
+      }
+
+      const pooled = new Map<string, PoolingCandidate>();
+      const record = (armName: string, rows: RetrievedRow[]): void => {
+        rows.forEach((row, index) => {
+          const existing = pooled.get(row.corpusId) ?? {
+            corpusId: row.corpusId,
+            createdAtMs: row.createdAtMs,
+            // The first arm to surface a candidate sets its content. Dense hits are
+            // placeholder-resolved ({user}→name) while FTS hits are raw SQL content;
+            // the tiny token delta doesn't move the lexical-echo verdict in practice.
+            content: row.content,
+            ranks: {} as Record<string, number>,
+          };
+          existing.ranks[armName] = index + 1;
+          pooled.set(row.corpusId, existing);
+        });
+      };
+
+      for (const [armName, query] of Object.entries(denseQueries)) {
+        record(armName, await denseArm(adapter, golden.personaId, query));
+      }
+      record('bare-fts', await ftsArm(prisma, golden.personaId, golden.message));
+      record(
+        `fold${PROD_FOLD_TURNS}-fts`,
+        await ftsArm(prisma, golden.personaId, denseQueries[`fold${PROD_FOLD_TURNS}-dense`])
+      );
+
+      // The guard classifies against FULL content; only the preview is persisted.
+      const candidates: PooledCandidate[] = [...pooled.values()].map(candidate => ({
+        corpusId: candidate.corpusId,
+        createdAtMs: candidate.createdAtMs,
+        contentPreview: candidate.content.replace(/\s+/g, ' ').slice(0, 240),
+        ranks: candidate.ranks,
+        verdict: classifyCandidate(
+          { createdAtMs: candidate.createdAtMs, content: candidate.content },
+          { oldestHistoryMs, foldWindowText }
+        ),
+      }));
+
+      pools.push({
+        goldenId: golden.id,
+        message: golden.message,
+        style: golden.style,
+        oldestHistoryMs,
+        arms: [...Object.keys(denseQueries), 'bare-fts', `fold${PROD_FOLD_TURNS}-fts`],
+        candidates,
+      });
+    }
+    expect(pools).toHaveLength(goldens.length);
+  });
+});
+
+interface RetrievedRow {
+  corpusId: string;
+  createdAtMs: number;
+  content: string;
+}
+
+/**
+ * Dense arm: the production retrieval path (embed → pgvector), persona-wide.
+ * Over-fetches then dedups by chunk group (falling back to id) so chunk siblings
+ * collapse to one candidate and the arm still yields K distinct rows — without the
+ * over-fetch, a top-K crowded with same-source chunks would under-fill the pool.
+ */
+async function denseArm(
+  adapter: PgvectorMemoryAdapter,
+  personaId: string,
+  query: string
+): Promise<RetrievedRow[]> {
+  const hits = await adapter.queryMemories(query, {
+    personaId,
+    limit: OVERFETCH,
+    scoreThreshold: SCORE_FLOOR,
+  });
+  const seen = new Set<string>();
+  const rows: RetrievedRow[] = [];
+  for (const hit of hits) {
+    const meta = hit.metadata as {
+      id?: string;
+      chunkGroupId?: string | null;
+      createdAt?: number;
+    };
+    const corpusId = meta.chunkGroupId ?? meta.id;
+    if (corpusId === undefined || corpusId === null || seen.has(corpusId)) {
+      continue;
+    }
+    seen.add(corpusId);
+    rows.push({ corpusId, createdAtMs: meta.createdAt ?? 0, content: hit.pageContent });
+    if (rows.length >= POOL_K) {
+      break;
+    }
+  }
+  return rows;
+}
+
+interface FtsRow {
+  id: string;
+  content: string;
+  created_at: Date;
+  chunk_group_id: string | null;
+}
+
+/**
+ * FTS arm: OR-of-lexemes over the message (plainto_tsquery ANDs every word, which
+ * a conversational message never satisfies). Scoped by persona_id + visibility ONLY
+ * — matching the dense arm's `buildWhereConditions` exactly (which has no `type`
+ * filter), so both arms see the same candidate universe (incl. any knowledge-type
+ * rows). Folding balloons the term set, so folded-FTS is near-degenerate — reported
+ * for completeness; the decisive arm is folded-dense.
+ */
+async function ftsArm(
+  prisma: PrismaClient,
+  personaId: string,
+  text: string
+): Promise<RetrievedRow[]> {
+  const orQuery = text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(word => word.length > 1)
+    .join(' | ');
+  if (orQuery.length === 0) {
+    return [];
+  }
+  const rows = await prisma.$queryRaw<FtsRow[]>`
+    SELECT id, content, created_at, chunk_group_id
+    FROM memories
+    WHERE persona_id = ${personaId}::uuid
+      AND visibility = 'normal'
+      AND to_tsvector('english', content) @@ to_tsquery('english', ${orQuery})
+    ORDER BY ts_rank(to_tsvector('english', content), to_tsquery('english', ${orQuery})) DESC
+    LIMIT ${OVERFETCH * 2}
+  `;
+  const seen = new Set<string>();
+  const out: RetrievedRow[] = [];
+  for (const row of rows) {
+    const corpusId = row.chunk_group_id ?? row.id;
+    if (seen.has(corpusId)) {
+      continue;
+    }
+    seen.add(corpusId);
+    out.push({ corpusId, createdAtMs: new Date(row.created_at).getTime(), content: row.content });
+    if (out.length >= POOL_K) {
+      break;
+    }
+  }
+  return out;
+}
+
+/** Build the owner/judge relevance sheet — one section per golden. */
+function buildJudgmentSheets(pools: GoldenPool[]): string {
+  const lines = [
+    '# Fold-aware pooled-judgment sheets',
+    '',
+    'For each golden: mark every candidate `[R]` relevant, `[S]` sort-of, or leave `[ ]`.',
+    'You judge ONLY what is listed. Rank badges show where each arm placed the candidate',
+    '(`B`=bare-dense, `F3/F5/F8`=folded-dense at 3/5/8 turns, `Bf/F3f`=bare/folded FTS).',
+    '`⊘in-window` / `⊘echo` mark candidates the non-circularity guard disqualifies — the',
+    'fold window already contains them, so they DO NOT count even if you mark them relevant.',
+    '',
+  ];
+  for (const pool of pools) {
+    lines.push(
+      '---',
+      '',
+      `## ${pool.goldenId.slice(0, 8)} (${pool.style})`,
+      '',
+      `> ${pool.message}`,
+      ''
+    );
+    const sorted = [...pool.candidates].sort((a, b) => armSortKey(a) - armSortKey(b));
+    for (const candidate of sorted) {
+      const badges = [
+        rankBadge(candidate, 'bare-dense', 'B'),
+        rankBadge(candidate, 'fold3-dense', 'F3'),
+        rankBadge(candidate, 'fold5-dense', 'F5'),
+        rankBadge(candidate, 'fold8-dense', 'F8'),
+        rankBadge(candidate, 'bare-fts', 'Bf'),
+        rankBadge(candidate, 'fold3-fts', 'F3f'),
+        candidate.verdict !== 'eligible' ? `⊘${candidate.verdict}` : null,
+      ]
+        .filter(Boolean)
+        .join(' · ');
+      lines.push(
+        `- [ ] \`${candidate.corpusId.slice(0, 8)}\` ${badges}`,
+        `      ${candidate.contentPreview}…`,
+        ''
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Sort candidates by best (lowest) rank across the dense arms for sheet readability. */
+function armSortKey(candidate: PooledCandidate): number {
+  const ranks = Object.values(candidate.ranks);
+  return ranks.length === 0 ? 99 : Math.min(...ranks);
+}
+
+function rankBadge(candidate: PooledCandidate, arm: string, label: string): string | null {
+  const rank = candidate.ranks[arm];
+  return rank === undefined ? null : `${label}#${rank}`;
+}

--- a/services/ai-worker/src/services/eval/nonCircularityGuard.test.ts
+++ b/services/ai-worker/src/services/eval/nonCircularityGuard.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import {
+  isInStmWindow,
+  isLexicalEcho,
+  classifyCandidate,
+  DEFAULT_ECHO_JACCARD,
+} from './nonCircularityGuard.js';
+
+const MINUTE = 60_000;
+
+describe('isInStmWindow (temporal guard)', () => {
+  const oldest = 1_000_000_000_000; // arbitrary fixed ms
+
+  it('flags a candidate at or newer than oldestHistory - buffer as in-window', () => {
+    // Exactly at the cutoff → in-window (>= is disqualifying).
+    expect(isInStmWindow(oldest - AI_DEFAULTS.STM_LTM_BUFFER_MS, oldest)).toBe(true);
+    // Newer than the window → in-window.
+    expect(isInStmWindow(oldest + MINUTE, oldest)).toBe(true);
+  });
+
+  it('clears a candidate older than the cutoff', () => {
+    expect(isInStmWindow(oldest - AI_DEFAULTS.STM_LTM_BUFFER_MS - 1, oldest)).toBe(false);
+    expect(isInStmWindow(oldest - MINUTE, oldest)).toBe(false);
+  });
+
+  it('mirrors production: the cutoff is oldestHistory minus STM_LTM_BUFFER_MS', () => {
+    // A memory 5s before the oldest history turn is still inside the 10s buffer → in-window.
+    expect(isInStmWindow(oldest - 5_000, oldest)).toBe(true);
+    // 11s before → past the buffer → eligible.
+    expect(isInStmWindow(oldest - 11_000, oldest)).toBe(false);
+  });
+
+  it('honors a custom buffer', () => {
+    expect(isInStmWindow(oldest - 500, oldest, 1_000)).toBe(true);
+    expect(isInStmWindow(oldest - 1_500, oldest, 1_000)).toBe(false);
+  });
+});
+
+describe('isLexicalEcho (lexical guard)', () => {
+  it('flags a candidate that is (nearly) the fold window verbatim', () => {
+    const text = 'we talked at length about the trip to the northern coast last winter';
+    expect(isLexicalEcho(text, text)).toBe(true);
+  });
+
+  it('clears a lexically distinct candidate even on the same topic', () => {
+    const fold = 'what did you think about that plan we discussed';
+    const candidate = 'The user prefers oat milk in their morning coffee.';
+    expect(isLexicalEcho(candidate, fold)).toBe(false);
+  });
+
+  it('flags a long verbatim word run even when overall Jaccard is low', () => {
+    const fold = 'she said the quick brown fox jumps over the lazy dog every single morning';
+    // Shares an ≥8-word run but is otherwise a much longer, different document.
+    const candidate = `${'unrelated preamble '.repeat(20)} the quick brown fox jumps over the lazy dog ${'unrelated tail '.repeat(20)}`;
+    expect(jaccardBelow(candidate, fold)).toBe(true); // sanity: overall overlap is low
+    expect(isLexicalEcho(candidate, fold)).toBe(true); // but the shingle catches it
+  });
+
+  it('returns false for an empty fold window', () => {
+    expect(isLexicalEcho('anything at all here', '')).toBe(false);
+  });
+});
+
+/** Test helper: confirm two texts are below the Jaccard echo threshold (so a true
+ * isLexicalEcho result must be coming from the shingle branch, not Jaccard). */
+function jaccardBelow(a: string, b: string): boolean {
+  // Re-derive a coarse trigram Jaccard the same way the guard does, to assert the
+  // shingle branch is what fired. Kept local so the guard's internals stay private.
+  const grams = (t: string): Set<string> => {
+    const n = t.toLowerCase().replace(/\s+/g, ' ').trim();
+    const g = new Set<string>();
+    for (let i = 0; i + 3 <= n.length; i++) g.add(n.slice(i, i + 3));
+    return g;
+  };
+  const ga = grams(a);
+  const gb = grams(b);
+  let inter = 0;
+  for (const x of ga) if (gb.has(x)) inter += 1;
+  const j = inter / (ga.size + gb.size - inter);
+  return j < DEFAULT_ECHO_JACCARD;
+}
+
+describe('classifyCandidate', () => {
+  const oldest = 1_000_000_000_000;
+  const context = { oldestHistoryMs: oldest, foldWindowText: 'the trip to the coast last winter' };
+
+  it('returns in-window when the temporal guard fails (checked first)', () => {
+    // Newer than cutoff AND an echo — temporal wins the label.
+    expect(
+      classifyCandidate({ createdAtMs: oldest, content: context.foldWindowText }, context)
+    ).toBe('in-window');
+  });
+
+  it('returns echo when old enough but lexically overlapping', () => {
+    expect(
+      classifyCandidate(
+        { createdAtMs: oldest - 10 * MINUTE, content: 'the trip to the coast last winter' },
+        context
+      )
+    ).toBe('echo');
+  });
+
+  it('returns eligible when old and lexically distinct', () => {
+    expect(
+      classifyCandidate(
+        { createdAtMs: oldest - 10 * MINUTE, content: 'user has a cat named Miso' },
+        context
+      )
+    ).toBe('eligible');
+  });
+});

--- a/services/ai-worker/src/services/eval/nonCircularityGuard.ts
+++ b/services/ai-worker/src/services/eval/nonCircularityGuard.ts
@@ -1,0 +1,155 @@
+/**
+ * Non-circularity guard for the fold-aware retrieval A/B.
+ *
+ * Folding the last few conversation turns into the embedded query can trivially
+ * "retrieve" a memory whose text the fold window already contains — the query
+ * literally holds the answer. Crediting that inflates the folded arm dishonestly.
+ * The fold's REAL value is reaching OLDER, lexically-distinct memories the bare
+ * message can't. So a pooled memory is credit-eligible for a turn only if it
+ * clears BOTH guards below.
+ *
+ * Pure + committed (the corpus/goldens are local-only, but the guard MATH is the
+ * reusable instrument the runner and `poolScoring` both apply).
+ */
+
+import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
+
+/**
+ * Temporal guard — mirrors production's own STM/LTM dedup cutoff
+ * (`MemoryRetriever.calculateDeduplicationCutoff`: `excludeNewerThan =
+ * oldestHistoryTimestamp - STM_LTM_BUFFER_MS`). A memory at or newer than that
+ * cutoff sits inside the recent-history window the fold already carries, so it's
+ * "in the STM window" and NOT credit-eligible. Enforcing this makes the folded
+ * arm MORE faithful to prod (which applies the same cutoff at retrieval), not less.
+ *
+ * @param candidateCreatedAtMs the pooled memory's createdAt (ms)
+ * @param oldestHistoryMs the oldest fold-window turn's timestamp (ms)
+ * @param bufferMs STM/LTM buffer; defaults to the production constant
+ * @returns true if the candidate is inside the STM window (disqualified)
+ */
+export function isInStmWindow(
+  candidateCreatedAtMs: number,
+  oldestHistoryMs: number,
+  bufferMs: number = AI_DEFAULTS.STM_LTM_BUFFER_MS
+): boolean {
+  return candidateCreatedAtMs >= oldestHistoryMs - bufferMs;
+}
+
+/** Default trigram-Jaccard overlap above which a candidate is treated as an echo. */
+export const DEFAULT_ECHO_JACCARD = 0.5;
+/** Default verbatim word-run length that flags an echo regardless of Jaccard. */
+export const DEFAULT_ECHO_SHINGLE_WORDS = 8;
+
+/** Lowercase character trigrams of a string (whitespace collapsed). */
+function charTrigrams(text: string): Set<string> {
+  const normalized = text.toLowerCase().replace(/\s+/g, ' ').trim();
+  const grams = new Set<string>();
+  for (let i = 0; i + 3 <= normalized.length; i++) {
+    grams.add(normalized.slice(i, i + 3));
+  }
+  return grams;
+}
+
+/** Jaccard similarity of two sets (|A∩B| / |A∪B|); 0 when both are empty. */
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) {
+    return 0;
+  }
+  let intersection = 0;
+  for (const item of a) {
+    if (b.has(item)) {
+      intersection += 1;
+    }
+  }
+  return intersection / (a.size + b.size - intersection);
+}
+
+/** Content words (alphanumeric tokens ≥ 2 chars), lowercased. */
+function contentWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(word => word.length >= 2);
+}
+
+/** True if the two texts share a verbatim run of ≥ `n` consecutive content words. */
+function hasSharedWordShingle(a: string, b: string, n: number): boolean {
+  const wordsA = contentWords(a);
+  if (wordsA.length < n) {
+    return false;
+  }
+  const shinglesB = new Set<string>();
+  const wordsB = contentWords(b);
+  for (let i = 0; i + n <= wordsB.length; i++) {
+    shinglesB.add(wordsB.slice(i, i + n).join(' '));
+  }
+  if (shinglesB.size === 0) {
+    return false;
+  }
+  for (let i = 0; i + n <= wordsA.length; i++) {
+    if (shinglesB.has(wordsA.slice(i, i + n).join(' '))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export interface EchoOptions {
+  jaccardThreshold?: number;
+  shingleWords?: number;
+}
+
+/**
+ * Lexical guard — belt-and-suspenders for the case where an OLDER memory
+ * (past the temporal cutoff) is nonetheless quoted verbatim in the fold window.
+ * A candidate is an echo if its trigram-Jaccard overlap with the fold window is
+ * high OR it shares a long verbatim word run with it.
+ *
+ * @returns true if the candidate echoes the fold window (disqualified)
+ */
+export function isLexicalEcho(
+  candidateContent: string,
+  foldWindowText: string,
+  options: EchoOptions = {}
+): boolean {
+  const jaccardThreshold = options.jaccardThreshold ?? DEFAULT_ECHO_JACCARD;
+  const shingleWords = options.shingleWords ?? DEFAULT_ECHO_SHINGLE_WORDS;
+  if (foldWindowText.trim().length === 0) {
+    return false;
+  }
+  if (jaccard(charTrigrams(candidateContent), charTrigrams(foldWindowText)) >= jaccardThreshold) {
+    return true;
+  }
+  return hasSharedWordShingle(candidateContent, foldWindowText, shingleWords);
+}
+
+/** A pooled candidate's guard inputs. */
+export interface GuardInput {
+  createdAtMs: number;
+  content: string;
+}
+
+/** Per-turn context the guard checks a candidate against. */
+export interface GuardContext {
+  oldestHistoryMs: number;
+  foldWindowText: string;
+  bufferMs?: number;
+  echo?: EchoOptions;
+}
+
+export type GuardVerdict = 'eligible' | 'in-window' | 'echo';
+
+/**
+ * Classify a candidate against both guards. Temporal is checked first (it mirrors
+ * production's own cutoff); lexical echo is the fallback for older-but-quoted rows.
+ */
+export function classifyCandidate(candidate: GuardInput, context: GuardContext): GuardVerdict {
+  if (isInStmWindow(candidate.createdAtMs, context.oldestHistoryMs, context.bufferMs)) {
+    return 'in-window';
+  }
+  if (isLexicalEcho(candidate.content, context.foldWindowText, context.echo)) {
+    return 'echo';
+  }
+  return 'eligible';
+}


### PR DESCRIPTION
## What

The payload of the memory-1c **honest re-baseline**: a runner that executes the bare-vs-folded retrieval A/B the way production actually retrieves — with the fold — plus the non-circularity guard that keeps the measurement honest.

## Why the architecture is dev-direct (not PGLite)

The approved plan used a PGLite corpus. Two things pivoted it (owner-confirmed):
1. **`shareLtmAcrossPersonalities=ON`** for the owner's persona → production retrieval is **persona-wide** across all characters, so the corpus must be the *full* persona pool (~19k memories), not a character-sample.
2. Embedding 19k rows into PGLite on the Steam Deck is infeasible — but **dev already has all 19k embedded** (synced from prod, same bge-small model).

So the runner queries **dev's real memory store directly** (read-only pgvector similarity), reusing the production `PgvectorMemoryAdapter` pointed at dev. Strictly more faithful than any sample, and it drops the whole mining/embedding step.

## How

Per real conversation golden (`conversation-goldens.json`, mined in #1611):
- Runs `bare-dense` + `folded-dense` (turn sweep 3/5/8, via the real `buildSearchQuery`+`extractRecentHistoryWindow`) + `bare/folded FTS`.
- Dedups by chunk group (over-fetch → cap to K), closing the pooling under-fill the #1609 review flagged.
- Flags every pooled candidate against the **non-circularity guard**.

### The guard (committed + tested — the correctness crux)
A memory is credit-eligible only if it clears BOTH:
- **Temporal**: older than production's own STM/LTM dedup cutoff (`oldestHistoryTimestamp − STM_LTM_BUFFER_MS`). Mirrors `MemoryRetriever.calculateDeduplicationCutoff`, so enforcing it is *more* faithful to prod.
- **Lexical echo**: not a trigram-Jaccard / verbatim-word-shingle match of the fold window.

This stops the fold from "winning" by retrieving text its own window already contains — without it, a short reactive message like "poke" would score the recent conversation as a folding win.

## Also (folds in #1611 review nits, per owner request — no backlog rot)

- Extract the shared bucket-sampling helper (`sampling.ts`) so `mine-goldens` / `mine-conversation-goldens` can't drift.
- `fetchPriorHistory` `(created_at, id)` tie-break; `historyWindow` comment clarity; `--persona-id` UUID validation. Resolves the `cold/follow-ups.md` miner-polish entry.

## Verification

- `pnpm --filter @tzurot/ai-worker typecheck:spec` + `pnpm --filter @tzurot/tooling test` (1484) + guard unit tests (11) — all green.
- **Validated end-to-end against dev**: 40 goldens pooled, guard classified 255 in-window / 5 echo / 1670 eligible. Raw (pre-judgment) signal: folded-dense surfaced 718 eligible candidates bare-dense missed vs 310 the other way.
- Run: `EVAL_MEMORY_DATABASE_URL=<dev-url> pnpm eval:fold-goldens` — local-only, excluded from CI (`eval.test.ts` glob).

Next: PR-4 (poolScoring metrics: recall / both-miss / paired flips) + I judge the sheet → the honest re-baseline number that decides rung-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)