### PR TITLE
fix: classify discord-50278 (no mutual guilds) as permanent DM failure

### DIFF
--- a/.claude/hooks/eslint-on-edit.sh
+++ b/.claude/hooks/eslint-on-edit.sh
@@ -26,6 +26,6 @@ cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
 
 # --no-warn-ignored: test files are excluded via eslint.config.js ignores;
 # without the flag every touched test file emits a pointless ignore warning.
-pnpm exec eslint --no-warn-ignored "$FILE" 2>&1 | head -50
+pnpm exec eslint --no-warn-ignored -- "$FILE" 2>&1 | head -50
 
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -17,6 +17,10 @@ SOURCE=$(jq -r '.source // empty' <<<"$INPUT" 2>/dev/null || echo "")
 ROOT="${CLAUDE_PROJECT_DIR:-.}"
 
 if [ "$SOURCE" = "compact" ]; then
+  # INDEPENDENT COPY WARNING: this checklist is a curated action-subset of
+  # CLAUDE.md's "Compaction Instructions" section (which stays auto-loaded
+  # with the full preservation list). It is NOT sourced from that file —
+  # when Compaction Instructions change, re-sync this block by hand.
   cat <<'EOF'
 POST-COMPACTION RECOVERY (structural checklist — act before new work):
 1. Session settings: recover effort level / permission mode from pre-compaction

--- a/scripts/src/db/flipTransient50278.ts
+++ b/scripts/src/db/flipTransient50278.ts
@@ -1,0 +1,61 @@
+/**
+ * One-off flip of misclassified release-DM delivery rows: discord-50278
+ * ("no mutual guilds") was bucketed failed_transient before the classifier
+ * fix landed; the durable reality is failed_permanent.
+ *
+ * Why flip instead of waiting: maybeAutoDisable reads only the user's most
+ * recent non-pending row, so a failed_transient row RESETS the two-permanent
+ * auto-disable streak. Left alone, each affected user eats one guaranteed-fail
+ * DM attempt per release for two more releases before quiescing; flipped, the
+ * next release's (permanent) failure lands on a permanent predecessor and
+ * auto-disables immediately.
+ *
+ * Idempotent and re-runnable: the WHERE matches only rows still marked
+ * failed_transient with the old 'discord-50278' errorCode. The errorCode is
+ * kept as-is ('discord-50278', not '50278') so the flipped rows remain
+ * distinguishable from organically-classified permanents in the ledger.
+ *
+ * Run: pnpm ops run --env <dev|prod> tsx scripts/src/db/flipTransient50278.ts [--dry-run]
+ * Delete after it has run against prod (rides the one-off-script cleanup PR).
+ */
+
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
+
+async function main(): Promise<void> {
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
+
+  try {
+    const candidates = await prisma.releaseDeliveryLog.findMany({
+      where: { status: 'failed_transient', errorCode: 'discord-50278' },
+      select: { id: true, userId: true, releaseId: true },
+      take: 10_000,
+    });
+    const distinctUsers = new Set(candidates.map(row => row.userId)).size;
+
+    console.log('=== FLIP PREVIEW ===');
+    console.log('failed_transient discord-50278 rows:', candidates.length);
+    console.log('distinct users affected:            ', distinctUsers);
+
+    if (process.argv.includes('--dry-run')) {
+      console.log('=== DRY RUN — no writes ===');
+      return;
+    }
+
+    const flipped = await prisma.releaseDeliveryLog.updateMany({
+      where: { status: 'failed_transient', errorCode: 'discord-50278' },
+      data: { status: 'failed_permanent' },
+    });
+    console.log(`flipped ${flipped.count} rows to failed_permanent`);
+    console.log('=== DONE ===');
+  } finally {
+    await dispose();
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
@@ -262,6 +262,23 @@ describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
     });
   });
 
+  it('does NOT auto-disable when the previous delivery failed TRANSIENT (streak needs two permanents)', async () => {
+    // Pins the interplay with historical misclassified rows: a failed_transient
+    // row between two permanents resets the streak, so a user whose prior
+    // failures were recorded transient needs two fresh permanent releases to
+    // quiesce unless the old rows are flipped to failed_permanent.
+    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
+    mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce({ status: 'failed_transient' });
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '50278' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
   it("does NOT auto-disable on a user's very first delivery failure (no history at all)", async () => {
     mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
     mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce(null);

--- a/services/bot-client/src/utils/dmErrorClassifier.test.ts
+++ b/services/bot-client/src/utils/dmErrorClassifier.test.ts
@@ -24,6 +24,11 @@ describe('classifyDmError', () => {
     expect(result).toEqual({ kind: 'permanent', code: 10013 });
   });
 
+  it('classifies 50278 (no mutual guilds) as permanent', () => {
+    const result = classifyDmError(makeDiscordError(50278));
+    expect(result).toEqual({ kind: 'permanent', code: 50278 });
+  });
+
   it('classifies other Discord API errors as transient', () => {
     const result = classifyDmError(makeDiscordError(0, 500));
     expect(result.kind).toBe('transient');

--- a/services/bot-client/src/utils/dmErrorClassifier.ts
+++ b/services/bot-client/src/utils/dmErrorClassifier.ts
@@ -21,6 +21,9 @@ export type DmErrorClass =
 const DM_PERMANENT_CODES = new Set<number>([
   10013, // Unknown User (deleted account)
   50007, // Cannot send messages to this user (DMs closed / bot blocked)
+  50278, // No mutual guilds (user left every shared server) — durable until
+  //       they rejoin, and a rejoin implies renewed interest anyway; retrying
+  //       without it fails identically every release.
 ]);
 
 export function classifyDmError(error: unknown): DmErrorClass {


### PR DESCRIPTION
## Summary

beta.167's first gated blast tallied `failedTransient=26` — every one of them discord-50278 (recipient left every shared server). That state is durable (a rejoin implies renewed interest anyway), so "transient" was a misclassification: the rows polluted the transient tally, and worse, sat invisible to `maybeAutoDisable` — a `failed_transient` row between two permanents resets the two-consecutive-permanents streak, so these users would eat one guaranteed-fail DM per release for two more releases before quiescing.

- **Classifier**: 50278 joins `DM_PERMANENT_CODES` (one line + test). Auto-disable on consecutive 50278s comes free — it's just "permanent follows permanent."
- **Streak-reset pinning test**: documents that a transient row resets the auto-disable counter — the exact mechanic that makes the historical rows worth flipping.
- **One-off flip script** (`scripts/src/db/flipTransient50278.ts`, dry-run gated, idempotent): flips existing `failed_transient` + `errorCode='discord-50278'` rows to `failed_permanent`, preserving the original errorCode so flipped rows stay distinguishable from organically-classified ones. With the flip, affected users auto-disable after ONE more failed release instead of three. Runs on dev + prod with owner-approved counts (dry-run first), then gets deleted alongside the two beta.167 one-off scripts in the pending cleanup PR.
- **Riders from #1687 round 3** (reviewer-sanctioned follow-through, two lines): sync-warning comment on the session-start compact checklist (independent copy of CLAUDE.md prose), and `--` before the file path in the eslint hook invocation.

## Verification

- `pnpm --filter bot-client test` (5611) and `pnpm --filter api-gateway test` (2509) green; full `pnpm quality` green; pre-push gate ran build/lint/test on affected packages.
- Flip script mirrors the reviewed backfill script's exact pattern (createPrismaClient + TRANSIENT_MAX pool, preview-then-write, `--dry-run` gate); not run against any environment yet — prod run follows the dry-run-counts-then-owner-go protocol post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)