### PR TITLE
feat: /settings data export — full-account data export (data rights)

### DIFF
--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -51,6 +51,44 @@ export class UserClient {
     this.user = options.user;
   }
 
+  async startAccountExport(input: z.infer<typeof ROUTE_MANIFEST.startAccountExport.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.startAccountExport.output>>> {
+    const fullPath = '/api/user/account/export';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'POST',
+      path: fullPath,
+      headers: {
+        'X-User-Id': this.actor,
+        'X-User-Username': encodeURIComponent(this.user.username),
+        'X-User-DisplayName': encodeURIComponent(this.user.displayName),
+        'X-User-Is-Bot': String(this.user.isBot),
+      },
+      body: input,
+      outputSchema: ROUTE_MANIFEST.startAccountExport.output,
+    });
+  }
+
+  /**
+   * @safeRead Server-side has no observable mutation — safe to cache client-side.
+   */
+  async getAccountExportStatus(): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.getAccountExportStatus.output>>> {
+    const fullPath = '/api/user/account/export/status';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'GET',
+      path: fullPath,
+      headers: {
+        'X-User-Id': this.actor,
+        'X-User-Username': encodeURIComponent(this.user.username),
+        'X-User-DisplayName': encodeURIComponent(this.user.displayName),
+        'X-User-Is-Bot': String(this.user.isBot),
+      },
+      outputSchema: ROUTE_MANIFEST.getAccountExportStatus.output,
+    });
+  }
+
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */

--- a/packages/clients/src/routes/user/account.test.ts
+++ b/packages/clients/src/routes/user/account.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for the user account data-rights sub-manifest.
+ *
+ * File-local invariants — every entry is a user-audience route on an
+ * `/account/*` URL with provisioning required and no acceptsSubject.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { userAccountRoutes } from './account.js';
+import type { AnyRouteDef } from '../types.js';
+
+const entries = Object.entries(userAccountRoutes) as [string, AnyRouteDef][];
+
+describe('user account routes', () => {
+  it('has at least one entry', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('every entry is on an /account/* URL', () => {
+    for (const [key, route] of entries) {
+      expect(route.path.startsWith('/account'), `${key} path ${route.path}`).toBe(true);
+    }
+  });
+
+  it('every entry requires provisioning', () => {
+    for (const [key, route] of entries) {
+      expect(route.requiresProvisionedUser, `${key} requiresProvisionedUser`).toBe(true);
+    }
+  });
+
+  it('no entry uses acceptsSubject', () => {
+    for (const [key, route] of entries) {
+      expect(route.acceptsSubject, `${key} acceptsSubject`).toBeFalsy();
+    }
+  });
+});

--- a/packages/clients/src/routes/user/account.ts
+++ b/packages/clients/src/routes/user/account.ts
@@ -1,0 +1,45 @@
+/**
+ * User-audience account data-rights routes.
+ *
+ * Full-account export (data portability). The export START handler requires
+ * BullMQ (aiQueue in RouteDeps) and short-circuits 503 without it. The
+ * delete-account routes land beside these when the erasure feature ships.
+ */
+
+import {
+  StartAccountExportInputSchema,
+  StartAccountExportResponseSchema,
+  AccountExportStatusResponseSchema,
+} from '@tzurot/common-types/schemas/api/account';
+import type { RouteDef } from '../types.js';
+
+const BASE = '/account';
+
+export const userAccountRoutes = {
+  /**
+   * Start a full-account export job. One active job per user (409 while
+   * pending/in_progress); a completed/failed job is replaced on re-run.
+   */
+  startAccountExport: {
+    audience: 'user',
+    method: 'post',
+    path: `${BASE}/export`,
+    id: 'startAccountExport',
+    input: StartAccountExportInputSchema,
+    output: StartAccountExportResponseSchema,
+    requiresProvisionedUser: true,
+  },
+
+  /** Latest account export job (null if never exported). */
+  getAccountExportStatus: {
+    audience: 'user',
+    method: 'get',
+    path: `${BASE}/export/status`,
+    id: 'getAccountExportStatus',
+    output: AccountExportStatusResponseSchema,
+    requiresProvisionedUser: true,
+    meta: { safeRead: true },
+    // No timeoutMs: GET defaults to DEFERRED — this is a local DB job-status
+    // read, same posture as listShapesExportJobs.
+  },
+} as const satisfies Record<string, RouteDef>;

--- a/packages/clients/src/routes/user/index.test.ts
+++ b/packages/clients/src/routes/user/index.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   userRoutes,
+  userAccountRoutes,
   userConfigRoutes,
   userOwnershipRoutes,
   userResourceRoutes,
@@ -102,6 +103,7 @@ describe('user route manifest', () => {
 
   it('all sub-manifests are disjoint (no id collisions on merge)', () => {
     const subManifests: [string, object][] = [
+      ['account', userAccountRoutes],
       ['configs', userConfigRoutes],
       ['ownership', userOwnershipRoutes],
       ['resources', userResourceRoutes],
@@ -125,7 +127,8 @@ describe('user route manifest', () => {
 
   it('merged manifest equals the size of its inputs combined', () => {
     expect(entries.length).toBe(
-      Object.keys(userConfigRoutes).length +
+      Object.keys(userAccountRoutes).length +
+        Object.keys(userConfigRoutes).length +
         Object.keys(userOwnershipRoutes).length +
         Object.keys(userResourceRoutes).length +
         Object.keys(userMemoryRoutes).length +

--- a/packages/clients/src/routes/user/index.ts
+++ b/packages/clients/src/routes/user/index.ts
@@ -23,6 +23,7 @@
  */
 
 import type { RouteDef } from '../types.js';
+import { userAccountRoutes } from './account.js';
 import { userConfigRoutes } from './configs.js';
 import { userOwnershipRoutes } from './ownership.js';
 import { userResourceRoutes } from './resources.js';
@@ -33,6 +34,7 @@ import { userShapesRoutes } from './shapes.js';
 import { userDiagnosticRoutes } from './diagnostics.js';
 
 export const userRoutes = {
+  ...userAccountRoutes,
   ...userConfigRoutes,
   ...userOwnershipRoutes,
   ...userResourceRoutes,
@@ -45,6 +47,7 @@ export const userRoutes = {
 // Re-export the sub-manifests so tests + future tooling can inspect them
 // individually (e.g., assert which file contributed which route id).
 export {
+  userAccountRoutes,
   userConfigRoutes,
   userOwnershipRoutes,
   userResourceRoutes,

--- a/packages/common-types/src/constants/queue.ts
+++ b/packages/common-types/src/constants/queue.ts
@@ -60,6 +60,8 @@ export const JOB_PREFIXES = {
   SHAPES_IMPORT: 'shapes-import-',
   /** Prefix for shapes.inc export jobs */
   SHAPES_EXPORT: 'shapes-export-',
+  /** Prefix for full-account export jobs */
+  ACCOUNT_EXPORT: 'account-export-',
 } as const;
 
 /**
@@ -206,6 +208,8 @@ export enum JobType {
   ShapesImport = 'shapes-import',
   /** Shapes.inc character data export job */
   ShapesExport = 'shapes-export',
+  /** Full-account data export job (data-rights; fills an export_jobs row) */
+  AccountExport = 'account-export',
   /** Async fact extraction from verbatim episodes (memory Phase 2) */
   FactExtraction = 'fact-extraction',
   /** Release-notes / broadcast DM delivery batch (consumed by bot-client) */

--- a/packages/common-types/src/schemas/api/account.test.ts
+++ b/packages/common-types/src/schemas/api/account.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  StartAccountExportInputSchema,
+  StartAccountExportResponseSchema,
+  AccountExportStatusResponseSchema,
+  AccountExportJobSummarySchema,
+} from './account.js';
+
+describe('StartAccountExportInputSchema', () => {
+  it('accepts an empty body and strips extras', () => {
+    expect(StartAccountExportInputSchema.safeParse({}).success).toBe(true);
+    const parsed = StartAccountExportInputSchema.parse({ stray: true });
+    expect(parsed).toEqual({});
+  });
+});
+
+describe('StartAccountExportResponseSchema', () => {
+  it('accepts the accepted-job shape', () => {
+    const result = StartAccountExportResponseSchema.safeParse({
+      success: true,
+      exportJobId: '123e4567-e89b-42d3-a456-426614174000',
+      status: 'pending',
+      downloadUrl: 'https://gateway.example/exports/123e4567-e89b-42d3-a456-426614174000',
+      expiresAt: '2026-07-16T00:00:00.000Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects success:false (the route only emits the happy shape)', () => {
+    expect(
+      StartAccountExportResponseSchema.safeParse({
+        success: false,
+        exportJobId: 'x',
+        status: 'pending',
+        downloadUrl: 'u',
+        expiresAt: 'e',
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('AccountExportJobSummarySchema', () => {
+  const BASE = {
+    id: 'job-1',
+    status: 'pending',
+    fileName: null,
+    fileSizeBytes: null,
+    createdAt: '2026-07-15T00:00:00.000Z',
+    completedAt: null,
+    expiresAt: '2026-07-16T00:00:00.000Z',
+    errorMessage: null,
+    downloadUrl: null,
+  };
+
+  it('accepts a pending job with all nullable fields null', () => {
+    expect(AccountExportJobSummarySchema.safeParse(BASE).success).toBe(true);
+  });
+
+  it('rejects a non-integer fileSizeBytes', () => {
+    expect(AccountExportJobSummarySchema.safeParse({ ...BASE, fileSizeBytes: 1.5 }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects a missing expiresAt (the download-lifetime field is required)', () => {
+    const { expiresAt: _expiresAt, ...withoutExpiry } = BASE;
+    expect(AccountExportJobSummarySchema.safeParse(withoutExpiry).success).toBe(false);
+  });
+});
+
+describe('AccountExportStatusResponseSchema', () => {
+  it('accepts a null job (never exported)', () => {
+    expect(AccountExportStatusResponseSchema.safeParse({ job: null }).success).toBe(true);
+  });
+
+  it('normalizes Date fields to ISO strings (wire-safety across serialization)', () => {
+    const parsed = AccountExportStatusResponseSchema.parse({
+      job: {
+        id: 'job-1',
+        status: 'completed',
+        fileName: 'tzurot-account-export-alice-2026-07-15.json',
+        fileSizeBytes: 1024,
+        createdAt: new Date('2026-07-15T00:00:00Z'),
+        completedAt: new Date('2026-07-15T00:01:00Z'),
+        expiresAt: '2026-07-16T00:00:00.000Z',
+        errorMessage: null,
+        downloadUrl: 'https://gateway.example/exports/job-1',
+      },
+    });
+    expect(parsed.job?.createdAt).toBe('2026-07-15T00:00:00.000Z');
+    expect(parsed.job?.expiresAt).toBe('2026-07-16T00:00:00.000Z');
+  });
+});

--- a/packages/common-types/src/schemas/api/account.ts
+++ b/packages/common-types/src/schemas/api/account.ts
@@ -1,0 +1,52 @@
+/**
+ * Zod schemas for the account data-rights endpoints:
+ * - POST /user/account/export        (start a full-account export job)
+ * - GET  /user/account/export/status (latest account export job state)
+ *
+ * The delete-account schemas land beside these when the erasure feature
+ * ships — the two features share this file by design.
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// POST /user/account/export
+// ============================================================================
+
+/** No inputs in v1 — the export always covers the whole account as JSON. */
+export const StartAccountExportInputSchema = z.object({});
+
+export const StartAccountExportResponseSchema = z.object({
+  success: z.literal(true),
+  exportJobId: z.string(),
+  status: z.string(),
+  downloadUrl: z.string(),
+  expiresAt: z.string(),
+});
+
+// ============================================================================
+// GET /user/account/export/status
+// ============================================================================
+
+export const AccountExportJobSummarySchema = z
+  .object({
+    id: z.string(),
+    status: z.string(),
+    fileName: z.string().nullable(),
+    fileSizeBytes: z.number().int().nullable(),
+    createdAt: z.union([z.string(), z.date()]).transform(value => new Date(value).toISOString()),
+    completedAt: z
+      .union([z.string(), z.date()])
+      .transform(value => new Date(value).toISOString())
+      .nullable(),
+    expiresAt: z.union([z.string(), z.date()]).transform(value => new Date(value).toISOString()),
+    errorMessage: z.string().nullable(),
+    /** Populated only for completed jobs. */
+    downloadUrl: z.string().nullable(),
+  })
+  .describe('Latest account export job, download-ready when completed');
+
+export const AccountExportStatusResponseSchema = z.object({
+  /** Null when the user has never started an account export. */
+  job: AccountExportJobSummarySchema.nullable(),
+});

--- a/packages/common-types/src/schemas/api/index.ts
+++ b/packages/common-types/src/schemas/api/index.ts
@@ -313,6 +313,9 @@ export {
   IncognitoSessionWithRemainingSchema,
 } from './memoryIncognito.js';
 
+// Account data-rights endpoints live in './account.js' — import via the
+// subpath (schemas/api/account); not re-exported here (max-lines budget).
+
 // Shapes.inc BYOK integration endpoints
 export {
   DeleteShapesAuthResponseSchema,

--- a/packages/common-types/src/types/account-export.ts
+++ b/packages/common-types/src/types/account-export.ts
@@ -1,0 +1,32 @@
+/**
+ * Account-export job contract.
+ *
+ * The full-account export rides the shapes export spine: an `export_jobs`
+ * row (24h expiry, public /exports/:jobId download) filled by an ai-worker
+ * job. The sentinels below distinguish account exports inside the shared
+ * table — `sourceService`/`sourceSlug` are shapes-shaped column names, so
+ * the constant definitions are where that naming stretch is documented.
+ */
+
+import { z } from 'zod';
+
+/** `export_jobs.sourceService` sentinel for full-account exports. */
+export const ACCOUNT_EXPORT_SOURCE = 'account';
+
+/** `export_jobs.sourceSlug` sentinel — one account export slot per user+format. */
+export const ACCOUNT_EXPORT_SLUG = 'account';
+
+export const accountExportJobDataSchema = z.object({
+  /** Internal user UUID whose data is being exported. */
+  userId: z.string().uuid(),
+  /** The export_jobs row this job fills. */
+  exportJobId: z.string().uuid(),
+});
+
+export type AccountExportJobData = z.infer<typeof accountExportJobDataSchema>;
+
+export interface AccountExportJobResult {
+  success: boolean;
+  fileSizeBytes: number;
+  error?: string;
+}

--- a/packages/common-types/src/types/jobs.test.ts
+++ b/packages/common-types/src/types/jobs.test.ts
@@ -37,6 +37,7 @@ import {
   type ShapesExportJobResult,
   shapesExportResultSchema,
 } from './shapes-import.js';
+import { accountExportJobDataSchema } from './account-export.js';
 import { JobType, JobStatus } from '../constants/queue.js';
 import {
   MINIMAL_CONTEXT,
@@ -1211,6 +1212,7 @@ describe('BullMQ Job Contract Tests', () => {
       [JobType.LLMGeneration]: llmGenerationJobDataSchema,
       [JobType.ShapesImport]: shapesImportJobDataSchema,
       [JobType.ShapesExport]: shapesExportJobDataSchema,
+      [JobType.AccountExport]: accountExportJobDataSchema,
       [JobType.FactExtraction]: factExtractionJobDataSchema,
       [JobType.ReleaseBroadcastDm]: releaseBroadcastDmJobDataSchema,
     };

--- a/packages/tooling/coverage-topology.json
+++ b/packages/tooling/coverage-topology.json
@@ -702,6 +702,20 @@
       ]
     },
     {
+      "id": "client:api-gateway:getAccountExportStatus",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /account/export/status",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
       "id": "client:api-gateway:getAdminSettings",
       "kind": "http-route",
       "producer": "client",
@@ -2009,6 +2023,20 @@
       "producer": "client",
       "consumer": "api-gateway",
       "schemaRef": "POST /wallet/set",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:startAccountExport",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /account/export",
       "mechanism": "route-conformance",
       "requiredTiers": [
         "component"

--- a/packages/tooling/src/codegen/handler-paths.ts
+++ b/packages/tooling/src/codegen/handler-paths.ts
@@ -45,6 +45,7 @@ const USER_SHAPES_AUTH = '../user/shapes/auth.js';
 const USER_SHAPES_LIST = '../user/shapes/list.js';
 const USER_SHAPES_IMPORT = '../user/shapes/import.js';
 const USER_SHAPES_EXPORT = '../user/shapes/export.js';
+const USER_ACCOUNT_EXPORT = '../user/account/export.js';
 const USER_MODEL_OVERRIDE = '../user/model-override.js';
 const USER_PERSONA_CRUD = '../user/persona/crud.js';
 const USER_PERSONA_OVERRIDE = '../user/persona/override.js';
@@ -275,6 +276,8 @@ const PATH_MAP: Readonly<Record<string, string>> = {
   listShapesImportJobs: USER_SHAPES_IMPORT,
   startShapesExport: USER_SHAPES_EXPORT,
   listShapesExportJobs: USER_SHAPES_EXPORT,
+  startAccountExport: USER_ACCOUNT_EXPORT,
+  getAccountExportStatus: USER_ACCOUNT_EXPORT,
 
   // Wallet
   listWalletKeys: '../wallet/listKeys.js',

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -112,6 +112,10 @@ const JOB_SCHEMA_BY_TYPE: Record<JobType, { schemaRef: string; consumer: string 
   [JobType.LLMGeneration]: { schemaRef: 'llmGenerationJobDataSchema', consumer: 'ai-worker' },
   [JobType.ShapesImport]: null,
   [JobType.ShapesExport]: null,
+  // Self-contained like the shapes jobs: status/results ride the export_jobs
+  // row (the real cross-service contract), not the payload — the two-uuid
+  // payload schema exists for enqueue-side validation only.
+  [JobType.AccountExport]: null,
   // Worker-internal: ai-worker both enqueues (LongTermMemoryService tail call)
   // and consumes fact-extraction jobs — no cross-service producer↔consumer seam,
   // so no bullmq-contract surface despite having a payload schema.

--- a/services/ai-worker/src/jobs/AIJobProcessor.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.ts
@@ -30,6 +30,10 @@ import {
   type ShapesImportJobResult,
   type ShapesExportJobResult,
 } from '@tzurot/common-types/types/shapes-import';
+import {
+  type AccountExportJobData,
+  type AccountExportJobResult,
+} from '@tzurot/common-types/types/account-export';
 import { generateUsageLogUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ExtractionTrigger } from '../services/extraction/ExtractionTrigger.js';
@@ -47,6 +51,7 @@ import { processImageDescriptionJob } from './ImageDescriptionJob.js';
 import { LLMGenerationHandler } from './handlers/LLMGenerationHandler.js';
 import { processShapesImportJob } from './ShapesImportJob.js';
 import { processShapesExportJob } from './ShapesExportJob.js';
+import { processAccountExportJob } from './AccountExportJob.js';
 
 const logger = createLogger('AIJobProcessor');
 const LOG_PROCESSING_JOB = '[AIJobProcessor] Processing job';
@@ -154,7 +159,9 @@ export class AIJobProcessor {
    */
   async processJob(
     job: Job<AnyJobData>
-  ): Promise<AnyJobResult | ShapesImportJobResult | ShapesExportJobResult> {
+  ): Promise<
+    AnyJobResult | ShapesImportJobResult | ShapesExportJobResult | AccountExportJobResult
+  > {
     // Shapes import/export jobs use job.name for routing (they don't extend BaseJobData)
     if (job.name === (JobType.ShapesImport as string)) {
       logger.info({ jobId: job.id, jobType: job.name }, LOG_PROCESSING_JOB);
@@ -163,6 +170,10 @@ export class AIJobProcessor {
     if (job.name === (JobType.ShapesExport as string)) {
       logger.info({ jobId: job.id, jobType: job.name }, LOG_PROCESSING_JOB);
       return this.processShapesExportJobWrapper(job as unknown as Job<ShapesExportJobData>);
+    }
+    if (job.name === (JobType.AccountExport as string)) {
+      logger.info({ jobId: job.id, jobType: job.name }, LOG_PROCESSING_JOB);
+      return processAccountExportJob(job as unknown as Job<AccountExportJobData>, this.prisma);
     }
 
     const jobType = job.data.jobType;

--- a/services/ai-worker/src/jobs/AccountExportAssembler.component.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.component.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Component test: account-export assembly over REAL PGLite.
+ *
+ * The assembler is pure DB reads, so the meaningful failure modes are
+ * schema-level: a renamed column, a missed section, secret material leaking
+ * into the payload, or the cursor sweep clipping rows. This test seeds a
+ * two-user graph and asserts section contents, cross-user isolation, and —
+ * critically — that the serialized payload never contains seeded secret
+ * values.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { type PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { assembleAccountExport } from './AccountExportAssembler.js';
+
+const USER_A = 'ac0e0000-0000-4000-8000-0000000000a1';
+const PERSONA_A = 'ac0e0000-0000-4000-8000-0000000000a2';
+const USER_B = 'ac0e0000-0000-4000-8000-0000000000b1';
+const PERSONA_B = 'ac0e0000-0000-4000-8000-0000000000b2';
+const SYSTEM_PROMPT = 'ac0e0000-0000-4000-8000-0000000000c1';
+const PERSONALITY_X = 'ac0e0000-0000-4000-8000-0000000000c2';
+const SECRET_VALUE = 'super-secret-encrypted-blob-DO-NOT-EXPORT';
+
+let seq = 0;
+const nextId = (): string =>
+  `ac0e0000-0000-4000-8000-0000000001${(seq++).toString().padStart(2, '0')}`;
+
+describe('assembleAccountExport (component, PGLite)', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+
+    await seedUserWithPersona(prisma, {
+      userId: USER_A,
+      personaId: PERSONA_A,
+      discordId: '900000000000000061',
+      username: 'exportalice',
+      personaName: 'Alice Persona',
+      personaPreferredName: 'Alice',
+      personaContent: 'Persona A content',
+    });
+    await seedUserWithPersona(prisma, {
+      userId: USER_B,
+      personaId: PERSONA_B,
+      discordId: '900000000000000062',
+      username: 'exportbob',
+      personaName: 'Bob Persona',
+      personaPreferredName: 'Bob',
+      personaContent: 'Persona B content',
+    });
+
+    await prisma.$executeRaw`
+      INSERT INTO system_prompts (id, name, content, updated_at)
+      VALUES (${SYSTEM_PROMPT}::uuid, 'X Prompt', 'You are X.', NOW())
+    `;
+    await prisma.$executeRaw`
+      INSERT INTO personalities (id, name, display_name, slug, system_prompt_id, character_info, personality_traits, owner_id, updated_at)
+      VALUES (${PERSONALITY_X}::uuid, 'XBot', 'X Bot', 'xbot', ${SYSTEM_PROMPT}::uuid, 'X character', 'Curious', ${USER_A}::uuid, NOW())
+    `;
+    await prisma.personalityOwner.create({
+      data: { personalityId: PERSONALITY_X, userId: USER_A },
+    });
+
+    // Conversation history + memories + facts for BOTH users' personas.
+    for (const [personaId, marker] of [
+      [PERSONA_A, 'alice-line'],
+      [PERSONA_B, 'bob-line'],
+    ] as const) {
+      await prisma.conversationHistory.create({
+        data: {
+          id: nextId(),
+          personaId,
+          personalityId: PERSONALITY_X,
+          channelId: 'chan-1',
+          role: 'user',
+          content: `${marker} says hello`,
+        },
+      });
+      await prisma.memory.create({
+        data: {
+          id: nextId(),
+          personaId,
+          personalityId: PERSONALITY_X,
+          content: `${marker} memory content`,
+          senders: [marker],
+        },
+      });
+      await prisma.memoryFact.create({
+        data: {
+          id: nextId(),
+          personaId,
+          personalityId: PERSONALITY_X,
+          statement: `${marker} fact statement`,
+          entityTags: [`user:${marker}`],
+        },
+      });
+    }
+
+    // Secret-bearing rows for A: BYOK key + credential.
+    await prisma.userApiKey.create({
+      data: {
+        id: nextId(),
+        userId: USER_A,
+        provider: 'openrouter',
+        iv: 'test-iv',
+        content: SECRET_VALUE,
+        tag: 'test-tag',
+      },
+    });
+    await prisma.userCredential.create({
+      data: {
+        id: nextId(),
+        userId: USER_A,
+        service: 'shapes_inc',
+        credentialType: 'session_cookie',
+        iv: 'cred-iv',
+        content: SECRET_VALUE,
+        tag: 'cred-tag',
+      },
+    });
+
+    await prisma.usageLog.create({
+      data: {
+        id: nextId(),
+        userId: USER_A,
+        provider: 'openrouter',
+        model: 'test/model',
+        tokensIn: 10,
+        tokensOut: 20,
+        requestType: 'chat',
+      },
+    });
+    await prisma.userFeedback.create({
+      data: { id: nextId(), userId: USER_A, content: 'love the bot', contentHash: 'fb-hash-1' },
+    });
+  });
+
+  it('assembles every section for the user, isolated from other users', async () => {
+    const payload = await assembleAccountExport(prisma, USER_A);
+
+    expect(payload.profile).toEqual(expect.objectContaining({ username: 'exportalice' }));
+    expect(payload.personas).toHaveLength(1);
+    expect(payload.characters.map(c => (c as { id: string }).id)).toEqual([PERSONALITY_X]);
+    expect(payload.conversationHistory).toHaveLength(1);
+    expect(payload.memories).toHaveLength(1);
+    expect(payload.facts).toHaveLength(1);
+    expect(payload.feedback).toHaveLength(1);
+    expect(payload.apiKeyMetadata).toEqual([expect.objectContaining({ provider: 'openrouter' })]);
+    expect(payload.usageSummary).toEqual([
+      expect.objectContaining({
+        provider: 'openrouter',
+        model: 'test/model',
+        _sum: expect.objectContaining({ tokensIn: 10, tokensOut: 20 }),
+      }),
+    ]);
+
+    // Cross-user isolation: nothing of Bob's rides along.
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain('bob-line');
+    expect(serialized).not.toContain('exportbob');
+  });
+
+  it('never includes secret material in the serialized payload', async () => {
+    const payload = await assembleAccountExport(prisma, USER_A);
+    const serialized = JSON.stringify(payload);
+
+    expect(serialized).not.toContain(SECRET_VALUE);
+    expect(serialized).not.toContain('test-iv');
+    expect(serialized).not.toContain('cred-iv');
+    // The meta.notes disclose the exclusions.
+    expect(payload.meta.notes.join(' ')).toContain('secret material is never exported');
+  });
+});

--- a/services/ai-worker/src/jobs/AccountExportAssembler.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { assembleAccountExport } from './AccountExportAssembler.js';
+
+function emptyModel(): { findMany: ReturnType<typeof vi.fn> } {
+  return { findMany: vi.fn().mockResolvedValue([]) };
+}
+
+function makePrisma(): Record<string, { findMany?: ReturnType<typeof vi.fn> }> {
+  return {
+    user: {
+      findUniqueOrThrow: vi.fn().mockResolvedValue({ username: 'alice', discordId: '1' }),
+    } as never,
+    persona: emptyModel(),
+    personalityOwner: emptyModel(),
+    personality: emptyModel(),
+    conversationHistory: emptyModel(),
+    memory: emptyModel(),
+    memoryFact: emptyModel(),
+    userPersonalityConfig: emptyModel(),
+    userPersonaHistoryConfig: emptyModel(),
+    llmConfig: emptyModel(),
+    ttsConfig: emptyModel(),
+    userApiKey: emptyModel(),
+    userCredential: emptyModel(),
+    usageLog: { groupBy: vi.fn().mockResolvedValue([]) } as never,
+    userFeedback: emptyModel(),
+    importJob: emptyModel(),
+    exportJob: emptyModel(),
+    releaseDeliveryLog: emptyModel(),
+  };
+}
+
+describe('assembleAccountExport', () => {
+  let prisma: ReturnType<typeof makePrisma>;
+
+  beforeEach(() => {
+    prisma = makePrisma();
+  });
+
+  it('assembles every section with the disclosure notes', async () => {
+    const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    expect(payload.profile).toEqual({ username: 'alice', discordId: '1' });
+    for (const section of [
+      'personas',
+      'characters',
+      'conversationHistory',
+      'memories',
+      'facts',
+      'usageSummary',
+      'feedback',
+      'apiKeyMetadata',
+      'credentialMetadata',
+    ] as const) {
+      expect(payload[section]).toEqual([]);
+    }
+    expect(payload.meta.formatVersion).toBe(1);
+    expect(payload.meta.notes.join(' ')).toContain('secret material is never exported');
+  });
+
+  it('selects only metadata columns for keys and credentials (never secret columns)', async () => {
+    await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    const keySelect = prisma.userApiKey.findMany?.mock.calls[0][0].select;
+    expect(keySelect).toEqual({ id: true, provider: true, createdAt: true, updatedAt: true });
+    const credSelect = prisma.userCredential.findMany?.mock.calls[0][0].select;
+    expect(credSelect).toEqual({
+      id: true,
+      service: true,
+      credentialType: true,
+      createdAt: true,
+      expiresAt: true,
+    });
+  });
+
+  it('sweeps the small sections too — feedback past the page boundary is not clipped', async () => {
+    const pageOne = Array.from({ length: 1000 }, (_, i) => ({ id: `fb-${i}` }));
+    prisma.userFeedback.findMany
+      ?.mockResolvedValueOnce(pageOne)
+      .mockResolvedValueOnce([{ id: 'fb-1000' }]);
+
+    const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    expect(payload.feedback).toHaveLength(1001);
+  });
+
+  it('cursor-sweeps big tables past the page boundary without clipping', async () => {
+    // Personas drive the sweep filters; one persona is enough.
+    prisma.persona.findMany?.mockResolvedValue([{ id: 'persona-1' }]);
+    const pageOne = Array.from({ length: 1000 }, (_, i) => ({ id: `row-${i}` }));
+    const pageTwo = [{ id: 'row-1000' }];
+    prisma.conversationHistory.findMany
+      ?.mockResolvedValueOnce(pageOne)
+      .mockResolvedValueOnce(pageTwo);
+
+    const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    expect(payload.conversationHistory).toHaveLength(1001);
+    const secondCall = prisma.conversationHistory.findMany?.mock.calls[1][0];
+    expect(secondCall.cursor).toEqual({ id: 'row-999' });
+    expect(secondCall.skip).toBe(1);
+  });
+});

--- a/services/ai-worker/src/jobs/AccountExportAssembler.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.ts
@@ -1,0 +1,278 @@
+/**
+ * Account Export Assembler
+ *
+ * Pure DB-read assembly of a user's full-account export payload (data
+ * portability). Separated from the job wrapper for testability, mirroring
+ * the ShapesExportFormatters split.
+ *
+ * Deliberate exclusions, each documented in the payload's meta.notes so the
+ * user sees them: secret material (BYOK keys/credentials export metadata
+ * only — encrypted blobs are useless and plaintext behind a bearer-URL is a
+ * hazard), embedding vectors (model internals, not user content), avatar and
+ * voice-reference binaries (avatars are re-downloadable via /avatars; voice
+ * references were user-supplied), stored export-file contents, and raw
+ * usage logs (an aggregate summary ships instead).
+ */
+
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+
+/** Page size for cursor sweeps over the big tables (bounded-query rule). */
+const EXPORT_PAGE_SIZE = 1000;
+
+export interface AccountExportFile {
+  meta: {
+    exportedAt: string;
+    formatVersion: 1;
+    notes: string[];
+  };
+  profile: Record<string, unknown>;
+  personas: unknown[];
+  characters: unknown[];
+  personalityConfigs: unknown[];
+  personaHistoryConfigs: unknown[];
+  conversationHistory: unknown[];
+  memories: unknown[];
+  facts: unknown[];
+  llmConfigs: unknown[];
+  ttsConfigs: unknown[];
+  apiKeyMetadata: unknown[];
+  credentialMetadata: unknown[];
+  usageSummary: unknown[];
+  feedback: unknown[];
+  importJobs: unknown[];
+  exportJobs: unknown[];
+  releaseDeliveries: unknown[];
+}
+
+const EXPORT_NOTES = [
+  'API keys and external credentials are listed as metadata only; secret material is never exported.',
+  'Memory embedding vectors are model internals and are not included.',
+  'Avatar images and voice-reference audio binaries are not included; avatars remain downloadable from the bot while the character exists.',
+  'Stored export/import file contents are not re-embedded; only job metadata is listed.',
+  'Usage is an aggregate summary per provider/model; raw per-request logs are not included.',
+];
+
+/**
+ * Cursor-sweep a table without clipping: bounded pages, unbounded total —
+ * an export must cover the whole account (same idiom as the broadcast
+ * recipient resolver).
+ */
+async function sweep<T extends { id: string }>(
+  fetchPage: (cursor: string | undefined) => Promise<T[]>
+): Promise<T[]> {
+  const rows: T[] = [];
+  let cursor: string | undefined;
+  for (;;) {
+    const page = await fetchPage(cursor);
+    rows.push(...page);
+    if (page.length < EXPORT_PAGE_SIZE) {
+      return rows;
+    }
+    cursor = page[page.length - 1].id;
+  }
+}
+
+function pageArgs(cursor: string | undefined): {
+  take: number;
+  orderBy: { id: 'asc' };
+  cursor?: { id: string };
+  skip?: number;
+} {
+  return {
+    take: EXPORT_PAGE_SIZE,
+    orderBy: { id: 'asc' },
+    ...(cursor !== undefined ? { cursor: { id: cursor }, skip: 1 } : {}),
+  };
+}
+
+/** The small per-user sections: configs, key/credential metadata, usage
+ *  aggregate, feedback, job metadata, delivery log. Fetched in parallel. */
+async function fetchAncillarySections(
+  prisma: PrismaClient,
+  userId: string
+): Promise<{
+  personalityConfigs: unknown[];
+  personaHistoryConfigs: unknown[];
+  llmConfigs: unknown[];
+  ttsConfigs: unknown[];
+  apiKeyMetadata: unknown[];
+  credentialMetadata: unknown[];
+  usageSummary: unknown[];
+  feedback: unknown[];
+  importJobs: unknown[];
+  exportJobs: unknown[];
+  releaseDeliveries: unknown[];
+}> {
+  const [
+    personalityConfigs,
+    personaHistoryConfigs,
+    llmConfigs,
+    ttsConfigs,
+    apiKeyMetadata,
+    credentialMetadata,
+    usageSummary,
+    feedback,
+    importJobs,
+    exportJobs,
+    releaseDeliveries,
+  ] = await Promise.all([
+    sweep(c => prisma.userPersonalityConfig.findMany({ where: { userId }, ...pageArgs(c) })),
+    sweep(c => prisma.userPersonaHistoryConfig.findMany({ where: { userId }, ...pageArgs(c) })),
+    sweep(c => prisma.llmConfig.findMany({ where: { ownerId: userId }, ...pageArgs(c) })),
+    sweep(c => prisma.ttsConfig.findMany({ where: { ownerId: userId }, ...pageArgs(c) })),
+    sweep(c =>
+      prisma.userApiKey.findMany({
+        where: { userId },
+        select: { id: true, provider: true, createdAt: true, updatedAt: true },
+        ...pageArgs(c),
+      })
+    ),
+    sweep(c =>
+      prisma.userCredential.findMany({
+        where: { userId },
+        select: { id: true, service: true, credentialType: true, createdAt: true, expiresAt: true },
+        ...pageArgs(c),
+      })
+    ),
+    prisma.usageLog.groupBy({
+      by: ['provider', 'model'],
+      where: { userId },
+      _count: { _all: true },
+      _sum: { tokensIn: true, tokensOut: true },
+    }),
+    sweep(c => prisma.userFeedback.findMany({ where: { userId }, ...pageArgs(c) })),
+    sweep(c => prisma.importJob.findMany({ where: { userId }, ...pageArgs(c) })),
+    sweep(c =>
+      prisma.exportJob.findMany({
+        where: { userId },
+        omit: { fileContent: true },
+        ...pageArgs(c),
+      })
+    ),
+    sweep(c => prisma.releaseDeliveryLog.findMany({ where: { userId }, ...pageArgs(c) })),
+  ]);
+
+  return {
+    personalityConfigs,
+    personaHistoryConfigs,
+    llmConfigs,
+    ttsConfigs,
+    apiKeyMetadata,
+    credentialMetadata,
+    usageSummary,
+    feedback,
+    importJobs,
+    exportJobs,
+    releaseDeliveries,
+  };
+}
+
+/**
+ * Every co-ownership junction row for the user. The junction has a composite
+ * PK (personalityId, userId); with userId fixed, personalityId is a valid
+ * cursor on its own.
+ */
+async function sweepOwnerships(prisma: PrismaClient, userId: string): Promise<string[]> {
+  const ids: string[] = [];
+  let cursor: string | undefined;
+  for (;;) {
+    const page = await prisma.personalityOwner.findMany({
+      where: { userId, ...(cursor !== undefined ? { personalityId: { gt: cursor } } : {}) },
+      select: { personalityId: true },
+      orderBy: { personalityId: 'asc' },
+      take: EXPORT_PAGE_SIZE,
+    });
+    ids.push(...page.map(row => row.personalityId));
+    if (page.length < EXPORT_PAGE_SIZE) {
+      return ids;
+    }
+    cursor = page[page.length - 1].personalityId;
+  }
+}
+
+/** Owned + co-owned character definitions, via the ownership junction. */
+async function fetchCharacters(prisma: PrismaClient, userId: string): Promise<unknown[]> {
+  const coOwned = await sweepOwnerships(prisma, userId);
+  const directlyOwned = await sweep(c =>
+    prisma.personality.findMany({
+      where: { ownerId: userId },
+      select: { id: true },
+      ...pageArgs(c),
+    })
+  );
+  const personalityIds = [...new Set([...coOwned, ...directlyOwned.map(row => row.id)])];
+  return sweep(c =>
+    prisma.personality.findMany({
+      where: { id: { in: personalityIds } },
+      ...pageArgs(c),
+      // Everything except binary blobs — the definition is the user's content.
+      omit: { avatarData: true, voiceReferenceData: true },
+    })
+  );
+}
+
+export async function assembleAccountExport(
+  prisma: PrismaClient,
+  userId: string
+): Promise<AccountExportFile> {
+  const user = await prisma.user.findUniqueOrThrow({
+    where: { id: userId },
+    select: {
+      discordId: true,
+      username: true,
+      timezone: true,
+      nsfwVerified: true,
+      nsfwVerifiedAt: true,
+      notifyEnabled: true,
+      notifyLevel: true,
+      createdAt: true,
+    },
+  });
+
+  const personas = await sweep(c =>
+    prisma.persona.findMany({ where: { ownerId: userId }, ...pageArgs(c) })
+  );
+  const personaIds = personas.map(persona => persona.id);
+
+  const characters = await fetchCharacters(prisma, userId);
+
+  const conversationHistory = await sweep(cursor =>
+    prisma.conversationHistory.findMany({
+      where: { personaId: { in: personaIds } },
+      ...pageArgs(cursor),
+    })
+  );
+
+  // Embedding vectors are Unsupported("vector") columns — the Prisma client
+  // never returns them, so no omit is needed for the "no embeddings" note.
+  const memories = await sweep(cursor =>
+    prisma.memory.findMany({
+      where: { personaId: { in: personaIds } },
+      ...pageArgs(cursor),
+    })
+  );
+
+  const facts = await sweep(cursor =>
+    prisma.memoryFact.findMany({
+      where: { personaId: { in: personaIds } },
+      ...pageArgs(cursor),
+    })
+  );
+
+  const ancillary = await fetchAncillarySections(prisma, userId);
+
+  return {
+    meta: {
+      exportedAt: new Date().toISOString(),
+      formatVersion: 1,
+      notes: EXPORT_NOTES,
+    },
+    profile: user,
+    personas,
+    characters,
+    conversationHistory,
+    memories,
+    facts,
+    ...ancillary,
+  };
+}

--- a/services/ai-worker/src/jobs/AccountExportJob.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportJob.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Job } from 'bullmq';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { AccountExportJobData } from '@tzurot/common-types/types/account-export';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const assembleMock = vi.hoisted(() => vi.fn());
+vi.mock('./AccountExportAssembler.js', () => ({
+  assembleAccountExport: assembleMock,
+}));
+
+import { processAccountExportJob } from './AccountExportJob.js';
+
+const mockPrisma = {
+  exportJob: { update: vi.fn().mockResolvedValue({}) },
+} as unknown as PrismaClient;
+
+function makeJob(
+  attempt: { attemptsMade?: number; attempts?: number } = {}
+): Job<AccountExportJobData> {
+  return {
+    id: 'bullmq-1',
+    data: { userId: 'user-uuid-1', exportJobId: 'export-job-1' },
+    attemptsMade: attempt.attemptsMade ?? 0,
+    opts: { attempts: attempt.attempts ?? 1 },
+  } as unknown as Job<AccountExportJobData>;
+}
+
+function makePayload(): Record<string, unknown> {
+  return {
+    meta: { exportedAt: 'now', formatVersion: 1, notes: [] },
+    profile: { username: 'alice' },
+    personas: [{}],
+    characters: [],
+    conversationHistory: [{}, {}],
+    memories: [{}],
+    facts: [],
+    feedback: [],
+  };
+}
+
+describe('processAccountExportJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('transitions pending → in_progress → completed with content and metadata', async () => {
+    assembleMock.mockResolvedValue(makePayload());
+
+    const result = await processAccountExportJob(makeJob(), mockPrisma);
+
+    expect(result.success).toBe(true);
+    expect(result.fileSizeBytes).toBeGreaterThan(0);
+
+    const updates = (mockPrisma.exportJob.update as ReturnType<typeof vi.fn>).mock.calls;
+    expect(updates[0][0].data.status).toBe('in_progress');
+    const final = updates[1][0].data;
+    expect(final.status).toBe('completed');
+    expect(final.fileName).toMatch(/^tzurot-account-export-alice-\d{4}-\d{2}-\d{2}\.json$/);
+    expect(final.exportMetadata).toEqual(
+      expect.objectContaining({ conversationHistory: 2, memories: 1, personas: 1 })
+    );
+    // The stored content is the assembled payload, serialized.
+    expect(JSON.parse(final.fileContent).profile.username).toBe('alice');
+  });
+
+  it('sanitizes usernames that are not filename-safe', async () => {
+    assembleMock.mockResolvedValue({ ...makePayload(), profile: { username: 'a/б c!' } });
+
+    await processAccountExportJob(makeJob(), mockPrisma);
+
+    const final = (mockPrisma.exportJob.update as ReturnType<typeof vi.fn>).mock.calls[1][0].data;
+    expect(final.fileName).not.toMatch(/[/!\s]/);
+  });
+
+  it('re-throws on non-final attempts so BullMQ actually retries (row stays in_progress)', async () => {
+    assembleMock.mockRejectedValue(new Error('transient pool timeout'));
+
+    await expect(
+      processAccountExportJob(makeJob({ attemptsMade: 0, attempts: 3 }), mockPrisma)
+    ).rejects.toThrow('transient pool timeout');
+
+    // Only the in_progress transition ran — the row was NOT marked failed.
+    const updates = (mockPrisma.exportJob.update as ReturnType<typeof vi.fn>).mock.calls;
+    expect(updates).toHaveLength(1);
+    expect(updates[0][0].data.status).toBe('in_progress');
+  });
+
+  it('marks the row failed (with the error message) only on the final attempt', async () => {
+    assembleMock.mockRejectedValue(new Error('db exploded'));
+
+    const result = await processAccountExportJob(
+      makeJob({ attemptsMade: 2, attempts: 3 }),
+      mockPrisma
+    );
+
+    expect(result).toEqual({ success: false, fileSizeBytes: 0, error: 'db exploded' });
+    const final = (mockPrisma.exportJob.update as ReturnType<typeof vi.fn>).mock.calls[1][0].data;
+    expect(final.status).toBe('failed');
+    expect(final.errorMessage).toBe('db exploded');
+  });
+});

--- a/services/ai-worker/src/jobs/AccountExportJob.ts
+++ b/services/ai-worker/src/jobs/AccountExportJob.ts
@@ -1,0 +1,94 @@
+/**
+ * Account Export Job Processor
+ *
+ * BullMQ job handler for full-account data exports (data portability):
+ * 1. Mark the export_jobs row in_progress
+ * 2. Assemble the account payload (AccountExportAssembler — pure DB reads)
+ * 3. Store the JSON in ExportJob.fileContent (PostgreSQL TEXT)
+ * 4. Update status with results
+ *
+ * Self-contained like the shapes export: status lives on the ExportJob row;
+ * the user downloads via the public /exports/:jobId route until expiry.
+ */
+
+import type { Job } from 'bullmq';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import {
+  type AccountExportJobData,
+  type AccountExportJobResult,
+} from '@tzurot/common-types/types/account-export';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { assembleAccountExport } from './AccountExportAssembler.js';
+
+const logger = createLogger('AccountExportJob');
+
+export async function processAccountExportJob(
+  job: Job<AccountExportJobData>,
+  prisma: PrismaClient
+): Promise<AccountExportJobResult> {
+  const { userId, exportJobId } = job.data;
+
+  logger.info({ jobId: job.id, exportJobId }, 'Starting account export');
+
+  await prisma.exportJob.update({
+    where: { id: exportJobId },
+    data: { status: 'in_progress', startedAt: new Date() },
+  });
+
+  try {
+    const payload = await assembleAccountExport(prisma, userId);
+
+    const fileContent = JSON.stringify(payload, null, 2);
+    const fileSizeBytes = Buffer.byteLength(fileContent, 'utf8');
+    const username =
+      typeof payload.profile.username === 'string' ? payload.profile.username : 'user';
+    const safeUsername = username.replace(/[^\w.-]/g, '_');
+    const fileName = `tzurot-account-export-${safeUsername}-${new Date().toISOString().slice(0, 10)}.json`;
+
+    await prisma.exportJob.update({
+      where: { id: exportJobId },
+      data: {
+        status: 'completed',
+        fileContent,
+        fileName,
+        fileSizeBytes,
+        completedAt: new Date(),
+        exportMetadata: {
+          personas: payload.personas.length,
+          characters: payload.characters.length,
+          conversationHistory: payload.conversationHistory.length,
+          memories: payload.memories.length,
+          facts: payload.facts.length,
+          feedback: payload.feedback.length,
+        },
+      },
+    });
+
+    logger.info({ jobId: job.id, exportJobId, fileSizeBytes }, 'Account export completed');
+    return { success: true, fileSizeBytes };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    // Assembly is pure DB reads, so every failure class is worth retrying —
+    // a transient pool timeout succeeds next attempt; a deterministic error
+    // just re-reads cheaply before exhausting. Re-throw while attempts
+    // remain (BullMQ retries only on a REJECTED processor promise; the row
+    // stays in_progress and the next attempt re-marks it from the top), and
+    // mark failed only on the final attempt so users never see a
+    // permanently stuck status. Attempt arithmetic mirrors
+    // handleShapesJobError.
+    const maxAttempts = job.opts.attempts ?? 1;
+    if (job.attemptsMade < maxAttempts - 1) {
+      logger.warn(
+        { err: error, jobId: job.id, exportJobId, attemptsMade: job.attemptsMade, maxAttempts },
+        'Account export attempt failed — BullMQ will retry'
+      );
+      throw error;
+    }
+    logger.error({ err: error, jobId: job.id, exportJobId }, 'Account export failed');
+    await prisma.exportJob.update({
+      where: { id: exportJobId },
+      data: { status: 'failed', completedAt: new Date(), errorMessage },
+    });
+    return { success: false, fileSizeBytes: 0, error: errorMessage };
+  }
+}

--- a/services/api-gateway/src/routes/_generated/mounts.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.ts
@@ -60,6 +60,7 @@ import { handleListGlobalLlmConfigs, handleGetGlobalLlmConfig, handleCreateGloba
 import { handleListGlobalTtsConfigs, handleGetGlobalTtsConfig, handleCreateGlobalTtsConfig, handleUpdateGlobalTtsConfig, handleSetGlobalTtsConfigDefault, handleSetGlobalTtsConfigFreeDefault, handleDeleteGlobalTtsConfig } from '../admin/tts-config.js';
 import { handleGetSystemSettings, handleUpdateSystemSettings } from '../admin/systemSettings.js';
 import { handleGetAdminUsageStats } from '../admin/usage.js';
+import { handleStartAccountExport, handleGetAccountExportStatus } from '../user/account/export.js';
 import { handleGetTimezone, handleSetTimezone } from '../user/timezone.js';
 import { handleGetNotificationPrefs, handleUpdateNotificationPrefs } from '../user/notifications.js';
 import { handleListUserLlmConfigs, handleGetUserLlmConfig, handleCreateUserLlmConfig, handleUpdateUserLlmConfig, handleDeleteUserLlmConfig, handleResolveUserLlmConfig } from '../user/llm-config.js';
@@ -160,6 +161,8 @@ export function mountAdminRoutes(app: Express, deps: RouteDeps): void {
 }
 
 export function mountUserRoutes(app: Express, deps: RouteDeps): void {
+  app.post('/api/user/account/export', requireUserAuth(), requireProvisionedUser(deps.prisma), handleStartAccountExport(deps));
+  app.get('/api/user/account/export/status', requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetAccountExportStatus(deps));
   app.get('/api/user/timezone', requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetTimezone(deps));
   app.put('/api/user/timezone', requireUserAuth(), requireProvisionedUser(deps.prisma), handleSetTimezone(deps));
   app.get('/api/user/notifications', requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetNotificationPrefs(deps));

--- a/services/api-gateway/src/routes/conformance/fixtures/registry.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/registry.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ConformanceEntry } from './types.js';
+import { userAccountFixtures } from './userAccount.js';
 import { adminFixtures } from './admin.js';
 import { internalFixtures } from './internal.js';
 import { userConfigFixtures } from './userConfigs.js';
@@ -21,6 +22,7 @@ import { userResourceFixtures } from './userResources.js';
 import { userDiagnosticFixtures, userShapesFixtures } from './userShapesAndDiagnostics.js';
 
 export const CONFORMANCE_REGISTRY: Record<string, ConformanceEntry> = {
+  ...userAccountFixtures,
   ...internalFixtures,
   ...adminFixtures,
   ...userOwnershipFixtures,

--- a/services/api-gateway/src/routes/conformance/fixtures/userAccount.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/userAccount.ts
@@ -1,0 +1,54 @@
+/**
+ * Conformance fixtures: user-audience account data-rights routes.
+ *
+ * Both export routes operate on locally-stored rows (export_jobs + a BullMQ
+ * enqueue the harness's queue stub absorbs), so they run for real.
+ */
+
+import {
+  ACCOUNT_EXPORT_SLUG,
+  ACCOUNT_EXPORT_SOURCE,
+} from '@tzurot/common-types/types/account-export';
+import { generateExportJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import type { ConformanceEntry } from './types.js';
+
+export const userAccountFixtures: Record<string, ConformanceEntry> = {
+  startAccountExport: {
+    body: {},
+  },
+
+  getAccountExportStatus: {
+    seed: async ctx => {
+      // Deterministic id: the (userId, slug, service, format) tuple is unique,
+      // and the startAccountExport fixture creates the same tuple — upserting
+      // the SAME deterministic row keeps the two fixtures order-independent.
+      const id = generateExportJobUuid(
+        ctx.actorUserId,
+        ACCOUNT_EXPORT_SLUG,
+        ACCOUNT_EXPORT_SOURCE,
+        'json'
+      );
+      await ctx.prisma.exportJob.upsert({
+        where: { id },
+        update: {
+          status: 'completed',
+          fileName: 'tzurot-account-export-conf-2026-01-01.json',
+          fileSizeBytes: 42,
+          completedAt: new Date(),
+        },
+        create: {
+          id,
+          userId: ctx.actorUserId,
+          sourceSlug: ACCOUNT_EXPORT_SLUG,
+          sourceService: ACCOUNT_EXPORT_SOURCE,
+          status: 'completed',
+          format: 'json',
+          fileName: 'tzurot-account-export-conf-2026-01-01.json',
+          fileSizeBytes: 42,
+          completedAt: new Date(),
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        },
+      });
+    },
+  },
+};

--- a/services/api-gateway/src/routes/user/account/export.test.ts
+++ b/services/api-gateway/src/routes/user/account/export.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for Account Data-Rights Export Routes (Async)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+vi.mock('../../../services/AuthMiddleware.js');
+
+vi.mock('../../../utils/asyncHandler.js', () => ({
+  asyncHandler: vi.fn(fn => fn),
+}));
+
+import { handleStartAccountExport, handleGetAccountExportStatus } from './export.js';
+import { JobType } from '@tzurot/common-types/constants/queue';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
+
+const mockTxExportJob = {
+  findFirst: vi.fn().mockResolvedValue(null),
+  upsert: vi.fn().mockResolvedValue({ id: 'export-job-123' }),
+};
+
+const mockPrisma = {
+  exportJob: {
+    findFirst: vi.fn().mockResolvedValue(null),
+  },
+  $transaction: vi.fn().mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+    return callback({ exportJob: mockTxExportJob });
+  }),
+};
+
+const mockQueue = {
+  add: vi.fn().mockResolvedValue({ id: 'bullmq-job-id' }),
+};
+
+function createMockReqRes(body: Record<string, unknown> = {}) {
+  const req = {
+    body,
+    query: {},
+    userId: 'discord-user-123',
+    provisionedUserId: 'user-uuid-123',
+    provisionedDefaultPersonaId: 'persona-uuid-default',
+  } as unknown as Request & { userId: string };
+
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+
+  return { req, res };
+}
+
+describe('Account Export Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTxExportJob.findFirst.mockResolvedValue(null);
+    mockTxExportJob.upsert.mockResolvedValue({ id: 'export-job-123' });
+    mockPrisma.exportJob.findFirst.mockResolvedValue(null);
+  });
+
+  describe('POST /account/export', () => {
+    async function callStart(body: Record<string, unknown> = {}) {
+      const { req, res } = createMockReqRes(body);
+      const handler = handleStartAccountExport({
+        ...stubRouteResolvers(),
+        prisma: mockPrisma as unknown as PrismaClient,
+        aiQueue: mockQueue as never,
+      });
+      await handler(req, res, vi.fn());
+      return { req, res };
+    }
+
+    it('503s when the job queue is not configured', async () => {
+      const { req, res } = createMockReqRes({});
+      const handler = handleStartAccountExport({
+        ...stubRouteResolvers(),
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
+      await handler(req, res, vi.fn());
+      expect(res.status).toHaveBeenCalledWith(503);
+    });
+
+    it('creates the job row and enqueues the worker job with the provisioned user id', async () => {
+      const { res } = await callStart();
+
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(mockTxExportJob.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            userId: 'user-uuid-123',
+            sourceService: 'account',
+            sourceSlug: 'account',
+            format: 'json',
+            status: 'pending',
+          }),
+        })
+      );
+      const [jobType, jobData] = mockQueue.add.mock.calls[0];
+      expect(jobType).toBe(JobType.AccountExport);
+      expect(jobData).toEqual({
+        userId: 'user-uuid-123',
+        exportJobId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          status: 'pending',
+          downloadUrl: expect.stringContaining('/exports/'),
+        })
+      );
+    });
+
+    it('409s while an account export is already active, without enqueueing', async () => {
+      mockTxExportJob.findFirst.mockResolvedValueOnce({ status: 'in_progress' });
+      const { res } = await callStart();
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /account/export/status', () => {
+    async function callStatus() {
+      const { req, res } = createMockReqRes();
+      const handler = handleGetAccountExportStatus({
+        ...stubRouteResolvers(),
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
+      await handler(req, res, vi.fn());
+      return { res };
+    }
+
+    it('returns null when the user never exported', async () => {
+      const { res } = await callStatus();
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ job: null }));
+    });
+
+    it('adds a downloadUrl only for completed jobs', async () => {
+      mockPrisma.exportJob.findFirst.mockResolvedValueOnce({
+        id: 'job-1',
+        status: 'completed',
+        fileName: 'tzurot-account-export-alice-2026-07-15.json',
+        fileSizeBytes: 42,
+        createdAt: new Date(),
+        completedAt: new Date(),
+        expiresAt: new Date(),
+        errorMessage: null,
+      });
+      const first = await callStatus();
+      expect(first.res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          job: expect.objectContaining({ downloadUrl: expect.stringContaining('/exports/job-1') }),
+        })
+      );
+
+      mockPrisma.exportJob.findFirst.mockResolvedValueOnce({
+        id: 'job-2',
+        status: 'pending',
+        fileName: null,
+        fileSizeBytes: null,
+        createdAt: new Date(),
+        completedAt: null,
+        expiresAt: new Date(),
+        errorMessage: null,
+      });
+      const second = await callStatus();
+      expect(second.res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ job: expect.objectContaining({ downloadUrl: null }) })
+      );
+    });
+  });
+});

--- a/services/api-gateway/src/routes/user/account/export.ts
+++ b/services/api-gateway/src/routes/user/account/export.ts
@@ -1,0 +1,243 @@
+/**
+ * Account Data-Rights Export Routes (Async)
+ *
+ * POST /user/account/export        - Start a full-account export job
+ * GET  /user/account/export/status - Latest account export job state
+ *
+ * Rides the shapes-export spine: an export_jobs row (sentinel
+ * sourceService='account') filled asynchronously by ai-worker, downloaded
+ * via the public GET /exports/:jobId route, expiring after 24 hours.
+ */
+
+import { type Response, type RequestHandler } from 'express';
+import type { Queue } from 'bullmq';
+import { StatusCodes } from 'http-status-codes';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { JobType, JOB_PREFIXES } from '@tzurot/common-types/constants/queue';
+import { StartAccountExportInputSchema } from '@tzurot/common-types/schemas/api/account';
+import { type PrismaClient, Prisma } from '@tzurot/common-types/services/prisma';
+import {
+  ACCOUNT_EXPORT_SOURCE,
+  ACCOUNT_EXPORT_SLUG,
+  type AccountExportJobData,
+} from '@tzurot/common-types/types/account-export';
+import { generateExportJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { asyncHandler } from '../../../utils/asyncHandler.js';
+import { resolveProvisionedUserId } from '../../../utils/resolveProvisionedUserId.js';
+import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
+import { parseBodyOrSendError } from '../../../utils/configRouteHelpers.js';
+import { ErrorResponses } from '../../../utils/errorResponses.js';
+import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
+import type { ProvisionedRequest } from '../../../types.js';
+import type { RouteDeps } from '../../routeDeps.js';
+
+const logger = createLogger('account-export');
+
+/** Export jobs expire after 24 hours (mirrors the shapes-export policy). */
+const EXPORT_EXPIRY_HOURS = 24;
+
+/** Account exports are JSON-only in v1. */
+const EXPORT_FORMAT = 'json';
+
+interface CreateOrConflictResult {
+  exportJobId: string;
+  conflictStatus: string | null;
+}
+
+/**
+ * Atomically check for an active job and create/reset the export row.
+ * The UUID is deterministic on (userId, 'account', 'account', 'json'), so a
+ * re-export upserts the same row — replacing any previous completed/failed
+ * export and invalidating its download URL. Only an active
+ * (pending/in_progress) job triggers a 409.
+ */
+async function createExportJobOrConflict(
+  prisma: PrismaClient,
+  userId: string,
+  expiresAt: Date
+): Promise<CreateOrConflictResult> {
+  const exportJobId = generateExportJobUuid(
+    userId,
+    ACCOUNT_EXPORT_SLUG,
+    ACCOUNT_EXPORT_SOURCE,
+    EXPORT_FORMAT
+  );
+
+  const conflictStatus = await prisma.$transaction(async tx => {
+    const existingJob = await tx.exportJob.findFirst({
+      where: {
+        userId,
+        sourceService: ACCOUNT_EXPORT_SOURCE,
+        status: { in: ['pending', 'in_progress'] },
+      },
+    });
+
+    if (existingJob !== null) {
+      return existingJob.status;
+    }
+
+    await tx.exportJob.upsert({
+      where: { id: exportJobId },
+      create: {
+        id: exportJobId,
+        userId,
+        sourceSlug: ACCOUNT_EXPORT_SLUG,
+        sourceService: ACCOUNT_EXPORT_SOURCE,
+        status: 'pending',
+        format: EXPORT_FORMAT,
+        expiresAt,
+      },
+      update: {
+        status: 'pending',
+        format: EXPORT_FORMAT,
+        fileContent: null,
+        fileName: null,
+        fileSizeBytes: null,
+        errorMessage: null,
+        startedAt: null,
+        completedAt: null,
+        expiresAt,
+        exportMetadata: Prisma.JsonNull,
+      },
+    });
+
+    return null;
+  });
+
+  return { exportJobId, conflictStatus };
+}
+
+/**
+ * Memoized base URL (env vars don't change at runtime); same posture as the
+ * shapes export module's resolver.
+ */
+let _baseUrlCache: string | undefined;
+function resolveBaseUrl(): string {
+  if (_baseUrlCache === undefined) {
+    const envConfig = getConfig();
+    _baseUrlCache = envConfig.PUBLIC_GATEWAY_URL ?? envConfig.GATEWAY_URL ?? '';
+  }
+  return _baseUrlCache;
+}
+
+function createStartExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: string) {
+  return async (req: ProvisionedRequest, res: Response) => {
+    const parsed = parseBodyOrSendError(res, StartAccountExportInputSchema, req.body ?? {});
+    if (parsed === null) {
+      return;
+    }
+
+    const userId = resolveProvisionedUserId(req);
+    const expiresAt = new Date(Date.now() + EXPORT_EXPIRY_HOURS * 60 * 60 * 1000);
+
+    let exportJobId: string;
+    let conflictStatus: string | null;
+    try {
+      ({ exportJobId, conflictStatus } = await createExportJobOrConflict(
+        prisma,
+        userId,
+        expiresAt
+      ));
+    } catch (error: unknown) {
+      if (isPrismaUniqueConstraintError(error)) {
+        logger.warn({ userId }, 'P2002 unique constraint — treating as conflict');
+        return sendError(
+          res,
+          ErrorResponses.conflict(
+            'An account export is already in progress. Wait for it to complete.'
+          )
+        );
+      }
+      throw error;
+    }
+
+    if (conflictStatus !== null) {
+      return sendError(
+        res,
+        ErrorResponses.conflict(
+          `An account export is already ${conflictStatus}. Wait for it to complete.`
+        )
+      );
+    }
+
+    const jobData: AccountExportJobData = { userId, exportJobId };
+
+    // Non-deterministic suffix: the DB transaction above prevents duplicate
+    // ACTIVE jobs; BullMQ dedups by jobId, and a deterministic ID would make
+    // re-exports after completion silently ignored.
+    const jobId = `${JOB_PREFIXES.ACCOUNT_EXPORT}${exportJobId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await queue.add(JobType.AccountExport, jobData, {
+      jobId,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5_000 },
+    });
+
+    logger.info({ userId, exportJobId }, 'Account export job created');
+
+    sendCustomSuccess(
+      res,
+      {
+        success: true,
+        exportJobId,
+        status: 'pending',
+        downloadUrl: `${baseUrl}/exports/${encodeURIComponent(exportJobId)}`,
+        expiresAt: expiresAt.toISOString(),
+      },
+      StatusCodes.ACCEPTED
+    );
+  };
+}
+
+function createStatusHandler(prisma: PrismaClient, baseUrl: string) {
+  return async (req: ProvisionedRequest, res: Response) => {
+    const userId = resolveProvisionedUserId(req);
+
+    const job = await prisma.exportJob.findFirst({
+      where: { userId, sourceService: ACCOUNT_EXPORT_SOURCE },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        status: true,
+        fileName: true,
+        fileSizeBytes: true,
+        createdAt: true,
+        completedAt: true,
+        expiresAt: true,
+        errorMessage: true,
+      },
+    });
+
+    sendCustomSuccess(res, {
+      job:
+        job === null
+          ? null
+          : {
+              ...job,
+              downloadUrl:
+                job.status === 'completed'
+                  ? `${baseUrl}/exports/${encodeURIComponent(job.id)}`
+                  : null,
+            },
+    });
+  };
+}
+
+/** POST /api/user/account/export — start a full-account export job. */
+export const handleStartAccountExport = (deps: RouteDeps): RequestHandler => {
+  const baseUrl = resolveBaseUrl();
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    if (deps.aiQueue === undefined) {
+      sendError(
+        res,
+        ErrorResponses.serviceUnavailable('Job queue required for account export is not configured')
+      );
+      return;
+    }
+    await createStartExportHandler(deps.prisma, deps.aiQueue, baseUrl)(req, res);
+  });
+};
+
+/** GET /api/user/account/export/status — latest account export job. */
+export const handleGetAccountExportStatus = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createStatusHandler(deps.prisma, resolveBaseUrl()));

--- a/services/api-gateway/src/utils/validatedQueue.ts
+++ b/services/api-gateway/src/utils/validatedQueue.ts
@@ -28,6 +28,7 @@ import {
   shapesImportJobDataSchema,
   shapesExportJobDataSchema,
 } from '@tzurot/common-types/types/shapes-import';
+import { accountExportJobDataSchema } from '@tzurot/common-types/types/account-export';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ZodSchema } from 'zod';
 
@@ -43,6 +44,7 @@ const SCHEMA_MAP: Record<JobType, ZodSchema> = {
   [JobType.LLMGeneration]: llmGenerationJobDataSchema,
   [JobType.ShapesImport]: shapesImportJobDataSchema,
   [JobType.ShapesExport]: shapesExportJobDataSchema,
+  [JobType.AccountExport]: accountExportJobDataSchema,
   [JobType.FactExtraction]: factExtractionJobDataSchema,
   [JobType.ReleaseBroadcastDm]: releaseBroadcastDmJobDataSchema,
 };

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -2100,6 +2100,19 @@
                 "options": []
               }
             ]
+          },
+          {
+            "type": 2,
+            "name": "data",
+            "description": "Your data: export everything you have stored",
+            "options": [
+              {
+                "type": 1,
+                "name": "export",
+                "description": "Export all your account data as a downloadable file",
+                "options": []
+              }
+            ]
           }
         ],
         "name": "settings",

--- a/services/bot-client/src/commands/settings/data/export.test.ts
+++ b/services/bot-client/src/commands/settings/data/export.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for /settings data export
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleDataExport } from './export.js';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { makeOk, makeErr, asUserClient } from '../../../test/gatewayClientStubs.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
+
+describe('handleDataExport', () => {
+  const mockEditReply = vi.fn();
+  let stub: {
+    startAccountExport: ReturnType<typeof vi.fn>;
+    getAccountExportStatus: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEditReply.mockResolvedValue(undefined);
+    stub = {
+      startAccountExport: vi.fn(),
+      getAccountExportStatus: vi.fn(),
+    };
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
+  function createMockContext(): DeferredCommandContext {
+    return {
+      user: { id: '123456789', username: 'testuser' },
+      editReply: mockEditReply,
+      guild: null,
+      member: null,
+      channel: null,
+      channelId: 'channel-123',
+      guildId: null,
+      commandName: 'settings',
+      getOption: vi.fn(),
+      getRequiredOption: vi.fn(),
+      getSubcommand: vi.fn().mockReturnValue('export'),
+      getSubcommandGroup: vi.fn().mockReturnValue('data'),
+      interaction: {
+        user: { id: '123456789', username: 'testuser' },
+        options: {},
+      },
+    } as unknown as DeferredCommandContext;
+  }
+
+  it('starts the export and shows the download link with expiry', async () => {
+    stub.startAccountExport.mockResolvedValue(
+      makeOk({
+        success: true,
+        exportJobId: 'job-1',
+        status: 'pending',
+        downloadUrl: 'https://gateway.example/exports/job-1',
+        expiresAt: new Date(Date.now() + 24 * 3600 * 1000).toISOString(),
+      })
+    );
+
+    await handleDataExport(createMockContext());
+
+    expect(stub.startAccountExport).toHaveBeenCalledWith({});
+    const embed = mockEditReply.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toContain('Export Started');
+    expect(embed.data.description).toContain('https://gateway.example/exports/job-1');
+    expect(embed.data.description).toContain('never included');
+  });
+
+  it('shows the current job status on 409 (re-run doubles as status check)', async () => {
+    stub.startAccountExport.mockResolvedValue(makeErr(409, 'already in progress'));
+    stub.getAccountExportStatus.mockResolvedValue(
+      makeOk({
+        job: {
+          id: 'job-1',
+          status: 'completed',
+          fileName: 'f.json',
+          fileSizeBytes: 10,
+          createdAt: new Date().toISOString(),
+          completedAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+          errorMessage: null,
+          downloadUrl: 'https://gateway.example/exports/job-1',
+        },
+      })
+    );
+
+    await handleDataExport(createMockContext());
+
+    expect(stub.getAccountExportStatus).toHaveBeenCalled();
+    const embed = mockEditReply.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toContain('Status');
+    expect(embed.data.description).toContain('https://gateway.example/exports/job-1');
+  });
+
+  it('reports non-409 failures plainly', async () => {
+    stub.startAccountExport.mockResolvedValue(makeErr(500, 'boom'));
+
+    await handleDataExport(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('failed to start') })
+    );
+  });
+});

--- a/services/bot-client/src/commands/settings/data/export.ts
+++ b/services/bot-client/src/commands/settings/data/export.ts
@@ -1,0 +1,87 @@
+/**
+ * /settings data export — full-account data export (data portability).
+ *
+ * Starts an async export job (ai-worker assembles the payload) and shows the
+ * download link. One active job per user: on 409 the handler fetches the
+ * current job's status instead, so re-running the command doubles as a
+ * status check.
+ */
+
+import { EmbedBuilder, time, TimestampStyles } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
+import { sanitizeErrorForDiscord } from '../../../utils/errorSanitization.js';
+
+const logger = createLogger('settings-data-export');
+
+function expiryLine(expiresAt: string | Date): string {
+  const expiry = new Date(expiresAt);
+  return `The link expires ${time(expiry, TimestampStyles.RelativeTime)} — download before then.`;
+}
+
+async function showCurrentJobStatus(context: DeferredCommandContext): Promise<void> {
+  const { userClient } = clientsFor(context.interaction);
+  const statusResult = await userClient.getAccountExportStatus();
+
+  if (!statusResult.ok || statusResult.data.job === null) {
+    await context.editReply({
+      content: '⏳ An account export is already in progress. Try again in a minute.',
+    });
+    return;
+  }
+
+  const job = statusResult.data.job;
+  const embed = new EmbedBuilder()
+    .setColor(job.status === 'completed' ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.WARNING)
+    .setTitle('📦 Account Export Status')
+    .setDescription(
+      job.status === 'completed' && job.downloadUrl !== null
+        ? `Your export is ready.\n\n[Download your data](${job.downloadUrl})\n\n${expiryLine(job.expiresAt)}`
+        : `Your export is **${job.status}**. Re-run this command to check again.`
+    )
+    .setTimestamp();
+
+  await context.editReply({ embeds: [embed] });
+}
+
+/** Handle /settings data export */
+export async function handleDataExport(context: DeferredCommandContext): Promise<void> {
+  const userId = context.user.id;
+
+  try {
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.startAccountExport({});
+
+    if (!result.ok) {
+      if (result.status === 409) {
+        await showCurrentJobStatus(context);
+        return;
+      }
+      await context.editReply({
+        content: `❌ Export failed to start: ${sanitizeErrorForDiscord(result.error)}`,
+      });
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(DISCORD_COLORS.SUCCESS)
+      .setTitle('📦 Account Export Started')
+      .setDescription(
+        'Your full account data is being assembled — profile, personas, ' +
+          'characters, conversation history, memories, facts, and settings ' +
+          '(secret material like API keys is never included).\n\n' +
+          `When it finishes, download it here:\n[Download your data](${result.data.downloadUrl})\n\n` +
+          `${expiryLine(result.data.expiresAt)} ` +
+          'If the link says the export is not ready yet, wait a moment and try it again.'
+      )
+      .setTimestamp();
+
+    await context.editReply({ embeds: [embed] });
+    logger.info({ userId }, 'Account export started');
+  } catch (error) {
+    logger.error({ err: error, userId }, 'Unexpected error starting account export');
+    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+  }
+}

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -57,6 +57,9 @@ import { handleSetDefault as handlePresetSetDefault } from './preset/set-default
 import { handleClearDefault as handlePresetClearDefault } from './preset/clear-default.js';
 import { handleAutocomplete as handlePresetAutocomplete } from './preset/autocomplete.js';
 
+// Data-rights handlers (account export)
+import { handleDataExport } from './data/export.js';
+
 // Defaults handlers (user-default config cascade settings)
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { renderSpec } from '../../ux/render/render.js';
@@ -113,6 +116,16 @@ const presetRouter = createTypedSubcommandRouter(
 );
 
 /**
+ * Data-rights subcommand group router (all deferred)
+ */
+const dataRouter = createTypedSubcommandRouter(
+  {
+    export: handleDataExport,
+  },
+  { logger, logPrefix: '[Settings/Data]' }
+);
+
+/**
  * Command execution router
  */
 async function execute(context: SafeCommandContext): Promise<void> {
@@ -124,6 +137,8 @@ async function execute(context: SafeCommandContext): Promise<void> {
     await apikeyRouter(context);
   } else if (group === 'preset') {
     await presetRouter(context as DeferredCommandContext);
+  } else if (group === 'data') {
+    await dataRouter(context as DeferredCommandContext);
   } else if (group === 'defaults') {
     await handleDefaultsEdit(context as DeferredCommandContext);
   } else {
@@ -390,6 +405,17 @@ export default defineCommand({
         .setDescription('Manage your global default settings')
         .addSubcommand(subcommand =>
           subcommand.setName('edit').setDescription('Open your default settings dashboard')
+        )
+    )
+    // Data-rights subcommand group (account export; account deletion follows)
+    .addSubcommandGroup(group =>
+      group
+        .setName('data')
+        .setDescription('Your data: export everything you have stored')
+        .addSubcommand(subcommand =>
+          subcommand
+            .setName('export')
+            .setDescription('Export all your account data as a downloadable file')
         )
     ),
   execute,

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
@@ -2678,6 +2678,23 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
     ],
     "type": 2,
   },
+  {
+    "description": "Your data: export everything you have stored",
+    "description_localizations": undefined,
+    "name": "data",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "description": "Export all your account data as a downloadable file",
+        "description_localizations": undefined,
+        "name": "export",
+        "name_localizations": undefined,
+        "options": [],
+        "type": 1,
+      },
+    ],
+    "type": 2,
+  },
 ]
 `;
 


### PR DESCRIPTION
## What

First half of the data-rights pair (PR-A of the approved plan) backing the privacy policy's portability clause. `/settings data export` produces a complete, portable JSON dump of everything the bot stores about a user.

- **Rides the shapes-export spine**: `export_jobs` row with sentinel `sourceService='account'` (deterministic UUID → one export slot per user; re-export after completion replaces the row and its URL), filled by a new ai-worker `JobType.AccountExport`, downloaded via the existing public `/exports/:jobId` route, 24h expiry, existing cleanup jobs apply unchanged (verified source-agnostic).
- **Assembler** (`AccountExportAssembler`): pure DB reads; cursor-sweeps conversation history, memories, and facts without clipping (bounded pages, unbounded total); parallel-fetches the small sections. Exports: profile, personas, owned+co-owned character definitions, per-user configs, history, memories (all visibilities), facts (incl. forgotten), config rows, key/credential **metadata only**, usage **aggregate**, feedback, job metadata, delivery log.
- **Deliberate exclusions, disclosed in the payload's `meta.notes`**: secret material (encrypted blobs are useless; plaintext behind a bearer-URL is a hazard), embedding vectors, avatar/voice binaries, stored export-file contents, raw usage logs.
- **Command**: `/settings data export` (new `data` subcommand group; `delete` arrives in PR-B). 409-while-active doubles as a status check via `GET /account/export/status`.
- Topology: `AccountExport` classified self-contained like the shapes jobs (contract rides the `export_jobs` row, not the two-uuid payload; payload schema exists for enqueue-side validation and satisfies the JobType schema-coverage gate).

## What I verified and how

- `pnpm test` (25/25), `pnpm test:component` (35/35 — conformance rounds both new manifest routes over PGLite; the two fixtures share the deterministic job UUID so they're order-independent), `pnpm quality` all green locally, sequential.
- **PGLite component test for the assembler**: seeds a two-user graph with secret-bearing rows and asserts every section's content, cross-user isolation (nothing of user B rides user A's export), and — the load-bearing one — that seeded secret values and IVs never appear anywhere in the serialized payload.
- Unit tests: sweep pagination across the page boundary (cursor + skip asserted), metadata-only selects for keys/credentials asserted at the query seam, job status transitions incl. failure path, route 503/409/202 behavior with the enqueued payload asserted across the queue seam, command embed content incl. the 409→status path.
- Codegen chain run in order (dist rebuilds → routes → command-types → manifest snapshot → CommandHandler component snapshot).

## Runtime-unverified (dev smoke, owner-driven)

`/settings data export` on dev → download the JSON, eyeball sections, confirm no key material; re-run → status response. Checklist lands in CURRENT.md at close-out.

## Out of scope (PR-B, already designed)

`/settings data delete` — the erasure service, typed-phrase + single-use-token confirmation, superuser self-delete block, and the zero-residue component test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)