### PR TITLE
fix(website): logo-cube thumbnail in the unfurl card

### DIFF
--- a/services/website/src/layouts/Base.astro
+++ b/services/website/src/layouts/Base.astro
@@ -30,7 +30,10 @@ const canonical = path !== undefined ? new URL(path, CANONICAL_ORIGIN).href : un
 const railwayDomain = process.env.RAILWAY_PUBLIC_DOMAIN;
 const assetOrigin =
   railwayDomain !== undefined && railwayDomain !== '' ? `https://${railwayDomain}` : CANONICAL_ORIGIN;
-const ogImage = await getImage({ src: BRAND.banner, format: 'jpeg', width: 1200 });
+// The square logo cube as a compact thumbnail card (twitter:card "summary"),
+// not the wide banner: Discord renders the logo beside the title/description,
+// which reads as brand identity rather than a marketing splash.
+const ogImage = await getImage({ src: BRAND.logo, format: 'jpeg', width: 512, height: 512 });
 const ogImageUrl = new URL(ogImage.src, assetOrigin).href;
 const year = new Date().getFullYear();
 ---
@@ -51,7 +54,11 @@ const year = new Date().getFullYear();
     <meta property="og:description" content={description} />
     {canonical !== undefined && <meta property="og:url" content={canonical} />}
     <meta property="og:image" content={ogImageUrl} />
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image:width" content={String(ogImage.attributes.width)} />
+    <meta property="og:image:height" content={String(ogImage.attributes.height)} />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:alt" content={`${BRAND.name} logo`} />
+    <meta name="twitter:card" content="summary" />
     <meta name="theme-color" content="#0b0812" />
   </head>
   <body>


### PR DESCRIPTION
Owner report: the Discord preview for the dev site shows no image. Two causes, one PR:

1. **Stale baked origin** — `og:image` resolves against `RAILWAY_PUBLIC_DOMAIN` at build time, and the service/domain rename left the deployed HTML pointing at the old host (`tzurot-development.up...` — dead), so Discord had nothing to fetch. Any post-rename deploy fixes this automatically; merging this PR triggers one.
2. **The owner wants the logo, not the banner** — og:image now emits the square logo cube (512×512 JPEG; alpha-keyed source flattens onto black, which is its original look) with `twitter:card: summary`, so Discord renders it as a compact thumbnail beside the title rather than a wide banner splash.

Verified with a local `SITE_BRAND=rotzot RAILWAY_PUBLIC_DOMAIN=...` build: emitted meta points at the correct origin's hashed logo JPEG, and the flattened asset was visually inspected.

Note for the owner post-merge: Discord caches unfurls per-URL — repost the link with a query string (e.g. `?v=2`) to see the fresh card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)