### PR TITLE
feat(ai-worker): shapes.inc fetch-layer hardening (bot detection, drift canary, phase-aware 401s)

### DIFF
--- a/services/ai-worker/src/jobs/shapesCredentials.test.ts
+++ b/services/ai-worker/src/jobs/shapesCredentials.test.ts
@@ -6,6 +6,7 @@ import {
 } from './shapesCredentials.js';
 import {
   ShapesAuthError,
+  ShapesBotProtectionError,
   ShapesFetchError,
   ShapesNotFoundError,
 } from '../services/shapes/shapesErrors.js';
@@ -139,6 +140,13 @@ describe('classifyShapesError', () => {
     const result = classifyShapesError(error);
     expect(result.isRetryable).toBe(false);
     expect(result.errorMessage).toBe('Forbidden');
+  });
+
+  it('should classify ShapesBotProtectionError as non-retryable (a bot wall does not clear on retry)', () => {
+    const error = new ShapesBotProtectionError("'x-datadome: protected' response header");
+    const result = classifyShapesError(error);
+    expect(result.isRetryable).toBe(false);
+    expect(result.errorMessage).toContain('bot-detection middleware');
   });
 
   it('should classify generic Error as retryable', () => {

--- a/services/ai-worker/src/jobs/shapesCredentials.ts
+++ b/services/ai-worker/src/jobs/shapesCredentials.ts
@@ -11,6 +11,7 @@ import { decryptApiKey, encryptApiKey } from '@tzurot/common-types/utils/encrypt
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import {
   ShapesAuthError,
+  ShapesBotProtectionError,
   ShapesFetchError,
   ShapesNotFoundError,
 } from '../services/shapes/shapesErrors.js';
@@ -79,7 +80,9 @@ interface ShapesErrorClassification {
 /**
  * Classify a shapes.inc error as retryable or non-retryable.
  *
- * Known non-retryable: ShapesAuthError, ShapesNotFoundError, ShapesFetchError.
+ * Known non-retryable: ShapesAuthError, ShapesNotFoundError, ShapesFetchError,
+ * ShapesBotProtectionError (a bot wall does not clear on retry — hammering it
+ * only makes the fingerprint worse).
  * Everything else (timeouts, network failures) defaults to retryable.
  */
 export function classifyShapesError(error: unknown): ShapesErrorClassification {
@@ -87,7 +90,8 @@ export function classifyShapesError(error: unknown): ShapesErrorClassification {
   const isNonRetryable =
     error instanceof ShapesAuthError ||
     error instanceof ShapesNotFoundError ||
-    error instanceof ShapesFetchError;
+    error instanceof ShapesFetchError ||
+    error instanceof ShapesBotProtectionError;
 
   return { isRetryable: !isNonRetryable, errorMessage };
 }

--- a/services/ai-worker/src/services/shapes/ShapesDataFetcher.test.ts
+++ b/services/ai-worker/src/services/shapes/ShapesDataFetcher.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ShapesDataFetcher } from './ShapesDataFetcher.js';
 import {
   ShapesAuthError,
+  ShapesBotProtectionError,
   ShapesNotFoundError,
   ShapesRateLimitError,
   ShapesServerError,
@@ -38,16 +39,20 @@ global.fetch = mockFetch;
 function createMockResponse(
   status: number,
   body: unknown,
-  setCookieHeaders: string[] = []
+  setCookieHeaders: string[] = [],
+  headerInit: Record<string, string> = {}
 ): Response {
-  const headers = new Headers();
-  // Headers.getSetCookie() needs the raw set-cookie values
+  // Real Headers instance backs get()/forEach() (bot-protection detection
+  // reads both); getSetCookie() is shimmed because undici's extension isn't
+  // on the standard Headers class.
+  const headers = new Headers(headerInit);
   const response = {
     ok: status >= 200 && status < 300,
     status,
     json: vi.fn().mockResolvedValue(body),
     headers: {
-      ...headers,
+      get: (name: string) => headers.get(name),
+      forEach: (callback: (value: string, key: string) => void) => headers.forEach(callback),
       getSetCookie: () => setCookieHeaders,
     },
   } as unknown as Response;
@@ -244,6 +249,116 @@ describe('ShapesDataFetcher', () => {
 
       expect(result.memories).toHaveLength(2);
       expect(result.stats.pagesTraversed).toBe(2);
+    });
+  });
+
+  describe('bot-protection detection', () => {
+    const COOKIE = '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-token-abcdef';
+
+    it('throws ShapesBotProtectionError (not AuthError) on a 403 carrying a mitigation header', async () => {
+      // A bot wall often presents as 403 — reporting it as an expired cookie
+      // would send the user re-harvesting for nothing.
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(403, { error: 'blocked' }, [], { 'x-datadome': 'protected' })
+      );
+
+      const promise = fetcher.fetchShapeData('test-shape', { sessionCookie: COOKIE });
+      const assertion = expect(promise).rejects.toThrow(ShapesBotProtectionError);
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+    });
+
+    it('throws ShapesBotProtectionError on cf-mitigated even with a 200 status', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(200, {}, [], { 'cf-mitigated': 'challenge' })
+      );
+
+      const promise = fetcher.fetchShapeData('test-shape', { sessionCookie: COOKIE });
+      const assertion = expect(promise).rejects.toThrow(ShapesBotProtectionError);
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+    });
+
+    it('throws ShapesBotProtectionError on an HTML content-type instead of an HTML-as-JSON parse error', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(200, '<html>challenge</html>', [], {
+          'content-type': 'text/html; charset=utf-8',
+        })
+      );
+
+      const promise = fetcher.fetchShapeData('test-shape', { sessionCookie: COOKIE });
+      const assertion = expect(promise).rejects.toThrow(ShapesBotProtectionError);
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+    });
+
+    it('does not retry a bot-protection failure (single fetch call)', async () => {
+      mockFetch.mockResolvedValue(
+        createMockResponse(403, { error: 'blocked' }, [], { 'x-datadome': 'protected' })
+      );
+
+      const promise = fetcher.fetchShapeData('test-shape', { sessionCookie: COOKIE });
+      const assertion = expect(promise).rejects.toThrow(ShapesBotProtectionError);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await assertion;
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('phase-aware auth failures', () => {
+    const COOKIE = '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-token-abcdef';
+
+    it('reports a FIRST-request 401 as a dead-on-arrival cookie with re-harvest guidance', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(401, { error: 'Unauthorized' }));
+
+      const promise = fetcher.fetchShapeData('test-shape', { sessionCookie: COOKIE });
+      const assertion = expect(promise).rejects.toThrow(/FIRST request.*Re-harvest/s);
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+    });
+
+    it('reports a mid-job 401 with the successful-request count and the memories page', async () => {
+      mockFetch
+        .mockResolvedValueOnce(createMockResponse(200, SAMPLE_CONFIG)) // config succeeds
+        .mockResolvedValueOnce(createMockResponse(401, { error: 'Unauthorized' })); // page 1 dies
+
+      const promise = fetcher.fetchShapeData('test-shape', { sessionCookie: COOKIE });
+      const assertion = expect(promise).rejects.toThrow(
+        /after 1 successful request\(s\).*expired mid-job.*memories traversal stopped at page 1/s
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+      await assertion;
+    });
+  });
+
+  describe('raw passthrough (schema-resilience invariant)', () => {
+    it('carries unknown top-level fields through to the fetch result untouched', async () => {
+      // The JSON export is the raw payload BECAUSE nothing on the fetch path
+      // strips fields — this pins that property so a future validator can't
+      // silently start dropping data users are entitled to.
+      const configWithUnknownFields = {
+        ...SAMPLE_CONFIG,
+        brand_new_field_we_have_never_seen: 'must survive',
+        nested_unknown: { keep: ['me'] },
+      };
+      mockFetch
+        .mockResolvedValueOnce(createMockResponse(200, configWithUnknownFields))
+        .mockResolvedValueOnce(
+          createMockResponse(200, { items: [SAMPLE_MEMORY], pagination: { has_next: false } })
+        )
+        .mockResolvedValueOnce(createMockResponse(200, [SAMPLE_STORY]))
+        .mockResolvedValueOnce(createMockResponse(200, SAMPLE_USER_PERSONALIZATION));
+
+      const promise = fetcher.fetchShapeData('test-shape', {
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      const rawConfig = result.config as Record<string, unknown>;
+      expect(rawConfig['brand_new_field_we_have_never_seen']).toBe('must survive');
+      expect(rawConfig['nested_unknown']).toEqual({ keep: ['me'] });
     });
   });
 

--- a/services/ai-worker/src/services/shapes/ShapesDataFetcher.ts
+++ b/services/ai-worker/src/services/shapes/ShapesDataFetcher.ts
@@ -25,12 +25,15 @@ import {
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import {
   ShapesAuthError,
+  ShapesBotProtectionError,
   ShapesFetchError,
   ShapesNotFoundError,
   ShapesRateLimitError,
   ShapesServerError,
 } from './shapesErrors.js';
 import { updateCookieFromResponse } from './shapesCookieParser.js';
+import { detectBotProtection } from './shapesBotProtection.js';
+import { observeShapesResponseShape } from './shapesResponseCanary.js';
 
 const logger = createLogger('ShapesDataFetcher');
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -80,6 +83,13 @@ export class ShapesDataFetcher {
   private currentCookie = '';
 
   /**
+   * Successful requests so far this fetch — distinguishes the two 401 modes:
+   * 0 means the harvested cookie was dead before the job started (re-harvest);
+   * >0 means the session expired mid-job (rare on a 7-day session).
+   */
+  private successfulRequests = 0;
+
+  /**
    * Fetch all data for a shape by username slug.
    *
    * @param slug - shapes.inc username (e.g., "lilith")
@@ -88,6 +98,7 @@ export class ShapesDataFetcher {
    */
   async fetchShapeData(slug: string, options: FetchOptions): Promise<ShapesDataFetchResult> {
     this.currentCookie = options.sessionCookie;
+    this.successfulRequests = 0;
 
     logger.info({ slug }, 'Starting data fetch');
 
@@ -155,7 +166,9 @@ export class ShapesDataFetcher {
     signal?: AbortSignal
   ): Promise<ShapesIncPersonalityConfig> {
     const url = `${SHAPES_BASE_URL}/api/shapes/username/${encodeURIComponent(slug)}`;
-    return this.makeRequest<ShapesIncPersonalityConfig>(url, signal);
+    const config = await this.makeRequest<ShapesIncPersonalityConfig>(url, signal);
+    observeShapesResponseShape('config', config);
+    return config;
   }
 
   private async fetchAllMemories(
@@ -177,7 +190,19 @@ export class ShapesDataFetcher {
         if (error instanceof ShapesNotFoundError) {
           break;
         }
+        // Mid-traversal auth failures carry the page number so a re-harvest
+        // can be judged against how much of the export was already fetched.
+        if (error instanceof ShapesAuthError) {
+          throw new ShapesAuthError(
+            `${error.message} [memories traversal stopped at page ${page}]`
+          );
+        }
         throw error;
+      }
+
+      // Page 1 only: drift affects every page identically — one warn suffices.
+      if (page === 1) {
+        observeShapesResponseShape('memoryPage', response);
       }
 
       const pageMemories = response.items ?? response.memories ?? [];
@@ -207,6 +232,7 @@ export class ShapesDataFetcher {
         url,
         signal
       );
+      observeShapesResponseShape('stories', response);
 
       if (Array.isArray(response)) {
         return response;
@@ -229,6 +255,7 @@ export class ShapesDataFetcher {
 
     try {
       const response = await this.makeRequest<ShapesIncUserPersonalization>(url, signal);
+      observeShapesResponseShape('userPersonalization', response);
 
       // Check if the response has meaningful data
       if (response.backstory === undefined && response.preferred_name === undefined) {
@@ -318,15 +345,23 @@ export class ShapesDataFetcher {
       // Update cookie from response headers
       this.currentCookie = updateCookieFromResponse(this.currentCookie, response);
 
+      // Bot-protection check runs BEFORE status handling: a 403 carrying a
+      // mitigation header is a bot wall, not an expired cookie — reporting it
+      // as an auth failure would send the user re-harvesting for nothing.
+      const botSignal = detectBotProtection(response);
+      if (botSignal !== null) {
+        throw new ShapesBotProtectionError(botSignal);
+      }
+
       if (response.ok) {
-        return (await response.json()) as T;
+        const body = (await response.json()) as T;
+        this.successfulRequests++;
+        return body;
       }
 
       // Handle specific error codes
       if (response.status === 401 || response.status === 403) {
-        throw new ShapesAuthError(
-          `Authentication failed (${response.status}). Session cookie may have expired.`
-        );
+        throw new ShapesAuthError(this.buildAuthFailureMessage(response.status));
       }
 
       if (response.status === 404) {
@@ -352,6 +387,30 @@ export class ShapesDataFetcher {
       clearTimeout(timeout);
       externalSignal?.removeEventListener('abort', onAbort);
     }
+  }
+
+  /**
+   * Phase-aware auth-failure message — the three 401 modes need different
+   * user actions, so they must read differently:
+   * - first request: the harvested cookie was dead before the job started
+   * - mid-job: the session expired during the fetch (rare on 7-day sessions)
+   * - fresh cookie still failing immediately: likely another cookie-scheme
+   *   migration (human investigation, not re-harvesting)
+   */
+  private buildAuthFailureMessage(status: number): string {
+    if (this.successfulRequests === 0) {
+      return (
+        `Authentication failed (${status}) on the FIRST request — the session cookie was ` +
+        'expired or invalid before the job started. Re-harvest it from a logged-in ' +
+        'shapes.inc browser session. If a freshly-harvested cookie also fails immediately, ' +
+        'the cookie scheme may have changed again and needs investigation.'
+      );
+    }
+    return (
+      `Authentication failed (${status}) after ${this.successfulRequests} successful ` +
+      'request(s) — the session expired mid-job. Re-harvest the cookie and re-run the ' +
+      'job (it restarts from the beginning).'
+    );
   }
 
   /**

--- a/services/ai-worker/src/services/shapes/shapesBotProtection.test.ts
+++ b/services/ai-worker/src/services/shapes/shapesBotProtection.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for bot-protection detection on shapes.inc responses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectBotProtection } from './shapesBotProtection.js';
+
+function responseWithHeaders(headerInit: Record<string, string>, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headerInit),
+  } as unknown as Response;
+}
+
+describe('detectBotProtection', () => {
+  it('returns null for a normal JSON response', () => {
+    expect(
+      detectBotProtection(responseWithHeaders({ 'content-type': 'application/json' }))
+    ).toBeNull();
+  });
+
+  it('returns null when no relevant headers are present at all', () => {
+    expect(detectBotProtection(responseWithHeaders({}))).toBeNull();
+  });
+
+  it('does NOT treat cf-ray alone as a signal (present on all Cloudflare-proxied traffic)', () => {
+    expect(
+      detectBotProtection(
+        responseWithHeaders({
+          'cf-ray': '8f1a2b3c4d5e6f70-EWR',
+          'content-type': 'application/json',
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('detects Cloudflare active mitigation via cf-mitigated', () => {
+    const signal = detectBotProtection(responseWithHeaders({ 'cf-mitigated': 'challenge' }));
+    expect(signal).toContain('cf-mitigated');
+    expect(signal).toContain('challenge');
+  });
+
+  it('detects Datadome via x-datadome', () => {
+    expect(detectBotProtection(responseWithHeaders({ 'x-datadome': 'protected' }))).toContain(
+      'x-datadome'
+    );
+  });
+
+  it('detects PerimeterX via any x-px* header', () => {
+    expect(detectBotProtection(responseWithHeaders({ 'x-px-block': '1' }))).toContain('x-px-block');
+    expect(detectBotProtection(responseWithHeaders({ 'x-pxhd': 'abc' }))).toContain('x-pxhd');
+  });
+
+  it('detects the Datadome header FAMILY, not just the bare name', () => {
+    expect(detectBotProtection(responseWithHeaders({ 'x-datadome-cid': 'abc' }))).toContain(
+      'x-datadome-cid'
+    );
+  });
+
+  it('detects an HTML block page on a JSON endpoint via content-type', () => {
+    const signal = detectBotProtection(
+      responseWithHeaders({ 'content-type': 'text/html; charset=utf-8' })
+    );
+    expect(signal).toContain('HTML response');
+  });
+
+  it('detects an HTML block page on a 403 (auth-shaped block)', () => {
+    const signal = detectBotProtection(responseWithHeaders({ 'content-type': 'text/html' }, 403));
+    expect(signal).toContain('HTML response');
+  });
+
+  it('does NOT treat an HTML error page on a transient 5xx/429 as a bot wall', () => {
+    // nginx/CDN default error pages are HTML — a 502 with an HTML body must
+    // stay a retryable server error, not a hard bot-protection failure. Real
+    // challenges on those statuses announce themselves via vendor headers.
+    expect(
+      detectBotProtection(responseWithHeaders({ 'content-type': 'text/html' }, 502))
+    ).toBeNull();
+    expect(
+      detectBotProtection(responseWithHeaders({ 'content-type': 'text/html' }, 429))
+    ).toBeNull();
+  });
+
+  it('still detects vendor headers regardless of status (headers beat status)', () => {
+    expect(
+      detectBotProtection(responseWithHeaders({ 'cf-mitigated': 'challenge' }, 503))
+    ).toContain('cf-mitigated');
+  });
+});

--- a/services/ai-worker/src/services/shapes/shapesBotProtection.ts
+++ b/services/ai-worker/src/services/shapes/shapesBotProtection.ts
@@ -1,0 +1,67 @@
+/**
+ * Bot-protection detection for shapes.inc responses.
+ *
+ * Checks a response for signals that shapes.inc has put bot-detection
+ * middleware in front of the API. Vendors announce themselves in headers:
+ * Cloudflare active mitigation (`cf-mitigated`), Datadome (`x-datadome*`,
+ * e.g. `x-datadome-cid`), PerimeterX (`x-px*`), or an HTML block/challenge
+ * page served where JSON was expected.
+ *
+ * Deliberately NOT a signal: `cf-ray`. It is present on every response that
+ * transits Cloudflare — including perfectly healthy 200s from any CF-proxied
+ * origin — so treating its presence as a block would false-positive on
+ * normal traffic the moment shapes.inc fronts with Cloudflare at all. Only
+ * the active-mitigation marker means a challenge fired.
+ */
+
+/** Headers whose exact presence means active bot mitigation. */
+const MITIGATION_HEADERS_EXACT = ['cf-mitigated'] as const;
+
+/**
+ * Header-name prefixes for vendors that use a header FAMILY rather than one
+ * fixed name (PerimeterX: x-px-block, x-pxhd, …; Datadome: x-datadome,
+ * x-datadome-cid, …).
+ */
+const MITIGATION_HEADER_PREFIXES = ['x-px', 'x-datadome'] as const;
+
+/**
+ * Inspect a response for bot-protection signals.
+ *
+ * @returns a human-readable description of the detected signal, or null when
+ *   the response looks like normal API traffic.
+ */
+export function detectBotProtection(response: Response): string | null {
+  for (const header of MITIGATION_HEADERS_EXACT) {
+    const value = response.headers.get(header);
+    if (value !== null) {
+      return `'${header}: ${value}' response header`;
+    }
+  }
+
+  let familyHeader: string | null = null;
+  response.headers.forEach((_value, name) => {
+    const lowered = name.toLowerCase();
+    if (MITIGATION_HEADER_PREFIXES.some(prefix => lowered.startsWith(prefix))) {
+      familyHeader = name;
+    }
+  });
+  if (familyHeader !== null) {
+    return `'${String(familyHeader)}' response header`;
+  }
+
+  // An HTML body where JSON was expected is a challenge/block page — but ONLY
+  // on responses that would otherwise read as success or an auth-shaped 403.
+  // Transient 429/5xx commonly serve default HTML error pages (nginx, CDN
+  // maintenance) and must keep their retryable classification; a real
+  // challenge on those statuses announces itself via the vendor headers
+  // above. Missing content-type stays quiet — only an explicit HTML type is
+  // a signal.
+  if (response.ok || response.status === 403) {
+    const contentType = response.headers.get('content-type');
+    if (contentType?.toLowerCase().includes('text/html') === true) {
+      return `HTML response ('content-type: ${contentType}') from a JSON endpoint`;
+    }
+  }
+
+  return null;
+}

--- a/services/ai-worker/src/services/shapes/shapesErrors.test.ts
+++ b/services/ai-worker/src/services/shapes/shapesErrors.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   ShapesAuthError,
+  ShapesBotProtectionError,
   ShapesNotFoundError,
   ShapesRateLimitError,
   ShapesServerError,
@@ -56,6 +57,17 @@ describe('ShapesFetchError', () => {
     expect(error.name).toBe('ShapesFetchError');
     expect(error.message).toBe('Unprocessable');
     expect(error.status).toBe(422);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe('ShapesBotProtectionError', () => {
+  it('should set name and weave the detected signal into the guidance message', () => {
+    const error = new ShapesBotProtectionError("'x-datadome: protected' response header");
+    expect(error.name).toBe('ShapesBotProtectionError');
+    expect(error.message).toContain("'x-datadome: protected' response header");
+    expect(error.message).toContain('bot-detection middleware');
+    expect(error.message).toContain('Retrying will not help');
     expect(error).toBeInstanceOf(Error);
   });
 });

--- a/services/ai-worker/src/services/shapes/shapesErrors.ts
+++ b/services/ai-worker/src/services/shapes/shapesErrors.ts
@@ -11,10 +11,11 @@
  *
  * **Tier 2 — Per-job (BullMQ via ShapesExportJob/ShapesImportJob):**
  * If all per-request retries are exhausted, the error propagates to the job
- * handler. Only ShapesAuthError, ShapesNotFoundError, and ShapesFetchError
- * are non-retryable (immediate failure). Everything else — including
- * ShapesRateLimitError and ShapesServerError that survived per-request
- * retries — triggers a BullMQ job-level retry (restarts from page 1).
+ * handler. Only ShapesAuthError, ShapesNotFoundError, ShapesFetchError, and
+ * ShapesBotProtectionError are non-retryable (immediate failure). Everything
+ * else — including ShapesRateLimitError and ShapesServerError that survived
+ * per-request retries — triggers a BullMQ job-level retry (restarts from
+ * page 1).
  */
 
 export class ShapesAuthError extends Error {
@@ -53,5 +54,24 @@ export class ShapesFetchError extends Error {
     super(message);
     this.name = 'ShapesFetchError';
     this.status = status;
+  }
+}
+
+/**
+ * shapes.inc appears to have put bot-detection middleware in front of the
+ * API (Cloudflare mitigation, PerimeterX, Datadome, or an HTML block page on
+ * a JSON endpoint). Distinct from ShapesAuthError so the failure mode is
+ * obvious instead of surfacing as a confusing 403 or an HTML-as-JSON parse
+ * error — the day this starts firing is the day the session-cookie fetch
+ * path needs a human decision, so it must never be masked by retries.
+ */
+export class ShapesBotProtectionError extends Error {
+  constructor(signal: string) {
+    super(
+      `shapes.inc appears to have added bot-detection middleware (${signal}); ` +
+        'the session-cookie fetch path may no longer be viable. Retrying will not help — ' +
+        'this needs investigation.'
+    );
+    this.name = 'ShapesBotProtectionError';
   }
 }

--- a/services/ai-worker/src/services/shapes/shapesResponseCanary.test.ts
+++ b/services/ai-worker/src/services/shapes/shapesResponseCanary.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the shapes.inc schema-drift canary.
+ *
+ * The load-bearing property is OBSERVE-ONLY: the canary warns on drift and
+ * never throws, no matter how mangled the payload — a drifted export must
+ * still complete with whatever data the API returned.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const warnSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { observeShapesResponseShape } from './shapesResponseCanary.js';
+
+const COMPLETE_CONFIG = {
+  id: 'shape-1',
+  name: 'Test',
+  username: 'test',
+  avatar: 'https://example.test/a.png',
+  jailbreak: 'jb',
+  user_prompt: 'up',
+  personality_traits: 'traits',
+  engine_model: 'model-x',
+  engine_temperature: 0.7,
+  stm_window: 10,
+  ltm_enabled: true,
+  ltm_threshold: 0.5,
+  ltm_max_retrieved_summaries: 5,
+};
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
+describe('observeShapesResponseShape', () => {
+  describe('config', () => {
+    it('stays silent on a complete config', () => {
+      observeShapesResponseShape('config', COMPLETE_CONFIG);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns with the missing field names when required fields are absent', () => {
+      const { jailbreak: _jb, engine_model: _em, ...drifted } = COMPLETE_CONFIG;
+      observeShapesResponseShape('config', drifted);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'config',
+          detail: { missing: ['jailbreak', 'engine_model'] },
+        }),
+        expect.stringContaining('drifted')
+      );
+    });
+
+    it('warns (and does not throw) on a non-object payload', () => {
+      expect(() => observeShapesResponseShape('config', 'not json at all')).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('memoryPage', () => {
+    it('stays silent when items + pagination are present', () => {
+      observeShapesResponseShape('memoryPage', { items: [], pagination: { has_next: false } });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("accepts the legacy 'memories' array key", () => {
+      observeShapesResponseShape('memoryPage', { memories: [], pagination: {} });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns when neither items nor memories is an array', () => {
+      observeShapesResponseShape('memoryPage', { pagination: {} });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns when pagination is missing (traversal may stop early)', () => {
+      observeShapesResponseShape('memoryPage', { items: [] });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stories', () => {
+    it('accepts a bare array', () => {
+      observeShapesResponseShape('stories', []);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('accepts an object with an items array', () => {
+      observeShapesResponseShape('stories', { items: [] });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns on an unrecognizable shape', () => {
+      observeShapesResponseShape('stories', { items: 'nope' });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('userPersonalization', () => {
+    it('accepts any object', () => {
+      observeShapesResponseShape('userPersonalization', {});
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns on a non-object', () => {
+      observeShapesResponseShape('userPersonalization', 42);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('never throws on adversarial payloads (observe-only invariant)', () => {
+    const garbage: unknown[] = [null, undefined, 0, '', [], () => {}, Symbol('x')];
+    for (const kind of ['config', 'memoryPage', 'stories', 'userPersonalization'] as const) {
+      for (const payload of garbage) {
+        expect(() => observeShapesResponseShape(kind, payload)).not.toThrow();
+      }
+    }
+  });
+});

--- a/services/ai-worker/src/services/shapes/shapesResponseCanary.ts
+++ b/services/ai-worker/src/services/shapes/shapesResponseCanary.ts
@@ -1,0 +1,123 @@
+/**
+ * Schema-drift canary for shapes.inc API responses.
+ *
+ * shapes.inc is an external API with no contract: a field rename or a
+ * restructured payload would previously make the fetcher silently succeed
+ * with partial data, and users would not learn their export was incomplete
+ * until they tried to use it. The canary checks each endpoint's TOP-LEVEL
+ * response shape and logs a warning when expected fields are missing.
+ *
+ * OBSERVE-ONLY BY DESIGN — the canary never throws and never transforms the
+ * payload. Two invariants depend on that:
+ *
+ * 1. Partial data beats no data: the export must still complete with
+ *    whatever the API returned (a warn tells us the contract drifted so the
+ *    types can be updated).
+ * 2. Raw passthrough: nothing on the fetch path strips unknown fields
+ *    (`response.json() as T` is a type-level cast), so the JSON export is
+ *    the raw payload — users get fields we have not surfaced. A validator
+ *    that replaced the payload (Zod strip mode) would silently break that.
+ */
+
+import { createLogger } from '@tzurot/common-types/utils/logger';
+
+const logger = createLogger('ShapesResponseCanary');
+
+/** Which endpoint's shape is being observed. */
+export type ShapesEndpointKind = 'config' | 'memoryPage' | 'stories' | 'userPersonalization';
+
+/**
+ * Required top-level keys of ShapesIncPersonalityConfig (the interface's
+ * non-optional fields). Kept as a literal list because the interface carries
+ * a string index signature, which makes a `keyof`-based tie-in vacuous —
+ * update this list when the interface's required surface changes.
+ */
+const CONFIG_REQUIRED_KEYS = [
+  'id',
+  'name',
+  'username',
+  'avatar',
+  'jailbreak',
+  'user_prompt',
+  'personality_traits',
+  'engine_model',
+  'engine_temperature',
+  'stm_window',
+  'ltm_enabled',
+  'ltm_threshold',
+  'ltm_max_retrieved_summaries',
+] as const;
+
+const NOT_AN_OBJECT = 'response is not an object';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function warnDrift(kind: ShapesEndpointKind, problem: string, detail?: unknown): void {
+  logger.warn(
+    { endpoint: kind, problem, detail },
+    'shapes.inc response shape drifted — continuing with available data; update the types'
+  );
+}
+
+function observeConfigShape(payload: unknown): void {
+  if (!isRecord(payload)) {
+    warnDrift('config', NOT_AN_OBJECT);
+    return;
+  }
+  const missing = CONFIG_REQUIRED_KEYS.filter(key => payload[key] === undefined);
+  if (missing.length > 0) {
+    warnDrift('config', 'expected top-level fields missing', { missing });
+  }
+}
+
+function observeMemoryPageShape(payload: unknown): void {
+  if (!isRecord(payload)) {
+    warnDrift('memoryPage', NOT_AN_OBJECT);
+    return;
+  }
+  const hasItemsArray = Array.isArray(payload.items) || Array.isArray(payload.memories);
+  if (!hasItemsArray) {
+    warnDrift('memoryPage', "neither 'items' nor 'memories' is an array");
+  }
+  if (payload.pagination === undefined) {
+    warnDrift('memoryPage', "'pagination' field missing — page traversal may stop early");
+  }
+}
+
+function observeStoriesShape(payload: unknown): void {
+  if (Array.isArray(payload)) {
+    return;
+  }
+  if (isRecord(payload) && (payload.items === undefined || Array.isArray(payload.items))) {
+    return;
+  }
+  warnDrift('stories', "response is neither an array nor an object with an 'items' array");
+}
+
+function observeUserPersonalizationShape(payload: unknown): void {
+  if (!isRecord(payload)) {
+    warnDrift('userPersonalization', NOT_AN_OBJECT);
+  }
+}
+
+/**
+ * Observe an endpoint response's top-level shape; warn on drift, never throw.
+ */
+export function observeShapesResponseShape(kind: ShapesEndpointKind, payload: unknown): void {
+  switch (kind) {
+    case 'config':
+      observeConfigShape(payload);
+      return;
+    case 'memoryPage':
+      observeMemoryPageShape(payload);
+      return;
+    case 'stories':
+      observeStoriesShape(payload);
+      return;
+    case 'userPersonalization':
+      observeUserPersonalizationShape(payload);
+      return;
+  }
+}


### PR DESCRIPTION
## What

Items 1, 2, 3, and 6 of the [shapes-inc fetcher hardening theme](../blob/develop/backlog/cold/themes/shapes-inc-fetcher-hardening.md) — bundled because in today's code they all converge on one concern, the fetcher's response layer (the April proposal assumed more spread).

### Bot-protection detection (item 3)
`detectBotProtection` checks every response for vendor mitigation markers (`cf-mitigated`, `x-datadome`, any `x-px*`) and HTML content-types on JSON endpoints → distinct `ShapesBotProtectionError`, non-retryable at **both** retry tiers (per-request and BullMQ job — a bot wall doesn't clear on retry). The check runs before status handling so a 403 carrying a mitigation header reads as a bot wall, not an expired cookie.

**Deliberate divergence from the proposal**: `cf-ray` is NOT a trigger — it's present on every Cloudflare-proxied response including healthy 200s, so using it would false-positive the moment shapes.inc fronts with CF at all. Only active-mitigation markers signal.

### Schema-drift canary (item 1) + raw passthrough (item 2)
`observeShapesResponseShape` checks each endpoint's top-level shape and `warn`s on drift — **observe-only by design**: it never throws (partial data beats no data) and never transforms the payload. That second property is item 2 delivered by construction: nothing on the fetch path strips unknown fields (`response.json() as T` is type-level only) and `formatExportAsJson` is a plain stringify, so the JSON export already IS the raw payload. A passthrough test pins unknown-field survival so a future validator can't silently break it.

### Phase-aware 401s (item 6, diagnostic half)
- First-request 401: "cookie was dead before the job started — re-harvest; if a fresh cookie also fails immediately, the scheme may have changed again."
- Mid-job 401: successful-request count + the memories page reached (`[memories traversal stopped at page N]`).
- The resume-from-page feature the proposal bundles into 6(b) is deliberately NOT built — filed as the theme's one residual (follow-ups row lands with the theme close-out).

## Tests

28 new: `shapesBotProtection.test.ts` (7 — including the cf-ray non-trigger pin), `shapesResponseCanary.test.ts` (14 — including the never-throws adversarial sweep), fetcher tests (6 — bot/auth-phase/passthrough; mock factory upgraded to real-Headers-backed `get`/`forEach`), classifier (1).

- `pnpm test` green (ai-worker 3882, full suite)
- `pnpm quality` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)