### PR TITLE
feat: auto-disabled release DMs self-heal on deliberate use

### DIFF
--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -34,6 +34,7 @@ CREATE TABLE "users" (
     "notify_enabled" BOOLEAN NOT NULL DEFAULT true,
     "notify_level" "notify_level" NOT NULL DEFAULT 'major',
     "notify_opted_in_at" TIMESTAMP(3),
+    "notify_auto_disabled_at" TIMESTAMP(3),
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
 

--- a/prisma/migrations/20260717153243_add_notify_auto_disabled_at/migration.sql
+++ b/prisma/migrations/20260717153243_add_notify_auto_disabled_at/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memory_facts_embedding";
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "notify_auto_disabled_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,14 @@ model User {
   /// row + default persona but never this). Release-DM eligibility requires
   /// it non-null, so passive bystanders are never in the blast radius.
   notifyOptedInAt       DateTime?                  @map("notify_opted_in_at")
+  /// State machine: null unless notifications were AUTO-disabled after
+  /// consecutive permanent release-DM failures (unreachable user); set
+  /// alongside notifyEnabled=false by that path only. Cleared — with
+  /// notifyEnabled restored — on the user's next deliberate use, or by any
+  /// explicit /notifications update (explicit choice supersedes
+  /// infrastructure history). Distinguishes infrastructure-disabled from
+  /// user-opted-out; a user-chosen opt-out always has this null.
+  notifyAutoDisabledAt  DateTime?                  @map("notify_auto_disabled_at")
   createdAt             DateTime                   @default(now()) @map("created_at")
   updatedAt             DateTime                   @updatedAt @map("updated_at")
   releaseDeliveries     ReleaseDeliveryLog[]

--- a/services/ai-worker/src/jobs/AIJobProcessor.test.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.test.ts
@@ -607,6 +607,20 @@ describe('AIJobProcessor', () => {
       });
     });
 
+    it('lifts an infrastructure auto-disable on a real generation (flag-guarded)', async () => {
+      const job = createMockJob(baseLLMJobData, 'llm-job-123');
+
+      await processor.processJob(job);
+
+      // Deliberate use = the user is demonstrably back in reach; the
+      // notifyAutoDisabledAt guard keeps explicit opt-outs (flag never set)
+      // untouchable by this path.
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: { id: 'user-internal-uuid-123', notifyAutoDisabledAt: { not: null } },
+        data: { notifyEnabled: true, notifyAutoDisabledAt: null },
+      });
+    });
+
     it('still succeeds when the notifyOptedInAt stamp write fails (best-effort)', async () => {
       vi.mocked(mockPrisma.user.updateMany).mockRejectedValueOnce(new Error('db down'));
       const job = createMockJob(baseLLMJobData, 'llm-job-123');

--- a/services/ai-worker/src/jobs/AIJobProcessor.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.ts
@@ -355,10 +355,14 @@ export class AIJobProcessor {
   }
 
   /**
-   * Mark a user as having deliberately used the bot (first real generation),
-   * gating release-DM eligibility. Null-guarded updateMany so it's a no-op
-   * after the first stamp; errors are swallowed — this must never fail a
-   * response.
+   * Mark a user as having deliberately used the bot (a real generation).
+   * Two null/flag-guarded updateManys, each a no-op in the steady state:
+   *   1. First-use stamp — gates release-DM eligibility (writes once, ever).
+   *   2. Auto-disable lift — an infrastructure disable (consecutive permanent
+   *      release-DM failures = unreachable) is reversed the moment the user
+   *      is demonstrably back; the notifyAutoDisabledAt guard means a
+   *      user-chosen opt-out (flag never set) is never overridden.
+   * Errors are swallowed — bookkeeping must never fail a response.
    */
   private async stampFirstDeliberateUse(userInternalId: string): Promise<void> {
     try {
@@ -366,8 +370,12 @@ export class AIJobProcessor {
         where: { id: userInternalId, notifyOptedInAt: null },
         data: { notifyOptedInAt: new Date() },
       });
+      await this.prisma.user.updateMany({
+        where: { id: userInternalId, notifyAutoDisabledAt: { not: null } },
+        data: { notifyEnabled: true, notifyAutoDisabledAt: null },
+      });
     } catch (error) {
-      logger.warn({ err: error, userId: userInternalId }, 'Failed to stamp notifyOptedInAt');
+      logger.warn({ err: error, userId: userInternalId }, 'Failed to stamp deliberate-use state');
     }
   }
 

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
@@ -227,7 +227,10 @@ describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
 
     expect(mockPrisma.user.update).toHaveBeenCalledWith({
       where: { id: USER_A },
-      data: { notifyEnabled: false },
+      // notifyAutoDisabledAt marks the infrastructure disable — the flag the
+      // deliberate-use lift keys on; without it a re-engaged user could never
+      // be distinguished from an explicit opt-out.
+      data: { notifyEnabled: false, notifyAutoDisabledAt: expect.any(Date) },
     });
     const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
       autoDisabledUserIds: string[];

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.ts
@@ -79,7 +79,13 @@ async function maybeAutoDisable(
   if (previous?.status !== 'failed_permanent') {
     return false;
   }
-  await prisma.user.update({ where: { id: userId }, data: { notifyEnabled: false } });
+  // notifyAutoDisabledAt marks this as an INFRASTRUCTURE disable (unreachable),
+  // distinct from a user-chosen opt-out — the next deliberate use lifts it
+  // (liftNotifyAutoDisable), which must never happen to an explicit opt-out.
+  await prisma.user.update({
+    where: { id: userId },
+    data: { notifyEnabled: false, notifyAutoDisabledAt: new Date() },
+  });
   return true;
 }
 

--- a/services/api-gateway/src/routes/user/notifications.test.ts
+++ b/services/api-gateway/src/routes/user/notifications.test.ts
@@ -122,7 +122,7 @@ describe('PATCH /user/notifications', () => {
 
     expect(mockPrisma.user.update).toHaveBeenCalledWith({
       where: { id: 'user-uuid-123' },
-      data: { notifyEnabled: false },
+      data: { notifyEnabled: false, notifyAutoDisabledAt: null },
       select: { notifyEnabled: true, notifyLevel: true },
     });
     expect(res.json).toHaveBeenCalledWith({ success: true, enabled: false, level: 'minor' });
@@ -140,7 +140,7 @@ describe('PATCH /user/notifications', () => {
 
     expect(mockPrisma.user.update).toHaveBeenCalledWith({
       where: { id: 'user-uuid-123' },
-      data: { notifyLevel: 'patch' },
+      data: { notifyLevel: 'patch', notifyAutoDisabledAt: null },
       select: { notifyEnabled: true, notifyLevel: true },
     });
     expect(res.json).toHaveBeenCalledWith({ success: true, enabled: true, level: 'patch' });
@@ -158,7 +158,7 @@ describe('PATCH /user/notifications', () => {
 
     expect(mockPrisma.user.update).toHaveBeenCalledWith({
       where: { id: 'user-uuid-123' },
-      data: { notifyEnabled: true, notifyLevel: 'major' },
+      data: { notifyEnabled: true, notifyLevel: 'major', notifyAutoDisabledAt: null },
       select: { notifyEnabled: true, notifyLevel: true },
     });
   });

--- a/services/api-gateway/src/routes/user/notifications.ts
+++ b/services/api-gateway/src/routes/user/notifications.ts
@@ -69,6 +69,11 @@ export const handleUpdateNotificationPrefs = (deps: RouteDeps): RequestHandler =
       data: {
         ...(enabled !== undefined ? { notifyEnabled: enabled } : {}),
         ...(level !== undefined ? { notifyLevel: level } : {}),
+        // Any explicit prefs update supersedes infrastructure history: an
+        // auto-disable (unreachable-user flag) is cleared whichever way the
+        // user sets things — enabling lifts it, disabling converts it into a
+        // genuine user-chosen opt-out that deliberate use must never undo.
+        notifyAutoDisabledAt: null,
       },
       select: { notifyEnabled: true, notifyLevel: true },
     });

--- a/services/api-gateway/src/routes/wallet/setKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.test.ts
@@ -351,6 +351,20 @@ describe('POST /wallet/set', () => {
       });
     });
 
+    it('lifts an infrastructure auto-disable on BYOK setup (flag-guarded, never touches opt-outs)', async () => {
+      const { req, res } = createMockReqRes({
+        provider: AIProvider.OpenRouter,
+        apiKey: 'sk-valid-key',
+      });
+
+      await callHandler(mockPrisma, req, res);
+
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: { id: 'user-uuid-123', notifyAutoDisabledAt: { not: null } },
+        data: { notifyEnabled: true, notifyAutoDisabledAt: null },
+      });
+    });
+
     it('still reports success when the stamp write fails (best-effort bookkeeping)', async () => {
       mockPrisma.user.updateMany.mockRejectedValueOnce(new Error('db blip'));
       const { req, res } = createMockReqRes({

--- a/services/api-gateway/src/routes/wallet/setKey.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.ts
@@ -18,7 +18,7 @@ import { encryptApiKey } from '@tzurot/common-types/utils/encryption';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type ApiKeyCacheInvalidationService } from '@tzurot/cache-invalidation';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
-import { stampNotifyOptedIn } from '../../services/notifyOptIn.js';
+import { stampNotifyOptedIn, liftNotifyAutoDisable } from '../../services/notifyOptIn.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -123,8 +123,9 @@ export const handleSetWalletKey = (deps: WalletSetDeps): RequestHandler => {
     // the stamp is load-bearing and deliberately propagates.
     try {
       await stampNotifyOptedIn(prisma, userId);
+      await liftNotifyAutoDisable(prisma, userId);
     } catch (error) {
-      logger.warn({ err: error, discordUserId }, 'Failed to stamp notifyOptedInAt');
+      logger.warn({ err: error, discordUserId }, 'Failed to stamp notify opt-in state');
     }
 
     sendCustomSuccess(

--- a/services/api-gateway/src/services/notifyOptIn.test.ts
+++ b/services/api-gateway/src/services/notifyOptIn.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { stampNotifyOptedIn } from './notifyOptIn.js';
+import { stampNotifyOptedIn, liftNotifyAutoDisable } from './notifyOptIn.js';
 
 const USER_ID = '423e4567-e89b-42d3-a456-426614174000';
 
@@ -26,5 +26,28 @@ describe('stampNotifyOptedIn', () => {
     const prisma = { user: { updateMany } } as unknown as PrismaClient;
 
     await expect(stampNotifyOptedIn(prisma, USER_ID)).rejects.toThrow('db down');
+  });
+});
+
+describe('liftNotifyAutoDisable', () => {
+  it('re-enables ONLY when the auto-disable flag is set (explicit opt-outs have it null)', async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const prisma = { user: { updateMany } } as unknown as PrismaClient;
+
+    await liftNotifyAutoDisable(prisma, USER_ID);
+
+    // The where-guard IS the opt-out protection: a user-chosen disable never
+    // sets notifyAutoDisabledAt, so this update cannot match their row.
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: USER_ID, notifyAutoDisabledAt: { not: null } },
+      data: { notifyEnabled: true, notifyAutoDisabledAt: null },
+    });
+  });
+
+  it('propagates a write failure (callers choose their own best-effort wrapping)', async () => {
+    const updateMany = vi.fn().mockRejectedValue(new Error('db down'));
+    const prisma = { user: { updateMany } } as unknown as PrismaClient;
+
+    await expect(liftNotifyAutoDisable(prisma, USER_ID)).rejects.toThrow('db down');
   });
 });

--- a/services/api-gateway/src/services/notifyOptIn.ts
+++ b/services/api-gateway/src/services/notifyOptIn.ts
@@ -22,3 +22,18 @@ export async function stampNotifyOptedIn(prisma: PrismaClient, userId: string): 
     data: { notifyOptedInAt: new Date() },
   });
 }
+
+/**
+ * Lift an infrastructure auto-disable on deliberate use. Auto-disable
+ * (consecutive permanent release-DM failures — see maybeAutoDisable) means
+ * "unreachable", not "uninterested"; a user actively using the bot again is
+ * reachable again, so their notifications come back. The notifyAutoDisabledAt
+ * guard makes this a strict no-op for explicit opt-outs (that path never sets
+ * the flag) — a user-chosen off is never overridden.
+ */
+export async function liftNotifyAutoDisable(prisma: PrismaClient, userId: string): Promise<void> {
+  await prisma.user.updateMany({
+    where: { id: userId, notifyAutoDisabledAt: { not: null } },
+    data: { notifyEnabled: true, notifyAutoDisabledAt: null },
+  });
+}


### PR DESCRIPTION
## Summary

Owner-raised gap on #1688: once auto-disable (two consecutive permanent DM failures) turns notifications off, nothing ever turns them back on — and the state was indistinguishable from a user-chosen opt-out, so no re-enable logic could safely exist. This ships the re-entry mechanism, sequenced (owner decision) **before** the prod flip of the 122 historical misclassified 50278 rows, so accelerated auto-disable is reversible from day one.

**Design: deliberate use IS the re-entry signal** — no guild-join watching. A user generating again necessarily shares a guild again *and* has demonstrated interest.

- New `users.notifyAutoDisabledAt` (nullable, state-machine null-semantics documented in the schema): set only by `maybeAutoDisable`, marking the disable as *infrastructure* (unreachable), never preference.
- ai-worker's per-generation deliberate-use stamp gains a flag-guarded lift: `notifyEnabled=true` + flag cleared, a strict no-op unless auto-disabled.
- BYOK `setKey` lifts identically (inside its existing best-effort wrapping).
- An explicit `/notifications` update clears the flag unconditionally: enabling lifts it; disabling converts it into a genuine opt-out that deliberate use must never undo.

**The invariant**: explicit opt-outs never have the flag set, so no path can ever re-enable them. Pinned by the `liftNotifyAutoDisable` where-guard test and the existing streak/opt-out suite.

## Migration

Additive (`ALTER TABLE users ADD COLUMN notify_auto_disabled_at TIMESTAMP`); applied locally, PGLite schema regenerated. Dev migration after merge; prod rides the next release's premigrate. Sync config untouched — the column rides row-level users sync exactly as `notifyOptedInAt` does.

## Verification

- `pnpm --filter api-gateway test` (2512) and `pnpm --filter ai-worker test` (3988) green; full `pnpm quality` green; pre-push ran build/lint/test across 16 affected packages.
- New/updated tests: lift shape + opt-out-guard (notifyOptIn), auto-disable now stamps the flag (releaseBroadcast), setKey lift seam, ai-worker lift seam, all three PATCH assertions carry the unconditional clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)