### PR TITLE
refactor: address #1659 review follow-ups (invariant + dead plumbing)

### DIFF
--- a/packages/common-types/src/schemas/api/configOverrides.test.ts
+++ b/packages/common-types/src/schemas/api/configOverrides.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { AI_DEFAULTS } from '../../constants/ai.js';
 import {
   ConfigOverridesSchema,
   HARDCODED_CONFIG_DEFAULTS,
@@ -207,6 +208,16 @@ describe('HARDCODED_CONFIG_DEFAULTS', () => {
     expect(HARDCODED_CONFIG_DEFAULTS.showModelFooter).toBe(true);
     expect(HARDCODED_CONFIG_DEFAULTS.voiceResponseMode).toBe('always');
     expect(HARDCODED_CONFIG_DEFAULTS.voiceTranscriptionEnabled).toBe(true);
+  });
+
+  it('should tie the memory defaults to AI_DEFAULTS (single source of truth)', () => {
+    // The cascade baseline and the ai-worker retrieval fallback must agree, or a
+    // request with no override would retrieve memories differently depending on
+    // which path resolved it. The type-level `typeof AI_DEFAULTS.*` derivation on
+    // HARDCODED_CONFIG_DEFAULTS makes drift a compile error; this asserts the tie
+    // at runtime too so the intent is visible where the values are read.
+    expect(HARDCODED_CONFIG_DEFAULTS.memoryScoreThreshold).toBe(AI_DEFAULTS.MEMORY_SCORE_THRESHOLD);
+    expect(HARDCODED_CONFIG_DEFAULTS.memoryLimit).toBe(AI_DEFAULTS.MEMORY_LIMIT);
   });
 
   it('should pass schema validation', () => {

--- a/packages/common-types/src/schemas/api/configOverrides.ts
+++ b/packages/common-types/src/schemas/api/configOverrides.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from 'zod';
+import { AI_DEFAULTS } from '../../constants/ai.js';
 
 // ============================================================================
 // Config Overrides Schema (JSONB column shape)
@@ -106,8 +107,11 @@ export const HARDCODED_CONFIG_DEFAULTS: {
   readonly maxMessages: 50;
   readonly maxAge: null;
   readonly maxImages: 10;
-  readonly memoryScoreThreshold: 0.5;
-  readonly memoryLimit: 20;
+  // Memory defaults are the SAME baseline the ai-worker retrieval path falls back
+  // to (`configOverrides?.memoryX ?? AI_DEFAULTS.MEMORY_X` in MemoryRetriever), so
+  // both the type and value derive from AI_DEFAULTS — the two cannot silently drift.
+  readonly memoryScoreThreshold: typeof AI_DEFAULTS.MEMORY_SCORE_THRESHOLD;
+  readonly memoryLimit: typeof AI_DEFAULTS.MEMORY_LIMIT;
   readonly focusModeEnabled: false;
   readonly crossChannelHistoryEnabled: false;
   readonly shareLtmAcrossPersonalities: false;
@@ -118,8 +122,8 @@ export const HARDCODED_CONFIG_DEFAULTS: {
   maxMessages: 50,
   maxAge: null,
   maxImages: 10,
-  memoryScoreThreshold: 0.5,
-  memoryLimit: 20,
+  memoryScoreThreshold: AI_DEFAULTS.MEMORY_SCORE_THRESHOLD,
+  memoryLimit: AI_DEFAULTS.MEMORY_LIMIT,
   focusModeEnabled: false,
   crossChannelHistoryEnabled: false,
   shareLtmAcrossPersonalities: false,

--- a/services/bot-client/src/services/character/PersonalityChatManager.test.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.test.ts
@@ -241,7 +241,6 @@ describe('PersonalityChatManager', () => {
             },
           },
           botUserId: 'bot-123',
-          crossChannelHistoryEnabled: false,
         })
       );
     });
@@ -256,7 +255,6 @@ describe('PersonalityChatManager', () => {
             maxMessages: 200,
             maxAge: 7,
             maxImages: 5,
-            crossChannelHistoryEnabled: false,
             sources: {
               maxMessages: 'user-personality',
               maxAge: 'channel',
@@ -288,40 +286,6 @@ describe('PersonalityChatManager', () => {
             },
           },
         })
-      );
-    });
-
-    it('threads crossChannelHistoryEnabled through from cascade override', async () => {
-      mockResolveUserLlmConfig.mockResolvedValueOnce({
-        ok: true,
-        data: {
-          config: { model: 'm', maxMessages: 50, maxAge: null, maxImages: 10 },
-          source: 'user-personality',
-          overrides: {
-            maxMessages: 50,
-            maxAge: null,
-            maxImages: 10,
-            crossChannelHistoryEnabled: true,
-            sources: {
-              maxMessages: 'user-personality',
-              maxAge: 'user-personality',
-              maxImages: 'user-personality',
-            },
-          },
-        },
-      } as never);
-
-      await manager.submitChatJob({
-        message: createMockMessage(),
-        personality: createMockPersonality(),
-        content: 'Hi',
-      });
-
-      expect(mockContextBuilder.buildContext).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({ crossChannelHistoryEnabled: true })
       );
     });
 

--- a/services/bot-client/src/services/character/PersonalityChatManager.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.ts
@@ -145,13 +145,10 @@ export class PersonalityChatManager {
     );
 
     const botUserId = message.client.user?.id;
-    const crossChannelHistoryEnabled =
-      resolvedConfig.overrides?.crossChannelHistoryEnabled ?? false;
 
     const buildResult = await this.contextBuilder.buildContext(message, personality, content, {
       extendedContext: extendedContextSettings,
       botUserId,
-      crossChannelHistoryEnabled,
     });
     const { context, personaId, messageContent } = buildResult;
 

--- a/services/bot-client/src/services/contextBuilder/ContextBuildOptions.ts
+++ b/services/bot-client/src/services/contextBuilder/ContextBuildOptions.ts
@@ -42,10 +42,4 @@ export interface ContextBuildOptions {
    * summon (false) keeps the epoch. Defaults to isWeighInMode at the call site.
    */
   incognito?: boolean;
-  /**
-   * Whether to fetch cross-channel history to fill unused context budget.
-   * When true and current channel history is under maxMessages, fills remaining
-   * budget with history from other channels where this user+personality interacted.
-   */
-  crossChannelHistoryEnabled?: boolean;
 }


### PR DESCRIPTION
Two small review follow-ups filed against #1659, from the unreleased pile on `develop`.

## L7 — tie memory config defaults to `AI_DEFAULTS` (compiler-enforced)

`HARDCODED_CONFIG_DEFAULTS.memoryScoreThreshold`/`memoryLimit` hardcoded `0.5`/`20` as magic literals — the exact values the ai-worker retrieval path falls back to via `AI_DEFAULTS.MEMORY_*` in `MemoryRetriever` (`configOverrides?.memoryX ?? AI_DEFAULTS.MEMORY_X`). If one changed and the other didn't, a no-override request would retrieve memories differently depending on which path resolved it.

Both the **type** (`typeof AI_DEFAULTS.MEMORY_*`) and the **value** now derive from `AI_DEFAULTS`, so drift is a compile error. Added a runtime assertion of the tie in the colocated test.

## L8 — remove dead `crossChannelHistoryEnabled` plumbing

`PersonalityChatManager` computed `crossChannelHistoryEnabled` from the resolved cascade and threaded it into the `ContextBuildOptions` envelope — but nothing on the bot-client side read it back. `MessageContextBuilder` ignores the field; the ai-worker re-resolves it independently from the job's `configOverrides` (`ContextAssembler` reads `configOverrides.crossChannelHistoryEnabled` directly). Confirmed set-but-never-consumed during #1659 review.

Dropped the computation + the `ContextBuildOptions` field. The `/settings` write path (`settingsConfig`/`settingsUpdate`/`settingsDataBuilder`) is untouched — the value is still a real user-configurable override; only the no-op re-derivation is gone. Removed the test that asserted the dead seam.

## Verification

- `pnpm --filter @tzurot/common-types test` (2518 tests) + `pnpm --filter @tzurot/bot-client test` (5585 tests) — green
- `pnpm quality` — green (typecheck across all packages confirms no other consumer read the removed field)

Behavior-neutral: L7 keeps the same `0.5`/`20` values (now derived); L8 removes a value nothing read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)