### PR TITLE
refactor: retire GUEST_MODE.DEFAULT_MODEL + VISION_FALLBACK_FREE aliases

### DIFF
--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -64,17 +64,6 @@ describe('toModelSlot', () => {
 });
 
 describe('GUEST_MODE', () => {
-  it('should have a default free model configured', () => {
-    expect(GUEST_MODE.DEFAULT_MODEL).toBe('openrouter/free');
-    expect(isFreeModel(GUEST_MODE.DEFAULT_MODEL)).toBe(true);
-  });
-
-  it('should have all FREE_MODELS be actually free', () => {
-    for (const model of GUEST_MODE.FREE_MODELS) {
-      expect(isFreeModel(model)).toBe(true);
-    }
-  });
-
   it('should have a footer message', () => {
     expect(GUEST_MODE.FOOTER_MESSAGE).toContain('free');
   });

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -165,9 +165,6 @@ export const AI_ENDPOINTS = {
   MISTRAL_BASE_URL: 'https://api.mistral.ai/v1',
 } as const;
 
-/** Primary free multimodal model — shared between vision fallback and guest mode */
-const FREE_MULTIMODAL_MODEL = 'google/gemma-4-31b-it:free';
-
 /**
  * OpenRouter's free-model router — a meta-model that routes to an available free
  * model. It is free to use, but its ID does NOT carry the `:free` suffix, so
@@ -198,12 +195,6 @@ export const MODEL_DEFAULTS = {
   // Specialized models
   /** Vision fallback for BYOK users (paid) — natively multimodal */
   VISION_FALLBACK: 'qwen/qwen3.5-397b-a17b',
-  /**
-   * Vision fallback for free-tier users (no BYOK) — the dynamic free-model router
-   * (vision-capable per OpenRouter's catalog), so it survives individual free
-   * models being rate-limited or rotated out rather than pinning one model.
-   */
-  VISION_FALLBACK_FREE: FREE_ROUTER_MODEL,
   /**
    * Fixed cheap system model for async fact extraction (memory Phase 2).
    * NEVER the personality's model — extraction cost must stay decoupled from
@@ -568,25 +559,6 @@ export enum AIProvider {
  * Guest users are restricted to free-tier models only.
  */
 export const GUEST_MODE = {
-  /**
-   * Last-resort free model for guest users when no free-default config is set
-   * (AuthStep prefers a configured free default over this). The OpenRouter
-   * free-model router (dynamic) rather than a single pinned model, so it survives
-   * individual free models being rate-limited or rotated out — whatever free
-   * models are in rotation, the router resolves one.
-   */
-  DEFAULT_MODEL: FREE_ROUTER_MODEL,
-
-  /**
-   * Alternative free models (for failover or user choice)
-   * Ordered by preference for chat/roleplay use cases.
-   * Verified against OpenRouter /api/v1/models (2026-04-04).
-   */
-  FREE_MODELS: [
-    FREE_MULTIMODAL_MODEL, // 131k context, multimodal, balanced quality/speed
-    'nvidia/nemotron-nano-12b-v2-vl:free', // 128k context, vision+video
-  ] as const,
-
   /**
    * Free model suffix used by OpenRouter
    * Models ending with this suffix are free to use

--- a/packages/common-types/src/schemas/api/systemSettings.ts
+++ b/packages/common-types/src/schemas/api/systemSettings.ts
@@ -354,7 +354,7 @@ export const SYSTEM_SETTINGS_REGISTRY: SystemSettingsRegistry = {
     control: 'model',
     liveness: 'live',
     fallback: FREE_ROUTER_MODEL,
-    seedSource: 'GUEST_MODE.DEFAULT_MODEL (constant)',
+    seedSource: 'FREE_ROUTER_MODEL (constant; formerly aliased as GUEST_MODE.DEFAULT_MODEL)',
     model: {
       slot: 'text',
       aliasAllowlist: [FREE_ROUTER_MODEL],
@@ -370,7 +370,8 @@ export const SYSTEM_SETTINGS_REGISTRY: SystemSettingsRegistry = {
     control: 'model',
     liveness: 'live',
     fallback: FREE_ROUTER_MODEL,
-    seedSource: 'MODEL_DEFAULTS.VISION_FALLBACK_FREE (constant)',
+    seedSource:
+      'FREE_ROUTER_MODEL (constant; formerly aliased as MODEL_DEFAULTS.VISION_FALLBACK_FREE)',
     model: {
       slot: 'vision',
       aliasAllowlist: [FREE_ROUTER_MODEL],

--- a/packages/config-resolver/src/VisionConfigResolver.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.ts
@@ -17,7 +17,8 @@
  * This subclass owns the vision-specific Prisma queries and the tier 3-5 fallback.
  *
  * Phase-1 scope: this resolves the PAID vision default for the no-override case. The
- * GUEST downgrade stays downstream (AuthStep + selectVisionModel → VISION_FALLBACK_FREE);
+ * GUEST downgrade stays downstream (AuthStep + selectVisionModel → the free floor,
+ * the `fallbackVisionModelFree` setting);
  * guest-aware DB resolution (consulting the free-default vision pointer) is deferred
  * alongside the vision editing surface.
  *
@@ -279,9 +280,9 @@ export class VisionConfigResolver extends BaseConfigResolver<
    * Get the free-tier vision default via the AdminSettings pointer
    * (`freeDefaultVisionConfigId`) — the vision analogue of
    * `LlmConfigResolver.getFreeDefaultConfig`. This is the admin-set free-tier
-   * fallback the worker's vision path consults before the hardcoded
-   * `VISION_FALLBACK_FREE` floor. Returns null if no pointer is set
-   * (callers fall through to the hardcoded floor). `source` is 'personality' (the
+   * fallback the worker's vision path consults before the free floor (the
+   * `fallbackVisionModelFree` setting). Returns null if no pointer is set
+   * (callers fall through to the floor). `source` is 'personality' (the
    * "system default" tier), matching `getGlobalDefaultConfig`.
    */
   async getFreeDefaultVisionConfig(): Promise<ResolvedVisionConfig | null> {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
@@ -4,7 +4,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Job } from 'bullmq';
-import { AIProvider, GUEST_MODE, ZAI_FREE_TIER_MODEL } from '@tzurot/common-types/constants/ai';
+import {
+  AIProvider,
+  FREE_ROUTER_MODEL,
+  ZAI_FREE_TIER_MODEL,
+} from '@tzurot/common-types/constants/ai';
 import type { ZaiFreeTierAdmission } from '../../../../services/ZaiFreeTierAdmission.js';
 import { JobType } from '@tzurot/common-types/constants/queue';
 import { type LLMGenerationJobData } from '@tzurot/common-types/types/jobs';
@@ -223,7 +227,7 @@ describe('AuthStep', () => {
 
       expect(result.auth?.isGuestMode).toBe(true);
       // Should override model to guest default
-      expect(result.config?.effectivePersonality.model).toBe(GUEST_MODE.DEFAULT_MODEL);
+      expect(result.config?.effectivePersonality.model).toBe(FREE_ROUTER_MODEL);
     });
 
     it('should fall back to guest mode when resolver throws', async () => {
@@ -1147,7 +1151,7 @@ describe('AuthStep', () => {
 
       const result = await step.process(guestContext());
 
-      expect(result.config?.effectivePersonality.model).toBe(GUEST_MODE.DEFAULT_MODEL);
+      expect(result.config?.effectivePersonality.model).toBe(FREE_ROUTER_MODEL);
       expect(result.auth?.apiKey).toBe('system-openrouter-key');
       expect(result.auth?.provider).toBe(AIProvider.OpenRouter);
     });
@@ -1157,7 +1161,7 @@ describe('AuthStep', () => {
 
       const result = await step.process(guestContext());
 
-      expect(result.config?.effectivePersonality.model).toBe(GUEST_MODE.DEFAULT_MODEL);
+      expect(result.config?.effectivePersonality.model).toBe(FREE_ROUTER_MODEL);
       expect(result.auth?.provider).toBe(AIProvider.OpenRouter);
     });
 
@@ -1172,7 +1176,7 @@ describe('AuthStep', () => {
 
       const result = await step.process(guestContext());
 
-      expect(result.config?.effectivePersonality.model).toBe(GUEST_MODE.DEFAULT_MODEL);
+      expect(result.config?.effectivePersonality.model).toBe(FREE_ROUTER_MODEL);
     });
   });
 });

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -11,7 +11,7 @@ import {
 } from './VisionProcessor.js';
 import type { AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import type { LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
-import { AI_DEFAULTS, MODEL_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { AI_DEFAULTS, FREE_ROUTER_MODEL } from '@tzurot/common-types/constants/ai';
 import { SYSTEM_SETTINGS_FALLBACKS } from '@tzurot/common-types/schemas/api/systemSettings';
 import {
   registerSystemSettings,
@@ -403,7 +403,7 @@ describe('VisionProcessor', () => {
 
         expect(mockCreateChatModel).toHaveBeenCalledWith(
           expect.objectContaining({
-            modelName: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+            modelName: FREE_ROUTER_MODEL,
           })
         );
       });
@@ -419,7 +419,7 @@ describe('VisionProcessor', () => {
 
         expect(mockCreateChatModel).toHaveBeenCalledWith(
           expect.objectContaining({
-            modelName: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+            modelName: FREE_ROUTER_MODEL,
           })
         );
       });

--- a/services/ai-worker/src/services/multimodal/describeImageWithFallback.test.ts
+++ b/services/ai-worker/src/services/multimodal/describeImageWithFallback.test.ts
@@ -12,7 +12,7 @@
  * - `resolveVisionAuth` / `createVisionQuotaTracker` from visionAuthResolver
  *   (the REAL `visionAuthFailFastDescription` is kept).
  * - the paid floor (fallbackVisionModel setting) to be deterministic
- *   (the REAL `MODEL_DEFAULTS` / `ApiErrorCategory` are kept).
+ *   (the REAL `ApiErrorCategory` is kept).
  */
 
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
@@ -22,7 +22,7 @@ import {
   type SystemSettingsService,
 } from '@tzurot/common-types/services/SystemSettingsService';
 import { SYSTEM_SETTINGS_FALLBACKS } from '@tzurot/common-types/schemas/api/systemSettings';
-import { AIProvider, MODEL_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { AIProvider, FREE_ROUTER_MODEL } from '@tzurot/common-types/constants/ai';
 import { ApiErrorCategory } from '@tzurot/common-types/constants/error';
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
@@ -187,10 +187,10 @@ describe('composeVisionTiers', () => {
     expect(tiers).toEqual(['primary/model', FALLBACK_PAID_MODEL]);
   });
 
-  it('appends the free floor (MODEL_DEFAULTS.VISION_FALLBACK_FREE) when guest mode', () => {
+  it('appends the free floor (FREE_ROUTER_MODEL) when guest mode', () => {
     const personality = makePersonality({ visionFallbackModels: [] });
     const tiers = composeVisionTiers('primary/model', personality, true);
-    expect(tiers).toEqual(['primary/model', MODEL_DEFAULTS.VISION_FALLBACK_FREE]);
+    expect(tiers).toEqual(['primary/model', FREE_ROUTER_MODEL]);
   });
 
   it('dedups repeated models across primary/fallbacks/floor', () => {

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
@@ -18,7 +18,7 @@ import {
   resetSystemSettingsRegistration,
   type SystemSettingsService,
 } from '@tzurot/common-types/services/SystemSettingsService';
-import { AIProvider, MODEL_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { AIProvider, FREE_ROUTER_MODEL } from '@tzurot/common-types/constants/ai';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import {
   resolveVisionConfig,
@@ -194,7 +194,7 @@ describe('resolveVisionConfig', () => {
   describe('genuine guest', () => {
     it('resolves system key + free model via resolveApiKey when isGuestMode=true', async () => {
       // selectVisionModel returns the free model for guests.
-      mockSelectVisionModel.mockResolvedValue(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
+      mockSelectVisionModel.mockResolvedValue(FREE_ROUTER_MODEL);
       mockResolveApiKey.mockResolvedValue({
         apiKey: 'system-or-key',
         source: 'system',
@@ -217,7 +217,7 @@ describe('resolveVisionConfig', () => {
         config: {
           apiKey: 'system-or-key',
           provider: AIProvider.OpenRouter,
-          model: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+          model: FREE_ROUTER_MODEL,
           source: 'system',
           isGuestMode: true,
         },
@@ -320,7 +320,7 @@ describe('resolveVisionConfig', () => {
       expect(result.kind).toBe('resolved');
       if (result.kind === 'resolved') {
         // Headline assertions: free model forced, system key, NOT guest.
-        expect(result.config.model).toBe(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
+        expect(result.config.model).toBe(FREE_ROUTER_MODEL);
         expect(result.config.apiKey).toBe('system-or-key');
         expect(result.config.source).toBe('system');
         expect(result.config.isGuestMode).toBe(false);
@@ -382,7 +382,7 @@ describe('resolveVisionConfig', () => {
       expect(result.kind).toBe('resolved');
       if (result.kind === 'resolved') {
         expect(result.config.source).toBe('user');
-        expect(result.config.model).toBe(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
+        expect(result.config.model).toBe(FREE_ROUTER_MODEL);
       }
       expect(mockTryConsume).not.toHaveBeenCalled();
     });
@@ -565,7 +565,7 @@ describe('resolveVisionAuth (direct, model-parameterized)', () => {
 
     expect(result.kind).toBe('resolved');
     if (result.kind === 'resolved') {
-      expect(result.config.model).toBe(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
+      expect(result.config.model).toBe(FREE_ROUTER_MODEL);
       expect(result.config.apiKey).toBe('system-key');
     }
   });


### PR DESCRIPTION
## What

Closes the `backlog/cold/follow-ups.md` row "Retire GUEST_MODE.DEFAULT_MODEL + MODEL_DEFAULTS.VISION_FALLBACK_FREE constants" — trigger met (admin-runtime PR 4 shipped in beta.162, released this morning).

Both constants were aliases of `FREE_ROUTER_MODEL` with **zero production read sites** since the PR 3/4 consumer swaps — every runtime consumer reads the `fallbackTextModelFree`/`fallbackVisionModelFree` settings through the guarded floor helpers (`freeFloors.ts`).

## Why the test conversions matter

The remaining test references were **coincidental-equality oracles**: the code under test read the (unregistered) setting, fell back to `FREE_ROUTER_MODEL`, and the test compared against a constant that happened to equal it — a broken live-read could never fail them. Conversions:

- **AuthStep.test (4), VisionProcessor.test (2), describeImageWithFallback.test (2)**: now assert `FREE_ROUTER_MODEL` directly — the honest registry-fallback value. The live-read invariant is separately pinned by the existing divergent-value tests (`freeFloors.test`, `quotaFallback.test` "reads the LIVE fallbackTextModelFree", `guestModeOverrides.test` `LIVE_TEXT_FLOOR`, VisionProcessor's "divergent-from-fallback values flow through").
- **visionAuthResolver.test (5)**: mock-plumbing pairs (mocked `selectVisionModel` returns X → assert X forwards); swapped to the same literal.
- **ai.test**: the constants' self-tests deleted with them.

## Enumeration (exhaustive-sweep)

`grep -rn "GUEST_MODE\.DEFAULT_MODEL|VISION_FALLBACK_FREE|GUEST_MODE\.FREE_MODELS|FREE_MULTIMODAL_MODEL"` across packages/ + services/ (dist excluded) — every hit either converted or deleted; post-edit sweep returns only the surviving `MODEL_DEFAULTS.DEFAULT_MODEL` (different symbol, main-generation model, out of scope) and the reworded provenance strings.

## Ride-alongs (same motivation, discovered by the sweep)

- `GUEST_MODE.FREE_MODELS` deleted — referenced only by its own self-test (`FOOTER_MESSAGE` + `FREE_MODEL_SUFFIX` stay; both live).
- `FREE_MULTIMODAL_MODEL` module const deleted — orphaned by the above.
- `seedSource` registry labels + `VisionConfigResolver` doc comments re-pointed at surviving names.

## Verification

- `pnpm test` green (25 tasks; common-types 2449, ai-worker 3854) — re-run **after** rebasing onto the #1627 dev-deps bumps
- `pnpm quality` green (27-check parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)