### PR TITLE
chore: pre-release polish — engines floor, link a11y, keptCount rename, stale comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "vitest": "^4.1.10"
   },
   "engines": {
-    "node": ">=25.0.0",
+    "node": ">=24.0.0",
     "pnpm": ">=10.0.0"
   },
   "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -300,8 +300,9 @@ export const ZAI_VALIDATION_MODEL = 'glm-4.5-air';
  *    request routes to z.ai-direct (the user has a z.ai key + the model is
  *    promoted), the model runs on z.ai, so its real limit is z.ai's documented
  *    one — NOT OpenRouter's, which differs (e.g. OpenRouter lists glm-5.1 at
- *    202752, but z.ai documents 200K). The catalog is also the ONLY source for
- *    z.ai-only models (`glm-5.2`, absent from OpenRouter). Keyless requests
+ *    202752, but z.ai documents 200K). The catalog is authoritative even for
+ *    models OpenRouter also lists (`glm-5.2` ships there as `z-ai/glm-5.2` —
+ *    it appeared after this catalog was written). Keyless requests
  *    fall through to OpenRouter and are capped from the OpenRouter cache
  *    instead (gateway validation gates on the z.ai key; the runtime resolver
  *    gates on the effective provider).
@@ -347,9 +348,10 @@ const ZAI_MODEL_CATALOG: Readonly<
 > = {
   'glm-5': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5', contextLength: 200_000 },
   'glm-5.1': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.1', contextLength: 200_000 },
-  // glm-5.2 is z.ai's flagship and is NOT on OpenRouter — the catalog is its
-  // only source for context length AND release date (so `/models` can rank it
-  // by recency). The docs URL follows z.ai's established per-model pattern.
+  // glm-5.2 is z.ai's flagship; OpenRouter also lists it (as `z-ai/glm-5.2`),
+  // but this catalog remains the z.ai-direct source for context length AND
+  // release date (so `/models` can rank it by recency). The docs URL follows
+  // z.ai's established per-model pattern.
   'glm-5.2': {
     docsUrl: 'https://docs.z.ai/guides/llm/glm-5.2',
     contextLength: 1_000_000,

--- a/services/bot-client/src/services/DiscordChannelFetcher.test.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.test.ts
@@ -235,7 +235,7 @@ describe('DiscordChannelFetcher', () => {
       });
 
       expect(result.fetchedCount).toBe(2);
-      expect(result.filteredCount).toBe(2);
+      expect(result.keptCount).toBe(2);
       expect(result.messages).toHaveLength(2);
 
       // Should be newest first - content no longer has [Name]: prefix (uses from attribute in XML)
@@ -662,7 +662,7 @@ describe('DiscordChannelFetcher', () => {
       });
 
       expect(result.fetchedCount).toBe(3);
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0].content).toContain('Normal message');
     });
@@ -708,7 +708,7 @@ describe('DiscordChannelFetcher', () => {
         botUserId: 'bot123',
       });
 
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       expect(result.messages[0].content).toContain('Has content');
     });
 
@@ -746,7 +746,7 @@ describe('DiscordChannelFetcher', () => {
 
       // Should have 2 messages (user + response), not 3 (thinking filtered out)
       expect(result.fetchedCount).toBe(3);
-      expect(result.filteredCount).toBe(2);
+      expect(result.keptCount).toBe(2);
       expect(result.messages).toHaveLength(2);
 
       // Verify thinking block was filtered
@@ -867,7 +867,7 @@ describe('DiscordChannelFetcher', () => {
 
       expect(result.messages).toEqual([]);
       expect(result.fetchedCount).toBe(0);
-      expect(result.filteredCount).toBe(0);
+      expect(result.keptCount).toBe(0);
     });
   });
 
@@ -1467,7 +1467,7 @@ describe('DiscordChannelFetcher', () => {
       });
 
       // Should have 1 message (voice message with transcript, bot reply filtered)
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       // Voice transcripts are now in messageMetadata for structured XML formatting
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
         'DB transcript content'
@@ -1565,7 +1565,7 @@ describe('DiscordChannelFetcher', () => {
         getTranscript,
       });
 
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       // Voice transcripts are now in messageMetadata for structured XML formatting
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
         'Fallback transcript from bot reply'
@@ -1617,7 +1617,7 @@ describe('DiscordChannelFetcher', () => {
         getTranscript,
       });
 
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       // Voice transcripts are now in messageMetadata for structured XML formatting
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
         'Fallback from empty DB'
@@ -1661,7 +1661,7 @@ describe('DiscordChannelFetcher', () => {
       });
 
       // Message should still be included (has attachment) but content may be empty/minimal
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       // The voice message attachment is processed but has no transcript
       expect(result.messages[0].content).not.toContain('transcript');
     });
@@ -1709,7 +1709,7 @@ describe('DiscordChannelFetcher', () => {
         // No getTranscript option
       });
 
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       // Voice transcripts are now in messageMetadata for structured XML formatting
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
         'Fallback when no DB function'
@@ -1774,7 +1774,7 @@ describe('DiscordChannelFetcher', () => {
 
       // Voice message included (has attachment), bot reply with image also included
       // but no transcript should be in the content
-      expect(result.filteredCount).toBe(2);
+      expect(result.keptCount).toBe(2);
     });
   });
 
@@ -1808,7 +1808,7 @@ describe('DiscordChannelFetcher', () => {
         botUserId: 'bot123',
       });
 
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       expect(result.messages.some(m => m.content.includes('v3.0.0 released'))).toBe(false);
       expect(result.messages.some(m => m.content.includes('what does'))).toBe(true);
     });
@@ -1857,7 +1857,7 @@ describe('DiscordChannelFetcher', () => {
 
       // Should have 2 messages (user msg, bot response)
       // Should NOT have transcript reply
-      expect(result.filteredCount).toBe(2);
+      expect(result.keptCount).toBe(2);
       expect(result.messages.some(m => m.content.includes('transcript of the voice'))).toBe(false);
       expect(result.messages.some(m => m.content.includes('Hello everyone'))).toBe(true);
       expect(result.messages.some(m => m.content.includes('How can I help'))).toBe(true);
@@ -1883,7 +1883,7 @@ describe('DiscordChannelFetcher', () => {
         botUserId: 'bot123',
       });
 
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       expect(result.messages[0].content).toContain('bot response without reply reference');
     });
 
@@ -1920,7 +1920,7 @@ describe('DiscordChannelFetcher', () => {
       });
 
       // Should still be included (has attachment, not a text transcript reply)
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
     });
 
     it('should NOT filter user reply messages', async () => {
@@ -1943,7 +1943,7 @@ describe('DiscordChannelFetcher', () => {
         botUserId: 'bot123',
       });
 
-      expect(result.filteredCount).toBe(1);
+      expect(result.keptCount).toBe(1);
       expect(result.messages[0].content).toContain('user reply');
     });
   });

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -124,7 +124,7 @@ export class DiscordChannelFetcher {
         {
           channelId: channel.id,
           fetchedCount: discordMessages.size,
-          filteredCount: processResult.messages.length,
+          keptCount: processResult.messages.length,
           imageAttachmentCount: processResult.imageAttachments.length,
           participantGuildInfoCount: participantCount,
           extendedContextUserCount: userCount,
@@ -136,7 +136,7 @@ export class DiscordChannelFetcher {
       return {
         messages: processResult.messages,
         fetchedCount: discordMessages.size,
-        filteredCount: processResult.messages.length,
+        keptCount: processResult.messages.length,
         rawMessages: discordMessages, // For opportunistic sync
         imageAttachments:
           processResult.imageAttachments.length > 0 ? processResult.imageAttachments : undefined,
@@ -159,7 +159,7 @@ export class DiscordChannelFetcher {
       return {
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       };
     }
   }

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -283,7 +283,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
         participantGuildInfo: { 'discord:other': { roles: ['Member'] } },
         imageAttachments: [{ url: 'https://cdn/x.png', contentType: 'image/png', id: 'x' }],
       });
@@ -667,7 +667,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       });
 
       // Extended context enabled so the Discord fetch receives the epoch —
@@ -717,7 +717,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       });
 
       await builder.buildContext(mockMessage, mockPersonality, 'Weigh in', {
@@ -758,7 +758,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       });
 
       await builder.buildContext(mockMessage, mockPersonality, 'Hello', {
@@ -794,7 +794,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: extendedMessages,
         fetchedCount: 10,
-        filteredCount: 1,
+        keptCount: 1,
       });
 
       // Merged history (what mergeWithHistory returns) — base is empty since
@@ -855,7 +855,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
         references: [],
@@ -894,7 +894,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
         references: [],
@@ -951,7 +951,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       });
       mockMergeWithHistory.mockReturnValue([]);
       mockExtractReferencesWithReplacement.mockResolvedValue({
@@ -1077,7 +1077,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: extendedMessages,
         fetchedCount: 10,
-        filteredCount: 1,
+        keptCount: 1,
         imageAttachments,
       });
       mockMergeWithHistory.mockReturnValue(extendedMessages);
@@ -1135,7 +1135,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: extendedMessages,
         fetchedCount: 10,
-        filteredCount: 1,
+        keptCount: 1,
         imageAttachments: [
           {
             url: 'https://cdn.discord.com/img.jpg',
@@ -1208,7 +1208,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: extendedMessages,
         fetchedCount: 10,
-        filteredCount: 2,
+        keptCount: 2,
         extendedContextUsers: [
           { discordId: 'user-alice', username: 'alice', isBot: false },
           { discordId: 'user-bob', username: 'bob', isBot: false },
@@ -1266,7 +1266,7 @@ describe('MessageContextBuilder', () => {
       mockFetchRecentMessages.mockResolvedValue({
         messages: [],
         fetchedCount: 0,
-        filteredCount: 0,
+        keptCount: 0,
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
         references: [],

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -211,7 +211,7 @@ export class MessageContextBuilder {
     logger.info(
       {
         channelId: message.channel.id,
-        discordMessages: fetchResult.filteredCount,
+        discordMessages: fetchResult.keptCount,
         dbMessages: history.length,
         totalMerged: mergedHistory.length,
       },

--- a/services/bot-client/src/services/channelFetcher/types.ts
+++ b/services/bot-client/src/services/channelFetcher/types.ts
@@ -39,8 +39,9 @@ export interface FetchResult {
   messages: ConversationMessage[];
   /** Number of messages fetched from Discord */
   fetchedCount: number;
-  /** Number of messages after filtering */
-  filteredCount: number;
+  /** Number of messages that SURVIVED filtering (== messages.length) —
+   *  the kept set, not the removed one. */
+  keptCount: number;
   /** Raw Discord messages for opportunistic sync (if needed) */
   rawMessages?: Collection<string, Message>;
   /** Image attachments collected from extended context messages, in collection

--- a/services/website/src/layouts/Base.astro
+++ b/services/website/src/layouts/Base.astro
@@ -72,7 +72,7 @@ const year = new Date().getFullYear();
           <a href="/docs">Docs</a>
           <a href="/terms">Terms</a>
           <a href="/privacy">Privacy</a>
-          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">GitHub<span class="sr-only"> (opens in new tab)</span></a>
         </div>
       </nav>
     </header>
@@ -84,18 +84,35 @@ const year = new Date().getFullYear();
     <footer class="site-footer">
       <div class="container footer-inner">
         <p>
-          © {year} Vladlena Costescu · <a href={`${GITHUB_URL}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer">MIT licensed</a>
+          © {year} Vladlena Costescu · <a href={`${GITHUB_URL}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer">MIT licensed<span class="sr-only"> (opens in new tab)</span></a>
         </p>
         <p class="footer-links">
           <a href="/docs">Documentation</a>
           <a href="/terms">Terms of Service</a>
           <a href="/privacy">Privacy Policy</a>
-          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">Source on GitHub</a>
+          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">Source on GitHub<span class="sr-only"> (opens in new tab)</span></a>
         </p>
       </div>
     </footer>
   </body>
 </html>
+
+<style is:global>
+  /* Visually-hidden text for screen readers — the standard clip-pattern
+     utility. Used by every target="_blank" anchor's "(opens in new tab)"
+     affordance; global so page-level links share it. */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>
 
 <style>
   .site-header {

--- a/services/website/src/pages/docs/index.astro
+++ b/services/website/src/pages/docs/index.astro
@@ -63,6 +63,7 @@ const sections: { emoji: string; title: string; body: string; href: string; exte
               {s.emoji}
             </span>
             {s.title}
+            {s.external === true && <span class="sr-only"> (opens in new tab)</span>}
           </h2>
           <p>{s.body}</p>
         </a>

--- a/services/website/src/pages/index.astro
+++ b/services/website/src/pages/index.astro
@@ -64,7 +64,9 @@ const features: { emoji: string; title: string; body: string; link?: FeatureLink
       <div class="hero-actions">
         <a class="button button--primary" href="/docs/getting-started">Get started</a>
         <a class="button" href="/docs">Docs</a>
-        <a class="button" href={GITHUB_URL} target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a class="button" href={GITHUB_URL} target="_blank" rel="noopener noreferrer"
+          >GitHub<span class="sr-only"> (opens in new tab)</span></a
+        >
       </div>
       <p class="hero-note">Public beta · bring your own key or use the free tier · 18+</p>
     </div>
@@ -88,6 +90,7 @@ const features: { emoji: string; title: string; body: string; link?: FeatureLink
               rel={f.link.external === true ? 'noopener noreferrer' : undefined}
             >
               {f.link.label} →
+              {f.link.external === true && <span class="sr-only"> (opens in new tab)</span>}
             </a>
           )}
         </article>


### PR DESCRIPTION
## Summary

Four owner-picked small riders bundled into one reviewable batch:

1. **`engines.node` >=25 → >=24** — CI pins Node 24 on all four jobs, this machine runs 24, runtime Dockerfiles run 25 (satisfies >=24 trivially). The floor now states the actually-tested minimum, and the constant local engine WARN dies.
2. **Website link accessibility** (#1674 follow-up) — all four `target="_blank"` anchors (header GitHub, footer license + source, hero GitHub) gain a visually-hidden "(opens in new tab)" span via a shared global `.sr-only` clip-pattern utility.
3. **`FetchResult.filteredCount` → `keptCount`** (#1669 follow-up) — the field carries the SURVIVOR count (`processResult.messages.length`), not the removed count. Renamed across type + writers + reader + 28 test sites, including the 12 untyped fixture payloads in `MessageContextBuilder.test.ts` that neither a type-name grep nor the compiler would catch (the field-name-sweep rule in `02-code-standards.md` §8 earning its keep). The ai-worker `filteredCount` locals are unrelated homonyms — one genuinely counts removals — and deliberately untouched.
4. **Stale `glm-5.2` catalog comments** — "absent from/NOT on OpenRouter" was demonstrably false (it ships as `z-ai/glm-5.2`); corrected in both spots while preserving the still-valid rationale that the z.ai catalog stays authoritative for z.ai-direct routing.

## Verification

bot-client 5616 + website 7 tests green; full `pnpm quality` green; zero `filteredCount` remnants in bot-client (field-name sweep verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)