### PR TITLE
feat(ai-worker): global concurrency gate for shapes.inc fetch jobs

### DIFF
--- a/packages/common-types/src/constants/redis-keys.ts
+++ b/packages/common-types/src/constants/redis-keys.ts
@@ -29,6 +29,14 @@ export const CACHE_KEY_PREFIXES = {
    */
   VISION_SYSTEM_FALLBACK_QUOTA: 'visionfallback:system:',
   /**
+   * Global concurrency counter for shapes.inc fetch jobs (import + export) —
+   * a single counter (prefix + fixed 'active' suffix) capping simultaneous
+   * fetches from one egress IP. Low-and-slow etiquette, not correctness:
+   * fail-open, TTL-bounded against crashed-worker slot leaks.
+   * Consumers: `ai-worker/shapes/shapesFetchGate`.
+   */
+  SHAPES_FETCH_GATE: 'shapes:fetchgate:',
+  /**
    * Rolling-window contention set for the shared-free-key fair-share quota — a
    * ZSET of userId→last-request-ms for users who consumed the free key within
    * the window. Its cardinality is the divisor N that shrinks each user's cap.

--- a/services/ai-worker/src/jobs/AIJobProcessor.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.ts
@@ -40,7 +40,7 @@ import {
   type ConfigCascadeResolver,
 } from '@tzurot/config-resolver';
 import { type PersonaResolver } from '@tzurot/identity';
-import { redisService } from '../redis.js';
+import { redisService, shapesFetchGate } from '../redis.js';
 import { cleanupOldJobResults } from './CleanupJobResults.js';
 import { processAudioTranscriptionJob } from './AudioTranscriptionJob.js';
 import { processImageDescriptionJob } from './ImageDescriptionJob.js';
@@ -489,6 +489,7 @@ export class AIJobProcessor {
     return processShapesImportJob(job, {
       prisma: this.prisma,
       memoryAdapter: this.memoryManager,
+      fetchGate: shapesFetchGate,
     });
   }
 
@@ -504,6 +505,7 @@ export class AIJobProcessor {
   ): Promise<ShapesExportJobResult> {
     return processShapesExportJob(job, {
       prisma: this.prisma,
+      fetchGate: shapesFetchGate,
     });
   }
 }

--- a/services/ai-worker/src/jobs/ShapesExportJob.test.ts
+++ b/services/ai-worker/src/jobs/ShapesExportJob.test.ts
@@ -314,3 +314,92 @@ describe('ShapesExportJob', () => {
     expect(updateCalls[1][0].data.status).toBe('failed');
   });
 });
+
+describe('ShapesExportJob fetch-concurrency gate', () => {
+  function createMockGate(acquireResult: 'acquired' | 'denied' | 'fail-open'): {
+    gate: import('../services/shapes/shapesFetchGate.js').ShapesFetchGate;
+    tryAcquire: ReturnType<typeof vi.fn>;
+    release: ReturnType<typeof vi.fn>;
+  } {
+    const tryAcquire = vi.fn().mockResolvedValue(acquireResult);
+    const release = vi.fn().mockResolvedValue(undefined);
+    return {
+      gate: {
+        tryAcquire,
+        release,
+        maxConcurrent: 2,
+      } as unknown as import('../services/shapes/shapesFetchGate.js').ShapesFetchGate,
+      tryAcquire,
+      release,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchShapeData.mockResolvedValue(mockFetchResult);
+  });
+
+  it('acquires before fetching and releases after success', async () => {
+    const { gate, tryAcquire, release } = createMockGate('acquired');
+    const job = createMockJob();
+
+    const result = await processShapesExportJob(job, {
+      prisma: mockPrisma as never,
+      fetchGate: gate,
+    });
+
+    expect(result.success).toBe(true);
+    expect(tryAcquire).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+    // Acquire happened before any shapes.inc traffic
+    expect(tryAcquire.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFetchShapeData.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('releases the slot even when the fetch throws (finally path)', async () => {
+    const { gate, release } = createMockGate('acquired');
+    mockFetchShapeData.mockRejectedValue(new Error('boom'));
+    // attempts: 3 → retryable generic error rethrows for BullMQ retry
+    const job = createMockJob({}, { attemptsMade: 0, attempts: 3 });
+
+    await expect(
+      processShapesExportJob(job, { prisma: mockPrisma as never, fetchGate: gate })
+    ).rejects.toThrow('boom');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws retryable busy when the gate denies (BullMQ backoff is the wait) and holds nothing', async () => {
+    const { gate, release } = createMockGate('denied');
+    const job = createMockJob({}, { attemptsMade: 0, attempts: 3 });
+
+    await expect(
+      processShapesExportJob(job, { prisma: mockPrisma as never, fetchGate: gate })
+    ).rejects.toThrow(/Too many simultaneous shapes\.inc fetches/);
+    // No shapes.inc traffic and no release for a slot never held
+    expect(mockFetchShapeData).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('marks the export failed with the busy message once retries are exhausted', async () => {
+    const { gate } = createMockGate('denied');
+    // Final attempt: attemptsMade=2 of attempts=3 → no retries remain
+    const job = createMockJob({}, { attemptsMade: 2, attempts: 3 });
+
+    const result = await processShapesExportJob(job, {
+      prisma: mockPrisma as never,
+      fetchGate: gate,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Too many simultaneous shapes\.inc fetches/);
+    const updateCalls = mockPrisma.exportJob.update.mock.calls;
+    expect(updateCalls[updateCalls.length - 1][0].data.status).toBe('failed');
+  });
+
+  it('runs ungated when no gate is supplied (fail-open posture)', async () => {
+    const job = createMockJob();
+    const result = await processShapesExportJob(job, { prisma: mockPrisma as never });
+    expect(result.success).toBe(true);
+  });
+});

--- a/services/ai-worker/src/jobs/ShapesExportJob.ts
+++ b/services/ai-worker/src/jobs/ShapesExportJob.ts
@@ -17,14 +17,21 @@ import {
 } from '@tzurot/common-types/types/shapes-import';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { ShapesDataFetcher } from '../services/shapes/ShapesDataFetcher.js';
+import type { ShapesFetchGate } from '../services/shapes/shapesFetchGate.js';
 import { formatExportAsMarkdown, formatExportAsJson } from './ShapesExportFormatters.js';
 import { getDecryptedCookie, persistUpdatedCookie } from './shapesCredentials.js';
-import { handleShapesJobError } from './shapesJobHelpers.js';
+import { claimShapesFetchSlot, handleShapesJobError } from './shapesJobHelpers.js';
 
 const logger = createLogger('ShapesExportJob');
 
 interface ShapesExportJobDeps {
   prisma: PrismaClient;
+  /**
+   * Global fetch-concurrency gate (low-and-slow etiquette). Optional and
+   * fail-open by design — absent means ungated, matching the gate's own
+   * degrade-gracefully posture.
+   */
+  fetchGate?: ShapesFetchGate;
 }
 
 /**
@@ -34,7 +41,7 @@ export async function processShapesExportJob(
   job: Job<ShapesExportJobData>,
   deps: ShapesExportJobDeps
 ): Promise<ShapesExportJobResult> {
-  const { prisma } = deps;
+  const { prisma, fetchGate } = deps;
   const { userId, sourceSlug, exportJobId, format } = job.data;
 
   logger.info({ jobId: job.id, sourceSlug, format, exportJobId }, 'Starting export');
@@ -46,16 +53,21 @@ export async function processShapesExportJob(
   });
 
   let fetcher: ShapesDataFetcher | null = null;
+  let gateHeld = false;
   try {
-    // 2. Decrypt session cookie
+    // 2. Claim a global fetch slot BEFORE any shapes.inc traffic (busy throws
+    // retryable — BullMQ's backoff is the wait; see claimShapesFetchSlot).
+    gateHeld = await claimShapesFetchSlot(fetchGate);
+
+    // 3. Decrypt session cookie
     const sessionCookie = await getDecryptedCookie(prisma, userId);
 
-    // 3. Fetch data from shapes.inc
+    // 4. Fetch data from shapes.inc
     fetcher = new ShapesDataFetcher();
     const fetchResult = await fetcher.fetchShapeData(sourceSlug, { sessionCookie });
     await persistUpdatedCookie(prisma, userId, fetcher.getUpdatedCookie());
 
-    // 4. Format export content
+    // 5. Format export content
     const exportPayload = {
       exportedAt: new Date().toISOString(),
       sourceSlug,
@@ -80,7 +92,7 @@ export async function processShapesExportJob(
     const fileExtension = format === 'markdown' ? 'md' : 'json';
     const fileName = `${sourceSlug}-export.${fileExtension}`;
 
-    // 5. Store result in ExportJob
+    // 6. Store result in ExportJob
     await prisma.exportJob.update({
       where: { id: exportJobId },
       data: {
@@ -133,5 +145,11 @@ export async function processShapesExportJob(
         error: errorMessage,
       }),
     });
+  } finally {
+    // Only release a slot that was actually claimed — a denied acquire holds
+    // nothing, and double-releasing would over-admit the next jobs.
+    if (gateHeld) {
+      await deps.fetchGate?.release();
+    }
   }
 }

--- a/services/ai-worker/src/jobs/ShapesImportJob.test.ts
+++ b/services/ai-worker/src/jobs/ShapesImportJob.test.ts
@@ -664,3 +664,76 @@ describe('slug sanitization seam', () => {
     expect(mockNormalizeSlugForUser).toHaveBeenCalledWith('s-123shape', 'discord-123', 'testuser');
   });
 });
+
+describe('ShapesImportJob fetch-concurrency gate', () => {
+  function createMockGate(acquireResult: 'acquired' | 'denied' | 'fail-open'): {
+    gate: import('../services/shapes/shapesFetchGate.js').ShapesFetchGate;
+    tryAcquire: ReturnType<typeof vi.fn>;
+    release: ReturnType<typeof vi.fn>;
+  } {
+    const tryAcquire = vi.fn().mockResolvedValue(acquireResult);
+    const release = vi.fn().mockResolvedValue(undefined);
+    return {
+      gate: {
+        tryAcquire,
+        release,
+        maxConcurrent: 2,
+      } as unknown as import('../services/shapes/shapesFetchGate.js').ShapesFetchGate,
+      tryAcquire,
+      release,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws retryable busy when the gate denies — no fetch, nothing to release', async () => {
+    const { gate, release } = createMockGate('denied');
+    const job = createMockJob({}, { attemptsMade: 0, attempts: 3 });
+
+    await expect(
+      processShapesImportJob(job, {
+        prisma: mockPrisma as never,
+        memoryAdapter: mockMemoryAdapter as never,
+        fetchGate: gate,
+      })
+    ).rejects.toThrow(/Too many simultaneous shapes\.inc fetches/);
+    expect(mockFetchShapeData).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('releases the claimed slot even when the fetch throws (finally path)', async () => {
+    const { gate, tryAcquire, release } = createMockGate('acquired');
+    mockFetchShapeData.mockRejectedValue(new Error('boom'));
+    const job = createMockJob({}, { attemptsMade: 0, attempts: 3 });
+
+    await expect(
+      processShapesImportJob(job, {
+        prisma: mockPrisma as never,
+        memoryAdapter: mockMemoryAdapter as never,
+        fetchGate: gate,
+      })
+    ).rejects.toThrow('boom');
+    expect(tryAcquire).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('proceeds on fail-open but never releases the slot it does not hold', async () => {
+    const { gate, release } = createMockGate('fail-open');
+    mockFetchShapeData.mockRejectedValue(new Error('boom'));
+    const job = createMockJob({}, { attemptsMade: 0, attempts: 3 });
+
+    await expect(
+      processShapesImportJob(job, {
+        prisma: mockPrisma as never,
+        memoryAdapter: mockMemoryAdapter as never,
+        fetchGate: gate,
+      })
+    ).rejects.toThrow('boom');
+    // The fetch ran (fail-open allows the job) but no slot was counted, so
+    // releasing would steal a legitimately-held slot from another job.
+    expect(mockFetchShapeData).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+  });
+});

--- a/services/ai-worker/src/jobs/ShapesImportJob.ts
+++ b/services/ai-worker/src/jobs/ShapesImportJob.ts
@@ -26,8 +26,9 @@ import {
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { normalizeSlugForUser, sanitizeExternalSlug } from '@tzurot/common-types/utils/slugUtils';
 import { ShapesDataFetcher } from '../services/shapes/ShapesDataFetcher.js';
+import type { ShapesFetchGate } from '../services/shapes/shapesFetchGate.js';
 import { getDecryptedCookie, persistUpdatedCookie } from './shapesCredentials.js';
-import { handleShapesJobError } from './shapesJobHelpers.js';
+import { claimShapesFetchSlot, handleShapesJobError } from './shapesJobHelpers.js';
 import { downloadAndStoreAvatar } from './ShapesImportHelpers.js';
 import { importMemories } from './ShapesImportMemories.js';
 import { resolvePersonality } from './ShapesImportResolver.js';
@@ -38,6 +39,12 @@ const logger = createLogger('ShapesImportJob');
 interface ShapesImportJobDeps {
   prisma: PrismaClient;
   memoryAdapter: PgvectorMemoryAdapter;
+  /**
+   * Global fetch-concurrency gate (low-and-slow etiquette). Optional and
+   * fail-open by design — absent means ungated, matching the gate's own
+   * degrade-gracefully posture.
+   */
+  fetchGate?: ShapesFetchGate;
 }
 
 /**
@@ -47,7 +54,7 @@ export async function processShapesImportJob(
   job: Job<ShapesImportJobData>,
   deps: ShapesImportJobDeps
 ): Promise<ShapesImportJobResult> {
-  const { prisma, memoryAdapter } = deps;
+  const { prisma, memoryAdapter, fetchGate } = deps;
   const { userId, discordUserId, sourceSlug, importJobId, importType } = job.data;
 
   logger.info({ jobId: job.id, sourceSlug, importType, userId: discordUserId }, 'Starting import');
@@ -56,7 +63,12 @@ export async function processShapesImportJob(
   await updateImportJobStatus(prisma, importJobId, 'in_progress');
 
   let fetcher: ShapesDataFetcher | null = null;
+  let gateHeld = false;
   try {
+    // Claim a global fetch slot BEFORE any shapes.inc traffic (busy throws
+    // retryable — BullMQ's backoff is the wait; see claimShapesFetchSlot).
+    gateHeld = await claimShapesFetchSlot(fetchGate);
+
     // 2. Decrypt session cookie — fail fast on expired/missing credentials
     const sessionCookie = await getDecryptedCookie(prisma, userId);
 
@@ -159,6 +171,12 @@ export async function processShapesImportJob(
       await persistUpdatedCookie(prisma, userId, fetcher.getUpdatedCookie());
     }
     return handleImportJobError({ error, prisma, importJobId, importType, job, sourceSlug });
+  } finally {
+    // Only release a slot that was actually claimed — a denied acquire holds
+    // nothing, and double-releasing would over-admit the next jobs.
+    if (gateHeld) {
+      await deps.fetchGate?.release();
+    }
   }
 }
 

--- a/services/ai-worker/src/jobs/shapesCredentials.test.ts
+++ b/services/ai-worker/src/jobs/shapesCredentials.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   ShapesAuthError,
   ShapesBotProtectionError,
+  ShapesFetchBusyError,
   ShapesFetchError,
   ShapesNotFoundError,
 } from '../services/shapes/shapesErrors.js';
@@ -147,6 +148,13 @@ describe('classifyShapesError', () => {
     const result = classifyShapesError(error);
     expect(result.isRetryable).toBe(false);
     expect(result.errorMessage).toContain('bot-detection middleware');
+  });
+
+  it('should classify ShapesFetchBusyError as RETRYABLE (BullMQ backoff waits out the gate)', () => {
+    const error = new ShapesFetchBusyError(2);
+    const result = classifyShapesError(error);
+    expect(result.isRetryable).toBe(true);
+    expect(result.errorMessage).toContain('Too many simultaneous shapes.inc fetches');
   });
 
   it('should classify generic Error as retryable', () => {

--- a/services/ai-worker/src/jobs/shapesJobHelpers.test.ts
+++ b/services/ai-worker/src/jobs/shapesJobHelpers.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleShapesJobError, type ShapesJobErrorContext } from './shapesJobHelpers.js';
-import { ShapesAuthError, ShapesFetchError } from '../services/shapes/shapesErrors.js';
+import {
+  claimShapesFetchSlot,
+  handleShapesJobError,
+  type ShapesJobErrorContext,
+} from './shapesJobHelpers.js';
+import {
+  ShapesAuthError,
+  ShapesFetchBusyError,
+  ShapesFetchError,
+} from '../services/shapes/shapesErrors.js';
+import type { ShapesFetchGate } from '../services/shapes/shapesFetchGate.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -121,5 +130,36 @@ describe('handleShapesJobError', () => {
     const result = await handleShapesJobError(ctx);
 
     expect(result).toEqual({ success: false, error: 'No credentials' });
+  });
+});
+
+describe('claimShapesFetchSlot', () => {
+  it('returns false (nothing to release) when no gate is supplied', async () => {
+    await expect(claimShapesFetchSlot(undefined)).resolves.toBe(false);
+  });
+
+  it('returns true when the gate grants a slot', async () => {
+    const gate = {
+      tryAcquire: vi.fn().mockResolvedValue('acquired'),
+      maxConcurrent: 2,
+    } as unknown as ShapesFetchGate;
+    await expect(claimShapesFetchSlot(gate)).resolves.toBe(true);
+  });
+
+  it('returns false on fail-open — the fetch proceeds but no slot is held to release', async () => {
+    const gate = {
+      tryAcquire: vi.fn().mockResolvedValue('fail-open'),
+      maxConcurrent: 2,
+    } as unknown as ShapesFetchGate;
+    await expect(claimShapesFetchSlot(gate)).resolves.toBe(false);
+  });
+
+  it('throws the retryable busy error naming the cap when the gate denies', async () => {
+    const gate = {
+      tryAcquire: vi.fn().mockResolvedValue('denied'),
+      maxConcurrent: 2,
+    } as unknown as ShapesFetchGate;
+    await expect(claimShapesFetchSlot(gate)).rejects.toThrow(ShapesFetchBusyError);
+    await expect(claimShapesFetchSlot(gate)).rejects.toThrow(/cap 2/);
   });
 });

--- a/services/ai-worker/src/jobs/shapesJobHelpers.ts
+++ b/services/ai-worker/src/jobs/shapesJobHelpers.ts
@@ -8,6 +8,8 @@
 
 import type { Job } from 'bullmq';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { ShapesFetchBusyError } from '../services/shapes/shapesErrors.js';
+import type { ShapesFetchGate } from '../services/shapes/shapesFetchGate.js';
 import { classifyShapesError } from './shapesCredentials.js';
 
 const logger = createLogger('shapesJobHelpers');
@@ -79,4 +81,27 @@ export async function handleShapesJobError<TResult>(
 
   await ctx.markFailed(errorMessage);
   return ctx.buildFailureResult(errorMessage);
+}
+
+/**
+ * Claim a slot on the global shapes.inc fetch-concurrency gate.
+ *
+ * Shared by the import and export jobs so the gate semantics can't drift
+ * between them: no gate supplied → ungated (returns false, nothing to
+ * release); gate at capacity → throws the retryable ShapesFetchBusyError
+ * (BullMQ's backoff is the wait); fail-open (Redis error) → the fetch is
+ * allowed but NO slot is held (returns false — never release an uncounted
+ * slot); slot claimed → returns true (caller MUST release in a finally).
+ */
+export async function claimShapesFetchSlot(
+  fetchGate: ShapesFetchGate | undefined
+): Promise<boolean> {
+  if (fetchGate === undefined) {
+    return false;
+  }
+  const outcome = await fetchGate.tryAcquire();
+  if (outcome === 'denied') {
+    throw new ShapesFetchBusyError(fetchGate.maxConcurrent);
+  }
+  return outcome === 'acquired';
 }

--- a/services/ai-worker/src/redis.ts
+++ b/services/ai-worker/src/redis.ts
@@ -16,6 +16,7 @@ import { RedisService } from './services/RedisService.js';
 import { RateLimitCache } from './services/RateLimitCache.js';
 import { CreditExhaustionCache } from './services/CreditExhaustionCache.js';
 import { VisionFallbackQuota } from './services/VisionFallbackQuota.js';
+import { ShapesFetchGate } from './services/shapes/shapesFetchGate.js';
 import { FreeTierRequestQuota, ZAI_FREE_TIER_KEYS } from './services/FreeTierRequestQuota.js';
 import { ZaiPlanMeter } from './services/ZaiPlanMeter.js';
 import { ZaiFreeTierAdmission } from './services/ZaiFreeTierAdmission.js';
@@ -45,6 +46,11 @@ export const visionDescriptionCache = new VisionDescriptionCache(redis);
 // (apiKey, model) pair is in a known rate-limit window.
 // eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: shared Redis client; multiple instances would each maintain a separate view of rate-limit state and miss the short-circuit.
 export const rateLimitCache = new RateLimitCache(redis);
+
+// Export singleton ShapesFetchGate — global concurrency etiquette for
+// shapes.inc import/export fetches (one shared counter, one egress IP).
+// eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: shared Redis client; the gate is a single global counter, so separate instances would still agree but waste connections.
+export const shapesFetchGate = new ShapesFetchGate(redis);
 
 // Export singleton CreditExhaustionCache instance — short-circuits LLM calls
 // when a BYOK account is known to be out of credits (per-account 402).

--- a/services/ai-worker/src/services/shapes/shapesErrors.ts
+++ b/services/ai-worker/src/services/shapes/shapesErrors.ts
@@ -15,7 +15,8 @@
  * ShapesBotProtectionError are non-retryable (immediate failure). Everything
  * else — including ShapesRateLimitError and ShapesServerError that survived
  * per-request retries — triggers a BullMQ job-level retry (restarts from
- * page 1).
+ * page 1). ShapesFetchBusyError is deliberately in the retryable bucket:
+ * BullMQ's exponential backoff IS the wait for a free concurrency slot.
  */
 
 export class ShapesAuthError extends Error {
@@ -73,5 +74,21 @@ export class ShapesBotProtectionError extends Error {
         'this needs investigation.'
     );
     this.name = 'ShapesBotProtectionError';
+  }
+}
+
+/**
+ * The global shapes.inc fetch-concurrency gate is at capacity (see
+ * shapesFetchGate.ts). Thrown BEFORE any fetching starts, so the job-level
+ * retry it triggers costs nothing — BullMQ's exponential backoff is the wait
+ * for a slot. Deliberately retryable at the job tier.
+ */
+export class ShapesFetchBusyError extends Error {
+  constructor(maxConcurrent: number) {
+    super(
+      `Too many simultaneous shapes.inc fetches (cap ${maxConcurrent}) — ` +
+        'the job will retry automatically once a slot frees up.'
+    );
+    this.name = 'ShapesFetchBusyError';
   }
 }

--- a/services/ai-worker/src/services/shapes/shapesFetchGate.test.ts
+++ b/services/ai-worker/src/services/shapes/shapesFetchGate.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the shapes.inc global fetch-concurrency gate.
+ *
+ * The load-bearing properties: fail-OPEN on Redis errors (etiquette must
+ * never break a user's export) WITHOUT holding a slot (so no unpaired
+ * release), deny-without-holding at the cap, and a relatively-corrected
+ * zero floor that composes with concurrent acquires.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Redis } from 'ioredis';
+import { ShapesFetchGate, MAX_CONCURRENT_SHAPES_FETCHES } from './shapesFetchGate.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+interface MockRedis {
+  redis: Redis;
+  incr: ReturnType<typeof vi.fn>;
+  decr: ReturnType<typeof vi.fn>;
+  expire: ReturnType<typeof vi.fn>;
+  incrby: ReturnType<typeof vi.fn>;
+}
+
+function createMockRedis(
+  overrides: Partial<Record<'incr' | 'decr' | 'expire', () => Promise<number>>> = {}
+): MockRedis {
+  const incr = vi.fn(overrides.incr ?? (() => Promise.resolve(1)));
+  const decr = vi.fn(overrides.decr ?? (() => Promise.resolve(0)));
+  const expire = vi.fn(overrides.expire ?? (() => Promise.resolve(1)));
+  const incrby = vi.fn().mockResolvedValue(0);
+  return { redis: { incr, decr, expire, incrby } as unknown as Redis, incr, decr, expire, incrby };
+}
+
+describe('ShapesFetchGate', () => {
+  describe('tryAcquire', () => {
+    it('acquires a slot under the cap and refreshes the leak-bound TTL', async () => {
+      const { redis, incr, decr, expire } = createMockRedis({ incr: () => Promise.resolve(1) });
+      const gate = new ShapesFetchGate(redis);
+
+      await expect(gate.tryAcquire()).resolves.toBe('acquired');
+      expect(incr).toHaveBeenCalledTimes(1);
+      expect(expire).toHaveBeenCalledTimes(1);
+      expect(decr).not.toHaveBeenCalled();
+    });
+
+    it('allows exactly the cap (inclusive)', async () => {
+      const { redis, decr } = createMockRedis({
+        incr: () => Promise.resolve(MAX_CONCURRENT_SHAPES_FETCHES),
+      });
+      const gate = new ShapesFetchGate(redis);
+
+      await expect(gate.tryAcquire()).resolves.toBe('acquired');
+      expect(decr).not.toHaveBeenCalled();
+    });
+
+    it('denies over the cap and gives the provisional slot back (holds nothing)', async () => {
+      const { redis, decr } = createMockRedis({
+        incr: () => Promise.resolve(MAX_CONCURRENT_SHAPES_FETCHES + 1),
+      });
+      const gate = new ShapesFetchGate(redis);
+
+      await expect(gate.tryAcquire()).resolves.toBe('denied');
+      expect(decr).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects a custom cap', async () => {
+      const { redis } = createMockRedis({ incr: () => Promise.resolve(4) });
+      expect(await new ShapesFetchGate(redis, 5).tryAcquire()).toBe('acquired');
+      expect(await new ShapesFetchGate(redis, 3).tryAcquire()).toBe('denied');
+    });
+
+    it('fails OPEN when the increment itself fails — allowed, but NO slot held', async () => {
+      // 'fail-open', not 'acquired': nothing was counted, so the caller must
+      // not release — a release here would steal a legitimately-held slot.
+      const { redis } = createMockRedis({ incr: () => Promise.reject(new Error('ECONNRESET')) });
+      const gate = new ShapesFetchGate(redis);
+
+      await expect(gate.tryAcquire()).resolves.toBe('fail-open');
+    });
+
+    it('still reports acquired when only the TTL refresh fails (the increment landed)', async () => {
+      // The slot IS counted once incr succeeds — reporting fail-open here
+      // would leak it until TTL. TTL refresh failure is non-fatal.
+      const { redis } = createMockRedis({
+        incr: () => Promise.resolve(1),
+        expire: () => Promise.reject(new Error('ECONNRESET')),
+      });
+      const gate = new ShapesFetchGate(redis);
+
+      await expect(gate.tryAcquire()).resolves.toBe('acquired');
+    });
+  });
+
+  describe('release', () => {
+    it('decrements the active counter', async () => {
+      const { redis, decr, incrby } = createMockRedis({ decr: () => Promise.resolve(1) });
+      const gate = new ShapesFetchGate(redis);
+
+      await gate.release();
+      expect(decr).toHaveBeenCalledTimes(1);
+      expect(incrby).not.toHaveBeenCalled();
+    });
+
+    it('walks a negative counter back to zero RELATIVELY (composes with concurrent acquires)', async () => {
+      // An absolute SET here would clobber a concurrent tryAcquire's
+      // increment landing between the decr and the correction; incrby(-count)
+      // adds back exactly the overshoot instead.
+      const { redis, incrby } = createMockRedis({ decr: () => Promise.resolve(-2) });
+      const gate = new ShapesFetchGate(redis);
+
+      await gate.release();
+      expect(incrby).toHaveBeenCalledWith(expect.stringContaining('active'), 2);
+    });
+
+    it('never throws on a Redis error (slot recovers via TTL)', async () => {
+      const { redis } = createMockRedis({ decr: () => Promise.reject(new Error('ECONNRESET')) });
+      const gate = new ShapesFetchGate(redis);
+
+      await expect(gate.release()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/services/ai-worker/src/services/shapes/shapesFetchGate.ts
+++ b/services/ai-worker/src/services/shapes/shapesFetchGate.ts
@@ -1,0 +1,124 @@
+/**
+ * Global concurrency gate for shapes.inc fetch jobs.
+ *
+ * All shapes.inc traffic leaves from one egress IP, so N users triggering
+ * imports/exports simultaneously look like a thundering herd to shapes.inc —
+ * the kind of aggregate footprint that invites rate-limiting or hardening.
+ * This gate caps simultaneous fetches globally; a job that can't get a slot
+ * throws `ShapesFetchBusyError` (retryable), and BullMQ's exponential backoff
+ * becomes the wait.
+ *
+ * Etiquette, not correctness — same fail-open posture as VisionFallbackQuota:
+ * - Any Redis error logs a warn and ALLOWS the fetch (a counter blip must not
+ *   break user exports).
+ * - A crashed worker leaks its slot only until the key TTL; the TTL is set on
+ *   every acquire, sized past the longest realistic job.
+ * - `release()` floors the counter at zero, so an unpaired decrement (e.g.
+ *   release after a fail-open acquire that never incremented) self-heals.
+ */
+
+import type { Redis } from 'ioredis';
+import { CACHE_KEY_PREFIXES } from '@tzurot/common-types/constants/redis-keys';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+
+const logger = createLogger('ShapesFetchGate');
+
+/**
+ * Max simultaneous shapes.inc fetch jobs across the whole deployment.
+ * Low-and-slow: with the fetcher's own 1s inter-request delay this keeps the
+ * aggregate request rate to at most a couple of requests per second.
+ */
+export const MAX_CONCURRENT_SHAPES_FETCHES = 2;
+
+const ACTIVE_KEY = `${CACHE_KEY_PREFIXES.SHAPES_FETCH_GATE}active`;
+
+/**
+ * Slot-leak bound. The largest observed export (461 memory pages at 1s
+ * spacing plus retries) runs well under an hour; two hours means a crashed
+ * worker's leaked slot degrades politeness at most that long.
+ */
+const SLOT_TTL_SECONDS = 2 * 60 * 60;
+
+/**
+ * Outcome of a slot claim. Three states rather than a boolean because
+ * "allowed" and "held" are different facts: a fail-open allows the fetch but
+ * holds NO counted slot, so the caller must not release one — a boolean
+ * conflating the two would make transient Redis errors silently under-count
+ * the very thing the gate exists to count.
+ */
+export type ShapesFetchSlotOutcome = 'acquired' | 'denied' | 'fail-open';
+
+/**
+ * Known trade-off — retry budget vs. long contention: the busy error rides
+ * the jobs' BullMQ backoff (attempts 5 × exponential 5s ≈ 75s total), which
+ * outlasts bursts but NOT two maximal hour-scale exports holding both slots.
+ * A third job during such contention exhausts its retries and fails with the
+ * honest busy message rather than waiting an hour — acceptable at this
+ * project's traffic (a handful of users, rare jobs).
+ */
+export class ShapesFetchGate {
+  constructor(
+    private readonly redis: Redis,
+    /** Public so a denied caller can name the cap in its error message. */
+    readonly maxConcurrent: number = MAX_CONCURRENT_SHAPES_FETCHES
+  ) {}
+
+  /**
+   * Try to claim a fetch slot.
+   *
+   * @returns 'acquired' — slot claimed and counted (caller MUST release);
+   *   'denied' — at the cap, nothing held (do NOT release);
+   *   'fail-open' — Redis failed before counting anything; the fetch is
+   *   ALLOWED but no slot is held (do NOT release).
+   */
+  async tryAcquire(): Promise<ShapesFetchSlotOutcome> {
+    let count: number;
+    try {
+      count = await this.redis.incr(ACTIVE_KEY);
+    } catch (error) {
+      logger.warn(
+        { err: error },
+        'Shapes fetch gate acquire failed — failing open (allowing the fetch, no slot held)'
+      );
+      return 'fail-open';
+    }
+
+    // The increment landed — from here on a slot IS counted, so every path
+    // returns 'acquired'/'denied' (never 'fail-open') to keep release paired.
+    try {
+      // Refresh the leak bound on every acquire (cheap; self-heals a miss).
+      await this.redis.expire(ACTIVE_KEY, SLOT_TTL_SECONDS);
+    } catch (error) {
+      logger.warn({ err: error }, 'Shapes fetch gate TTL refresh failed — continuing');
+    }
+
+    if (count > this.maxConcurrent) {
+      try {
+        await this.redis.decr(ACTIVE_KEY);
+      } catch (error) {
+        logger.warn({ err: error }, 'Shapes fetch gate deny-decrement failed — recovers via TTL');
+      }
+      logger.info(
+        { activeFetches: count - 1, maxConcurrent: this.maxConcurrent },
+        'Concurrent shapes.inc fetch cap reached — job will wait via BullMQ backoff'
+      );
+      return 'denied';
+    }
+    return 'acquired';
+  }
+
+  /** Release a claimed slot. Never throws; floors the counter at zero. */
+  async release(): Promise<void> {
+    try {
+      const count = await this.redis.decr(ACTIVE_KEY);
+      if (count < 0) {
+        // Unpaired decrement (TTL expiry mid-job) — walk the counter back to
+        // exactly zero RELATIVELY, so a concurrent acquire's increment in
+        // this window is preserved instead of clobbered by an absolute SET.
+        await this.redis.incrby(ACTIVE_KEY, -count);
+      }
+    } catch (error) {
+      logger.warn({ err: error }, 'Shapes fetch gate release failed — slot recovers via TTL');
+    }
+  }
+}


### PR DESCRIPTION
## What

Item 5 of the shapes-inc fetcher hardening theme — the low-and-slow etiquette cap.

- **`ShapesFetchGate`**: one global Redis counter (`shapes:fetchgate:active`), cap 2, the VisionFallbackQuota shape — plain INCR/EXPIRE, **fail-open** on Redis errors, TTL-bounded (2h) against crashed-worker slot leaks, zero-floored release so unpaired decrements self-heal.
- **`claimShapesFetchSlot`** (shared in `shapesJobHelpers`): both jobs claim before any shapes.inc traffic; a denied claim throws `ShapesFetchBusyError` — **deliberately retryable**, so BullMQ's exponential backoff (`attempts: 5`, 5s base) is the wait, and exhausted retries still mark the export/import row failed with an honest message through the existing shared error handler. Release runs in `finally`, only for slots actually held.
- Wired via a singleton in ai-worker's `redis.ts` (house pattern); the dep is **optional** on both jobs, matching the gate's own degrade-gracefully posture.

## Deliberate divergence from the proposal

The April sketch said "BullMQ concurrency cap" (a dedicated queue). Shapes jobs ride the main worker queue (global concurrency 5), traffic is a handful of users, and the fact-extraction precedent of a dedicated queue is heavy machinery for an etiquette concern — a counter gate delivers the same low-and-slow property at a tenth of the complexity. (Also the project's standing "no reflexive Lua / plain incr-expire fail-open" posture for Redis counters.)

## Tests

19 new: gate unit tests (8 — cap-inclusive boundary, deny-holds-nothing, fail-open, zero-floor, custom cap), export-job gate tests (5 — acquire-before-fetch ordering, finally-release on throw, busy-throw holds nothing, exhausted-retries marks failed with the busy message, ungated-when-absent), helper tests (3), classifier (1: busy is RETRYABLE), plus the existing suites green.

- `pnpm test` green (ai-worker 3901, full suite)
- `pnpm quality` green (one `max-lines-per-function` trip during development led to the shared-helper extraction — a better shape anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)