### PR TITLE
chore(ci): ignore TypeScript majors in dependabot (TS 7 breaks typescript-eslint)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,8 +43,16 @@ updates:
       # maintained in parallel) that drops the `.jscpd.json` `ignore` key — only
       # the CLI `--ignore-pattern` works — and shifts detection counts vs the JS
       # engine. Pinned to 4.x until the CPD tooling is migrated. See the
-      # "Migrate CPD tooling to jscpd 5" entry in backlog/deferred.md.
+      # "Migrate CPD tooling to jscpd 5" entry in backlog/cold/follow-ups.md.
       - dependency-name: 'jscpd'
+        update-types: ['version-update:semver-major']
+      # TypeScript 7.x is not yet supported by typescript-eslint —
+      # @typescript-eslint/typescript-estree crashes at parse time under TS 7
+      # ("Cannot read properties of undefined (reading 'Cjs')"), which turns
+      # every dev-deps group PR carrying the major permanently red. Take the
+      # TS 7 upgrade deliberately once typescript-eslint ships support, then
+      # remove this ignore. See the follow-up in backlog/cold/follow-ups.md.
+      - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
 
   # GitHub Actions workflow file dependencies — separate ecosystem.


### PR DESCRIPTION
## What

Adds `typescript` + `version-update:semver-major` to the dependabot npm ignore list, mirroring the existing jscpd-major entry.

## Why

Dependabot group PR #1622 (dev-dependencies) is red because it bundles the TypeScript 6.0.3 → 7.0.2 **major** with routine patch/minor bumps. typescript-eslint (even at the bundled 8.63.0) does not support TS 7 — `@typescript-eslint/typescript-estree` crashes at parse time with `Cannot read properties of undefined (reading 'Cjs')`, so lint/tests can never pass while the major rides the group.

## Activation + follow-through

Dependabot reads this config from the **default branch (`main`)**, so the rule activates when the next release lands. After that: `@dependabot recreate` on #1622 regenerates the group without TS 7 (tracked as a Quick Win). The deliberate TS 7 upgrade (bump + remove this ignore once typescript-eslint ships support) is filed in `backlog/cold/follow-ups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)