### PR TITLE
fix(api-gateway): export download URL uses an unguessable token, not the job id

### DIFF
--- a/packages/common-types/src/utils/exportDownloadToken.test.ts
+++ b/packages/common-types/src/utils/exportDownloadToken.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { generateExportDownloadToken, isExportDownloadToken } from './exportDownloadToken.js';
+
+describe('exportDownloadToken', () => {
+  it('mints a 64-char lowercase-hex token', () => {
+    const token = generateExportDownloadToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is unguessable — successive tokens never collide', () => {
+    const tokens = new Set(Array.from({ length: 1000 }, () => generateExportDownloadToken()));
+    expect(tokens.size).toBe(1000);
+  });
+
+  it('accepts a well-formed token and rejects malformed ones', () => {
+    expect(isExportDownloadToken(generateExportDownloadToken())).toBe(true);
+    // A deterministic export-job UUID (the thing that must NOT be a download
+    // token) is the exact shape the guard rejects — hyphens, uppercase, wrong length.
+    expect(isExportDownloadToken('a1b2c3d4-e5f6-42a3-8b1c-000000000000')).toBe(false);
+    expect(isExportDownloadToken('ABCDEF'.repeat(11))).toBe(false); // uppercase
+    expect(isExportDownloadToken('a'.repeat(63))).toBe(false); // too short
+    expect(isExportDownloadToken('')).toBe(false);
+  });
+});

--- a/packages/common-types/src/utils/exportDownloadToken.ts
+++ b/packages/common-types/src/utils/exportDownloadToken.ts
@@ -1,0 +1,30 @@
+/**
+ * Export download-URL tokens.
+ *
+ * Export job IDs are DETERMINISTIC (uuidv5 over (userId, source, format) for
+ * idempotency — a re-export upserts the same row). That makes the job ID
+ * computable offline from a user's Discord ID, so it must NEVER appear in a
+ * public, unauthenticated download URL. The download URL instead carries this
+ * unguessable random token, regenerated on every job (re)creation so a shared
+ * or leaked URL dies as soon as the export is re-run.
+ */
+
+import crypto from 'crypto';
+
+/** 32 bytes = 256 bits of entropy, hex-encoded to 64 chars. */
+const TOKEN_BYTES = 32;
+
+const TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+
+/** Mint a fresh, unguessable download token for an export job's public URL. */
+export function generateExportDownloadToken(): string {
+  return crypto.randomBytes(TOKEN_BYTES).toString('hex');
+}
+
+/**
+ * Cheap shape guard for the download route: reject anything that isn't a
+ * 64-char lowercase-hex token before touching the database.
+ */
+export function isExportDownloadToken(value: string): boolean {
+  return TOKEN_PATTERN.test(value);
+}

--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -510,6 +510,7 @@ CREATE TABLE "export_jobs" (
     "file_data" BYTEA,
     "file_name" VARCHAR(255),
     "file_size_bytes" INTEGER,
+    "download_token" VARCHAR(64),
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "started_at" TIMESTAMP(3),
     "completed_at" TIMESTAMP(3),
@@ -854,6 +855,9 @@ CREATE INDEX "import_jobs_status_idx" ON "import_jobs"("status");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "import_jobs_user_id_source_slug_source_service_key" ON "import_jobs"("user_id", "source_slug", "source_service");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "export_jobs_download_token_key" ON "export_jobs"("download_token");
 
 -- CreateIndex
 CREATE INDEX "export_jobs_user_id_idx" ON "export_jobs"("user_id");

--- a/prisma/migrations/20260716170603_add_export_download_token/migration.sql
+++ b/prisma/migrations/20260716170603_add_export_download_token/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memory_facts_embedding";
+
+-- AlterTable
+ALTER TABLE "export_jobs" ADD COLUMN     "download_token" VARCHAR(64);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "export_jobs_download_token_key" ON "export_jobs"("download_token");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -931,6 +931,11 @@ model ExportJob {
   fileName       String?   @map("file_name") @db.VarChar(255)
   /// Size of the stored payload (fileContent or fileData) in bytes
   fileSizeBytes  Int?      @map("file_size_bytes")
+  /// Unguessable random token carried in the PUBLIC download URL (the job `id`
+  /// is deterministic and must never be the download handle). Deferred-set:
+  /// null only on legacy rows predating this column; every new/reset job mints
+  /// one. Unique so the unauthenticated download route can look up by it.
+  downloadToken  String?   @unique @map("download_token") @db.VarChar(64)
   createdAt      DateTime  @default(now()) @map("created_at")
   startedAt      DateTime? @map("started_at")
   completedAt    DateTime? @map("completed_at")

--- a/services/ai-worker/src/jobs/AccountExportJob.ts
+++ b/services/ai-worker/src/jobs/AccountExportJob.ts
@@ -8,7 +8,7 @@
  * 4. Store the archive in ExportJob.fileData (BYTEA) and update status
  *
  * Self-contained like the shapes export: status lives on the ExportJob row;
- * the user downloads via the public /exports/:jobId route until expiry.
+ * the user downloads via the public /exports/:token route until expiry.
  */
 
 import type { Job } from 'bullmq';

--- a/services/api-gateway/src/routes/conformance/fixtures/userAccount.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/userAccount.ts
@@ -32,6 +32,10 @@ export const userAccountFixtures: Record<string, ConformanceEntry> = {
         ACCOUNT_EXPORT_SOURCE,
         'zip'
       );
+      // A completed job needs a downloadToken so the status route builds the
+      // populated downloadUrl branch — keeps conformance representative of the
+      // real response shape.
+      const downloadToken = 'f'.repeat(64);
       await ctx.prisma.exportJob.upsert({
         where: { id },
         update: {
@@ -39,6 +43,7 @@ export const userAccountFixtures: Record<string, ConformanceEntry> = {
           fileName: 'tzurot-account-export-conf-2026-01-01.zip',
           fileSizeBytes: 42,
           completedAt: staleCompletedAt,
+          downloadToken,
         },
         create: {
           id,
@@ -50,6 +55,7 @@ export const userAccountFixtures: Record<string, ConformanceEntry> = {
           fileName: 'tzurot-account-export-conf-2026-01-01.zip',
           fileSizeBytes: 42,
           completedAt: staleCompletedAt,
+          downloadToken,
           expiresAt: new Date(Date.now() + 60 * 60 * 1000),
         },
       });

--- a/services/api-gateway/src/routes/conformance/fixtures/userShapesAndDiagnostics.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/userShapesAndDiagnostics.ts
@@ -102,6 +102,9 @@ export const userShapesFixtures: Record<string, ConformanceEntry> = {
           format: 'json',
           fileName: 'conf-export-listed.json',
           fileSizeBytes: 42,
+          // A completed job needs a downloadToken so the list route builds the
+          // populated downloadUrl branch.
+          downloadToken: 'e'.repeat(64),
           expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
         },
       });

--- a/services/api-gateway/src/routes/public/exports.test.ts
+++ b/services/api-gateway/src/routes/public/exports.test.ts
@@ -24,7 +24,9 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
 import { createExportsRouter } from './exports.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 
-const VALID_UUID = '12345678-1234-1234-1234-123456789012';
+const VALID_TOKEN = 'a'.repeat(64); // 64-char lowercase hex — a well-formed download token
+/** A deterministic export-job UUID: the shape that must NOT work as a download handle. */
+const DETERMINISTIC_JOB_UUID = '12345678-1234-1234-1234-123456789012';
 /** Fixed time for deterministic tests */
 const NOW = new Date('2026-02-17T00:00:00.000Z').getTime();
 const FUTURE_DATE = new Date(NOW + 86400000);
@@ -52,18 +54,39 @@ describe('Public Export Download Route', () => {
     vi.useRealTimers();
   });
 
-  it('should return 400 for invalid UUID format', async () => {
+  it('should return 400 for a malformed download token', async () => {
     const app = createApp();
-    const res = await request(app).get('/not-a-uuid');
+    const res = await request(app).get('/not-a-token');
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Invalid export job ID');
+    expect(res.body.error).toBe('Invalid export download token');
+    expect(mockPrisma.exportJob.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects a deterministic export-job UUID as a download handle (the vuln fix)', async () => {
+    // The job id is computable offline from a Discord id; it must never be a
+    // valid download URL. It fails the token-shape guard before any DB lookup.
+    const app = createApp();
+    const res = await request(app).get(`/${DETERMINISTIC_JOB_UUID}`);
+
+    expect(res.status).toBe(400);
+    expect(mockPrisma.exportJob.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('looks the job up by downloadToken, never by id', async () => {
+    mockPrisma.exportJob.findUnique.mockResolvedValue(null);
+    const app = createApp();
+    await request(app).get(`/${VALID_TOKEN}`);
+
+    expect(mockPrisma.exportJob.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { downloadToken: VALID_TOKEN } })
+    );
   });
 
   it('should return 404 when export not found', async () => {
     mockPrisma.exportJob.findUnique.mockResolvedValue(null);
     const app = createApp();
-    const res = await request(app).get(`/${VALID_UUID}`);
+    const res = await request(app).get(`/${VALID_TOKEN}`);
 
     expect(res.status).toBe(404);
   });
@@ -80,7 +103,7 @@ describe('Public Export Download Route', () => {
     });
 
     const app = createApp();
-    const res = await request(app).get(`/${VALID_UUID}`);
+    const res = await request(app).get(`/${VALID_TOKEN}`);
 
     expect(res.status).toBe(404);
     expect(res.body.status).toBe('pending');
@@ -98,7 +121,7 @@ describe('Public Export Download Route', () => {
     });
 
     const app = createApp();
-    const res = await request(app).get(`/${VALID_UUID}`);
+    const res = await request(app).get(`/${VALID_TOKEN}`);
 
     expect(res.status).toBe(404);
     expect(res.body.error).toBe('Export failed');
@@ -118,7 +141,7 @@ describe('Public Export Download Route', () => {
     });
 
     const app = createApp();
-    const res = await request(app).get(`/${VALID_UUID}`);
+    const res = await request(app).get(`/${VALID_TOKEN}`);
 
     expect(res.status).toBe(410);
     expect(res.body.error).toBe('Export has expired');
@@ -136,7 +159,7 @@ describe('Public Export Download Route', () => {
     });
 
     const app = createApp();
-    const res = await request(app).get(`/${VALID_UUID}`);
+    const res = await request(app).get(`/${VALID_TOKEN}`);
 
     expect(res.status).toBe(410);
     expect(res.body.error).toBe('Export has expired');
@@ -155,7 +178,7 @@ describe('Public Export Download Route', () => {
     });
 
     const app = createApp();
-    const res = await request(app).get(`/${VALID_UUID}`);
+    const res = await request(app).get(`/${VALID_TOKEN}`);
 
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('application/json');
@@ -178,7 +201,7 @@ describe('Public Export Download Route', () => {
     });
 
     const app = createApp();
-    const res = await request(app).get(`/${VALID_UUID}`);
+    const res = await request(app).get(`/${VALID_TOKEN}`);
 
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/markdown');
@@ -199,7 +222,7 @@ describe('Public Export Download Route', () => {
 
     const app = createApp();
     const res = await request(app)
-      .get(`/${VALID_UUID}`)
+      .get(`/${VALID_TOKEN}`)
       .buffer(true)
       .parse((response, cb) => {
         const chunks: Buffer[] = [];

--- a/services/api-gateway/src/routes/public/exports.ts
+++ b/services/api-gateway/src/routes/public/exports.ts
@@ -1,16 +1,20 @@
 /**
  * Public Export Download Route
  *
- * GET /exports/:jobId - Download a completed export file
+ * GET /exports/:token - Download a completed export file
  *
- * Public endpoint (no auth required). The UUID serves as an unguessable token.
- * Returns the export file content with appropriate Content-Type and Content-Disposition.
+ * Public endpoint (no auth required). The lookup handle is a random,
+ * unguessable `downloadToken` — NOT the export job `id`, which is a
+ * deterministic uuidv5 over (userId, source, format) and therefore computable
+ * offline from a user's Discord ID. Using the job ID here would let anyone who
+ * knows a target's Discord ID download their export; the random token closes
+ * that. Returns the export file with appropriate Content-Type/Disposition.
  */
 
 import { Router, type Request, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { isUuidFormat } from '@tzurot/common-types/utils/deterministicUuid';
+import { isExportDownloadToken } from '@tzurot/common-types/utils/exportDownloadToken';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { getParam } from '../../utils/requestParams.js';
 
@@ -19,18 +23,20 @@ const logger = createLogger('exports-download');
 export function createExportsRouter(prisma: PrismaClient): Router {
   const router = Router();
 
-  router.get('/:jobId', async (req: Request, res: Response) => {
-    const jobId = getParam(req.params.jobId);
+  router.get('/:token', async (req: Request, res: Response) => {
+    const token = getParam(req.params.token);
 
-    if (jobId === undefined || !isUuidFormat(jobId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: 'Invalid export job ID' });
+    if (token === undefined || !isExportDownloadToken(token)) {
+      res.status(StatusCodes.BAD_REQUEST).json({ error: 'Invalid export download token' });
       return;
     }
 
     try {
       const job = await prisma.exportJob.findUnique({
-        where: { id: jobId },
+        where: { downloadToken: token },
         select: {
+          // id is the deterministic job UUID — safe to log; the token is not.
+          id: true,
           fileContent: true,
           fileData: true,
           fileName: true,
@@ -93,9 +99,10 @@ export function createExportsRouter(prisma: PrismaClient): Router {
 
       res.status(StatusCodes.OK).send(body);
 
-      logger.info({ jobId, fileName, fileSizeBytes: job.fileSizeBytes }, 'File downloaded');
+      logger.info({ jobId: job.id, fileName, fileSizeBytes: job.fileSizeBytes }, 'File downloaded');
     } catch (error) {
-      logger.error({ err: error, jobId }, 'Download error');
+      // The token is a capability — never log it, even on error.
+      logger.error({ err: error }, 'Download error');
       res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: 'Download failed' });
     }
   });

--- a/services/api-gateway/src/routes/user/account/export.test.ts
+++ b/services/api-gateway/src/routes/user/account/export.test.ts
@@ -112,13 +112,19 @@ describe('Account Export Routes', () => {
         userId: 'user-uuid-123',
         exportJobId: expect.stringMatching(/^[0-9a-f-]{36}$/),
       });
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          success: true,
-          status: 'pending',
-          downloadUrl: expect.stringContaining('/exports/'),
-        })
-      );
+      const jsonMock = res.json as unknown as ReturnType<typeof vi.fn>;
+      const body = jsonMock.mock.calls[0][0] as {
+        exportJobId: string;
+        downloadUrl: string;
+        success: boolean;
+        status: string;
+      };
+      expect(body.success).toBe(true);
+      expect(body.status).toBe('pending');
+      // The download URL must carry a random 64-hex token — NOT the
+      // deterministic (Discord-ID-derivable) export job id.
+      expect(body.downloadUrl).toMatch(/\/exports\/[0-9a-f]{64}$/);
+      expect(body.downloadUrl).not.toContain(body.exportJobId);
     });
 
     it('409s while an account export is already active, without enqueueing', async () => {
@@ -166,6 +172,7 @@ describe('Account Export Routes', () => {
     });
 
     it('adds a downloadUrl only for completed jobs', async () => {
+      const completedToken = 'b'.repeat(64);
       mockPrisma.exportJob.findFirst.mockResolvedValueOnce({
         id: 'job-1',
         status: 'completed',
@@ -174,17 +181,21 @@ describe('Account Export Routes', () => {
         createdAt: new Date(),
         completedAt: new Date(),
         expiresAt: new Date(),
+        downloadToken: completedToken,
       });
       const first = await callStatus();
-      expect(first.res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          job: expect.objectContaining({ downloadUrl: expect.stringContaining('/exports/job-1') }),
-        })
-      );
+      const firstJsonMock = first.res.json as unknown as ReturnType<typeof vi.fn>;
+      const firstJob = (firstJsonMock.mock.calls[0][0] as { job: Record<string, unknown> }).job;
+      // URL carries the random token, never the deterministic job id, and the
+      // raw token never leaks as a bare field.
+      expect(firstJob.downloadUrl).toContain(`/exports/${completedToken}`);
+      expect(firstJob).not.toHaveProperty('downloadToken');
+      expect(firstJob.downloadUrl).not.toContain('job-1');
 
       mockPrisma.exportJob.findFirst.mockResolvedValueOnce({
         id: 'job-2',
         status: 'pending',
+        downloadToken: 'c'.repeat(64),
         fileName: null,
         fileSizeBytes: null,
         createdAt: new Date(),
@@ -193,6 +204,25 @@ describe('Account Export Routes', () => {
       });
       const second = await callStatus();
       expect(second.res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ job: expect.objectContaining({ downloadUrl: null }) })
+      );
+    });
+
+    it('yields a null downloadUrl for a completed job that predates the token column', async () => {
+      // Legacy row: completed before the download_token migration → null token.
+      // The status route must NOT build a URL (there is no valid handle).
+      mockPrisma.exportJob.findFirst.mockResolvedValueOnce({
+        id: 'legacy-job',
+        status: 'completed',
+        fileName: 'legacy-export.zip',
+        fileSizeBytes: 42,
+        createdAt: new Date(),
+        completedAt: new Date(),
+        expiresAt: new Date(),
+        downloadToken: null,
+      });
+      const { res } = await callStatus();
+      expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ job: expect.objectContaining({ downloadUrl: null }) })
       );
     });

--- a/services/api-gateway/src/routes/user/account/export.ts
+++ b/services/api-gateway/src/routes/user/account/export.ts
@@ -6,7 +6,7 @@
  *
  * Rides the shapes-export spine: an export_jobs row (sentinel
  * sourceService='account') filled asynchronously by ai-worker, downloaded
- * via the public GET /exports/:jobId route, expiring after 24 hours.
+ * via the public GET /exports/:token route, expiring after 24 hours.
  */
 
 import { type Response, type RequestHandler } from 'express';
@@ -22,6 +22,7 @@ import {
   type AccountExportJobData,
 } from '@tzurot/common-types/types/account-export';
 import { generateExportJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { generateExportDownloadToken } from '@tzurot/common-types/utils/exportDownloadToken';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../../utils/resolveProvisionedUserId.js';
@@ -50,6 +51,8 @@ const EXPORT_COOLDOWN_HOURS = 24;
 
 interface CreateOrConflictResult {
   exportJobId: string;
+  /** The random public-download token, always minted for this run. */
+  downloadToken: string;
   conflictStatus: string | null;
   onCooldown: boolean;
 }
@@ -73,6 +76,9 @@ async function createExportJobOrConflict(
     ACCOUNT_EXPORT_SOURCE,
     EXPORT_FORMAT
   );
+  // Fresh random token on every (re)creation — a previously-shared download
+  // URL stops working the moment the export is re-run.
+  const downloadToken = generateExportDownloadToken();
   const cooldownFloor = new Date(Date.now() - EXPORT_COOLDOWN_HOURS * 60 * 60 * 1000);
 
   const outcome = await prisma.$transaction(async tx => {
@@ -110,11 +116,13 @@ async function createExportJobOrConflict(
         sourceService: ACCOUNT_EXPORT_SOURCE,
         status: 'pending',
         format: EXPORT_FORMAT,
+        downloadToken,
         expiresAt,
       },
       update: {
         status: 'pending',
         format: EXPORT_FORMAT,
+        downloadToken,
         fileContent: null,
         fileData: null,
         fileName: null,
@@ -130,7 +138,7 @@ async function createExportJobOrConflict(
     return { conflictStatus: null, onCooldown: false };
   });
 
-  return { exportJobId, ...outcome };
+  return { exportJobId, downloadToken, ...outcome };
 }
 
 /**
@@ -157,10 +165,11 @@ function createStartExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: s
     const expiresAt = new Date(Date.now() + EXPORT_EXPIRY_HOURS * 60 * 60 * 1000);
 
     let exportJobId: string;
+    let downloadToken: string;
     let conflictStatus: string | null;
     let onCooldown: boolean;
     try {
-      ({ exportJobId, conflictStatus, onCooldown } = await createExportJobOrConflict(
+      ({ exportJobId, downloadToken, conflictStatus, onCooldown } = await createExportJobOrConflict(
         prisma,
         userId,
         expiresAt
@@ -222,7 +231,7 @@ function createStartExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: s
         success: true,
         exportJobId,
         status: 'pending',
-        downloadUrl: `${baseUrl}/exports/${encodeURIComponent(exportJobId)}`,
+        downloadUrl: `${baseUrl}/exports/${encodeURIComponent(downloadToken)}`,
         expiresAt: expiresAt.toISOString(),
       },
       StatusCodes.ACCEPTED
@@ -248,20 +257,25 @@ function createStatusHandler(prisma: PrismaClient, baseUrl: string) {
         createdAt: true,
         completedAt: true,
         expiresAt: true,
+        downloadToken: true,
       },
     });
 
+    if (job === null) {
+      sendCustomSuccess(res, { job: null });
+      return;
+    }
+    // downloadToken never leaves the server as a bare field — it is only ever
+    // rendered into the download URL.
+    const { downloadToken, ...jobFields } = job;
     sendCustomSuccess(res, {
-      job:
-        job === null
-          ? null
-          : {
-              ...job,
-              downloadUrl:
-                job.status === 'completed'
-                  ? `${baseUrl}/exports/${encodeURIComponent(job.id)}`
-                  : null,
-            },
+      job: {
+        ...jobFields,
+        downloadUrl:
+          job.status === 'completed' && downloadToken !== null
+            ? `${baseUrl}/exports/${encodeURIComponent(downloadToken)}`
+            : null,
+      },
     });
   };
 }

--- a/services/api-gateway/src/routes/user/shapes/export.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.test.ts
@@ -160,6 +160,8 @@ describe('Shapes Export Routes', () => {
             sourceService: 'shapes_inc',
             status: 'pending',
             format: 'json',
+            // A random token is persisted for the public download URL.
+            downloadToken: expect.stringMatching(/^[0-9a-f]{64}$/),
           }),
         })
       );
@@ -174,6 +176,11 @@ describe('Shapes Export Routes', () => {
       );
 
       expect(res.status).toHaveBeenCalledWith(202);
+      const createJsonMock = res.json as unknown as ReturnType<typeof vi.fn>;
+      const body = createJsonMock.mock.calls[0][0] as { downloadUrl: string; exportJobId: string };
+      // Download URL carries the random token, never the deterministic job id.
+      expect(body.downloadUrl).toMatch(/\/exports\/[0-9a-f]{64}$/);
+      expect(body.downloadUrl).not.toContain(body.exportJobId);
     });
 
     it('should accept markdown format', async () => {
@@ -215,6 +222,7 @@ describe('Shapes Export Routes', () => {
     });
 
     it('should return export jobs with download URLs', async () => {
+      const listToken = 'd'.repeat(64);
       mockPrisma.exportJob.findMany.mockResolvedValueOnce([
         {
           id: 'job-1',
@@ -228,22 +236,47 @@ describe('Shapes Export Routes', () => {
           expiresAt: new Date(Date.now() + 86400000),
           errorMessage: null,
           exportMetadata: null,
+          downloadToken: listToken,
         },
       ]);
 
       const { res } = await callListHandler();
 
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          jobs: expect.arrayContaining([
-            expect.objectContaining({
-              sourceSlug: 'test-shape',
-              status: 'completed',
-              downloadUrl: expect.stringContaining('/exports/job-1'),
-            }),
-          ]),
-        })
-      );
+      const listJsonMock = res.json as unknown as ReturnType<typeof vi.fn>;
+      const listedJob = (listJsonMock.mock.calls[0][0] as { jobs: Record<string, unknown>[] })
+        .jobs[0];
+      // URL carries the random token, not the deterministic job id, and the
+      // raw token never leaks as a bare field.
+      expect(listedJob.downloadUrl).toContain(`/exports/${listToken}`);
+      expect(listedJob.downloadUrl).not.toContain('job-1');
+      expect(listedJob).not.toHaveProperty('downloadToken');
+    });
+
+    it('yields a null downloadUrl for a completed job that predates the token column', async () => {
+      // Legacy row: completed before the download_token migration → null token.
+      mockPrisma.exportJob.findMany.mockResolvedValueOnce([
+        {
+          id: 'legacy-job',
+          sourceSlug: 'test-shape',
+          status: 'completed',
+          format: 'json',
+          fileName: 'legacy.json',
+          fileSizeBytes: 1024,
+          createdAt: new Date(),
+          completedAt: new Date(),
+          expiresAt: new Date(Date.now() + 86400000),
+          errorMessage: null,
+          exportMetadata: null,
+          downloadToken: null,
+        },
+      ]);
+
+      const { res } = await callListHandler();
+      const legacyJsonMock = res.json as unknown as ReturnType<typeof vi.fn>;
+      const legacyJob = (legacyJsonMock.mock.calls[0][0] as { jobs: Record<string, unknown>[] })
+        .jobs[0];
+      expect(legacyJob.downloadUrl).toBeNull();
+      expect(legacyJob).not.toHaveProperty('downloadToken');
     });
 
     it('should filter by slug when ?slug= query param is provided', async () => {

--- a/services/api-gateway/src/routes/user/shapes/export.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.ts
@@ -5,7 +5,7 @@
  * GET  /user/shapes/export/jobs - List export job history
  *
  * Export data is fetched asynchronously by ai-worker and stored in PostgreSQL.
- * Users download completed exports via GET /exports/:jobId (public endpoint).
+ * Users download completed exports via GET /exports/:token (public endpoint).
  */
 
 import { type Response, type RequestHandler } from 'express';
@@ -22,6 +22,7 @@ import {
   CREDENTIAL_TYPES,
 } from '@tzurot/common-types/types/shapes-import';
 import { generateExportJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { generateExportDownloadToken } from '@tzurot/common-types/utils/exportDownloadToken';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../../utils/resolveProvisionedUserId.js';
@@ -40,6 +41,8 @@ const EXPORT_EXPIRY_HOURS = 24;
 
 interface CreateOrConflictResult {
   exportJobId: string;
+  /** The random public-download token, minted for a freshly created/reset job. */
+  downloadToken: string;
   conflictStatus: string | null;
 }
 
@@ -67,6 +70,9 @@ async function createExportJobOrConflict(
     IMPORT_SOURCES.SHAPES_INC,
     format
   );
+  // Fresh random token on every (re)creation — a previously-shared download
+  // URL stops working the moment the export is re-run.
+  const downloadToken = generateExportDownloadToken();
 
   const conflictStatus = await prisma.$transaction(async tx => {
     const existingJob = await tx.exportJob.findFirst({
@@ -92,11 +98,13 @@ async function createExportJobOrConflict(
         sourceService: IMPORT_SOURCES.SHAPES_INC,
         status: 'pending',
         format,
+        downloadToken,
         expiresAt,
       },
       update: {
         status: 'pending',
         format,
+        downloadToken,
         fileContent: null,
         fileName: null,
         fileSizeBytes: null,
@@ -111,7 +119,7 @@ async function createExportJobOrConflict(
     return null;
   });
 
-  return { exportJobId, conflictStatus };
+  return { exportJobId, downloadToken, conflictStatus };
 }
 
 function createExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: string) {
@@ -151,9 +159,10 @@ function createExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: string
     const expiresAt = new Date(Date.now() + EXPORT_EXPIRY_HOURS * 60 * 60 * 1000);
 
     let exportJobId: string;
+    let downloadToken: string;
     let conflictStatus: string | null;
     try {
-      ({ exportJobId, conflictStatus } = await createExportJobOrConflict(
+      ({ exportJobId, downloadToken, conflictStatus } = await createExportJobOrConflict(
         prisma,
         userId,
         normalizedSlug,
@@ -215,7 +224,7 @@ function createExportHandler(prisma: PrismaClient, queue: Queue, baseUrl: string
       'Export job created'
     );
 
-    const downloadUrl = `${baseUrl}/exports/${encodeURIComponent(exportJobId)}`;
+    const downloadUrl = `${baseUrl}/exports/${encodeURIComponent(downloadToken)}`;
 
     sendCustomSuccess(
       res,
@@ -258,14 +267,18 @@ function createListExportJobsHandler(prisma: PrismaClient, baseUrl: string) {
         expiresAt: true,
         errorMessage: true,
         exportMetadata: true,
+        downloadToken: true,
       },
     });
 
-    // Add download URLs to completed jobs
-    const jobsWithUrls = jobs.map(job => ({
+    // Render the download token into the URL and drop it as a bare field —
+    // it must never leave the server except as part of the download URL.
+    const jobsWithUrls = jobs.map(({ downloadToken, ...job }) => ({
       ...job,
       downloadUrl:
-        job.status === 'completed' ? `${baseUrl}/exports/${encodeURIComponent(job.id)}` : null,
+        job.status === 'completed' && downloadToken !== null
+          ? `${baseUrl}/exports/${encodeURIComponent(downloadToken)}`
+          : null,
     }));
 
     sendCustomSuccess(res, { jobs: jobsWithUrls });


### PR DESCRIPTION
**Release-blocking security fix** — caught by the beta.166 holistic review (#1675).

## The vulnerability
`GET /exports/:jobId` is unauthenticated (a browser opens it), and looked up by the export job `id` — which is a **deterministic** `uuidv5(("export_job:{userId}:{source}:{format}"), DNS_NAMESPACE)`, and `userId` is itself `uuidv5("discord:{discordId}", DNS_NAMESPACE)`. Every seed and the namespace are committed public constants; **no server secret is in the chain**. So anyone who knows a target's Discord ID could compute the exact URL and download their full account-export ZIP (conversation history, memories, facts, personas, configs) for the 24h window after they ran `/settings data export`. Verified end-to-end in the code before fixing.

## The fix
- New `export_jobs.downloadToken` column: a `crypto.randomBytes(32)` hex token, minted on every export (re)creation. Additive migration, `@unique`, nullable (legacy rows).
- Every download URL — account + shapes, POST-create + GET-status — now carries the **token**, never the job id.
- The route looks up by `downloadToken` and rejects anything that isn't a 64-hex token before touching the DB.
- The token is treated as a capability: never logged (route logs the deterministic `job.id` instead), never returned as a bare field (status/list strip it into the URL only).
- Job ids stay deterministic, so idempotent re-export still upserts the same row; a re-export mints a fresh token, invalidating any previously-shared URL.

## Coverage
- **Regression test**: the deterministic job UUID is asserted to 400 at the route *without a DB hit*.
- Route looks up by `downloadToken` (asserted), rejects malformed tokens.
- Create responses assert the URL is a 64-hex token and does **not** contain the job id.
- Status/list responses assert the token never leaks as a field.
- New `exportDownloadToken` unit tests (shape + uniqueness + guard).
- Applied to the shapes-export path too (same ID class, pre-existing route).

Full unit + component + quality green locally. **Merging this to develop clears the blocker on release PR #1675, which will carry it.** Prod needs the additive migration premigrated before the release merges (the column must exist when the new code deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)