### PR TITLE
fix(ai-worker): 5-min worker lock — deploy-killed jobs stall-recover in minutes

### DIFF
--- a/packages/common-types/src/constants/message.test.ts
+++ b/packages/common-types/src/constants/message.test.ts
@@ -19,10 +19,21 @@ describe('MULTI_TAG timing invariants', () => {
     expect(MULTI_TAG.COORDINATOR_TIMEOUT_MS).toBeGreaterThanOrEqual(MULTI_TAG.ORDERING_MAX_WAIT_MS);
   });
 
-  it('coordinator timeout stays under the worker lock duration', () => {
-    // The bot-side coordinator wait must finish before the worker lock expires,
-    // or the lock can be reclaimed mid-coordination and two replicas race.
-    expect(MULTI_TAG.COORDINATOR_TIMEOUT_MS).toBeLessThan(TIMEOUTS.WORKER_LOCK_DURATION);
+  it('worker lock (stall detection) fires well before the coordinator flush', () => {
+    // A deploy-killed job must stall-recover and re-run with time to complete
+    // BEFORE the coordinator's last-resort flush synthesizes an error. The lock
+    // is dead-process detection (auto-renewed while the worker lives), so it
+    // must sit far below the flush window; if this inverts, orphaned jobs wedge
+    // until the flush again and the stall re-run becomes pure wasted spend.
+    expect(TIMEOUTS.WORKER_LOCK_DURATION).toBeLessThan(MULTI_TAG.COORDINATOR_TIMEOUT_MS);
+  });
+
+  it('coordinator timeout stays under the in-process job runtime ceiling', () => {
+    // The flush is sized above legitimate long-job runtimes but below the
+    // runtime ceiling — past MAX_JOB_RUNTIME every live job has already been
+    // timed out in-process and delivered a real error, so a flush later than
+    // that could only ever synthesize noise.
+    expect(MULTI_TAG.COORDINATOR_TIMEOUT_MS).toBeLessThan(TIMEOUTS.MAX_JOB_RUNTIME);
   });
 
   it('Redis TTL outlives the coordinator safety window', () => {

--- a/packages/common-types/src/constants/message.ts
+++ b/packages/common-types/src/constants/message.ts
@@ -112,10 +112,13 @@ export const MULTI_TAG = {
    * timeout content for the rest.
    *
    * Sized at 18 min: vision-heavy jobs (many extended-context images +
-   * a slow model) legitimately run 10–15 min, and the worker lock
-   * (TIMEOUTS.WORKER_LOCK_DURATION) is 20 min — so this sits below the
-   * worker ceiling with headroom while no longer firing on jobs that are
-   * still genuinely processing. A late result that lands after this fires
+   * a slow model) legitimately run 10–15 min, and the in-process job
+   * runtime ceiling (TIMEOUTS.MAX_JOB_RUNTIME) is 20 min — so this sits
+   * below that ceiling with headroom while no longer firing on jobs that
+   * are still genuinely processing. Deploy-killed jobs don't ride this
+   * out: lock expiry + stall recovery (TIMEOUTS.WORKER_LOCK_DURATION,
+   * 5 min) re-runs them within ~6 min, so this flush is the last resort,
+   * not the primary recovery. A late result that lands after this fires
    * is recovered (not dropped) by the synthetic-timeout recovery path in
    * MessageHandler. Keep this >= ORDERING_MAX_WAIT_MS so the per-channel
    * ordering buffer never force-processes a group before this backstop.

--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -51,8 +51,22 @@ export const TIMEOUTS = {
    * the transcription and can clip this for a long first message — the keep-warm
    * backlog item addresses that. Bump if AUDIO_FETCH or VOICE_ENGINE_API change. */
   STT_GATEWAY: 540_000,
-  /** BullMQ worker lock duration - maximum time a job can run before being considered stalled (20 minutes - safety net for hung jobs) */
-  WORKER_LOCK_DURATION: 20 * 60 * 1000,
+  /** BullMQ worker lock duration — dead-process detection latency, NOT max job
+   * runtime. Workers auto-renew every active job's lock on a lockDuration/4
+   * cadence, so a live process holds a job indefinitely (long vision/STT jobs
+   * never stall), and a hung-but-alive worker renews forever — in-process job
+   * timeouts (calculateJobTimeout → MAX_JOB_RUNTIME) are the hung-job defense,
+   * not this. The lock only expires when the process DIES (deploy, crash, OOM);
+   * the stalled checker then re-queues the job for a real re-run
+   * (maxStalledCount 1). 5 min bounds orphan invisibility at ~6 min (expiry +
+   * stall sweep) while tolerating minutes of event-loop or Redis stall without
+   * false positives (BullMQ's own default is 30 s). */
+  WORKER_LOCK_DURATION: 5 * 60 * 1000,
+  /** Ceiling for in-process job timeouts (the calculateJobTimeout clamp) — the
+   * true "max job runtime" safety net for a LIVE job. Formerly conflated with
+   * WORKER_LOCK_DURATION; lock renewal makes the two independent: the lock
+   * detects dead processes, this cap bounds how long a live job may run. */
+  MAX_JOB_RUNTIME: 20 * 60 * 1000,
   /** Default timeout for bot-client → api-gateway internal RPC calls (5 s).
    * Covers small JSON request/response shapes (channel lookups, session
    * writes, confirm-delivery acks, settings reads, diagnostic patches).

--- a/packages/common-types/src/utils/timeout.test.ts
+++ b/packages/common-types/src/utils/timeout.test.ts
@@ -46,28 +46,28 @@ describe('calculateJobTimeout - Independent Component Budgets with Retries', () 
   });
 
   describe('Audio attachments (with retries)', () => {
-    it('caps the audio job at WORKER_LOCK_DURATION (retry budget exceeds the cap)', () => {
+    it('caps the audio job at MAX_JOB_RUNTIME (retry budget exceeds the cap)', () => {
       // SYSTEM_OVERHEAD: 15s
       // AUDIO_FETCH + VOICE_ENGINE_API with retries: 510s × 3 attempts + 3s delays = 1533s
-      // LLM_INVOCATION: 480s → 15 + 1533 + 480 = 2028s, clamped to the 20-min worker lock.
+      // LLM_INVOCATION: 480s → 15 + 1533 + 480 = 2028s, clamped to the 20-min runtime cap.
       const timeout = calculateJobTimeout(0, 1);
-      expect(timeout).toBe(TIMEOUTS.WORKER_LOCK_DURATION); // 1200s (capped)
+      expect(timeout).toBe(TIMEOUTS.MAX_JOB_RUNTIME); // 1200s (capped)
     });
 
     it('should NOT scale with audio count (both capped)', () => {
       const oneAudio = calculateJobTimeout(0, 1);
       const threeAudio = calculateJobTimeout(0, 3);
 
-      expect(oneAudio).toBe(threeAudio); // Both capped at WORKER_LOCK_DURATION
+      expect(oneAudio).toBe(threeAudio); // Both capped at MAX_JOB_RUNTIME
     });
   });
 
   describe('Mixed attachments', () => {
     it('should use slowest attachment type (audio wins, capped)', () => {
       // Audio (1533s) is slower than images (273s); audio's component pushes the total
-      // over the worker-lock cap.
+      // over the runtime cap.
       const timeout = calculateJobTimeout(3, 2);
-      expect(timeout).toBe(TIMEOUTS.WORKER_LOCK_DURATION); // Audio wins, capped
+      expect(timeout).toBe(TIMEOUTS.MAX_JOB_RUNTIME); // Audio wins, capped
     });
 
     it('should handle images only (under cap)', () => {
@@ -91,31 +91,39 @@ describe('calculateJobTimeout - Independent Component Budgets with Retries', () 
     });
 
     it('should handle voice message request', () => {
-      // User sends voice message — audio retry budget caps the job at the worker lock.
+      // User sends voice message — audio retry budget caps the job at MAX_JOB_RUNTIME.
       const timeout = calculateJobTimeout(0, 1);
-      expect(timeout).toBe(TIMEOUTS.WORKER_LOCK_DURATION); // 1200s (capped)
+      expect(timeout).toBe(TIMEOUTS.MAX_JOB_RUNTIME); // 1200s (capped)
     });
 
     it('should handle mixed media request', () => {
-      // User sends 2 images + 1 audio — audio wins and caps at the worker lock.
+      // User sends 2 images + 1 audio — audio wins and caps at MAX_JOB_RUNTIME.
       const timeout = calculateJobTimeout(2, 1);
-      expect(timeout).toBe(TIMEOUTS.WORKER_LOCK_DURATION); // Audio timeout wins, capped
+      expect(timeout).toBe(TIMEOUTS.MAX_JOB_RUNTIME); // Audio timeout wins, capped
     });
   });
 
-  describe('Worker lock duration enforcement', () => {
-    it('should cap at WORKER_LOCK_DURATION (20 min safety net)', () => {
+  describe('Max job runtime enforcement', () => {
+    it('should cap at MAX_JOB_RUNTIME (20 min safety net)', () => {
       // Audio's retry budget (1533s) + LLM (480s) + overhead exceeds the cap, so any
-      // request with audio clamps to WORKER_LOCK_DURATION.
+      // request with audio clamps to MAX_JOB_RUNTIME.
       const timeout = calculateJobTimeout(10, 10);
-      expect(timeout).toBe(TIMEOUTS.WORKER_LOCK_DURATION); // Capped
+      expect(timeout).toBe(TIMEOUTS.MAX_JOB_RUNTIME); // Capped
     });
 
-    it('does NOT cap an images-only request (stays under the lock)', () => {
+    it('does NOT cap an images-only request (stays under the cap)', () => {
       // Images alone (273s + 480s + 15s = 768s) stay well under the cap.
       const timeout = calculateJobTimeout(10, 0);
       expect(timeout).toBe(768000);
-      expect(timeout).toBeLessThan(TIMEOUTS.WORKER_LOCK_DURATION);
+      expect(timeout).toBeLessThan(TIMEOUTS.MAX_JOB_RUNTIME);
+    });
+
+    it('clamps to MAX_JOB_RUNTIME, never the (shorter, auto-renewed) worker lock', () => {
+      // The lock bounds dead-process detection, not runtime — locks auto-renew
+      // while the worker lives. Clamping to the lock would clip long audio/vision
+      // jobs; this pins the decoupling so a future "simplification" can't rewire it.
+      expect(TIMEOUTS.WORKER_LOCK_DURATION).toBeLessThan(TIMEOUTS.MAX_JOB_RUNTIME);
+      expect(calculateJobTimeout(0, 1)).toBeGreaterThan(TIMEOUTS.WORKER_LOCK_DURATION);
     });
   });
 
@@ -128,10 +136,10 @@ describe('calculateJobTimeout - Independent Component Budgets with Retries', () 
       // No-attachment and image jobs preserve the full independent LLM budget.
       expect(noAttachments).toBe(495000); // 15s + 480s
       expect(withImages).toBe(768000); // 15s + 273s + 480s (LLM still gets 480s!)
-      // Audio's retry budget alone exceeds the worker lock, so the audio job clamps to
+      // Audio's retry budget alone exceeds the runtime cap, so the audio job clamps to
       // the cap — the per-component independent-budget property gives way to the safety
       // net here (the actual STT call self-limits to one ~480s attempt).
-      expect(withAudio).toBe(TIMEOUTS.WORKER_LOCK_DURATION);
+      expect(withAudio).toBe(TIMEOUTS.MAX_JOB_RUNTIME);
     });
 
     it('should demonstrate retry budget - preprocessing can retry without starving LLM', () => {
@@ -149,9 +157,9 @@ describe('calculateJobTimeout - Independent Component Budgets with Retries', () 
 
       // Image job still grants LLM its full independent 480s (verified by subtraction).
       expect(imageTimeout - TIMEOUTS.SYSTEM_OVERHEAD - 273000).toBe(TIMEOUTS.LLM_INVOCATION);
-      // Audio job is clamped to the worker lock — its uncapped budget (2028s) would have
+      // Audio job is clamped to MAX_JOB_RUNTIME — its uncapped budget (2028s) would have
       // exceeded it, so the cap is what holds.
-      expect(audioTimeout).toBe(TIMEOUTS.WORKER_LOCK_DURATION);
+      expect(audioTimeout).toBe(TIMEOUTS.MAX_JOB_RUNTIME);
     });
   });
 });

--- a/packages/common-types/src/utils/timeout.ts
+++ b/packages/common-types/src/utils/timeout.ts
@@ -67,7 +67,7 @@ function calculateTimeoutWithRetries(
  *
  * @param imageCount - Number of images in the request
  * @param audioCount - Number of audio/voice attachments in the request
- * @returns Timeout in milliseconds, capped at WORKER_LOCK_DURATION (20 min safety net)
+ * @returns Timeout in milliseconds, capped at MAX_JOB_RUNTIME (20 min safety net)
  *
  * @example
  * // No attachments: overhead + LLM
@@ -78,9 +78,9 @@ function calculateTimeoutWithRetries(
  * calculateJobTimeout(5, 0) // 273s + 480s + 15s = 768s
  *
  * @example
- * // 1 audio: audio with retries + LLM + overhead exceeds the worker-lock cap.
+ * // 1 audio: audio with retries + LLM + overhead exceeds the runtime cap.
  * // Audio component = (30s fetch + 480s STT) × 3 attempts + 3s = 1533s; + 480s LLM
- * // + 15s = 2028s, clamped to WORKER_LOCK_DURATION.
+ * // + 15s = 2028s, clamped to MAX_JOB_RUNTIME.
  * calculateJobTimeout(0, 1) // capped at 1200s (20 min)
  */
 export function calculateJobTimeout(imageCount: number, audioCount = 0): number {
@@ -92,7 +92,7 @@ export function calculateJobTimeout(imageCount: number, audioCount = 0): number 
     imageCount > 0 ? calculateTimeoutWithRetries(TIMEOUTS.VISION_MODEL) : 0;
 
   // Audio: (30s fetch + 480s STT) per attempt × 3 attempts + backoff delays = 1533s.
-  // With the long-audio STT budget, this alone exceeds WORKER_LOCK_DURATION, so an
+  // With the long-audio STT budget, this alone exceeds MAX_JOB_RUNTIME, so an
   // audio request's job timeout clamps to that 20-min ceiling below (the actual STT
   // call self-limits to one ~480s attempt, so the cap is a safety net, not the budget).
   const audioProcessingTime =
@@ -106,6 +106,9 @@ export function calculateJobTimeout(imageCount: number, audioCount = 0): number 
   // LLM_INVOCATION already includes retry budget (480s total)
   timeout += attachmentTime + TIMEOUTS.LLM_INVOCATION;
 
-  // Cap at worker lock duration (20 minutes - safety net)
-  return Math.min(timeout, TIMEOUTS.WORKER_LOCK_DURATION);
+  // Cap at MAX_JOB_RUNTIME (20 min) — the in-process ceiling for a LIVE job.
+  // NOT the worker lock: locks auto-renew, so they bound dead-process
+  // detection, never runtime. Clamping to the (shorter) lock would clip
+  // legitimate long audio/vision jobs.
+  return Math.min(timeout, TIMEOUTS.MAX_JOB_RUNTIME);
 }

--- a/services/ai-worker/src/index.ts
+++ b/services/ai-worker/src/index.ts
@@ -163,6 +163,10 @@ function createMainWorker(jobProcessor: AIJobProcessor): Worker {
       removeOnComplete: { count: QUEUE_CONFIG.COMPLETED_HISTORY_LIMIT },
       removeOnFail: { count: QUEUE_CONFIG.FAILED_HISTORY_LIMIT },
       lockDuration: TIMEOUTS.WORKER_LOCK_DURATION,
+      // Explicit BullMQ default: a deploy-killed job gets exactly ONE
+      // stall-recovery re-run; a second stall fails it with a real error
+      // (which propagates to the coordinator) instead of looping.
+      maxStalledCount: 1,
     }
   );
 
@@ -193,6 +197,15 @@ function createMainWorker(jobProcessor: AIJobProcessor): Worker {
   worker.on('failed', (job: Job | undefined, error: Error) => {
     const jobId = job?.id ?? 'unknown';
     logger.error({ err: error }, `Job ${jobId} failed`);
+  });
+
+  // Stall = the job's lock expired, meaning its owning process died
+  // (deploy, crash, OOM) — a live worker auto-renews. BullMQ re-queues the
+  // job: it re-runs, unless the stall limit was already exceeded, in which
+  // case it fails on pickup ("job stalled more than allowable limit").
+  // This log is the deploy-orphan recovery trail.
+  worker.on('stalled', (jobId: string) => {
+    logger.warn({ jobId }, 'Job stalled (owning process died) — re-queued');
   });
 
   worker.on('error', (error: Error) => {

--- a/services/ai-worker/src/jobs/factExtractionSetup.test.ts
+++ b/services/ai-worker/src/jobs/factExtractionSetup.test.ts
@@ -9,20 +9,25 @@ const {
   addMock,
   queueCloseMock,
   workerCloseMock,
+  workerOnHandlers,
   getConfigMock,
   systemSettingsFixture,
   processBatchMock,
   loggerErrorMock,
+  loggerWarnMock,
   MockDelayedError,
 } = vi.hoisted(() => ({
   addMock: vi.fn(),
   queueCloseMock: vi.fn(),
   workerCloseMock: vi.fn(),
+  /** Event handlers the worker registers via .on(), keyed by event name. */
+  workerOnHandlers: new Map<string, (...args: never[]) => unknown>(),
   getConfigMock: vi.fn(),
   /** Per-test overrides for getSystemSetting reads (fallbacks otherwise). */
   systemSettingsFixture: new Map<string, unknown>(),
   processBatchMock: vi.fn().mockResolvedValue(2),
   loggerErrorMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
   MockDelayedError: class MockDelayedError extends Error {},
 }));
 let capturedProcessor:
@@ -34,7 +39,12 @@ vi.mock('bullmq', () => ({
   }),
   Worker: vi.fn().mockImplementation(function (_name: string, processor: typeof capturedProcessor) {
     capturedProcessor = processor;
-    return { on: vi.fn(), close: workerCloseMock };
+    return {
+      on: vi.fn((event: string, cb: (...args: never[]) => unknown) => {
+        workerOnHandlers.set(event, cb);
+      }),
+      close: workerCloseMock,
+    };
   }),
   // The worker throws `new DelayedError()` after job.moveToDelayed — BullMQ's
   // documented per-job manual-delay pattern (no retry attempt consumed).
@@ -69,7 +79,7 @@ vi.mock('@tzurot/common-types/services/SystemSettingsService', async importOrigi
 vi.mock('@tzurot/common-types/utils/logger', () => ({
   createLogger: () => ({
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: loggerWarnMock,
     error: loggerErrorMock,
     debug: vi.fn(),
   }),
@@ -86,6 +96,7 @@ describe('setupFactExtraction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedProcessor = undefined;
+    workerOnHandlers.clear();
     systemSettingsFixture.clear();
     getConfigMock.mockReturnValue({ EXTRACTION_DAILY_LIMIT: 100, ZAI_CODING_API_KEY: undefined });
   });
@@ -106,6 +117,29 @@ describe('setupFactExtraction', () => {
     expect(assembly).toBeDefined();
     expect(assembly?.trigger).toBeDefined();
     expect(capturedProcessor).toBeDefined();
+  });
+
+  it('logs a stalled event at warn with the jobId — the deploy-orphan recovery trail', () => {
+    setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+    const stalled = workerOnHandlers.get('stalled');
+    expect(stalled).toBeDefined();
+    (stalled as (jobId: string) => void)('job-42');
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      { jobId: 'job-42' },
+      expect.stringContaining('stalled')
+    );
+  });
+
+  it('logs a failed event at warn with the jobId and error', () => {
+    setupFactExtraction(prisma, redis, bullmqConnection, embeddings);
+    const failed = workerOnHandlers.get('failed');
+    expect(failed).toBeDefined();
+    const err = new Error('boom');
+    (failed as (job: { id: string } | undefined, err: Error) => void)({ id: 'job-7' }, err);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      { jobId: 'job-7', err },
+      expect.stringContaining('failed')
+    );
   });
 
   it('logs loudly (but still boots) when zai-coding is configured without the system key', () => {
@@ -179,6 +213,7 @@ describe('delay-not-downgrade (provider busy at the BullMQ seam)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedProcessor = undefined;
+    workerOnHandlers.clear();
     systemSettingsFixture.clear();
     getConfigMock.mockReturnValue({ EXTRACTION_DAILY_LIMIT: 100, ZAI_CODING_API_KEY: undefined });
   });

--- a/services/ai-worker/src/jobs/factExtractionSetup.ts
+++ b/services/ai-worker/src/jobs/factExtractionSetup.ts
@@ -246,13 +246,23 @@ export function setupFactExtraction(
       // Explicit rather than BullMQ's 30s default: the extraction call may
       // legitimately run to EXTRACTION_TIMEOUT_MS (180s). Auto-renewal covers
       // I/O-bound waits, but after one timing surprise in this worker the
-      // safety margin should be self-documenting (mirrors index.ts).
+      // safety margin should be self-documenting (mirrors index.ts; 5-min
+      // lock = dead-process detection, not a runtime bound).
       lockDuration: TIMEOUTS.WORKER_LOCK_DURATION,
+      // One stall-recovery re-run for deploy-killed jobs (spend-safe: the
+      // busy path shrinks remainingMemoryIds via job.updateData, so a re-run
+      // never re-bills completed sub-units); a second stall fails the job.
+      maxStalledCount: 1,
     }
   );
 
   worker.on('failed', (job, err) => {
     logger.warn({ jobId: job?.id, err }, 'Fact-extraction job failed (BullMQ will retry)');
+  });
+  // Stall = lock expired because the owning process died mid-extraction
+  // (deploy/crash); BullMQ has re-queued the job for a re-run.
+  worker.on('stalled', (jobId: string) => {
+    logger.warn({ jobId }, 'Fact-extraction job stalled (owning process died) — re-queued');
   });
   // Connection-level errors (Redis blips, lock renewal) emit 'error', not
   // 'failed' — an unhandled 'error' event throws synchronously and would


### PR DESCRIPTION
## What

Shortens the BullMQ `lockDuration` from 20 min to 5 min and decouples the job-timeout clamp from it (new `MAX_JOB_RUNTIME`, stays 20 min). Closes the multi-tag wedge entry's open sub-question (b).

## Why — the 20-min lock was doing nothing we thought it was

All claims verified against the installed BullMQ 5.80.2 source (`lock-manager.js`, `worker.js`, `moveStalledJobsToWait-9.js`):

1. **Locks auto-renew** on a `lockDuration/4` cadence via `LockManager`, so `lockDuration` was never "max job runtime" — a live worker holds a job indefinitely. Our comment said otherwise; it was wrong.
2. **The lock can't catch hung jobs either**: a hung-but-alive worker renews forever. The real hung-job defense is the in-process `calculateJobTimeout`/AbortSignal, which already exists. The lock's only function is **dead-process detection latency**.
3. **Deploy-killed jobs already re-run today, uselessly**: `maxStalledCount` defaults to 1 and the Lua fails a job only when its stall count *exceeds* it, so first stall → re-queued → re-run. At a 20-min lock that re-run lands *after* the 18-min coordinator flush already synthesized an error — spend paid, result dropped. At 5 min, the same re-run delivers a **real reply ~6–7 min post-deploy**.

Corroboration: the scheduled-jobs worker has always run on BullMQ's default **30-second** lock (it never sets `lockDuration`) with multi-minute maintenance jobs, with no stall-failures observed — renewal works under our real load.

## The coupling that made this non-trivial

`calculateJobTimeout` clamped to `WORKER_LOCK_DURATION` (audio jobs deliberately cap at 1200 s; tests pin it). Shortening the constant naively would clip 15-min vision/audio jobs to 5 min. Decoupled into `MAX_JOB_RUNTIME` (20 min); numeric behavior of every existing timeout is unchanged.

## Changes

- `timing.ts`: `WORKER_LOCK_DURATION` 20 min → 5 min with corrected semantics doc; new `MAX_JOB_RUNTIME` (20 min)
- `timeout.ts`: clamp moves to `MAX_JOB_RUNTIME` (values unchanged)
- `index.ts` + `factExtractionSetup.ts`: explicit `maxStalledCount: 1`; `stalled`-event log handlers (the deploy-orphan recovery trail was previously invisible)
- `message.ts`: `COORDINATOR_TIMEOUT_MS` rationale rewritten (its "sits below the worker lock" reasoning inverted)
- `message.test.ts`: the old `flush < lock` invariant test encoded the same misunderstanding — replaced with the two real orderings: `lock ≪ flush` (stall recovery must beat the synthetic error) and `flush < MAX_JOB_RUNTIME`
- `timeout.test.ts`: constant rename + a new test pinning the decouple (`calculateJobTimeout` result may exceed the lock; lock < runtime ceiling)

## Verified

- `pnpm --filter @tzurot/common-types test` (2457 passed) and `pnpm --filter @tzurot/ai-worker test` (3945 passed) locally; full pre-push Turbo gate (38 tasks build/lint/test + typecheck:spec + guards) green.
- False-stall risk at 5 min requires ~4–5 min of continuous event-loop blockage or a 5-min Redis outage (embedding runs on a worker thread; all else is async I/O). BullMQ's own default is 30 s — this remains 10× more conservative.
- Vision worst-case behavior unchanged: a 15-min job's re-run completes past the flush and is dropped, exactly as today.

Runtime proof arrives with the first prod deploy that catches an in-flight job: expect a `Job stalled (owning process died)` warn followed by a normal completion, minutes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)