### PR TITLE
fix(tooling): ZAI_CODING_API_KEY on both services in the deploy manifest

### DIFF
--- a/packages/common-types/src/schemas/api/systemSettings.ts
+++ b/packages/common-types/src/schemas/api/systemSettings.ts
@@ -40,7 +40,7 @@ export const SystemSettingsSchema = z.object({
   extractionBatchThreshold: z.number().int().min(1).max(50),
   /** Extraction engine — switching models MUST re-run `pnpm eval:extraction` first. */
   extractionModel: z.string().min(1),
-  /** Which provider bills extraction; 'zai-coding' requires ZAI_CODING_API_KEY. */
+  /** Which provider bills extraction; 'zai-coding' requires ZAI_CODING_API_KEY on BOTH ai-worker and api-gateway. */
   extractionProvider: z.enum(['openrouter', 'zai-coding']),
   /** The shared free key's daily free-request allowance (the pie). */
   freeTierGlobalDailyBudget: z.number().int().min(1),
@@ -215,7 +215,8 @@ export const SYSTEM_SETTINGS_REGISTRY: SystemSettingsRegistry = {
   extractionProvider: {
     key: 'extractionProvider',
     label: 'Extraction Provider',
-    description: "Which provider bills extraction; 'zai-coding' requires the system z.ai key.",
+    description:
+      "Which provider bills extraction; 'zai-coding' requires ZAI_CODING_API_KEY on BOTH ai-worker (bills the calls) and api-gateway (validates writes to this setting).",
     group: GROUP_EXTRACTION,
     control: 'enum',
     liveness: 'live',

--- a/packages/tooling/src/deployment/setup-railway-variables.test.ts
+++ b/packages/tooling/src/deployment/setup-railway-variables.test.ts
@@ -109,6 +109,27 @@ BOT_OWNER_ID=987654321
       expect(output).toContain('[DRY RUN]');
       expect(output).toContain('Would set shared variable');
     });
+
+    it('sets ZAI_CODING_API_KEY on BOTH api-gateway and ai-worker', async () => {
+      // The both-services invariant: the worker bills z.ai calls with the key,
+      // the gateway's write validator checks it before accepting zai-coding
+      // settings. An env carrying it on only one service accepts settings it
+      // cannot serve (the bag mis-seed incident class) — this test pins the
+      // manifest pairing so the key can't quietly drop from either list.
+      mockReadFileSync.mockReturnValue(`
+AI_PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-test-key
+DISCORD_TOKEN=test-discord-token
+DISCORD_CLIENT_ID=123456789
+ZAI_CODING_API_KEY=test-zai-key
+`);
+
+      await setupRailwayVariables({ env: 'dev', dryRun: true, yes: true });
+
+      const output = consoleLogs.join('\n');
+      expect(output).toContain('Would set api-gateway variable: ZAI_CODING_API_KEY');
+      expect(output).toContain('Would set ai-worker variable: ZAI_CODING_API_KEY');
+    });
   });
 
   describe('environment validation', () => {

--- a/packages/tooling/src/deployment/setup-railway-variables.ts
+++ b/packages/tooling/src/deployment/setup-railway-variables.ts
@@ -88,6 +88,21 @@ const BOT_CLIENT_VARIABLES: VariableConfig[] = [
   },
 ];
 
+/**
+ * ZAI_CODING_API_KEY belongs on BOTH ai-worker and api-gateway — the worker
+ * bills z.ai extraction/free-tier calls with it, and the gateway's system-
+ * settings write validator checks it before accepting zai-coding values. An
+ * environment that carries it on only one service accepts settings it cannot
+ * serve (the bag mis-seed incident class). Declared once, listed in both
+ * service configs; a manifest test pins the pairing.
+ */
+const ZAI_CODING_KEY_VARIABLE: VariableConfig = {
+  key: 'ZAI_CODING_API_KEY',
+  description: 'z.ai coding-plan API key (extraction billing + guest free tier + write validation)',
+  isSecret: true,
+  required: false,
+};
+
 const API_GATEWAY_VARIABLES: VariableConfig[] = [
   {
     key: 'API_GATEWAY_PORT',
@@ -97,6 +112,7 @@ const API_GATEWAY_VARIABLES: VariableConfig[] = [
     required: true,
     defaultValue: '3000',
   },
+  ZAI_CODING_KEY_VARIABLE,
 ];
 
 const AI_WORKER_VARIABLES: VariableConfig[] = [
@@ -115,6 +131,7 @@ const AI_WORKER_VARIABLES: VariableConfig[] = [
     required: true,
     defaultValue: '3001',
   },
+  ZAI_CODING_KEY_VARIABLE,
 ];
 
 const ALL_SERVICE_CONFIGS: ServiceConfig[] = [


### PR DESCRIPTION
## What

Closes the `backlog/cold/follow-ups.md` row "ZAI_CODING_API_KEY belongs on BOTH services in the deploy manifest" — the structural residue of the system-settings bag mis-seed incident.

- `ZAI_CODING_KEY_VARIABLE` declared once, listed in **both** `API_GATEWAY_VARIABLES` and `AI_WORKER_VARIABLES` (`isSecret: true, required: false` — the z.ai free tier is an optional feature). The worker bills z.ai calls with it; the gateway's system-settings write validator checks it before accepting `zai-coding` values. Previously the manifest listed it on *neither* service — both Railway envs were hand-set, which is exactly how the gateway copy went missing and the write validator rejected the owner's dashboard edits.
- **Pinning test**: dry-run manifest test asserts the key appears for both services, so it can't quietly drop from either list (the structural-guard step of the remediation protocol).
- `extractionProvider` registry description now names the both-services requirement, per the follow-up's "note the per-service-env assumption" item.

## Verification

- `pnpm test` green (tooling 1485 incl. the new pin, full suite)
- `pnpm quality` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)