### PR TITLE
fix: close the #1658 cache-eviction follow-ups (TOCTOU, bulk evict, broadcast coverage)

### DIFF
--- a/packages/cache-invalidation/src/UserCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/UserCacheInvalidationService.ts
@@ -8,9 +8,12 @@
  * write against it FK-violates (runtime-confirmed: export_jobs, and the same
  * class on ai-worker's usage-log insert).
  *
- * - Publisher: api-gateway (the account-deletion route).
- * - Subscribers: every process with a long-lived UserService — api-gateway
- *   (also evicts locally + synchronously) and ai-worker's context pipeline.
+ * - Publisher: api-gateway (the account-deletion route). It does NOT
+ *   subscribe — the route evicts its own process's cache synchronously
+ *   instead, which covers a single api-gateway replica. If api-gateway ever
+ *   runs multiple replicas, it must also subscribe or the non-deleting
+ *   replicas' caches stay stale until the TTL.
+ * - Subscriber: ai-worker's context pipeline (the only subscriber today).
  */
 
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';

--- a/packages/identity/src/UserService.test.ts
+++ b/packages/identity/src/UserService.test.ts
@@ -200,6 +200,64 @@ describe('UserService', () => {
       expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(2);
     });
 
+    it('does not repopulate the cache when an invalidation races an in-flight read', async () => {
+      // Simulates the TOCTOU: this read started before the account-delete
+      // committed (sees the still-live row), but the delete's invalidateUser
+      // fires mid-read. The generation guard must skip the cache write so the
+      // now-dead userId is never served from cache.
+      mockPrisma.user.findUnique
+        .mockImplementationOnce(async () => {
+          userService.invalidateUser('123456'); // delete evicts during our read
+          return {
+            id: 'user-doomed',
+            isSuperuser: false,
+            username: 'testuser',
+            defaultPersonaId: 'persona-doomed',
+          };
+        })
+        .mockResolvedValueOnce({
+          id: 'user-recreated',
+          isSuperuser: false,
+          username: 'testuser',
+          defaultPersonaId: 'persona-recreated',
+        });
+
+      const first = await userService.getOrCreateUser('123456', 'testuser');
+      expect(first?.userId).toBe('user-doomed'); // caller still gets its result
+
+      // The write was skipped, so the next call re-reads instead of serving the
+      // doomed id from cache.
+      const second = await userService.getOrCreateUser('123456', 'testuser');
+      expect(second?.userId).toBe('user-recreated');
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(2);
+    });
+
+    it('clearCache evicts every entry so the next call re-reads the DB', async () => {
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce({
+          id: 'user-a',
+          isSuperuser: false,
+          username: 'testuser',
+          defaultPersonaId: 'persona-a',
+        })
+        .mockResolvedValueOnce({
+          id: 'user-a2',
+          isSuperuser: false,
+          username: 'testuser',
+          defaultPersonaId: 'persona-a2',
+        });
+
+      const first = await userService.getOrCreateUser('123456', 'testuser');
+      expect(first?.userId).toBe('user-a');
+
+      // Without clearCache the second call would hit the cache (findUnique once).
+      userService.clearCache();
+
+      const afterClear = await userService.getOrCreateUser('123456', 'testuser');
+      expect(afterClear?.userId).toBe('user-a2');
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(2);
+    });
+
     it('should return existing user ID if found in database', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         id: 'existing-user-id',

--- a/packages/identity/src/UserService.ts
+++ b/packages/identity/src/UserService.ts
@@ -97,6 +97,15 @@ export class UserService {
    */
   private userCache: TTLCache<ProvisionedUser>;
 
+  /**
+   * Monotonic counter bumped on every cache invalidation ({@link invalidateUser}
+   * / {@link clearCache}). {@link getOrCreateUser} captures it before its DB read
+   * and re-checks before writing, so an account deletion that races an in-flight
+   * read cannot re-populate the cache with a now-dead userId. See the guard at
+   * the `userCache.set` site.
+   */
+  private cacheGeneration = 0;
+
   constructor(private prisma: PrismaClient) {
     this.userCache = new TTLCache<ProvisionedUser>({
       ttl: USER_CACHE_TTL_MS,
@@ -136,6 +145,11 @@ export class UserService {
       return cached;
     }
 
+    // Capture the invalidation generation BEFORE the DB read. If an account
+    // deletion evicts this cache while our read is in flight, the generation
+    // moves and the write below is skipped (see the guard there).
+    const generationAtRead = this.cacheGeneration;
+
     try {
       // Try to find existing user
       let user: UserWithMaintenanceFields | null = await this.prisma.user.findUnique({
@@ -158,7 +172,16 @@ export class UserService {
       );
 
       const provisioned: ProvisionedUser = { userId: user.id, defaultPersonaId };
-      this.userCache.set(discordId, provisioned);
+      // TOCTOU guard: if the cache was invalidated for anyone between our
+      // cache-miss and now, an account deletion may have raced our DB read —
+      // the row we read (and `user.id`) could already be dead. Skip the write
+      // rather than re-populate a stale mapping that would FK-violate until the
+      // 1h TTL. Deliberately coarse (any concurrent invalidation, not just this
+      // discordId's, skips the write), but invalidations are rare (deliberate
+      // account deletion) and the next call simply re-reads.
+      if (this.cacheGeneration === generationAtRead) {
+        this.userCache.set(discordId, provisioned);
+      }
       return provisioned;
     } catch (error) {
       logger.error({ err: error, discordId }, 'Failed to get/create user');
@@ -172,13 +195,28 @@ export class UserService {
    * userId — so the next {@link getOrCreateUser} would return the stale id
    * and any write against it (e.g. an export_jobs insert) FK-violates.
    *
-   * This evicts ONE process's cache. Every process runs its own long-lived
-   * UserService (api-gateway AND ai-worker's context pipeline), so the delete
-   * route also broadcasts via `UserCacheInvalidationService` and each process
-   * calls this on the event — see that service for the cross-process wiring.
+   * This evicts ONE process's cache. Coverage today: the api-gateway delete
+   * route calls this synchronously (its own process), then broadcasts via
+   * `UserCacheInvalidationService`; ai-worker subscribes and calls this on the
+   * event. api-gateway itself does NOT subscribe — the synchronous call covers
+   * its single replica. If api-gateway ever runs multiple replicas, it must
+   * subscribe too, or the other replicas' caches stay stale until the TTL.
    */
   invalidateUser(discordId: string): void {
     this.userCache.delete(discordId);
+    this.cacheGeneration++;
+  }
+
+  /**
+   * Evict EVERY entry in this process's provisioning cache. Backs the
+   * cross-process `'all'` invalidation broadcast (bulk admin/migration changes);
+   * a single-user delete uses {@link invalidateUser}. Bumps the same generation
+   * counter so an in-flight {@link getOrCreateUser} read that races the clear
+   * won't re-populate a stale entry.
+   */
+  clearCache(): void {
+    this.userCache.clear();
+    this.cacheGeneration++;
   }
 
   /**

--- a/services/ai-worker/src/cacheInvalidation.test.ts
+++ b/services/ai-worker/src/cacheInvalidation.test.ts
@@ -152,13 +152,17 @@ vi.mock('./services/ApiKeyResolver.js', () => ({
 }));
 
 const mockInvalidateUser = vi.fn();
+const mockClearUserCache = vi.fn();
 vi.mock('@tzurot/identity', () => ({
   PersonalityService: class {},
   PersonaResolver: class {
     clearCache = mockPersonaResolver.clearCache;
     invalidateUserCache = mockPersonaResolver.invalidateUserCache;
   },
-  getOrCreateUserService: () => ({ invalidateUser: mockInvalidateUser }),
+  getOrCreateUserService: () => ({
+    invalidateUser: mockInvalidateUser,
+    clearCache: mockClearUserCache,
+  }),
 }));
 
 // The wallet-update recovery edge calls the worker's credit-exhaustion cache
@@ -321,9 +325,10 @@ describe('setupCacheInvalidation', () => {
       expect(mockInvalidateUser).toHaveBeenCalledWith('user-123');
     });
 
-    it('no-ops on an "all" event (TTL bounds staleness; no bulk-evict API)', async () => {
+    it('clears the whole user provisioning cache on an "all" event', async () => {
       await setupCacheInvalidation({ cacheRedis: mockRedis, prisma: mockPrisma });
       capturedCallbacks.user?.({ type: 'all' });
+      expect(mockClearUserCache).toHaveBeenCalled();
       expect(mockInvalidateUser).not.toHaveBeenCalled();
     });
   });

--- a/services/ai-worker/src/cacheInvalidation.ts
+++ b/services/ai-worker/src/cacheInvalidation.ts
@@ -204,9 +204,9 @@ async function wireApiKeyInvalidation(
  * Wire the UserService provisioning cache to its invalidation channel. Account
  * deletion removes the users row, so ai-worker's long-lived UserService (shared
  * via getOrCreateUserService) must drop the dead discordId→userId mapping or the
- * next generation job FK-violates on the usage-log insert. The 'all' event has
- * no bulk-evict API on the shared instance — a process restart is its only
- * consumer today, and the 1h TTL bounds staleness meanwhile.
+ * next generation job FK-violates on the usage-log insert. The 'all' event
+ * clears the whole cache (bulk admin/migration changes) — same clear-all shape
+ * every sibling resolver above uses; no publisher exists yet.
  */
 async function wireUserCacheInvalidation(
   prisma: PrismaClient,
@@ -216,7 +216,8 @@ async function wireUserCacheInvalidation(
   const userCacheInvalidation = new UserCacheInvalidationService(cacheRedis);
   await userCacheInvalidation.subscribe(event => {
     if (event.type === 'all') {
-      logger.info('User cache "all" invalidation received (no-op; TTL bounds staleness)');
+      getOrCreateUserService(prisma).clearCache();
+      logger.info('Cleared all user provisioning cache entries');
     } else {
       getOrCreateUserService(prisma).invalidateUser(event.discordId);
       logger.info({ discordId: event.discordId }, 'Invalidated user provisioning cache');

--- a/services/api-gateway/src/routes/user/account/delete.test.ts
+++ b/services/api-gateway/src/routes/user/account/delete.test.ts
@@ -6,13 +6,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Request, Response } from 'express';
 
+const loggerWarnMock = vi.hoisted(() => vi.fn());
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
   );
   return {
     ...actual,
-    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: loggerWarnMock, error: vi.fn() }),
   };
 });
 
@@ -248,6 +249,27 @@ describe('Account Deletion Routes', () => {
       const { req, res } = createMockReqRes(VALID_BODY);
       await handleDeleteAccount(makeDeps())(req, res, vi.fn());
 
+      const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+    });
+
+    it('swallows a failed cache broadcast — deletion still returns success', async () => {
+      // The cross-process broadcast fails (Redis publish error), but this
+      // process was already evicted synchronously and the account is gone, so
+      // the response must still succeed. Other processes stay stale until the
+      // 1h TTL — bounded, self-healing.
+      broadcastInvalidateMock.mockRejectedValueOnce(new Error('redis publish failed'));
+      const { req, res } = createMockReqRes(VALID_BODY);
+      await handleDeleteAccount(makeDeps())(req, res, vi.fn());
+
+      // Local eviction still happened; only the broadcast failed.
+      expect(invalidateUserMock).toHaveBeenCalledWith('discord-user-123');
+      expect(broadcastInvalidateMock).toHaveBeenCalledWith('discord-user-123');
+      // Failure is warn-logged, not surfaced.
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        expect.stringContaining('broadcast failed')
+      );
       const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(payload.success).toBe(true);
     });

--- a/services/api-gateway/src/routes/user/account/delete.ts
+++ b/services/api-gateway/src/routes/user/account/delete.ts
@@ -228,6 +228,13 @@ export const handleDeleteAccount = (deps: RouteDeps): RequestHandler =>
     try {
       await new UserCacheInvalidationService(redis).invalidateUser(discordUserId);
     } catch (error) {
+      // Swallowed on purpose: THIS process was evicted synchronously above and
+      // the account is already gone, so the delete must still return 200. Blast
+      // radius of a failed broadcast: other processes' UserService caches (e.g.
+      // ai-worker's context pipeline) stay stale until the 1h TTL expires — a
+      // queued generation job for this discordId in that window can still
+      // FK-violate on the usage-log insert. Bounded and self-healing; not worth
+      // failing the deletion over.
       logger.warn({ err: error }, 'Post-deletion user-cache broadcast failed');
     }
 


### PR DESCRIPTION
Closes the three review follow-ups filed against #1658 (account-deletion cache eviction).

## TOCTOU race on cache re-population (r4 follow-up)

A `getOrCreateUser()` that read the still-live `users` row **before** the delete transaction committed could run its `userCache.set()` **after** the delete route's `invalidateUser()` — re-populating the shared cache with the now-dead userId and reopening the FK-violation class for that discordId until the 1h TTL.

Fix: `UserService` tracks a monotonic `cacheGeneration`, bumped on every invalidation. `getOrCreateUser` captures it before the DB read and skips the cache write if it moved. Deliberately coarse (any concurrent invalidation skips the write) — deletions are rare and deliberate, and the next call simply re-reads. Test simulates the race by firing `invalidateUser` from inside the mocked `findUnique`.

## `invalidateAll()` was a silent no-op + inaccurate comment (r4 follow-up)

ai-worker's subscriber logged-and-ignored the `'all'` event, justified by a "no bulk-evict API on the shared instance" comment — inaccurate, since `TTLCache` exposes `clear()`. `UserService` gains `clearCache()` (which also bumps the generation), and the `'all'` branch now calls it — the same clear-all shape every sibling resolver in `setupCacheInvalidation` already uses. No publisher exists yet; a future admin/migration tool calling `invalidateAll()` now actually works instead of silently no-oping.

## Untested broadcast-failure catch (r4 follow-up)

The delete route's cross-process broadcast catch (swallow + warn; the account is already gone, the response must stay 200) had no test. Added one (rejects the publish, asserts warn-logged + 200 + local eviction still ran), and the catch now documents its blast radius: other processes stay stale up to the 1h TTL, during which the FK-violation class can still occur — bounded and self-healing.

## Verification

- `pnpm --filter @tzurot/identity test` (172) + `pnpm --filter @tzurot/ai-worker test` (3978) + `pnpm --filter @tzurot/api-gateway test` (2474) — green
- `pnpm quality` — green (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)