### PR TITLE
debug: instrument db-sync silent hang (transport + handler probes)

### DIFF
--- a/packages/clients/src/clients/transport.test.ts
+++ b/packages/clients/src/clients/transport.test.ts
@@ -250,3 +250,86 @@ describe('callGateway', () => {
     );
   });
 });
+
+describe('long-call diagnostic probes (temporary db-sync silent-hang scaffolding)', () => {
+  // The probes are the diagnostic for a prod incident that produced ZERO
+  // observables — so the probe path itself must be exercised, or the next
+  // occurrence risks a silent diagnostic on top of a silent hang. Stryker is
+  // deliberately disabled on the probe block (diagnostic-only output), which
+  // makes this suite the only verification it gets.
+
+  /** Parse captured stdout writes down to the probe lines. */
+  function collectProbes(writeSpy: {
+    mock: { calls: unknown[][] };
+  }): Array<Record<string, unknown>> {
+    return writeSpy.mock.calls
+      .map(call => String(call[0]))
+      .flatMap(text => text.split('\n'))
+      .map(line => {
+        try {
+          return JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .filter(
+        (parsed): parsed is Record<string, unknown> =>
+          parsed !== null && parsed['probe'] === 'transport-long-call'
+      );
+  }
+
+  function spyOnStdout(): ReturnType<typeof vi.spyOn> {
+    // Swallow the write so probe lines don't pollute the test reporter's
+    // output; restored by the top-level afterEach's restoreAllMocks.
+    return vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  }
+
+  it('emits request-start → response-headers → settled with one tag on a LONG_SYNC success', async () => {
+    const writeSpy = spyOnStdout();
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await callGateway({ ...baseOpts, method: 'POST', timeoutMs: GATEWAY_TIMEOUTS.LONG_SYNC });
+
+    const probes = collectProbes(writeSpy);
+    expect(probes.map(p => p['stage'])).toEqual(['request-start', 'response-headers', 'settled']);
+    // One correlation tag across the call, and the fields that make a line
+    // actionable in prod logs are present on every stage.
+    expect(new Set(probes.map(p => p['tag'])).size).toBe(1);
+    for (const probe of probes) {
+      expect(probe['path']).toBe(baseOpts.path);
+      expect(typeof probe['elapsedMs']).toBe('number');
+    }
+    expect(probes[0]).toMatchObject({ method: 'POST', timeoutMs: GATEWAY_TIMEOUTS.LONG_SYNC });
+    expect(probes[2]).toMatchObject({ ok: true });
+  });
+
+  it('emits settled-http-error on a LONG_SYNC non-2xx', async () => {
+    const writeSpy = spyOnStdout();
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ message: 'Boom', code: 'INTERNAL_ERROR' }, { status: 500 })
+    );
+    await callGateway({ ...baseOpts, method: 'POST', timeoutMs: GATEWAY_TIMEOUTS.LONG_SYNC });
+
+    const stages = collectProbes(writeSpy).map(p => p['stage']);
+    expect(stages).toEqual(['request-start', 'response-headers', 'settled-http-error']);
+  });
+
+  it('emits threw with the failure kind when the fetch rejects on a LONG_SYNC call', async () => {
+    const writeSpy = spyOnStdout();
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNRESET'));
+    await callGateway({ ...baseOpts, method: 'POST', timeoutMs: GATEWAY_TIMEOUTS.LONG_SYNC });
+
+    const probes = collectProbes(writeSpy);
+    expect(probes.map(p => p['stage'])).toEqual(['request-start', 'threw']);
+    expect(probes[1]).toMatchObject({ kind: 'network', error: 'ECONNRESET' });
+  });
+
+  it('emits nothing for calls below the long-call threshold', async () => {
+    const writeSpy = spyOnStdout();
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    // Default tiers (DEFERRED/WRITE/BULK_OPERATION) are all under the 100s
+    // threshold — the probe must stay silent on the hot path.
+    await callGateway({ ...baseOpts, method: 'POST', timeoutMs: GATEWAY_TIMEOUTS.BULK_OPERATION });
+
+    expect(collectProbes(writeSpy)).toEqual([]);
+  });
+});

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -212,6 +212,33 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
   const effectiveTimeoutMs =
     timeoutMs ?? (isWriteMethod ? GATEWAY_TIMEOUTS.WRITE : GATEWAY_TIMEOUTS.DEFERRED);
 
+  // Silent-hang probe (temporary debug scaffolding): prod db-sync calls have
+  // vanished without settling — no response, no abort firing, no envelope
+  // returned. Long-budget calls (the LONG_SYNC tier — owner-triggered ops
+  // only, so volume is a handful of lines per run) log each transport stage
+  // so the next run shows exactly where the await stops. Raw stdout write
+  // because transport has no logger dependency by design (see onWarn).
+  // Stryker disable all: diagnostic-only output slated for removal — same class as the logger-calls ignorer
+  const probeTag = effectiveTimeoutMs >= 100_000 ? Math.random().toString(36).slice(2, 8) : null;
+  const probeStart = Date.now();
+  const probe = (stage: string, extra?: Record<string, unknown>): void => {
+    if (probeTag === null) {
+      return;
+    }
+    process.stdout.write(
+      JSON.stringify({
+        probe: 'transport-long-call',
+        tag: probeTag,
+        stage,
+        path,
+        elapsedMs: Date.now() - probeStart,
+        ...extra,
+      }) + '\n'
+    );
+  };
+  probe('request-start', { method, timeoutMs: effectiveTimeoutMs });
+  // Stryker restore all
+
   if (baseUrl.length === 0) {
     return { ok: false, kind: 'config', error: 'baseUrl is empty', status: 0 };
   }
@@ -238,9 +265,13 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: AbortSignal.timeout(effectiveTimeoutMs),
     });
+    // Stryker disable next-line all: diagnostic probe
+    probe('response-headers', { status: response.status });
 
     if (!response.ok) {
       const parsed = await parseErrorResponse(response);
+      // Stryker disable next-line all: diagnostic probe
+      probe('settled-http-error', { status: response.status });
       onWarn?.({ path, method, kind: 'http', status: response.status }, 'Request failed');
       return {
         ok: false,
@@ -252,12 +283,16 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
     }
 
     const parsed = await readValidatedBody({ response, outputSchema, onWarn, path, method });
+    // Stryker disable next-line all: diagnostic probe
+    probe('settled', { ok: parsed.ok });
     if (!parsed.ok) {
       return parsed.result;
     }
     return { ok: true, data: parsed.data as T };
   } catch (error) {
     const { kind, error: errorMessage } = classifyThrownError(error);
+    // Stryker disable next-line all: diagnostic probe
+    probe('threw', { kind, error: errorMessage });
     // Pass `kind` (not a collapsed boolean) so log consumers keep the
     // network-vs-timeout distinction; `error` field name matches the HTTP path.
     onWarn?.({ path, method, error: errorMessage, kind }, 'Request error');

--- a/services/bot-client/src/commands/admin/db-sync.ts
+++ b/services/bot-client/src/commands/admin/db-sync.ts
@@ -289,7 +289,12 @@ export async function handleDbSync(context: DeferredCommandContext): Promise<voi
 
   try {
     const { ownerClient } = clientsFor(context.interaction);
+    // Milestone logs (here through 'reply edited'): prod runs have died
+    // silently between the gateway call and the reply edit — no settle, no
+    // abort, no stash. These pin the death point for the next occurrence.
+    logger.info({ dryRun, allowSchemaSkew }, 'db-sync: calling gateway');
     const apiResult = await ownerClient.dbSync({ dryRun, allowSchemaSkew });
+    logger.info({ ok: apiResult.ok }, 'db-sync: gateway call settled');
 
     if (!apiResult.ok) {
       logger.error({ status: apiResult.status, error: apiResult.error }, 'DB sync failed');
@@ -323,6 +328,7 @@ export async function handleDbSync(context: DeferredCommandContext): Promise<voi
     // the details are never silently lost.
     const reportText = buildSyncReportText(result, dryRun);
     const reportKey = await storeDbSyncReport(reportText);
+    logger.info({ stashed: reportKey !== null }, 'db-sync: report stash done');
 
     if (reportKey !== null) {
       const detailsRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -333,10 +339,12 @@ export async function handleDbSync(context: DeferredCommandContext): Promise<voi
           .setStyle(ButtonStyle.Secondary)
       );
       await context.editReply({ embeds: [embed], components: [detailsRow] });
+      logger.info('db-sync: reply edited (embed + details button)');
       return;
     }
 
     await context.editReply({ embeds: [embed] });
+    logger.info('db-sync: reply edited (embed only, inline report follows)');
 
     // Stash unavailable: full report flows below the summary as chunked
     // ephemeral follow-ups — 'followUp' mode leaves the embed message


### PR DESCRIPTION
## What

Diagnostic instrumentation for the prod db-sync silent hang — per the bug-remediation protocol, the fix waits for a runtime observation this ships.

## The mystery (runtime-traced today, 3/3 prod runs)

- `/admin db-sync` at 12:24, 14:32, and 14:41 UTC: gateway received each POST, completed the sync, and sent a 200 (117s, 117s, and **14s** — so this is NOT duration-dependent).
- bot-client logged **nothing** after `Executing subcommand` for any run: no `DB sync failed`, no outer-catch error, no transport abort at the 300s `AbortSignal.timeout` deadline (verified hours past deadline, unfiltered log windows).
- Prod Redis has **zero** `dbsync:report:*` keys during the 30-min stash TTL window → the handler never reached `storeDbSyncReport`.
- Every link read-through and verified against the deployed `v3.0.0-beta.162` tag (byte-identical to develop for these files): route `timeoutMs: LONG_SYNC` threads through the generated `OwnerClient.dbSync` into `callGateway`'s `AbortSignal.timeout`; `readValidatedBody` returns envelopes on every branch; the Redis stash has a 30s command timeout and fail-open catch; `editReply` throws propagate to a logging catch. **No code path can hang or fail silently — yet all three runs did.**

## What this adds

1. **Transport probes** (`packages/clients/src/clients/transport.ts`): calls with an effective timeout ≥100s (only the LONG_SYNC tier: db-sync, cleanup — owner-triggered, a handful of lines per run) write staged JSON probe lines to stdout: `request-start` → `response-headers` → `settled` / `settled-http-error` / `threw`, each with elapsed ms and a correlation tag. No env flag needed; volume is negligible and it must be active in prod without a config step.
2. **Handler milestones** (`db-sync.ts`): `calling gateway` → `gateway call settled` → `report stash done` → `reply edited`, via the existing logger.

The next run (dev after this merges; prod after the next release) shows exactly which stage the await stops at — e.g. probes ending at `request-start` mean the fetch promise genuinely never settles in-process (runtime/undici suspicion, Node 25); ending at `response-headers` means a body-read hang; handler milestones without transport stages are impossible and would indicate log-pipeline loss.

## Verification

- `pnpm test` green (clients 170, bot-client 5490, full suite)
- `pnpm quality` green

Both probe layers are `debug`-type scaffolding — a removal PR follows once the mechanism is named (anything worth keeping gets re-justified as feat observability there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)