### PR TITLE
docs: add dependency-additions-land-on-latest rule

### DIFF
--- a/.claude/rules/02-code-standards.md
+++ b/.claude/rules/02-code-standards.md
@@ -240,6 +240,17 @@ import { normalizeSlugForUser } from '@tzurot/common-types';
 Re-export wrappers add indirection, break vitest mocking (the mock of the package
 doesn't intercept internal imports), and make dependency tracing harder.
 
+## Dependency Additions Land on Latest
+
+When adding a **new** dependency (not bumping an existing one), check the latest
+stable version first — `pnpm view <pkg> version` — and pin to it, rather than
+whatever version is top-of-mind or copied from a stale example. A dep added a
+major behind starts its life needing an upgrade (Astro was added at v5 with v6
+already shipped). This applies at the **add** moment; keeping deps current
+afterward is Dependabot's job. When the latest major is very new (days old) and
+the ecosystem around it may lag, that's a reason to _note_ the choice, not to
+default to the old major.
+
 ## Python Standards (voice-engine)
 
 The `services/voice-engine/` service uses Python 3.11+ with FastAPI. These


### PR DESCRIPTION
## What

Adds the "Dependency Additions Land on Latest" section to `.claude/rules/02-code-standards.md` — text the owner approved during the Astro-bump discussion (2026-07-16).

## Why

Astro was added at v5 with v6 already shipped, so the dependency started life a major behind and the debt surfaced as 10 Dependabot alerts (resolved by #1678's deliberate 5→7 bump). The rule pins the check to the **add** moment (`pnpm view <pkg> version`), leaves ongoing currency to Dependabot, and handles the brand-new-major edge (note the choice, don't default to the old major).

Rules are review-gated per 00-critical, hence the PR instead of a direct doc commit. `pnpm ops lines:check` passes (rules: 2196/2270).

🤖 Generated with [Claude Code](https://claude.com/claude-code)