### PR TITLE
ci: path-filtered docker build smoke for all four service images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,77 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+  # Path-filtered full image builds. Dockerfiles are otherwise verified only
+  # by the real Railway deploy the merge triggers — post-merge is too late: a
+  # shell-form CMD typo or a turbo-prune/COPY drift ships broken and takes
+  # the service down at deploy time. Each leg builds only when its Dockerfile
+  # or its build-input config changes, so most PRs skip all four. No layer
+  # caching for now — the trigger is rare enough that a cold build per firing
+  # is cheaper than carrying cache plumbing.
+  docker-build-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Node services build from the REPO ROOT context (their pruner
+          # stage COPYs the whole monorepo for turbo prune).
+          - service: ai-worker
+            context: .
+          - service: api-gateway
+            context: .
+          - service: bot-client
+            context: .
+          # voice-engine is self-contained; its context is its own directory.
+          - service: voice-engine
+            context: services/voice-engine
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            ai-worker:
+              - 'services/ai-worker/Dockerfile'
+              - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+            api-gateway:
+              - 'services/api-gateway/Dockerfile'
+              - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+            bot-client:
+              - 'services/bot-client/Dockerfile'
+              - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+            voice-engine:
+              - 'services/voice-engine/Dockerfile'
+              - 'services/voice-engine/requirements.txt'
+
+      - name: Build image
+        if: steps.filter.outputs[matrix.service] == 'true'
+        run: docker build ${{ matrix.context }} -f services/${{ matrix.service }}/Dockerfile -t smoke/${{ matrix.service }}:ci
+
+  # Join job: one stable check name aggregating the matrix legs, so branch
+  # protection can require "docker-build-smoke-ok" instead of four
+  # matrix-suffixed contexts. A skipped leg still reports success (its build
+  # step was gated, the job itself passed), so this only fails when a fired
+  # build genuinely failed.
+  docker-build-smoke-ok:
+    runs-on: ubuntu-latest
+    needs: docker-build-smoke
+    if: always()
+    steps:
+      - name: All fired legs built successfully
+        run: test "${{ needs.docker-build-smoke.result }}" = "success"
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/services/bot-client/Dockerfile
+++ b/services/bot-client/Dockerfile
@@ -6,6 +6,8 @@
 # `dist` MANUALLY (one COPY per runtime dependency, see Stage 4). When adding a
 # new `@tzurot/*` runtime dependency, you MUST add its dist COPY there too, or
 # the runtime image will be missing it and crash with ERR_MODULE_NOT_FOUND.
+# The `docker-build-smoke` CI job builds this image whenever this file (or the
+# prune-affecting workspace config) changes, so that class fails pre-merge.
 # =============================================================================
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What

Owner-directed after today's HF incident work: Dockerfiles were verified only by the real Railway deploy the merge triggers — post-merge is too late. A shell-form CMD typo or a turbo-prune/COPY drift ships broken and takes the service down at deploy time (the 2026-01-17 postmortem class; re-flagged by #1639's review after a Dockerfile CMD change shipped with zero build validation).

## Design

New `docker-build-smoke` job — a four-leg matrix, each leg a **full `docker build`** of one service image, gated by `dorny/paths-filter` (same idiom as `voice-engine-tests`):

| Leg | Context | Fires on |
|---|---|---|
| ai-worker / api-gateway / bot-client | repo root (their pruner stage COPYs the monorepo) | own `Dockerfile`, `pnpm-workspace.yaml`, `turbo.json`, `pnpm-lock.yaml`, root `package.json` |
| voice-engine | `services/voice-engine` | own `Dockerfile`, `requirements.txt` |

Most PRs skip all four legs (checkout + filter only, seconds). A dependabot lockfile batch fires the three node builds; a Dockerfile touch fires one. `fail-fast: false` so one service's build failure doesn't mask another's; 30-min timeout bounds the voice-engine torch install. No layer caching in v1 — the firing rate is low enough that cold builds beat carrying cache plumbing (revisit if dependabot batches make this annoying).

## Proof-of-fire

A ci.yml-only PR would run with all four legs skipped — proving the YAML but never a build. The bot-client Dockerfile comment addition in this PR is deliberate: exactly one leg (bot-client) must actually build on this PR's CI run. Reviewers can check the job output shows three skips + one real ~5-min build.

YAML validated locally (`yaml.safe_load`). Note: `guard:workflow-sync` covers only the claude workflow files — `ci.yml` changes ride develop PRs normally per the documented scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)