### PR TITLE
docs(rules): add the URL-substring CodeQL pattern to 00-critical

### DIFF
--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -70,6 +70,29 @@ const url = `${BASE_URL}/api/resource/${encodeURIComponent(apiResponseId)}/detai
 
 **Applies to ALL dynamic URL segments**, including values from trusted API responses (defense in depth).
 
+### URL Substring Checks (CodeQL)
+
+**Never validate a URL or host with `.includes()`, `.indexOf()`, `.startsWith()`, or an unanchored regex.** CodeQL flags `url.includes('example.com')` as "Incomplete URL substring sanitization" (`js/incomplete-url-substring-sanitization`, high severity) — `evil-example.com.attacker.io` passes it. **This fires even on allowlist checks over trusted, build-time input** (a legal-doc content guard tripped it): CodeQL judges the code shape, not where the string came from, so "it's not attacker-controlled" is not a defense — the check will block the merge.
+
+```typescript
+// ❌ WRONG - substring host check (CodeQL high)
+if (token.includes('tzurot.org')) {
+  /* treat as trusted */
+}
+
+// ✅ CORRECT - parse and compare the host exactly
+if (new URL(token).hostname === 'tzurot.org') {
+  /* trusted */
+}
+
+// ✅ ALSO OK - when it isn't host validation at all: strip the known strings,
+//    then test the remnant, so no host-decision substring match exists
+const residual = text.replaceAll('tzurot.org', '');
+if (/tzurot/i.test(residual)) {
+  /* something unexpected remains */
+}
+```
+
 ### Logging (No PII)
 
 ```typescript

--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -80,8 +80,16 @@ if (token.includes('tzurot.org')) {
   /* treat as trusted */
 }
 
-// ✅ CORRECT - parse and compare the host exactly
-if (new URL(token).hostname === 'tzurot.org') {
+// ✅ CORRECT - parse and compare the host exactly. `new URL()` THROWS on a
+//    non-absolute string, so guard the parse (see discordCdnGuard.ts for the
+//    codebase's canonical try/catch form that returns a tagged result).
+let host: string | undefined;
+try {
+  host = new URL(token).hostname;
+} catch {
+  /* not an absolute URL — reject */
+}
+if (host === 'tzurot.org') {
   /* trusted */
 }
 


### PR DESCRIPTION
We were bitten by `js/incomplete-url-substring-sanitization` on the website PR (#1667) — a legal-doc content guard used `token.includes('tzurot.org')`, which CodeQL flags high-severity as an incomplete URL/host check even though the input is trusted, checked-in markdown. CodeQL judges the code *shape*, not provenance, so "not attacker-controlled" isn't a defense; the red check blocks merge either way.

Adds a third entry to the Security section's existing CodeQL-pattern cluster (alongside tag-stripping and SSRF) so this gets caught at write time rather than in CI. Documents both fixes: parse-and-compare-host for real validation, and strip-then-check-remnant for the "not host validation at all" case. Folds into the existing cluster — no new top-level rule, per the owner's steer.

(The owner also noted a broader "does the rules structure still make sense?" review — captured as a non-blocking thought, not this PR's scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)