### PR TITLE
fix: memoryLimit-0 semantics, atomic prune, export stuck-pending, atLimit telemetry

### DIFF
--- a/services/ai-worker/src/services/MemoryRetriever.test.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.test.ts
@@ -872,6 +872,38 @@ describe('MemoryRetriever', () => {
         );
       });
 
+      it('skips retrieval entirely when cascade memoryLimit is 0 (disabled)', async () => {
+        mockPersonaResolver.resolveForMemory.mockResolvedValue({
+          personaId: 'persona-123',
+          focusModeEnabled: false,
+        });
+
+        const disabledOverrides: ResolvedConfigOverrides = {
+          ...cascadeOverrides,
+          memoryLimit: 0,
+        };
+
+        const result = await retriever.retrieveRelevantMemories(
+          mockPersonality,
+          'test query',
+          context,
+          disabledOverrides
+        );
+
+        // 0 must mean "no memories", not "fall through to a downstream
+        // default" — the query builder treats a non-positive limit as
+        // "use the default", so the skip has to happen here. personaId must
+        // be ABSENT like every other skip branch: the fact-retrieval path
+        // gates on it, so its omission is what keeps facts (distilled
+        // memories) suppressed together with the memories.
+        expect(result).toEqual({
+          memories: [],
+          focusModeEnabled: false,
+        });
+        expect(result.personaId).toBeUndefined();
+        expect(mockMemoryManager.queryMemories).not.toHaveBeenCalled();
+      });
+
       it('should use cascade focusModeEnabled over DB column value', async () => {
         mockPersonaResolver.resolveForMemory.mockResolvedValue({
           personaId: 'persona-123',

--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -33,8 +33,9 @@ export interface MemoryRetrievalResult {
   /**
    * The resolved persona for this turn — present ONLY when LTM retrieval
    * actually ran. Undefined when retrieval was skipped (incognito, focus mode,
-   * or no persona), so the fact-retrieval path (Phase 2 slice 4a) inherits the
-   * exact same scope AND the same skip decisions from one source of truth.
+   * memoryLimit 0, or no persona), so the fact-retrieval path (Phase 2 slice
+   * 4a) inherits the exact same scope AND the same skip decisions from one
+   * source of truth.
    */
   personaId?: string;
 }
@@ -234,6 +235,22 @@ export class MemoryRetriever {
     const effectiveScoreThreshold =
       configOverrides?.memoryScoreThreshold ?? AI_DEFAULTS.MEMORY_SCORE_THRESHOLD;
 
+    // memoryLimit: 0 means "LTM retrieval disabled" (the schema documents it;
+    // same off-semantics as maxImages: 0). Return here rather than passing
+    // limit: 0 downstream — PgvectorQueryBuilder treats a non-positive limit
+    // as "use the default" and would silently retrieve memories anyway.
+    // personaId is deliberately OMITTED, like every other skip branch: the
+    // fact-retrieval path gates on it, so facts (distilled memories) stay
+    // suppressed together with the memories they derive from — full parity
+    // with the focus-mode skip.
+    if (effectiveMemoryLimit === 0) {
+      logger.info(
+        { userId: context.userId, personalityId: personality.id },
+        '[MemoryRetriever] memoryLimit is 0 - skipping LTM retrieval (memories still being saved)'
+      );
+      return { memories: [], focusModeEnabled: false };
+    }
+
     const memoryQueryOptions: MemoryQueryOptions = {
       personaId,
       personalityId: shareLtmAcrossPersonalities ? undefined : personality.id,
@@ -255,26 +272,34 @@ export class MemoryRetriever {
       );
     }
 
-    // Query memories only if memory manager is available.
-    //
-    // Storage→RAG boundary: `queryMemories*` returns `PgvectorMemoryDocument[]`
-    // (wider `metadata?: Record<string, unknown>`), assigned here into the
-    // RAG-layer `MemoryDocument[]` shape (narrower typed metadata). The two
-    // are structurally compatible because all RAG-layer metadata fields are
-    // optional — see `PgvectorTypes.ts` for the change-together invariant.
-    const relevantMemories =
-      this.memoryManager !== undefined
-        ? memoryQueryOptions.channelIds !== undefined && memoryQueryOptions.channelIds.length > 0
-          ? await this.memoryManager.queryMemoriesWithChannelScoping(
-              userMessage,
-              memoryQueryOptions
-            )
-          : await this.memoryManager.queryMemories(userMessage, memoryQueryOptions)
-        : [];
+    const relevantMemories = await this.runMemoryQuery(userMessage, memoryQueryOptions);
 
     this.logRetrievedMemories(relevantMemories, personality.name);
 
     return { memories: relevantMemories, focusModeEnabled: false, personaId };
+  }
+
+  /**
+   * Run the vector query, dispatching channel-scoped vs plain retrieval.
+   * Returns empty when no memory manager is configured.
+   *
+   * Storage→RAG boundary: `queryMemories*` returns `PgvectorMemoryDocument[]`
+   * (wider `metadata?: Record<string, unknown>`), assigned here into the
+   * RAG-layer `MemoryDocument[]` shape (narrower typed metadata). The two
+   * are structurally compatible because all RAG-layer metadata fields are
+   * optional — see `PgvectorTypes.ts` for the change-together invariant.
+   */
+  private async runMemoryQuery(
+    userMessage: string,
+    options: MemoryQueryOptions
+  ): Promise<MemoryDocument[]> {
+    if (this.memoryManager === undefined) {
+      return [];
+    }
+    const channelScoped = options.channelIds !== undefined && options.channelIds.length > 0;
+    return channelScoped
+      ? this.memoryManager.queryMemoriesWithChannelScoping(userMessage, options)
+      : this.memoryManager.queryMemories(userMessage, options);
   }
 
   /**

--- a/services/api-gateway/src/routes/internal/usersRecent.test.ts
+++ b/services/api-gateway/src/routes/internal/usersRecent.test.ts
@@ -10,6 +10,7 @@ vi.mock('@tzurot/common-types/utils/outboundDmAllowlist', () => ({
   getOutboundDmAllowlist: () => allowlistMock.value,
 }));
 
+const loggerInfoMock = vi.hoisted(() => vi.fn());
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
@@ -17,7 +18,7 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   return {
     ...actual,
     createLogger: () => ({
-      info: vi.fn(),
+      info: loggerInfoMock,
       debug: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
@@ -133,6 +134,28 @@ describe('GET /internal/users/recent', () => {
 
     expect(response.status).toBe(500);
     expect(mockPrisma.$queryRaw).toHaveBeenCalled();
+  });
+
+  it('logs atLimit from the RAW query count, not the post-allowlist count', async () => {
+    // The regression this guards: atLimit computed after the allowlist filter
+    // reads false on dev-with-gate even when the query itself hit MAX_RESULTS,
+    // hiding "rows may have been clipped" from quarantine investigations.
+    const MAX_RESULTS = 1000;
+    mockPrisma.$queryRaw.mockResolvedValue(
+      Array.from({ length: MAX_RESULTS }, (_, i) => ({
+        discord_id: `${100000000000000000n + BigInt(i)}`,
+      }))
+    );
+    allowlistMock.value = new Set(['100000000000000000']); // trims to 1
+
+    const response = await request(app).get('/internal/users/recent');
+
+    expect(response.status).toBe(200);
+    expect(response.body.discordIds).toEqual(['100000000000000000']);
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({ total: 1, atLimit: true }),
+      'Returning recent active users'
+    );
   });
 
   it('filters non-snowflake discord_ids from the DB result and warns', async () => {

--- a/services/api-gateway/src/routes/internal/usersRecent.ts
+++ b/services/api-gateway/src/routes/internal/usersRecent.ts
@@ -84,6 +84,12 @@ export const handleRecentUsers = (deps: RouteDeps): RequestHandler => {
 
     const allIds = rows.map(r => r.discord_id);
 
+    // Snapshot BEFORE the snowflake + allowlist filters below: atLimit means
+    // "the QUERY hit MAX_RESULTS" (rows may have been clipped). Computing it
+    // from the post-filter count under-reports — on dev with the allowlist
+    // gate active it reads false even when the query clipped.
+    const atLimit = rows.length === MAX_RESULTS;
+
     // Filter non-snowflake IDs before schema validation. The DB stores
     // snowflakes by schema (`discord_id @db.VarChar(20)`), so this guards
     // against a near-zero data-drift scenario (migration leakage, test
@@ -115,14 +121,11 @@ export const handleRecentUsers = (deps: RouteDeps): RequestHandler => {
 
     const parsed = RecentUsersResponseSchema.parse({ discordIds, sinceDays });
 
-    // `atLimit: true` means the result count equals MAX_RESULTS. That's the
-    // signal LIMIT clipped — but technically also true if exactly MAX_RESULTS
-    // users were active in the window with no extras. Use as a "rows may
-    // have been dropped" indicator, not an absolute truth.
-    logger.info(
-      { sinceDays, total: discordIds.length, atLimit: discordIds.length === MAX_RESULTS },
-      'Returning recent active users'
-    );
+    // `atLimit: true` means the raw query returned exactly MAX_RESULTS rows.
+    // That's the signal LIMIT clipped — but technically also true if exactly
+    // MAX_RESULTS users were active in the window with no extras. Use as a
+    // "rows may have been dropped" indicator, not an absolute truth.
+    logger.info({ sinceDays, total: discordIds.length, atLimit }, 'Returning recent active users');
 
     sendCustomSuccess(res, parsed, StatusCodes.OK);
   });

--- a/services/api-gateway/src/routes/user/account/export.ts
+++ b/services/api-gateway/src/routes/user/account/export.ts
@@ -29,6 +29,7 @@ import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js'
 import { parseBodyOrSendError } from '../../../utils/configRouteHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
 import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
+import { enqueueExportJobOrMarkFailed } from '../../../utils/enqueueExportJob.js';
 import type { ProvisionedRequest } from '../../../types.js';
 import type { RouteDeps } from '../../routeDeps.js';
 
@@ -202,10 +203,15 @@ function createStartExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: s
     // ACTIVE jobs; BullMQ dedups by jobId, and a deterministic ID would make
     // re-exports after completion silently ignored.
     const jobId = `${JOB_PREFIXES.ACCOUNT_EXPORT}${exportJobId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    await queue.add(JobType.AccountExport, jobData, {
-      jobId,
-      attempts: 3,
-      backoff: { type: 'exponential', delay: 5_000 },
+    // The row above is already committed 'pending'; an enqueue failure must
+    // mark it 'failed' or it 409s every retry until the 24h expiry.
+    await enqueueExportJobOrMarkFailed({
+      queue,
+      prisma,
+      exportJobId,
+      jobName: JobType.AccountExport,
+      jobData,
+      jobOptions: { jobId, attempts: 3, backoff: { type: 'exponential', delay: 5_000 } },
     });
 
     logger.info({ userId, exportJobId }, 'Account export job created');

--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -113,6 +113,7 @@ const mockPrisma = {
     update: vi.fn(),
     upsert: vi.fn(),
     delete: vi.fn(),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
   },
 };
 
@@ -572,16 +573,13 @@ describe('/user/config-overrides routes', () => {
 
     it('prunes the anchor row when a merge-to-empty PATCH leaves every slice null', async () => {
       // Existing row's only slice was a single override key; PATCH clears it.
-      mockPrisma.userPersonalityConfig.findUnique
-        .mockResolvedValueOnce({ configOverrides: { maxMessages: 25 } }) // route's pre-merge read
-        .mockResolvedValueOnce({
-          personaId: null,
-          llmConfigId: null,
-          visionConfigId: null,
-          ttsConfigId: null,
-          configOverrides: null,
-        }); // prune's slice read — all null after the merge cleared the last key
+      // The prune itself is one atomic deleteMany (no slice re-read) — the
+      // all-null predicate lives in its WHERE.
+      mockPrisma.userPersonalityConfig.findUnique.mockResolvedValueOnce({
+        configOverrides: { maxMessages: 25 },
+      }); // route's pre-merge read
       mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({});
+      mockPrisma.userPersonalityConfig.deleteMany.mockResolvedValue({ count: 1 });
 
       const router = createConfigOverrideRoutes(mockDeps);
       const handler = getHandler(router, 'patch', '/:personalityId');
@@ -592,7 +590,9 @@ describe('/user/config-overrides routes', () => {
 
       await handler(req, res);
 
-      expect(mockPrisma.userPersonalityConfig.delete).toHaveBeenCalled();
+      expect(mockPrisma.userPersonalityConfig.deleteMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({ personaId: null, llmConfigId: null }),
+      });
       expect(res.status).toHaveBeenCalledWith(200);
     });
 

--- a/services/api-gateway/src/routes/user/memory.test.ts
+++ b/services/api-gateway/src/routes/user/memory.test.ts
@@ -73,6 +73,7 @@ const mockPrisma = {
   userPersonalityConfig: {
     findUnique: vi.fn(),
     upsert: vi.fn(),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
   },
   memory: {
     count: vi.fn(),

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -61,6 +61,7 @@ const mockPrisma = {
     upsert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
   },
   $executeRaw: vi.fn().mockResolvedValue(1),
   $transaction: vi.fn().mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {

--- a/services/api-gateway/src/routes/user/persona/override.test.ts
+++ b/services/api-gateway/src/routes/user/persona/override.test.ts
@@ -252,14 +252,12 @@ describe('persona override routes', () => {
   });
 
   describe('DELETE /user/persona/override/:personalitySlug', () => {
-    it('clears the persona slice and prunes the row when no other slice remains', async () => {
+    it('clears the persona slice and issues the atomic all-null prune', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: MOCK_PERSONALITY_ID,
         name: 'Lilith',
         displayName: 'Lilith the Succubus',
       });
-      // Route reads the row (id), then the prune re-reads the full slice set —
-      // both hit this mock; an all-null slice set means the prune deletes.
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue({
         id: 'config-1',
         personaId: null,
@@ -269,7 +267,7 @@ describe('persona override routes', () => {
         configOverrides: null,
       });
       mockPrisma.userPersonalityConfig.update.mockResolvedValue({});
-      mockPrisma.userPersonalityConfig.delete.mockResolvedValue({});
+      mockPrisma.userPersonalityConfig.deleteMany.mockResolvedValue({ count: 1 });
 
       const handler = handleClearPersonaOverride({
         ...stubRouteResolvers(),
@@ -282,8 +280,10 @@ describe('persona override routes', () => {
       expect(mockPrisma.userPersonalityConfig.update).toHaveBeenCalledWith(
         expect.objectContaining({ data: { personaId: null } })
       );
-      expect(mockPrisma.userPersonalityConfig.delete).toHaveBeenCalledWith({
-        where: { id: 'config-1' },
+      // The prune is a single deleteMany whose WHERE carries the empty-slice
+      // predicate — whether the row survives is decided by the DB, atomically.
+      expect(mockPrisma.userPersonalityConfig.deleteMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({ id: 'config-1', personaId: null }),
       });
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -298,7 +298,7 @@ describe('persona override routes', () => {
       );
     });
 
-    it('clears the persona slice but keeps the row when another slice is set', async () => {
+    it('clears the persona slice; the prune predicate leaves non-empty rows alone', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: MOCK_PERSONALITY_ID,
         name: 'Lilith',
@@ -313,6 +313,8 @@ describe('persona override routes', () => {
         configOverrides: null,
       });
       mockPrisma.userPersonalityConfig.update.mockResolvedValue({});
+      // The WHERE won't match this row (llmConfigId still set) — the DB keeps it.
+      mockPrisma.userPersonalityConfig.deleteMany.mockResolvedValue({ count: 0 });
 
       const handler = handleClearPersonaOverride({
         ...stubRouteResolvers(),
@@ -328,6 +330,10 @@ describe('persona override routes', () => {
           data: { personaId: null },
         })
       );
+      // The guarded predicate must be present — that's what keeps the row.
+      expect(mockPrisma.userPersonalityConfig.deleteMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({ id: 'config-1', llmConfigId: null }),
+      });
       expect(mockPrisma.userPersonalityConfig.delete).not.toHaveBeenCalled();
     });
 

--- a/services/api-gateway/src/routes/user/persona/test-utils.ts
+++ b/services/api-gateway/src/routes/user/persona/test-utils.ts
@@ -81,6 +81,7 @@ interface MockPrismaClient {
     upsert: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
   };
   $transaction: ReturnType<typeof vi.fn>;
 }
@@ -116,6 +117,7 @@ export function createMockPrisma(): MockPrismaClient {
       upsert: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
     // Pass-through transaction: the callback runs against the same mock,
     // so individual model calls (persona.create, userPersonalityConfig.upsert)

--- a/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.component.test.ts
+++ b/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.component.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Component test: the atomic prune's WHERE against REAL Postgres JSONB
+ * semantics (PGLite). The unit test can only assert the predicate's shape;
+ * this proves `Prisma.AnyNull` actually matches BOTH null representations the
+ * configOverrides slice can hold — SQL NULL (never set) and JSON null (what
+ * the clear paths write via Prisma.JsonNull) — and that any live slice keeps
+ * the row.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { type PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { Prisma, PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
+
+const USER_ID = 'aa1e0000-0000-4000-8000-0000000000a1';
+const PERSONA_ID = 'aa1e0000-0000-4000-8000-0000000000a2';
+// One anchor row per (user, personality) — unique pair constraint — so each
+// test row gets its own personality.
+const PERSONALITY_IDS = [
+  'aa1e0000-0000-4000-8000-0000000000c1',
+  'aa1e0000-0000-4000-8000-0000000000c2',
+  'aa1e0000-0000-4000-8000-0000000000c3',
+  'aa1e0000-0000-4000-8000-0000000000c4',
+] as const;
+const DISCORD_ID = '900000000000000081';
+
+const ROW_SQL_NULL = 'aa1e0000-0000-4000-8000-000000000101';
+const ROW_JSON_NULL = 'aa1e0000-0000-4000-8000-000000000102';
+const ROW_LIVE_OVERRIDES = 'aa1e0000-0000-4000-8000-000000000103';
+const ROW_LIVE_PERSONA = 'aa1e0000-0000-4000-8000-000000000104';
+
+describe('pruneEmptyPersonalityConfig (component, PGLite)', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+
+    await seedUserWithPersona(prisma, {
+      userId: USER_ID,
+      personaId: PERSONA_ID,
+      discordId: DISCORD_ID,
+      username: 'pruneuser',
+      personaName: 'Prune Persona',
+      personaContent: 'content',
+    });
+    for (const [i, personalityId] of PERSONALITY_IDS.entries()) {
+      await prisma.personality.create({
+        data: {
+          id: personalityId,
+          name: `Prune Personality ${i + 1}`,
+          slug: `prune-personality-${i + 1}`,
+          ownerId: USER_ID,
+          characterInfo: '',
+          personalityTraits: '',
+        },
+      });
+    }
+
+    // Never-set slice: configOverrides is SQL NULL.
+    await prisma.userPersonalityConfig.create({
+      data: { id: ROW_SQL_NULL, userId: USER_ID, personalityId: PERSONALITY_IDS[0] },
+    });
+    // Cleared slice: configOverrides is JSON null — exactly what the clear
+    // paths write (Prisma.JsonNull). This is the case a plain `null` filter
+    // would MISS; AnyNull must match it.
+    await prisma.userPersonalityConfig.create({
+      data: {
+        id: ROW_JSON_NULL,
+        userId: USER_ID,
+        personalityId: PERSONALITY_IDS[1],
+        configOverrides: Prisma.JsonNull,
+      },
+    });
+    // Live JSONB slice: must survive the prune.
+    await prisma.userPersonalityConfig.create({
+      data: {
+        id: ROW_LIVE_OVERRIDES,
+        userId: USER_ID,
+        personalityId: PERSONALITY_IDS[2],
+        configOverrides: { maxMessages: 25 },
+      },
+    });
+    // Live scalar slice: must survive the prune.
+    await prisma.userPersonalityConfig.create({
+      data: {
+        id: ROW_LIVE_PERSONA,
+        userId: USER_ID,
+        personalityId: PERSONALITY_IDS[3],
+        personaId: PERSONA_ID,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  });
+
+  it('deletes a row whose configOverrides is SQL NULL (never set)', async () => {
+    const pruned = await pruneEmptyPersonalityConfig(prisma, ROW_SQL_NULL);
+
+    expect(pruned).toBe(true);
+    const row = await prisma.userPersonalityConfig.findUnique({ where: { id: ROW_SQL_NULL } });
+    expect(row).toBeNull();
+  });
+
+  it('deletes a row whose configOverrides is JSON null (cleared via JsonNull)', async () => {
+    const pruned = await pruneEmptyPersonalityConfig(prisma, ROW_JSON_NULL);
+
+    expect(pruned).toBe(true);
+    const row = await prisma.userPersonalityConfig.findUnique({ where: { id: ROW_JSON_NULL } });
+    expect(row).toBeNull();
+  });
+
+  it('keeps a row with live configOverrides JSONB', async () => {
+    const pruned = await pruneEmptyPersonalityConfig(prisma, ROW_LIVE_OVERRIDES);
+
+    expect(pruned).toBe(false);
+    const row = await prisma.userPersonalityConfig.findUnique({
+      where: { id: ROW_LIVE_OVERRIDES },
+    });
+    expect(row).not.toBeNull();
+  });
+
+  it('keeps a row with a live scalar slice (personaId set)', async () => {
+    const pruned = await pruneEmptyPersonalityConfig(prisma, ROW_LIVE_PERSONA);
+
+    expect(pruned).toBe(false);
+    const row = await prisma.userPersonalityConfig.findUnique({
+      where: { id: ROW_LIVE_PERSONA },
+    });
+    expect(row).not.toBeNull();
+  });
+});

--- a/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.test.ts
+++ b/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.test.ts
@@ -1,51 +1,44 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
 
-const findUnique = vi.fn();
-const del = vi.fn();
+const deleteMany = vi.fn();
 const prisma = {
-  userPersonalityConfig: { findUnique, delete: del },
+  userPersonalityConfig: { deleteMany },
 } as unknown as PrismaClient;
-
-const ALL_NULL = {
-  personaId: null,
-  llmConfigId: null,
-  visionConfigId: null,
-  ttsConfigId: null,
-  configOverrides: null,
-};
 
 describe('pruneEmptyPersonalityConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    del.mockResolvedValue({});
   });
 
-  it('deletes the row when every slice is null', async () => {
-    findUnique.mockResolvedValue(ALL_NULL);
+  it('issues one atomic delete whose WHERE carries every all-null slice', async () => {
+    deleteMany.mockResolvedValue({ count: 1 });
 
     const pruned = await pruneEmptyPersonalityConfig(prisma, 'row-1');
 
     expect(pruned).toBe(true);
-    expect(del).toHaveBeenCalledWith({ where: { id: 'row-1' } });
+    // The WHERE is the whole safety story: the id AND all five slices must be
+    // in the predicate (atomicity), and the JSONB slice must use AnyNull so
+    // both never-set (SQL NULL) and cleared (Prisma.JsonNull) rows match.
+    expect(deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: 'row-1',
+        personaId: null,
+        llmConfigId: null,
+        visionConfigId: null,
+        ttsConfigId: null,
+        configOverrides: { equals: Prisma.AnyNull },
+      },
+    });
   });
 
-  it('keeps the row when any slice is still set', async () => {
-    findUnique.mockResolvedValue({ ...ALL_NULL, ttsConfigId: 'tts-1' });
+  it('reports false when zero rows matched (non-empty row or already gone)', async () => {
+    deleteMany.mockResolvedValue({ count: 0 });
 
     const pruned = await pruneEmptyPersonalityConfig(prisma, 'row-1');
 
     expect(pruned).toBe(false);
-    expect(del).not.toHaveBeenCalled();
-  });
-
-  it('is a no-op when the row is already gone', async () => {
-    findUnique.mockResolvedValue(null);
-
-    const pruned = await pruneEmptyPersonalityConfig(prisma, 'row-1');
-
-    expect(pruned).toBe(false);
-    expect(del).not.toHaveBeenCalled();
+    expect(deleteMany).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.ts
+++ b/services/api-gateway/src/routes/user/pruneEmptyPersonalityConfig.ts
@@ -3,31 +3,39 @@
  * slice null. Without this, set-then-clear accumulates dead anchor rows that
  * resolve to nothing and clutter data exports.
  *
- * Call AFTER the clear's `update`. The re-read → conditional-delete race
- * against a concurrent set is benign (single-user sequential command flow;
- * worst case a just-re-set row is dropped and re-created on next use).
+ * Call AFTER the clear's `update`. The all-null predicate lives in the WHERE,
+ * so the check-and-delete is one atomic statement — a concurrent set between
+ * "read the row" and "delete it" cannot lose its write (`deleteMany` simply
+ * matches zero rows).
  */
 
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { isEmptyPersonalityConfig } from '@tzurot/common-types/utils/personalityConfigShape';
+import { Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { type PersonalityConfigSlices } from '@tzurot/common-types/utils/personalityConfigShape';
+
+/**
+ * The SQL-side twin of `isEmptyPersonalityConfig` (the export filter's JS
+ * predicate). `satisfies` ties the field list to the shared
+ * {@link PersonalityConfigSlices} shape, so adding a new slice breaks this
+ * predicate at compile time instead of silently widening what "empty" means.
+ *
+ * `AnyNull` is required for the JSONB slice: the clear paths write
+ * `Prisma.JsonNull` (a JSON null value), while a never-set slice is SQL NULL —
+ * a plain `null` filter would miss the cleared rows entirely.
+ */
+const EMPTY_SLICES_WHERE = {
+  personaId: null,
+  llmConfigId: null,
+  visionConfigId: null,
+  ttsConfigId: null,
+  configOverrides: { equals: Prisma.AnyNull },
+} satisfies Record<keyof PersonalityConfigSlices, unknown>;
 
 export async function pruneEmptyPersonalityConfig(
   prisma: PrismaClient,
   id: string
 ): Promise<boolean> {
-  const row = await prisma.userPersonalityConfig.findUnique({
-    where: { id },
-    select: {
-      personaId: true,
-      llmConfigId: true,
-      visionConfigId: true,
-      ttsConfigId: true,
-      configOverrides: true,
-    },
+  const deleted = await prisma.userPersonalityConfig.deleteMany({
+    where: { id, ...EMPTY_SLICES_WHERE },
   });
-  if (row === null || !isEmptyPersonalityConfig(row)) {
-    return false;
-  }
-  await prisma.userPersonalityConfig.delete({ where: { id } });
-  return true;
+  return deleted.count > 0;
 }

--- a/services/api-gateway/src/routes/user/shapes/export.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.ts
@@ -29,6 +29,7 @@ import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js'
 import { parseBodyOrSendError } from '../../../utils/configRouteHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
 import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
+import { enqueueExportJobOrMarkFailed } from '../../../utils/enqueueExportJob.js';
 import type { ProvisionedRequest } from '../../../types.js';
 import type { RouteDeps } from '../../routeDeps.js';
 
@@ -198,10 +199,15 @@ function createExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: string
     // prevents true duplicate jobs, but BullMQ deduplicates by jobId — a deterministic ID
     // would cause retries of completed/failed exports to be silently ignored by BullMQ.
     const jobId = `${JOB_PREFIXES.SHAPES_EXPORT}${exportJobId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    await queue.add(JobType.ShapesExport, jobData, {
-      jobId,
-      attempts: 5,
-      backoff: { type: 'exponential', delay: 5_000 },
+    // The row above is already committed 'pending'; an enqueue failure must
+    // mark it 'failed' or it 409s every retry until the 24h expiry.
+    await enqueueExportJobOrMarkFailed({
+      queue,
+      prisma,
+      exportJobId,
+      jobName: JobType.ShapesExport,
+      jobData,
+      jobOptions: { jobId, attempts: 5, backoff: { type: 'exponential', delay: 5_000 } },
     });
 
     logger.info(

--- a/services/api-gateway/src/routes/user/tts-override.test.ts
+++ b/services/api-gateway/src/routes/user/tts-override.test.ts
@@ -110,6 +110,7 @@ const mockPrisma = {
     upsert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
   },
   user: {
     findUnique: vi.fn(),

--- a/services/api-gateway/src/utils/enqueueExportJob.test.ts
+++ b/services/api-gateway/src/utils/enqueueExportJob.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Queue } from 'bullmq';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+
+const loggerWarnMock = vi.hoisted(() => vi.fn());
+const loggerErrorMock = vi.hoisted(() => vi.fn());
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: loggerWarnMock,
+      error: loggerErrorMock,
+    }),
+  };
+});
+
+import { enqueueExportJobOrMarkFailed } from './enqueueExportJob.js';
+
+const queueAdd = vi.fn();
+const exportJobUpdate = vi.fn();
+const queue = { add: queueAdd } as unknown as Queue;
+const prisma = { exportJob: { update: exportJobUpdate } } as unknown as PrismaClient;
+
+const OPTS = {
+  queue,
+  prisma,
+  exportJobId: 'export-1',
+  jobName: 'AccountExport',
+  jobData: { userId: 'u1', exportJobId: 'export-1' },
+  jobOptions: { jobId: 'job-1', attempts: 3 },
+};
+
+describe('enqueueExportJobOrMarkFailed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queueAdd.mockResolvedValue({});
+    exportJobUpdate.mockResolvedValue({});
+  });
+
+  it('passes name, data, and options through to queue.add on success', async () => {
+    await enqueueExportJobOrMarkFailed(OPTS);
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      'AccountExport',
+      { userId: 'u1', exportJobId: 'export-1' },
+      { jobId: 'job-1', attempts: 3 }
+    );
+    expect(exportJobUpdate).not.toHaveBeenCalled();
+  });
+
+  it('marks the row failed and rethrows when the enqueue throws', async () => {
+    queueAdd.mockRejectedValue(new Error('redis connection refused'));
+
+    await expect(enqueueExportJobOrMarkFailed(OPTS)).rejects.toThrow('redis connection refused');
+
+    // The whole point: the pending row must not be left to 409 until expiry.
+    // The stored message must be GENERIC — the shapes list route returns
+    // errorMessage verbatim to users, so the raw error (which can carry
+    // connection detail) must never be written to the row.
+    expect(exportJobUpdate).toHaveBeenCalledWith({
+      where: { id: 'export-1' },
+      data: {
+        status: 'failed',
+        errorMessage: 'Failed to queue the export job — please retry.',
+      },
+    });
+    const storedMessage = exportJobUpdate.mock.calls[0][0].data.errorMessage as string;
+    expect(storedMessage).not.toContain('redis connection refused');
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), exportJobId: 'export-1' }),
+      expect.stringContaining('marked failed')
+    );
+  });
+
+  it('still rethrows the ORIGINAL error when the failure-marking update also fails', async () => {
+    queueAdd.mockRejectedValue(new Error('redis connection refused'));
+    exportJobUpdate.mockRejectedValue(new Error('db also down'));
+
+    await expect(enqueueExportJobOrMarkFailed(OPTS)).rejects.toThrow('redis connection refused');
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), exportJobId: 'export-1' }),
+      expect.stringContaining('409 until expiry')
+    );
+  });
+});

--- a/services/api-gateway/src/utils/enqueueExportJob.ts
+++ b/services/api-gateway/src/utils/enqueueExportJob.ts
@@ -1,0 +1,58 @@
+/**
+ * Enqueue an export's BullMQ work item AFTER its export_jobs row was committed
+ * 'pending'. If the enqueue throws (Redis blip), the pending row would
+ * otherwise sit forever — 409ing every retry as "already in progress" until
+ * the 24h expiry, with no job ever coming (the deterministic job UUID that
+ * makes re-exports idempotent is also what makes the stuck row sticky).
+ * Marking the row 'failed' lets the user immediately re-run instead.
+ *
+ * The original enqueue error is rethrown either way, so the route's error
+ * handling surfaces the failure to the caller.
+ */
+
+import { type Queue, type JobsOptions } from 'bullmq';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+
+const logger = createLogger('enqueueExportJob');
+
+export async function enqueueExportJobOrMarkFailed(opts: {
+  queue: Queue;
+  prisma: PrismaClient;
+  exportJobId: string;
+  jobName: string;
+  jobData: unknown;
+  jobOptions: JobsOptions;
+}): Promise<void> {
+  const { queue, prisma, exportJobId, jobName, jobData, jobOptions } = opts;
+  try {
+    await queue.add(jobName, jobData, jobOptions);
+  } catch (error) {
+    // Best-effort failure-marking: if this update ALSO fails (DB blip on top
+    // of the Redis blip), the original error still propagates and the row
+    // falls back to the old stuck-pending-until-expiry behavior.
+    try {
+      await prisma.exportJob.update({
+        where: { id: exportJobId },
+        data: {
+          status: 'failed',
+          // Deliberately generic: the shapes list route returns errorMessage
+          // verbatim to the user, so a raw enqueue error (which can carry
+          // connection detail) must not be written here. The full error is
+          // warn-logged below for the operator.
+          errorMessage: 'Failed to queue the export job — please retry.',
+        },
+      });
+      logger.warn(
+        { err: error, exportJobId, jobName },
+        'Export enqueue failed - job row marked failed so the user can re-run'
+      );
+    } catch (markError) {
+      logger.error(
+        { err: markError, exportJobId, jobName },
+        'Failed to mark export row failed after enqueue error - row will 409 until expiry'
+      );
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
Four small fixes from the this-release review-nit burn-down.

## memoryLimit: 0 now actually disables LTM retrieval (ai-worker)

The schema documents `memoryLimit: 0` as "disabled" (same off-semantics as `maxImages: 0`), but `0` survived the `??` fallback in `MemoryRetriever`, reached `PgvectorQueryBuilder`, and its non-positive-limit guard silently substituted the default of 10 — a user disabling memories got **ten memories instead of none**. Fixed with an early return mirroring the focus-mode skip (memories still get saved); the query-builder guard stays as a backstop. Surfaced by #1660's review sanity-check across the three `AI_DEFAULTS.MEMORY_*` consumers.

## Atomic empty-anchor prune (#1657 follow-up, owner-approved)

`pruneEmptyPersonalityConfig` was read-then-delete (round-trip + TOCTOU window where a concurrent set could lose its row). The all-null predicate now lives in one `deleteMany` WHERE — atomic, one query, self-guarding. Notable details:
- The JSONB slice filters with `Prisma.AnyNull` — clear paths write `Prisma.JsonNull` (JSON null) while never-set slices are SQL NULL; a plain `null` filter would miss every cleared row.
- The predicate's field list is tied to the shared `PersonalityConfigSlices` shape via `satisfies`, so adding a slice breaks it at compile time instead of silently widening "empty".

## Export routes: stuck-pending row when enqueue fails (#1653 follow-up)

Both export routes commit the `export_jobs` row 'pending' in a transaction, then `queue.add`. An enqueue throw (Redis blip) left a permanently-pending row that 409'd every retry until the 24h expiry with no job ever coming. New shared `enqueueExportJobOrMarkFailed` helper marks the row 'failed' (server-side error message) and rethrows, so the user can immediately re-run. One fix covers both routes.

## atLimit telemetry accuracy (#1650 follow-up)

`usersRecent`'s `atLimit` log field was computed post-allowlist-filter, so on dev-with-gate it read `false` even when the query hit MAX_RESULTS. Now snapshotted from the raw query row count. (The entry's second half — caching the allowlist env parse — stays gated on "moves into a hotter path", which hasn't fired.)

## Also investigated, no code change

**ChannelSettings dead-anchor scrutiny** (#1657 follow-up, owner-requested): the accumulation pattern IS reachable, but unlike UserPersonalityConfig, row existence is load-bearing — for threads, "settings row with null personality" means *explicitly deactivated, don't inherit parent activation* (`PersonalityTriggerProcessor`), while "no row" means *inherit*. A prune would silently re-activate deactivated threads, and the DB can't distinguish a top-level channel's dead row from a thread's deactivation row. All other readers (cascade, DM, list) are null-safe, so residual rows are inert. Ruled out as correct-as-is; backlog entry will be removed with this rationale.

## Verification

- `pnpm --filter @tzurot/ai-worker test` (3979) + `pnpm --filter @tzurot/api-gateway test` (2475) — green
- `pnpm quality` — green (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)