### PR TITLE
feat(bot-client): STT wait feedback + retry-aware unavailable error

### DIFF
--- a/packages/common-types/src/utils/errors.test.ts
+++ b/packages/common-types/src/utils/errors.test.ts
@@ -4,6 +4,8 @@ import {
   isTimeoutError,
   AudioTooLongError,
   isTooLongError,
+  SttUnavailableError,
+  isSttUnavailableError,
   normalizeErrorForLogging,
 } from './errors.js';
 
@@ -75,6 +77,40 @@ describe('isTooLongError', () => {
     expect(isTooLongError(new Error('boom'))).toBe(false);
     expect(isTooLongError(null)).toBe(false);
     expect(isTooLongError({ name: 'AudioTooLongError' })).toBe(false);
+  });
+});
+
+describe('SttUnavailableError', () => {
+  it('uses the provided detail as the message', () => {
+    const err = new SttUnavailableError('voice-engine and BYOK cascade both failed');
+    expect(err.name).toBe('SttUnavailableError');
+    expect(err.message).toBe('voice-engine and BYOK cascade both failed');
+  });
+
+  it('falls back to a default message when no detail is given', () => {
+    const err = new SttUnavailableError();
+    expect(err.name).toBe('SttUnavailableError');
+    expect(err.message).toBe('Speech-to-text service unavailable after retries');
+  });
+});
+
+describe('isSttUnavailableError', () => {
+  it('returns true for our SttUnavailableError class', () => {
+    expect(isSttUnavailableError(new SttUnavailableError())).toBe(true);
+  });
+
+  it('returns true for a native Error tagged with name "SttUnavailableError"', () => {
+    const err = new Error('unavailable');
+    err.name = 'SttUnavailableError';
+    expect(isSttUnavailableError(err)).toBe(true);
+  });
+
+  it('returns false for sibling typed errors and generic/non-Error values', () => {
+    expect(isSttUnavailableError(new TimeoutError(1, 'op'))).toBe(false);
+    expect(isSttUnavailableError(new AudioTooLongError())).toBe(false);
+    expect(isSttUnavailableError(new Error('boom'))).toBe(false);
+    expect(isSttUnavailableError(null)).toBe(false);
+    expect(isSttUnavailableError({ name: 'SttUnavailableError' })).toBe(false);
   });
 });
 

--- a/packages/common-types/src/utils/errors.ts
+++ b/packages/common-types/src/utils/errors.ts
@@ -60,6 +60,29 @@ export function isTooLongError(error: unknown): error is AudioTooLongError {
 }
 
 /**
+ * The STT service was unavailable after the per-provider retries within the
+ * cascade all failed. (Job-level retries deliberately do NOT run for this
+ * shape — "No STT provider available" fast-fails the job to avoid re-running
+ * a guaranteed-identical failure.) Distinct from {@link TimeoutError}: a
+ * timeout is one slow/stalled inference, whereas unavailable means retries
+ * actually ran and none could connect. The STT job carries it across the job
+ * boundary as `failureReason: 'unavailable'` (Error instances don't survive
+ * BullMQ/Redis serialization); bot-client maps it to a retry-aware user
+ * message instead of the generic "couldn't transcribe".
+ */
+export class SttUnavailableError extends Error {
+  constructor(detail?: string) {
+    super(detail ?? 'Speech-to-text service unavailable after retries');
+    this.name = 'SttUnavailableError';
+  }
+}
+
+/** Check whether an error is an {@link SttUnavailableError} (name-based, survives bundling). */
+export function isSttUnavailableError(error: unknown): error is SttUnavailableError {
+  return error instanceof Error && error.name === 'SttUnavailableError';
+}
+
+/**
  * Normalize a caught error for Pino logging.
  *
  * LangChain/OpenAI SDK sometimes throws plain objects (e.g., literal `{}`)

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -38,7 +38,7 @@ vi.mock('@tzurot/common-types/utils/discord', async () => {
 });
 
 import { splitMessage } from '@tzurot/common-types/utils/discord';
-import { AudioTooLongError } from '@tzurot/common-types/utils/errors';
+import { AudioTooLongError, SttUnavailableError } from '@tzurot/common-types/utils/errors';
 import { voiceTranscriptCache } from '../redis.js';
 import { transcribe } from '../utils/gatewayServiceCalls.js';
 
@@ -843,6 +843,147 @@ describe('VoiceTranscriptionService', () => {
       expect((message.channel as any).sendTyping).toHaveBeenCalledTimes(callCount);
     });
 
+    describe('taking-longer notice', () => {
+      const VOICE_ATTACHMENT = {
+        url: 'https://cdn.discord.com/voice/123.ogg',
+        contentType: 'audio/ogg',
+        name: 'voice.ogg',
+        size: 50000,
+        duration: 5.2,
+      };
+
+      function transcribeResolvingAfter(ms: number, outcome: 'resolve' | 'reject'): void {
+        vi.mocked(transcribe).mockImplementation(
+          () =>
+            new Promise((resolve, reject) => {
+              setTimeout(() => {
+                if (outcome === 'resolve') {
+                  resolve({ content: 'Slow but successful transcript' });
+                } else {
+                  reject(new Error('slow failure'));
+                }
+              }, ms);
+            })
+        );
+      }
+
+      it('sends the notice ONCE past the threshold and deletes it on success', async () => {
+        const message = createMockMessage({ attachments: [VOICE_ATTACHMENT], channelSend: true });
+        transcribeResolvingAfter(40_000, 'resolve');
+
+        const promise = service.transcribe(message, false, false);
+        // Interval ticks at 8/16/24/32s — threshold (20s) crossed at the 24s tick.
+        await vi.advanceTimersByTimeAsync(35_000);
+        const send = (message.channel as any).send;
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0]).toContain('taking longer than expected');
+
+        await vi.advanceTimersByTimeAsync(10_000); // completes the transcription
+        const result = await promise;
+        expect(result?.transcript).toBe('Slow but successful transcript');
+
+        // The notice must not linger next to the delivered transcript.
+        const sentNotice = await send.mock.results[0].value;
+        expect(sentNotice.delete).toHaveBeenCalledTimes(1);
+      });
+
+      it('never sends the notice on the fast path', async () => {
+        const message = createMockMessage({ attachments: [VOICE_ATTACHMENT], channelSend: true });
+        vi.mocked(transcribe).mockResolvedValue({ content: 'Fast transcript' });
+
+        await service.transcribe(message, false, false);
+        await vi.advanceTimersByTimeAsync(60_000); // interval already cleared
+
+        expect((message.channel as any).send).not.toHaveBeenCalled();
+      });
+
+      it('deletes a notice whose send resolves AFTER the transcription finishes (race guard)', async () => {
+        // The trickiest branch: finish() fires while channel.send is still in
+        // flight. The late-resolving notice must be deleted on arrival, not
+        // stranded as a false "still stuck" signal.
+        const message = createMockMessage({ attachments: [VOICE_ATTACHMENT], channelSend: true });
+        const lateDelete = vi.fn().mockResolvedValue(undefined);
+        // Fake-timer delay (suite runs under vi.useFakeTimers): the send
+        // resolves 30s after being triggered (~24s) = ~54s, well past the
+        // transcription completing at 26s.
+        const sendResolveDelayMs = 30_000;
+        (message.channel as any).send = vi.fn().mockImplementation(
+          () =>
+            new Promise(resolve => {
+              setTimeout(
+                () => resolve({ id: 'late-notice', delete: lateDelete }),
+                sendResolveDelayMs
+              );
+            })
+        );
+        transcribeResolvingAfter(26_000, 'resolve');
+
+        const promise = service.transcribe(message, false, false);
+        await vi.advanceTimersByTimeAsync(26_000); // notice triggered at 24s; transcription done at 26s
+        const result = await promise;
+        expect(result?.transcript).toBe('Slow but successful transcript');
+        expect(lateDelete).not.toHaveBeenCalled(); // send still in flight
+
+        await vi.advanceTimersByTimeAsync(30_000); // the late send resolves
+        expect(lateDelete).toHaveBeenCalledTimes(1);
+      });
+
+      it('survives a failed notice send (transcript still delivered)', async () => {
+        const message = createMockMessage({ attachments: [VOICE_ATTACHMENT], channelSend: true });
+        (message.channel as any).send = vi.fn().mockRejectedValue(new Error('Missing Permissions'));
+        transcribeResolvingAfter(30_000, 'resolve');
+
+        const promise = service.transcribe(message, false, false);
+        await vi.advanceTimersByTimeAsync(35_000);
+        const result = await promise;
+
+        expect((message.channel as any).send).toHaveBeenCalledTimes(1);
+        expect(result?.transcript).toBe('Slow but successful transcript');
+      });
+
+      it('deletes the notice on error too (three-state UX: typing → notice → error)', async () => {
+        const message = createMockMessage({ attachments: [VOICE_ATTACHMENT], channelSend: true });
+        transcribeResolvingAfter(30_000, 'reject');
+
+        const promise = service.transcribe(message, false, false);
+        await vi.advanceTimersByTimeAsync(24_000);
+        const send = (message.channel as any).send;
+        expect(send).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        const result = await promise;
+        expect(result).toBeNull(); // error path replies + returns null
+
+        const sentNotice = await send.mock.results[0].value;
+        expect(sentNotice.delete).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('shows the retry-aware message for SttUnavailableError', async () => {
+      const message = createMockMessage({
+        attachments: [
+          {
+            url: 'https://cdn.discord.com/voice/123.ogg',
+            contentType: 'audio/ogg',
+            name: 'voice.ogg',
+            size: 50000,
+            duration: 5.2,
+          },
+        ],
+      });
+
+      vi.mocked(transcribe).mockRejectedValue(new SttUnavailableError());
+
+      const result = await service.transcribe(message, false, false);
+
+      expect(result).toBeNull();
+      expect(message.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('temporarily unavailable'),
+        })
+      );
+    });
+
     it('should skip typing indicator if channel does not support it', async () => {
       const message = createMockMessage({
         attachments: [
@@ -1278,6 +1419,8 @@ interface MockMessageOptions {
   messageSnapshots?: MockMessageSnapshot[];
   noTypingSupport?: boolean;
   authorId?: string;
+  /** Give the mock channel a `send` method (the taking-longer notice path). */
+  channelSend?: boolean;
 }
 
 function createMockAttachmentsMap(attachmentsList: MockSnapshotAttachment[] | null): Map<
@@ -1349,6 +1492,13 @@ function createMockMessage(options: MockMessageOptions = {}): Message {
     ? {}
     : {
         sendTyping: vi.fn().mockResolvedValue(undefined),
+        ...(options.channelSend === true && {
+          send: vi
+            .fn()
+            .mockImplementation(() =>
+              Promise.resolve({ id: 'notice-123', delete: vi.fn().mockResolvedValue(undefined) })
+            ),
+        }),
       };
 
   // If messageSnapshots is provided, include forward reference type

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -15,7 +15,11 @@ import {
   type SttProvider,
 } from '@tzurot/common-types/types/sttProvider';
 import { splitMessage } from '@tzurot/common-types/utils/discord';
-import { isTimeoutError, isTooLongError } from '@tzurot/common-types/utils/errors';
+import {
+  isSttUnavailableError,
+  isTimeoutError,
+  isTooLongError,
+} from '@tzurot/common-types/utils/errors';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { voiceTranscriptCache } from '../redis.js';
 import { hasForwardedSnapshots, getSnapshots } from '../utils/forwardedMessageUtils.js';
@@ -27,6 +31,110 @@ const logger = createLogger('VoiceTranscriptionService');
 
 /** Interval for refreshing the typing indicator (Discord expires at ~10s, matches JobTracker.ts) */
 const TYPING_INDICATOR_INTERVAL_MS = 8000;
+
+/**
+ * Elapsed wall time after which ONE "taking longer than expected" notice is
+ * sent (then deleted on completion — same discipline as JobTracker's
+ * TAKING_LONGER notification). Sized for the voice-engine's serverless cold
+ * start (~56s boot, 120s warmup budget): a warm transcription returns in a
+ * few seconds, so crossing this threshold almost always means a cold start
+ * the user would otherwise experience as unexplained silence. Checked on the
+ * 8s typing cadence, so the notice actually lands at the first tick past the
+ * threshold (~24s).
+ */
+const TRANSCRIPTION_TAKING_LONGER_MS = 20_000;
+
+/**
+ * Map a transcription failure to its user-facing reply. Each typed error
+ * carries a distinct user action: timeout → try again in a moment (cold
+ * start), too-long → send shorter audio, unavailable → retries already ran,
+ * wait and retry. Everything else stays generic.
+ */
+function classifyTranscriptionErrorMessage(error: unknown): string {
+  if (isTimeoutError(error)) {
+    return 'Sorry, transcription is taking too long — the voice service may be starting up. Please try again in a moment.';
+  }
+  if (isTooLongError(error)) {
+    return 'Sorry, that voice message is too long to transcribe. Please try sending a shorter one.';
+  }
+  if (isSttUnavailableError(error)) {
+    return 'Sorry, the voice service is temporarily unavailable — it was retried several times without luck. Please try again shortly.';
+  }
+  return "Sorry, I couldn't transcribe that voice message.";
+}
+
+/**
+ * The one-shot "taking longer" notice lifecycle (mirrors JobTracker's
+ * TAKING_LONGER discipline): sent at most once past the elapsed threshold,
+ * captured so it can be deleted on completion, with a race guard for a send
+ * still in flight when the transcription finishes. The STT wait is a
+ * synchronous long-poll with no progress channel, so status is a function of
+ * local elapsed time only — the fast path (warm engine, cache hits) never
+ * crosses the threshold and sees nothing beyond the typing indicator.
+ */
+class TakingLongerNotice {
+  private readonly startTime = Date.now();
+  private notified = false;
+  private finished = false;
+  private sentMessage: Message | null = null;
+
+  constructor(private readonly sourceMessage: Message) {}
+
+  /** Called on each typing tick — sends the notice once past the threshold. */
+  onTick(): void {
+    const channel = this.sourceMessage.channel;
+    if (
+      this.notified ||
+      !('send' in channel) ||
+      Date.now() - this.startTime <= TRANSCRIPTION_TAKING_LONGER_MS
+    ) {
+      return;
+    }
+    // Flag BEFORE the async send — prevents a double-send if the next tick
+    // fires while this send is in flight (JobTracker.ts pattern).
+    this.notified = true;
+    void channel
+      .send(
+        '⏱️ Transcription is taking longer than expected — the voice service may be waking up. Hang tight…'
+      )
+      .then(sent => {
+        if (this.finished) {
+          // Finished while the send was in flight — the notice is already
+          // stale; remove it instead of stranding it.
+          void sent.delete().catch((deleteError: unknown) => {
+            logger.debug(
+              { err: deleteError, messageId: this.sourceMessage.id },
+              'Failed to delete stale taking-longer notice (send raced completion)'
+            );
+          });
+        } else {
+          this.sentMessage = sent;
+        }
+      })
+      .catch((sendError: unknown) => {
+        logger.debug(
+          { err: sendError, messageId: this.sourceMessage.id },
+          'Taking-longer notice failed to send'
+        );
+      });
+  }
+
+  /**
+   * Delete the notice so it doesn't linger as a false "still stuck" signal
+   * next to the transcript/error (JobTracker.ts does the same on completion).
+   */
+  async finish(): Promise<void> {
+    this.finished = true;
+    if (this.sentMessage !== null) {
+      await this.sentMessage.delete().catch((deleteError: unknown) => {
+        logger.debug(
+          { err: deleteError, messageId: this.sourceMessage.id },
+          'Failed to delete taking-longer notice'
+        );
+      });
+    }
+  }
+}
 
 /**
  * Uses Discord `-#` subtext so the line renders small+muted under the transcript.
@@ -263,6 +371,7 @@ export class VoiceTranscriptionService {
     }
 
     let typingInterval: NodeJS.Timeout | undefined;
+    const notice = new TakingLongerNotice(message);
     try {
       // Show typing indicator (if channel supports it). All sendTyping calls
       // route through the helper for fire-and-forget semantics + latency
@@ -284,6 +393,7 @@ export class VoiceTranscriptionService {
             typingInterval,
             extraContext: { messageId: message.id },
           });
+          notice.onTick();
         }, TYPING_INDICATOR_INTERVAL_MS);
         sendTypingIndicator(channel, {
           logger,
@@ -347,11 +457,7 @@ export class VoiceTranscriptionService {
     } catch (error) {
       logger.error({ err: error }, 'Error transcribing voice message');
 
-      const userMessage = isTimeoutError(error)
-        ? 'Sorry, transcription is taking too long \u2014 the voice service may be starting up. Please try again in a moment.'
-        : isTooLongError(error)
-          ? 'Sorry, that voice message is too long to transcribe. Please try sending a shorter one.'
-          : "Sorry, I couldn't transcribe that voice message.";
+      const userMessage = classifyTranscriptionErrorMessage(error);
 
       await message
         .reply({
@@ -369,6 +475,7 @@ export class VoiceTranscriptionService {
       if (typingInterval !== undefined) {
         clearInterval(typingInterval);
       }
+      await notice.finish();
     }
   }
 

--- a/services/bot-client/src/utils/gatewayServiceCalls.test.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { JobStatus } from '@tzurot/common-types/constants/queue';
-import { TimeoutError, AudioTooLongError } from '@tzurot/common-types/utils/errors';
+import {
+  TimeoutError,
+  AudioTooLongError,
+  SttUnavailableError,
+} from '@tzurot/common-types/utils/errors';
 
 // Mock the ServiceClient factory + the service-secret accessor so the helpers
 // run without real config/network. (The context write-path helpers live in
@@ -255,6 +259,24 @@ describe('raw-fetch helpers (allow-listed)', () => {
 
     await expect(transcribe([{ url: 'a', contentType: 'audio/ogg' }], 'user-1')).rejects.toThrow(
       AudioTooLongError
+    );
+  });
+
+  it('transcribe reconstructs an SttUnavailableError from failureReason=unavailable', async () => {
+    // 'unavailable' means every retry layer already ran server-side — the
+    // typed error lets the bot show a retry-aware message instead of the
+    // generic "couldn't transcribe".
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        jobId: 'jt-unavailable',
+        status: JobStatus.Completed,
+        result: { success: false, content: '', failureReason: 'unavailable' },
+      }),
+    } as Response);
+
+    await expect(transcribe([{ url: 'a', contentType: 'audio/ogg' }], 'user-1')).rejects.toThrow(
+      SttUnavailableError
     );
   });
 

--- a/services/bot-client/src/utils/gatewayServiceCalls.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.ts
@@ -22,7 +22,11 @@ import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import { type GetAdminSettingsResponse } from '@tzurot/common-types/schemas/api/adminSettings';
 import { type GetChannelSettingsResponse } from '@tzurot/common-types/schemas/api/channel';
 import { type SttProvider } from '@tzurot/common-types/types/sttProvider';
-import { TimeoutError, AudioTooLongError } from '@tzurot/common-types/utils/errors';
+import {
+  TimeoutError,
+  AudioTooLongError,
+  SttUnavailableError,
+} from '@tzurot/common-types/utils/errors';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 import type { LoadedPersonality, MessageContext, TranscribeResponse } from '../types.js';
@@ -384,6 +388,12 @@ async function transcribeOnce(
   }
   if (failureReason === 'too_long') {
     throw new AudioTooLongError(data.result?.error);
+  }
+  if (failureReason === 'unavailable') {
+    // The per-provider retries within the cascade already ran server-side
+    // (job-level retries deliberately fast-fail this shape) — surface a
+    // retry-aware message, not the generic one.
+    throw new SttUnavailableError(data.result?.error);
   }
 
   if (


### PR DESCRIPTION
## What

Voice-engine theme items 3+4 (per the approved close-out plan): the STT wait/failure UX pair.

### Taking-longer notice (three-state UX: typing → notice → result)

The STT path is a synchronous blocking long-poll (540s wall) with deliberately no mid-job progress channel, so status is a function of local elapsed time. Past a **20s threshold** (sized for the voice-engine's ~56s serverless cold start; checked on the existing 8s typing cadence, so it lands ~24s), ONE "⏱️ taking longer than expected" notice is sent — then **deleted on completion** so it never lingers as a false "still stuck" signal. Extracted as a small `TakingLongerNotice` class mirroring `JobTracker`'s TAKING_LONGER discipline exactly: notified-flag set *before* the async send (double-send guard), race guard for a send still in flight when transcription finishes, fast paths see nothing beyond typing.

### Retry-aware unavailable error

`failureReason: 'unavailable'` (every server-side retry layer exhausted: provider cascade + job retries) already crossed the BullMQ/Redis boundary but was unmapped — it fell through to the generic "couldn't transcribe." Now reconstructs as `SttUnavailableError` (new class in common-types errors, same name-based-guard idiom as `AudioTooLongError`) and the reply tells the user retries already ran and to try again shortly.

## Tests

5 new: notice sent once past threshold + deleted on success, never sent on fast path, deleted on error, `failureReason=unavailable` → typed error (gatewayServiceCalls), unavailable → retry-aware reply (service). Mock channel gained an opt-in `send` method; all existing cases untouched.

- `pnpm test` green (bot-client 5495 + suite), `pnpm quality` green
- Complexity budgets forced two extractions (`TakingLongerNotice` class, `classifyTranscriptionErrorMessage`) — better shapes than the inline versions.

## Manual verification (dev, later)

Send a voice message with the voice-engine cold: typing → notice at ~24s → transcript with the notice deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)