### PR TITLE
chore(ci): sync dependabot TS-major ignore to main (activates the #1625 rule now)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,8 +43,16 @@ updates:
       # maintained in parallel) that drops the `.jscpd.json` `ignore` key — only
       # the CLI `--ignore-pattern` works — and shifts detection counts vs the JS
       # engine. Pinned to 4.x until the CPD tooling is migrated. See the
-      # "Migrate CPD tooling to jscpd 5" entry in backlog/deferred.md.
+      # "Migrate CPD tooling to jscpd 5" entry in backlog/cold/follow-ups.md.
       - dependency-name: 'jscpd'
+        update-types: ['version-update:semver-major']
+      # TypeScript 7.x is not yet supported by typescript-eslint —
+      # @typescript-eslint/typescript-estree crashes at parse time under TS 7
+      # ("Cannot read properties of undefined (reading 'Cjs')"), which turns
+      # every dev-deps group PR carrying the major permanently red. Take the
+      # TS 7 upgrade deliberately once typescript-eslint ships support, then
+      # remove this ignore. See the follow-up in backlog/cold/follow-ups.md.
+      - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
 
   # GitHub Actions workflow file dependencies — separate ecosystem.


### PR DESCRIPTION
## What

Byte-identical sync of `.github/dependabot.yml` from develop to main: the TypeScript major-version ignore merged in #1625, plus the stale `backlog/deferred.md` comment-ref fix.

## Why main directly

Dependabot reads its config from the **default branch** — on develop alone, the rule is dormant until the next release, which would mean two releases just to unblock the red dev-deps group PR (#1622, carrying the typescript-eslint-incompatible TS 7 major). Owner-requested main-cut so the rule activates immediately; after merge, `@dependabot recreate` on #1622 regenerates the group without TS 7. Same main-cut pattern as default-branch-validated workflow files.

## Follow-through

- develop already carries this exact file content (#1625) — after merge, `release:finalize` resyncs develop onto main so the histories reconverge (the patch-identical develop commit drops out).
- The deliberate TS 7 upgrade (and removal of this ignore) is tracked in `backlog/cold/follow-ups.md` with a promote-when trigger (typescript-eslint ships TS 7 support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)