### PR TITLE
feat: account export v2 — ZIP with per-section JSON+Markdown files

### DIFF
--- a/packages/common-types/src/schemas/api/account.test.ts
+++ b/packages/common-types/src/schemas/api/account.test.ts
@@ -4,6 +4,7 @@ import {
   StartAccountExportResponseSchema,
   AccountExportStatusResponseSchema,
   AccountExportJobSummarySchema,
+  AccountExportJobStatusSchema,
 } from './account.js';
 
 describe('StartAccountExportInputSchema', () => {
@@ -48,7 +49,6 @@ describe('AccountExportJobSummarySchema', () => {
     createdAt: '2026-07-15T00:00:00.000Z',
     completedAt: null,
     expiresAt: '2026-07-16T00:00:00.000Z',
-    errorMessage: null,
     downloadUrl: null,
   };
 
@@ -66,6 +66,21 @@ describe('AccountExportJobSummarySchema', () => {
     const { expiresAt: _expiresAt, ...withoutExpiry } = BASE;
     expect(AccountExportJobSummarySchema.safeParse(withoutExpiry).success).toBe(false);
   });
+
+  it('rejects statuses outside the lifecycle vocabulary', () => {
+    expect(AccountExportJobSummarySchema.safeParse({ ...BASE, status: 'exploded' }).success).toBe(
+      false
+    );
+  });
+});
+
+describe('AccountExportJobStatusSchema', () => {
+  it('accepts exactly the four lifecycle states', () => {
+    for (const status of ['pending', 'in_progress', 'completed', 'failed']) {
+      expect(AccountExportJobStatusSchema.safeParse(status).success).toBe(true);
+    }
+    expect(AccountExportJobStatusSchema.safeParse('done').success).toBe(false);
+  });
 });
 
 describe('AccountExportStatusResponseSchema', () => {
@@ -78,12 +93,11 @@ describe('AccountExportStatusResponseSchema', () => {
       job: {
         id: 'job-1',
         status: 'completed',
-        fileName: 'tzurot-account-export-alice-2026-07-15.json',
+        fileName: 'tzurot-account-export-alice-2026-07-15.zip',
         fileSizeBytes: 1024,
         createdAt: new Date('2026-07-15T00:00:00Z'),
         completedAt: new Date('2026-07-15T00:01:00Z'),
         expiresAt: '2026-07-16T00:00:00.000Z',
-        errorMessage: null,
         downloadUrl: 'https://gateway.example/exports/job-1',
       },
     });

--- a/packages/common-types/src/schemas/api/account.ts
+++ b/packages/common-types/src/schemas/api/account.ts
@@ -13,13 +13,22 @@ import { z } from 'zod';
 // POST /user/account/export
 // ============================================================================
 
-/** No inputs in v1 — the export always covers the whole account as JSON. */
+/** No inputs — the export always covers the whole account as a ZIP archive
+ *  containing JSON + Markdown files per section. */
 export const StartAccountExportInputSchema = z.object({});
+
+/** Export-job lifecycle states (the export_jobs.status vocabulary). */
+export const AccountExportJobStatusSchema = z.enum([
+  'pending',
+  'in_progress',
+  'completed',
+  'failed',
+]);
 
 export const StartAccountExportResponseSchema = z.object({
   success: z.literal(true),
   exportJobId: z.string(),
-  status: z.string(),
+  status: AccountExportJobStatusSchema,
   downloadUrl: z.string(),
   expiresAt: z.string(),
 });
@@ -28,10 +37,12 @@ export const StartAccountExportResponseSchema = z.object({
 // GET /user/account/export/status
 // ============================================================================
 
+/** No errorMessage field by design: raw failure detail stays in server logs;
+ *  clients render generic copy off status === 'failed'. */
 export const AccountExportJobSummarySchema = z
   .object({
     id: z.string(),
-    status: z.string(),
+    status: AccountExportJobStatusSchema,
     fileName: z.string().nullable(),
     fileSizeBytes: z.number().int().nullable(),
     createdAt: z.union([z.string(), z.date()]).transform(value => new Date(value).toISOString()),
@@ -40,7 +51,6 @@ export const AccountExportJobSummarySchema = z
       .transform(value => new Date(value).toISOString())
       .nullable(),
     expiresAt: z.union([z.string(), z.date()]).transform(value => new Date(value).toISOString()),
-    errorMessage: z.string().nullable(),
     /** Populated only for completed jobs. */
     downloadUrl: z.string().nullable(),
   })

--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -507,6 +507,7 @@ CREATE TABLE "export_jobs" (
     "status" VARCHAR(50) NOT NULL DEFAULT 'pending',
     "format" VARCHAR(20) NOT NULL DEFAULT 'json',
     "file_content" TEXT,
+    "file_data" BYTEA,
     "file_name" VARCHAR(255),
     "file_size_bytes" INTEGER,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       fast-xml-parser:
         specifier: ^5.10.0
         version: 5.10.0
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
@@ -3778,6 +3781,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -9112,6 +9118,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:

--- a/prisma/migrations/20260715172213_add_export_job_file_data/migration.sql
+++ b/prisma/migrations/20260715172213_add_export_job_file_data/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memory_facts_embedding";
+
+-- AlterTable
+ALTER TABLE "export_jobs" ADD COLUMN     "file_data" BYTEA;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -919,13 +919,17 @@ model ExportJob {
   sourceService  String    @map("source_service") @db.VarChar(50)
   /// Job status: pending, in_progress, completed, failed
   status         String    @default("pending") @db.VarChar(50)
-  /// Export format: json or markdown
+  /// Export format: json, markdown, or zip
   format         String    @default("json") @db.VarChar(20)
   /// Full export content stored as text (TOAST-compressed, supports 35MB+)
   fileContent    String?   @map("file_content")
+  /// Binary export payload (ZIP archives). Deferred-set like fileContent:
+  /// null until a binary-format job completes; a completed job populates
+  /// exactly one of fileContent (text formats) or fileData (binary formats).
+  fileData       Bytes?    @map("file_data")
   /// Generated filename for download
   fileName       String?   @map("file_name") @db.VarChar(255)
-  /// Size of fileContent in bytes
+  /// Size of the stored payload (fileContent or fileData) in bytes
   fileSizeBytes  Int?      @map("file_size_bytes")
   createdAt      DateTime  @default(now()) @map("created_at")
   startedAt      DateTime? @map("started_at")

--- a/services/ai-worker/package.json
+++ b/services/ai-worker/package.json
@@ -31,6 +31,7 @@
     "@tzurot/identity": "workspace:*",
     "bullmq": "^5.80.2",
     "fast-xml-parser": "^5.10.0",
+    "fflate": "^0.8.3",
     "ioredis": "^5.11.1",
     "langchain": "^1.5.3",
     "onnxruntime-node": "^1.27.0",

--- a/services/ai-worker/src/jobs/AccountExportAssembler.component.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.component.test.ts
@@ -15,6 +15,7 @@ import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
 import { assembleAccountExport } from './AccountExportAssembler.js';
+import { buildAccountExportFiles } from './AccountExportFiles.js';
 
 const USER_A = 'ac0e0000-0000-4000-8000-0000000000a1';
 const PERSONA_A = 'ac0e0000-0000-4000-8000-0000000000a2';
@@ -22,6 +23,7 @@ const USER_B = 'ac0e0000-0000-4000-8000-0000000000b1';
 const PERSONA_B = 'ac0e0000-0000-4000-8000-0000000000b2';
 const SYSTEM_PROMPT = 'ac0e0000-0000-4000-8000-0000000000c1';
 const PERSONALITY_X = 'ac0e0000-0000-4000-8000-0000000000c2';
+const PERSONALITY_Y = 'ac0e0000-0000-4000-8000-0000000000c3';
 const SECRET_VALUE = 'super-secret-encrypted-blob-DO-NOT-EXPORT';
 
 let seq = 0;
@@ -66,6 +68,23 @@ describe('assembleAccountExport (component, PGLite)', () => {
     `;
     await prisma.personalityOwner.create({
       data: { personalityId: PERSONALITY_X, userId: USER_A },
+    });
+
+    // A character OWNED BY B that A merely conversed with — the personality
+    // directory must cover it even though A's characters section won't.
+    await prisma.$executeRaw`
+      INSERT INTO personalities (id, name, slug, character_info, personality_traits, owner_id, updated_at)
+      VALUES (${PERSONALITY_Y}::uuid, 'YBot', 'ybot', 'Y character', 'Reserved', ${USER_B}::uuid, NOW())
+    `;
+    await prisma.conversationHistory.create({
+      data: {
+        id: nextId(),
+        personaId: PERSONA_A,
+        personalityId: PERSONALITY_Y,
+        channelId: 'chan-2',
+        role: 'user',
+        content: 'alice-line talks to a character she does not own',
+      },
     });
 
     // Conversation history + memories + facts for BOTH users' personas.
@@ -147,8 +166,8 @@ describe('assembleAccountExport (component, PGLite)', () => {
 
     expect(payload.profile).toEqual(expect.objectContaining({ username: 'exportalice' }));
     expect(payload.personas).toHaveLength(1);
-    expect(payload.characters.map(c => (c as { id: string }).id)).toEqual([PERSONALITY_X]);
-    expect(payload.conversationHistory).toHaveLength(1);
+    expect(payload.characters.map(c => c.id)).toEqual([PERSONALITY_X]);
+    expect(payload.conversationHistory).toHaveLength(2);
     expect(payload.memories).toHaveLength(1);
     expect(payload.facts).toHaveLength(1);
     expect(payload.feedback).toHaveLength(1);
@@ -167,14 +186,34 @@ describe('assembleAccountExport (component, PGLite)', () => {
     expect(serialized).not.toContain('exportbob');
   });
 
-  it('never includes secret material in the serialized payload', async () => {
+  it('directory covers unowned characters; the file map folders their content by slug', async () => {
     const payload = await assembleAccountExport(prisma, USER_A);
-    const serialized = JSON.stringify(payload);
 
-    expect(serialized).not.toContain(SECRET_VALUE);
-    expect(serialized).not.toContain('test-iv');
-    expect(serialized).not.toContain('cred-iv');
-    // The meta.notes disclose the exclusions.
-    expect(payload.meta.notes.join(' ')).toContain('secret material is never exported');
+    // A owns X; Y belongs to B but A conversed with it.
+    expect(payload.characters.map(c => c.id)).toEqual([PERSONALITY_X]);
+    expect(payload.personalityDirectory).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: PERSONALITY_X, slug: 'xbot' }),
+        expect.objectContaining({ id: PERSONALITY_Y, slug: 'ybot' }),
+      ])
+    );
+
+    const files = buildAccountExportFiles(payload);
+    expect(files['conversations/ybot.md']).toContain('does not own');
+    // The unowned character gets NO definition files — only foldered content.
+    expect(files['characters/ybot.json']).toBeUndefined();
+    expect(files['characters/xbot.json']).toBeDefined();
+  });
+
+  it('never includes secret material anywhere in the built export files', async () => {
+    const payload = await assembleAccountExport(prisma, USER_A);
+    const files = buildAccountExportFiles(payload);
+    const everything = Object.values(files).join('\n');
+
+    expect(everything).not.toContain(SECRET_VALUE);
+    expect(everything).not.toContain('test-iv');
+    expect(everything).not.toContain('cred-iv');
+    // The README discloses the exclusions.
+    expect(files['README.md']).toContain('secret material is never exported');
   });
 });

--- a/services/ai-worker/src/jobs/AccountExportAssembler.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.test.ts
@@ -17,6 +17,7 @@ function makePrisma(): Record<string, { findMany?: ReturnType<typeof vi.fn> }> {
     conversationHistory: emptyModel(),
     memory: emptyModel(),
     memoryFact: emptyModel(),
+    shapesPersonaMapping: emptyModel(),
     userPersonalityConfig: emptyModel(),
     userPersonaHistoryConfig: emptyModel(),
     llmConfig: emptyModel(),
@@ -45,6 +46,7 @@ describe('assembleAccountExport', () => {
     for (const section of [
       'personas',
       'characters',
+      'personalityDirectory',
       'conversationHistory',
       'memories',
       'facts',
@@ -52,10 +54,11 @@ describe('assembleAccountExport', () => {
       'feedback',
       'apiKeyMetadata',
       'credentialMetadata',
+      'shapesMappings',
     ] as const) {
       expect(payload[section]).toEqual([]);
     }
-    expect(payload.meta.formatVersion).toBe(1);
+    expect(payload.meta.formatVersion).toBe(2);
     expect(payload.meta.notes.join(' ')).toContain('secret material is never exported');
   });
 
@@ -88,8 +91,11 @@ describe('assembleAccountExport', () => {
   it('cursor-sweeps big tables past the page boundary without clipping', async () => {
     // Personas drive the sweep filters; one persona is enough.
     prisma.persona.findMany?.mockResolvedValue([{ id: 'persona-1' }]);
-    const pageOne = Array.from({ length: 1000 }, (_, i) => ({ id: `row-${i}` }));
-    const pageTwo = [{ id: 'row-1000' }];
+    const pageOne = Array.from({ length: 1000 }, (_, i) => ({
+      id: `row-${i}`,
+      personalityId: 'char-1',
+    }));
+    const pageTwo = [{ id: 'row-1000', personalityId: 'char-1' }];
     prisma.conversationHistory.findMany
       ?.mockResolvedValueOnce(pageOne)
       .mockResolvedValueOnce(pageTwo);
@@ -100,5 +106,48 @@ describe('assembleAccountExport', () => {
     const secondCall = prisma.conversationHistory.findMany?.mock.calls[1][0];
     expect(secondCall.cursor).toEqual({ id: 'row-999' });
     expect(secondCall.skip).toBe(1);
+  });
+
+  it('directory covers unowned personalities referenced by conversations', async () => {
+    prisma.persona.findMany?.mockResolvedValue([{ id: 'persona-1' }]);
+    // No owned characters (personality.findMany first two calls return []),
+    // but conversations reference someone else's character.
+    prisma.conversationHistory.findMany?.mockResolvedValue([
+      { id: 'msg-1', personalityId: 'char-unowned' },
+    ]);
+    prisma.personality.findMany
+      ?.mockResolvedValueOnce([]) // directlyOwned id scan
+      .mockResolvedValueOnce([]) // owned+co-owned definition fetch
+      .mockResolvedValueOnce([{ id: 'char-unowned', name: 'Azura', slug: 'azura' }]); // directory fill
+
+    const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    expect(payload.characters).toEqual([]);
+    expect(payload.personalityDirectory).toEqual([
+      { id: 'char-unowned', name: 'Azura', slug: 'azura' },
+    ]);
+    // Directory lookup fetches only name/slug — never the full definition of
+    // a character the user doesn't own.
+    const directoryCall = prisma.personality.findMany?.mock.calls[2][0];
+    expect(directoryCall.select).toEqual({ id: true, name: true, slug: true });
+  });
+
+  it('falls back to unknown-<id8> for directory ids that no longer resolve', async () => {
+    prisma.persona.findMany?.mockResolvedValue([{ id: 'persona-1' }]);
+    prisma.memory.findMany?.mockResolvedValue([
+      { id: 'mem-1', personalityId: 'deadbeef-0000-0000-0000-000000000000' },
+    ]);
+    // Directory fill finds nothing for the referenced id.
+    prisma.personality.findMany?.mockResolvedValue([]);
+
+    const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    expect(payload.personalityDirectory).toEqual([
+      {
+        id: 'deadbeef-0000-0000-0000-000000000000',
+        name: 'Unknown character',
+        slug: 'unknown-deadbeef',
+      },
+    ]);
   });
 });

--- a/services/ai-worker/src/jobs/AccountExportAssembler.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.ts
@@ -1,50 +1,94 @@
 /**
  * Account Export Assembler
  *
- * Pure DB-read assembly of a user's full-account export payload (data
+ * Pure DB-read assembly of a user's full-account export data (data
  * portability). Separated from the job wrapper for testability, mirroring
- * the ShapesExportFormatters split.
+ * the ShapesExportFormatters split. AccountExportFiles turns this data into
+ * the per-section ZIP file map.
  *
- * Deliberate exclusions, each documented in the payload's meta.notes so the
- * user sees them: secret material (BYOK keys/credentials export metadata
- * only — encrypted blobs are useless and plaintext behind a bearer-URL is a
+ * Deliberate exclusions, each documented in the export README so the user
+ * sees them: secret material (BYOK keys/credentials export metadata only —
+ * encrypted blobs are useless and plaintext behind a bearer-URL is a
  * hazard), embedding vectors (model internals, not user content), avatar and
  * voice-reference binaries (avatars are re-downloadable via /avatars; voice
  * references were user-supplied), stored export-file contents, and raw
  * usage logs (an aggregate summary ships instead).
  */
 
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { type PrismaClient, type Prisma } from '@tzurot/common-types/services/prisma';
 
 /** Page size for cursor sweeps over the big tables (bounded-query rule). */
 const EXPORT_PAGE_SIZE = 1000;
 
-export interface AccountExportFile {
+export type ExportProfile = Prisma.UserGetPayload<{
+  select: {
+    discordId: true;
+    username: true;
+    timezone: true;
+    nsfwVerified: true;
+    nsfwVerifiedAt: true;
+    notifyEnabled: true;
+    notifyLevel: true;
+    createdAt: true;
+  };
+}>;
+export type ExportPersona = Prisma.PersonaGetPayload<object>;
+export type ExportCharacter = Omit<
+  Prisma.PersonalityGetPayload<object>,
+  'avatarData' | 'voiceReferenceData'
+>;
+export type ExportConversationRow = Prisma.ConversationHistoryGetPayload<object>;
+export type ExportMemoryRow = Prisma.MemoryGetPayload<object>;
+export type ExportFactRow = Prisma.MemoryFactGetPayload<object>;
+export type ExportFeedbackRow = Prisma.UserFeedbackGetPayload<object>;
+
+export interface ExportUsageSummaryRow {
+  provider: string;
+  model: string;
+  _count: { _all: number };
+  _sum: { tokensIn: number | null; tokensOut: number | null };
+}
+
+/**
+ * Name/slug lookup for every personality referenced anywhere in the export.
+ * Users converse with characters they don't own, so this is a superset of
+ * the owned+co-owned `characters` section — it's what lets the file builder
+ * folder conversations/memories/facts by character slug.
+ */
+export interface PersonalityDirectoryEntry {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface AccountExportData {
   meta: {
     exportedAt: string;
-    formatVersion: 1;
+    formatVersion: 2;
     notes: string[];
   };
-  profile: Record<string, unknown>;
-  personas: unknown[];
-  characters: unknown[];
+  profile: ExportProfile;
+  personas: ExportPersona[];
+  characters: ExportCharacter[];
+  personalityDirectory: PersonalityDirectoryEntry[];
+  conversationHistory: ExportConversationRow[];
+  memories: ExportMemoryRow[];
+  facts: ExportFactRow[];
   personalityConfigs: unknown[];
   personaHistoryConfigs: unknown[];
-  conversationHistory: unknown[];
-  memories: unknown[];
-  facts: unknown[];
   llmConfigs: unknown[];
   ttsConfigs: unknown[];
   apiKeyMetadata: unknown[];
   credentialMetadata: unknown[];
-  usageSummary: unknown[];
-  feedback: unknown[];
+  usageSummary: ExportUsageSummaryRow[];
+  feedback: ExportFeedbackRow[];
   importJobs: unknown[];
   exportJobs: unknown[];
   releaseDeliveries: unknown[];
+  shapesMappings: unknown[];
 }
 
-const EXPORT_NOTES = [
+export const EXPORT_NOTES = [
   'API keys and external credentials are listed as metadata only; secret material is never exported.',
   'Memory embedding vectors are model internals and are not included.',
   'Avatar images and voice-reference audio binaries are not included; avatars remain downloadable from the bot while the character exists.',
@@ -97,8 +141,8 @@ async function fetchAncillarySections(
   ttsConfigs: unknown[];
   apiKeyMetadata: unknown[];
   credentialMetadata: unknown[];
-  usageSummary: unknown[];
-  feedback: unknown[];
+  usageSummary: ExportUsageSummaryRow[];
+  feedback: ExportFeedbackRow[];
   importJobs: unknown[];
   exportJobs: unknown[];
   releaseDeliveries: unknown[];
@@ -145,7 +189,7 @@ async function fetchAncillarySections(
     sweep(c =>
       prisma.exportJob.findMany({
         where: { userId },
-        omit: { fileContent: true },
+        omit: { fileContent: true, fileData: true },
         ...pageArgs(c),
       })
     ),
@@ -191,7 +235,7 @@ async function sweepOwnerships(prisma: PrismaClient, userId: string): Promise<st
 }
 
 /** Owned + co-owned character definitions, via the ownership junction. */
-async function fetchCharacters(prisma: PrismaClient, userId: string): Promise<unknown[]> {
+async function fetchCharacters(prisma: PrismaClient, userId: string): Promise<ExportCharacter[]> {
   const coOwned = await sweepOwnerships(prisma, userId);
   const directlyOwned = await sweep(c =>
     prisma.personality.findMany({
@@ -211,10 +255,56 @@ async function fetchCharacters(prisma: PrismaClient, userId: string): Promise<un
   );
 }
 
+/**
+ * {id, name, slug} for every personality the export references — owned
+ * characters plus any the user merely conversed with. FK cascades mean
+ * referenced ids should always resolve; the unknown-<id8> fallback keeps the
+ * export self-consistent if that invariant ever breaks.
+ */
+async function buildPersonalityDirectory(
+  prisma: PrismaClient,
+  characters: ExportCharacter[],
+  referencedIds: Iterable<string>
+): Promise<PersonalityDirectoryEntry[]> {
+  const directory = new Map<string, PersonalityDirectoryEntry>();
+  for (const character of characters) {
+    directory.set(character.id, {
+      id: character.id,
+      name: character.name,
+      slug: character.slug,
+    });
+  }
+
+  const missing = [...new Set(referencedIds)].filter(id => !directory.has(id));
+  if (missing.length > 0) {
+    const rows = await sweep(c =>
+      prisma.personality.findMany({
+        where: { id: { in: missing } },
+        select: { id: true, name: true, slug: true },
+        ...pageArgs(c),
+      })
+    );
+    for (const row of rows) {
+      directory.set(row.id, row);
+    }
+    for (const id of missing) {
+      if (!directory.has(id)) {
+        directory.set(id, {
+          id,
+          name: 'Unknown character',
+          slug: `unknown-${id.slice(0, 8)}`,
+        });
+      }
+    }
+  }
+
+  return [...directory.values()];
+}
+
 export async function assembleAccountExport(
   prisma: PrismaClient,
   userId: string
-): Promise<AccountExportFile> {
+): Promise<AccountExportData> {
   const user = await prisma.user.findUniqueOrThrow({
     where: { id: userId },
     select: {
@@ -259,20 +349,35 @@ export async function assembleAccountExport(
     })
   );
 
+  const shapesMappings = await sweep(cursor =>
+    prisma.shapesPersonaMapping.findMany({
+      where: { personaId: { in: personaIds } },
+      ...pageArgs(cursor),
+    })
+  );
+
+  const personalityDirectory = await buildPersonalityDirectory(prisma, characters, [
+    ...conversationHistory.map(row => row.personalityId),
+    ...memories.map(row => row.personalityId),
+    ...facts.map(row => row.personalityId),
+  ]);
+
   const ancillary = await fetchAncillarySections(prisma, userId);
 
   return {
     meta: {
       exportedAt: new Date().toISOString(),
-      formatVersion: 1,
+      formatVersion: 2,
       notes: EXPORT_NOTES,
     },
     profile: user,
     personas,
     characters,
+    personalityDirectory,
     conversationHistory,
     memories,
     facts,
+    shapesMappings,
     ...ancillary,
   };
 }

--- a/services/ai-worker/src/jobs/AccountExportFiles.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportFiles.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import type { AccountExportData } from './AccountExportAssembler.js';
+import { buildAccountExportFiles } from './AccountExportFiles.js';
+
+const NOW = new Date('2026-07-15T12:00:00Z');
+
+function makeData(overrides: Partial<AccountExportData> = {}): AccountExportData {
+  return {
+    meta: { exportedAt: NOW.toISOString(), formatVersion: 2, notes: ['no secrets ever'] },
+    profile: {
+      username: 'alice',
+      discordId: '123456789012345678',
+      timezone: null,
+      nsfwVerified: false,
+      nsfwVerifiedAt: null,
+      notifyEnabled: true,
+      notifyLevel: 'minor',
+      createdAt: NOW,
+    },
+    personas: [],
+    characters: [],
+    personalityDirectory: [],
+    conversationHistory: [],
+    memories: [],
+    facts: [],
+    personalityConfigs: [],
+    personaHistoryConfigs: [],
+    llmConfigs: [],
+    ttsConfigs: [],
+    apiKeyMetadata: [],
+    credentialMetadata: [],
+    usageSummary: [],
+    feedback: [],
+    importJobs: [],
+    exportJobs: [],
+    releaseDeliveries: [],
+    shapesMappings: [],
+    ...overrides,
+  } as AccountExportData;
+}
+
+describe('buildAccountExportFiles', () => {
+  it('always emits README, directory, profile pair, top-level pairs, and JSON-only sections', () => {
+    const files = buildAccountExportFiles(makeData());
+
+    expect(files['README.md']).toContain('# Tzurot Account Export');
+    expect(files['README.md']).toContain('no secrets ever');
+    expect(files['personality-directory.json']).toBe('[]');
+    expect(files['profile.json']).toContain('"username": "alice"');
+    expect(files['profile.md']).toContain('# Account Profile');
+    expect(files['feedback.json']).toBe('[]');
+    expect(files['feedback.md']).toContain('# Feedback');
+    expect(files['usage-summary.md']).toContain('# Usage Summary');
+    for (const jsonOnly of [
+      'configs/llm.json',
+      'configs/tts.json',
+      'configs/personality-overrides.json',
+      'configs/persona-history.json',
+      'account/api-key-metadata.json',
+      'account/credential-metadata.json',
+      'account/jobs.json',
+      'account/release-deliveries.json',
+      'account/shapes-mappings.json',
+    ]) {
+      expect(files[jsonOnly]).toBeDefined();
+      expect(files[`${jsonOnly.replace('.json', '.md')}`]).toBeUndefined();
+    }
+  });
+
+  it('writes one json/md pair per persona, stem = sanitized name + id prefix', () => {
+    const files = buildAccountExportFiles(
+      makeData({
+        personas: [
+          {
+            id: 'aaaabbbb-1111-2222-3333-444444444444',
+            name: 'Ny x/…',
+            preferredName: null,
+            pronouns: null,
+            description: null,
+            content: 'about',
+            ownerId: 'u1',
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+        ] as AccountExportData['personas'],
+      })
+    );
+
+    expect(files['personas/Ny_x__-aaaabbbb.json']).toContain('"name": "Ny x/…"');
+    expect(files['personas/Ny_x__-aaaabbbb.md']).toContain('# Ny x/…');
+  });
+
+  it('folders character-scoped sections by directory slug, falling back to unknown-<id8>', () => {
+    const files = buildAccountExportFiles(
+      makeData({
+        personalityDirectory: [{ id: 'char-1', name: 'Azura', slug: 'azura' }],
+        memories: [
+          {
+            id: 'mem-1',
+            personalityId: 'char-1',
+            content: 'remembered',
+            createdAt: NOW,
+            isLocked: false,
+            visibility: 'normal',
+            type: 'memory',
+            isSummarized: false,
+          },
+          {
+            id: 'mem-2',
+            personalityId: 'feedbeef-0000-0000-0000-000000000000',
+            content: 'orphaned',
+            createdAt: NOW,
+            isLocked: false,
+            visibility: 'normal',
+            type: 'memory',
+            isSummarized: false,
+          },
+        ] as unknown as AccountExportData['memories'],
+      })
+    );
+
+    expect(files['memories/azura.json']).toContain('remembered');
+    expect(files['memories/azura.md']).toContain('# Memories — Azura');
+    expect(files['memories/unknown-feedbeef.json']).toContain('orphaned');
+    expect(files['memories/unknown-feedbeef.md']).toContain('# Memories — Unknown character');
+  });
+
+  it('uses persona preferred names as transcript speakers', () => {
+    const files = buildAccountExportFiles(
+      makeData({
+        personas: [
+          {
+            id: 'persona-1',
+            name: 'Nyx',
+            preferredName: 'Vee',
+            pronouns: null,
+            description: null,
+            content: 'about',
+            ownerId: 'u1',
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+        ] as AccountExportData['personas'],
+        personalityDirectory: [{ id: 'char-1', name: 'Azura', slug: 'azura' }],
+        conversationHistory: [
+          {
+            id: 'msg-1',
+            channelId: 'chan-1',
+            guildId: null,
+            personalityId: 'char-1',
+            personaId: 'persona-1',
+            role: 'user',
+            content: 'hello',
+            createdAt: NOW,
+            deletedAt: null,
+            editedAt: null,
+          },
+        ] as unknown as AccountExportData['conversationHistory'],
+      })
+    );
+
+    expect(files['conversations/azura.md']).toContain('Vee:');
+    // Persona files keep the real name even when a preferred name exists.
+    expect(files['personas/Nyx-persona-.json']).toBeDefined();
+  });
+
+  it('writes character definition pairs keyed by slug', () => {
+    const files = buildAccountExportFiles(
+      makeData({
+        characters: [
+          {
+            id: 'char-1',
+            name: 'azura',
+            displayName: 'Azura',
+            slug: 'azura',
+            isPublic: true,
+            createdAt: NOW,
+            characterInfo: 'sea spirit',
+            personalityTraits: 'calm',
+            personalityTone: null,
+            personalityAge: null,
+            personalityAppearance: null,
+            personalityLikes: null,
+            personalityDislikes: null,
+            conversationalGoals: null,
+            conversationalExamples: null,
+          },
+        ] as unknown as AccountExportData['characters'],
+      })
+    );
+
+    expect(files['characters/azura.json']).toContain('"slug": "azura"');
+    expect(files['characters/azura.md']).toContain('sea spirit');
+    expect(files['README.md']).toContain('**Characters (owned or co-owned):** 1');
+  });
+});

--- a/services/ai-worker/src/jobs/AccountExportFiles.ts
+++ b/services/ai-worker/src/jobs/AccountExportFiles.ts
@@ -1,0 +1,191 @@
+/**
+ * Account Export File Map
+ *
+ * Turns assembled account-export data into the ZIP's path → text-content
+ * map. Layout convention: user-readable content ships as .json/.md pairs;
+ * operational metadata is JSON-only. Character-scoped content
+ * (conversations, memories, facts) is foldered by character slug, covering
+ * characters the user conversed with but doesn't own — the personality
+ * directory provides the slug for every referenced character.
+ */
+
+import {
+  type AccountExportData,
+  type PersonalityDirectoryEntry,
+} from './AccountExportAssembler.js';
+import {
+  formatCharacterMd,
+  formatConversationsMd,
+  formatFactsMd,
+  formatFeedbackMd,
+  formatMemoriesMd,
+  formatPersonaMd,
+  formatProfileMd,
+  formatUsageSummaryMd,
+} from './AccountExportMarkdown.js';
+
+function json(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/** Filename stem from user-controlled text (persona names, slugs). */
+function sanitizeFileStem(stem: string): string {
+  const sanitized = stem.replace(/[^\w.-]/g, '_');
+  return sanitized === '' ? 'unnamed' : sanitized;
+}
+
+function groupByPersonality<T extends { personalityId: string }>(rows: T[]): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const row of rows) {
+    const existing = groups.get(row.personalityId);
+    if (existing === undefined) {
+      groups.set(row.personalityId, [row]);
+    } else {
+      existing.push(row);
+    }
+  }
+  return groups;
+}
+
+function directorySlug(
+  directory: ReadonlyMap<string, PersonalityDirectoryEntry>,
+  personalityId: string
+): string {
+  return sanitizeFileStem(
+    directory.get(personalityId)?.slug ?? `unknown-${personalityId.slice(0, 8)}`
+  );
+}
+
+function directoryName(
+  directory: ReadonlyMap<string, PersonalityDirectoryEntry>,
+  personalityId: string
+): string {
+  return directory.get(personalityId)?.name ?? 'Unknown character';
+}
+
+function buildReadme(data: AccountExportData): string {
+  const counts: [string, number][] = [
+    ['Personas', data.personas.length],
+    ['Characters (owned or co-owned)', data.characters.length],
+    ['Conversation messages', data.conversationHistory.length],
+    ['Memories', data.memories.length],
+    ['Facts', data.facts.length],
+    ['Feedback items', data.feedback.length],
+  ];
+  return [
+    '# Tzurot Account Export',
+    '',
+    `Exported: ${data.meta.exportedAt}`,
+    `Format version: ${String(data.meta.formatVersion)}`,
+    '',
+    '## Contents',
+    '',
+    ...counts.map(([label, count]) => `- **${label}:** ${String(count)}`),
+    '',
+    'Every user-readable section ships as a `.json`/`.md` pair; operational',
+    'metadata (`configs/`, `account/`) is JSON-only.',
+    '',
+    '- `profile.{json,md}` — your account record',
+    '- `personas/` — one file per persona you authored',
+    '- `characters/` — full definitions of characters you own or co-own',
+    '- `conversations/`, `memories/`, `facts/` — foldered by character slug',
+    '- `feedback.{json,md}`, `usage-summary.{json,md}`',
+    '- `configs/` — your LLM/TTS configs and per-character overrides',
+    '- `account/` — key/credential metadata, job history, release deliveries',
+    '- `personality-directory.json` — id → name/slug for every character referenced above',
+    '',
+    '## Profile vs. personas',
+    '',
+    '**Profile** is your account record: Discord identity, settings, and',
+    'verification state. **Personas** are the identities you authored for',
+    'conversations — the name, pronouns, and self-description a character',
+    'sees when talking with you.',
+    '',
+    '## Characters you talked with but do not own',
+    '',
+    'The `conversations/`, `memories/`, and `facts/` folders include every',
+    'character you interacted with. Full definitions of characters you do',
+    'not own belong to their owners and are not included; use',
+    '`personality-directory.json` to map slugs to character names.',
+    '',
+    '## What is NOT included',
+    '',
+    ...data.meta.notes.map(note => `- ${note}`),
+    '',
+  ].join('\n');
+}
+
+function buildPersonaFiles(data: AccountExportData, files: Record<string, string>): void {
+  for (const persona of data.personas) {
+    const stem = `${sanitizeFileStem(persona.name)}-${persona.id.slice(0, 8)}`;
+    files[`personas/${stem}.json`] = json(persona);
+    files[`personas/${stem}.md`] = formatPersonaMd(persona);
+  }
+}
+
+function buildCharacterFiles(data: AccountExportData, files: Record<string, string>): void {
+  for (const character of data.characters) {
+    const stem = sanitizeFileStem(character.slug);
+    files[`characters/${stem}.json`] = json(character);
+    files[`characters/${stem}.md`] = formatCharacterMd(character);
+  }
+}
+
+function buildCharacterScopedFiles(
+  data: AccountExportData,
+  directory: ReadonlyMap<string, PersonalityDirectoryEntry>,
+  files: Record<string, string>
+): void {
+  const personaNameById = new Map(
+    data.personas.map(persona => [persona.id, persona.preferredName ?? persona.name])
+  );
+
+  for (const [personalityId, rows] of groupByPersonality(data.conversationHistory)) {
+    const stem = directorySlug(directory, personalityId);
+    const name = directoryName(directory, personalityId);
+    files[`conversations/${stem}.json`] = json(rows);
+    files[`conversations/${stem}.md`] = formatConversationsMd(name, rows, personaNameById);
+  }
+  for (const [personalityId, rows] of groupByPersonality(data.memories)) {
+    const stem = directorySlug(directory, personalityId);
+    files[`memories/${stem}.json`] = json(rows);
+    files[`memories/${stem}.md`] = formatMemoriesMd(directoryName(directory, personalityId), rows);
+  }
+  for (const [personalityId, rows] of groupByPersonality(data.facts)) {
+    const stem = directorySlug(directory, personalityId);
+    files[`facts/${stem}.json`] = json(rows);
+    files[`facts/${stem}.md`] = formatFactsMd(directoryName(directory, personalityId), rows);
+  }
+}
+
+export function buildAccountExportFiles(data: AccountExportData): Record<string, string> {
+  const directory = new Map(data.personalityDirectory.map(entry => [entry.id, entry]));
+  const files: Record<string, string> = {};
+
+  files['README.md'] = buildReadme(data);
+  files['personality-directory.json'] = json(data.personalityDirectory);
+  files['profile.json'] = json(data.profile);
+  files['profile.md'] = formatProfileMd(data.profile);
+
+  buildPersonaFiles(data, files);
+  buildCharacterFiles(data, files);
+  buildCharacterScopedFiles(data, directory, files);
+
+  files['feedback.json'] = json(data.feedback);
+  files['feedback.md'] = formatFeedbackMd(data.feedback);
+  files['usage-summary.json'] = json(data.usageSummary);
+  files['usage-summary.md'] = formatUsageSummaryMd(data.usageSummary);
+
+  files['configs/llm.json'] = json(data.llmConfigs);
+  files['configs/tts.json'] = json(data.ttsConfigs);
+  files['configs/personality-overrides.json'] = json(data.personalityConfigs);
+  files['configs/persona-history.json'] = json(data.personaHistoryConfigs);
+
+  files['account/api-key-metadata.json'] = json(data.apiKeyMetadata);
+  files['account/credential-metadata.json'] = json(data.credentialMetadata);
+  files['account/jobs.json'] = json({ importJobs: data.importJobs, exportJobs: data.exportJobs });
+  files['account/release-deliveries.json'] = json(data.releaseDeliveries);
+  files['account/shapes-mappings.json'] = json(data.shapesMappings);
+
+  return files;
+}

--- a/services/ai-worker/src/jobs/AccountExportJob.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportJob.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Job } from 'bullmq';
+import { unzipSync, strFromU8 } from 'fflate';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { AccountExportJobData } from '@tzurot/common-types/types/account-export';
+import type { AccountExportData } from './AccountExportAssembler.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -35,16 +37,89 @@ function makeJob(
   } as unknown as Job<AccountExportJobData>;
 }
 
-function makePayload(): Record<string, unknown> {
+const NOW = new Date('2026-07-15T12:00:00Z');
+
+/** Minimal but formatter-complete payload: the job runs the REAL file
+ *  builder + zip, so every field the markdown formatters touch is present. */
+function makePayload(): AccountExportData {
   return {
-    meta: { exportedAt: 'now', formatVersion: 1, notes: [] },
-    profile: { username: 'alice' },
-    personas: [{}],
+    meta: { exportedAt: NOW.toISOString(), formatVersion: 2, notes: ['note one'] },
+    profile: {
+      username: 'alice',
+      discordId: '123456789012345678',
+      timezone: 'UTC',
+      nsfwVerified: false,
+      nsfwVerifiedAt: null,
+      notifyEnabled: true,
+      notifyLevel: 'minor',
+      createdAt: NOW,
+    },
+    personas: [
+      {
+        id: 'aaaaaaaa-1111-2222-3333-444444444444',
+        name: 'Nyx',
+        preferredName: null,
+        pronouns: null,
+        description: null,
+        content: 'about me',
+        ownerId: 'user-uuid-1',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ],
     characters: [],
-    conversationHistory: [{}, {}],
-    memories: [{}],
+    personalityDirectory: [{ id: 'char-1', name: 'Azura', slug: 'azura' }],
+    conversationHistory: [
+      {
+        id: 'msg-1',
+        channelId: 'chan-1',
+        guildId: null,
+        personalityId: 'char-1',
+        personaId: 'aaaaaaaa-1111-2222-3333-444444444444',
+        role: 'user',
+        content: 'hello there',
+        createdAt: NOW,
+        deletedAt: null,
+        editedAt: null,
+      },
+      {
+        id: 'msg-2',
+        channelId: 'chan-1',
+        guildId: null,
+        personalityId: 'char-1',
+        personaId: 'aaaaaaaa-1111-2222-3333-444444444444',
+        role: 'assistant',
+        content: 'greetings',
+        createdAt: NOW,
+        deletedAt: null,
+        editedAt: null,
+      },
+    ] as unknown as AccountExportData['conversationHistory'],
+    memories: [
+      {
+        id: 'mem-1',
+        personalityId: 'char-1',
+        content: 'a shared moment',
+        createdAt: NOW,
+        isLocked: false,
+        visibility: 'normal',
+        type: 'memory',
+        isSummarized: false,
+      },
+    ] as unknown as AccountExportData['memories'],
     facts: [],
+    personalityConfigs: [],
+    personaHistoryConfigs: [],
+    llmConfigs: [],
+    ttsConfigs: [],
+    apiKeyMetadata: [],
+    credentialMetadata: [],
+    usageSummary: [],
     feedback: [],
+    importJobs: [],
+    exportJobs: [],
+    releaseDeliveries: [],
+    shapesMappings: [],
   };
 }
 
@@ -53,7 +128,7 @@ describe('processAccountExportJob', () => {
     vi.clearAllMocks();
   });
 
-  it('transitions pending → in_progress → completed with content and metadata', async () => {
+  it('transitions pending → in_progress → completed with a ZIP payload and metadata', async () => {
     assembleMock.mockResolvedValue(makePayload());
 
     const result = await processAccountExportJob(makeJob(), mockPrisma);
@@ -65,16 +140,25 @@ describe('processAccountExportJob', () => {
     expect(updates[0][0].data.status).toBe('in_progress');
     const final = updates[1][0].data;
     expect(final.status).toBe('completed');
-    expect(final.fileName).toMatch(/^tzurot-account-export-alice-\d{4}-\d{2}-\d{2}\.json$/);
+    expect(final.fileName).toMatch(/^tzurot-account-export-alice-\d{4}-\d{2}-\d{2}\.zip$/);
+    expect(final.fileContent).toBeNull();
+    expect(final.fileData).toBeInstanceOf(Uint8Array);
     expect(final.exportMetadata).toEqual(
       expect.objectContaining({ conversationHistory: 2, memories: 1, personas: 1 })
     );
-    // The stored content is the assembled payload, serialized.
-    expect(JSON.parse(final.fileContent).profile.username).toBe('alice');
+
+    // The stored bytes are a real ZIP of the file map — unzip and verify.
+    const files = unzipSync(final.fileData as Uint8Array);
+    expect(strFromU8(files['README.md'])).toContain('Tzurot Account Export');
+    expect(JSON.parse(strFromU8(files['profile.json'])).username).toBe('alice');
+    expect(strFromU8(files['conversations/azura.md'])).toContain('greetings');
+    expect(final.exportMetadata.files).toBe(Object.keys(files).length);
   });
 
   it('sanitizes usernames that are not filename-safe', async () => {
-    assembleMock.mockResolvedValue({ ...makePayload(), profile: { username: 'a/б c!' } });
+    const payload = makePayload();
+    payload.profile = { ...payload.profile, username: 'a/б c!' };
+    assembleMock.mockResolvedValue(payload);
 
     await processAccountExportJob(makeJob(), mockPrisma);
 

--- a/services/ai-worker/src/jobs/AccountExportJob.ts
+++ b/services/ai-worker/src/jobs/AccountExportJob.ts
@@ -3,15 +3,16 @@
  *
  * BullMQ job handler for full-account data exports (data portability):
  * 1. Mark the export_jobs row in_progress
- * 2. Assemble the account payload (AccountExportAssembler — pure DB reads)
- * 3. Store the JSON in ExportJob.fileContent (PostgreSQL TEXT)
- * 4. Update status with results
+ * 2. Assemble the account data (AccountExportAssembler — pure DB reads)
+ * 3. Build the per-section file map (JSON + Markdown) and ZIP it
+ * 4. Store the archive in ExportJob.fileData (BYTEA) and update status
  *
  * Self-contained like the shapes export: status lives on the ExportJob row;
  * the user downloads via the public /exports/:jobId route until expiry.
  */
 
 import type { Job } from 'bullmq';
+import { zipSync, strToU8 } from 'fflate';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type AccountExportJobData,
@@ -19,6 +20,7 @@ import {
 } from '@tzurot/common-types/types/account-export';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { assembleAccountExport } from './AccountExportAssembler.js';
+import { buildAccountExportFiles } from './AccountExportFiles.js';
 
 const logger = createLogger('AccountExportJob');
 
@@ -37,19 +39,26 @@ export async function processAccountExportJob(
 
   try {
     const payload = await assembleAccountExport(prisma, userId);
+    const files = buildAccountExportFiles(payload);
 
-    const fileContent = JSON.stringify(payload, null, 2);
-    const fileSizeBytes = Buffer.byteLength(fileContent, 'utf8');
+    const zipEntries: Record<string, Uint8Array> = {};
+    for (const [path, content] of Object.entries(files)) {
+      zipEntries[path] = strToU8(content);
+    }
+    const fileData = zipSync(zipEntries);
+    const fileSizeBytes = fileData.length;
+
     const username =
       typeof payload.profile.username === 'string' ? payload.profile.username : 'user';
     const safeUsername = username.replace(/[^\w.-]/g, '_');
-    const fileName = `tzurot-account-export-${safeUsername}-${new Date().toISOString().slice(0, 10)}.json`;
+    const fileName = `tzurot-account-export-${safeUsername}-${new Date().toISOString().slice(0, 10)}.zip`;
 
     await prisma.exportJob.update({
       where: { id: exportJobId },
       data: {
         status: 'completed',
-        fileContent,
+        fileContent: null,
+        fileData,
         fileName,
         fileSizeBytes,
         completedAt: new Date(),
@@ -60,6 +69,7 @@ export async function processAccountExportJob(
           memories: payload.memories.length,
           facts: payload.facts.length,
           feedback: payload.feedback.length,
+          files: Object.keys(files).length,
         },
       },
     });

--- a/services/ai-worker/src/jobs/AccountExportMarkdown.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportMarkdown.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  ExportCharacter,
+  ExportConversationRow,
+  ExportFactRow,
+  ExportFeedbackRow,
+  ExportMemoryRow,
+  ExportPersona,
+  ExportProfile,
+} from './AccountExportAssembler.js';
+import {
+  formatCharacterMd,
+  formatConversationsMd,
+  formatFactsMd,
+  formatFeedbackMd,
+  formatMemoriesMd,
+  formatPersonaMd,
+  formatProfileMd,
+  formatUsageSummaryMd,
+} from './AccountExportMarkdown.js';
+
+function makeConversationRow(overrides: Partial<ExportConversationRow>): ExportConversationRow {
+  return {
+    id: 'msg-1',
+    channelId: 'chan-1',
+    guildId: null,
+    personalityId: 'char-1',
+    personaId: 'persona-1',
+    role: 'user',
+    content: 'hello',
+    createdAt: new Date('2026-07-14T10:00:00Z'),
+    deletedAt: null,
+    editedAt: null,
+    ...overrides,
+  } as ExportConversationRow;
+}
+
+function makeMemoryRow(overrides: Partial<ExportMemoryRow>): ExportMemoryRow {
+  return {
+    id: 'mem-1',
+    personalityId: 'char-1',
+    content: 'a shared moment',
+    createdAt: new Date('2026-07-14T10:00:00Z'),
+    isLocked: false,
+    visibility: 'normal',
+    type: 'memory',
+    isSummarized: false,
+    ...overrides,
+  } as ExportMemoryRow;
+}
+
+function makeFactRow(overrides: Partial<ExportFactRow>): ExportFactRow {
+  return {
+    id: 'fact-1',
+    statement: 'Alice likes tea',
+    validFrom: new Date('2026-06-01T00:00:00Z'),
+    supersededAt: null,
+    forgotten: false,
+    entityTags: [],
+    isLocked: false,
+    ...overrides,
+  } as ExportFactRow;
+}
+
+describe('formatProfileMd', () => {
+  it('renders populated fields and skips nulls', () => {
+    const md = formatProfileMd({
+      username: 'alice',
+      discordId: '123',
+      timezone: 'America/New_York',
+      nsfwVerified: false,
+      nsfwVerifiedAt: null,
+      notifyEnabled: false,
+      notifyLevel: 'minor',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    } as ExportProfile);
+
+    expect(md).toContain('# Account Profile');
+    expect(md).toContain('**Username:** alice');
+    expect(md).toContain('**Timezone:** America/New_York');
+    expect(md).toContain('**Release notifications:** disabled');
+    expect(md).not.toContain('NSFW verified at');
+  });
+});
+
+describe('formatPersonaMd', () => {
+  it('renders name, optional fields, and the about section', () => {
+    const md = formatPersonaMd({
+      id: 'p1',
+      name: 'Nyx',
+      preferredName: 'N',
+      pronouns: 'she/her',
+      description: 'short desc',
+      content: 'longer about text',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+      ownerId: 'u1',
+    } as ExportPersona);
+
+    expect(md).toContain('# Nyx');
+    expect(md).toContain('**Preferred name:** N');
+    expect(md).toContain('**Pronouns:** she/her');
+    expect(md).toContain('## Description\n\nshort desc');
+    expect(md).toContain('## About\n\nlonger about text');
+  });
+});
+
+describe('formatCharacterMd', () => {
+  it('renders title with display name and only populated personality fields', () => {
+    const md = formatCharacterMd({
+      name: 'azura',
+      displayName: 'Azura',
+      slug: 'azura',
+      isPublic: true,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      characterInfo: 'A sea spirit.',
+      personalityTraits: 'calm, watchful',
+      personalityTone: null,
+      personalityAge: null,
+      personalityAppearance: null,
+      personalityLikes: null,
+      personalityDislikes: null,
+      conversationalGoals: null,
+      conversationalExamples: null,
+    } as ExportCharacter);
+
+    expect(md).toContain('# azura (Azura)');
+    expect(md).toContain('**Slug:** azura');
+    expect(md).toContain('## Character Info\n\nA sea spirit.');
+    expect(md).toContain('### Traits\n\ncalm, watchful');
+    expect(md).not.toContain('### Tone');
+  });
+});
+
+describe('formatConversationsMd', () => {
+  const personaNames = new Map([['persona-1', 'Vee']]);
+
+  it('sorts chronologically within a channel and adds day headers', () => {
+    const md = formatConversationsMd(
+      'Azura',
+      [
+        makeConversationRow({
+          id: 'late',
+          content: 'second day',
+          createdAt: new Date('2026-07-15T08:00:00Z'),
+        }),
+        makeConversationRow({
+          id: 'early',
+          content: 'first day',
+          createdAt: new Date('2026-07-14T10:00:00Z'),
+          role: 'assistant',
+        }),
+      ],
+      personaNames
+    );
+
+    expect(md).toContain('# Conversations — Azura');
+    expect(md.indexOf('first day')).toBeLessThan(md.indexOf('second day'));
+    expect(md).toContain('### 2026-07-14');
+    expect(md).toContain('### 2026-07-15');
+    // Assistant rows speak as the character; user rows as the persona.
+    expect(md).toContain('**[10:00] Azura:** first day');
+    expect(md).toContain('**[08:00] Vee:** second day');
+  });
+
+  it('labels DM channels, marks deleted/edited rows, and falls back to You', () => {
+    const md = formatConversationsMd(
+      'Azura',
+      [
+        makeConversationRow({
+          personaId: 'unknown-persona',
+          deletedAt: new Date('2026-07-14T11:00:00Z'),
+          editedAt: new Date('2026-07-14T10:30:00Z'),
+        }),
+        makeConversationRow({
+          id: 'msg-2',
+          channelId: 'chan-2',
+          guildId: 'guild-9',
+          content: 'in a server',
+        }),
+      ],
+      personaNames
+    );
+
+    expect(md).toContain('## Direct messages (channel chan-1)');
+    expect(md).toContain('## Channel chan-2 (server guild-9)');
+    expect(md).toContain('**[10:00] You:** _(deleted, edited)_ hello');
+  });
+});
+
+describe('formatMemoriesMd', () => {
+  it('numbers memories chronologically and renders a flag line only when flagged', () => {
+    const md = formatMemoriesMd('Azura', [
+      makeMemoryRow({
+        id: 'mem-2',
+        content: 'newer locked memory',
+        createdAt: new Date('2026-07-15T10:00:00Z'),
+        isLocked: true,
+        visibility: 'deleted',
+      }),
+      makeMemoryRow({ content: 'older plain memory' }),
+    ]);
+
+    expect(md).toContain('# Memories — Azura');
+    expect(md.indexOf('older plain memory')).toBeLessThan(md.indexOf('newer locked memory'));
+    expect(md).toContain('_locked · deleted_');
+    // The unflagged memory has no marker line between header and content.
+    expect(md).toContain('## Memory #1 — 2026-07-14 10:00 UTC\n\nolder plain memory');
+  });
+});
+
+describe('formatFactsMd', () => {
+  it('buckets facts into current, superseded, and forgotten with details', () => {
+    const md = formatFactsMd('Azura', [
+      makeFactRow({ entityTags: ['user:alice', 'topic:tea'] }),
+      makeFactRow({
+        id: 'fact-2',
+        statement: 'Alice liked coffee',
+        supersededAt: new Date('2026-06-15T00:00:00Z'),
+      }),
+      makeFactRow({ id: 'fact-3', statement: 'never mind', forgotten: true }),
+    ]);
+
+    expect(md).toContain('## Current (1)');
+    expect(md).toContain('- Alice likes tea — _since 2026-06-01; tags: user:alice, topic:tea_');
+    expect(md).toContain('## Superseded (1)');
+    expect(md).toContain('superseded 2026-06-15');
+    expect(md).toContain('## Forgotten (1)');
+    expect(md).toContain('- never mind');
+  });
+
+  it('omits empty buckets', () => {
+    const md = formatFactsMd('Azura', [makeFactRow({})]);
+    expect(md).not.toContain('## Superseded');
+    expect(md).not.toContain('## Forgotten');
+  });
+});
+
+describe('formatFeedbackMd', () => {
+  it('renders each item with timestamp and status', () => {
+    const md = formatFeedbackMd([
+      {
+        id: 'fb-1',
+        content: 'love the bot',
+        status: 'new',
+        createdAt: new Date('2026-07-01T12:00:00Z'),
+      } as ExportFeedbackRow,
+    ]);
+
+    expect(md).toContain('## 2026-07-01 12:00 UTC — status: new');
+    expect(md).toContain('love the bot');
+  });
+});
+
+describe('formatUsageSummaryMd', () => {
+  it('renders a table row per provider/model with null token sums as 0', () => {
+    const md = formatUsageSummaryMd([
+      {
+        provider: 'openrouter',
+        model: 'claude-sonnet-4',
+        _count: { _all: 12 },
+        _sum: { tokensIn: 3400, tokensOut: null },
+      },
+    ]);
+
+    expect(md).toContain('| openrouter | claude-sonnet-4 | 12 | 3400 | 0 |');
+  });
+});

--- a/services/ai-worker/src/jobs/AccountExportMarkdown.ts
+++ b/services/ai-worker/src/jobs/AccountExportMarkdown.ts
@@ -1,0 +1,295 @@
+/**
+ * Account Export Markdown Formatters
+ *
+ * Pure formatters turning assembled account-export rows into the
+ * human-readable .md halves of the export ZIP (every user-readable section
+ * ships as a .json/.md pair; see AccountExportFiles for the layout).
+ */
+
+import {
+  type ExportProfile,
+  type ExportPersona,
+  type ExportCharacter,
+  type ExportConversationRow,
+  type ExportMemoryRow,
+  type ExportFactRow,
+  type ExportFeedbackRow,
+  type ExportUsageSummaryRow,
+} from './AccountExportAssembler.js';
+
+/** `YYYY-MM-DD HH:MM UTC` — compact and unambiguous for export documents. */
+function formatTimestamp(date: Date): string {
+  const iso = date.toISOString();
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+}
+
+function formatDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function formatClock(date: Date): string {
+  return date.toISOString().slice(11, 16);
+}
+
+/** Render `label: value` lines, skipping null/undefined/empty values. */
+function fieldLines(pairs: [string, string | null | undefined][]): string[] {
+  return pairs
+    .filter(
+      (pair): pair is [string, string] =>
+        pair[1] !== null && pair[1] !== undefined && pair[1] !== ''
+    )
+    .map(([label, value]) => `- **${label}:** ${value}`);
+}
+
+export function formatProfileMd(profile: ExportProfile): string {
+  const lines = [
+    '# Account Profile',
+    '',
+    ...fieldLines([
+      ['Username', profile.username],
+      ['Discord ID', profile.discordId],
+      ['Timezone', profile.timezone],
+      ['NSFW verified', profile.nsfwVerified ? 'yes' : 'no'],
+      [
+        'NSFW verified at',
+        profile.nsfwVerifiedAt === null ? null : formatTimestamp(profile.nsfwVerifiedAt),
+      ],
+      [
+        'Release notifications',
+        profile.notifyEnabled ? `enabled (${profile.notifyLevel})` : 'disabled',
+      ],
+      ['Account created', formatTimestamp(profile.createdAt)],
+    ]),
+    '',
+  ];
+  return lines.join('\n');
+}
+
+export function formatPersonaMd(persona: ExportPersona): string {
+  const lines = [
+    `# ${persona.name}`,
+    '',
+    ...fieldLines([
+      ['Preferred name', persona.preferredName],
+      ['Pronouns', persona.pronouns],
+      ['Created', formatTimestamp(persona.createdAt)],
+    ]),
+  ];
+  if (persona.description !== null && persona.description !== '') {
+    lines.push('', '## Description', '', persona.description);
+  }
+  if (persona.content !== '') {
+    lines.push('', '## About', '', persona.content);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+const CHARACTER_PERSONALITY_FIELDS: readonly {
+  key: keyof ExportCharacter;
+  label: string;
+}[] = [
+  { key: 'personalityTraits', label: 'Traits' },
+  { key: 'personalityTone', label: 'Tone' },
+  { key: 'personalityAge', label: 'Age' },
+  { key: 'personalityAppearance', label: 'Appearance' },
+  { key: 'personalityLikes', label: 'Likes' },
+  { key: 'personalityDislikes', label: 'Dislikes' },
+  { key: 'conversationalGoals', label: 'Conversational Goals' },
+  { key: 'conversationalExamples', label: 'Conversational Examples' },
+] as const;
+
+export function formatCharacterMd(character: ExportCharacter): string {
+  const title =
+    character.displayName !== null &&
+    character.displayName !== '' &&
+    character.displayName !== character.name
+      ? `${character.name} (${character.displayName})`
+      : character.name;
+  const lines = [
+    `# ${title}`,
+    '',
+    ...fieldLines([
+      ['Slug', character.slug],
+      ['Public', character.isPublic ? 'yes' : 'no'],
+      ['Created', formatTimestamp(character.createdAt)],
+    ]),
+  ];
+
+  if (character.characterInfo !== '') {
+    lines.push('', '## Character Info', '', character.characterInfo);
+  }
+
+  const personalitySections = CHARACTER_PERSONALITY_FIELDS.map(({ key, label }) => ({
+    label,
+    value: character[key],
+  })).filter(
+    (field): field is { label: string; value: string } =>
+      typeof field.value === 'string' && field.value !== ''
+  );
+  if (personalitySections.length > 0) {
+    lines.push('', '## Personality');
+    for (const { label, value } of personalitySections) {
+      lines.push('', `### ${label}`, '', value);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Human label for a conversation channel grouping. */
+function channelHeading(row: ExportConversationRow): string {
+  return row.guildId === null
+    ? `Direct messages (channel ${row.channelId})`
+    : `Channel ${row.channelId} (server ${row.guildId})`;
+}
+
+function speakerName(
+  row: ExportConversationRow,
+  characterName: string,
+  personaNameById: ReadonlyMap<string, string>
+): string {
+  if (row.role === 'assistant') {
+    return characterName;
+  }
+  return personaNameById.get(row.personaId) ?? 'You';
+}
+
+function messageMarkers(row: ExportConversationRow): string {
+  const markers = [
+    ...(row.deletedAt !== null ? ['deleted'] : []),
+    ...(row.editedAt !== null ? ['edited'] : []),
+  ];
+  return markers.length > 0 ? ` _(${markers.join(', ')})_` : '';
+}
+
+/**
+ * Transcript for one character: grouped by channel, ordered chronologically,
+ * day headers with per-message clock times (sweeps return id order, which is
+ * NOT chronological — the sort here is load-bearing).
+ */
+export function formatConversationsMd(
+  characterName: string,
+  rows: ExportConversationRow[],
+  personaNameById: ReadonlyMap<string, string>
+): string {
+  const byChannel = new Map<string, ExportConversationRow[]>();
+  for (const row of rows) {
+    const existing = byChannel.get(row.channelId);
+    if (existing === undefined) {
+      byChannel.set(row.channelId, [row]);
+    } else {
+      existing.push(row);
+    }
+  }
+
+  const lines = [
+    `# Conversations — ${characterName}`,
+    '',
+    `*${String(rows.length)} messages across ${String(byChannel.size)} channel(s)*`,
+  ];
+
+  for (const channelRows of byChannel.values()) {
+    channelRows.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    lines.push('', `## ${channelHeading(channelRows[0])}`);
+    let currentDay = '';
+    for (const row of channelRows) {
+      const day = formatDay(row.createdAt);
+      if (day !== currentDay) {
+        currentDay = day;
+        lines.push('', `### ${day}`, '');
+      }
+      const speaker = speakerName(row, characterName, personaNameById);
+      lines.push(
+        `**[${formatClock(row.createdAt)}] ${speaker}:**${messageMarkers(row)} ${row.content}`
+      );
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function memoryFlags(memory: ExportMemoryRow): string[] {
+  return [
+    ...(memory.isLocked ? ['locked'] : []),
+    ...(memory.visibility !== 'normal' ? [memory.visibility] : []),
+    ...(memory.type !== 'memory' ? [memory.type] : []),
+    ...(memory.isSummarized ? ['summarized'] : []),
+  ];
+}
+
+export function formatMemoriesMd(characterName: string, rows: ExportMemoryRow[]): string {
+  const sorted = [...rows].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  const lines = [`# Memories — ${characterName}`, '', `*${String(rows.length)} memories*`];
+  sorted.forEach((memory, index) => {
+    lines.push('', `## Memory #${String(index + 1)} — ${formatTimestamp(memory.createdAt)}`, '');
+    const flags = memoryFlags(memory);
+    if (flags.length > 0) {
+      lines.push(`_${flags.join(' · ')}_`, '');
+    }
+    lines.push(memory.content);
+  });
+  lines.push('');
+  return lines.join('\n');
+}
+
+function factBullet(fact: ExportFactRow): string {
+  const details = [
+    `since ${formatDay(fact.validFrom)}`,
+    ...(fact.supersededAt !== null ? [`superseded ${formatDay(fact.supersededAt)}`] : []),
+    ...(fact.entityTags.length > 0 ? [`tags: ${fact.entityTags.join(', ')}`] : []),
+    ...(fact.isLocked ? ['locked'] : []),
+  ];
+  return `- ${fact.statement} — _${details.join('; ')}_`;
+}
+
+export function formatFactsMd(characterName: string, rows: ExportFactRow[]): string {
+  const current = rows.filter(fact => !fact.forgotten && fact.supersededAt === null);
+  const superseded = rows.filter(fact => !fact.forgotten && fact.supersededAt !== null);
+  const forgotten = rows.filter(fact => fact.forgotten);
+
+  const lines = [`# Facts — ${characterName}`];
+  const sections: [string, ExportFactRow[]][] = [
+    ['Current', current],
+    ['Superseded', superseded],
+    ['Forgotten', forgotten],
+  ];
+  for (const [heading, sectionRows] of sections) {
+    if (sectionRows.length === 0) {
+      continue;
+    }
+    lines.push('', `## ${heading} (${String(sectionRows.length)})`, '');
+    lines.push(...sectionRows.map(factBullet));
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function formatFeedbackMd(rows: ExportFeedbackRow[]): string {
+  const sorted = [...rows].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  const lines = [`# Feedback You Submitted`, '', `*${String(rows.length)} item(s)*`];
+  for (const row of sorted) {
+    lines.push('', `## ${formatTimestamp(row.createdAt)} — status: ${row.status}`, '', row.content);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function formatUsageSummaryMd(rows: ExportUsageSummaryRow[]): string {
+  const lines = [
+    '# Usage Summary',
+    '',
+    'Aggregate request counts per provider/model. Raw per-request logs are not exported.',
+    '',
+    '| Provider | Model | Requests | Tokens in | Tokens out |',
+    '| --- | --- | ---: | ---: | ---: |',
+  ];
+  for (const row of rows) {
+    lines.push(
+      `| ${row.provider} | ${row.model} | ${String(row._count._all)} | ` +
+        `${String(row._sum.tokensIn ?? 0)} | ${String(row._sum.tokensOut ?? 0)} |`
+    );
+  }
+  lines.push('');
+  return lines.join('\n');
+}

--- a/services/api-gateway/src/routes/conformance/fixtures/userAccount.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/userAccount.ts
@@ -22,19 +22,22 @@ export const userAccountFixtures: Record<string, ConformanceEntry> = {
       // Deterministic id: the (userId, slug, service, format) tuple is unique,
       // and the startAccountExport fixture creates the same tuple — upserting
       // the SAME deterministic row keeps the two fixtures order-independent.
+      // completedAt sits outside the 24h export cooldown window so this seed
+      // can never 409 the startAccountExport fixture regardless of run order.
+      const staleCompletedAt = new Date(Date.now() - 25 * 60 * 60 * 1000);
       const id = generateExportJobUuid(
         ctx.actorUserId,
         ACCOUNT_EXPORT_SLUG,
         ACCOUNT_EXPORT_SOURCE,
-        'json'
+        'zip'
       );
       await ctx.prisma.exportJob.upsert({
         where: { id },
         update: {
           status: 'completed',
-          fileName: 'tzurot-account-export-conf-2026-01-01.json',
+          fileName: 'tzurot-account-export-conf-2026-01-01.zip',
           fileSizeBytes: 42,
-          completedAt: new Date(),
+          completedAt: staleCompletedAt,
         },
         create: {
           id,
@@ -42,10 +45,10 @@ export const userAccountFixtures: Record<string, ConformanceEntry> = {
           sourceSlug: ACCOUNT_EXPORT_SLUG,
           sourceService: ACCOUNT_EXPORT_SOURCE,
           status: 'completed',
-          format: 'json',
-          fileName: 'tzurot-account-export-conf-2026-01-01.json',
+          format: 'zip',
+          fileName: 'tzurot-account-export-conf-2026-01-01.zip',
           fileSizeBytes: 42,
-          completedAt: new Date(),
+          completedAt: staleCompletedAt,
           expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         },
       });

--- a/services/api-gateway/src/routes/public/exports.test.ts
+++ b/services/api-gateway/src/routes/public/exports.test.ts
@@ -72,6 +72,7 @@ describe('Public Export Download Route', () => {
     mockPrisma.exportJob.findUnique.mockResolvedValue({
       status: 'pending',
       fileContent: null,
+      fileData: null,
       fileName: null,
       fileSizeBytes: null,
       format: 'json',
@@ -89,6 +90,7 @@ describe('Public Export Download Route', () => {
     mockPrisma.exportJob.findUnique.mockResolvedValue({
       status: 'failed',
       fileContent: null,
+      fileData: null,
       fileName: null,
       fileSizeBytes: null,
       format: 'json',
@@ -108,6 +110,7 @@ describe('Public Export Download Route', () => {
     mockPrisma.exportJob.findUnique.mockResolvedValue({
       status: 'failed',
       fileContent: null,
+      fileData: null,
       fileName: null,
       fileSizeBytes: null,
       format: 'json',
@@ -125,6 +128,7 @@ describe('Public Export Download Route', () => {
     mockPrisma.exportJob.findUnique.mockResolvedValue({
       status: 'completed',
       fileContent: '{"data": true}',
+      fileData: null,
       fileName: 'test-export.json',
       fileSizeBytes: 14,
       format: 'json',
@@ -143,6 +147,7 @@ describe('Public Export Download Route', () => {
     mockPrisma.exportJob.findUnique.mockResolvedValue({
       status: 'completed',
       fileContent: content,
+      fileData: null,
       fileName: 'test-export.json',
       fileSizeBytes: Buffer.byteLength(content),
       format: 'json',
@@ -165,6 +170,7 @@ describe('Public Export Download Route', () => {
     mockPrisma.exportJob.findUnique.mockResolvedValue({
       status: 'completed',
       fileContent: content,
+      fileData: null,
       fileName: 'test-export.md',
       fileSizeBytes: Buffer.byteLength(content),
       format: 'markdown',
@@ -177,5 +183,33 @@ describe('Public Export Download Route', () => {
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/markdown');
     expect(res.text).toBe(content);
+  });
+
+  it('should serve ZIP exports from fileData with application/zip', async () => {
+    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x01, 0x02, 0x03]);
+    mockPrisma.exportJob.findUnique.mockResolvedValue({
+      status: 'completed',
+      fileContent: null,
+      fileData: bytes,
+      fileName: 'tzurot-account-export-alice-2026-07-15.zip',
+      fileSizeBytes: bytes.length,
+      format: 'zip',
+      expiresAt: FUTURE_DATE,
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get(`/${VALID_UUID}`)
+      .buffer(true)
+      .parse((response, cb) => {
+        const chunks: Buffer[] = [];
+        response.on('data', chunk => chunks.push(chunk as Buffer));
+        response.on('end', () => cb(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/zip');
+    expect(res.headers['content-length']).toBe(String(bytes.length));
+    expect(Buffer.from(res.body as Buffer).equals(Buffer.from(bytes))).toBe(true);
   });
 });

--- a/services/api-gateway/src/routes/public/exports.ts
+++ b/services/api-gateway/src/routes/public/exports.ts
@@ -32,6 +32,7 @@ export function createExportsRouter(prisma: PrismaClient): Router {
         where: { id: jobId },
         select: {
           fileContent: true,
+          fileData: true,
           fileName: true,
           fileSizeBytes: true,
           status: true,
@@ -51,7 +52,9 @@ export function createExportsRouter(prisma: PrismaClient): Router {
         return;
       }
 
-      if (job.status !== 'completed' || job.fileContent === null) {
+      // A completed job carries exactly one payload column: fileData for
+      // binary formats (ZIP), fileContent for text formats.
+      if (job.status !== 'completed' || (job.fileContent === null && job.fileData === null)) {
         res.status(StatusCodes.NOT_FOUND).json({
           error: job.status === 'failed' ? 'Export failed' : 'Export not ready yet',
           status: job.status,
@@ -59,11 +62,23 @@ export function createExportsRouter(prisma: PrismaClient): Router {
         return;
       }
 
-      const contentType =
-        job.format === 'markdown'
-          ? 'text/markdown; charset=utf-8'
-          : 'application/json; charset=utf-8';
-      const fileName = job.fileName ?? `export.${job.format === 'markdown' ? 'md' : 'json'}`;
+      const body =
+        job.fileData !== null
+          ? Buffer.from(job.fileData)
+          : Buffer.from(job.fileContent ?? '', 'utf8');
+      let contentType: string;
+      let defaultExtension: string;
+      if (job.fileData !== null) {
+        contentType = 'application/zip';
+        defaultExtension = 'zip';
+      } else if (job.format === 'markdown') {
+        contentType = 'text/markdown; charset=utf-8';
+        defaultExtension = 'md';
+      } else {
+        contentType = 'application/json; charset=utf-8';
+        defaultExtension = 'json';
+      }
+      const fileName = job.fileName ?? `export.${defaultExtension}`;
 
       res.setHeader('Content-Type', contentType);
       // RFC 5987: filename* for UTF-8 percent-encoding,
@@ -74,9 +89,9 @@ export function createExportsRouter(prisma: PrismaClient): Router {
         'Content-Disposition',
         `attachment; filename="${safeName}"; filename*=UTF-8''${encodedName}`
       );
-      res.setHeader('Content-Length', String(Buffer.byteLength(job.fileContent, 'utf8')));
+      res.setHeader('Content-Length', String(body.length));
 
-      res.status(StatusCodes.OK).send(job.fileContent);
+      res.status(StatusCodes.OK).send(body);
 
       logger.info({ jobId, fileName, fileSizeBytes: job.fileSizeBytes }, 'File downloaded');
     } catch (error) {

--- a/services/api-gateway/src/routes/user/account/export.test.ts
+++ b/services/api-gateway/src/routes/user/account/export.test.ts
@@ -101,7 +101,7 @@ describe('Account Export Routes', () => {
             userId: 'user-uuid-123',
             sourceService: 'account',
             sourceSlug: 'account',
-            format: 'json',
+            format: 'zip',
             status: 'pending',
           }),
         })
@@ -128,6 +128,25 @@ describe('Account Export Routes', () => {
       expect(res.status).toHaveBeenCalledWith(409);
       expect(mockQueue.add).not.toHaveBeenCalled();
     });
+
+    it('409s during the 24h cooldown after a completed export, without resetting the row', async () => {
+      mockTxExportJob.findFirst
+        .mockResolvedValueOnce(null) // no active job
+        .mockResolvedValueOnce({ status: 'completed', completedAt: new Date() }); // recent completion
+      const { res } = await callStart();
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(mockTxExportJob.upsert).not.toHaveBeenCalled();
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('cooldown query only counts completed jobs — failed runs are exempt by construction', async () => {
+      await callStart();
+
+      const cooldownWhere = mockTxExportJob.findFirst.mock.calls[1][0].where;
+      expect(cooldownWhere.status).toBe('completed');
+      expect(cooldownWhere.completedAt.gt).toBeInstanceOf(Date);
+    });
   });
 
   describe('GET /account/export/status', () => {
@@ -150,12 +169,11 @@ describe('Account Export Routes', () => {
       mockPrisma.exportJob.findFirst.mockResolvedValueOnce({
         id: 'job-1',
         status: 'completed',
-        fileName: 'tzurot-account-export-alice-2026-07-15.json',
+        fileName: 'tzurot-account-export-alice-2026-07-15.zip',
         fileSizeBytes: 42,
         createdAt: new Date(),
         completedAt: new Date(),
         expiresAt: new Date(),
-        errorMessage: null,
       });
       const first = await callStatus();
       expect(first.res.json).toHaveBeenCalledWith(
@@ -172,7 +190,6 @@ describe('Account Export Routes', () => {
         createdAt: new Date(),
         completedAt: null,
         expiresAt: new Date(),
-        errorMessage: null,
       });
       const second = await callStatus();
       expect(second.res.json).toHaveBeenCalledWith(

--- a/services/api-gateway/src/routes/user/account/export.ts
+++ b/services/api-gateway/src/routes/user/account/export.ts
@@ -37,20 +37,29 @@ const logger = createLogger('account-export');
 /** Export jobs expire after 24 hours (mirrors the shapes-export policy). */
 const EXPORT_EXPIRY_HOURS = 24;
 
-/** Account exports are JSON-only in v1. */
-const EXPORT_FORMAT = 'json';
+/** Account exports are a ZIP archive (JSON + Markdown per section) from v2 on. */
+const EXPORT_FORMAT = 'zip';
+
+/**
+ * One completed export per 24 hours (measured from completedAt) — a full
+ * account assembly is the most expensive read path a user can trigger.
+ * Failed jobs are exempt so a failure never locks the user out.
+ */
+const EXPORT_COOLDOWN_HOURS = 24;
 
 interface CreateOrConflictResult {
   exportJobId: string;
   conflictStatus: string | null;
+  onCooldown: boolean;
 }
 
 /**
- * Atomically check for an active job and create/reset the export row.
- * The UUID is deterministic on (userId, 'account', 'account', 'json'), so a
- * re-export upserts the same row — replacing any previous completed/failed
- * export and invalidating its download URL. Only an active
- * (pending/in_progress) job triggers a 409.
+ * Atomically check for an active job / cooldown and create/reset the export
+ * row. The UUID is deterministic on (userId, 'account', 'account', 'zip'),
+ * so a re-export upserts the same row — replacing any previous
+ * completed/failed export and invalidating its download URL. An active
+ * (pending/in_progress) job or a completed job newer than the cooldown
+ * window triggers a 409 instead.
  */
 async function createExportJobOrConflict(
   prisma: PrismaClient,
@@ -63,8 +72,9 @@ async function createExportJobOrConflict(
     ACCOUNT_EXPORT_SOURCE,
     EXPORT_FORMAT
   );
+  const cooldownFloor = new Date(Date.now() - EXPORT_COOLDOWN_HOURS * 60 * 60 * 1000);
 
-  const conflictStatus = await prisma.$transaction(async tx => {
+  const outcome = await prisma.$transaction(async tx => {
     const existingJob = await tx.exportJob.findFirst({
       where: {
         userId,
@@ -74,7 +84,20 @@ async function createExportJobOrConflict(
     });
 
     if (existingJob !== null) {
-      return existingJob.status;
+      return { conflictStatus: existingJob.status, onCooldown: false };
+    }
+
+    const recentCompleted = await tx.exportJob.findFirst({
+      where: {
+        userId,
+        sourceService: ACCOUNT_EXPORT_SOURCE,
+        status: 'completed',
+        completedAt: { gt: cooldownFloor },
+      },
+    });
+
+    if (recentCompleted !== null) {
+      return { conflictStatus: null, onCooldown: true };
     }
 
     await tx.exportJob.upsert({
@@ -92,6 +115,7 @@ async function createExportJobOrConflict(
         status: 'pending',
         format: EXPORT_FORMAT,
         fileContent: null,
+        fileData: null,
         fileName: null,
         fileSizeBytes: null,
         errorMessage: null,
@@ -102,10 +126,10 @@ async function createExportJobOrConflict(
       },
     });
 
-    return null;
+    return { conflictStatus: null, onCooldown: false };
   });
 
-  return { exportJobId, conflictStatus };
+  return { exportJobId, ...outcome };
 }
 
 /**
@@ -133,8 +157,9 @@ function createStartExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: s
 
     let exportJobId: string;
     let conflictStatus: string | null;
+    let onCooldown: boolean;
     try {
-      ({ exportJobId, conflictStatus } = await createExportJobOrConflict(
+      ({ exportJobId, conflictStatus, onCooldown } = await createExportJobOrConflict(
         prisma,
         userId,
         expiresAt
@@ -157,6 +182,16 @@ function createStartExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: s
         res,
         ErrorResponses.conflict(
           `An account export is already ${conflictStatus}. Wait for it to complete.`
+        )
+      );
+    }
+
+    if (onCooldown) {
+      return sendError(
+        res,
+        ErrorResponses.conflict(
+          'You can export your account once every 24 hours. ' +
+            'Your latest export is still available via the status endpoint.'
         )
       );
     }
@@ -193,6 +228,9 @@ function createStatusHandler(prisma: PrismaClient, baseUrl: string) {
   return async (req: ProvisionedRequest, res: Response) => {
     const userId = resolveProvisionedUserId(req);
 
+    // errorMessage stays server-side by design: raw assembly errors can leak
+    // infrastructure detail, and the worker already logged them. Clients show
+    // generic failure copy off the status field alone.
     const job = await prisma.exportJob.findFirst({
       where: { userId, sourceService: ACCOUNT_EXPORT_SOURCE },
       orderBy: { createdAt: 'desc' },
@@ -204,7 +242,6 @@ function createStatusHandler(prisma: PrismaClient, baseUrl: string) {
         createdAt: true,
         completedAt: true,
         expiresAt: true,
-        errorMessage: true,
       },
     });
 

--- a/services/bot-client/src/commands/settings/data/export.test.ts
+++ b/services/bot-client/src/commands/settings/data/export.test.ts
@@ -87,12 +87,11 @@ describe('handleDataExport', () => {
         job: {
           id: 'job-1',
           status: 'completed',
-          fileName: 'f.json',
+          fileName: 'f.zip',
           fileSizeBytes: 10,
           createdAt: new Date().toISOString(),
           completedAt: new Date().toISOString(),
           expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
-          errorMessage: null,
           downloadUrl: 'https://gateway.example/exports/job-1',
         },
       })
@@ -104,6 +103,31 @@ describe('handleDataExport', () => {
     const embed = mockEditReply.mock.calls[0][0].embeds[0];
     expect(embed.data.title).toContain('Status');
     expect(embed.data.description).toContain('https://gateway.example/exports/job-1');
+    // Completed-on-409 means the cooldown blocked a re-export — say so.
+    expect(embed.data.description).toContain('once every 24 hours');
+  });
+
+  it('shows generic failure copy for failed jobs (no raw error detail)', async () => {
+    stub.startAccountExport.mockResolvedValue(makeErr(409, 'already in progress'));
+    stub.getAccountExportStatus.mockResolvedValue(
+      makeOk({
+        job: {
+          id: 'job-1',
+          status: 'failed',
+          fileName: null,
+          fileSizeBytes: null,
+          createdAt: new Date().toISOString(),
+          completedAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+          downloadUrl: null,
+        },
+      })
+    );
+
+    await handleDataExport(createMockContext());
+
+    const embed = mockEditReply.mock.calls[0][0].embeds[0];
+    expect(embed.data.description).toContain('Your last export failed');
   });
 
   it('reports non-409 failures plainly', async () => {

--- a/services/bot-client/src/commands/settings/data/export.ts
+++ b/services/bot-client/src/commands/settings/data/export.ts
@@ -21,6 +21,23 @@ function expiryLine(expiresAt: string | Date): string {
   return `The link expires ${time(expiry, TimestampStyles.RelativeTime)} — download before then.`;
 }
 
+function statusDescription(job: {
+  status: string;
+  downloadUrl: string | null;
+  expiresAt: string;
+}): string {
+  if (job.status === 'completed' && job.downloadUrl !== null) {
+    return (
+      'You can export your account once every 24 hours. Your latest export is still available:\n\n' +
+      `[Download your data](${job.downloadUrl})\n\n${expiryLine(job.expiresAt)}`
+    );
+  }
+  if (job.status === 'failed') {
+    return 'Your last export failed. Re-run this command to start a new one.';
+  }
+  return `Your export is **${job.status}**. Re-run this command to check again.`;
+}
+
 async function showCurrentJobStatus(context: DeferredCommandContext): Promise<void> {
   const { userClient } = clientsFor(context.interaction);
   const statusResult = await userClient.getAccountExportStatus();
@@ -36,11 +53,7 @@ async function showCurrentJobStatus(context: DeferredCommandContext): Promise<vo
   const embed = new EmbedBuilder()
     .setColor(job.status === 'completed' ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.WARNING)
     .setTitle('📦 Account Export Status')
-    .setDescription(
-      job.status === 'completed' && job.downloadUrl !== null
-        ? `Your export is ready.\n\n[Download your data](${job.downloadUrl})\n\n${expiryLine(job.expiresAt)}`
-        : `Your export is **${job.status}**. Re-run this command to check again.`
-    )
+    .setDescription(statusDescription(job))
     .setTimestamp();
 
   await context.editReply({ embeds: [embed] });
@@ -69,7 +82,8 @@ export async function handleDataExport(context: DeferredCommandContext): Promise
       .setColor(DISCORD_COLORS.SUCCESS)
       .setTitle('📦 Account Export Started')
       .setDescription(
-        'Your full account data is being assembled — profile, personas, ' +
+        'Your full account data is being assembled into a ZIP archive with ' +
+          'JSON and Markdown files per section — profile, personas, ' +
           'characters, conversation history, memories, facts, and settings ' +
           '(secret material like API keys is never included).\n\n' +
           `When it finishes, download it here:\n[Download your data](${result.data.downloadUrl})\n\n` +


### PR DESCRIPTION
## What

The `/settings data export` payload becomes a **ZIP archive** with distinct per-section files instead of one giant JSON (owner-directed after the dev smoke produced an 80MB single file). Both JSON and Markdown ship for every user-readable section.

### ZIP layout
- `README.md` — counts, profile-vs-personas definitions, exclusion disclosures
- `profile.{json,md}` · `personas/<name>-<id8>.{json,md}` · `characters/<slug>.{json,md}`
- `conversations|memories|facts/<character-slug>.{json,md}` — foldered by character, **including characters the user conversed with but doesn't own** (new personality-directory lookup; `unknown-<id8>` fallback)
- `feedback.{json,md}` · `usage-summary.{json,md}`
- `configs/*.json` and `account/*.json` (operational metadata, JSON-only) — now includes `shapes-mappings.json` so the export map matches the deletion map

### Mechanics
- **Additive migration**: `export_jobs.file_data BYTEA` (ZIP is binary; `file_content` stays TEXT for shapes exports). Download route serves `application/zip` from `file_data` when set, text formats from `file_content` otherwise.
- **Zip dependency**: `fflate` (zero-dep, in-memory `zipSync` — fine at current scale).
- Markdown formatters: transcripts grouped by channel with day headers + per-message clock times (explicit chronological sort — sweeps return id order), memories with flag lines, facts bucketed current/superseded/forgotten.

### Absorbed riders (from the data-rights plan)
- **24h export cooldown** measured from `completedAt`; failed runs exempt so a failure never locks the user out; the bot's 409 path shows the still-live download link with "once every 24 hours" copy.
- **Status route drops `errorMessage`** from the wire (raw assembly errors are server-log-only); clients render generic failure copy.
- **Status is a closed enum** (`pending | in_progress | completed | failed`) on the API schema.

## Verified
- `pnpm test` (full), `pnpm test:component` (full tier), `pnpm quality` — all green locally, run sequentially.
- Job unit test unzips the stored `fileData` and asserts real file contents (README, profile.json, per-character transcript).
- PGLite component test proves: unowned-character directory coverage with slug-foldered files, owned-only `characters/` definitions, and **zero secret material across every built file** (seeded BYOK key + credential values never appear).
- Conformance fixtures updated: seeded completed job backdated past the cooldown window so fixture order can't 409.

## Follow-ups
- Dev smoke after deploy: re-run export → ZIP downloads and opens, per-character files readable, README accurate, size sanity vs the 80MB baseline. Transcript timestamp style (per-day headers + clock times) is an owner judgment call against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)