### PR TITLE
feat(ai-worker): conditional query-fold gate

### DIFF
--- a/services/ai-worker/src/services/ConversationInputProcessor.test.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.test.ts
@@ -483,4 +483,64 @@ describe('ConversationInputProcessor', () => {
       expect(result.searchQuery).toBe('search query');
     });
   });
+
+  describe('query-fold gate (conditional recent-history fold)', () => {
+    const mockMessage: MessageContent = 'Hello, how are you?';
+    const mockPersonality = createMockPersonality();
+
+    it('folds the recent history window when the unfolded query is content-poor', async () => {
+      // Unfolded query "poke" (1 content word) → below the gate threshold → fold.
+      (mockPromptBuilder.buildSearchQuery as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce('poke')
+        .mockReturnValueOnce('recent history window\n\npoke');
+      const context = createMockContext({ rawConversationHistory: [{ id: 'history1' }] });
+
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
+
+      // The window is extracted from the raw history and crosses the builder seam.
+      expect(mockExtractRecentHistoryWindow).toHaveBeenCalledWith(context.rawConversationHistory);
+      expect(mockPromptBuilder.buildSearchQuery).toHaveBeenNthCalledWith(
+        1,
+        'formatted user message',
+        [],
+        undefined,
+        undefined
+      );
+      expect(mockPromptBuilder.buildSearchQuery).toHaveBeenNthCalledWith(
+        2,
+        'formatted user message',
+        [],
+        undefined,
+        'recent history window'
+      );
+      expect(result.searchQuery).toBe('recent history window\n\npoke');
+    });
+
+    it('embeds the query bare when the unfolded query is content-rich', async () => {
+      const richQuery =
+        'the echo was a technical bug in the message pipeline, not an intentional repeat of your reply';
+      (mockPromptBuilder.buildSearchQuery as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+        richQuery
+      );
+      const context = createMockContext({ rawConversationHistory: [{ id: 'history1' }] });
+
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
+
+      // No fold: the window is never extracted, the builder is called exactly once
+      // with no window, and the bare query ships as-is.
+      expect(mockExtractRecentHistoryWindow).not.toHaveBeenCalled();
+      expect(mockPromptBuilder.buildSearchQuery).toHaveBeenCalledTimes(1);
+      expect(mockPromptBuilder.buildSearchQuery).toHaveBeenCalledWith(
+        'formatted user message',
+        [],
+        undefined,
+        undefined
+      );
+      expect(result.searchQuery).toBe(richQuery);
+    });
+  });
 });

--- a/services/ai-worker/src/services/ConversationInputProcessor.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.ts
@@ -18,6 +18,7 @@ import {
   type ProcessedAttachment,
 } from './MultimodalProcessor.js';
 import { extractRecentHistoryWindow } from './RAGUtils.js';
+import { shouldFoldSearchQuery } from './prompt/queryFoldGate.js';
 import { collectPersonalityNames } from '../jobs/utils/conversationUtils.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
@@ -150,16 +151,26 @@ export class ConversationInputProcessor {
         ? this.referencedMessageFormatter.extractTextForSearch(referencedMessagesDescriptions)
         : undefined;
 
-    // Extract recent conversation history for context-aware LTM search
-    const recentHistoryWindow = extractRecentHistoryWindow(context.rawConversationHistory);
-
-    // Build search query for memory retrieval
-    const searchQuery = this.promptBuilder.buildSearchQuery(
+    // Build the search query for memory retrieval. The recent conversation
+    // window is folded in ONLY when the unfolded query is content-poor: the
+    // fold rescues reactive turns ("poke") that carry nothing to embed, but
+    // dilutes content-rich ones — recent-context chatter pushes the on-topic
+    // memory out of the top-K (measured on real conversation goldens; the
+    // gate rule and its rationale live in prompt/queryFoldGate.ts).
+    const unfoldedSearchQuery = this.promptBuilder.buildSearchQuery(
       userMessage,
       processedAttachments,
       referencedMessagesTextForSearch,
-      recentHistoryWindow
+      undefined
     );
+    const searchQuery = shouldFoldSearchQuery(unfoldedSearchQuery)
+      ? this.promptBuilder.buildSearchQuery(
+          userMessage,
+          processedAttachments,
+          referencedMessagesTextForSearch,
+          extractRecentHistoryWindow(context.rawConversationHistory)
+        )
+      : unfoldedSearchQuery;
 
     return {
       processedAttachments,

--- a/services/ai-worker/src/services/eval/foldAwareScoring.eval.test.ts
+++ b/services/ai-worker/src/services/eval/foldAwareScoring.eval.test.ts
@@ -23,6 +23,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { scoreArm, pairedFlips, combinedMissRate, type ScoredQuery } from './poolScoring.js';
 import { reconcile, type GoldenPool, type PrefixQrels, type Qrels } from './qrelsReconciliation.js';
+import { shouldFoldSearchQuery, FOLD_GATE_MAX_CONTENT_WORDS } from '../prompt/queryFoldGate.js';
 
 const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
 const POOL_PATH = join(WORK_DIR, 'fold-pool.json');
@@ -33,6 +34,9 @@ const REPORT_PATH = join(WORK_DIR, 'fold-ab-result.md');
 const ARMS = ['bare-dense', 'fold3-dense', 'fold5-dense', 'fold8-dense', 'bare-fts', 'fold3-fts'];
 const DENSE_SWEEP = ['fold3-dense', 'fold5-dense', 'fold8-dense'];
 const K_VALUES = [5, 10] as const;
+
+/** Gate-threshold sensitivity sweep — the pre-registered default plus one either side. */
+const GATE_THRESHOLDS = [3, FOLD_GATE_MAX_CONTENT_WORDS, 8] as const;
 
 const ready = existsSync(POOL_PATH) && existsSync(QRELS_PATH);
 
@@ -115,7 +119,94 @@ function buildReport(pools: GoldenPool[], queries: ScoredQuery[], qrels: Qrels):
   lines.push('');
 
   lines.push(perStyleSection(pools, queries, qrels));
+  lines.push('', conditionalSection(pools, queries, qrels));
   return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Derive the per-turn conditional-policy arms: per golden, adopt fold3 or bare
+ * ranks according to the production gate run on the golden's message. The pool's
+ * `message` approximates the UNFOLDED query production would gate on — history
+ * content already carries attachment descriptions/voice transcripts inline, and
+ * the pooling runner passed no referenced-message text.
+ */
+function withConditionalArms(
+  pools: GoldenPool[],
+  queries: ScoredQuery[],
+  threshold: number
+): { queries: ScoredQuery[]; foldedTurns: number } {
+  const messageById = new Map(pools.map(p => [p.goldenId, p.message]));
+  let foldedTurns = 0;
+  const derived = queries.map(query => {
+    const fold = shouldFoldSearchQuery(messageById.get(query.queryId) ?? '', threshold);
+    if (fold) {
+      foldedTurns += 1;
+    }
+    const dense = fold ? 'fold3-dense' : 'bare-dense';
+    const fts = fold ? 'fold3-fts' : 'bare-fts';
+    return {
+      queryId: query.queryId,
+      candidates: query.candidates.map(c => ({
+        ...c,
+        ranks: {
+          ...c.ranks,
+          'cond-dense': c.ranks[dense] ?? null,
+          'cond-fts': c.ranks[fts] ?? null,
+        },
+      })),
+    };
+  });
+  return { queries: derived, foldedTurns };
+}
+
+/**
+ * The conditional-fold policy simulation — scores the PRE-REGISTERED gate
+ * (fold iff the unfolded query is content-poor) against the already-judged pool.
+ * Every per-turn arm-selection policy is scoreable retroactively because the pool
+ * carries every arm's ranks; no new dev queries or judging needed.
+ */
+function conditionalSection(pools: GoldenPool[], queries: ScoredQuery[], qrels: Qrels): string {
+  const lines = [
+    '## Conditional-fold policy simulation (pre-registered gate)',
+    '',
+    `Gate: fold iff content words < threshold (default ${FOLD_GATE_MAX_CONTENT_WORDS}, registered before scoring).`,
+    'Sensitivity shown one step either side — a policy that only wins at one threshold is noise.',
+    '',
+    '| Threshold | folded turns | cond recall@10 | cond miss@10 (dense) | combined miss@10 | vs bare (fix/break) | vs fold3 (fix/break) |',
+    '| --- | --- | --- | --- | --- | --- | --- |',
+  ];
+  for (const threshold of GATE_THRESHOLDS) {
+    const { queries: cond, foldedTurns } = withConditionalArms(pools, queries, threshold);
+    const m = scoreArm(cond, qrels, 'cond-dense', 10);
+    const combined = combinedMissRate(cond, qrels, ['cond-dense', 'cond-fts'], 10);
+    const vsBare = pairedFlips(cond, qrels, 'bare-dense', 'cond-dense', 10);
+    const vsFold = pairedFlips(cond, qrels, 'fold3-dense', 'cond-dense', 10);
+    lines.push(
+      `| <${threshold} | ${foldedTurns}/${pools.length} | ${fmt(m.recallAtK)} | ${fmt(m.missRate)} | ${combined.missedTurns}/${combined.scoredQueries} (${fmt(combined.rate)}) | ${signed(vsBare.net)} (${vsBare.treatmentFixes}/${vsBare.treatmentBreaks}) | ${signed(vsFold.net)} (${vsFold.treatmentFixes}/${vsFold.treatmentBreaks}) |`
+    );
+  }
+
+  // Per-style at the pre-registered default: does conditional keep each stratum's winner?
+  const { queries: cond } = withConditionalArms(pools, queries, FOLD_GATE_MAX_CONTENT_WORDS);
+  const styleById = new Map(pools.map(p => [p.goldenId, p.style]));
+  const styles = [...new Set(pools.map(p => p.style))].sort();
+  lines.push(
+    '',
+    `### Per-style combined miss @ K=10 (threshold <${FOLD_GATE_MAX_CONTENT_WORDS})`,
+    '',
+    '| Style | bare | fold3 | conditional |',
+    '| --- | --- | --- | --- |'
+  );
+  for (const style of styles) {
+    const subset = cond.filter(q => styleById.get(q.queryId) === style);
+    const bare = combinedMissRate(subset, qrels, ['bare-dense', 'bare-fts'], 10);
+    const fold = combinedMissRate(subset, qrels, ['fold3-dense', 'fold3-fts'], 10);
+    const condMiss = combinedMissRate(subset, qrels, ['cond-dense', 'cond-fts'], 10);
+    lines.push(
+      `| ${style} | ${bare.missedTurns}/${bare.scoredQueries} | ${fold.missedTurns}/${fold.scoredQueries} | ${condMiss.missedTurns}/${condMiss.scoredQueries} |`
+    );
+  }
+  return lines.join('\n');
 }
 
 /** Per-style both-arms-miss (bare vs fold3) — where does folding help most? */

--- a/services/ai-worker/src/services/prompt/queryFoldGate.test.ts
+++ b/services/ai-worker/src/services/prompt/queryFoldGate.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  countContentWords,
+  shouldFoldSearchQuery,
+  FOLD_GATE_MAX_CONTENT_WORDS,
+} from './queryFoldGate.js';
+
+describe('countContentWords', () => {
+  it('counts plain words with ≥2 alphanumerics', () => {
+    expect(countContentWords('the quick brown fox')).toBe(4);
+  });
+
+  it('drops 1-char tokens and punctuation-only tokens', () => {
+    // "I" and "a" are 1 alphanumeric; "..." and "—" carry none.
+    expect(countContentWords('I a ... — ok')).toBe(1);
+  });
+
+  it('counts contractions via their alphanumeric residue', () => {
+    // "I'm" → "Im" (2 alphanumerics) → counts.
+    expect(countContentWords("I'm crying again")).toBe(3);
+  });
+
+  it('strips plain-text @/& tags as stored in history content', () => {
+    expect(countContentWords('@Ha-Shem any other advice?')).toBe(3);
+    expect(countContentWords('&Cold did you see my voice message?')).toBe(6);
+  });
+
+  it('strips raw Discord mention syntax (user/role/channel, animated flag)', () => {
+    expect(countContentWords('<@123456789012345678> <@!42> <@&99> <#77> hello there')).toBe(2);
+  });
+
+  it('strips custom emoji, static and animated', () => {
+    expect(
+      countContentWords('<:anime_teehee:1108796741425319956> <a:kekw_animated:139> nice')
+    ).toBe(1);
+  });
+
+  it('strips URLs but keeps surrounding text', () => {
+    expect(countContentWords('look at this https://example.com/x?y=z lol')).toBe(4);
+  });
+
+  it('leaves residual tokens from multi-word display names (documented limitation)', () => {
+    // "@Charlie" strips; "Morningstar" survives as one content word.
+    expect(countContentWords('@Charlie Morningstar 😳')).toBe(1);
+  });
+
+  it('returns 0 for empty and tag-only messages', () => {
+    expect(countContentWords('')).toBe(0);
+    expect(countContentWords('@Emily')).toBe(0);
+    expect(countContentWords('@Millie @Moxxie')).toBe(0);
+  });
+});
+
+describe('shouldFoldSearchQuery', () => {
+  it('folds content-poor reactive turns', () => {
+    expect(shouldFoldSearchQuery('poke')).toBe(true);
+    expect(shouldFoldSearchQuery('yes')).toBe(true);
+    expect(shouldFoldSearchQuery('okay 🥺 😭')).toBe(true);
+    expect(shouldFoldSearchQuery('@Emily')).toBe(true);
+  });
+
+  it('does not fold content-rich turns', () => {
+    expect(
+      shouldFoldSearchQuery(
+        "ugh it's like that fucking xkcd meme about someone being wrong on the internet"
+      )
+    ).toBe(false);
+  });
+
+  it('does not fold short-text turns whose attachment description carries the content', () => {
+    // The gate input is the UNFOLDED QUERY — message plus attachment text — so an
+    // image post with a rich description is content-rich even if the typed text is short.
+    const unfoldedQuery =
+      'check this out This is a screenshot of a mobile chess application showing a puzzle in dark mode';
+    expect(shouldFoldSearchQuery(unfoldedQuery)).toBe(false);
+  });
+
+  it('applies the threshold as a strict less-than at the boundary', () => {
+    const fourWords = 'one two three four';
+    const fiveWords = 'one two three four five';
+    expect(countContentWords(fourWords)).toBe(4);
+    expect(countContentWords(fiveWords)).toBe(5);
+    expect(shouldFoldSearchQuery(fourWords, 5)).toBe(true);
+    expect(shouldFoldSearchQuery(fiveWords, 5)).toBe(false);
+  });
+
+  it('honors a custom threshold', () => {
+    expect(shouldFoldSearchQuery('one two three', 3)).toBe(false);
+    expect(shouldFoldSearchQuery('one two', 3)).toBe(true);
+  });
+
+  it('pre-registered default is 5', () => {
+    expect(FOLD_GATE_MAX_CONTENT_WORDS).toBe(5);
+  });
+});

--- a/services/ai-worker/src/services/prompt/queryFoldGate.ts
+++ b/services/ai-worker/src/services/prompt/queryFoldGate.ts
@@ -1,0 +1,72 @@
+/**
+ * Query-fold gate: should the LTM search query be augmented with the recent
+ * conversation window (the "context fold"), or embedded bare?
+ *
+ * The fold-aware A/B on real conversation goldens showed the uniform fold is a
+ * net-negative trade: it rescues content-POOR turns (a bare "poke" has nothing
+ * to embed, so recent context is its only hope) but dilutes content-RICH turns
+ * (song lyrics, a bug report — the message already retrieves the right memory,
+ * and prepending recent-context chatter pushes it out of the top-K). The gate
+ * makes the fold conditional: fold only when the UNFOLDED query is content-poor.
+ *
+ * The input is the query as it would be embedded WITHOUT the fold — message plus
+ * any attachment descriptions / referenced-message text — because that is the
+ * string whose semantic content decides whether folding helps or dilutes.
+ *
+ * The rule is deliberately dumb and was PRE-REGISTERED before the conditional
+ * policy was scored (strip mentions/emoji/URLs, count content words, threshold)
+ * — it must not be tuned against the judged goldens, or the offline simulation
+ * that validated it becomes circular.
+ */
+
+/**
+ * Fold when the unfolded query has fewer content words than this. Multi-word
+ * mention display names ("@Charlie Morningstar") leave residual name tokens
+ * after stripping, so the threshold leaves headroom above zero rather than
+ * trying to strip names perfectly.
+ */
+export const FOLD_GATE_MAX_CONTENT_WORDS = 5;
+
+/** Raw Discord mention syntax: user (<@123>, <@!123>), role (<@&123>), channel (<#123>). */
+const RAW_MENTION_RE = /<[@#][!&]?\d+>/g;
+
+/** Custom Discord emoji, static and animated: <:name:id> / <a:name:id>. */
+const CUSTOM_EMOJI_RE = /<a?:\w+:\d+>/g;
+
+/** Plain-text persona/user tags as stored in history content: "@Name", "&BotName". */
+const TEXT_TAG_RE = /(?:^|\s)[@&]\S+/g;
+
+const URL_RE = /https?:\/\/\S+/g;
+
+/**
+ * Count the content words of a query: whitespace tokens carrying at least two
+ * alphanumeric characters, after mentions, custom emoji, text tags, and URLs
+ * are stripped. Unicode emoji and punctuation-only tokens fall out naturally
+ * (no alphanumerics). "Content" is deliberately generous — stopwords count,
+ * because the signal is "is there ANY substance to embed", not keyword quality.
+ */
+export function countContentWords(query: string): number {
+  const stripped = query
+    .replace(RAW_MENTION_RE, ' ')
+    .replace(CUSTOM_EMOJI_RE, ' ')
+    .replace(TEXT_TAG_RE, ' ')
+    .replace(URL_RE, ' ');
+  return stripped.split(/\s+/).filter(token => token.replace(/[^a-zA-Z0-9]/g, '').length >= 2)
+    .length;
+}
+
+/**
+ * True when the unfolded search query is content-poor enough that folding the
+ * recent conversation window into it is likely to help rather than dilute.
+ *
+ * @param unfoldedQuery the search query WITHOUT the recent-history window
+ *   (message + attachment text + referenced-message text)
+ * @param maxContentWords fold below this many content words; defaults to the
+ *   pre-registered production threshold
+ */
+export function shouldFoldSearchQuery(
+  unfoldedQuery: string,
+  maxContentWords: number = FOLD_GATE_MAX_CONTENT_WORDS
+): boolean {
+  return countContentWords(unfoldedQuery) < maxContentWords;
+}


### PR DESCRIPTION
## What

Makes the LTM search-query context-fold **conditional**: fold the recent conversation window in only when the unfolded query is content-poor. Direct follow-on from the 1c honest re-baseline, which showed the uniform fold is a net-negative trade (rescues reactive turns, dilutes content-rich ones).

## The evidence (simulated offline BEFORE wiring)

The gate rule was **pre-registered** (fold iff `< 5` content words after stripping mentions/custom-emoji/text-tags/URLs), then scored against the already-judged 40-golden pool — the pooled design makes any per-turn arm-selection policy scoreable retroactively, no new dev queries or judging:

| Threshold | folded | cond recall@10 | combined miss@10 | vs bare (fix/break) | vs fold3 (fix/break) |
|---|---|---|---|---|---|
| <3 | 8/40 | 0.530 | 1/37 (2.7%) | +3 (3/0) | +4 (7/3) |
| **<5 (pre-reg)** | 11/40 | **0.548** | **1/37 (2.7%)** | **+4 (4/0)** | **+5 (7/2)** |
| <8 | 16/40 | 0.539 | 2/37 (5.4%) | +3 (4/1) | +4 (6/2) |

Reference points: bare 0.436 recall@10 / 3/37 miss; current prod (fold3) 0.390 / 7/37. At the pre-registered default the gate has **zero breaks vs bare** — strictly dominant on this set — and no style stratum regresses (each keeps its best arm: compound 0/9, referential 1/8, short-reactive 0/10, standalone 0/10).

**Honest caveats**: n=37, single judge, and the validation set is the same corpus that generated the hypothesis — mitigated by pre-registering the rule (not tuned; sensitivity shown at 3/8) and by the mechanism being independently explicable (dilution). A fresh mine (dev's rolling 30-day window) is a natural future holdout.

## User-visible behavior change

- **Content-rich messages** (most typed messages, image posts with descriptions, voice messages): LTM retrieval now embeds the query **without** recent-chat context mixed in — on-topic memories stop being displaced by conversation chatter.
- **Short reactive messages** ("poke", "yes", a bare @mention): unchanged — still folded, still context-rescued.

## Design

- `prompt/queryFoldGate.ts` — the pre-registered rule, exported constants, 15 unit tests (CI). Gate input is the **unfolded query** (message + attachment text + refs), i.e. exactly what would be embedded without the fold.
- Gate is **policy at the call site** (`ConversationInputProcessor`); `buildSearchQuery` stays an unconditional mechanism — the eval runner's fold arms depend on that.
- Seam tests for both branches (window crosses / doesn't cross the builder boundary; `extractRecentHistoryWindow` not invoked when gated off).
- Simulation section added to the fold-score eval glue (`pnpm eval:fold-score` reproduces the table).

## Testing

`pnpm test` (3,818 unit) + `pnpm quality` green. Simulation re-run confirms the 1c headline tables byte-identical (the gate changes no scoring math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)