### PR TITLE
fix(bot-client): release-DM opt-out copy + persona-context exclusion

### DIFF
--- a/services/bot-client/src/services/DiscordChannelFetcher.test.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.test.ts
@@ -1777,6 +1777,42 @@ describe('DiscordChannelFetcher', () => {
     });
   });
 
+  describe('release-notes DM filtering', () => {
+    it('should filter out release DMs but keep a user quoting the footer', async () => {
+      const footerText = '-# Opt out of release DMs anytime with /notifications disable';
+      const messages = [
+        // Bot-authored release DM (should be FILTERED OUT — otherwise it
+        // classifies as a relay-echo and enters context as user speech)
+        createMockMessage({
+          id: 'release-dm-1',
+          content: `## v3.0.0 released!\nNew stuff.\n\n${footerText}`,
+          authorId: 'bot123',
+          authorUsername: 'TestBot',
+          isBot: true,
+          createdAt: new Date('2024-01-01T12:00:01Z'),
+        }),
+        // A user quoting the footer text (should be INCLUDED — author gate)
+        createMockMessage({
+          id: 'user-msg-1',
+          content: `what does ${footerText} mean?`,
+          authorId: 'user2',
+          authorUsername: 'bob',
+          createdAt: new Date('2024-01-01T12:00:02Z'),
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId: 'bot123',
+      });
+
+      expect(result.filteredCount).toBe(1);
+      expect(result.messages.some(m => m.content.includes('v3.0.0 released'))).toBe(false);
+      expect(result.messages.some(m => m.content.includes('what does'))).toBe(true);
+    });
+  });
+
   describe('bot transcript reply filtering', () => {
     it('should filter out bot transcript replies from extended context', async () => {
       // Bot transcript replies are: bot message + reply reference + has text content

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -28,8 +28,8 @@ import { resolveHistoryLinks } from '../utils/HistoryLinkResolver.js';
 import { extractPersonalityName, stripBotSuffix } from '../utils/webhookNaming.js';
 
 import {
-  isThinkingBlockMessage,
   isBotTranscriptReply,
+  isContextExcludedBotMessage,
 } from './channelFetcher/messageTypeFilters.js';
 import {
   extractGuildInfo,
@@ -244,10 +244,7 @@ export class DiscordChannelFetcher {
       if (!hasMessageContent(msg) && resolvedReferences?.has(msg.id) !== true) {
         continue;
       }
-      if (isBotTranscriptReply(msg, options.botUserId)) {
-        continue;
-      }
-      if (isThinkingBlockMessage(msg)) {
+      if (isContextExcludedBotMessage(msg, options.botUserId)) {
         continue;
       }
       // Filter BLOCK-denied users from extended context

--- a/services/bot-client/src/services/channelFetcher/messageTypeFilters.test.ts
+++ b/services/bot-client/src/services/channelFetcher/messageTypeFilters.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isThinkingBlockMessage, isBotTranscriptReply } from './messageTypeFilters.js';
+import {
+  isThinkingBlockMessage,
+  isBotTranscriptReply,
+  isContextExcludedBotMessage,
+} from './messageTypeFilters.js';
+import { OPT_OUT_FOOTER } from '../releaseDm/releaseDmContext.js';
 import type { Message } from 'discord.js';
 
 /**
@@ -129,6 +134,41 @@ describe('messageTypeFilters', () => {
       (msg as unknown as Record<string, unknown>).reference = undefined;
 
       expect(isBotTranscriptReply(msg, botUserId)).toBe(false);
+    });
+  });
+
+  describe('isContextExcludedBotMessage', () => {
+    const botUserId = 'bot-123';
+
+    it('excludes each of the three bot-message shapes', () => {
+      const transcript = createMockMessage({
+        authorId: botUserId,
+        content: 'transcript text',
+        referenceMessageId: 'voice-1',
+      });
+      const thinking = createMockMessage({ content: '💭 **Thinking:**\n||...||' });
+      const releaseDm = createMockMessage({
+        authorId: botUserId,
+        content: `## v3.0 released${OPT_OUT_FOOTER}`,
+      });
+      (releaseDm as unknown as Record<string, unknown>).reference = undefined;
+
+      expect(isContextExcludedBotMessage(transcript, botUserId)).toBe(true);
+      expect(isContextExcludedBotMessage(thinking, botUserId)).toBe(true);
+      expect(isContextExcludedBotMessage(releaseDm, botUserId)).toBe(true);
+    });
+
+    it('keeps ordinary bot replies and user messages', () => {
+      const botReply = createMockMessage({ authorId: botUserId, content: 'a persona reply' });
+      (botReply as unknown as Record<string, unknown>).reference = undefined;
+      const userMsg = createMockMessage({
+        authorId: 'user-9',
+        content: `quoting ${OPT_OUT_FOOTER.trimStart()}`,
+      });
+      (userMsg as unknown as Record<string, unknown>).reference = undefined;
+
+      expect(isContextExcludedBotMessage(botReply, botUserId)).toBe(false);
+      expect(isContextExcludedBotMessage(userMsg, botUserId)).toBe(false);
     });
   });
 });

--- a/services/bot-client/src/services/channelFetcher/messageTypeFilters.ts
+++ b/services/bot-client/src/services/channelFetcher/messageTypeFilters.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Message } from 'discord.js';
+import { isReleaseNotesDm } from '../releaseDm/releaseDmContext.js';
 
 /**
  * Check if a message is a thinking block output
@@ -53,4 +54,19 @@ export function isBotTranscriptReply(msg: Message, botUserId: string): boolean {
   }
 
   return true;
+}
+
+/**
+ * Combined exclusion for bot-authored messages that are surfaced to users but
+ * must never enter model context: transcript replies (content duplicated via
+ * TranscriptRetriever), thinking blocks (display-only reasoning), and
+ * release-notes DMs (notifications that would otherwise classify as
+ * relay-echoes and read as user speech).
+ */
+export function isContextExcludedBotMessage(msg: Message, botUserId: string): boolean {
+  return (
+    isBotTranscriptReply(msg, botUserId) ||
+    isThinkingBlockMessage(msg) ||
+    isReleaseNotesDm(msg, botUserId)
+  );
 }

--- a/services/bot-client/src/services/releaseDm/releaseDmContext.test.ts
+++ b/services/bot-client/src/services/releaseDm/releaseDmContext.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import type { Message } from 'discord.js';
+import { OPT_OUT_FOOTER, isReleaseNotesDm } from './releaseDmContext.js';
+
+const BOT_ID = 'bot-123';
+
+function asMessage(authorId: string, content: string): Message {
+  return { author: { id: authorId }, content } as unknown as Message;
+}
+
+describe('releaseDmContext', () => {
+  it('footer names the explicit opt-out invocation', () => {
+    expect(OPT_OUT_FOOTER).toContain('/notifications disable');
+    // Discord subtext line — starts blank-line-separated, renders small.
+    expect(OPT_OUT_FOOTER.startsWith('\n\n-# ')).toBe(true);
+  });
+
+  describe('isReleaseNotesDm', () => {
+    it('matches a bot-authored message carrying the footer', () => {
+      const msg = asMessage(BOT_ID, `## v3.0 released${OPT_OUT_FOOTER}`);
+      expect(isReleaseNotesDm(msg, BOT_ID)).toBe(true);
+    });
+
+    it('never matches a user message, even one quoting the footer verbatim', () => {
+      const msg = asMessage('user-456', `what does ${OPT_OUT_FOOTER.trimStart()} mean?`);
+      expect(isReleaseNotesDm(msg, BOT_ID)).toBe(false);
+    });
+
+    it('never matches ordinary bot messages without the footer', () => {
+      const msg = asMessage(BOT_ID, 'a persona reply or transcript');
+      expect(isReleaseNotesDm(msg, BOT_ID)).toBe(false);
+    });
+  });
+});

--- a/services/bot-client/src/services/releaseDm/releaseDmContext.ts
+++ b/services/bot-client/src/services/releaseDm/releaseDmContext.ts
@@ -1,0 +1,27 @@
+/**
+ * Release-DM footer + extended-context exclusion.
+ *
+ * The footer serves two jobs: it steers recipients to the explicit opt-out
+ * invocation (spam-report mitigation), and it doubles as the marker by which
+ * extended-context fetching recognizes a release DM. Release DMs are
+ * bot-authored notifications, not conversation — without the exclusion they
+ * classify as relay-echoes (bot-authored, not in the personality registry)
+ * and enter DM persona context as user-role content, so personas would treat
+ * the release notes as something the user said.
+ */
+
+import type { Message } from 'discord.js';
+
+export const OPT_OUT_FOOTER = '\n\n-# Opt out of release DMs anytime with /notifications disable';
+
+/**
+ * The match is on the footer's subtext line itself (sans leading newlines):
+ * bot-controlled, distinctive, and present on every release DM by
+ * construction. Author check first so a user quoting the footer text is
+ * never filtered.
+ */
+const FOOTER_MARKER = OPT_OUT_FOOTER.trimStart();
+
+export function isReleaseNotesDm(msg: Message, botUserId: string): boolean {
+  return msg.author.id === botUserId && msg.content.includes(FOOTER_MARKER);
+}

--- a/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.test.ts
+++ b/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.test.ts
@@ -75,7 +75,9 @@ describe('createReleaseDmProcessor', () => {
     expect(deps.send).toHaveBeenCalledTimes(2);
     const sendArg = deps.send.mock.calls[0][0] as { content: string; allowedMentions: unknown };
     expect(sendArg.content).toContain('Hello from the release pipeline');
-    expect(sendArg.content).toContain('/notifications');
+    // The footer must name the explicit opt-out invocation, not just the
+    // command family — that affordance is the spam-report mitigation.
+    expect(sendArg.content).toContain('/notifications disable');
     expect(sendArg.allowedMentions).toEqual({ parse: [] });
     // One sleep between two sends, none after the last.
     expect(deps.sleep).toHaveBeenCalledTimes(1);

--- a/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.ts
+++ b/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.ts
@@ -30,14 +30,12 @@ import {
   reportDeliveries,
   type DeliveryReport,
 } from '../../utils/gatewayServiceCalls.js';
+import { OPT_OUT_FOOTER } from './releaseDmContext.js';
 
 const logger = createLogger('ReleaseDmWorker');
 
 /** Inter-DM delay — mirrors StartupDMPrewarmer's REST-queue-friendly pacing. */
 const DM_SEND_DELAY_MS = 1000;
-
-/** Small text steering recipients to the prefs surface (spam-flag mitigation). */
-const OPT_OUT_FOOTER = '\n\n-# Manage these DMs with /notifications';
 
 export interface ReleaseDmWorkerDeps {
   client: Client;


### PR DESCRIPTION
Two hygiene fixes for the release-DM broadcast shipping in the upcoming release, both from the owner's DM-clutter concern:

**1. Opt-out footer names the actual invocation.** `-# Manage these DMs with /notifications` → `-# Opt out of release DMs anytime with /notifications disable`. A recipient who doesn't want these should see the exact command that stops them — that's also the spam-report mitigation. Test tightened to assert the `disable` invocation specifically.

**2. Release DMs are excluded from extended context.** Traced in `DiscordChannelFetcher.classifyAuthorship`: a release DM is primary-bot-authored but not in the personality-message registry, so it classifies as a relay-echo → role=User. With extended context active in DMs (it has no off switch, only limits), personas would read the release notes as something the user said. Fix: the opt-out footer doubles as the detection marker — `releaseDmContext.ts` owns one constant shared by the sender (`setupReleaseDmWorker`) and the filter, so the copy and the detection cannot drift. Author gate first, so a user quoting the footer text is never filtered.

The fetcher's three bot-message exclusions (transcript replies, thinking blocks, release DMs) are consolidated behind `isContextExcludedBotMessage` in `messageTypeFilters.ts` — which also keeps `DiscordChannelFetcher.ts` inside its max-lines/max-statements budgets.

**Verification:** full bot-client suite green (5,592 tests) including new predicate tests, a fetcher-level exclusion test (release DM dropped, user quoting the footer kept), and the structure test for the new module; `pnpm quality` green.

Note: this covers context pollution. DM *accumulation* across releases (delete-previous-on-send) is a separate follow-up being filed to the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)