### PR TITLE
chore: hook blocking code commits on develop/main

### DIFF
--- a/.claude/hooks/develop-code-commit-guard.probe.sh
+++ b/.claude/hooks/develop-code-commit-guard.probe.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Fixture check for develop-code-commit-guard.sh — run after ANY edit to the
+# hook. Asserts the exit-code table over the command shapes that have
+# historically been missed: the first live-probe round only exercised
+# single-line `-m "..."` commits and shipped a strip step that silently
+# no-opped on the repo's canonical heredoc commit format.
+#
+# Colocated with the hook (not packages/tooling) because it IS the hook's
+# verification mechanism — a bash exit-code harness over a bash hook, run
+# manually on hook edits, with no ops-CLI surface.
+#
+# Usage: .claude/hooks/develop-code-commit-guard.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/develop-code-commit-guard.sh"
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+TMP_BASE=$(mktemp -d)
+WT="$TMP_BASE/probe-wt"
+FEATURE_WT="$TMP_BASE/probe-feature-wt"
+cleanup() {
+  git -C "$REPO_ROOT" worktree remove "$WT" --force 2>/dev/null
+  git -C "$REPO_ROOT" worktree remove "$FEATURE_WT" --force 2>/dev/null
+  git -C "$REPO_ROOT" branch -D probe/feature-fixture 2>/dev/null
+  rm -rf "$TMP_BASE"
+}
+trap cleanup EXIT
+# --force: the primary checkout routinely sits ON develop (doc commits,
+# post-release), and worktree add refuses a branch checked out elsewhere.
+# Safe here — the probe never commits, it only reads branch + status.
+git -C "$REPO_ROOT" worktree add --force "$WT" develop >/dev/null || {
+  echo "FATAL: could not create develop worktree (git error above)" >&2
+  exit 1
+}
+# Second worktree on a FEATURE branch: pins the hook's highest-traffic path
+# (stay silent off develop/main) — the branch of the control flow that would
+# regress invisibly (fail-open) if the branch check were ever broken.
+git -C "$REPO_ROOT" worktree add --force -b probe/feature-fixture "$FEATURE_WT" develop >/dev/null || {
+  echo "FATAL: could not create feature worktree (git error above)" >&2
+  exit 1
+}
+
+FAILURES=0
+
+# run <expected-exit> <label> <command> [space-separated dirty relpaths]
+# TARGET_WT selects the worktree (defaults to the develop one).
+TARGET_WT=""
+run() {
+  local expected="$1" label="$2" cmd="$3" dirty="${4:-}" wt="${TARGET_WT:-$WT}" f
+  for f in $dirty; do
+    mkdir -p "$wt/$(dirname "$f")"
+    printf 'probe\n' > "$wt/$f"
+  done
+  jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}' \
+    | CLAUDE_PROJECT_DIR="$wt" "$HOOK" >/dev/null 2>&1
+  local actual=$?
+  for f in $dirty; do
+    rm -f "$wt/$f"
+  done
+  if [ "$actual" -eq "$expected" ]; then
+    printf 'PASS  (exit %d)  %s\n' "$actual" "$label"
+  else
+    printf 'FAIL  (exit %d, expected %d)  %s\n' "$actual" "$expected" "$label"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+CANONICAL_HEREDOC='git add -A && git commit -m "$(cat <<'\''EOF'\''
+feat(ai-worker): add pgvector memory retrieval
+
+Body mentioning git commit and TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 in prose.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"'
+
+EARLY_HEREDOC='cat <<EOF > notes.txt
+some generated content
+EOF
+git commit -m "x"'
+
+run 2 "plain single-line commit, dirty ts"        'git add -A && git commit -m "x"'                        'services/probe.ts'
+run 2 "CANONICAL heredoc commit form, dirty ts"   "$CANONICAL_HEREDOC"                                     'services/probe.ts'
+run 2 "heredoc earlier in compound, dirty ts"     "$EARLY_HEREDOC"                                         'services/probe.ts'
+run 2 "git -C global-flag form, dirty ts"         'git -C /some/path commit -m "x"'                        'services/probe.ts'
+run 2 "escape token in MESSAGE prose only"        'git commit -m "prose TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1"' 'services/probe.ts'
+run 2 "dirty .claude/rules carve-out"             'git commit -m "x"'                                      '.claude/rules/probe.md'
+run 2 "dirty workflow yml"                        'git commit -m "x"'                                      '.github/workflows/probe.yml'
+run 2 "dirty json manifest"                       'git commit -m "x"'                                      'packages/probe/package.json'
+run 2 "dirty yaml config"                         'git commit -m "x"'                                      'services/probe/config.yaml'
+run 2 "dirty Dockerfile"                          'git commit -m "x"'                                      'services/probe/Dockerfile'
+run 0 "escape hatch in command position"          'TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 git commit -m "x"'   'services/probe.ts'
+run 0 "escape hatch, canonical heredoc form"      "TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 $CANONICAL_HEREDOC"  'services/probe.ts'
+run 0 "non-git command"                           'echo hello'                                             'services/probe.ts'
+run 0 "clean tree commit"                         'git add -A && git commit -m "x"'
+run 0 "docs-only dirty file"                      'git commit -m "x"'                                      'docs/probe-notes.md'
+# Accepted-tradeoff pin: dirty-tree (not staged-set) design means an
+# incidental lockfile diff blocks even a doc-only commit — escape hatch or
+# stash is the sanctioned path.
+run 2 "mixed tree: doc + incidental lockfile"     'git commit -m "x"'                                      'docs/probe-notes.md probe-lock.yaml'
+# Highest-traffic path: feature branches never block, whatever is dirty.
+TARGET_WT="$FEATURE_WT"
+run 0 "feature branch, dirty ts stays silent"     'git add -A && git commit -m "x"'                        'services/probe.ts'
+TARGET_WT=""
+
+if [ "$FAILURES" -gt 0 ]; then
+  printf '\n%d probe(s) FAILED\n' "$FAILURES" >&2
+  exit 1
+fi
+printf '\nAll probes passed\n'

--- a/.claude/hooks/develop-code-commit-guard.sh
+++ b/.claude/hooks/develop-code-commit-guard.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# PreToolUse hook: block `git commit` on develop/main when review-gated files
+# are in play. Direct commits to develop are doc-only by policy
+# (00-critical.md § "Direct doc commits to develop"); code, CI config,
+# dependency manifests, Dockerfiles, and .claude rules/skills/hooks must go
+# branch → PR → review.
+#
+# The gate keys off the DIRTY TREE, not the staging area: the failure shape
+# is an `git add … && git commit` chain, where at PreToolUse time nothing is
+# staged yet — only the working tree carries the signal.
+#
+# Matching notes (review-hardened):
+# - Heredoc bodies and quoted strings are stripped BEFORE any matching (the
+#   sibling git-commit-filter-guard.sh python technique — delimiter-scoped,
+#   so the repo's canonical `-m "$(cat <<'EOF' … EOF)"` commit shape strips
+#   to just its command skeleton instead of blinding the scan). A commit
+#   MESSAGE can therefore neither trigger the guard nor supply the escape
+#   token.
+# - `git commit` matching tolerates global flags (`git -C x commit`,
+#   `git --git-dir=y commit`).
+# - The escape hatch is an assignment token leading ANY chain segment of the
+#   command (typically the first): its presence in command position — never
+#   in quoted/heredoc prose — is the deliberate, review-visible unlock for
+#   the whole command. This is a visibility guard, not a security boundary,
+#   so per-segment env semantics are intentionally not modeled.
+# - Known limitation: the branch check runs in CLAUDE_PROJECT_DIR; a command
+#   that cd's into a DIFFERENT checkout/worktree is checked against the main
+#   checkout's branch. Accepted — the failure pattern this guards is in-repo.
+#
+# Fixture check: run .claude/hooks/develop-code-commit-guard.probe.sh after
+# ANY edit to this file — it asserts the exit-code table over the command
+# shapes that have historically been missed (canonical heredoc commit form
+# included).
+
+set -uo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$COMMAND" ] && exit 0
+
+# Cheap short-circuit before spawning python: no git+commit tokens at all.
+case "$COMMAND" in
+  *git*commit*) ;;
+  *) exit 0 ;;
+esac
+
+VERDICT=$(GUARD_CMD="$COMMAND" python3 << 'PYEOF'
+import os
+import re
+
+cmd = os.environ.get("GUARD_CMD", "")
+if not cmd:
+    print("ok")
+    raise SystemExit
+
+# Strip $(cat <<'EOF' … EOF) commit-message substitutions, bare heredoc
+# bodies, and quoted strings — each scoped to its own terminator — so
+# message CONTENT can't influence the structural checks below. (A sed
+# line-range delete is NOT equivalent: /<<EOF/,$d runs to end-of-buffer
+# and erases the very line carrying `git commit`.)
+cmd = re.sub(r"\$\(cat <<'?\"?(\w+)'?\"?.*?\n\1\s*\)", "MSG", cmd, flags=re.S)
+cmd = re.sub(r"<<[-~]?\s*'?\"?(\w+)'?\"?.*?\n\1(?=\s|$)", "HEREDOC", cmd, flags=re.S)
+cmd = re.sub(r"'[^']*'", "S", cmd)
+cmd = re.sub(r'"[^"]*"', "S", cmd)
+
+# `git commit` with optional global flags (-C <path>, --git-dir=…, etc.).
+if not re.search(r"\bgit(\s+-{1,2}\S+(\s+\S+)?)*\s+commit\b", cmd):
+    print("ok")
+    raise SystemExit
+
+# Escape hatch: an assignment token leading a chain segment — never prose
+# (prose lived in quotes/heredocs, which are already stripped).
+for segment in re.split(r"&&|\|\||;|\||\n", cmd):
+    if re.match(r"\s*TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1(\s|$)", segment):
+        print("ok")
+        raise SystemExit
+
+print("check")
+PYEOF
+) || exit 0
+
+[ "$VERDICT" != "check" ] && exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$BRANCH" != "develop" ] && [ "$BRANCH" != "main" ]; then
+  exit 0
+fi
+
+# Review-gated files anywhere in the dirty tree (staged, unstaged, untracked):
+# code, CI/workflow config, dependency manifests, Dockerfiles, and the
+# .claude rules/skills/hooks carve-out (load-bearing .md per 00-critical.md).
+# -uall is load-bearing: without it, files inside a NEW untracked directory
+# collapse to `?? dir/` and no extension ever matches — a fresh package full
+# of code would slip through. `cut -c4-` keeps full paths (porcelain =
+# 2 status chars + space) so space-containing filenames render correctly.
+GATED_FILES=$(git status --porcelain -uall 2>/dev/null \
+  | cut -c4- \
+  | grep -E '\.(ts|tsx|js|jsx|mjs|cjs|py|prisma|sql|sh|yml|yaml|json|toml)$|(^|/)Dockerfile[^/]*$|^\.github/|^\.claude/(rules|skills|hooks)/' \
+  || true)
+
+if [ -z "$GATED_FILES" ]; then
+  exit 0
+fi
+
+GATED_COUNT=$(printf '%s\n' "$GATED_FILES" | wc -l)
+
+cat >&2 <<'BANNER'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+DEVELOP CODE-COMMIT GUARD — commit blocked on a long-lived branch
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Review-gated files are in the working tree while committing on
+develop/main. Direct commits here are DOC-ONLY (00-critical.md); code,
+CI config, dependency manifests, and .claude rules/skills/hooks go
+branch → PR → review. This has bitten twice — hence this hook.
+
+Dirty gated files (first 10):
+BANNER
+printf '%s\n' "$GATED_FILES" | head -10 >&2
+if [ "$GATED_COUNT" -gt 10 ]; then
+  printf '  …and %d more\n' "$((GATED_COUNT - 10))" >&2
+fi
+cat >&2 <<'FOOTER'
+
+Fix: git checkout -b <type>/<name> first, then commit there.
+Doc-only commit with an incidentally dirty tree? Stage ONLY the doc
+files and prefix the command with TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1
+(assignment position, not prose — deliberate, review-visible friction).
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FOOTER
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/git-commit-filter-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/develop-code-commit-guard.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Structural fix for a twice-today failure: feature code committed directly to develop (second occurrence pushed and reverted — see #1695's process note). Per `00-critical.md` § Fix Recurring Failures Structurally, occurrence two gets a hook.

`develop-code-commit-guard.sh` (PreToolUse on Bash): when `git commit` runs while the current branch is develop/main **and** the dirty tree contains code-looking files (`.ts/.tsx/.js/.py/.prisma/.sql/.sh` etc.), the commit is blocked with branch-first instructions. The dirty-tree signal (not the staging area) is deliberate — the failing pattern is `git add … && git commit` chains, where nothing is staged at PreToolUse time. Doc-only direct commits on a clean code tree pass untouched, preserving the sanctioned exception. Inline `TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1` escape hatch for sanctioned edge cases (e.g. reverts), visible in review by construction.

## Verification

Live-probed all three paths: blocks with a dirty code file on develop (message + exit 2), silent on feature branches, escape hatch passes. `bash -n` clean, settings.json jq-valid. Takes effect next session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)