### PR TITLE
fix(ai-worker): halt orphaned TTS work when the outer budget expires

### DIFF
--- a/packages/common-types/src/services/tts/TtsProvider.ts
+++ b/packages/common-types/src/services/tts/TtsProvider.ts
@@ -110,6 +110,18 @@ export interface TtsContext {
   byokKey?: string;
   /** Optional model override from the resolved tts_config row. */
   modelId?: string;
+  /**
+   * Cooperative-cancellation signal from the caller's outer time budget
+   * (TTSStep's 300s race). Checked between chunk batches (self-hosted
+   * chunker) and between fallback-chain attempts (dispatcher) so that work
+   * whose result is already discarded stops dispatching NEW requests — the
+   * voice-engine's 2-slot inference semaphore is shared with STT, and a
+   * post-timeout fallback attempt would spend BYOK quota for nothing.
+   * In-flight HTTP requests are deliberately NOT aborted: server-side
+   * inference runs in an executor thread a socket close cannot interrupt,
+   * so aborting them frees nothing.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -258,7 +258,11 @@ describe('TTSStep', () => {
       const call = mockDispatchTts.mock.calls[0][0];
       expect(call.text).toBe('Hello world');
       expect(call.resolvedConfig).toEqual(RESOLVED_CONFIG);
-      expect(call.ctx).toEqual({ slug: 'testbot', modelId: 'voxtral-mini-tts-latest' });
+      expect(call.ctx).toEqual({
+        slug: 'testbot',
+        modelId: 'voxtral-mini-tts-latest',
+        signal: expect.any(AbortSignal),
+      });
       expect(call.audioProviderKeys.get('mistral')).toBe('sk-mi');
       expect(call.registry).toEqual({ _id: 'mock-registry' });
     });
@@ -419,6 +423,24 @@ describe('TTSStep', () => {
 
       expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
       expect(result.result?.content).toBe('Hello world');
+    });
+
+    it('aborts the dispatch signal when the outer timeout fires (halts orphaned work)', async () => {
+      mockDispatchTts.mockImplementationOnce(() => new Promise(() => {}));
+      const ctx = createContext();
+
+      const promise = step.process(ctx);
+      // Let the async step reach the dispatch call before reading the mock.
+      await vi.advanceTimersByTimeAsync(0);
+      const dispatchCtx = mockDispatchTts.mock.calls.at(-1)?.[0]?.ctx;
+      expect(dispatchCtx?.signal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(300_001);
+      await promise;
+
+      // The orphaned work's chunker/dispatcher checks this signal before any
+      // new dispatch — aborted means no further batches or fallback attempts.
+      expect(dispatchCtx?.signal?.aborted).toBe(true);
     });
 
     it('does not store anything when dispatcher fails', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -183,9 +183,12 @@ export class TTSStep implements IPipelineStep {
 
   /**
    * Wrap the dispatch + normalize + store in the outer 300s budget. When the
-   * timeout wins the race, the underlying work continues in the background;
-   * its result is discarded (ttsAudioKey never written) and the audio expires
-   * via Redis TTL.
+   * timeout wins the race, requests already in flight run to completion in
+   * the background (server-side inference can't be interrupted) and their
+   * result is discarded (ttsAudioKey never written; stored audio expires via
+   * Redis TTL) — but the abort signal stops any NEW dispatches: the chunker
+   * won't start further batches and the dispatcher won't try fallback
+   * providers for a result nobody will receive.
    */
   private async runWithTimeout(
     text: string,
@@ -196,6 +199,7 @@ export class TTSStep implements IPipelineStep {
   ): Promise<TtsResult | null> {
     let timedOut = false;
     let timeoutId: NodeJS.Timeout | undefined;
+    const abortController = new AbortController();
 
     const work = (async () => {
       // BYOK key threading: the base ctx intentionally has no `byokKey` field —
@@ -207,7 +211,11 @@ export class TTSStep implements IPipelineStep {
       const dispatchResult = await dispatchTts({
         text,
         resolvedConfig,
-        ctx: { slug, modelId: resolvedConfig.modelId ?? undefined },
+        ctx: {
+          slug,
+          modelId: resolvedConfig.modelId ?? undefined,
+          signal: abortController.signal,
+        },
         audioProviderKeys,
         registry: ttsProviderRegistry,
       });
@@ -273,7 +281,11 @@ export class TTSStep implements IPipelineStep {
       new Promise<null>((_, reject) => {
         timeoutId = setTimeout(() => {
           timedOut = true;
-          reject(new TimeoutError(TTS_MAX_TOTAL_MS, 'TTS processing'));
+          const timeoutError = new TimeoutError(TTS_MAX_TOTAL_MS, 'TTS processing');
+          // Halt the orphaned work's NEW dispatches (chunk batches, fallback
+          // providers) — its in-flight requests run to completion regardless.
+          abortController.abort(timeoutError);
+          reject(timeoutError);
         }, TTS_MAX_TOTAL_MS);
       }),
     ]);

--- a/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
@@ -574,6 +574,61 @@ describe('dispatchTts — isFallbackEligible semantics', () => {
     });
     expect(result.providerUsed).toBe('self-hosted');
   });
+
+  it('threads the abort signal into every candidate ctx (the chunker check depends on it)', async () => {
+    // Regression: buildCtxForProvider rebuilds the ctx per candidate and once
+    // dropped `signal`, making the chunker's between-batch abort check dead
+    // code in the real dispatch path. Assert the SAME signal instance reaches
+    // both the BYOK branch (primary) and the non-BYOK branch (fallback).
+    const controller = new AbortController();
+    const eleven = makeProvider('elevenlabs', {
+      synthesize: vi.fn(async () => {
+        throw new Error('network blip');
+      }),
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    await dispatchTts({
+      text: 'hi',
+      resolvedConfig: elevenlabsConfig,
+      ctx: { ...baseCtx, signal: controller.signal },
+      audioProviderKeys: audioKeysOnlyEleven,
+      registry: makeRegistry([eleven, selfHosted]),
+    });
+
+    const elevenCtx = vi.mocked(eleven.synthesize).mock.calls[0]?.[2];
+    const selfHostedCtx = vi.mocked(selfHosted.synthesize).mock.calls[0]?.[2];
+    expect(elevenCtx?.signal).toBe(controller.signal);
+    expect(selfHostedCtx?.signal).toBe(controller.signal);
+  });
+
+  it('does not fall back once the outer-budget signal aborts (post-timeout)', async () => {
+    const controller = new AbortController();
+    const budgetExpired = new Error('outer TTS budget expired');
+    const eleven = makeProvider('elevenlabs', {
+      synthesize: vi.fn(async () => {
+        // The outer budget expires while the primary synthesis is in flight;
+        // the failure itself is a shape that would normally fall back.
+        controller.abort(budgetExpired);
+        throw new Error('network blip');
+      }),
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    await expect(
+      dispatchTts({
+        text: 'hi',
+        resolvedConfig: elevenlabsConfig,
+        ctx: { ...baseCtx, signal: controller.signal },
+        audioProviderKeys: audioKeysOnlyEleven,
+        registry: makeRegistry([eleven, selfHosted]),
+      })
+    ).rejects.toThrow('outer TTS budget expired');
+
+    // No fresh synthesis may start for a result nobody will receive.
+    expect(selfHosted.prepare).not.toHaveBeenCalled();
+    expect(selfHosted.synthesize).not.toHaveBeenCalled();
+  });
 });
 
 // ===== canHandle skip path ==================================================

--- a/services/ai-worker/src/services/voice/TtsDispatcher.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.ts
@@ -213,13 +213,17 @@ function buildCtxForProvider(
   isPrimaryAttempt: boolean
 ): TtsContext {
   const modelId = isPrimaryAttempt ? baseCtx.modelId : undefined;
+  // The abort signal crosses provider boundaries untouched — unlike modelId /
+  // byokKey it isn't provider-specific, and the self-hosted chunker's
+  // between-batch abort check depends on receiving it here.
+  const signal = baseCtx.signal;
 
   if (!BYOK_PROVIDERS.has(providerId)) {
-    return { slug: baseCtx.slug, modelId };
+    return { slug: baseCtx.slug, modelId, signal };
   }
   const audioId = TTS_TO_AUDIO_PROVIDER.get(providerId);
   const byokKey = audioId !== undefined ? audioProviderKeys.get(audioId) : undefined;
-  return { slug: baseCtx.slug, modelId, byokKey };
+  return { slug: baseCtx.slug, modelId, byokKey, signal };
 }
 
 /**
@@ -424,6 +428,11 @@ export async function dispatchTts(options: DispatchOptions): Promise<DispatchRes
   let primaryAttempted = false;
 
   for (const candidateId of chain) {
+    // An attempt halted by the caller's outer budget must not fall through
+    // to the next provider — a fresh post-timeout synthesis wastes the
+    // fallback's capacity (and BYOK quota) on an already-discarded result.
+    // throwIfAborted rethrows the abort reason (the outer TimeoutError).
+    ctx.signal?.throwIfAborted();
     const isPrimaryAttempt = !primaryAttempted && candidateId === primaryProviderId;
     if (candidateId === primaryProviderId) {
       primaryAttempted = true;

--- a/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.test.ts
+++ b/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.test.ts
@@ -134,10 +134,23 @@ describe('SelfHostedTtsProvider', () => {
       expect(mockedSynthesizeWithChunking).toHaveBeenCalledWith(
         regService.client,
         'hello',
-        'emily'
+        'emily',
+        undefined
       );
       expect(buf).toBeInstanceOf(Buffer);
       expect(buf.length).toBeGreaterThan(0);
+    });
+
+    it('forwards the ctx abort signal to the chunker', async () => {
+      const controller = new AbortController();
+      const handle = await provider.prepare({ slug: 'emily' });
+      await provider.synthesize('hello', handle, { slug: 'emily', signal: controller.signal });
+      expect(mockedSynthesizeWithChunking).toHaveBeenCalledWith(
+        regService.client,
+        'hello',
+        'emily',
+        controller.signal
+      );
     });
 
     it('rejects inlineAudio handles', async () => {

--- a/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.ts
@@ -92,17 +92,24 @@ export class SelfHostedTtsProvider implements TtsProvider {
    * Synthesize text via the existing chunker, which handles single-chunk
    * Opus output AND multi-chunk WAV-concat-then-Opus-transcode for long text.
    *
-   * Self-hosted ignores `ctx` (no auth needed; voice id is in the handle).
+   * Self-hosted needs no auth from `ctx` (voice id is in the handle) but
+   * threads `ctx.signal` to the chunker so an expired outer budget stops
+   * new chunk batches from dispatching.
    * Throws on `kind: 'inlineAudio'` handles — self-hosted is a stateful provider.
    */
-  async synthesize(text: string, handle: PreparedTts, _ctx: TtsContext): Promise<Buffer> {
+  async synthesize(text: string, handle: PreparedTts, ctx: TtsContext): Promise<Buffer> {
     if (handle.kind !== 'voiceId') {
       throw new Error(
         `SelfHostedTtsProvider received an inlineAudio handle — expected voiceId. Got: ${handle.kind}`
       );
     }
     const start = Date.now();
-    const result = await synthesizeWithChunking(this.registrationService.client, text, handle.id);
+    const result = await synthesizeWithChunking(
+      this.registrationService.client,
+      text,
+      handle.id,
+      ctx.signal
+    );
     logger.info(
       {
         event: 'tts.synthesize',

--- a/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
@@ -671,6 +671,12 @@ describe('synthesizeWithChunking', () => {
   });
 });
 
+/** Text long enough to split into at least four ~1500-char chunks. */
+function fourChunkText(): string {
+  const sentences = ['A', 'B', 'C', 'D'].map(letter => letter.repeat(1500) + '.');
+  return sentences.join(' ');
+}
+
 describe('synthesizeWithChunking concurrency', () => {
   let mockClient: VoiceEngineClient;
 
@@ -679,12 +685,6 @@ describe('synthesizeWithChunking concurrency', () => {
       synthesize: vi.fn(),
     } as unknown as VoiceEngineClient;
   });
-
-  /** Text long enough to split into at least four ~1500-char chunks. */
-  function fourChunkText(): string {
-    const sentences = ['A', 'B', 'C', 'D'].map(letter => letter.repeat(1500) + '.');
-    return sentences.join(' ');
-  }
 
   it('never exceeds the concurrency cap (matches voice-engine INFERENCE_CONCURRENCY)', async () => {
     let inFlight = 0;
@@ -747,15 +747,43 @@ describe('synthesizeWithChunking failure propagation', () => {
       }),
     } as unknown as VoiceEngineClient;
 
-    const sentences = ['A', 'B', 'C', 'D'].map(letter => letter.repeat(1500) + '.');
-    const text = sentences.join(' ');
-
-    await expect(synthesizeWithChunking(mockClient, text, 'voice-1')).rejects.toThrow(
+    await expect(synthesizeWithChunking(mockClient, fourChunkText(), 'voice-1')).rejects.toThrow(
       'voice-engine 500 on chunk B'
     );
     // The failing chunk's batch-mate had already been dispatched (calls fire
     // synchronously inside the batch .map), but chunks in LATER batches were
     // never requested — bounded waste, same overall rejection.
     expect(vi.mocked(mockClient.synthesize).mock.calls.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('synthesizeWithChunking abort (outer budget expiry)', () => {
+  it('stops dispatching new batches once the signal aborts', async () => {
+    const controller = new AbortController();
+    const budgetExpired = new Error('outer TTS budget expired');
+    const mockClient = {
+      synthesize: vi.fn().mockImplementation(async () => {
+        // The outer budget expires while batch 1 is in flight.
+        controller.abort(budgetExpired);
+        return { audioBuffer: createFakeWav(Buffer.from([0x01])), contentType: 'audio/wav' };
+      }),
+    } as unknown as VoiceEngineClient;
+
+    await expect(
+      synthesizeWithChunking(mockClient, fourChunkText(), 'voice-1', controller.signal)
+    ).rejects.toThrow('outer TTS budget expired');
+    // Batch 1's two calls had already been dispatched; batch 2 must never be.
+    expect(vi.mocked(mockClient.synthesize).mock.calls.length).toBe(2);
+  });
+
+  it('makes no calls at all when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('already expired'));
+    const mockClient = { synthesize: vi.fn() } as unknown as VoiceEngineClient;
+
+    await expect(
+      synthesizeWithChunking(mockClient, 'short text', 'voice-1', controller.signal)
+    ).rejects.toThrow('already expired');
+    expect(vi.mocked(mockClient.synthesize)).not.toHaveBeenCalled();
   });
 });

--- a/services/ai-worker/src/services/voice/ttsSynthesizer.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.ts
@@ -281,8 +281,12 @@ export function inferSampleRate(wavBuffer: Buffer): number {
 export async function synthesizeWithChunking(
   client: VoiceEngineClient,
   text: string,
-  voiceId: string
+  voiceId: string,
+  signal?: AbortSignal
 ): Promise<SynthesisResult> {
+  // Don't start anything for a result the caller has already discarded.
+  signal?.throwIfAborted();
+
   // splitTextIntoChunks always returns at least one element (even for empty string)
   const chunks = splitTextIntoChunks(text);
 
@@ -319,6 +323,12 @@ export async function synthesizeWithChunking(
   // audioNormalizer downstream, after multi-chunk concatenation.
   const results: SynthesisResult[] = [];
   for (let batchStart = 0; batchStart < chunks.length; batchStart += TTS_CHUNK_CONCURRENCY) {
+    // Between-batch abort check: once the outer budget expires, dispatching
+    // further batches is pure dead work — each one holds both slots of the
+    // shared inference semaphore against live TTS AND STT traffic. In-flight
+    // batch-mates run to completion (server-side inference can't be
+    // interrupted); only NEW dispatches stop.
+    signal?.throwIfAborted();
     const batch = chunks.slice(batchStart, batchStart + TTS_CHUNK_CONCURRENCY);
     const batchResults = await Promise.all(
       batch.map((chunk, offset) => {


### PR DESCRIPTION
## What

When the 300s `TTS_MAX_TOTAL_MS` race fires, the losing work chain used to keep running unchecked: the chunker dispatched brand-new batches — each holding **both** slots of the voice-engine inference semaphore, which is shared with STT (`server.py:589`) — and the dispatcher's fallback walk would start a **fresh post-timeout synthesis** on the next provider, spending BYOK quota for a result already discarded. The budget only expires when the engine is already slow, so the dead work piled on at exactly the wrong time.

Surfaced by the #1634 review as a "pre-existing, not a regression" observation; judged on merits per the new origin-language rule and fixed (the #1634 change had widened the orphan's hold from one semaphore slot to two).

## How

- `TTSStep.runWithTimeout` aborts an `AbortController` (reason = the same `TimeoutError`) alongside the timeout rejection; the signal rides `TtsContext`.
- `synthesizeWithChunking` checks `signal.throwIfAborted()` at entry and before each batch dispatch.
- `dispatchTts` checks it at the top of each fallback-chain iteration — an abort mid-attempt must not fall through to the next provider.
- **Deliberate boundary**: in-flight HTTP requests are NOT aborted. Server-side inference is an executor-thread call (`run_in_executor`) that a socket close cannot interrupt — the semaphore slot frees only when inference completes, so aborting in-flight buys nothing. Documented on the `signal` field.

## Tests

- Chunker: abort mid-batch-1 → batch 2 never dispatched (`calls.length === 2`); pre-aborted signal → zero calls.
- Dispatcher: primary fails with a normally-fallback-eligible error after the signal aborts → self-hosted `prepare`/`synthesize` never called, rejects with the abort reason.
- TTSStep: dispatch ctx's signal is unaborted at dispatch time and aborted after the 300s timer fires.
- Provider: signal forwarding across the `synthesizeWithChunking` seam asserted (both undefined and real-signal cases).
- Also hoists the test-file `fourChunkText` helper to file scope (was duplicated across describe blocks; this PR's tests would have added a third copy).

Full ai-worker suite green locally (3917 tests); `pnpm quality` equivalent via pre-push pipeline (build/lint/test 38 tasks + typecheck:spec + guards) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)