### PR TITLE
feat: export completeness + empty personality-config anchor hygiene

### DIFF
--- a/packages/common-types/src/utils/personalityConfigShape.test.ts
+++ b/packages/common-types/src/utils/personalityConfigShape.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isEmptyPersonalityConfig } from './personalityConfigShape.js';
+
+const EMPTY = {
+  personaId: null,
+  llmConfigId: null,
+  visionConfigId: null,
+  ttsConfigId: null,
+  configOverrides: null,
+};
+
+describe('isEmptyPersonalityConfig', () => {
+  it('is true only when every slice is null', () => {
+    expect(isEmptyPersonalityConfig(EMPTY)).toBe(true);
+  });
+
+  it('is false when any single slice is set', () => {
+    expect(isEmptyPersonalityConfig({ ...EMPTY, personaId: 'p' })).toBe(false);
+    expect(isEmptyPersonalityConfig({ ...EMPTY, llmConfigId: 'l' })).toBe(false);
+    expect(isEmptyPersonalityConfig({ ...EMPTY, visionConfigId: 'v' })).toBe(false);
+    expect(isEmptyPersonalityConfig({ ...EMPTY, ttsConfigId: 't' })).toBe(false);
+    expect(
+      isEmptyPersonalityConfig({ ...EMPTY, configOverrides: { focusModeEnabled: true } })
+    ).toBe(false);
+  });
+});

--- a/packages/common-types/src/utils/personalityConfigShape.ts
+++ b/packages/common-types/src/utils/personalityConfigShape.ts
@@ -1,0 +1,31 @@
+/**
+ * UserPersonalityConfig is a shared anchor row across several override
+ * "slices" (persona, LLM config, vision config, TTS config, and the
+ * config-overrides JSONB). Each override route sets/clears its own slice on
+ * the same row. When every slice is null the row is a dead anchor — it
+ * resolves to nothing in the cascade and only clutters exports.
+ *
+ * This is the single source of truth for "which fields count as slices" so
+ * the write-path prune (api-gateway clear routes) and the export filter
+ * (ai-worker assembler) can never disagree on what "empty" means.
+ */
+
+/** The nullable override slices whose all-null state makes the anchor dead. */
+export interface PersonalityConfigSlices {
+  personaId: string | null;
+  llmConfigId: string | null;
+  visionConfigId: string | null;
+  ttsConfigId: string | null;
+  configOverrides: unknown;
+}
+
+/** True when every override slice is null — a dead anchor row. */
+export function isEmptyPersonalityConfig(row: PersonalityConfigSlices): boolean {
+  return (
+    row.personaId === null &&
+    row.llmConfigId === null &&
+    row.visionConfigId === null &&
+    row.ttsConfigId === null &&
+    row.configOverrides === null
+  );
+}

--- a/services/ai-worker/src/jobs/AccountExportAssembler.component.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.component.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { type PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
 import { assembleAccountExport } from './AccountExportAssembler.js';
 import { buildAccountExportFiles } from './AccountExportFiles.js';
@@ -215,5 +216,48 @@ describe('assembleAccountExport (component, PGLite)', () => {
     expect(everything).not.toContain('cred-iv');
     // The README discloses the exclusions.
     expect(files['README.md']).toContain('secret material is never exported');
+  });
+
+  it('exports the user config-defaults, filters dead anchor rows, and gates admin settings on superuser', async () => {
+    // A user-tier config default + a GENUINELY partial override (configOverrides
+    // set, no FK dependency) + a dead all-null anchor.
+    await prisma.user.update({ where: { id: USER_A }, data: { configDefaults: { maxImages: 4 } } });
+    const liveId = nextId();
+    await prisma.userPersonalityConfig.create({
+      data: {
+        id: liveId,
+        userId: USER_A,
+        personalityId: PERSONALITY_X,
+        configOverrides: { focusModeEnabled: true },
+      },
+    });
+    const deadId = nextId();
+    await prisma.userPersonalityConfig.create({
+      data: { id: deadId, userId: USER_A, personalityId: PERSONALITY_Y },
+    });
+
+    const asNormalUser = await assembleAccountExport(prisma, USER_A);
+    expect((asNormalUser.profile as { configDefaults: unknown }).configDefaults).toEqual({
+      maxImages: 4,
+    });
+    const configIds = asNormalUser.personalityConfigs.map(r => (r as { id: string }).id);
+    // The genuinely-partial row survives; the all-null anchor is filtered.
+    expect(configIds).toContain(liveId);
+    expect(configIds).not.toContain(deadId);
+    // Non-superuser: no admin settings.
+    expect(asNormalUser.adminSettings).toBeNull();
+
+    // Promote A to superuser + seed the global admin-settings singleton row.
+    await prisma.user.update({ where: { id: USER_A }, data: { isSuperuser: true } });
+    await prisma.$executeRaw`
+      INSERT INTO admin_settings (id, system_settings, updated_at)
+      VALUES (${ADMIN_SETTINGS_SINGLETON_ID}::uuid, '{"fallbackModel":"gpt"}'::jsonb, NOW())
+    `;
+
+    const asAdmin = await assembleAccountExport(prisma, USER_A);
+    expect(asAdmin.adminSettings).toEqual(
+      expect.objectContaining({ systemSettings: { fallbackModel: 'gpt' } })
+    );
+    expect(buildAccountExportFiles(asAdmin)['account/admin-settings.json']).toBeDefined();
   });
 });

--- a/services/ai-worker/src/jobs/AccountExportAssembler.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.test.ts
@@ -9,8 +9,14 @@ function emptyModel(): { findMany: ReturnType<typeof vi.fn> } {
 function makePrisma(): Record<string, { findMany?: ReturnType<typeof vi.fn> }> {
   return {
     user: {
-      findUniqueOrThrow: vi.fn().mockResolvedValue({ username: 'alice', discordId: '1' }),
+      findUniqueOrThrow: vi.fn().mockResolvedValue({
+        username: 'alice',
+        discordId: '1',
+        configDefaults: null,
+        isSuperuser: false,
+      }),
     } as never,
+    adminSettings: { findUnique: vi.fn().mockResolvedValue(null) } as never,
     persona: emptyModel(),
     personalityOwner: emptyModel(),
     personality: emptyModel(),
@@ -42,7 +48,13 @@ describe('assembleAccountExport', () => {
   it('assembles every section with the disclosure notes', async () => {
     const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
 
-    expect(payload.profile).toEqual({ username: 'alice', discordId: '1' });
+    expect(payload.profile).toEqual({
+      username: 'alice',
+      discordId: '1',
+      configDefaults: null,
+    });
+    // A non-superuser export never includes admin settings.
+    expect(payload.adminSettings).toBeNull();
     for (const section of [
       'personas',
       'characters',
@@ -60,6 +72,56 @@ describe('assembleAccountExport', () => {
     }
     expect(payload.meta.formatVersion).toBe(2);
     expect(payload.meta.notes.join(' ')).toContain('secret material is never exported');
+  });
+
+  it('includes admin settings only for a superuser', async () => {
+    (
+      prisma.user as unknown as { findUniqueOrThrow: ReturnType<typeof vi.fn> }
+    ).findUniqueOrThrow.mockResolvedValue({
+      username: 'owner',
+      discordId: '1',
+      configDefaults: { maxImages: 4 },
+      isSuperuser: true,
+    });
+    (
+      prisma.adminSettings as unknown as { findUnique: ReturnType<typeof vi.fn> }
+    ).findUnique.mockResolvedValue({ id: 'admin-1', systemSettings: { fallbackModel: 'x' } });
+
+    const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    expect(payload.adminSettings).toEqual({
+      id: 'admin-1',
+      systemSettings: { fallbackModel: 'x' },
+    });
+    // Personal config defaults ride in the profile.
+    expect((payload.profile as { configDefaults: unknown }).configDefaults).toEqual({
+      maxImages: 4,
+    });
+  });
+
+  it('filters out dead all-null personality-config anchor rows', async () => {
+    prisma.userPersonalityConfig.findMany?.mockResolvedValue([
+      {
+        id: 'live',
+        personaId: 'p',
+        llmConfigId: null,
+        visionConfigId: null,
+        ttsConfigId: null,
+        configOverrides: null,
+      },
+      {
+        id: 'dead',
+        personaId: null,
+        llmConfigId: null,
+        visionConfigId: null,
+        ttsConfigId: null,
+        configOverrides: null,
+      },
+    ]);
+
+    const payload = await assembleAccountExport(prisma as unknown as PrismaClient, 'user-1');
+
+    expect(payload.personalityConfigs).toEqual([expect.objectContaining({ id: 'live' })]);
   });
 
   it('selects only metadata columns for keys and credentials (never secret columns)', async () => {

--- a/services/ai-worker/src/jobs/AccountExportAssembler.ts
+++ b/services/ai-worker/src/jobs/AccountExportAssembler.ts
@@ -15,23 +15,29 @@
  * usage logs (an aggregate summary ships instead).
  */
 
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import { type PrismaClient, type Prisma } from '@tzurot/common-types/services/prisma';
+import { isEmptyPersonalityConfig } from '@tzurot/common-types/utils/personalityConfigShape';
 
 /** Page size for cursor sweeps over the big tables (bounded-query rule). */
 const EXPORT_PAGE_SIZE = 1000;
 
-export type ExportProfile = Prisma.UserGetPayload<{
-  select: {
-    discordId: true;
-    username: true;
-    timezone: true;
-    nsfwVerified: true;
-    nsfwVerifiedAt: true;
-    notifyEnabled: true;
-    notifyLevel: true;
-    createdAt: true;
-  };
-}>;
+const PROFILE_SELECT = {
+  discordId: true,
+  username: true,
+  timezone: true,
+  nsfwVerified: true,
+  nsfwVerifiedAt: true,
+  notifyEnabled: true,
+  notifyLevel: true,
+  createdAt: true,
+  /** Personal config-cascade defaults (the user tier — what /settings
+   *  defaults writes). Exported as the user's own data. */
+  configDefaults: true,
+} as const;
+
+export type ExportProfile = Prisma.UserGetPayload<{ select: typeof PROFILE_SELECT }>;
+export type ExportAdminSettings = Prisma.AdminSettingsGetPayload<object>;
 export type ExportPersona = Prisma.PersonaGetPayload<object>;
 export type ExportCharacter = Omit<
   Prisma.PersonalityGetPayload<object>,
@@ -86,6 +92,9 @@ export interface AccountExportData {
   exportJobs: unknown[];
   releaseDeliveries: unknown[];
   shapesMappings: unknown[];
+  /** The global admin-settings row — populated only when the exporting user
+   *  is the superuser (the owner IS the admin); null for everyone else. */
+  adminSettings: ExportAdminSettings | null;
 }
 
 export const EXPORT_NOTES = [
@@ -160,7 +169,11 @@ async function fetchAncillarySections(
     exportJobs,
     releaseDeliveries,
   ] = await Promise.all([
-    sweep(c => prisma.userPersonalityConfig.findMany({ where: { userId }, ...pageArgs(c) })),
+    sweep(c => prisma.userPersonalityConfig.findMany({ where: { userId }, ...pageArgs(c) })).then(
+      // Drop dead anchor rows (every override slice null) — belt-and-suspenders
+      // vs. the write-path prune and the one-off cleanup.
+      rows => rows.filter(row => !isEmptyPersonalityConfig(row))
+    ),
     sweep(c => prisma.userPersonaHistoryConfig.findMany({ where: { userId }, ...pageArgs(c) })),
     sweep(c => prisma.llmConfig.findMany({ where: { ownerId: userId }, ...pageArgs(c) })),
     sweep(c => prisma.ttsConfig.findMany({ where: { ownerId: userId }, ...pageArgs(c) })),
@@ -305,19 +318,18 @@ export async function assembleAccountExport(
   prisma: PrismaClient,
   userId: string
 ): Promise<AccountExportData> {
-  const user = await prisma.user.findUniqueOrThrow({
+  const userRow = await prisma.user.findUniqueOrThrow({
     where: { id: userId },
-    select: {
-      discordId: true,
-      username: true,
-      timezone: true,
-      nsfwVerified: true,
-      nsfwVerifiedAt: true,
-      notifyEnabled: true,
-      notifyLevel: true,
-      createdAt: true,
-    },
+    select: { ...PROFILE_SELECT, isSuperuser: true },
   });
+  const { isSuperuser, ...user } = userRow;
+
+  // The owner IS the admin, so the superuser's export includes the global
+  // admin-settings row (config defaults, system settings, default-config
+  // pointers — no secret material). Everyone else gets null.
+  const adminSettings = isSuperuser
+    ? await prisma.adminSettings.findUnique({ where: { id: ADMIN_SETTINGS_SINGLETON_ID } })
+    : null;
 
   const personas = await sweep(c =>
     prisma.persona.findMany({ where: { ownerId: userId }, ...pageArgs(c) })
@@ -378,6 +390,7 @@ export async function assembleAccountExport(
     memories,
     facts,
     shapesMappings,
+    adminSettings,
     ...ancillary,
   };
 }

--- a/services/ai-worker/src/jobs/AccountExportFiles.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportFiles.test.ts
@@ -16,6 +16,7 @@ function makeData(overrides: Partial<AccountExportData> = {}): AccountExportData
       notifyEnabled: true,
       notifyLevel: 'minor',
       createdAt: NOW,
+      configDefaults: null,
     },
     personas: [],
     characters: [],
@@ -35,6 +36,7 @@ function makeData(overrides: Partial<AccountExportData> = {}): AccountExportData
     exportJobs: [],
     releaseDeliveries: [],
     shapesMappings: [],
+    adminSettings: null,
     ...overrides,
   } as AccountExportData;
 }
@@ -56,6 +58,7 @@ describe('buildAccountExportFiles', () => {
       'configs/tts.json',
       'configs/personality-overrides.json',
       'configs/persona-history.json',
+      'configs/user-defaults.json',
       'account/api-key-metadata.json',
       'account/credential-metadata.json',
       'account/jobs.json',
@@ -65,6 +68,30 @@ describe('buildAccountExportFiles', () => {
       expect(files[jsonOnly]).toBeDefined();
       expect(files[`${jsonOnly.replace('.json', '.md')}`]).toBeUndefined();
     }
+  });
+
+  it('emits admin-settings only when present (superuser), and notes it in the README', () => {
+    const withoutAdmin = buildAccountExportFiles(makeData());
+    expect(withoutAdmin['account/admin-settings.json']).toBeUndefined();
+    expect(withoutAdmin['README.md']).not.toContain('admin settings');
+
+    const withAdmin = buildAccountExportFiles(
+      makeData({ adminSettings: { id: 'a1', systemSettings: { fallbackModel: 'x' } } as never })
+    );
+    expect(withAdmin['account/admin-settings.json']).toContain('"id": "a1"');
+    expect(withAdmin['README.md']).toContain('admin settings');
+  });
+
+  it('writes user-defaults from the profile config-cascade defaults', () => {
+    const files = buildAccountExportFiles(
+      makeData({
+        profile: {
+          ...makeData().profile,
+          configDefaults: { maxImages: 4 },
+        },
+      })
+    );
+    expect(files['configs/user-defaults.json']).toContain('"maxImages": 4');
   });
 
   it('writes one json/md pair per persona, stem = sanitized name + id prefix', () => {

--- a/services/ai-worker/src/jobs/AccountExportFiles.ts
+++ b/services/ai-worker/src/jobs/AccountExportFiles.ts
@@ -90,8 +90,9 @@ function buildReadme(data: AccountExportData): string {
     '- `characters/` — full definitions of characters you own or co-own',
     '- `conversations/`, `memories/`, `facts/` — foldered by character slug',
     '- `feedback.{json,md}`, `usage-summary.{json,md}`',
-    '- `configs/` — your LLM/TTS configs and per-character overrides',
-    '- `account/` — key/credential metadata, job history, release deliveries',
+    '- `configs/` — your LLM/TTS configs, per-character overrides, and personal defaults',
+    '- `account/` — key/credential metadata, job history, release deliveries' +
+      (data.adminSettings !== null ? ', admin settings' : ''),
     '- `personality-directory.json` — id → name/slug for every character referenced above',
     '',
     '## Profile vs. personas',
@@ -180,12 +181,19 @@ export function buildAccountExportFiles(data: AccountExportData): Record<string,
   files['configs/tts.json'] = json(data.ttsConfigs);
   files['configs/personality-overrides.json'] = json(data.personalityConfigs);
   files['configs/persona-history.json'] = json(data.personaHistoryConfigs);
+  // Personal config-cascade defaults (the user tier — what /settings defaults
+  // writes). null when the user has set none.
+  files['configs/user-defaults.json'] = json(data.profile.configDefaults ?? null);
 
   files['account/api-key-metadata.json'] = json(data.apiKeyMetadata);
   files['account/credential-metadata.json'] = json(data.credentialMetadata);
   files['account/jobs.json'] = json({ importJobs: data.importJobs, exportJobs: data.exportJobs });
   files['account/release-deliveries.json'] = json(data.releaseDeliveries);
   files['account/shapes-mappings.json'] = json(data.shapesMappings);
+  // Superuser only — the owner IS the admin.
+  if (data.adminSettings !== null) {
+    files['account/admin-settings.json'] = json(data.adminSettings);
+  }
 
   return files;
 }

--- a/services/ai-worker/src/jobs/AccountExportJob.test.ts
+++ b/services/ai-worker/src/jobs/AccountExportJob.test.ts
@@ -53,6 +53,7 @@ function makePayload(): AccountExportData {
       notifyEnabled: true,
       notifyLevel: 'minor',
       createdAt: NOW,
+      configDefaults: null,
     },
     personas: [
       {
@@ -120,6 +121,7 @@ function makePayload(): AccountExportData {
     exportJobs: [],
     releaseDeliveries: [],
     shapesMappings: [],
+    adminSettings: null,
   };
 }
 

--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -112,6 +112,7 @@ const mockPrisma = {
     findUnique: vi.fn(),
     update: vi.fn(),
     upsert: vi.fn(),
+    delete: vi.fn(),
   },
 };
 
@@ -567,6 +568,32 @@ describe('/user/config-overrides routes', () => {
           configOverrides: { maxMessages: 25 },
         })
       );
+    });
+
+    it('prunes the anchor row when a merge-to-empty PATCH leaves every slice null', async () => {
+      // Existing row's only slice was a single override key; PATCH clears it.
+      mockPrisma.userPersonalityConfig.findUnique
+        .mockResolvedValueOnce({ configOverrides: { maxMessages: 25 } }) // route's pre-merge read
+        .mockResolvedValueOnce({
+          personaId: null,
+          llmConfigId: null,
+          visionConfigId: null,
+          ttsConfigId: null,
+          configOverrides: null,
+        }); // prune's slice read — all null after the merge cleared the last key
+      mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({});
+
+      const router = createConfigOverrideRoutes(mockDeps);
+      const handler = getHandler(router, 'patch', '/:personalityId');
+      const { req, res } = createMockReqRes(
+        { maxMessages: null },
+        { personalityId: TEST_PERSONALITY_ID }
+      );
+
+      await handler(req, res);
+
+      expect(mockPrisma.userPersonalityConfig.delete).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
     });
 
     it('should reject invalid config format', async () => {

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -38,6 +38,7 @@ import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest, ProvisionedRequest } from '../../types.js';
 import { type RouteDeps } from '../routeDeps.js';
+import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
 
 const logger = createLogger('user-config-overrides');
 
@@ -241,6 +242,10 @@ export const handleUpdatePersonalityOverrides = (deps: RouteDeps): RequestHandle
         configOverrides: prismaValue,
       },
     });
+    // A merge-to-empty PATCH clears the only slice this route sets (and the
+    // create branch can mint a fresh all-null row) — prune so it doesn't
+    // leave, or manufacture, a dead anchor.
+    await pruneEmptyPersonalityConfig(prisma, upcId);
 
     await tryInvalidateCache(
       cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
@@ -273,6 +278,7 @@ export const handleClearPersonalityOverrides = (deps: RouteDeps): RequestHandler
         where: { id: upcId },
         data: { configOverrides: Prisma.JsonNull },
       });
+      await pruneEmptyPersonalityConfig(prisma, upcId);
     }
 
     await tryInvalidateCache(

--- a/services/api-gateway/src/routes/user/memory.ts
+++ b/services/api-gateway/src/routes/user/memory.ts
@@ -30,6 +30,7 @@ import { Prisma } from '@tzurot/common-types/services/prisma';
 import { generateUserPersonalityConfigUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { RouteDeps } from '../routeDeps.js';
+import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -221,7 +222,7 @@ export const handleSetFocus = (deps: RouteDeps): RequestHandler => {
         ? (mergedOverrides as Prisma.InputJsonValue)
         : Prisma.JsonNull;
 
-    await prisma.userPersonalityConfig.upsert({
+    const upserted = await prisma.userPersonalityConfig.upsert({
       where: { userId_personalityId: { userId, personalityId } },
       update: { configOverrides: configOverridesValue },
       create: {
@@ -230,7 +231,11 @@ export const handleSetFocus = (deps: RouteDeps): RequestHandler => {
         personalityId,
         configOverrides: configOverridesValue,
       },
+      select: { id: true },
     });
+    // Disabling focus clears the only slice this route sets — if nothing else
+    // is set, don't leave (or create) a dead anchor row.
+    await pruneEmptyPersonalityConfig(prisma, upserted.id);
 
     logger.info(
       { discordUserId, personalityId, enabled },

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -57,8 +57,10 @@ const mockPrisma = {
   userPersonalityConfig: {
     findMany: vi.fn(),
     findFirst: vi.fn(),
+    findUnique: vi.fn(),
     upsert: vi.fn(),
     update: vi.fn(),
+    delete: vi.fn(),
   },
   $executeRaw: vi.fn().mockResolvedValue(1),
   $transaction: vi.fn().mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
@@ -119,6 +121,7 @@ describe('/user/model-override routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
+    mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue(null);
     // UserService uses findUnique to look up users
     mockPrisma.user.findUnique.mockResolvedValue({
       id: 'user-uuid-123',

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -43,6 +43,7 @@ import { getParam } from '../../utils/requestParams.js';
 import { OVERRIDE_SUMMARY_SELECT, parseClearSlots } from './modelOverrideShared.js';
 import type { ProvisionedRequest } from '../../types.js';
 import type { RouteDeps } from '../routeDeps.js';
+import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
 
 const logger = createLogger('user-model-override');
 
@@ -468,6 +469,7 @@ export const handleDeleteModelOverride = (deps: RouteDeps): RequestHandler => {
         ...(clearVision ? { visionConfigId: null } : {}),
       },
     });
+    await pruneEmptyPersonalityConfig(prisma, override.id);
 
     logger.info(
       { discordUserId, personalityId, personalityName: override.personality.name, slot },

--- a/services/api-gateway/src/routes/user/persona/override.test.ts
+++ b/services/api-gateway/src/routes/user/persona/override.test.ts
@@ -252,16 +252,23 @@ describe('persona override routes', () => {
   });
 
   describe('DELETE /user/persona/override/:personalitySlug', () => {
-    it('should clear persona override and delete config if no llmConfigId', async () => {
+    it('clears the persona slice and prunes the row when no other slice remains', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: MOCK_PERSONALITY_ID,
         name: 'Lilith',
         displayName: 'Lilith the Succubus',
       });
+      // Route reads the row (id), then the prune re-reads the full slice set —
+      // both hit this mock; an all-null slice set means the prune deletes.
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue({
         id: 'config-1',
+        personaId: null,
         llmConfigId: null,
+        visionConfigId: null,
+        ttsConfigId: null,
+        configOverrides: null,
       });
+      mockPrisma.userPersonalityConfig.update.mockResolvedValue({});
       mockPrisma.userPersonalityConfig.delete.mockResolvedValue({});
 
       const handler = handleClearPersonaOverride({
@@ -272,7 +279,12 @@ describe('persona override routes', () => {
       const { req, res } = createMockReqRes({}, { personalitySlug: 'lilith' });
       await handler(req, res, vi.fn());
 
-      expect(mockPrisma.userPersonalityConfig.delete).toHaveBeenCalled();
+      expect(mockPrisma.userPersonalityConfig.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { personaId: null } })
+      );
+      expect(mockPrisma.userPersonalityConfig.delete).toHaveBeenCalledWith({
+        where: { id: 'config-1' },
+      });
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
@@ -286,7 +298,7 @@ describe('persona override routes', () => {
       );
     });
 
-    it('should only clear personaId if config has llmConfigId', async () => {
+    it('clears the persona slice but keeps the row when another slice is set', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: MOCK_PERSONALITY_ID,
         name: 'Lilith',
@@ -294,7 +306,11 @@ describe('persona override routes', () => {
       });
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue({
         id: 'config-1',
+        personaId: null,
         llmConfigId: 'some-llm-config',
+        visionConfigId: null,
+        ttsConfigId: null,
+        configOverrides: null,
       });
       mockPrisma.userPersonalityConfig.update.mockResolvedValue({});
 

--- a/services/api-gateway/src/routes/user/persona/override.ts
+++ b/services/api-gateway/src/routes/user/persona/override.ts
@@ -32,6 +32,7 @@ import type { ProvisionedRequest } from '../../../types.js';
 import type { PersonaOverrideSummary } from './types.js';
 import { getOrCreateInternalUser } from '../userHelpers.js';
 import type { RouteDeps } from '../../routeDeps.js';
+import { pruneEmptyPersonalityConfig } from '../pruneEmptyPersonalityConfig.js';
 
 const logger = createLogger('user-persona-override');
 
@@ -194,7 +195,7 @@ export const handleClearPersonaOverride = (deps: RouteDeps): RequestHandler => {
 
     const existing = await prisma.userPersonalityConfig.findUnique({
       where: { userId_personalityId: { userId: user.id, personalityId: personality.id } },
-      select: { id: true, llmConfigId: true },
+      select: { id: true },
     });
 
     const personalityResponse = {
@@ -213,14 +214,14 @@ export const handleClearPersonaOverride = (deps: RouteDeps): RequestHandler => {
       return;
     }
 
-    if (existing.llmConfigId !== null) {
-      await prisma.userPersonalityConfig.update({
-        where: { id: existing.id },
-        data: { personaId: null },
-      });
-    } else {
-      await prisma.userPersonalityConfig.delete({ where: { id: existing.id } });
-    }
+    // Null the persona slice, then drop the row only if EVERY slice is now
+    // null. (The prior check looked at llmConfigId alone, so it would have
+    // wrongly deleted a row still carrying a vision/TTS/config override.)
+    await prisma.userPersonalityConfig.update({
+      where: { id: existing.id },
+      data: { personaId: null },
+    });
+    await pruneEmptyPersonalityConfig(prisma, existing.id);
 
     logger.info({ userId: user.id, personalityId: personality.id }, 'Cleared persona override');
     sendCustomSuccess(res, { success: true, personality: personalityResponse, hadOverride: true });

--- a/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.test.ts
+++ b/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
+
+const findUnique = vi.fn();
+const del = vi.fn();
+const prisma = {
+  userPersonalityConfig: { findUnique, delete: del },
+} as unknown as PrismaClient;
+
+const ALL_NULL = {
+  personaId: null,
+  llmConfigId: null,
+  visionConfigId: null,
+  ttsConfigId: null,
+  configOverrides: null,
+};
+
+describe('pruneEmptyPersonalityConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    del.mockResolvedValue({});
+  });
+
+  it('deletes the row when every slice is null', async () => {
+    findUnique.mockResolvedValue(ALL_NULL);
+
+    const pruned = await pruneEmptyPersonalityConfig(prisma, 'row-1');
+
+    expect(pruned).toBe(true);
+    expect(del).toHaveBeenCalledWith({ where: { id: 'row-1' } });
+  });
+
+  it('keeps the row when any slice is still set', async () => {
+    findUnique.mockResolvedValue({ ...ALL_NULL, ttsConfigId: 'tts-1' });
+
+    const pruned = await pruneEmptyPersonalityConfig(prisma, 'row-1');
+
+    expect(pruned).toBe(false);
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the row is already gone', async () => {
+    findUnique.mockResolvedValue(null);
+
+    const pruned = await pruneEmptyPersonalityConfig(prisma, 'row-1');
+
+    expect(pruned).toBe(false);
+    expect(del).not.toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.ts
+++ b/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.ts
@@ -1,0 +1,33 @@
+/**
+ * Delete a UserPersonalityConfig anchor row if clearing an override left every
+ * slice null. Without this, set-then-clear accumulates dead anchor rows that
+ * resolve to nothing and clutter data exports.
+ *
+ * Call AFTER the clear's `update`. The re-read → conditional-delete race
+ * against a concurrent set is benign (single-user sequential command flow;
+ * worst case a just-re-set row is dropped and re-created on next use).
+ */
+
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { isEmptyPersonalityConfig } from '@tzurot/common-types/utils/personalityConfigShape';
+
+export async function pruneEmptyPersonalityConfig(
+  prisma: PrismaClient,
+  id: string
+): Promise<boolean> {
+  const row = await prisma.userPersonalityConfig.findUnique({
+    where: { id },
+    select: {
+      personaId: true,
+      llmConfigId: true,
+      visionConfigId: true,
+      ttsConfigId: true,
+      configOverrides: true,
+    },
+  });
+  if (row === null || !isEmptyPersonalityConfig(row)) {
+    return false;
+  }
+  await prisma.userPersonalityConfig.delete({ where: { id } });
+  return true;
+}

--- a/services/api-gateway/src/routes/user/tts-override.test.ts
+++ b/services/api-gateway/src/routes/user/tts-override.test.ts
@@ -106,8 +106,10 @@ const mockPrisma = {
   userPersonalityConfig: {
     findMany: vi.fn(),
     findFirst: vi.fn(),
+    findUnique: vi.fn(),
     upsert: vi.fn(),
     update: vi.fn(),
+    delete: vi.fn(),
   },
   user: {
     findUnique: vi.fn(),
@@ -140,6 +142,7 @@ const VALID_UUID_B = '22222222-2222-4222-8222-222222222222';
 describe('user/tts-override routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(mockPrisma.userPersonalityConfig.findUnique).mockResolvedValue(null);
   });
 
   describe('GET / (list overrides)', () => {

--- a/services/api-gateway/src/routes/user/tts-override.ts
+++ b/services/api-gateway/src/routes/user/tts-override.ts
@@ -40,6 +40,7 @@ import { sendZodError } from '../../utils/zodHelpers.js';
 import { getParam } from '../../utils/requestParams.js';
 import type { ProvisionedRequest } from '../../types.js';
 import type { RouteDeps } from '../routeDeps.js';
+import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
 
 const logger = createLogger('user-tts-override');
 
@@ -318,6 +319,7 @@ export const handleDeleteTtsOverride = (deps: RouteDeps): RequestHandler => {
       where: { id: override.id },
       data: { ttsConfigId: null },
     });
+    await pruneEmptyPersonalityConfig(prisma, override.id);
 
     logger.info(
       { discordUserId, personalityId, personalityName: override.personality.name },


### PR DESCRIPTION
## What

Export-v2 smoke surfaced four data-quality issues (owner-reported). This PR handles the three additive/code-only ones; the dead-column drop is a separate destructive PR.

### Export completeness
- **`configs/user-defaults.json`** — the personal config-cascade defaults (`users.config_defaults`, what `/settings defaults` writes) were silently absent from the export. Now included.
- **`account/admin-settings.json`** — for the **superuser only** (the owner IS the admin), the global `AdminSettings` row (config defaults, system settings, default-config pointers — no secrets). Null/absent for everyone else. README notes it when present.

### Empty anchor-row hygiene
`UserPersonalityConfig` is a shared anchor across override slices (persona / llm / vision / tts / configOverrides). Every clear-path nulled its one slice and left the row, so set-then-clear accumulated dead all-null anchors that resolve to nothing and clutter the export.

- New shared predicate `isEmptyPersonalityConfig` (common-types) — single source of truth for "which fields are slices."
- New `pruneEmptyPersonalityConfig` helper (api-gateway), called after every clear (`model-override`, `tts-override`, `persona/override`, `config-overrides`, and the `memory` focus-clear): deletes the row iff all slices are now null.
- The assembler also filters all-null anchors from the export (belt-and-suspenders vs. the DB cleanup + races).
- **Latent-bug fix**: the persona-override clear previously deleted the row when `llmConfigId` alone was null — which would have dropped a row still carrying a vision/TTS/config override. The full-slice prune is correct.

## Verified
- `pnpm test` (full), `pnpm test:component` (38/38), `pnpm quality` — green, sequential.
- Assembler unit + component (PGLite): user-defaults populated, admin-settings superuser-gated (present for a superuser seed, null for a normal user), dead anchor filtered while partially-set survives.
- Prune helper unit test (delete-when-empty / keep-when-partial / no-op-when-missing) + all five clear-route tests updated to the prune behavior.

## Follow-ups (not this PR)
- **PR-B (separate, destructive)**: drop the 5 dead LlmConfig context columns (`memoryScoreThreshold`, `memoryLimit`, `maxMessages`, `maxAge`, `maxImages`) — superseded by the ConfigOverrides cascade; needs a maintenance-window release + shapes-import/service write-surface strip.
- **One-off cleanup**: existing dead anchor rows on dev + prod (write-path fix prevents new ones; existing ones get filtered from exports meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)