### PR TITLE
fix(ai-worker): close the STM/LTM dedup hole — history-first allocation

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
@@ -484,6 +484,85 @@ describe('ContextStep', () => {
       );
     });
 
+    it('nonHistoryOldestTimestamp: current-channel history timestamps must NOT leak into it', async () => {
+      // The field feeds the PESSIMISTIC side of the STM/LTM cutoff; folding
+      // history times back in would silently re-widen the exclusion the exact
+      // shipped-boundary mode exists to avoid.
+      const { step: envStep } = envelopeStep({
+        history: [
+          { role: MessageRole.User, content: 'ancient', createdAt: '2023-06-01T00:00:00Z' },
+        ],
+        referencedMessages: [
+          {
+            referenceNumber: 1,
+            content: 'ref',
+            authorName: 'A',
+            timestamp: '2024-02-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await envStep.process({ job: envelopeJob(), startTime: Date.now(), config });
+
+      // Refs-only value — the (older) history timestamp is excluded.
+      expect(result.preparedContext?.nonHistoryOldestTimestamp).toBe(
+        new Date('2024-02-01T00:00:00Z').getTime()
+      );
+      // …while the combined legacy field still includes history.
+      expect(result.preparedContext?.oldestHistoryTimestamp).toBe(
+        new Date('2023-06-01T00:00:00Z').getTime()
+      );
+    });
+
+    it('nonHistoryOldestTimestamp: min over refs AND cross-channel when both exist', async () => {
+      const { step: envStep } = envelopeStep({
+        referencedMessages: [
+          {
+            referenceNumber: 1,
+            content: 'ref',
+            authorName: 'A',
+            timestamp: '2024-03-01T00:00:00Z',
+          },
+        ],
+        crossChannelHistory: [
+          {
+            channelEnvironment: {
+              type: 'dm' as const,
+              channel: { id: 'dm-1', name: 'DM', type: 'dm' },
+            },
+            messages: [
+              {
+                id: 'msg-cross',
+                role: MessageRole.User,
+                content: 'older cross-channel',
+                createdAt: '2024-01-05T00:00:00Z',
+                personaName: 'Alice',
+                tokenCount: 5,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await envStep.process({ job: envelopeJob(), startTime: Date.now(), config });
+
+      expect(result.preparedContext?.nonHistoryOldestTimestamp).toBe(
+        new Date('2024-01-05T00:00:00Z').getTime()
+      );
+    });
+
+    it('nonHistoryOldestTimestamp: undefined when there are no refs and no cross-channel', async () => {
+      const { step: envStep } = envelopeStep({
+        history: [
+          { role: MessageRole.User, content: 'only history', createdAt: '2024-01-01T00:00:00Z' },
+        ],
+      });
+
+      const result = await envStep.process({ job: envelopeJob(), startTime: Date.now(), config });
+
+      expect(result.preparedContext?.nonHistoryOldestTimestamp).toBeUndefined();
+    });
+
     it('includes cross-channel message timestamps in oldestHistoryTimestamp', async () => {
       // The current-channel history is newer; the older cross-channel message
       // must win the oldest-timestamp calculation (the assembled crossChannelHistory

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
@@ -176,11 +176,12 @@ export class ContextStep implements IPipelineStep {
     // Timestamps from referenced messages (replies, message links)
     // These should also be excluded from LTM to prevent the AI from echoing
     // the content of messages being replied to
+    const nonHistoryTimestamps: number[] = [];
     if (jobContext.referencedMessages && jobContext.referencedMessages.length > 0) {
       const refTimestamps = jobContext.referencedMessages
         .map(ref => extractTimestamp(ref.timestamp as string | Date | undefined))
         .filter((t): t is number => t !== null);
-      allTimestamps.push(...refTimestamps);
+      nonHistoryTimestamps.push(...refTimestamps);
     }
 
     // Timestamps from cross-channel history (also excluded from LTM deduplication)
@@ -189,9 +190,19 @@ export class ContextStep implements IPipelineStep {
         const crossTimestamps = group.messages
           .map(msg => extractTimestamp(msg.createdAt))
           .filter((t): t is number => t !== null);
-        allTimestamps.push(...crossTimestamps);
+        nonHistoryTimestamps.push(...crossTimestamps);
       }
     }
+    allTimestamps.push(...nonHistoryTimestamps);
+
+    // Kept separate from oldestHistoryTimestamp: the STM/LTM cutoff treats
+    // current-channel history EXACTLY (only what actually ships excludes LTM)
+    // but stays pessimistic for refs + cross-channel (they lack per-message
+    // shipped-id plumbing) — so the budget pre-pass needs this min on its own.
+    const nonHistoryOldestTimestamp =
+      nonHistoryTimestamps.length > 0
+        ? nonHistoryTimestamps.reduce((min, ts) => Math.min(min, ts), Infinity)
+        : undefined;
 
     if (allTimestamps.length > 0) {
       // Use reduce() instead of spread to avoid potential stack overflow with large arrays
@@ -222,6 +233,7 @@ export class ContextStep implements IPipelineStep {
       conversationHistory,
       rawConversationHistory: historyEntries,
       oldestHistoryTimestamp,
+      nonHistoryOldestTimestamp,
       participants: allParticipants,
       crossChannelHistory,
     };

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
@@ -53,6 +53,7 @@ export function buildConversationContext(
     conversationHistory: preparedContext.conversationHistory,
     rawConversationHistory: preparedContext.rawConversationHistory,
     oldestHistoryTimestamp: preparedContext.oldestHistoryTimestamp,
+    nonHistoryOldestTimestamp: preparedContext.nonHistoryOldestTimestamp,
     participants: preparedContext.participants,
     attachments: jobContext.attachments,
     preprocessedAttachments:

--- a/services/ai-worker/src/jobs/handlers/pipeline/types.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/types.ts
@@ -180,6 +180,10 @@ export interface PreparedContext {
   rawConversationHistory: ConversationHistoryEntry[];
   /** Oldest timestamp in history (for LTM deduplication) */
   oldestHistoryTimestamp?: number;
+  /** Oldest timestamp over refs + cross-channel ONLY (no current-channel
+   * history) — the pessimistic component of the STM/LTM cutoff; the budget
+   * pre-pass combines it with the EXACT oldest-shipped history timestamp. */
+  nonHistoryOldestTimestamp?: number;
   /** All participants in the conversation */
   participants: Participant[];
   /** Cross-channel conversation history groups (from other channels with same personality) */

--- a/services/ai-worker/src/jobs/utils/conversationUtils.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.ts
@@ -161,7 +161,7 @@ interface FormatConversationHistoryOptions {
  * Uses discordMessageId (Discord snowflakes) NOT id (internal database UUIDs) because
  * referenced messages are identified by their Discord message ID.
  */
-function buildHistoryMessageIdSet(history: RawHistoryEntry[]): Set<string> {
+export function buildHistoryMessageIdSet(history: RawHistoryEntry[]): Set<string> {
   const historyMessageIds = new Set<string>();
   for (const msg of history) {
     // Each message may have multiple Discord IDs (for chunked messages)

--- a/services/ai-worker/src/services/ContentBudgetManager.test.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SystemMessage, HumanMessage } from '@langchain/core/messages';
-import { ContentBudgetManager } from './ContentBudgetManager.js';
+import { ContentBudgetManager, type PreselectedHistory } from './ContentBudgetManager.js';
+import { ContextWindowManager as RealContextWindowManager } from './context/ContextWindowManager.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ContextWindowManager } from './context/ContextWindowManager.js';
 import type { BudgetAllocationOptions, MemoryDocument } from './ConversationalRAGTypes.js';
@@ -54,13 +55,13 @@ describe('ContentBudgetManager', () => {
         memoriesDropped: 0,
         droppedDueToSize: 0,
       }),
-      calculateHistoryBudget: vi.fn().mockReturnValue(500),
       selectAndSerializeHistory: vi.fn().mockReturnValue({
         serializedHistory: '',
         historyTokensUsed: 0,
         messagesIncluded: 0,
         messagesDropped: 0,
         crossChannelMessagesIncluded: 0,
+        selectedEntries: [],
       }),
     } as unknown as ContextWindowManager;
 
@@ -86,7 +87,7 @@ describe('ContentBudgetManager', () => {
     it('should return budget allocation result with all required fields', () => {
       const options = createBaseOptions();
 
-      const result = budgetManager.allocate(options);
+      const result = budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(result).toHaveProperty('relevantMemories');
       expect(result).toHaveProperty('serializedHistory');
@@ -101,7 +102,7 @@ describe('ContentBudgetManager', () => {
     it('should build human message from prompt builder', () => {
       const options = createBaseOptions();
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       // Uses expect.objectContaining to focus on key parameters without being brittle
       // to implementation details (e.g., referencedMessagesDescriptions can be undefined)
@@ -123,7 +124,7 @@ describe('ContentBudgetManager', () => {
       // clamped to the model's real limit) is what must drive the budget
       options.effectiveContextWindowTokens = 6000;
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(mockContextWindowManager.calculateMemoryBudget).toHaveBeenCalledWith(
         6000,
@@ -148,7 +149,7 @@ describe('ContentBudgetManager', () => {
         droppedDueToSize: 0,
       });
 
-      const result = budgetManager.allocate(options);
+      const result = budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(mockContextWindowManager.selectMemoriesWithinBudget).toHaveBeenCalledWith(
         memories,
@@ -173,9 +174,10 @@ describe('ContentBudgetManager', () => {
         messagesIncluded: 2,
         messagesDropped: 0,
         crossChannelMessagesIncluded: 0,
+        selectedEntries: [],
       });
 
-      const result = budgetManager.allocate(options);
+      const result = budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(mockContextWindowManager.selectAndSerializeHistory).toHaveBeenCalled();
       expect(result.serializedHistory).toBe('Serialized history content');
@@ -186,13 +188,16 @@ describe('ContentBudgetManager', () => {
     it('should build final system prompt with memories and history', () => {
       const options = createBaseOptions();
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
-      // buildFullSystemPrompt should be called 3 times:
-      // 1. Base system prompt (for token counting)
-      // 2. With memories (for history budget calculation)
-      // 3. Final with memories AND history
-      expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledTimes(3);
+      // buildFullSystemPrompt is called exactly twice:
+      // 1. Base system prompt (pre-pass, for token counting)
+      // 2. Final with memories AND history
+      // The old middle build (prompt-with-memories to size the history
+      // budget) is gone by design: the history budget uses the memory
+      // RESERVE so it is computable BEFORE retrieval — that ordering is what
+      // closes the STM/LTM coverage hole.
+      expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledTimes(2);
     });
 
     it('should pass participant personas to system prompt builder', () => {
@@ -201,7 +206,7 @@ describe('ContentBudgetManager', () => {
         ['Alice', { content: 'User persona', isActive: true, personaId: 'persona-alice' }],
       ]);
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -214,7 +219,7 @@ describe('ContentBudgetManager', () => {
       const options = createBaseOptions();
       options.referencedMessagesDescriptions = 'Referenced: Some quoted message';
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -227,7 +232,7 @@ describe('ContentBudgetManager', () => {
       const options = createBaseOptions();
       options.context.userTimezone = 'America/New_York';
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(mockContextWindowManager.selectMemoriesWithinBudget).toHaveBeenCalledWith(
         expect.anything(),
@@ -244,7 +249,7 @@ describe('ContentBudgetManager', () => {
 
       const options = createBaseOptions();
 
-      const result = budgetManager.allocate(options);
+      const result = budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(result.contentForStorage).toBe('Clean content for LTM storage');
     });
@@ -265,7 +270,7 @@ describe('ContentBudgetManager', () => {
         droppedDueToSize: 1,
       });
 
-      const result = budgetManager.allocate(options);
+      const result = budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(result.relevantMemories).toHaveLength(1);
       expect(result.memoriesDroppedCount).toBe(2);
@@ -286,9 +291,10 @@ describe('ContentBudgetManager', () => {
         messagesIncluded: 2,
         messagesDropped: 2,
         crossChannelMessagesIncluded: 0,
+        selectedEntries: [],
       });
 
-      const result = budgetManager.allocate(options);
+      const result = budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       expect(result.messagesDropped).toBe(2);
     });
@@ -315,7 +321,7 @@ describe('ContentBudgetManager', () => {
         },
       ];
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       // Verify cross-channel groups were passed as 4th arg
       const call = vi.mocked(mockContextWindowManager.selectAndSerializeHistory).mock.calls[0];
@@ -335,7 +341,7 @@ describe('ContentBudgetManager', () => {
       };
       options.context.environment = environment;
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       const call = vi.mocked(mockContextWindowManager.selectAndSerializeHistory).mock.calls[0];
       expect(call).toBeDefined();
@@ -347,7 +353,7 @@ describe('ContentBudgetManager', () => {
       const options = createBaseOptions();
       // No environment set in context
 
-      budgetManager.allocate(options);
+      budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
       const call = vi.mocked(mockContextWindowManager.selectAndSerializeHistory).mock.calls[0];
       expect(call).toBeDefined();
@@ -374,7 +380,10 @@ describe('ContentBudgetManager', () => {
     });
 
     it('selects facts within the reserved slice and reduces the episode budget by exactly that cost', () => {
-      const result = budgetManager.allocate(withFacts(3));
+      const result = (() => {
+        const o = withFacts(3);
+        return budgetManager.allocate(o, budgetManager.preselectHistory(o));
+      })();
 
       // 2 of 3 facts fit the 300-token slice; factTokensUsed = 300.
       expect(result.selectedFacts).toHaveLength(2);
@@ -392,7 +401,10 @@ describe('ContentBudgetManager', () => {
     });
 
     it('no facts → episodes keep the full memory budget, factTokensUsed 0', () => {
-      const result = budgetManager.allocate(withFacts(0));
+      const result = (() => {
+        const o = withFacts(0);
+        return budgetManager.allocate(o, budgetManager.preselectHistory(o));
+      })();
 
       expect(result.selectedFacts).toEqual([]);
       expect(result.factTokensUsed).toBe(0);
@@ -406,7 +418,10 @@ describe('ContentBudgetManager', () => {
       // below the 100-token wrapper overhead. The FIRST fact can never fit, so the
       // block collapses to empty rather than emitting a wrapper with no facts inside.
       vi.mocked(mockContextWindowManager.calculateMemoryBudget).mockReturnValue(300);
-      const result = budgetManager.allocate(withFacts(3));
+      const result = (() => {
+        const o = withFacts(3);
+        return budgetManager.allocate(o, budgetManager.preselectHistory(o));
+      })();
 
       expect(result.selectedFacts).toEqual([]);
       expect(result.factTokensUsed).toBe(0);
@@ -419,6 +434,203 @@ describe('ContentBudgetManager', () => {
         .mocked(mockPromptBuilder.buildFullSystemPrompt)
         .mock.calls.at(-1)?.[0].facts;
       expect(promptFacts).toEqual([]);
+    });
+  });
+
+  describe('STM/LTM selection filter (dedup-hole fix)', () => {
+    const mem = (
+      id: string,
+      createdAt: number,
+      messageIds: string[] | undefined,
+      channelId = 'channel-123'
+    ): MemoryDocument => ({
+      pageContent: `memory ${id}`,
+      metadata: { id, createdAt, score: 0.9, messageIds, channelId },
+    });
+
+    const preselectedWith = (overrides: Partial<PreselectedHistory>): PreselectedHistory => ({
+      currentMessage: new HumanMessage('hi'),
+      contentForStorage: 'hi',
+      systemPromptBaseTokens: 100,
+      currentMessageTokens: 10,
+      memoryReserve: 1000,
+      historyBudget: 500,
+      serializedHistory: '<chat_log/>',
+      historyTokensUsed: 50,
+      messagesDropped: 0,
+      crossChannelMessagesIncluded: 0,
+      shippedMessageIds: new Set<string>(),
+      ...overrides,
+    });
+
+    const allocateAndCaptureFiltered = (
+      memories: MemoryDocument[],
+      preselected: PreselectedHistory
+    ): MemoryDocument[] => {
+      const options = { ...createFilterOptions(), retrievedMemories: memories };
+      budgetManager.allocate(options, preselected);
+      // Seam assertion target: whatever survived the filter is what memory
+      // selection receives.
+      const calls = vi.mocked(mockContextWindowManager.selectMemoriesWithinBudget).mock.calls;
+      return calls[calls.length - 1][0] as MemoryDocument[];
+    };
+
+    const createFilterOptions = (): BudgetAllocationOptions => ({
+      personality: mockPersonality,
+      processedPersonality: mockPersonality,
+      participantPersonas: new Map(),
+      retrievedMemories: [],
+      context: { userId: 'user-123', channelId: 'channel-123' },
+      userMessage: 'hello',
+      processedAttachments: [],
+      referencedMessagesDescriptions: undefined,
+      effectiveContextWindowTokens: 8000,
+    });
+
+    const CUTOFF = 1_000_000;
+
+    it('keeps memories older than the oldest SHIPPED message (exact time baseline)', () => {
+      const kept = allocateAndCaptureFiltered(
+        [mem('old', CUTOFF - 1, ['m-old'])],
+        preselectedWith({ oldestSelectedTs: CUTOFF, shippedMessageIds: new Set(['s1']) })
+      );
+      expect(kept.map(m => m.metadata?.id)).toEqual(['old']);
+    });
+
+    it('drops a memory whose source message SHIPPED (ID-authoritative dedup)', () => {
+      const kept = allocateAndCaptureFiltered(
+        [mem('shipped', CUTOFF + 50, ['s1'])],
+        preselectedWith({ oldestSelectedTs: CUTOFF, shippedMessageIds: new Set(['s1']) })
+      );
+      expect(kept).toEqual([]);
+    });
+
+    it('RESCUES a dropped-range memory: newer than the cutoff (persistence lag) but its source never shipped', () => {
+      const kept = allocateAndCaptureFiltered(
+        [mem('dropped-range', CUTOFF + 50, ['m-dropped'])],
+        preselectedWith({ oldestSelectedTs: CUTOFF, shippedMessageIds: new Set(['s1']) })
+      );
+      expect(kept.map(m => m.metadata?.id)).toEqual(['dropped-range']);
+    });
+
+    it('does NOT rescue across channels — shipped cross-channel content must not re-enter as duplication', () => {
+      const kept = allocateAndCaptureFiltered(
+        [mem('other-channel', CUTOFF + 50, ['x1'], 'other-channel-id')],
+        preselectedWith({ oldestSelectedTs: CUTOFF, shippedMessageIds: new Set(['s1']) })
+      );
+      expect(kept).toEqual([]);
+    });
+
+    it('legacy id-less rows get only the time baseline (no rescue)', () => {
+      const kept = allocateAndCaptureFiltered(
+        [mem('legacy-band', CUTOFF + 50, undefined), mem('legacy-old', CUTOFF - 1, undefined)],
+        preselectedWith({ oldestSelectedTs: CUTOFF, shippedMessageIds: new Set(['s1']) })
+      );
+      expect(kept.map(m => m.metadata?.id)).toEqual(['legacy-old']);
+    });
+
+    it('normalizes a STRING createdAt — a predating memory is kept, not silently dropped', () => {
+      // channelId mismatched + ids unshipped: the time baseline is the ONLY
+      // path that can keep this memory, isolating the normalization.
+      const kept = allocateAndCaptureFiltered(
+        [
+          {
+            pageContent: 'string-stamped memory',
+            metadata: {
+              id: 'str-ts',
+              createdAt: new Date(CUTOFF - 1).toISOString(),
+              score: 0.9,
+              messageIds: ['m-x'],
+              channelId: 'some-other-channel',
+            },
+          },
+        ],
+        preselectedWith({ oldestSelectedTs: CUTOFF, shippedMessageIds: new Set(['s1']) })
+      );
+      expect(kept.map(m => m.metadata?.id)).toEqual(['str-ts']);
+    });
+
+    it('applies no filter when nothing shipped (everything-truncated turns keep full LTM coverage)', () => {
+      const kept = allocateAndCaptureFiltered(
+        [mem('any', CUTOFF + 50, ['m1'])],
+        preselectedWith({ oldestSelectedTs: undefined })
+      );
+      expect(kept.map(m => m.metadata?.id)).toEqual(['any']);
+    });
+  });
+
+  describe('invariant: a budget-dropped message stays LTM-reachable (real history selection)', () => {
+    it('preselect with a REAL ContextWindowManager exposes the exact shipped boundary and ids', () => {
+      // Four entries, newest-first selection under a budget that fits only
+      // the newest two — E1/E2 drop, E3/E4 ship.
+      const entry = (n: number): Record<string, unknown> => ({
+        id: `uuid-${n}`,
+        discordMessageId: [`snowflake-${n}`],
+        role: n % 2 === 0 ? 'assistant' : 'user',
+        content: `message ${n}`,
+        createdAt: new Date(1_000_000 + n * 60_000).toISOString(),
+        // Sized so the REAL budget math (window 1450 − base 100 − msg 100 −
+        // real memory hardCap) fits exactly TWO entries: E1/E2 drop, E3/E4 ship.
+        tokenCount: 400,
+      });
+      const realManager = new RealContextWindowManager();
+      const manager = new ContentBudgetManager(mockPromptBuilder, realManager);
+      const options = {
+        personality: mockPersonality,
+        processedPersonality: mockPersonality,
+        participantPersonas: new Map(),
+        context: {
+          userId: 'user-123',
+          channelId: 'channel-123',
+          rawConversationHistory: [entry(1), entry(2), entry(3), entry(4)],
+        },
+        userMessage: 'hello',
+        processedAttachments: [],
+        referencedMessagesDescriptions: undefined,
+        // base(100 via countTokens mock) + msg(100) + reserve leaves a history
+        // budget that fits ~2 entries of 100 tokens + wrapper.
+        effectiveContextWindowTokens: 100 + 100 + 1000 + 250,
+      } as unknown as BudgetAllocationOptions;
+      vi.mocked(mockPromptBuilder.countTokens).mockReturnValue(100);
+
+      const preselected = manager.preselectHistory(options);
+
+      // The exact boundary: E3 is the oldest SHIPPED entry.
+      expect(preselected.messagesDropped).toBe(2);
+      expect(preselected.oldestSelectedTs).toBe(1_000_000 + 3 * 60_000);
+      expect([...preselected.shippedMessageIds].sort()).toEqual(['snowflake-3', 'snowflake-4']);
+      // The invariant, composed: a memory of DROPPED E1 — created after the
+      // boundary (persistence lag) with E1's snowflake — survives the filter…
+      const droppedMemory: MemoryDocument = {
+        pageContent: 'memory of E1',
+        metadata: {
+          id: 'mem-e1',
+          createdAt: (preselected.oldestSelectedTs as number) + 5_000,
+          score: 0.9,
+          messageIds: ['snowflake-1'],
+          channelId: 'channel-123',
+        },
+      };
+      // …while a memory of SHIPPED E4 is dropped.
+      const shippedMemory: MemoryDocument = {
+        pageContent: 'memory of E4',
+        metadata: {
+          id: 'mem-e4',
+          createdAt: (preselected.oldestSelectedTs as number) + 6_000,
+          score: 0.9,
+          messageIds: ['snowflake-4'],
+          channelId: 'channel-123',
+        },
+      };
+      manager.allocate(
+        { ...options, retrievedMemories: [droppedMemory, shippedMemory], facts: [] },
+        preselected
+      );
+      const calls = vi.mocked(mockPromptBuilder.buildFullSystemPrompt).mock.calls;
+      const finalPromptArgs = calls[calls.length - 1][0] as {
+        relevantMemories: MemoryDocument[];
+      };
+      expect(finalPromptArgs.relevantMemories.map(m => m.metadata?.id)).toEqual(['mem-e1']);
     });
   });
 });

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -9,6 +9,7 @@
 import type { HumanMessage } from '@langchain/core/messages';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { contentToText } from '../utils/baseMessageContent.js';
+import { buildHistoryMessageIdSet } from '../jobs/utils/conversationUtils.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ContextWindowManager } from './context/ContextWindowManager.js';
 import {
@@ -35,11 +36,192 @@ const logger = createLogger('ContentBudgetManager');
 const FACT_BUDGET_MAX_TOKENS = 600;
 const FACT_BUDGET_MAX_FRACTION = 0.3;
 
+/**
+ * The history pre-pass result (STM/LTM dedup-hole fix). History is selected
+ * BEFORE memory retrieval — it needs nothing from memories once the memory
+ * budget is a reserve — so the EXACT shipped-history boundary is known when
+ * the LTM query runs, instead of assuming all fetched history ships and
+ * losing the truncated range to neither path.
+ */
+export interface PreselectedHistory {
+  currentMessage: HumanMessage;
+  contentForStorage: string;
+  systemPromptBaseTokens: number;
+  currentMessageTokens: number;
+  /** Memory budget (same formula as always) — reserved up front so the
+   * history budget is computable pre-retrieval. */
+  memoryReserve: number;
+  historyBudget: number;
+  serializedHistory: string;
+  historyTokensUsed: number;
+  messagesDropped: number;
+  crossChannelMessagesIncluded: number;
+  /** min createdAt over SELECTED current-channel entries; undefined when
+   * nothing shipped. The exact time baseline for STM/LTM dedup. */
+  oldestSelectedTs?: number;
+  /** Discord snowflakes of every shipped current-channel entry (incl. chunk
+   * ids) — the authoritative ID-dedup set. */
+  shippedMessageIds: Set<string>;
+}
+
 export class ContentBudgetManager {
   constructor(
     private readonly promptBuilder: PromptBuilder,
     private readonly contextWindowManager: ContextWindowManager
   ) {}
+
+  /**
+   * Select history BEFORE memory retrieval. The memory budget uses the same
+   * formula as always (contention floor preserved: recency yields to identity
+   * at the margin) but as a RESERVE, so the history budget — and therefore the
+   * exact set of shipped messages — no longer depends on what retrieval
+   * returns. Known behavioral delta vs the old order: when memories underuse
+   * their reserve AND history exceeds the reserve-based budget, a few oldest
+   * messages truncate that previously squeaked in — but they become
+   * LTM-reachable by construction (the safe direction).
+   */
+  preselectHistory(
+    opts: Omit<BudgetAllocationOptions, 'retrievedMemories' | 'facts'>
+  ): PreselectedHistory {
+    const { personality, context, historyReductionPercent } = opts;
+    const contextWindowTokens = opts.effectiveContextWindowTokens;
+
+    // Cast is safe: buildBaseComponents reads only prompt/message inputs,
+    // never the omitted retrieval fields (retrievedMemories/facts) — they
+    // don't exist yet at pre-pass time, which is the whole point. If
+    // buildBaseComponents ever grows a retrieval-field read, narrow its
+    // parameter type instead of widening this call.
+    const { currentMessage, contentForStorage, systemPromptBaseTokens } = this.buildBaseComponents(
+      opts as BudgetAllocationOptions
+    );
+    const currentMessageTokens = this.promptBuilder.countTokens(
+      contentToText(currentMessage.content)
+    );
+
+    const historyTokens = this.contextWindowManager.countHistoryTokens(
+      context.rawConversationHistory,
+      personality.name
+    );
+    const memoryReserve = this.contextWindowManager.calculateMemoryBudget(
+      contextWindowTokens,
+      systemPromptBaseTokens,
+      currentMessageTokens,
+      historyTokens
+    );
+
+    let historyBudget = Math.max(
+      0,
+      contextWindowTokens - systemPromptBaseTokens - currentMessageTokens - memoryReserve
+    );
+    // History reduction for duplicate-detection retries (changes the context
+    // window to break API-level caching on free models) — history absorbs it;
+    // the memory reserve is untouched, same as the old order.
+    if (historyReductionPercent !== undefined && historyReductionPercent > 0) {
+      const reducedBudget = Math.floor(historyBudget * (1 - historyReductionPercent));
+      logger.info(
+        {
+          reductionPercent: Math.round(historyReductionPercent * 100),
+          originalBudget: historyBudget,
+          reducedBudget,
+        },
+        'Reducing history budget for duplicate retry'
+      );
+      historyBudget = reducedBudget;
+    }
+
+    const {
+      serializedHistory,
+      historyTokensUsed,
+      messagesDropped,
+      crossChannelMessagesIncluded,
+      selectedEntries,
+    } = this.contextWindowManager.selectAndSerializeHistory(
+      context.rawConversationHistory,
+      personality.name,
+      historyBudget,
+      context.crossChannelHistory,
+      context.environment
+    );
+
+    const selectedTimestamps = selectedEntries
+      .map(entry => (entry.createdAt !== undefined ? new Date(entry.createdAt).getTime() : NaN))
+      .filter(ts => Number.isFinite(ts));
+    const oldestSelectedTs =
+      selectedTimestamps.length > 0
+        ? selectedTimestamps.reduce((min, ts) => Math.min(min, ts), Infinity)
+        : undefined;
+
+    return {
+      currentMessage,
+      contentForStorage,
+      systemPromptBaseTokens,
+      currentMessageTokens,
+      memoryReserve,
+      historyBudget,
+      serializedHistory,
+      historyTokensUsed,
+      messagesDropped,
+      crossChannelMessagesIncluded,
+      oldestSelectedTs,
+      shippedMessageIds: buildHistoryMessageIdSet(selectedEntries),
+    };
+  }
+
+  /**
+   * STM/LTM dedup at selection time — the authoritative filter (the query
+   * cutoff over-retrieves past the boundary to catch memory-persistence lag).
+   * Keep a memory iff:
+   *   - it predates the oldest SHIPPED current-channel message (exact time
+   *     baseline, strict — no buffer band), OR
+   *   - it is a current-channel memory whose source messages were all DROPPED
+   *     (has messageIds, none shipped) — the rescue that closes the hole.
+   * The rescue is CHANNEL-SCOPED: without that, memories of shipped
+   * cross-channel content would re-enter as duplication (their ids are not in
+   * the shipped-current set). Legacy id-less rows get only the time baseline —
+   * today's semantics. No filter when nothing shipped.
+   */
+  private filterShippedMemories(
+    memories: MemoryDocument[],
+    preselected: PreselectedHistory,
+    currentChannelId: string | undefined
+  ): MemoryDocument[] {
+    const { oldestSelectedTs, shippedMessageIds } = preselected;
+    if (oldestSelectedTs === undefined) {
+      return memories;
+    }
+    const kept = memories.filter(memory => {
+      // createdAt is string | number by type; normalize once so a
+      // string-stamped memory that predates the boundary cannot silently
+      // fall through to the (stricter) rescue branch and be dropped — that
+      // would be the exact coverage-loss class this filter exists to close.
+      const createdAtRaw = memory.metadata?.createdAt;
+      const createdAtMs = createdAtRaw !== undefined ? new Date(createdAtRaw).getTime() : NaN;
+      if (Number.isFinite(createdAtMs) && createdAtMs < oldestSelectedTs) {
+        return true;
+      }
+      const messageIds = memory.metadata?.messageIds;
+      const channelId = memory.metadata?.channelId;
+      return (
+        currentChannelId !== undefined &&
+        channelId === currentChannelId &&
+        Array.isArray(messageIds) &&
+        messageIds.length > 0 &&
+        !messageIds.some(id => shippedMessageIds.has(id))
+      );
+    });
+    if (kept.length < memories.length) {
+      logger.info(
+        {
+          retrieved: memories.length,
+          kept: kept.length,
+          filtered: memories.length - kept.length,
+          oldestSelectedTs,
+        },
+        'STM/LTM selection filter dropped shipped-range memories'
+      );
+    }
+    return kept;
+  }
 
   /**
    * Allocate token budgets and select memories/history within constraints
@@ -53,39 +235,38 @@ export class ContentBudgetManager {
    * 5. Select and serialize history
    * 6. Build final system prompt with all content
    */
-  allocate(opts: BudgetAllocationOptions): BudgetAllocationResult {
+  allocate(opts: BudgetAllocationOptions, preselected: PreselectedHistory): BudgetAllocationResult {
     const { processedPersonality, participantPersonas, context } = opts;
     const contextWindowTokens = opts.effectiveContextWindowTokens;
 
-    // Build current message and base system prompt
-    const { currentMessage, contentForStorage, systemPromptBaseTokens } =
-      this.buildBaseComponents(opts);
-    const currentMessageTokens = this.promptBuilder.countTokens(
-      contentToText(currentMessage.content)
+    // History was selected BEFORE retrieval (preselectHistory) so the exact
+    // shipped boundary informed the LTM query; here memories are dedup-filtered
+    // against what actually shipped, then selected into the reserve.
+    const {
+      contentForStorage,
+      systemPromptBaseTokens,
+      currentMessageTokens,
+      serializedHistory,
+      historyTokensUsed,
+      historyBudget,
+      messagesDropped,
+      crossChannelMessagesIncluded,
+    } = preselected;
+
+    const dedupedMemories = this.filterShippedMemories(
+      opts.retrievedMemories,
+      preselected,
+      context.channelId
     );
 
-    // Select memories + facts within budget (facts get a reserved sub-budget)
+    // Select memories + facts within the reserve (facts get a reserved sub-budget)
     const {
       relevantMemories,
       memoryTokensUsed,
       memoriesDroppedCount,
       selectedFacts,
       factTokensUsed,
-    } = this.selectMemories(
-      opts,
-      contextWindowTokens,
-      systemPromptBaseTokens,
-      currentMessageTokens
-    );
-
-    // Select history within budget
-    const {
-      serializedHistory,
-      historyTokensUsed,
-      historyBudget,
-      messagesDropped,
-      crossChannelMessagesIncluded,
-    } = this.selectHistory(opts, relevantMemories, contextWindowTokens, currentMessageTokens);
+    } = this.selectMemories(opts, dedupedMemories, preselected.memoryReserve);
 
     // Build final system prompt
     // Note: Image descriptions are now inline in serializedHistory (via injectImageDescriptions)
@@ -174,9 +355,8 @@ export class ContentBudgetManager {
 
   private selectMemories(
     opts: BudgetAllocationOptions,
-    contextWindowTokens: number,
-    systemPromptBaseTokens: number,
-    currentMessageTokens: number
+    dedupedMemories: MemoryDocument[],
+    memoryBudget: number
   ): {
     relevantMemories: MemoryDocument[];
     memoryTokensUsed: number;
@@ -184,18 +364,7 @@ export class ContentBudgetManager {
     selectedFacts: FactForPrompt[];
     factTokensUsed: number;
   } {
-    const { personality, retrievedMemories, context } = opts;
-    const historyTokens = this.contextWindowManager.countHistoryTokens(
-      context.rawConversationHistory,
-      personality.name
-    );
-
-    const memoryBudget = this.contextWindowManager.calculateMemoryBudget(
-      contextWindowTokens,
-      systemPromptBaseTokens,
-      currentMessageTokens,
-      historyTokens
-    );
+    const { personality, context } = opts;
 
     // Facts take their reserved slice FIRST; episodes get the remainder — so a
     // dense cluster of short facts can't starve verbose episodes, and vice versa.
@@ -212,7 +381,7 @@ export class ContentBudgetManager {
       memoriesDropped: memoriesDroppedCount,
       droppedDueToSize,
     } = this.contextWindowManager.selectMemoriesWithinBudget(
-      retrievedMemories,
+      dedupedMemories,
       episodeBudget,
       context.userTimezone
     );
@@ -221,7 +390,7 @@ export class ContentBudgetManager {
       logger.info(
         {
           kept: relevantMemories.length,
-          total: retrievedMemories.length,
+          total: dedupedMemories.length,
           tokensUsed: memoryTokensUsed,
           budget: memoryBudget,
           episodeBudget,
@@ -281,81 +450,6 @@ export class ContentBudgetManager {
     return selected.length > 0
       ? { selectedFacts: selected, factTokensUsed: used }
       : { selectedFacts: [], factTokensUsed: 0 };
-  }
-
-  private selectHistory(
-    opts: BudgetAllocationOptions,
-    relevantMemories: MemoryDocument[],
-    contextWindowTokens: number,
-    currentMessageTokens: number
-  ): {
-    serializedHistory: string;
-    historyTokensUsed: number;
-    historyBudget: number;
-    messagesDropped: number;
-    crossChannelMessagesIncluded: number;
-  } {
-    const {
-      personality,
-      processedPersonality,
-      participantPersonas,
-      context,
-      referencedMessagesDescriptions,
-      historyReductionPercent,
-    } = opts;
-
-    const systemPromptWithMemories = this.promptBuilder.buildFullSystemPrompt({
-      personality: processedPersonality,
-      participantPersonas,
-      relevantMemories,
-      context,
-      referencedMessagesFormatted: referencedMessagesDescriptions,
-    });
-
-    const systemPromptWithMemoriesTokens = this.promptBuilder.countTokens(
-      contentToText(systemPromptWithMemories.content)
-    );
-
-    let historyBudget = this.contextWindowManager.calculateHistoryBudget(
-      contextWindowTokens,
-      systemPromptWithMemoriesTokens,
-      currentMessageTokens,
-      0
-    );
-
-    // Apply history reduction for duplicate detection retries
-    // This changes the context window to help break API-level caching on free models
-    if (historyReductionPercent !== undefined && historyReductionPercent > 0) {
-      const reducedBudget = Math.floor(historyBudget * (1 - historyReductionPercent));
-      logger.info(
-        {
-          reductionPercent: Math.round(historyReductionPercent * 100),
-          originalBudget: historyBudget,
-          reducedBudget,
-        },
-        'Reducing history budget for duplicate retry'
-      );
-      historyBudget = reducedBudget;
-    }
-
-    const crossChannelGroups = context.crossChannelHistory;
-
-    const { serializedHistory, historyTokensUsed, messagesDropped, crossChannelMessagesIncluded } =
-      this.contextWindowManager.selectAndSerializeHistory(
-        context.rawConversationHistory,
-        personality.name,
-        historyBudget,
-        crossChannelGroups,
-        context.environment
-      );
-
-    return {
-      serializedHistory,
-      historyTokensUsed,
-      historyBudget,
-      messagesDropped,
-      crossChannelMessagesIncluded,
-    };
   }
 
   private logAllocation(opts: {

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -272,13 +272,49 @@ describe('ConversationalRAGService', () => {
       );
     });
 
+    it('pre-pass boundary crosses the seam: oldestSelectedTs is ON the context WHEN retrieval runs', async () => {
+      const personality = createMockPersonality();
+      const context = createMockContext();
+      const shippedTs = new Date('2026-03-01T00:00:00.000Z');
+      getContextWindowManagerMock().selectAndSerializeHistory.mockReturnValue({
+        serializedHistory: '<chat_log/>',
+        historyTokensUsed: 50,
+        messagesIncluded: 1,
+        messagesDropped: 2,
+        crossChannelMessagesIncluded: 0,
+        selectedEntries: [{ role: 'user', content: 'shipped', createdAt: shippedTs.toISOString() }],
+      });
+      // Snapshot AT CALL TIME — the context object is mutated in place, so a
+      // post-hoc assertion on it would pass even if the wiring ran too late
+      // (after retrieval) or never ran at all.
+      let cutoffSeenByRetrieval: number | undefined | null = null;
+      getMemoryRetrieverMock().retrieveRelevantMemories.mockImplementation(
+        async (
+          _p: unknown,
+          _q: unknown,
+          ctx: { stmLtmCutoffInputs?: { oldestSelectedTs?: number } }
+        ) => {
+          cutoffSeenByRetrieval = ctx.stmLtmCutoffInputs?.oldestSelectedTs ?? undefined;
+          return { memories: [], focusModeEnabled: false };
+        }
+      );
+
+      await service.generateResponse(personality, 'Test message', context);
+
+      expect(cutoffSeenByRetrieval).toBe(shippedTs.getTime());
+    });
+
     it('should build context window via ContextWindowManager', async () => {
       const personality = createMockPersonality();
       const context = createMockContext();
 
       await service.generateResponse(personality, 'Test message', context);
 
-      expect(getContextWindowManagerMock().calculateHistoryBudget).toHaveBeenCalled();
+      // calculateHistoryBudget is no longer consulted: the history budget is
+      // window − base − msg − memoryReserve, computed in the pre-pass BEFORE
+      // retrieval (the STM/LTM dedup-hole fix); the reserve comes from
+      // calculateMemoryBudget as before.
+      expect(getContextWindowManagerMock().calculateMemoryBudget).toHaveBeenCalled();
       expect(getContextWindowManagerMock().selectAndSerializeHistory).toHaveBeenCalled();
     });
 

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -381,6 +381,28 @@ export class ConversationalRAGService {
         context
       );
 
+      // Step 2.5: History pre-pass — select shipped history BEFORE retrieval
+      // (STM/LTM dedup-hole fix: the exact shipped boundary must inform the
+      // LTM query, or budget-truncated messages become reachable by neither
+      // shipped-history nor LTM).
+      const effectiveContextWindowTokens = await resolveEffectiveContextWindow(
+        personality,
+        options.effectiveProvider
+      );
+      const budgetOptionsBase = {
+        personality,
+        processedPersonality,
+        participantPersonas,
+        context,
+        userMessage: inputs.userMessage,
+        processedAttachments: inputs.processedAttachments,
+        referencedMessagesDescriptions: inputs.referencedMessagesDescriptions,
+        historyReductionPercent: retryConfig?.historyReductionPercent,
+        effectiveContextWindowTokens,
+      };
+      const preselected = this.contentBudgetManager.preselectHistory(budgetOptionsBase);
+      context.stmLtmCutoffInputs = { oldestSelectedTs: preselected.oldestSelectedTs };
+
       // Step 3: Retrieve memories + facts (gate/scope semantics live on the helper)
       const {
         memories: retrievedMemories,
@@ -399,23 +421,10 @@ export class ConversationalRAGService {
       // Step 4: Allocate token budgets and select content
       // Note: Image descriptions and stored reference hydration are handled by
       // enrichConversationHistory (Step 1.5) — history is already enriched here
-      const effectiveContextWindowTokens = await resolveEffectiveContextWindow(
-        personality,
-        options.effectiveProvider
+      const budgetResult = this.contentBudgetManager.allocate(
+        { ...budgetOptionsBase, retrievedMemories, facts },
+        preselected
       );
-      const budgetResult = this.contentBudgetManager.allocate({
-        personality,
-        processedPersonality,
-        participantPersonas,
-        retrievedMemories,
-        facts,
-        context,
-        userMessage: inputs.userMessage,
-        processedAttachments: inputs.processedAttachments,
-        referencedMessagesDescriptions: inputs.referencedMessagesDescriptions,
-        historyReductionPercent: retryConfig?.historyReductionPercent,
-        effectiveContextWindowTokens,
-      });
 
       // Record memory retrieval and token budget for diagnostics
       if (diagnosticCollector) {

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -43,6 +43,11 @@ export interface MemoryDocument {
     id?: string;
     createdAt?: string | number;
     score?: number;
+    /** Discord snowflakes of the memory's source messages (Phase 0 R8
+     * linkage) — the STM/LTM selection filter's ID-dedup key. */
+    messageIds?: string[] | null;
+    /** Channel the memory was formed in — scopes the dedup rescue. */
+    channelId?: string | null;
   };
 }
 
@@ -144,6 +149,15 @@ export interface ConversationContext {
     };
   }[];
   oldestHistoryTimestamp?: number;
+  /** Oldest timestamp over refs + cross-channel only (see PreparedContext). */
+  nonHistoryOldestTimestamp?: number;
+  /**
+   * Set by the RAG orchestrator AFTER the history pre-pass, BEFORE retrieval.
+   * Presence of the object means the pre-pass ran (exact-dedup mode);
+   * oldestSelectedTs is the min createdAt of SHIPPED current-channel history
+   * (undefined = nothing shipped → no time exclusion needed: LTM covers all).
+   */
+  stmLtmCutoffInputs?: { oldestSelectedTs?: number };
   participants?: ParticipantPersona[];
   /** Attachments from triggering message */
   attachments?: AttachmentMetadata[];

--- a/services/ai-worker/src/services/MemoryRetriever.test.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.test.ts
@@ -708,6 +708,71 @@ describe('MemoryRetriever', () => {
       );
     });
 
+    it('exact mode: cutoff = oldest SHIPPED message PLUS buffer (over-retrieve past the boundary)', async () => {
+      mockPersonaResolver.resolveForMemory.mockResolvedValue({
+        personaId: 'persona-123',
+        focusModeEnabled: false,
+      });
+
+      const oldestShipped = Date.now() - 3600000;
+      const contextExact: ConversationContext = {
+        ...context,
+        // Legacy field present too — exact mode must take precedence over it.
+        oldestHistoryTimestamp: oldestShipped - 999999,
+        stmLtmCutoffInputs: { oldestSelectedTs: oldestShipped },
+      };
+
+      await retriever.retrieveRelevantMemories(mockPersonality, 'test', contextExact);
+
+      expect(mockMemoryManager.queryMemories).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ excludeNewerThan: oldestShipped + 10000 })
+      );
+    });
+
+    it('exact mode: refs/cross-channel keep the pessimistic MINUS-buffer bound when older', async () => {
+      mockPersonaResolver.resolveForMemory.mockResolvedValue({
+        personaId: 'persona-123',
+        focusModeEnabled: false,
+      });
+
+      const oldestShipped = Date.now() - 3600000;
+      const oldCrossChannel = oldestShipped - 500000; // older → binding
+      const contextExact: ConversationContext = {
+        ...context,
+        nonHistoryOldestTimestamp: oldCrossChannel,
+        stmLtmCutoffInputs: { oldestSelectedTs: oldestShipped },
+      };
+
+      await retriever.retrieveRelevantMemories(mockPersonality, 'test', contextExact);
+
+      expect(mockMemoryManager.queryMemories).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ excludeNewerThan: oldCrossChannel - 10000 })
+      );
+    });
+
+    it('exact mode: nothing shipped and no refs → NO cutoff (everything-truncated turns keep full LTM coverage)', async () => {
+      mockPersonaResolver.resolveForMemory.mockResolvedValue({
+        personaId: 'persona-123',
+        focusModeEnabled: false,
+      });
+
+      const contextExact: ConversationContext = {
+        ...context,
+        // Legacy field present (fetched history existed) but nothing SHIPPED.
+        oldestHistoryTimestamp: Date.now() - 3600000,
+        stmLtmCutoffInputs: {},
+      };
+
+      await retriever.retrieveRelevantMemories(mockPersonality, 'test', contextExact);
+
+      expect(mockMemoryManager.queryMemories).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ excludeNewerThan: undefined })
+      );
+    });
+
     it('should use session context if provided', async () => {
       mockPersonaResolver.resolveForMemory.mockResolvedValue({
         personaId: 'persona-123',

--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -54,10 +54,46 @@ export class MemoryRetriever {
   }
 
   /**
-   * Calculate STM/LTM deduplication cutoff timestamp
-   * Applies buffer to prevent overlap between short-term and long-term memories
+   * Calculate STM/LTM deduplication cutoff timestamp.
+   *
+   * Exact mode (history pre-pass ran — `stmLtmCutoffInputs` present): the
+   * current-channel bound is the oldest SHIPPED message PLUS the buffer —
+   * over-retrieving past the boundary so memories of DROPPED messages (whose
+   * persistence lags their source) stay reachable; the selection-time ID
+   * filter is the authoritative dedup, so over-retrieval cannot duplicate.
+   * Refs/cross-channel keep the pessimistic minus-buffer bound (no shipped-id
+   * plumbing for them). Nothing shipped and no refs → no cutoff: LTM covers
+   * the whole range (the everything-truncated case).
+   *
+   * Legacy mode (no pre-pass — non-pipeline callers): pessimistic
+   * oldest-FETCHED minus buffer, as before.
    */
   private calculateDeduplicationCutoff(context: ConversationContext): number | undefined {
+    if (context.stmLtmCutoffInputs !== undefined) {
+      const { oldestSelectedTs } = context.stmLtmCutoffInputs;
+      const bounds: number[] = [];
+      if (oldestSelectedTs !== undefined) {
+        bounds.push(oldestSelectedTs + AI_DEFAULTS.STM_LTM_BUFFER_MS);
+      }
+      if (context.nonHistoryOldestTimestamp !== undefined) {
+        bounds.push(context.nonHistoryOldestTimestamp - AI_DEFAULTS.STM_LTM_BUFFER_MS);
+      }
+      const cutoff = bounds.length > 0 ? Math.min(...bounds) : undefined;
+      logger.info(
+        {
+          oldestSelectedTs:
+            oldestSelectedTs !== undefined ? formatMemoryTimestamp(oldestSelectedTs) : undefined,
+          nonHistoryOldestTimestamp:
+            context.nonHistoryOldestTimestamp !== undefined
+              ? formatMemoryTimestamp(context.nonHistoryOldestTimestamp)
+              : undefined,
+          excludeNewerThan: cutoff !== undefined ? formatMemoryTimestamp(cutoff) : 'none',
+        },
+        'STM/LTM dedup cutoff (exact mode — shipped-history boundary)'
+      );
+      return cutoff;
+    }
+
     let excludeNewerThan: number | undefined = context.oldestHistoryTimestamp;
 
     if (excludeNewerThan !== undefined) {

--- a/services/ai-worker/src/services/context/ContextWindowManager.test.ts
+++ b/services/ai-worker/src/services/context/ContextWindowManager.test.ts
@@ -10,22 +10,6 @@ describe('ContextWindowManager', () => {
     manager = new ContextWindowManager();
   });
 
-  describe('calculateHistoryBudget', () => {
-    it('should calculate correct budget breakdown', () => {
-      // 1000 total - 200 system - 100 current - 50 memory = 650 history budget
-      const budget = manager.calculateHistoryBudget(1000, 200, 100, 50);
-
-      expect(budget).toBe(650);
-    });
-
-    it('should clamp to zero when components exceed context window', () => {
-      // 100 total - 500 system - 300 current - 0 memory = -700, clamped to 0
-      const budget = manager.calculateHistoryBudget(100, 500, 300, 0);
-
-      expect(budget).toBe(0);
-    });
-  });
-
   describe('selectAndSerializeHistory', () => {
     it('should serialize current channel history as XML', () => {
       const rawHistory = [

--- a/services/ai-worker/src/services/context/ContextWindowManager.ts
+++ b/services/ai-worker/src/services/context/ContextWindowManager.ts
@@ -72,6 +72,10 @@ export class ContextWindowManager {
     messagesIncluded: number;
     messagesDropped: number;
     crossChannelMessagesIncluded: number;
+    /** The current-channel entries that actually shipped (newest-first walk
+     * keeps a contiguous newest suffix) — the STM/LTM pre-pass derives the
+     * EXACT dedup cutoff + shipped-message-id set from these. */
+    selectedEntries: RawHistoryEntry[];
   } {
     const hasCurrentChannel = rawHistory !== undefined && rawHistory.length > 0;
     const hasCrossChannel = crossChannelGroups !== undefined && crossChannelGroups.length > 0;
@@ -83,6 +87,7 @@ export class ContextWindowManager {
         messagesIncluded: 0,
         messagesDropped: rawHistory?.length ?? 0,
         crossChannelMessagesIncluded: 0,
+        selectedEntries: [],
       };
     }
 
@@ -131,6 +136,7 @@ export class ContextWindowManager {
       messagesIncluded: selectedEntries.length,
       messagesDropped: (rawHistory?.length ?? 0) - selectedEntries.length,
       crossChannelMessagesIncluded,
+      selectedEntries,
     };
   }
 
@@ -245,22 +251,6 @@ export class ContextWindowManager {
       crossChannelMessagesIncluded: crossResult.messagesIncluded,
       crossTokens,
     };
-  }
-
-  /**
-   * Calculate history token budget: remaining tokens after system prompt, current message,
-   * and memories are subtracted from the context window.
-   */
-  calculateHistoryBudget(
-    contextWindowTokens: number,
-    systemPromptBaseTokens: number,
-    currentMessageTokens: number,
-    memoryTokens: number
-  ): number {
-    return Math.max(
-      0,
-      contextWindowTokens - systemPromptBaseTokens - currentMessageTokens - memoryTokens
-    );
   }
 
   /**

--- a/services/ai-worker/src/services/eval/nonCircularityGuard.ts
+++ b/services/ai-worker/src/services/eval/nonCircularityGuard.ts
@@ -15,9 +15,13 @@
 import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
 
 /**
- * Temporal guard — mirrors production's own STM/LTM dedup cutoff
- * (`MemoryRetriever.calculateDeduplicationCutoff`: `excludeNewerThan =
- * oldestHistoryTimestamp - STM_LTM_BUFFER_MS`). A memory at or newer than that
+ * Temporal guard — mirrors production's LEGACY STM/LTM dedup cutoff
+ * (`MemoryRetriever.calculateDeduplicationCutoff` fallback: `excludeNewerThan =
+ * oldestHistoryTimestamp - STM_LTM_BUFFER_MS`). Production's pipeline path now
+ * uses the exact shipped-history boundary + a selection-time ID filter (the
+ * dedup-hole fix); for eval goldens the full window ships (no truncation), so
+ * the legacy formula and the exact one coincide and this guard stays faithful.
+ * A memory at or newer than that
  * cutoff sits inside the recent-history window the fold already carries, so it's
  * "in the STM window" and NOT credit-eligible. Enforcing this makes the folded
  * arm MORE faithful to prod (which applies the same cutoff at retrieval), not less.

--- a/services/ai-worker/src/test/mocks/ContextWindowManager.mock.ts
+++ b/services/ai-worker/src/test/mocks/ContextWindowManager.mock.ts
@@ -10,7 +10,6 @@ import { vi } from 'vitest';
  * Type definition for the ContextWindowManager mock instance
  */
 interface MockContextWindowManagerInstance {
-  calculateHistoryBudget: ReturnType<typeof vi.fn>;
   selectAndSerializeHistory: ReturnType<typeof vi.fn>;
   countHistoryTokens: ReturnType<typeof vi.fn>;
   calculateMemoryBudget: ReturnType<typeof vi.fn>;
@@ -23,23 +22,21 @@ let mockInstance: MockContextWindowManagerInstance | null = null;
  * Create fresh mock functions with default implementations
  *
  * **Default Behaviors:**
- * - `calculateHistoryBudget()` → Returns `7000` tokens
  * - `selectAndSerializeHistory()` → Returns serialized history with 1 message, 50 tokens
  * - `countHistoryTokens()` → Returns `100` tokens
  * - `calculateMemoryBudget()` → Returns `32000` tokens (25% of 128k)
  * - `selectMemoriesWithinBudget(memories)` → Returns ALL memories (no budget filtering by default)
  *
- * Override in tests: `getContextWindowManagerMock().calculateHistoryBudget.mockReturnValue(1000)`
  */
 function createMockFunctions(): MockContextWindowManagerInstance {
   return {
-    calculateHistoryBudget: vi.fn().mockReturnValue(7000),
     selectAndSerializeHistory: vi.fn().mockReturnValue({
       serializedHistory: '<msg user="Lila" role="user">Previous message</msg>',
       historyTokensUsed: 50,
       messagesIncluded: 1,
       messagesDropped: 0,
       crossChannelMessagesIncluded: 0,
+      selectedEntries: [],
     }),
     countHistoryTokens: vi.fn().mockReturnValue(100),
     calculateMemoryBudget: vi.fn().mockReturnValue(32000), // 25% of 128k
@@ -57,7 +54,6 @@ function createMockFunctions(): MockContextWindowManagerInstance {
  */
 export const mockContextWindowManager = {
   ContextWindowManager: class MockContextWindowManager {
-    calculateHistoryBudget: ReturnType<typeof vi.fn>;
     selectAndSerializeHistory: ReturnType<typeof vi.fn>;
     countHistoryTokens: ReturnType<typeof vi.fn>;
     calculateMemoryBudget: ReturnType<typeof vi.fn>;
@@ -65,7 +61,6 @@ export const mockContextWindowManager = {
 
     constructor() {
       const fns = createMockFunctions();
-      this.calculateHistoryBudget = fns.calculateHistoryBudget;
       this.selectAndSerializeHistory = fns.selectAndSerializeHistory;
       this.countHistoryTokens = fns.countHistoryTokens;
       this.calculateMemoryBudget = fns.calculateMemoryBudget;


### PR DESCRIPTION
## What (epic must-fix, external review item 8 — council-reviewed design)

**The hole**: LTM retrieval excluded everything newer than the oldest *fetched* history message, assuming all fetched history ships — but allocation later drops the oldest entries under token pressure (and the duplicate-retry path shrinks the history budget *by design*). The dropped range was reachable by **neither** shipped-history nor LTM. Measured incidence: 0/58 turns in current prod logs (500k windows) — latent, but guaranteed on small-context model configs, duplicate-retries, and giant pasted messages.

## The design (3-model council red-team; two of three converged on this shape)

1. **History selection moves BEFORE retrieval** (`preselectHistory`): with the memory budget as a *reserve* (identical `calculateMemoryBudget` formula — the contention floor / "recency yields to identity" semantics unchanged), the history budget needs nothing from retrieval. The exact shipped boundary + shipped Discord-id set exist before the LTM query runs. No prediction math, no second DB query, `allocate()` stays synchronous.
2. **Query cutoff** = oldest **shipped** message **plus** the buffer — flipped to the over-retrieve side per the council's unanimous buffer-band finding (memories of dropped messages persist slightly after their sources). Refs/cross-channel keep today's pessimistic minus-buffer bound (no shipped-id plumbing for them — no regression, exactness filed as the existing cross-channel follow-up). Nothing shipped → no cutoff: the everything-truncated turn keeps full LTM coverage.
3. **Selection-time ID filter** (authoritative dedup): keep a memory iff it predates the shipped boundary, OR it's a **same-channel** memory whose source messages all dropped (`Memory.messageIds ∩ shipped = ∅`) — the rescue that closes the hole. Channel-scoping prevents shipped cross-channel content re-entering as duplication; legacy id-less rows keep today's time-baseline semantics.
4. `calculateHistoryBudget` deleted — production-dead after the reorder.

**Behavioral deltas**: non-truncating turns (100% of current prod traffic) byte-identical except one accepted narrow band — memories underusing their reserve no longer lend history the slack; council verdict: acceptable, the affected messages become LTM-covered by construction. Documented residuals: boundary memory-chunk spanning shipped+dropped is filtered (dedup wins); an old ref/cross-channel message re-binds the pessimistic cutoff (= today).

## Verification
- **Invariant test with REAL history selection** (not mocks): four entries under a budget that fits two; asserts the exact boundary + shipped-id set, then that the dropped message's memory (created *after* the boundary, source id unshipped — the persistence-lag case) reaches the final prompt while the shipped message's memory is filtered.
- Filter-rule unit tests: time baseline, ID drop, dropped-range rescue, cross-channel scope, legacy id-less rows, no-filter-when-nothing-shipped.
- Exact-mode cutoff tests: plus-buffer flip, refs/cross-channel min binding, everything-dropped → no cutoff. Legacy fallback path retains its original tests.
- `pnpm test` (25 tasks), `pnpm test:component` (506), `pnpm quality` all green locally.

Council record: buffer-band hole and prediction-fragility found by all three reviewers against my original sketch (predicted cutoff) — the shipped design is the simpler one they converged on. Facts remain unfiltered (unanimous: durable statements are the coverage for dropped content, not duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)