### PR TITLE
test(ai-worker): fold-aware poolScoring + A/B scoring glue

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eval:memory": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryRetrieval.eval.test.ts",
     "eval:pool-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/goldensPooling.eval.test.ts",
     "eval:fold-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts",
+    "eval:fold-score": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/foldAwareScoring.eval.test.ts",
     "eval:extraction": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts"
   },
   "devDependencies": {

--- a/services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts
@@ -28,7 +28,8 @@ import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
 import { PgvectorMemoryAdapter } from '../PgvectorMemoryAdapter.js';
 import { buildSearchQuery } from '../prompt/SearchQueryBuilder.js';
 import { extractRecentHistoryWindow } from '../RAGUtils.js';
-import { classifyCandidate, type GuardVerdict } from './nonCircularityGuard.js';
+import { classifyCandidate } from './nonCircularityGuard.js';
+import type { PooledCandidate, GoldenPool } from './qrelsReconciliation.js';
 
 const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
 const GOLDENS_PATH = join(WORK_DIR, 'conversation-goldens.json');
@@ -64,35 +65,17 @@ interface ConversationGolden {
   priorHistory: ConversationTurn[];
 }
 
-/** A persisted pooled candidate: its rank in each arm + the guard verdict. */
-interface PooledCandidate {
-  corpusId: string;
-  createdAtMs: number;
-  contentPreview: string;
-  ranks: Record<string, number>;
-  verdict: GuardVerdict;
-}
-
 /**
  * Transient during pooling — carries the FULL memory content the guard must see.
  * A truncated preview would let a verbatim fold-window overlap past the cutoff
  * slip through as `eligible`, flattering the folded arm; only the preview is
- * persisted (below), never the full content.
+ * persisted (as `PooledCandidate.contentPreview`), never the full content.
  */
 interface PoolingCandidate {
   corpusId: string;
   createdAtMs: number;
   content: string;
   ranks: Record<string, number>;
-}
-
-interface GoldenPool {
-  goldenId: string;
-  message: string;
-  style: string;
-  oldestHistoryMs: number;
-  arms: string[];
-  candidates: PooledCandidate[];
 }
 
 const ready = DB_URL !== undefined && DB_URL.length > 0 && existsSync(GOLDENS_PATH);

--- a/services/ai-worker/src/services/eval/foldAwareScoring.eval.test.ts
+++ b/services/ai-worker/src/services/eval/foldAwareScoring.eval.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Fold-aware scoring glue (the honest re-baseline NUMBER).
+ *
+ * Reads the local pool (`fold-pool.json`, produced by `foldAwarePooling.eval.test.ts`)
+ * and the judged relevance labels (`qrels.json`, produced by hand-judging the
+ * sheet), and emits the bare-vs-folded A/B table via the committed `poolScoring`
+ * instrument. The scoring MATH lives in `poolScoring.ts` (+ its CI-run test); this
+ * file is only the eval-only glue that feeds it the local artifacts and formats
+ * the report.
+ *
+ * The integrity fix over the old hand-assembled `AB-RESULT.md`: the judgment sheet
+ * shows 8-char id prefixes, so `qrels.json` is keyed by those prefixes. This
+ * reconciles every prefix back to its FULL corpus/golden id and HARD-ERRORS on any
+ * ambiguous or unresolvable prefix — a mis-keyed qrels can no longer silently score
+ * against the wrong candidate.
+ *
+ * NOT a CI test: it reads LOCAL-ONLY gitignored artifacts. Skips itself cleanly
+ * when either file is absent. Run: `pnpm eval:fold-score`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { scoreArm, pairedFlips, combinedMissRate, type ScoredQuery } from './poolScoring.js';
+import { reconcile, type GoldenPool, type PrefixQrels, type Qrels } from './qrelsReconciliation.js';
+
+const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
+const POOL_PATH = join(WORK_DIR, 'fold-pool.json');
+const QRELS_PATH = join(WORK_DIR, 'fold-qrels.json');
+const REPORT_PATH = join(WORK_DIR, 'fold-ab-result.md');
+
+/** Arms in report order; production retrieves with fold3-dense. */
+const ARMS = ['bare-dense', 'fold3-dense', 'fold5-dense', 'fold8-dense', 'bare-fts', 'fold3-fts'];
+const DENSE_SWEEP = ['fold3-dense', 'fold5-dense', 'fold8-dense'];
+const K_VALUES = [5, 10] as const;
+
+const ready = existsSync(POOL_PATH) && existsSync(QRELS_PATH);
+
+describe.skipIf(!ready)('fold-aware scoring (local pool + qrels)', () => {
+  it('emits the bare-vs-folded A/B table', () => {
+    const pools = (JSON.parse(readFileSync(POOL_PATH, 'utf8')) as { pools: GoldenPool[] }).pools;
+    const prefixQrels = JSON.parse(readFileSync(QRELS_PATH, 'utf8')) as PrefixQrels;
+
+    const { queries, qrels } = reconcile(pools, prefixQrels);
+    const report = buildReport(pools, queries, qrels);
+    writeFileSync(REPORT_PATH, report);
+    console.log(`\n=== fold-aware A/B → ${REPORT_PATH} ===\n`);
+    console.log(report);
+
+    // The report must have scored at least one query, or the qrels reconciliation
+    // silently produced nothing (the failure mode this glue exists to prevent).
+    const scored = scoreArm(queries, qrels, 'fold3-dense', 10).scoredQueries;
+    expect(scored).toBeGreaterThan(0);
+  });
+});
+
+function buildReport(pools: GoldenPool[], queries: ScoredQuery[], qrels: Qrels): string {
+  const lines: string[] = [
+    '# Fold-aware A/B result (honest re-baseline)',
+    '',
+    'Bare-vs-folded retrieval on real mined Lila turns. Every metric masks the relevant',
+    'set to the non-circularity guard — a memory the fold window already contained is',
+    'excluded, so the fold earns credit only for reaching PAST what it carries.',
+    '',
+    `Goldens: ${pools.length}. Production retrieves with **fold3-dense**.`,
+    '',
+  ];
+
+  for (const k of K_VALUES) {
+    lines.push(`## Per-arm metrics @ K=${k}`, '');
+    lines.push('| Arm | recall@K | MRR | miss-rate | scored |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const arm of ARMS) {
+      const m = scoreArm(queries, qrels, arm, k);
+      lines.push(
+        `| ${arm} | ${fmt(m.recallAtK)} | ${fmt(m.mrr)} | ${fmt(m.missRate)} | ${m.scoredQueries} |`
+      );
+    }
+    lines.push('');
+  }
+
+  // The decisive comparison: does the production fold beat the bare message?
+  lines.push('## Decisive paired comparison — bare-dense → fold3-dense', '');
+  lines.push('| K | both-hit | both-miss | fold-fixes | fold-breaks | net |');
+  lines.push('| --- | --- | --- | --- | --- | --- |');
+  for (const k of K_VALUES) {
+    const f = pairedFlips(queries, qrels, 'bare-dense', 'fold3-dense', k);
+    lines.push(
+      `| ${k} | ${f.bothHit} | ${f.bothMiss} | ${f.treatmentFixes} | ${f.treatmentBreaks} | ${signed(f.net)} |`
+    );
+  }
+  lines.push('');
+
+  // The original A/B headline reproduced honestly: both dense AND fts miss.
+  lines.push('## Both-arms-miss (the original 30% metric, guard-honest)', '');
+  lines.push('| K | bare (dense+fts) | fold3 (dense+fts) |');
+  lines.push('| --- | --- | --- |');
+  for (const k of K_VALUES) {
+    const bare = combinedMissRate(queries, qrels, ['bare-dense', 'bare-fts'], k);
+    const fold = combinedMissRate(queries, qrels, ['fold3-dense', 'fold3-fts'], k);
+    lines.push(
+      `| ${k} | ${bare.missedTurns}/${bare.scoredQueries} (${fmt(bare.rate)}) | ${fold.missedTurns}/${fold.scoredQueries} (${fmt(fold.rate)}) |`
+    );
+  }
+  lines.push('');
+
+  // Turn sweep: does more folded context beyond production's 3 turns help?
+  lines.push('## Fold-depth sweep (dense) @ K=10', '');
+  lines.push('| Arm | recall@10 | miss-rate |');
+  lines.push('| --- | --- | --- |');
+  for (const arm of DENSE_SWEEP) {
+    const m = scoreArm(queries, qrels, arm, 10);
+    lines.push(`| ${arm} | ${fmt(m.recallAtK)} | ${fmt(m.missRate)} |`);
+  }
+  lines.push('');
+
+  lines.push(perStyleSection(pools, queries, qrels));
+  return `${lines.join('\n')}\n`;
+}
+
+/** Per-style both-arms-miss (bare vs fold3) — where does folding help most? */
+function perStyleSection(pools: GoldenPool[], queries: ScoredQuery[], qrels: Qrels): string {
+  const styleById = new Map(pools.map(p => [p.goldenId, p.style]));
+  const styles = [...new Set(pools.map(p => p.style))].sort();
+  const lines = [
+    '## Per-style both-arms-miss @ K=10 (bare dense+fts vs fold3 dense+fts)',
+    '',
+    '| Style | bare miss | fold3 miss |',
+    '| --- | --- | --- |',
+  ];
+  for (const style of styles) {
+    const subset = queries.filter(q => styleById.get(q.queryId) === style);
+    const bare = combinedMissRate(subset, qrels, ['bare-dense', 'bare-fts'], 10);
+    const fold = combinedMissRate(subset, qrels, ['fold3-dense', 'fold3-fts'], 10);
+    lines.push(
+      `| ${style} | ${bare.missedTurns}/${bare.scoredQueries} (${fmt(bare.rate)}) | ${fold.missedTurns}/${fold.scoredQueries} (${fmt(fold.rate)}) |`
+    );
+  }
+  return lines.join('\n');
+}
+
+function fmt(value: number): string {
+  return value.toFixed(3);
+}
+
+function signed(value: number): string {
+  return value > 0 ? `+${value}` : `${value}`;
+}

--- a/services/ai-worker/src/services/eval/poolScoring.test.ts
+++ b/services/ai-worker/src/services/eval/poolScoring.test.ts
@@ -1,104 +1,239 @@
 import { describe, it, expect } from 'vitest';
-import { scoreArm, scoreAllArms, RRF_K, type ScoredQuery, type Qrels } from './poolScoring.js';
+import {
+  scoreArm,
+  scoreArms,
+  pairedFlips,
+  combinedMissRate,
+  eligibleRelevantIds,
+  rankedIds,
+  rrfRanks,
+  withRrfArm,
+  RRF_K,
+  type ScoredQuery,
+  type ScoredCandidate,
+  type Qrels,
+} from './poolScoring.js';
 
-function q(queryId: string, candidates: ScoredQuery['candidates']): ScoredQuery {
+/** Build a candidate with all-eligible verdict unless overridden. */
+function cand(
+  corpusId: string,
+  ranks: Record<string, number | null>,
+  verdict: ScoredCandidate['verdict'] = 'eligible'
+): ScoredCandidate {
+  return { corpusId, verdict, ranks };
+}
+
+function q(queryId: string, candidates: ScoredCandidate[]): ScoredQuery {
   return { queryId, candidates };
 }
 
-describe('scoreArm', () => {
-  it('recall@K counts relevant in the top-K of the arm ranking', () => {
-    const queries = [
-      q('q1', [
-        { corpusId: 'a', denseRank: 1, ftsRank: null },
-        { corpusId: 'b', denseRank: 2, ftsRank: null },
-        { corpusId: 'c', denseRank: 3, ftsRank: null },
-      ]),
-    ];
-    const qrels: Qrels = { q1: { a: 1, c: 1 } }; // 2 relevant
-    // k=2 → top-2 is [a,b], one hit of two relevant → 0.5
-    expect(scoreArm(queries, qrels, 'dense', 2).recallAtK).toBe(0.5);
-    // k=3 → both a and c in → 1.0
-    expect(scoreArm(queries, qrels, 'dense', 3).recallAtK).toBe(1);
+describe('eligibleRelevantIds (the guard mask)', () => {
+  it('keeps judged-relevant candidates whose verdict is eligible', () => {
+    const query = q('q1', [cand('a', { d: 1 }), cand('b', { d: 2 })]);
+    const qrels: Qrels = { q1: { a: 1, b: 1 } };
+    expect([...eligibleRelevantIds(query, qrels)].sort()).toEqual(['a', 'b']);
   });
 
-  it('MRR is the reciprocal rank of the FIRST relevant candidate', () => {
-    const queries = [
-      q('q1', [
-        { corpusId: 'a', denseRank: 1, ftsRank: null }, // not relevant
-        { corpusId: 'b', denseRank: 2, ftsRank: null }, // first relevant → 1/2
-        { corpusId: 'c', denseRank: 3, ftsRank: null },
-      ]),
-    ];
-    expect(scoreArm(queries, { q1: { b: 1 } }, 'dense', 10).mrr).toBe(0.5);
+  it('EXCLUDES a judged-relevant candidate the guard flagged in-window', () => {
+    // 'a' is relevant per qrels but sits inside the fold window → cannot earn credit.
+    const query = q('q1', [cand('a', { d: 1 }, 'in-window'), cand('b', { d: 2 })]);
+    const qrels: Qrels = { q1: { a: 1, b: 1 } };
+    expect([...eligibleRelevantIds(query, qrels)]).toEqual(['b']);
   });
 
-  it('excludes queries with no relevant candidate from both means', () => {
-    const queries = [
-      q('q1', [{ corpusId: 'a', denseRank: 1, ftsRank: null }]),
-      q('q2', [{ corpusId: 'b', denseRank: 1, ftsRank: null }]),
-    ];
-    const qrels: Qrels = { q1: { a: 1 } }; // q2 has nothing relevant
-    const metrics = scoreArm(queries, qrels, 'dense', 10);
-    expect(metrics.scoredQueries).toBe(1);
-    expect(metrics.recallAtK).toBe(1); // only q1 counts, perfect
+  it('EXCLUDES a judged-relevant candidate the guard flagged echo', () => {
+    const query = q('q1', [cand('a', { d: 1 }, 'echo'), cand('b', { d: 2 })]);
+    const qrels: Qrels = { q1: { a: 1, b: 1 } };
+    expect([...eligibleRelevantIds(query, qrels)]).toEqual(['b']);
   });
 
-  it('an arm that never surfaced the relevant doc scores zero, not NaN', () => {
-    const queries = [
-      q('q1', [
-        { corpusId: 'a', denseRank: 1, ftsRank: null },
-        { corpusId: 'rel', denseRank: null, ftsRank: 1 }, // only FTS found it
-      ]),
-    ];
-    const qrels: Qrels = { q1: { rel: 1 } };
-    const dense = scoreArm(queries, qrels, 'dense', 10);
-    expect(dense.recallAtK).toBe(0);
-    expect(dense.mrr).toBe(0);
-    const fts = scoreArm(queries, qrels, 'fts', 10);
-    expect(fts.recallAtK).toBe(1);
+  it('ignores grade-0 (not-relevant) entries', () => {
+    const query = q('q1', [cand('a', { d: 1 }), cand('b', { d: 2 })]);
+    const qrels: Qrels = { q1: { a: 1, b: 0 } };
+    expect([...eligibleRelevantIds(query, qrels)]).toEqual(['a']);
   });
 });
 
-describe('RRF fusion', () => {
-  it('fuses ranks so a doc found by BOTH arms outranks a doc found by one', () => {
-    const queries = [
-      q('q1', [
-        { corpusId: 'both', denseRank: 3, ftsRank: 3 }, // in both, mid rank
-        { corpusId: 'denseTop', denseRank: 1, ftsRank: null }, // dense #1 only
-      ]),
+describe('rankedIds', () => {
+  it('orders by ascending rank, ties broken by corpus id', () => {
+    const cands = [
+      cand('c', { d: 2 }),
+      cand('a', { d: 1 }),
+      cand('b', { d: 1 }),
+      cand('z', { d: null }),
     ];
-    // RRF('both') = 1/(60+3)+1/(60+3) ≈ 0.0317; RRF('denseTop') = 1/(60+1) ≈ 0.0164.
-    // So 'both' ranks first under fusion — the whole point of hybrid.
-    const qrels: Qrels = { q1: { both: 1 } };
-    expect(scoreArm(queries, qrels, 'rrf', 1).recallAtK).toBe(1); // 'both' is rank-1 in RRF
-    // Under dense alone, 'both' is rank 3 → not in top-1.
-    expect(scoreArm(queries, qrels, 'dense', 1).recallAtK).toBe(0);
+    // rank1 tie a,b → id order; then c; z has no rank → dropped.
+    expect(rankedIds(cands, 'd')).toEqual(['a', 'b', 'c']);
   });
 
-  it('RRF surfaces a doc that only ONE arm found (union recall)', () => {
+  it('drops candidates the arm did not surface (undefined or null rank)', () => {
+    const cands = [cand('a', { d: 1 }), cand('b', {}), cand('c', { d: null })];
+    expect(rankedIds(cands, 'd')).toEqual(['a']);
+  });
+});
+
+describe('scoreArm', () => {
+  it('recall@K counts eligible relevant in the arm top-K', () => {
+    const queries = [q('q1', [cand('a', { d: 1 }), cand('b', { d: 2 }), cand('c', { d: 3 })])];
+    const qrels: Qrels = { q1: { a: 1, c: 1 } }; // 2 relevant
+    expect(scoreArm(queries, qrels, 'd', 2).recallAtK).toBe(0.5); // top-2 [a,b] → 1 of 2
+    expect(scoreArm(queries, qrels, 'd', 3).recallAtK).toBe(1); // top-3 → both
+  });
+
+  it('MRR is the reciprocal rank of the first eligible relevant', () => {
+    const queries = [q('q1', [cand('a', { d: 1 }), cand('b', { d: 2 }), cand('c', { d: 3 })])];
+    expect(scoreArm(queries, { q1: { b: 1 } }, 'd', 10).mrr).toBe(0.5);
+  });
+
+  it('missRate flags turns where the arm surfaced no eligible relevant in top-K', () => {
     const queries = [
-      q('q1', [
-        { corpusId: 'ftsOnly', denseRank: null, ftsRank: 1 },
-        { corpusId: 'denseOnly', denseRank: 1, ftsRank: null },
-      ]),
+      q('q1', [cand('a', { d: 1 }), cand('rel', { d: 2 })]), // rel at position 2
+      q('q2', [cand('rel2', { d: 1 }), cand('x', { d: 2 })]), // rel2 at position 1
     ];
-    const qrels: Qrels = { q1: { ftsOnly: 1 } };
-    // dense alone can't see ftsOnly; RRF can.
-    expect(scoreArm(queries, qrels, 'dense', 5).recallAtK).toBe(0);
-    expect(scoreArm(queries, qrels, 'rrf', 5).recallAtK).toBe(1);
+    const qrels: Qrels = { q1: { rel: 1 }, q2: { rel2: 1 } };
+    const m = scoreArm(queries, qrels, 'd', 1); // top-1: q1 misses rel, q2 hits rel2
+    expect(m.missRate).toBe(0.5);
+    expect(m.scoredQueries).toBe(2);
+  });
+
+  it('the guard mask denies credit for an in-window relevant even at rank 1', () => {
+    // 'a' is judged relevant AND ranked #1, but it's in-window → not eligible → miss.
+    const queries = [q('q1', [cand('a', { d: 1 }, 'in-window')])];
+    const m = scoreArm(queries, { q1: { a: 1 } }, 'd', 10);
+    // no eligible relevant at all → query is not scored (can't distinguish arms).
+    expect(m.scoredQueries).toBe(0);
+    expect(m.recallAtK).toBe(0);
+  });
+
+  it('excludes queries with no eligible relevant from the denominator', () => {
+    const queries = [
+      q('q1', [cand('a', { d: 1 })]),
+      q('q2', [cand('b', { d: 1 }, 'in-window')]), // only relevant is guard-masked
+    ];
+    const qrels: Qrels = { q1: { a: 1 }, q2: { b: 1 } };
+    const m = scoreArm(queries, qrels, 'd', 10);
+    expect(m.scoredQueries).toBe(1);
+    expect(m.recallAtK).toBe(1);
+  });
+
+  it('an arm that never surfaced the relevant doc scores zero, not NaN', () => {
+    const queries = [q('q1', [cand('a', { dense: 1 }), cand('rel', { fts: 1 })])];
+    const qrels: Qrels = { q1: { rel: 1 } };
+    expect(scoreArm(queries, qrels, 'dense', 10).recallAtK).toBe(0);
+    expect(scoreArm(queries, qrels, 'dense', 10).mrr).toBe(0);
+    expect(scoreArm(queries, qrels, 'fts', 10).recallAtK).toBe(1);
+  });
+});
+
+describe('scoreArms', () => {
+  it('scores each named arm against one qrels set', () => {
+    const queries = [q('q1', [cand('a', { 'bare-dense': 1, 'fold3-dense': 2 })])];
+    const result = scoreArms(queries, { q1: { a: 1 } }, ['bare-dense', 'fold3-dense'], 10);
+    expect(result['bare-dense'].recallAtK).toBe(1);
+    expect(result['fold3-dense'].recallAtK).toBe(1);
+  });
+});
+
+describe('pairedFlips (McNemar discordant pairs)', () => {
+  it('classifies each turn into both-hit / both-miss / fix / break', () => {
+    // k=1 throughout: a "hit" means the relevant doc is at POSITION 1 in the arm.
+    const queries = [
+      // q1: rel is position 1 in both arms → bothHit
+      q('q1', [cand('rel', { bare: 1, fold: 1 })]),
+      // q2: bare puts filler first (miss), fold puts rel first (hit) → treatmentFixes
+      q('q2', [cand('rel', { bare: 2, fold: 1 }), cand('x', { bare: 1, fold: 2 })]),
+      // q3: bare puts rel first (hit), fold puts filler first (miss) → treatmentBreaks
+      q('q3', [cand('rel', { bare: 1, fold: 2 }), cand('y', { bare: 2, fold: 1 })]),
+      // q4: filler is position 1 in both arms, rel is position 2 → bothMiss
+      q('q4', [cand('rel', { bare: 2, fold: 2 }), cand('z', { bare: 1, fold: 1 })]),
+    ];
+    const qrels: Qrels = { q1: { rel: 1 }, q2: { rel: 1 }, q3: { rel: 1 }, q4: { rel: 1 } };
+    const flips = pairedFlips(queries, qrels, 'bare', 'fold', 1);
+    expect(flips.bothHit).toBe(1);
+    expect(flips.treatmentFixes).toBe(1);
+    expect(flips.treatmentBreaks).toBe(1);
+    expect(flips.bothMiss).toBe(1);
+    expect(flips.net).toBe(0); // 1 fix − 1 break
+    expect(flips.scoredQueries).toBe(4);
+  });
+
+  it('net is positive when the treatment fixes more than it breaks', () => {
+    const queries = [
+      q('q1', [cand('rel', { bare: 2, fold: 1 }), cand('o', { bare: 1, fold: 2 })]), // fix
+      q('q2', [cand('rel', { bare: 2, fold: 1 }), cand('o', { bare: 1, fold: 2 })]), // fix
+      q('q3', [cand('rel', { bare: 1, fold: 2 }), cand('o', { bare: 2, fold: 1 })]), // break
+    ];
+    const qrels: Qrels = { q1: { rel: 1 }, q2: { rel: 1 }, q3: { rel: 1 } };
+    expect(pairedFlips(queries, qrels, 'bare', 'fold', 1).net).toBe(1);
+  });
+
+  it('excludes a query whose only relevant is guard-masked', () => {
+    const queries = [
+      q('q1', [cand('rel', { bare: 1, fold: 1 })]),
+      q('q2', [cand('masked', { bare: 1, fold: 1 }, 'in-window')]), // only relevant is guard-masked → skipped
+    ];
+    const qrels: Qrels = { q1: { rel: 1 }, q2: { masked: 1 } };
+    const f = pairedFlips(queries, qrels, 'bare', 'fold', 1);
+    expect(f.scoredQueries).toBe(1);
+    expect(f.bothHit).toBe(1);
+  });
+});
+
+describe('combinedMissRate (both-arms-miss reproduction)', () => {
+  it('counts turns where EVERY listed arm missed', () => {
+    // k=1: a combined miss is a turn where the relevant doc is position-1 in NO listed arm.
+    const queries = [
+      // q1: dense puts rel first → dense hits → not a combined miss
+      q('q1', [cand('rel', { dense: 1, fts: 2 }), cand('x', { dense: 2, fts: 1 })]),
+      // q2: filler is position-1 in both arms → both miss → combined miss
+      q('q2', [cand('rel', { dense: 2, fts: 2 }), cand('x', { dense: 1, fts: 1 })]),
+    ];
+    const qrels: Qrels = { q1: { rel: 1 }, q2: { rel: 1 } };
+    const m = combinedMissRate(queries, qrels, ['dense', 'fts'], 1);
+    expect(m.missedTurns).toBe(1);
+    expect(m.scoredQueries).toBe(2);
+    expect(m.rate).toBe(0.5);
+  });
+
+  it('excludes a query whose only relevant is guard-masked', () => {
+    const queries = [
+      q('q1', [cand('rel', { dense: 2, fts: 2 }), cand('x', { dense: 1, fts: 1 })]), // both miss
+      q('q2', [cand('masked', { dense: 1, fts: 1 }, 'in-window')]), // guard-masked → skipped
+    ];
+    const qrels: Qrels = { q1: { rel: 1 }, q2: { masked: 1 } };
+    const m = combinedMissRate(queries, qrels, ['dense', 'fts'], 1);
+    expect(m.scoredQueries).toBe(1);
+    expect(m.missedTurns).toBe(1);
+  });
+
+  it('throws on an empty arms list (every() is vacuously true → would count all as miss)', () => {
+    const queries = [q('q1', [cand('rel', { dense: 1 })])];
+    expect(() => combinedMissRate(queries, { q1: { rel: 1 } }, [], 1)).toThrow(
+      /requires at least one arm/
+    );
+  });
+});
+
+describe('rrfRanks / withRrfArm', () => {
+  it('fuses ranks so a doc found by BOTH arms outranks a doc found by one', () => {
+    const cands = [
+      cand('both', { dense: 3, fts: 3 }), // 1/(60+3)+1/(60+3) ≈ 0.0317
+      cand('denseTop', { dense: 1 }), // 1/(60+1) ≈ 0.0164
+    ];
+    const fused = rrfRanks(cands, ['dense', 'fts']);
+    expect(fused.get('both')).toBe(1);
+    expect(fused.get('denseTop')).toBe(2);
+  });
+
+  it('withRrfArm makes the fused arm scoreable alongside the raw arms', () => {
+    const query = q('q1', [cand('both', { dense: 3, fts: 3 }), cand('denseTop', { dense: 1 })]);
+    const withRrf = withRrfArm(query, 'rrf', ['dense', 'fts']);
+    // 'both' is rank-1 under RRF though it's rank-3 under dense alone.
+    expect(scoreArm([withRrf], { q1: { both: 1 } }, 'rrf', 1).recallAtK).toBe(1);
+    expect(scoreArm([withRrf], { q1: { both: 1 } }, 'dense', 1).recallAtK).toBe(0);
   });
 
   it('uses the standard RRF_K constant', () => {
     expect(RRF_K).toBe(60);
-  });
-});
-
-describe('scoreAllArms', () => {
-  it('returns all three arms scored against one qrels set', () => {
-    const queries = [q('q1', [{ corpusId: 'a', denseRank: 1, ftsRank: 2 }])];
-    const result = scoreAllArms(queries, { q1: { a: 1 } }, 10);
-    expect(result.dense.recallAtK).toBe(1);
-    expect(result.fts.recallAtK).toBe(1);
-    expect(result.rrf.recallAtK).toBe(1);
   });
 });

--- a/services/ai-worker/src/services/eval/poolScoring.ts
+++ b/services/ai-worker/src/services/eval/poolScoring.ts
@@ -1,24 +1,32 @@
 /**
- * Pool scoring: turn pooled per-arm rankings + owner/judge relevance labels
- * (qrels) into the retrieval metrics that decide the dense-vs-hybrid A/B.
+ * Pool scoring: turn pooled per-arm rankings + judge relevance labels (qrels)
+ * into the retrieval metrics that decide the bare-vs-folded retrieval A/B.
  *
  * Pure and committed (the pooling RUNNER and the qrels are local-only — the
  * corpus is sensitive — but the scoring MATH is the reusable, testable
  * instrument the memory epic's phase gates read).
  *
- * Three arms are scored against ONE qrels set:
- *  - dense  — production pgvector ranking
- *  - fts    — Postgres FTS-OR ranking (the lexical perspective)
- *  - rrf    — Reciprocal Rank Fusion of the two (what the parked hybrid branch
- *             implements in SQL; computed here from the collected ranks so the
- *             A/B needs no branch checkout).
+ * The fold-aware A/B pools SIX arms (bare-dense, fold{3,5,8}-dense, bare-fts,
+ * fold3-fts) into one judgment sheet, judged once, scored against ONE qrels set.
+ * Arms are named strings (a candidate carries a `rank` per arm it surfaced in),
+ * so this generalizes to any arm set without a fixed dense/fts/rrf enum.
+ *
+ * The honesty hinge is the **non-circularity guard**: a candidate the fold window
+ * already contains ('in-window' / 'echo') CANNOT earn credit for either arm —
+ * folding must reach PAST what it carries. Every metric here masks the relevant
+ * set to `verdict === 'eligible'` candidates, so both arms are scored only on
+ * legitimately-reachable memories.
  */
 
-/** A pooled candidate with its rank in each arm (null = arm didn't surface it). */
+import type { GuardVerdict } from './nonCircularityGuard.js';
+
+/** A pooled candidate: its guard verdict + its 1-based rank in each arm that surfaced it. */
 export interface ScoredCandidate {
   corpusId: string;
-  denseRank: number | null;
-  ftsRank: number | null;
+  /** Non-circularity guard verdict; only 'eligible' candidates can earn credit. */
+  verdict: GuardVerdict;
+  /** Arm name → 1-based rank (absent/null = the arm did not surface this candidate). */
+  ranks: Record<string, number | null>;
 }
 
 export interface ScoredQuery {
@@ -29,74 +37,72 @@ export interface ScoredQuery {
 /** query id → (corpus id → relevance grade). Absent = judged not-relevant (0). */
 export type Qrels = Record<string, Record<string, number>>;
 
-export type ArmName = 'dense' | 'fts' | 'rrf';
-
 export interface ArmMetrics {
-  /** Mean recall@K across queries that have ≥1 relevant candidate. */
+  /** Mean recall@K across queries with ≥1 guard-eligible relevant candidate. */
   recallAtK: number;
-  /** Mean reciprocal rank of the first relevant candidate. */
+  /** Mean reciprocal rank of the first guard-eligible relevant candidate. */
   mrr: number;
-  /** Queries with ≥1 relevant candidate anywhere in the pool (the denominator). */
+  /** Fraction of scored queries where this arm surfaced NO eligible relevant in top-K. */
+  missRate: number;
+  /** Queries with ≥1 guard-eligible relevant candidate anywhere in the pool (the denominator). */
   scoredQueries: number;
 }
 
 /** RRF constant — the standard 60; damps the top-rank dominance of raw 1/rank. */
 export const RRF_K = 60;
 
-/** A rank list per arm for one query, ties broken by corpus id for determinism. */
-function rankedIds(candidates: ScoredCandidate[], arm: ArmName): string[] {
-  const keyed = candidates
-    .map(candidate => ({ id: candidate.corpusId, score: armScore(candidate, arm) }))
-    .filter(entry => entry.score !== null) as { id: string; score: number }[];
-  // Higher score = better. dense/fts scores are negative rank (rank 1 → -1),
-  // rrf is the summed reciprocal (higher = better) — both sort descending.
-  keyed.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
-  return keyed.map(entry => entry.id);
+/**
+ * Guard-eligible relevant ids for a query: judged relevant (grade > 0) AND the
+ * candidate's guard verdict is 'eligible'. A relevant candidate the fold window
+ * already carries (in-window / echo) is excluded — neither arm may earn it, so
+ * the fold is credited only for reaching memories it did NOT already hold.
+ */
+export function eligibleRelevantIds(query: ScoredQuery, qrels: Qrels): Set<string> {
+  const grades = qrels[query.queryId] ?? {};
+  const verdictById = new Map(
+    query.candidates.map(candidate => [candidate.corpusId, candidate.verdict])
+  );
+  const ids = new Set<string>();
+  for (const [id, grade] of Object.entries(grades)) {
+    if (grade > 0 && verdictById.get(id) === 'eligible') {
+      ids.add(id);
+    }
+  }
+  return ids;
 }
 
-/** Per-arm comparable score (higher = better), or null if the arm didn't rank it. */
-function armScore(candidate: ScoredCandidate, arm: ArmName): number | null {
-  if (arm === 'dense') {
-    return candidate.denseRank === null ? null : -candidate.denseRank;
+/** Ranked corpus ids for one arm, best (rank 1) first, ties broken by id for determinism. */
+export function rankedIds(candidates: ScoredCandidate[], arm: string): string[] {
+  const ranked: { id: string; rank: number }[] = [];
+  for (const candidate of candidates) {
+    const rank = candidate.ranks[arm];
+    if (rank !== null && rank !== undefined) {
+      ranked.push({ id: candidate.corpusId, rank });
+    }
   }
-  if (arm === 'fts') {
-    return candidate.ftsRank === null ? null : -candidate.ftsRank;
-  }
-  // RRF: sum of 1/(K+rank) over the arms that surfaced this candidate.
-  let score = 0;
-  let present = false;
-  if (candidate.denseRank !== null) {
-    score += 1 / (RRF_K + candidate.denseRank);
-    present = true;
-  }
-  if (candidate.ftsRank !== null) {
-    score += 1 / (RRF_K + candidate.ftsRank);
-    present = true;
-  }
-  return present ? score : null;
+  ranked.sort((a, b) => a.rank - b.rank || a.id.localeCompare(b.id));
+  return ranked.map(entry => entry.id);
+}
+
+/** True if the arm surfaced ≥1 of `relevant` within its top-K. */
+function armHits(query: ScoredQuery, relevant: Set<string>, arm: string, k: number): boolean {
+  const topK = rankedIds(query.candidates, arm).slice(0, k);
+  return topK.some(id => relevant.has(id));
 }
 
 /**
- * Score one arm over all queries. recall@K uses the arm's ranked list capped at
- * `k`; queries with no relevant candidate in the pool are excluded from both
- * means (they can't distinguish arms).
+ * Score one arm over all queries. recall@K / MRR / missRate use the arm's ranked
+ * list capped at `k` against the guard-eligible relevant set; queries with no
+ * eligible relevant candidate are excluded from every mean (they can't distinguish arms).
  */
-export function scoreArm(
-  queries: ScoredQuery[],
-  qrels: Qrels,
-  arm: ArmName,
-  k: number
-): ArmMetrics {
+export function scoreArm(queries: ScoredQuery[], qrels: Qrels, arm: string, k: number): ArmMetrics {
   let recallSum = 0;
   let mrrSum = 0;
+  let misses = 0;
   let scored = 0;
 
   for (const query of queries) {
-    const relevant = new Set(
-      Object.entries(qrels[query.queryId] ?? {})
-        .filter(([, grade]) => grade > 0)
-        .map(([id]) => id)
-    );
+    const relevant = eligibleRelevantIds(query, qrels);
     if (relevant.size === 0) {
       continue;
     }
@@ -106,6 +112,9 @@ export function scoreArm(
     const topK = ranked.slice(0, k);
     const hits = topK.filter(id => relevant.has(id)).length;
     recallSum += hits / relevant.size;
+    if (hits === 0) {
+      misses += 1;
+    }
 
     const firstRelevantIndex = ranked.findIndex(id => relevant.has(id));
     mrrSum += firstRelevantIndex === -1 ? 0 : 1 / (firstRelevantIndex + 1);
@@ -114,19 +123,174 @@ export function scoreArm(
   return {
     recallAtK: scored === 0 ? 0 : recallSum / scored,
     mrr: scored === 0 ? 0 : mrrSum / scored,
+    missRate: scored === 0 ? 0 : misses / scored,
     scoredQueries: scored,
   };
 }
 
-/** Score all three arms at once — the A/B table. */
-export function scoreAllArms(
+/** Score a set of named arms at once — the A/B table. */
+export function scoreArms(
   queries: ScoredQuery[],
   qrels: Qrels,
+  arms: string[],
   k: number
-): Record<ArmName, ArmMetrics> {
+): Record<string, ArmMetrics> {
+  const out: Record<string, ArmMetrics> = {};
+  for (const arm of arms) {
+    out[arm] = scoreArm(queries, qrels, arm, k);
+  }
+  return out;
+}
+
+/**
+ * Paired within-turn flips between a baseline and a treatment arm — the McNemar
+ * discordant-pair signal that is the trustworthy comparison at small n (more
+ * robust than a mean-recall delta). "Hit" = the arm surfaced ≥1 eligible relevant
+ * in top-K. For (bare-dense, fold3-dense): `treatmentFixes` is folds that rescued
+ * a bare miss; `treatmentBreaks` is folds that lost a bare hit; `net` is the signed win.
+ */
+export interface PairedFlips {
+  /** Baseline hit AND treatment hit. */
+  bothHit: number;
+  /** Baseline missed AND treatment missed. */
+  bothMiss: number;
+  /** Treatment rescued a baseline miss (baseline miss → treatment hit). */
+  treatmentFixes: number;
+  /** Treatment lost a baseline hit (baseline hit → treatment miss). */
+  treatmentBreaks: number;
+  /** Signed win of treatment over baseline (treatmentFixes − treatmentBreaks). */
+  net: number;
+  scoredQueries: number;
+}
+
+export function pairedFlips(
+  queries: ScoredQuery[],
+  qrels: Qrels,
+  baselineArm: string,
+  treatmentArm: string,
+  k: number
+): PairedFlips {
+  let bothHit = 0;
+  let bothMiss = 0;
+  let treatmentFixes = 0;
+  let treatmentBreaks = 0;
+  let scored = 0;
+
+  for (const query of queries) {
+    const relevant = eligibleRelevantIds(query, qrels);
+    if (relevant.size === 0) {
+      continue;
+    }
+    scored += 1;
+    const baseHit = armHits(query, relevant, baselineArm, k);
+    const treatHit = armHits(query, relevant, treatmentArm, k);
+    if (baseHit && treatHit) {
+      bothHit += 1;
+    } else if (!baseHit && !treatHit) {
+      bothMiss += 1;
+    } else if (!baseHit && treatHit) {
+      treatmentFixes += 1;
+    } else {
+      treatmentBreaks += 1;
+    }
+  }
+
   return {
-    dense: scoreArm(queries, qrels, 'dense', k),
-    fts: scoreArm(queries, qrels, 'fts', k),
-    rrf: scoreArm(queries, qrels, 'rrf', k),
+    bothHit,
+    bothMiss,
+    treatmentFixes,
+    treatmentBreaks,
+    net: treatmentFixes - treatmentBreaks,
+    scoredQueries: scored,
+  };
+}
+
+/**
+ * Combined miss rate over a SET of arms — the fraction of scored turns where EVERY
+ * listed arm missed. Reproduces the original A/B's "both-arms-miss" headline
+ * (e.g. `['bare-dense', 'bare-fts']` vs `['fold3-dense', 'fold3-fts']`) honestly
+ * under the guard, so the fold's effect on the residual gap is directly comparable.
+ */
+export interface CombinedMiss {
+  /** Turns where every listed arm missed. */
+  missedTurns: number;
+  scoredQueries: number;
+  rate: number;
+}
+
+export function combinedMissRate(
+  queries: ScoredQuery[],
+  qrels: Qrels,
+  arms: string[],
+  k: number
+): CombinedMiss {
+  // `arms.every(...)` is vacuously true on an empty list, which would count EVERY
+  // scored turn as a combined miss — a caller error, not a meaningful rate.
+  if (arms.length === 0) {
+    throw new Error('combinedMissRate requires at least one arm');
+  }
+  let missedTurns = 0;
+  let scored = 0;
+
+  for (const query of queries) {
+    const relevant = eligibleRelevantIds(query, qrels);
+    if (relevant.size === 0) {
+      continue;
+    }
+    scored += 1;
+    if (arms.every(arm => !armHits(query, relevant, arm, k))) {
+      missedTurns += 1;
+    }
+  }
+
+  return { missedTurns, scoredQueries: scored, rate: scored === 0 ? 0 : missedTurns / scored };
+}
+
+/**
+ * RRF-fused rank map from a set of base arms: corpus id → 1-based fused rank.
+ * A candidate is included iff at least one base arm surfaced it (union recall).
+ * Kept as a derivation (not baked into every candidate) so the arm set stays open;
+ * inject it via `withRrfArm` when an RRF perspective is wanted alongside the raw arms.
+ */
+export function rrfRanks(
+  candidates: ScoredCandidate[],
+  baseArms: string[],
+  rrfK: number = RRF_K
+): Map<string, number> {
+  const scored = candidates
+    .map(candidate => {
+      let score = 0;
+      let present = false;
+      for (const arm of baseArms) {
+        const rank = candidate.ranks[arm];
+        if (rank !== null && rank !== undefined) {
+          score += 1 / (rrfK + rank);
+          present = true;
+        }
+      }
+      return { id: candidate.corpusId, score: present ? score : null };
+    })
+    .filter((entry): entry is { id: string; score: number } => entry.score !== null);
+
+  scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+  const map = new Map<string, number>();
+  scored.forEach((entry, index) => map.set(entry.id, index + 1));
+  return map;
+}
+
+/** Return a copy of the query with a derived RRF arm added to every candidate's rank map. */
+export function withRrfArm(
+  query: ScoredQuery,
+  newArm: string,
+  baseArms: string[],
+  rrfK: number = RRF_K
+): ScoredQuery {
+  const fused = rrfRanks(query.candidates, baseArms, rrfK);
+  return {
+    queryId: query.queryId,
+    candidates: query.candidates.map(candidate => ({
+      ...candidate,
+      ranks: { ...candidate.ranks, [newArm]: fused.get(candidate.corpusId) ?? null },
+    })),
   };
 }

--- a/services/ai-worker/src/services/eval/qrelsReconciliation.test.ts
+++ b/services/ai-worker/src/services/eval/qrelsReconciliation.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { reconcile, type GoldenPool, type PrefixQrels } from './qrelsReconciliation.js';
+
+function pool(goldenId: string, candidateIds: string[]): GoldenPool {
+  return {
+    goldenId,
+    message: 'msg',
+    style: 'short-reactive',
+    oldestHistoryMs: 0,
+    arms: ['bare-dense'],
+    candidates: candidateIds.map(id => ({
+      corpusId: id,
+      createdAtMs: 0,
+      contentPreview: 'preview',
+      ranks: { 'bare-dense': 1 },
+      verdict: 'eligible' as const,
+    })),
+  };
+}
+
+const G1 = 'aaaa1111-1111-1111-1111-111111111111';
+const G2 = 'bbbb2222-2222-2222-2222-222222222222';
+const C1 = 'cccc1111-0000-0000-0000-000000000000';
+const C2 = 'dddd2222-0000-0000-0000-000000000000';
+
+describe('reconcile', () => {
+  it('resolves prefix-keyed qrels to full ids and preserves grades', () => {
+    const pools = [pool(G1, [C1, C2])];
+    const prefixQrels: PrefixQrels = { aaaa1111: { cccc1111: 1, dddd2222: 0.5 } };
+    const { queries, qrels } = reconcile(pools, prefixQrels);
+    expect(queries).toHaveLength(1);
+    expect(queries[0].queryId).toBe(G1);
+    expect(qrels[G1]).toEqual({ [C1]: 1, [C2]: 0.5 });
+  });
+
+  it('maps every pool candidate into ScoredQuery with its verdict + ranks', () => {
+    const { queries } = reconcile([pool(G1, [C1])], { aaaa1111: { cccc1111: 1 } });
+    expect(queries[0].candidates[0]).toEqual({
+      corpusId: C1,
+      verdict: 'eligible',
+      ranks: { 'bare-dense': 1 },
+    });
+  });
+
+  it('skips `_`-prefixed annotation keys (free-text) at both golden and candidate level', () => {
+    const pools = [pool(G1, [C1])];
+    const prefixQrels: PrefixQrels = {
+      _rubric: 'the whole scoring rubric goes here',
+      aaaa1111: { _theme: 'a note about this golden', cccc1111: 1 },
+    };
+    const { qrels } = reconcile(pools, prefixQrels);
+    expect(qrels[G1]).toEqual({ [C1]: 1 }); // _theme skipped, no error thrown
+  });
+
+  it('HARD-ERRORS on a non-numeric grade for a real (non-annotation) candidate key', () => {
+    const pools = [pool(G1, [C1])];
+    expect(() => reconcile(pools, { aaaa1111: { cccc1111: 'typo' } })).toThrow(
+      /candidate prefix "cccc1111".*non-numeric grade/
+    );
+  });
+
+  it('HARD-ERRORS when two prefixes resolve to the SAME candidate (silent-overwrite hole)', () => {
+    const pools = [pool(G1, [C1])];
+    // Both "cccc" and "cccc1111" uniquely resolve to C1 — the second would overwrite.
+    expect(() => reconcile(pools, { aaaa1111: { cccc: 1, cccc1111: 0.5 } })).toThrow(
+      /already graded by another prefix/
+    );
+  });
+
+  it('HARD-ERRORS on a candidate prefix that matches zero ids', () => {
+    const pools = [pool(G1, [C1])];
+    expect(() => reconcile(pools, { aaaa1111: { deadbeef: 1 } })).toThrow(
+      /candidate prefix "deadbeef".*matched 0 ids/
+    );
+  });
+
+  it('HARD-ERRORS on a golden prefix that matches zero ids', () => {
+    const pools = [pool(G1, [C1])];
+    expect(() => reconcile(pools, { ffffffff: { cccc1111: 1 } })).toThrow(
+      /golden prefix "ffffffff".*matched 0 ids/
+    );
+  });
+
+  it('HARD-ERRORS on an ambiguous prefix that matches multiple ids', () => {
+    // Two candidates share the 4-char prefix "cccc" → ambiguous.
+    const pools = [pool(G1, ['cccc1111-a', 'cccc2222-b'])];
+    expect(() => reconcile(pools, { aaaa1111: { cccc: 1 } })).toThrow(
+      /candidate prefix "cccc".*matched 2 ids/
+    );
+  });
+
+  it('collects ALL bad prefixes and throws once (not one-per-run)', () => {
+    const pools = [pool(G1, [C1]), pool(G2, [C2])];
+    const prefixQrels: PrefixQrels = {
+      aaaa1111: { deadbeef: 1 }, // bad candidate
+      ffffffff: { cccc1111: 1 }, // bad golden
+    };
+    let message = '';
+    try {
+      reconcile(pools, prefixQrels);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain('failed for 2 prefix(es)');
+    expect(message).toContain('deadbeef');
+    expect(message).toContain('ffffffff');
+  });
+
+  it('produces an empty grade map for a golden judged with only annotation keys', () => {
+    // A golden with no real relevant marks (e.g. an excluded turn) is still a valid
+    // query with empty qrels — poolScoring then drops it from the denominator.
+    const { qrels } = reconcile([pool(G1, [C1])], {
+      aaaa1111: { _theme: 'excluded — no relevant' as unknown as number },
+    });
+    expect(qrels[G1]).toEqual({});
+  });
+});

--- a/services/ai-worker/src/services/eval/qrelsReconciliation.ts
+++ b/services/ai-worker/src/services/eval/qrelsReconciliation.ts
@@ -1,0 +1,167 @@
+/**
+ * Qrels reconciliation: translate a prefix-keyed judgment file into the full-id
+ * `ScoredQuery[]` + qrels the `poolScoring` instrument consumes.
+ *
+ * The judgment sheet shows 8-char id prefixes, so the hand-authored `qrels` is
+ * keyed by those prefixes. This resolves every prefix back to its FULL corpus/golden
+ * id and HARD-ERRORS on any ambiguous (>1 match) or unresolvable (0 match) prefix —
+ * the integrity guarantee that a mis-keyed judgment can never silently score against
+ * the wrong candidate (it caught a real cross-golden mis-attribution in practice).
+ *
+ * Pure JSON→object logic with no external dependency, so it lives here (CI-tested)
+ * rather than inside the eval-only glue that merely calls it — the shared pool types
+ * (`PooledCandidate` / `GoldenPool`) are the single source both the pooling producer
+ * and the scoring consumer import, so the two can't drift.
+ */
+
+import type { GuardVerdict } from './nonCircularityGuard.js';
+import type { ScoredQuery, ScoredCandidate } from './poolScoring.js';
+
+/** A persisted pooled candidate: its rank in each arm + the non-circularity guard verdict. */
+export interface PooledCandidate {
+  corpusId: string;
+  createdAtMs: number;
+  contentPreview: string;
+  ranks: Record<string, number>;
+  verdict: GuardVerdict;
+}
+
+/** One golden's pooled candidates across all arms, plus the fold-window metadata. */
+export interface GoldenPool {
+  goldenId: string;
+  message: string;
+  style: string;
+  oldestHistoryMs: number;
+  arms: string[];
+  candidates: PooledCandidate[];
+}
+
+/**
+ * One golden's judgments: candidate-prefix → numeric grade, plus optional `_`-prefixed
+ * free-text annotations (e.g. `_theme`) — hence `number | string`. A non-`_` key with a
+ * non-numeric value is a typo, caught during reconcile.
+ */
+export type GoldenQrels = Record<string, number | string>;
+
+/**
+ * Prefix-keyed qrels: golden-prefix → that golden's judgments, plus optional top-level
+ * `_`-prefixed free-text annotations (e.g. `_rubric`) — hence `GoldenQrels | string`.
+ * Skipping `_` keys keeps the local artifact self-documenting; a non-`_` top-level key
+ * whose value isn't an object is a malformed entry, caught during reconcile.
+ */
+export type PrefixQrels = Record<string, GoldenQrels | string>;
+
+/** Full-id qrels: golden id → (corpus id → grade). */
+export type Qrels = Record<string, Record<string, number>>;
+
+export interface ReconcileResult {
+  queries: ScoredQuery[];
+  qrels: Qrels;
+}
+
+/**
+ * Map the pools into `ScoredQuery[]` (full ids) and translate the prefix-keyed qrels
+ * into full-id qrels. Collects EVERY prefix that matches zero or multiple ids and
+ * throws once with the full list — so a hand-authored qrels with several typos is
+ * fixed in one pass, not one run-fail cycle per bad prefix.
+ */
+export function reconcile(pools: GoldenPool[], prefixQrels: PrefixQrels): ReconcileResult {
+  const queries: ScoredQuery[] = pools.map(pool => ({
+    queryId: pool.goldenId,
+    candidates: pool.candidates.map((candidate): ScoredCandidate => ({
+      corpusId: candidate.corpusId,
+      verdict: candidate.verdict,
+      ranks: candidate.ranks,
+    })),
+  }));
+
+  const qrels: Qrels = {};
+  const errors: string[] = [];
+  for (const [goldenPrefix, candGrades] of Object.entries(prefixQrels)) {
+    if (goldenPrefix.startsWith('_')) {
+      continue;
+    }
+    if (typeof candGrades !== 'object' || candGrades === null) {
+      errors.push(
+        `golden prefix "${goldenPrefix}" has a non-object value (expected a judgments map)`
+      );
+      continue;
+    }
+    const pool = resolveOne(
+      pools,
+      p => p.goldenId.startsWith(goldenPrefix),
+      `golden prefix "${goldenPrefix}"`,
+      errors
+    );
+    if (pool === undefined) {
+      continue;
+    }
+    qrels[pool.goldenId] = resolveGrades(pool, candGrades, errors);
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `qrels reconciliation failed for ${errors.length} prefix(es):\n  ${errors.join('\n  ')}`
+    );
+  }
+  return { queries, qrels };
+}
+
+/**
+ * Resolve one golden's `candidate-prefix → grade` map into full-id grades, pushing a
+ * diagnostic (rather than throwing) for each: `_`-annotation keys are skipped, a
+ * non-numeric grade on a data key is a typo, an unresolvable/ambiguous prefix is caught
+ * by `resolveOne`, and two prefixes resolving to the same candidate is a silent-overwrite
+ * hole — the exact "mis-keyed judgment scores wrong" class this module exists to close.
+ */
+function resolveGrades(
+  pool: GoldenPool,
+  candGrades: GoldenQrels,
+  errors: string[]
+): Record<string, number> {
+  const where = `in golden ${pool.goldenId.slice(0, 8)}`;
+  const grades: Record<string, number> = {};
+  for (const [candPrefix, grade] of Object.entries(candGrades)) {
+    if (candPrefix.startsWith('_')) {
+      continue;
+    }
+    if (typeof grade !== 'number') {
+      errors.push(
+        `candidate prefix "${candPrefix}" ${where} has a non-numeric grade (${JSON.stringify(grade)})`
+      );
+      continue;
+    }
+    const candidate = resolveOne(
+      pool.candidates,
+      c => c.corpusId.startsWith(candPrefix),
+      `candidate prefix "${candPrefix}" ${where}`,
+      errors
+    );
+    if (candidate === undefined) {
+      continue;
+    }
+    if (candidate.corpusId in grades) {
+      errors.push(
+        `candidate prefix "${candPrefix}" ${where} resolves to ${candidate.corpusId.slice(0, 8)}, already graded by another prefix`
+      );
+      continue;
+    }
+    grades[candidate.corpusId] = grade;
+  }
+  return grades;
+}
+
+/** Record exactly-one match, or push a diagnostic to `errors` (no throw — the caller
+ * collects all failures and throws once). Returns undefined on a zero/ambiguous match. */
+function resolveOne<T>(
+  items: T[],
+  match: (item: T) => boolean,
+  label: string,
+  errors: string[]
+): T | undefined {
+  const hits = items.filter(match);
+  if (hits.length !== 1) {
+    errors.push(`${label} matched ${hits.length} ids (expected exactly 1)`);
+    return undefined;
+  }
+  return hits[0];
+}


### PR DESCRIPTION
## What

PR-4 of the memory-1c honest re-baseline. Generalizes the committed pool-scoring instrument and adds the eval-only glue that turns the judged sheet into the bare-vs-folded A/B number.

### Committed instrument (`poolScoring.ts` + CI-run test)
- Generalizes `ScoredCandidate` from the fixed `{denseRank, ftsRank}` shape to **named arms** (`ranks: Record<string, number|null>` + guard `verdict`), so it scores the fold-aware A/B's six arms against one qrels set.
- **Guard-eligibility mask**: only `verdict === 'eligible'` candidates earn credit. A memory the fold window already carries (`in-window` / `echo`) is excluded from the relevant set for *both* arms — folding is credited only for reaching PAST what it holds. This mirrors production's own STM/LTM dedup cutoff, so it makes the folded arm *more* faithful to prod, not less.
- Adds **per-arm miss-rate**, **McNemar paired within-turn flips** (`pairedFlips` — the trustworthy small-n signal), and **combined both-arms-miss** (`combinedMissRate` — the original 30% headline reproduced guard-honestly).
- RRF stays available as a *derivable* arm (`withRrfArm`) rather than a hardcoded dense+fts pair.

### Eval-only glue (`foldAwareScoring.eval.test.ts`, no CI)
- Reads the local pool + `fold-qrels.json`, emits the A/B table (per-arm metrics @ K=5/10, decisive bare→fold3 paired flips, both-arms-miss, fold-depth sweep, per-style breakdown).
- **Integrity fix**: the judgment sheet shows 8-char id prefixes, so the qrels is prefix-keyed. The glue reconciles every prefix back to its full UUID and **hard-errors on any ambiguous/unresolvable prefix** — closing the hole that forced the old `AB-RESULT.md` to be hand-assembled.

## Testing
- `poolScoring.test.ts` — 19 cases, incl. the guard-mask denials, McNemar flip classification, combined-miss, and RRF derivation. Rides CI.
- `pnpm quality` green (lint/typecheck/knip/cpd/guards).
- The glue skips cleanly until `fold-qrels.json` exists (produced by the judging pass, next).

## Not in this PR
The judging → `fold-qrels.json` → the actual re-baseline number is the immediate next step (task 132); this PR is the instrument it feeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)