### PR TITLE
perf(ai-worker): parallelize TTS chunk synthesis (capped to match voice-engine)

### DIFF
--- a/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
@@ -670,3 +670,92 @@ describe('synthesizeWithChunking', () => {
     expect(pcmData.subarray(100, 300).every(b => b === 0xbb)).toBe(true);
   });
 });
+
+describe('synthesizeWithChunking concurrency', () => {
+  let mockClient: VoiceEngineClient;
+
+  beforeEach(() => {
+    mockClient = {
+      synthesize: vi.fn(),
+    } as unknown as VoiceEngineClient;
+  });
+
+  /** Text long enough to split into at least four ~1500-char chunks. */
+  function fourChunkText(): string {
+    const sentences = ['A', 'B', 'C', 'D'].map(letter => letter.repeat(1500) + '.');
+    return sentences.join(' ');
+  }
+
+  it('never exceeds the concurrency cap (matches voice-engine INFERENCE_CONCURRENCY)', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    vi.mocked(mockClient.synthesize).mockImplementation(async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Yield so batch-mates actually overlap before resolving.
+      await Promise.resolve();
+      inFlight--;
+      return { audioBuffer: createFakeWav(Buffer.from([0x01, 0x02])), contentType: 'audio/wav' };
+    });
+
+    await synthesizeWithChunking(mockClient, fourChunkText(), 'voice-1');
+
+    expect(vi.mocked(mockClient.synthesize).mock.calls.length).toBeGreaterThanOrEqual(4);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+    // And parallelism actually happened (this is the point of the change).
+    expect(maxInFlight).toBe(2);
+  });
+
+  it('preserves chunk order in the output even when a later chunk resolves first', async () => {
+    // First chunk (starts with 'A') resolves SLOWER than its batch-mate; the
+    // combined PCM must still be in chunk order — the concat depends on
+    // results[] order, not completion order.
+    const pcmA = Buffer.from([0xaa, 0xaa]);
+    const pcmOther = Buffer.from([0xbb, 0xbb]);
+    vi.mocked(mockClient.synthesize).mockImplementation(async (chunk: string) => {
+      const isFirst = chunk.startsWith('A');
+      if (isFirst) {
+        // Multiple microtask yields — batch-mate finishes well before this.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      return {
+        audioBuffer: createFakeWav(isFirst ? pcmA : pcmOther),
+        contentType: 'audio/wav',
+      };
+    });
+
+    const result = await synthesizeWithChunking(mockClient, fourChunkText(), 'voice-1');
+
+    // PCM starts with chunk 1's bytes (0xAA) despite it finishing last.
+    const pcmData = result.audioBuffer.subarray(44);
+    expect(pcmData[0]).toBe(0xaa);
+    expect(pcmData[1]).toBe(0xaa);
+    expect(pcmData[2]).toBe(0xbb);
+  });
+});
+
+describe('synthesizeWithChunking failure propagation', () => {
+  it('rejects the whole synthesis when any chunk fails (unchanged outcome under batching)', async () => {
+    const mockClient = {
+      synthesize: vi.fn().mockImplementation(async (chunk: string) => {
+        if (chunk.startsWith('B')) {
+          throw new Error('voice-engine 500 on chunk B');
+        }
+        return { audioBuffer: createFakeWav(Buffer.from([0x01])), contentType: 'audio/wav' };
+      }),
+    } as unknown as VoiceEngineClient;
+
+    const sentences = ['A', 'B', 'C', 'D'].map(letter => letter.repeat(1500) + '.');
+    const text = sentences.join(' ');
+
+    await expect(synthesizeWithChunking(mockClient, text, 'voice-1')).rejects.toThrow(
+      'voice-engine 500 on chunk B'
+    );
+    // The failing chunk's batch-mate had already been dispatched (calls fire
+    // synchronously inside the batch .map), but chunks in LATER batches were
+    // never requested — bounded waste, same overall rejection.
+    expect(vi.mocked(mockClient.synthesize).mock.calls.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/services/ai-worker/src/services/voice/ttsSynthesizer.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.ts
@@ -22,6 +22,16 @@ const logger = createLogger('ttsSynthesizer');
 /** Maximum characters per TTS chunk (voice-engine limit) */
 const MAX_CHUNK_LENGTH = 2000;
 
+/**
+ * Max chunks synthesized concurrently. Mirrors voice-engine's own inference
+ * semaphore (`INFERENCE_CONCURRENCY`, default 2 — services/voice-engine/
+ * server.py), which exists to prevent OOM on Railway's 4 GB ceiling: a higher
+ * client cap wouldn't synthesize any faster, it would just park excess
+ * requests on the server-side semaphore while the TTS step's outer 300s
+ * budget burns. Bump BOTH sides together or not at all.
+ */
+const TTS_CHUNK_CONCURRENCY = 2;
+
 /** WAV header size in bytes */
 const WAV_HEADER_SIZE = 44;
 
@@ -298,16 +308,28 @@ export async function synthesizeWithChunking(
     'Multi-chunk TTS synthesis'
   );
 
-  // Synthesize chunks sequentially to avoid overwhelming the single-process
-  // voice-engine. Voice-engine always returns WAV; the Opus encoding is
-  // applied by audioNormalizer downstream, after multi-chunk concatenation.
+  // Synthesize chunks in capped-parallel batches. The cap mirrors
+  // voice-engine's own inference semaphore (INFERENCE_CONCURRENCY, default 2
+  // — see services/voice-engine/server.py): matching it roughly halves
+  // multi-chunk latency, while a higher client cap would only queue on the
+  // server semaphore as the 300s TTS_MAX_TOTAL_MS outer budget burns.
+  // `results` stays in chunk order (batch slices are contiguous and
+  // Promise.all preserves input order) — the concat below depends on it.
+  // Voice-engine always returns WAV; the Opus encoding is applied by
+  // audioNormalizer downstream, after multi-chunk concatenation.
   const results: SynthesisResult[] = [];
-  for (let index = 0; index < chunks.length; index++) {
-    logger.debug(
-      { voiceId, chunkIndex: index, chunkLength: chunks[index].length },
-      'Synthesizing chunk'
+  for (let batchStart = 0; batchStart < chunks.length; batchStart += TTS_CHUNK_CONCURRENCY) {
+    const batch = chunks.slice(batchStart, batchStart + TTS_CHUNK_CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map((chunk, offset) => {
+        logger.debug(
+          { voiceId, chunkIndex: batchStart + offset, chunkLength: chunk.length },
+          'Synthesizing chunk'
+        );
+        return client.synthesize(chunk, voiceId);
+      })
     );
-    results.push(await client.synthesize(chunks[index], voiceId));
+    results.push(...batchResults);
   }
 
   // Extract PCM data from each WAV result and concatenate


### PR DESCRIPTION
## What

Voice-engine theme item: parallel TTS chunking (per the approved close-out plan).

The self-hosted TTS path synthesized multi-chunk messages strictly sequentially (`synthesizeWithChunking`'s for-loop) — for a ~3.5k-char message that's ~190s of stacked round-trips against the 300s `TTS_MAX_TOTAL_MS` budget. Now: contiguous batches of **2** via `Promise.all` (the `resolveLinksWithConcurrency` slice idiom).

**Why cap 2**: voice-engine caps model inference server-side at `asyncio.Semaphore(INFERENCE_CONCURRENCY=2)` (OOM protection on Railway's 4 GB ceiling) — a higher client cap synthesizes nothing faster, it just parks requests on the server semaphore while the outer budget burns. The constant's doc says bump both sides together or not at all.

**Ordering**: preserved by construction (contiguous slices + `Promise.all` input order); the downstream sample-rate check and PCM concat are untouched. Delivery is chunk-agnostic (one merged WAV → one loudnorm/Opus pass → one Redis key), so nothing outside this function changes. Error semantics unchanged: any chunk failure fails the whole synthesis, as before.

## Tests

All 42 existing `ttsSynthesizer` tests pass unchanged (including the two issue-order-dependent mocks — calls are still issued in `.map` order). 2 new:
- **Cap test**: tracks in-flight count in the mock — asserts max ≤ 2 AND that parallelism actually occurred (= 2).
- **Staggered-completion ordering**: chunk 1 resolves after its batch-mate; combined PCM still starts with chunk 1's bytes.

- `pnpm test` green (ai-worker 3911, full suite), `pnpm quality` green

## Manual verification (dev, later)

Long message (>2000 chars) with self-hosted voice: audio plays in correct order; synthesis duration in logs vs. pre-change baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)