### PR TITLE
feat(bot-client): component router + purge/account-delete onto Tier-B (UX Phase 2, PR-1b)

### DIFF
--- a/packages/common-types/src/schemas/api/index.ts
+++ b/packages/common-types/src/schemas/api/index.ts
@@ -376,7 +376,6 @@ export {
   MemoryStatsResponseSchema,
   MemoryUpdateSchema,
   PreviewTokenSchema,
-  type PurgeMemoriesResponse,
   PurgeMemoriesResponseSchema,
   PurgeMemoriesSchema,
   PurgeTokenSchema,

--- a/packages/common-types/src/schemas/api/memory.ts
+++ b/packages/common-types/src/schemas/api/memory.ts
@@ -261,8 +261,6 @@ export const PurgeMemoriesResponseSchema = z.object({
   message: z.string(),
 });
 
-export type PurgeMemoriesResponse = z.infer<typeof PurgeMemoriesResponseSchema>;
-
 /**
  * GET /user/memory/:id  ·  PATCH /user/memory/:id  ·  PUT /user/memory/:id/lock
  * All three return the same `{ memory }` envelope.

--- a/packages/common-types/src/schemas/index.ts
+++ b/packages/common-types/src/schemas/index.ts
@@ -229,7 +229,6 @@ export {
   PersonaUpdateSchema,
   PreviewTokenSchema,
   ProviderWarningSchema,
-  type PurgeMemoriesResponse,
   PurgeMemoriesResponseSchema,
   PurgeMemoriesSchema,
   PurgeTokenSchema,

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -1149,7 +1149,6 @@
         "memory-browse",
         "memory-search",
         "memory-detail",
-        "memory-purge",
         "memory-fact-browse",
         "memory-fact"
       ],
@@ -1893,8 +1892,7 @@
       },
       "componentPrefixes": [
         "user-defaults-settings",
-        "settings-preset-override",
-        "settings-data-delete"
+        "settings-preset-override"
       ],
       "data": {
         "options": [

--- a/services/bot-client/src/commands/memory/index.ts
+++ b/services/bot-client/src/commands/memory/index.ts
@@ -36,7 +36,7 @@ import {
   handleIncognitoForget,
 } from './incognito.js';
 import { handleBatchDelete } from './batchDelete.js';
-import { handlePurge, MEMORY_PURGE_PREFIX } from './purge.js';
+import { handlePurge } from './purge.js';
 import { handlePersonalityAutocomplete } from './autocomplete.js';
 import { MEMORY_DETAIL_PREFIX } from './detail.js';
 import { handleFacts, FACT_BROWSE_PREFIX } from './factsBrowse.js';
@@ -343,7 +343,6 @@ export default defineCommand({
     MEMORY_BROWSE_PREFIX,
     MEMORY_SEARCH_PREFIX,
     MEMORY_DETAIL_PREFIX,
-    MEMORY_PURGE_PREFIX,
     FACT_BROWSE_PREFIX,
     FACT_DETAIL_PREFIX,
   ],

--- a/services/bot-client/src/commands/memory/interactionHandlers.ts
+++ b/services/bot-client/src/commands/memory/interactionHandlers.ts
@@ -1,10 +1,10 @@
 /**
  * Memory Command - Interaction Handlers
  *
- * Router-pattern handlers for button, modal, and select menu interactions.
- * Routes to:
- * - Memory browse pagination (browse.ts)
- * - Memory search pagination (search.ts)
+ * Declarative dispatch table over `createComponentRouter` covering:
+ * - Memory browse/search pagination + selects (browse.ts / search.ts)
+ * - Purge destructive confirmation (purge.ts, Tier-B flow)
+ * - Fact browse/detail surfaces (factsBrowse.ts / factsDetail.ts)
  * - Memory detail actions (detail.ts via detailActionRouter.ts)
  *
  * All state lives in dashboard sessions (keyed by messageId) or in the
@@ -18,6 +18,9 @@ import {
   type StringSelectMenuInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { createComponentRouter, type ComponentRoute } from '../../utils/componentRouter.js';
+import { replyValidationError } from '../../utils/confirmation/confirmDestructive.js';
+import { DestructiveCustomIds } from '../../utils/customIds.js';
 import { parseMemoryActionId, handleMemorySelect } from './detail.js';
 import { handleEditModalSubmit } from './detailModals.js';
 import { findMemoryListSessionByMessage } from './browseSession.js';
@@ -35,7 +38,7 @@ import {
   handleSearchDetailAction,
   isMemorySearchPagination,
 } from './search.js';
-import { MEMORY_PURGE_PREFIX, handlePurgeButton, handlePurgeModal } from './purge.js';
+import { MEMORY_PURGE_OPERATION, handlePurgeButton, handlePurgeModal } from './purge.js';
 import {
   factBrowseHelpers,
   isFactBrowsePagination,
@@ -56,6 +59,9 @@ import { renderSpec } from '../../ux/render/render.js';
 
 const logger = createLogger('memory-command');
 
+/** Shared copy for unrecognized component customIds. */
+const UNKNOWN_INTERACTION = 'Unknown interaction.';
+
 /**
  * Detail actions that operate on a single memory without needing to know
  * which list (browse vs search) the detail view was opened from. These can
@@ -74,84 +80,35 @@ const SESSION_INDEPENDENT_ACTIONS = new Set([
 ]);
 
 /**
- * Handle button interactions for memory commands.
- * Routes pagination to browse/search handlers, detail actions to the
- * detail action router (which calls back to refresh the list view).
+ * Memory-detail button dispatch (memory-detail::...).
+ *
+ * Session-independent actions (edit, lock, view-full, etc.) only need the
+ * memoryId from the custom ID. Session-dependent actions (back,
+ * confirm-delete) need to know which list to refresh after the action
+ * completes — that requires a session lookup, which is async, so we must
+ * deferUpdate BEFORE it (ack-first rule). The downstream handlers tolerate
+ * an already-deferred interaction, and the expired-session path uses
+ * followUp instead of reply.
+ *
+ * Failure mode to watch: if any action in SESSION_INDEPENDENT_ACTIONS ever
+ * starts calling onRefresh, memories opened from a search result will
+ * silently skip the list refresh — refreshBrowseList bails when the
+ * session kind is 'search'. The fix in that case is to move the newly
+ * refreshing action out of SESSION_INDEPENDENT_ACTIONS so it falls through
+ * to the kind-based dispatch below.
  */
-export async function handleButton(interaction: ButtonInteraction): Promise<void> {
-  const { customId } = interaction;
-
-  // Browse pagination button (memory-browse::browse::...)
-  if (isMemoryBrowsePagination(customId)) {
-    await handleBrowsePagination(interaction);
-    return;
-  }
-
-  // Search pagination button (memory-search::browse::...)
-  if (isMemorySearchPagination(customId)) {
-    await handleSearchPagination(interaction);
-    return;
-  }
-
-  // Purge confirmation buttons (memory-purge::proceed::... or memory-purge::cancel)
-  if (customId.startsWith(`${MEMORY_PURGE_PREFIX}::`)) {
-    await handlePurgeButton(interaction);
-    return;
-  }
-
-  // Fact browse pagination (memory-fact-browse::browse::...) — checked before
-  // the fact detail parse because the prefixes share the 'memory-fact' stem.
-  if (isFactBrowsePagination(customId)) {
-    await handleFactsPagination(interaction);
-    return;
-  }
-
-  // Fact detail buttons (memory-fact::...)
-  const factAction = parseFactActionId(customId);
-  if (factAction !== null) {
-    await routeFactButton(interaction, factAction);
-    return;
-  }
-
-  // Detail action buttons (memory-detail::...)
-  const parsed = parseMemoryActionId(customId);
+async function handleDetailButton(interaction: ButtonInteraction): Promise<void> {
+  const parsed = parseMemoryActionId(interaction.customId);
   if (parsed === null) {
-    logger.debug({ customId }, 'Unknown button customId');
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Unknown interaction.')),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyValidationError(interaction, UNKNOWN_INTERACTION);
     return;
   }
 
-  // Session-independent actions (edit, lock, view-full, etc.) only need the
-  // memoryId from the custom ID — they don't care which list the detail view
-  // was opened from. Route them directly via handleBrowseDetailAction which
-  // delegates to handleMemoryDetailAction for the action dispatch.
-  // Note: the onRefresh callback is only invoked for 'back' and 'confirm-delete',
-  // which ARE session-dependent — those fall through to the kind-based routing below.
-  //
-  // Failure mode to watch: if any action in SESSION_INDEPENDENT_ACTIONS ever
-  // starts calling onRefresh, memories opened from a search result will
-  // silently skip the list refresh — refreshBrowseList bails when the
-  // session kind is 'search'. The fix in that case is to move the newly
-  // refreshing action out of SESSION_INDEPENDENT_ACTIONS so it falls through
-  // to the kind-based dispatch below.
   if (SESSION_INDEPENDENT_ACTIONS.has(parsed.action)) {
     await handleBrowseDetailAction(interaction);
     return;
   }
 
-  // Session-dependent actions (back, confirm-delete) need to know which list
-  // to refresh after the action completes. Look up the session to find out.
-  //
-  // Ack-first rule compliance (.claude/rules/04-discord.md): the session
-  // lookup is async, so we must deferUpdate BEFORE it to stay inside the
-  // 3-second interaction window. The downstream 'back' and confirm-delete
-  // handlers in detailActionRouter / detail.ts tolerate an already-deferred
-  // interaction (they guard with !interaction.deferred), so this early
-  // defer doesn't double-ack. After the defer, the expired-session path
-  // must use followUp instead of reply.
   await interaction.deferUpdate();
 
   const session = await findMemoryListSessionByMessage(interaction.message.id);
@@ -169,7 +126,7 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
       : await handleSearchDetailAction(interaction);
 
   if (!handled) {
-    logger.warn({ customId }, 'Unhandled detail action');
+    logger.warn({ customId: interaction.customId }, 'Unhandled detail action');
     // Interaction is already deferred at this point, so use followUp.
     await interaction.followUp({
       content: renderSpec(CATALOG.error.validation('Unknown action.')),
@@ -179,17 +136,19 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
 }
 
 /**
- * Route a parsed fact-detail button to its handler.
+ * Fact-detail button dispatch (memory-fact::...).
  *
  * Ack discipline: 'correct' must NOT be deferred here — it opens a modal, and
  * showModal must be the interaction's first response. 'lock' and 'forget'
  * self-defer. 'back' and 'confirm-forget' are deferred here because they
  * refresh the list view (their handlers guard against double-acking).
  */
-async function routeFactButton(
-  interaction: ButtonInteraction,
-  parsed: { action: string; factId?: string; extra?: string }
-): Promise<void> {
+async function handleFactButton(interaction: ButtonInteraction): Promise<void> {
+  const parsed = parseFactActionId(interaction.customId);
+  if (parsed === null) {
+    await replyValidationError(interaction, UNKNOWN_INTERACTION);
+    return;
+  }
   const { action, factId, extra } = parsed;
 
   if (action === 'correct' && factId !== undefined) {
@@ -219,106 +178,92 @@ async function routeFactButton(
   }
 
   logger.warn({ customId: interaction.customId }, 'Unhandled fact action');
-  await interaction.reply({
-    content: renderSpec(CATALOG.error.validation('Unknown action.')),
-    flags: MessageFlags.Ephemeral,
-  });
+  await replyValidationError(interaction, 'Unknown action.');
 }
 
-/**
- * Handle modal submit interactions for memory editing.
- *
- * Every path must acknowledge the interaction (reply or defer) — unacknowledged
- * modal submits surface as "This interaction failed" in Discord, which is worse
- * than a clean error message.
- */
-export async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
-  const { customId } = interaction;
-
-  // Purge confirmation modal (memory-purge::confirm::<personalityId>)
-  if (customId.startsWith(`${MEMORY_PURGE_PREFIX}::`)) {
-    await handlePurgeModal(interaction);
+/** Fact correction modal (memory-fact::correct::<factId>). */
+async function handleFactCorrectModal(interaction: ModalSubmitInteraction): Promise<void> {
+  const parsed = parseFactActionId(interaction.customId);
+  if (parsed?.factId === undefined) {
+    await replyValidationError(interaction, 'Malformed correction modal (missing fact ID).');
     return;
   }
+  await handleCorrectModalSubmit(interaction, parsed.factId);
+}
 
-  // Fact correction modal (memory-fact::correct::<factId>)
-  const factParsed = parseFactActionId(customId);
-  if (factParsed?.action === 'correct' && factParsed.factId !== undefined) {
-    await handleCorrectModalSubmit(interaction, factParsed.factId);
-    return;
-  }
-
-  const parsed = parseMemoryActionId(customId);
-
-  if (parsed?.action !== 'edit') {
-    logger.warn({ customId }, 'Unknown modal');
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Unknown modal submission.')),
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-
-  if (parsed.memoryId === undefined) {
+/** Memory edit modal (memory-detail::edit::<memoryId>). */
+async function handleMemoryEditModal(interaction: ModalSubmitInteraction): Promise<void> {
+  const parsed = parseMemoryActionId(interaction.customId);
+  if (parsed?.memoryId === undefined) {
     logger.warn({ customId: interaction.customId }, 'Edit modal missing memoryId');
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Malformed edit modal (missing memory ID).')),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyValidationError(interaction, 'Malformed edit modal (missing memory ID).');
     return;
   }
-
   await handleEditModalSubmit(interaction, parsed.memoryId);
 }
 
 /**
- * Handle select menu interactions for memory commands.
- * Routes to browse or search select handlers based on the custom ID prefix.
+ * The dispatch table. Order matters in two places: fact-browse before the
+ * fact-detail parse (the prefixes share the 'memory-fact' stem), and the
+ * memory-detail parse last (its parser is the loosest).
  */
-export async function handleSelectMenu(interaction: StringSelectMenuInteraction): Promise<void> {
-  const { customId } = interaction;
+const routes: ComponentRoute[] = [
+  // Browse/search pagination + selects
+  { matches: isMemoryBrowsePagination, onButton: handleBrowsePagination },
+  { matches: id => browseHelpers.isBrowseSelect(id), onSelect: handleBrowseSelect },
+  { matches: isMemorySearchPagination, onButton: handleSearchPagination },
+  { matches: id => searchHelpers.isBrowseSelect(id), onSelect: handleSearchSelect },
+  // Purge destructive confirmation (memory::destructive::...::purge::...)
+  {
+    matches: id => DestructiveCustomIds.parse(id)?.operation === MEMORY_PURGE_OPERATION,
+    onButton: handlePurgeButton,
+    onModal: handlePurgeModal,
+  },
+  // Fact browse before fact detail (shared 'memory-fact' stem)
+  { matches: isFactBrowsePagination, onButton: handleFactsPagination },
+  {
+    // Fact browse select or the detail select id — both open the fact detail view.
+    matches: id =>
+      factBrowseHelpers.isBrowseSelect(id) || parseFactActionId(id)?.action === 'select',
+    onSelect: handleFactSelect,
+  },
+  {
+    matches: id => parseFactActionId(id)?.action === 'correct',
+    onModal: handleFactCorrectModal,
+  },
+  { matches: id => parseFactActionId(id) !== null, onButton: handleFactButton },
+  // Memory detail (memory-detail::...). The select id is used by
+  // buildMemorySelectMenu for both browse and search result lists — both
+  // origins open the same detail view, and "back" resolves the original
+  // list via the messageId-keyed session when clicked.
+  {
+    matches: id => parseMemoryActionId(id)?.action === 'select',
+    onSelect: handleMemorySelect,
+  },
+  {
+    matches: id => parseMemoryActionId(id)?.action === 'edit',
+    onModal: handleMemoryEditModal,
+  },
+  { matches: id => parseMemoryActionId(id) !== null, onButton: handleDetailButton },
+];
 
-  // Browse select (memory-browse::browse-select::...)
-  if (browseHelpers.isBrowseSelect(customId)) {
-    await handleBrowseSelect(interaction);
-    return;
-  }
+const router = createComponentRouter({
+  routes,
+  // Every unrouted path must still acknowledge the interaction —
+  // unacknowledged submits surface as "This interaction failed" in Discord.
+  // "Unknown interaction" (not "expired") so the user doesn't chase the
+  // wrong cause and re-run the command needlessly.
+  unrouted: async (interaction, kind) => {
+    logger.debug({ customId: interaction.customId, kind }, 'Unrouted memory interaction');
+    await replyValidationError(
+      interaction,
+      kind === 'modal' ? 'Unknown modal submission.' : UNKNOWN_INTERACTION
+    );
+  },
+});
 
-  // Search select (memory-search::browse-select::...)
-  if (searchHelpers.isBrowseSelect(customId)) {
-    await handleSearchSelect(interaction);
-    return;
-  }
-
-  // Fact browse select (memory-fact-browse::browse-select) or the detail
-  // select id (memory-fact::select) — both open the fact detail view.
-  if (
-    factBrowseHelpers.isBrowseSelect(customId) ||
-    parseFactActionId(customId)?.action === 'select'
-  ) {
-    await handleFactSelect(interaction);
-    return;
-  }
-
-  // memory-detail::select — used by buildMemorySelectMenu for both browse
-  // and search result lists. Route directly to handleMemorySelect without
-  // a session lookup: both origins open the same detail view, and the
-  // detail view's "back" button looks up the original list via the
-  // messageId-keyed session when it's clicked (see refreshBrowseList /
-  // refreshSearchList in detailActionRouter). No up-front session kind
-  // disambiguation is needed here.
-  const parsed = parseMemoryActionId(customId);
-  if (parsed?.action === 'select') {
-    await handleMemorySelect(interaction);
-    return;
-  }
-
-  logger.debug({ customId }, 'Unknown select menu customId');
-  // The session may still be valid; the customId itself isn't recognized.
-  // Show "Unknown interaction" rather than "expired" so the user doesn't
-  // chase the wrong cause (e.g., re-running the command needlessly).
-  await interaction.reply({
-    content: renderSpec(CATALOG.error.validation('Unknown interaction.')),
-    flags: MessageFlags.Ephemeral,
-  });
-}
+export const handleButton: (interaction: ButtonInteraction) => Promise<void> = router.handleButton;
+export const handleSelectMenu: (interaction: StringSelectMenuInteraction) => Promise<void> =
+  router.handleSelectMenu;
+export const handleModal: (interaction: ModalSubmitInteraction) => Promise<void> =
+  router.handleModal;

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -13,7 +13,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GatewayApiError } from '@tzurot/clients';
-import { handlePurge, handlePurgeButton, handlePurgeModal, MEMORY_PURGE_PREFIX } from './purge.js';
+import {
+  handlePurge,
+  handlePurgeButton,
+  handlePurgeModal,
+  MEMORY_PURGE_OPERATION,
+} from './purge.js';
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
@@ -103,6 +108,9 @@ function createMockButtonInteraction(
     customId,
     user: { id: opts.userId ?? 'user-123' },
     message: {
+      // The Tier-B factory reads invoker ownership from the parent message's
+      // interactionMetadata (the original slash invoker).
+      interactionMetadata: { user: { id: 'user-123' } },
       embeds: [
         {
           footer: footerText === null ? null : { text: footerText },
@@ -126,7 +134,7 @@ function createMockModalInteraction(
 ) {
   const customId =
     opts.customId ??
-    `${MEMORY_PURGE_PREFIX}::confirm::${PERSONALITY_ID}::${opts.userId ?? 'user-123'}`;
+    `memory::destructive::modal_submit::${MEMORY_PURGE_OPERATION}::${PERSONALITY_ID}`;
   // Use `in` check so explicit `null` overrides the default — `??` would replace null with the default.
   const footerText: string | null =
     'footerText' in opts && opts.footerText !== undefined
@@ -143,6 +151,7 @@ function createMockModalInteraction(
       footerText === null
         ? null
         : {
+            interactionMetadata: { user: { id: 'user-123' } },
             embeds: [{ footer: { text: footerText } }],
             edit: messageEdit,
           },
@@ -263,7 +272,9 @@ describe('handlePurge (slash command entry)', () => {
 
 describe('handlePurgeButton (button routing)', () => {
   it('updates message on cancel', async () => {
-    const interaction = createMockButtonInteraction(`${MEMORY_PURGE_PREFIX}::cancel::user-123`);
+    const interaction = createMockButtonInteraction(
+      `memory::destructive::cancel_button::${MEMORY_PURGE_OPERATION}::${PERSONALITY_ID}`
+    );
 
     await handlePurgeButton(interaction);
 
@@ -277,21 +288,24 @@ describe('handlePurgeButton (button routing)', () => {
 
   it('shows modal on proceed (no async work before showModal)', async () => {
     const interaction = createMockButtonInteraction(
-      `${MEMORY_PURGE_PREFIX}::proceed::${PERSONALITY_ID}::user-123`
+      `memory::destructive::confirm_button::${MEMORY_PURGE_OPERATION}::${PERSONALITY_ID}`
     );
 
     await handlePurgeButton(interaction);
 
     expect(interaction.showModal).toHaveBeenCalledTimes(1);
     const modal = interaction.showModal.mock.calls[0][0];
-    expect(modal.data.title).toBe('Confirm Memory Purge');
+    expect(modal.data.title).toBe('Confirm Deletion');
+    // Derived from the button's own customId by the Tier-B factory.
     expect(modal.data.custom_id).toBe(
-      `${MEMORY_PURGE_PREFIX}::confirm::${PERSONALITY_ID}::user-123`
+      `memory::destructive::modal_submit::${MEMORY_PURGE_OPERATION}::${PERSONALITY_ID}`
     );
   });
 
   it('rejects proceed without personalityId in customId', async () => {
-    const interaction = createMockButtonInteraction(`${MEMORY_PURGE_PREFIX}::proceed::::user-123`);
+    const interaction = createMockButtonInteraction(
+      `memory::destructive::confirm_button::${MEMORY_PURGE_OPERATION}::`
+    );
 
     await handlePurgeButton(interaction);
 
@@ -303,7 +317,7 @@ describe('handlePurgeButton (button routing)', () => {
 
   it('rejects proceed when footer state missing', async () => {
     const interaction = createMockButtonInteraction(
-      `${MEMORY_PURGE_PREFIX}::proceed::${PERSONALITY_ID}::user-123`,
+      `memory::destructive::confirm_button::${MEMORY_PURGE_OPERATION}::${PERSONALITY_ID}`,
       { footerText: null }
     );
 
@@ -316,7 +330,9 @@ describe('handlePurgeButton (button routing)', () => {
   });
 
   it('rejects unknown actions', async () => {
-    const interaction = createMockButtonInteraction(`${MEMORY_PURGE_PREFIX}::nonsense`);
+    const interaction = createMockButtonInteraction(
+      `memory::destructive::nonsense_button::${MEMORY_PURGE_OPERATION}`
+    );
 
     await handlePurgeButton(interaction);
 
@@ -327,7 +343,7 @@ describe('handlePurgeButton (button routing)', () => {
 
   it('rejects proceed click from a different user (cross-user guard)', async () => {
     const interaction = createMockButtonInteraction(
-      `${MEMORY_PURGE_PREFIX}::proceed::${PERSONALITY_ID}::user-123`,
+      `memory::destructive::confirm_button::${MEMORY_PURGE_OPERATION}::${PERSONALITY_ID}`,
       { userId: 'user-OTHER' }
     );
 
@@ -342,9 +358,10 @@ describe('handlePurgeButton (button routing)', () => {
   });
 
   it('rejects cancel click from a different user (cross-user guard)', async () => {
-    const interaction = createMockButtonInteraction(`${MEMORY_PURGE_PREFIX}::cancel::user-123`, {
-      userId: 'user-OTHER',
-    });
+    const interaction = createMockButtonInteraction(
+      `memory::destructive::cancel_button::${MEMORY_PURGE_OPERATION}::${PERSONALITY_ID}`,
+      { userId: 'user-OTHER' }
+    );
 
     await handlePurgeButton(interaction);
 
@@ -497,7 +514,7 @@ describe('handlePurgeModal (modal submission)', () => {
 
   it('rejects modal with missing personalityId in customId', async () => {
     const interaction = createMockModalInteraction(EXPECTED_PHRASE, {
-      customId: `${MEMORY_PURGE_PREFIX}::confirm::::user-123`,
+      customId: `memory::destructive::modal_submit::${MEMORY_PURGE_OPERATION}::`,
     });
 
     await handlePurgeModal(interaction);
@@ -519,7 +536,6 @@ describe('handlePurgeModal (modal submission)', () => {
 
   it('rejects modal submission from a different user (cross-user guard)', async () => {
     const interaction = createMockModalInteraction(EXPECTED_PHRASE, {
-      customId: `${MEMORY_PURGE_PREFIX}::confirm::${PERSONALITY_ID}::user-123`,
       userId: 'user-OTHER',
     });
 

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -1,61 +1,62 @@
 /**
  * Purge Handler
  * Handles /memory purge command - delete ALL memories for a character.
- * Requires typed confirmation modal for safety.
+ * Requires typed confirmation via the shared Tier-B destructive flow
+ * (utils/confirmation/confirmDestructive.ts): warning + Cancel/Proceed →
+ * typed-phrase modal → token handshake → purge.
  *
- * Routing model (per `.claude/rules/04-discord.md` "Component Interaction Routing"):
- * The slash command renders a warning + proceed/cancel buttons, then returns.
- * Button + modal interactions are routed via CommandHandler → memory's
- * `handleButton` / `handleModal` → the exports below. No `awaitMessageComponent`
- * or `awaitModalSubmit` (those race with CommandHandler and produce 10062
- * "Unknown interaction" errors).
- *
- * State is encoded in custom IDs (personalityId) and the warning embed's
- * footer (personality display name) — restart-safe, multi-replica-safe.
+ * Routing model (per `.claude/rules/04-discord.md` "Component Interaction
+ * Routing"): the slash command renders the warning and returns; button +
+ * modal interactions route via CommandHandler → memory's component router →
+ * the exports below. State is restart-safe: personalityId rides the
+ * destructive customId's entity segment, and the personality display name
+ * (needed for the gateway-validated dynamic phrase) rides the warning
+ * embed's footer.
  */
 
-import {
-  ButtonBuilder,
-  ButtonStyle,
-  ActionRowBuilder,
-  ModalBuilder,
-  TextInputBuilder,
-  TextInputStyle,
-  MessageFlags,
-  escapeMarkdown,
-  type ButtonInteraction,
-  type ModalSubmitInteraction,
-} from 'discord.js';
+import { escapeMarkdown, type ButtonInteraction, type ModalSubmitInteraction } from 'discord.js';
 import { memoryPurgeOptions } from '@tzurot/common-types/generated/commandOptions';
-import { type PurgeMemoriesResponse } from '@tzurot/common-types/schemas/api/memory';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
-import { createDangerEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
+import { createSuccessEmbed } from '../../utils/commandHelpers.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
+import {
+  buildDestructiveWarning,
+  handleDestructiveCancel,
+  handleDestructiveConfirmButton,
+  handleDestructiveModalSubmit,
+  hardDeleteModalDisplay,
+  replyValidationError,
+  type DestructiveModalDisplay,
+  type DestructiveOperationResult,
+} from '../../utils/confirmation/confirmDestructive.js';
+import { DestructiveCustomIds } from '../../utils/customIds.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { renderSpec } from '../../ux/render/render.js';
 
 const logger = createLogger('memory-purge');
 
-/**
- * Custom ID prefix used by CommandHandler to route purge component interactions
- * to memory's handleButton / handleModal. Must be registered in
- * memory/index.ts `componentPrefixes`.
- */
-export const MEMORY_PURGE_PREFIX = 'memory-purge';
+/** Destructive-customId operation segment for /memory purge. */
+export const MEMORY_PURGE_OPERATION = 'purge';
 
 /** Footer marker that encodes the character display name on the warning embed. */
 const FOOTER_PREFIX = 'Character: ';
 
-/** Buffer for confirmation phrase input to allow minor whitespace. */
-const CONFIRMATION_PHRASE_LENGTH_BUFFER = 5;
-
-/** Build the confirmation phrase the user must type to confirm the purge. */
+/**
+ * Build the confirmation phrase the user must type. The GATEWAY validates
+ * this exact form server-side (issuePurgeToken) — a wire contract; never
+ * derive it any other way.
+ */
 function getConfirmationPhrase(personalityName: string): string {
   return `DELETE ${personalityName.toUpperCase()} MEMORIES`;
+}
+
+/** Modal display for the purge flow — phrase is the wire-contract override. */
+function purgeModalDisplay(personalityName: string): DestructiveModalDisplay {
+  return hardDeleteModalDisplay(personalityName, getConfirmationPhrase(personalityName));
 }
 
 /** Read the personality display name from the warning embed's footer. */
@@ -67,43 +68,6 @@ function readPersonalityNameFromMessage(
     return null;
   }
   return footerText.slice(FOOTER_PREFIX.length);
-}
-
-/**
- * Reject the interaction with an ephemeral message if the clicker isn't the
- * original command invoker. Defense-in-depth: the API also rejects cross-user
- * purge attempts at the data layer, but this surfaces the right UX message
- * instead of an opaque "Failed to purge memories: ..." error.
- *
- * Returns true when the check passed (interaction may proceed); false when
- * the check failed and an error reply was already sent.
- */
-async function assertInvokerOwnership(
-  interaction: ButtonInteraction | ModalSubmitInteraction,
-  invokerIdFromCustomId: string | undefined
-): Promise<boolean> {
-  if (invokerIdFromCustomId === undefined || invokerIdFromCustomId === '') {
-    logger.warn({ customId: interaction.customId }, 'Purge interaction missing invoker ID');
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.validation('Malformed purge interaction (missing invoker ID).')
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
-    return false;
-  }
-  if (interaction.user.id !== invokerIdFromCustomId) {
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.permissionDenied(
-          'confirm or cancel this purge — only the original command invoker can'
-        )
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
-    return false;
-  }
-  return true;
 }
 
 /**
@@ -159,28 +123,18 @@ export async function handlePurge(context: DeferredCommandContext): Promise<void
     description += '\n\nTo confirm, you will need to type:';
     description += `\n\`${confirmPhrase}\``;
 
-    const embed = createDangerEmbed('DANGER: Purge All Memories', description).setFooter({
-      text: `${FOOTER_PREFIX}${stats.personalityName}`,
+    const warning = buildDestructiveWarning({
+      source: 'memory',
+      operation: MEMORY_PURGE_OPERATION,
+      entityId: personalityId,
+      warningTitle: 'DANGER: Purge All Memories',
+      warningDescription: description,
+      footerText: `${FOOTER_PREFIX}${stats.personalityName}`,
+      buttonLabel: 'I Understand - Proceed',
+      ...purgeModalDisplay(stats.personalityName),
     });
 
-    // Embed the invoker's user ID in the customId so the button/modal handlers
-    // can reject cross-user clicks before any work runs (defense-in-depth on
-    // top of the API's data-layer enforcement).
-    const proceedButton = new ButtonBuilder()
-      .setCustomId(`${MEMORY_PURGE_PREFIX}::proceed::${personalityId}::${userId}`)
-      .setLabel('I Understand - Proceed')
-      .setStyle(ButtonStyle.Danger)
-      .setEmoji('🗑️');
-
-    const cancelButton = new ButtonBuilder()
-      .setCustomId(`${MEMORY_PURGE_PREFIX}::cancel::${userId}`)
-      .setLabel('Cancel')
-      .setStyle(ButtonStyle.Secondary);
-
-    // Cancel → Danger order (design-system button rule: Danger is always last).
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(cancelButton, proceedButton);
-
-    await context.editReply({ embeds: [embed], components: [row] });
+    await context.editReply(warning);
   } catch (error) {
     logger.error({ err: error, userId }, 'Unexpected error');
     await context.editReply({
@@ -194,89 +148,45 @@ export async function handlePurge(context: DeferredCommandContext): Promise<void
 }
 
 /**
- * Handle proceed/cancel button clicks for /memory purge.
- * Routed from CommandHandler → memory's handleButton.
- *
- * The proceed branch MUST call `showModal()` as its first action — Discord
- * requires the modal to be the first response to a button interaction
- * (no `deferUpdate` first), and the 3-second budget for that response is
- * indivisible. State needed for the modal (personalityId, personalityName)
- * comes from the customId and the parent message's embed footer respectively.
+ * Handle proceed/cancel button clicks for /memory purge, routed from the
+ * memory component router's destructive branch. Invoker ownership, modal
+ * derivation, and ack discipline are owned by the Tier-B factory.
  */
 export async function handlePurgeButton(interaction: ButtonInteraction): Promise<void> {
-  const parts = interaction.customId.split('::');
-  // parts[0] = 'memory-purge'
-  // proceed: parts[1] = 'proceed', parts[2] = personalityId, parts[3] = invokerId
-  // cancel:  parts[1] = 'cancel', parts[2] = invokerId
-  const action = parts[1];
-
-  if (action === 'cancel') {
-    if (!(await assertInvokerOwnership(interaction, parts[2]))) {
-      return;
-    }
-    await interaction.update({ content: 'Purge cancelled.', embeds: [], components: [] });
+  const parsed = DestructiveCustomIds.parse(interaction.customId);
+  if (parsed === null) {
+    await replyValidationError(interaction, 'Malformed purge interaction.');
     return;
   }
 
-  if (action !== 'proceed') {
+  if (parsed.action === 'cancel_button') {
+    await handleDestructiveCancel(interaction, 'Purge cancelled.');
+    return;
+  }
+
+  if (parsed.action !== 'confirm_button') {
     logger.warn({ customId: interaction.customId }, 'Unknown purge button action');
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Unknown interaction.')),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyValidationError(interaction, 'Unknown interaction.');
     return;
   }
 
-  const personalityId = parts[2];
-  if (personalityId === undefined || personalityId === '') {
+  if (parsed.entityId === undefined || parsed.entityId === '') {
     logger.warn({ customId: interaction.customId }, 'Purge proceed button missing personalityId');
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.validation('Malformed purge button (missing character ID).')
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-
-  if (!(await assertInvokerOwnership(interaction, parts[3]))) {
+    await replyValidationError(interaction, 'Malformed purge button (missing character ID).');
     return;
   }
 
   const personalityName = readPersonalityNameFromMessage(interaction);
   if (personalityName === null) {
     logger.warn({ customId: interaction.customId }, 'Purge proceed button missing footer name');
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.validation(
-          'This confirmation prompt is missing required state. Please run `/memory purge` again.'
-        )
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyValidationError(
+      interaction,
+      'This confirmation prompt is missing required state. Please run `/memory purge` again.'
+    );
     return;
   }
 
-  const confirmPhrase = getConfirmationPhrase(personalityName);
-
-  const modal = new ModalBuilder()
-    .setCustomId(`${MEMORY_PURGE_PREFIX}::confirm::${personalityId}::${interaction.user.id}`)
-    .setTitle('Confirm Memory Purge');
-
-  const confirmInput = new TextInputBuilder()
-    .setCustomId('confirmation_phrase')
-    .setLabel(`Type: ${confirmPhrase}`)
-    .setPlaceholder(confirmPhrase)
-    .setStyle(TextInputStyle.Short)
-    .setRequired(true)
-    .setMinLength(confirmPhrase.length)
-    .setMaxLength(confirmPhrase.length + CONFIRMATION_PHRASE_LENGTH_BUFFER);
-
-  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(confirmInput));
-
-  // First (and only) response to the button interaction; no async work above
-  // this line so the 3-second budget stays indivisible.
-  await interaction.showModal(modal);
+  await handleDestructiveConfirmButton(interaction, purgeModalDisplay(personalityName));
 }
 
 /**
@@ -284,163 +194,91 @@ export async function handlePurgeButton(interaction: ButtonInteraction): Promise
  * lived purge token, then redeem the token to actually purge. The execute
  * call sees only the token — `personalityId` lives server-side under the
  * token key, eliminating phrase-vs-personality drift across the round trip.
- *
- * Returns the purge result on success, or null when either step failed
- * (in which case the user-facing error has already been written via
- * `interaction.editReply`).
  */
 async function executePurgeHandshake(
   userClient: UserClient,
+  userId: string,
   personalityId: string,
-  enteredPhrase: string,
-  interaction: ModalSubmitInteraction
-): Promise<PurgeMemoriesResponse | null> {
+  enteredPhrase: string
+): Promise<DestructiveOperationResult> {
   const tokenResult = await userClient.issuePurgeToken({
     personalityId,
     confirmationPhrase: enteredPhrase,
   });
 
   if (!tokenResult.ok) {
-    await interaction.editReply({
-      content: renderSpec(
+    return {
+      success: false,
+      errorMessage: renderSpec(
         classifyGatewayFailure(tokenResult, 'purge', { failedAction: 'confirm the purge' })
       ),
-      embeds: [],
-      components: [],
-    });
-    return null;
+    };
   }
 
   const purgeResult = await userClient.purge({ purgeToken: tokenResult.data.purgeToken });
 
   if (!purgeResult.ok) {
-    await interaction.editReply({
-      content: renderSpec(
+    return {
+      success: false,
+      errorMessage: renderSpec(
         classifyGatewayFailure(purgeResult, 'memories', { failedAction: 'purge the memories' })
       ),
-      embeds: [],
-      components: [],
-    });
-    return null;
+    };
   }
 
-  return purgeResult.data;
+  const result = purgeResult.data;
+  let successDescription = `Purged **${result.deletedCount}** memories for **${escapeMarkdown(result.personalityName)}**.`;
+  if (result.lockedPreserved > 0) {
+    successDescription += `\n\n**${result.lockedPreserved}** locked (core) memories were preserved.`;
+  }
+
+  logger.warn(
+    {
+      userId,
+      personalityId,
+      deletedCount: result.deletedCount,
+      lockedPreserved: result.lockedPreserved,
+    },
+    'PURGE completed'
+  );
+
+  return {
+    success: true,
+    successEmbed: createSuccessEmbed('Memories Purged', successDescription),
+  };
 }
 
 /**
- * Handle the "type the phrase" modal submission for /memory purge.
- * Routed from CommandHandler → memory's handleModal.
+ * Handle the "type the phrase" modal submission for /memory purge, routed
+ * from the memory component router's destructive branch.
  */
 export async function handlePurgeModal(interaction: ModalSubmitInteraction): Promise<void> {
-  const parts = interaction.customId.split('::');
-  // parts[0] = 'memory-purge', parts[1] = 'confirm', parts[2] = personalityId, parts[3] = invokerId
-  const personalityId = parts[2];
+  const parsed = DestructiveCustomIds.parse(interaction.customId);
+  const personalityId = parsed?.entityId;
   if (personalityId === undefined || personalityId === '') {
     logger.warn({ customId: interaction.customId }, 'Purge modal missing personalityId');
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.validation('Malformed purge modal (missing character ID).')
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-
-  if (!(await assertInvokerOwnership(interaction, parts[3]))) {
+    await replyValidationError(interaction, 'Malformed purge modal (missing character ID).');
     return;
   }
 
   const personalityName = readPersonalityNameFromMessage(interaction);
   if (personalityName === null) {
     logger.warn({ customId: interaction.customId }, 'Purge modal missing footer name');
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.validation('Confirmation state lost. Please run `/memory purge` again.')
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyValidationError(
+      interaction,
+      'Confirmation state lost. Please run `/memory purge` again.'
+    );
     return;
   }
 
   const expectedPhrase = getConfirmationPhrase(personalityName);
-  const enteredPhrase = interaction.fields.getTextInputValue('confirmation_phrase').trim();
-
-  // Case-insensitive compare matches the api-gateway's own validation —
-  // a user typing 'delete lilith memories' lowercase shouldn't fail at
-  // the client gate when the server would have accepted it.
-  if (enteredPhrase.toUpperCase() !== expectedPhrase.toUpperCase()) {
-    await interaction.reply({
-      content: `Purge cancelled - confirmation phrase did not match.\n\nYou entered: \`${enteredPhrase}\`\nExpected: \`${expectedPhrase}\``,
-      flags: MessageFlags.Ephemeral,
-    });
-    if (interaction.message !== null) {
-      // Best-effort cleanup. If the parent message was deleted, perms changed,
-      // or the bot was restarted between modal-submit and now, the edit can
-      // throw — but the user already saw the ephemeral mismatch reply, so the
-      // failure isn't user-visible and shouldn't crash the handler.
-      try {
-        await interaction.message.edit({
-          content: 'Purge cancelled - confirmation phrase did not match.',
-          embeds: [],
-          components: [],
-        });
-      } catch (err) {
-        logger.warn({ err, customId: interaction.customId }, 'Failed to clear purge warning');
-      }
-    }
-    return;
-  }
-
-  // Phrase validated. Ack the modal, clear the warning, then perform the purge.
-  // `update()` is only available on modal submits that originated from a
-  // message component — for our flow that's always true (the modal is shown
-  // by the proceed button), but we narrow to satisfy the type checker.
-  if (!interaction.isFromMessage()) {
-    logger.warn({ customId: interaction.customId }, 'Purge modal submitted without parent message');
-    // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: on the phrase-matched path that reaches here, no real async precedes this ack (assertInvokerOwnership is exempt; the rest is sync). The rule's source-order sawRealAsync leaked from the phrase-MISMATCH branch's interaction.message.edit above, which returns before this point.
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Internal error: malformed modal context.')),
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-  // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: this is the ack-first update() for the phrase-matched path (executePurgeHandshake runs after it). sawRealAsync leaked from the phrase-mismatch branch's message.edit above (which returns).
-  await interaction.update({
-    content: 'Purging memories…',
-    embeds: [],
-    components: [],
-  });
-
   const { userClient } = clientsFor(interaction);
-  const purgeResult = await executePurgeHandshake(
-    userClient,
-    personalityId,
-    enteredPhrase,
-    interaction
-  );
-  if (purgeResult === null) {
-    return;
-  }
 
-  const result = purgeResult;
-  let successDescription = `Purged **${result.deletedCount}** memories for **${escapeMarkdown(result.personalityName)}**.`;
-  if (result.lockedPreserved > 0) {
-    successDescription += `\n\n**${result.lockedPreserved}** locked (core) memories were preserved.`;
-  }
-
-  await interaction.editReply({
-    content: '',
-    embeds: [createSuccessEmbed('Memories Purged', successDescription)],
-    components: [],
-  });
-
-  logger.warn(
-    {
-      userId: interaction.user.id,
-      personalityId,
-      deletedCount: result.deletedCount,
-      lockedPreserved: result.lockedPreserved,
-    },
-    'PURGE completed'
+  await handleDestructiveModalSubmit(
+    interaction,
+    expectedPhrase,
+    enteredPhrase =>
+      executePurgeHandshake(userClient, interaction.user.id, personalityId, enteredPhrase),
+    { progressContent: 'Purging memories…' }
   );
 }

--- a/services/bot-client/src/commands/settings/data/delete.test.ts
+++ b/services/bot-client/src/commands/settings/data/delete.test.ts
@@ -9,8 +9,7 @@ import {
   handleDataDelete,
   handleDataDeleteButton,
   handleDataDeleteModal,
-  isDataDeleteInteraction,
-  SETTINGS_DATA_DELETE_PREFIX,
+  SETTINGS_ACCOUNT_DELETE_OPERATION,
 } from './delete.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { makeOk, makeErr, asUserClient } from '../../../test/gatewayClientStubs.js';
@@ -36,13 +35,6 @@ const PREVIEW = {
   counts: { personas: 2, characters: 1, conversationMessages: 10, memories: 5, facts: 3 },
   hasActiveExport: false,
 };
-
-describe('isDataDeleteInteraction', () => {
-  it('matches only the settings-data-delete prefix', () => {
-    expect(isDataDeleteInteraction(`${SETTINGS_DATA_DELETE_PREFIX}::proceed::1`)).toBe(true);
-    expect(isDataDeleteInteraction('memory-purge::proceed::1')).toBe(false);
-  });
-});
 
 describe('handleDataDelete', () => {
   const mockEditReply = vi.fn();
@@ -80,8 +72,8 @@ describe('handleDataDelete', () => {
     );
     // Cancel → Danger order (design-system button rule: Danger is always last).
     expect(customIds).toEqual([
-      `${SETTINGS_DATA_DELETE_PREFIX}::cancel::123456789`,
-      `${SETTINGS_DATA_DELETE_PREFIX}::proceed::123456789`,
+      `settings::destructive::cancel_button::${SETTINGS_ACCOUNT_DELETE_OPERATION}`,
+      `settings::destructive::confirm_button::${SETTINGS_ACCOUNT_DELETE_OPERATION}`,
     ]);
   });
 
@@ -108,6 +100,8 @@ describe('handleDataDeleteButton', () => {
     return {
       customId,
       user: { id: userId },
+      // Invoker ownership is read from the parent message's interactionMetadata.
+      message: { interactionMetadata: { user: { id: '123456789' } } },
       update: vi.fn().mockResolvedValue(undefined),
       reply: vi.fn().mockResolvedValue(undefined),
       showModal: vi.fn().mockResolvedValue(undefined),
@@ -115,7 +109,9 @@ describe('handleDataDeleteButton', () => {
   }
 
   it('cancel clears the warning', async () => {
-    const interaction = makeButton(`${SETTINGS_DATA_DELETE_PREFIX}::cancel::123456789`);
+    const interaction = makeButton(
+      `settings::destructive::cancel_button::${SETTINGS_ACCOUNT_DELETE_OPERATION}`
+    );
     await handleDataDeleteButton(interaction);
     expect(interaction.update).toHaveBeenCalledWith(
       expect.objectContaining({ content: 'Deletion cancelled.' })
@@ -123,16 +119,24 @@ describe('handleDataDeleteButton', () => {
   });
 
   it('proceed shows the typed-phrase modal as the FIRST response', async () => {
-    const interaction = makeButton(`${SETTINGS_DATA_DELETE_PREFIX}::proceed::123456789`);
+    const interaction = makeButton(
+      `settings::destructive::confirm_button::${SETTINGS_ACCOUNT_DELETE_OPERATION}`
+    );
     await handleDataDeleteButton(interaction);
 
     expect(interaction.showModal).toHaveBeenCalledTimes(1);
     const modal = (interaction.showModal as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(modal.data.custom_id).toBe(`${SETTINGS_DATA_DELETE_PREFIX}::confirm::123456789`);
+    // Derived from the button's own customId by the Tier-B factory.
+    expect(modal.data.custom_id).toBe(
+      `settings::destructive::modal_submit::${SETTINGS_ACCOUNT_DELETE_OPERATION}`
+    );
   });
 
   it('rejects clicks from a different user', async () => {
-    const interaction = makeButton(`${SETTINGS_DATA_DELETE_PREFIX}::proceed::999`, '123456789');
+    const interaction = makeButton(
+      `settings::destructive::confirm_button::${SETTINGS_ACCOUNT_DELETE_OPERATION}`,
+      'user-OTHER'
+    );
     await handleDataDeleteButton(interaction);
 
     expect(interaction.showModal).not.toHaveBeenCalled();
@@ -159,14 +163,17 @@ describe('handleDataDeleteModal', () => {
   // assert on `update`, which only exists post-isFromMessage() narrowing.
   function makeModal(phrase: string) {
     return {
-      customId: `${SETTINGS_DATA_DELETE_PREFIX}::confirm::123456789`,
+      customId: `settings::destructive::modal_submit::${SETTINGS_ACCOUNT_DELETE_OPERATION}`,
       user: { id: '123456789' },
       fields: { getTextInputValue: vi.fn().mockReturnValue(phrase) },
       reply: vi.fn().mockResolvedValue(undefined),
       update: vi.fn().mockResolvedValue(undefined),
       editReply: mockEditReply,
       isFromMessage: vi.fn().mockReturnValue(true),
-      message: { edit: vi.fn().mockResolvedValue(undefined) },
+      message: {
+        edit: vi.fn().mockResolvedValue(undefined),
+        interactionMetadata: { user: { id: '123456789' } },
+      },
     };
   }
 

--- a/services/bot-client/src/commands/settings/data/delete.ts
+++ b/services/bot-client/src/commands/settings/data/delete.ts
@@ -1,80 +1,51 @@
 /**
  * /settings data delete — full-account erasure (data-rights).
  *
- * Purge-pattern confirmation flow (mirrors /memory purge): warning embed
- * with the deletion impact → Proceed/Cancel buttons → typed-phrase modal →
- * token handshake → synchronous erasure. Routing goes through
- * CommandHandler via settings' handleButton/handleModal (no collectors).
- *
- * State is encoded in custom IDs (invoker id only — the deletion target is
- * always the invoker's own account, so no other state needs to survive the
- * round trip).
+ * Uses the shared Tier-B destructive flow
+ * (utils/confirmation/confirmDestructive.ts): warning embed with the
+ * deletion impact → Cancel/Proceed buttons → typed-phrase modal → token
+ * handshake → synchronous erasure. Routing goes through CommandHandler via
+ * settings' handleButton/handleModal destructive branch (no collectors).
+ * The deletion target is always the invoker's own account, so no entity
+ * state needs to survive the round trip.
  */
 
-import {
-  ButtonBuilder,
-  ButtonStyle,
-  ActionRowBuilder,
-  ModalBuilder,
-  TextInputBuilder,
-  TextInputStyle,
-  MessageFlags,
-  escapeMarkdown,
-  type ButtonInteraction,
-  type ModalSubmitInteraction,
-} from 'discord.js';
+import { escapeMarkdown, type ButtonInteraction, type ModalSubmitInteraction } from 'discord.js';
 import { ACCOUNT_DELETE_CONFIRMATION_PHRASE } from '@tzurot/common-types/schemas/api/account';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
-import { createDangerEmbed, createSuccessEmbed } from '../../../utils/commandHelpers.js';
+import { createSuccessEmbed } from '../../../utils/commandHelpers.js';
+import {
+  buildDestructiveWarning,
+  handleDestructiveCancel,
+  handleDestructiveConfirmButton,
+  handleDestructiveModalSubmit,
+  hardDeleteModalDisplay,
+  replyValidationError,
+  type DestructiveModalDisplay,
+  type DestructiveOperationResult,
+} from '../../../utils/confirmation/confirmDestructive.js';
+import { DestructiveCustomIds } from '../../../utils/customIds.js';
 import { CATALOG } from '../../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../../ux/catalog/classify.js';
 import { renderSpec } from '../../../ux/render/render.js';
 
 const logger = createLogger('settings-data-delete');
 
-/** Registered in settings/index.ts componentPrefixes. */
-export const SETTINGS_DATA_DELETE_PREFIX = 'settings-data-delete';
-
-/** Buffer for confirmation phrase input to allow minor whitespace. */
-const CONFIRMATION_PHRASE_LENGTH_BUFFER = 5;
+/** Destructive-customId operation segment for /settings data delete. */
+export const SETTINGS_ACCOUNT_DELETE_OPERATION = 'account-delete';
 
 /** Cap the per-character warning list so the embed stays under limits. */
 const MAX_LISTED_CHARACTERS = 12;
 
-export function isDataDeleteInteraction(customId: string): boolean {
-  return customId.startsWith(`${SETTINGS_DATA_DELETE_PREFIX}::`);
-}
-
-/** Same invoker-assert shape as memory purge: reject other users' clicks. */
-async function assertInvokerOwnership(
-  interaction: ButtonInteraction | ModalSubmitInteraction,
-  invokerIdFromCustomId: string | undefined
-): Promise<boolean> {
-  if (invokerIdFromCustomId === undefined || invokerIdFromCustomId === '') {
-    logger.warn({ customId: interaction.customId }, 'Delete interaction missing invoker ID');
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.validation('Malformed deletion interaction (missing invoker ID).')
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
-    return false;
-  }
-  if (interaction.user.id !== invokerIdFromCustomId) {
-    await interaction.reply({
-      content: renderSpec(
-        CATALOG.error.permissionDenied(
-          'confirm or cancel this deletion — only the original command invoker can'
-        )
-      ),
-      flags: MessageFlags.Ephemeral,
-    });
-    return false;
-  }
-  return true;
+/**
+ * Modal display for the account-delete flow — the phrase is the gateway-
+ * validated wire contract, passed as an explicit override.
+ */
+function accountDeleteModalDisplay(): DestructiveModalDisplay {
+  return hardDeleteModalDisplay('your account', ACCOUNT_DELETE_CONFIRMATION_PHRASE);
 }
 
 function characterImpactLines(
@@ -172,25 +143,15 @@ export async function handleDataDelete(context: DeferredCommandContext): Promise
       return;
     }
 
-    const embed = createDangerEmbed(
-      'DANGER: Delete Your Account',
-      buildWarningDescription(previewResult.data)
-    );
-
-    const proceedButton = new ButtonBuilder()
-      .setCustomId(`${SETTINGS_DATA_DELETE_PREFIX}::proceed::${userId}`)
-      .setLabel('I Understand - Proceed')
-      .setStyle(ButtonStyle.Danger)
-      .setEmoji('🗑️');
-
-    const cancelButton = new ButtonBuilder()
-      .setCustomId(`${SETTINGS_DATA_DELETE_PREFIX}::cancel::${userId}`)
-      .setLabel('Cancel')
-      .setStyle(ButtonStyle.Secondary);
-
-    // Cancel → Danger order (design-system button rule: Danger is always last).
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(cancelButton, proceedButton);
-    await context.editReply({ embeds: [embed], components: [row] });
+    const warning = buildDestructiveWarning({
+      source: 'settings',
+      operation: SETTINGS_ACCOUNT_DELETE_OPERATION,
+      warningTitle: 'DANGER: Delete Your Account',
+      warningDescription: buildWarningDescription(previewResult.data),
+      buttonLabel: 'I Understand - Proceed',
+      ...accountDeleteModalDisplay(),
+    });
+    await context.editReply(warning);
   } catch (error) {
     logger.error({ err: error, userId }, 'Unexpected error building deletion preview');
     await context.editReply({
@@ -202,163 +163,67 @@ export async function handleDataDelete(context: DeferredCommandContext): Promise
 }
 
 /**
- * Handle proceed/cancel button clicks. The proceed branch MUST call
- * `showModal()` as its first response (no deferUpdate first) — same
- * constraint as memory purge.
+ * Handle proceed/cancel button clicks, routed from settings' destructive
+ * branch. Invoker ownership, modal derivation, and ack discipline are owned
+ * by the Tier-B factory.
  */
 export async function handleDataDeleteButton(interaction: ButtonInteraction): Promise<void> {
-  const parts = interaction.customId.split('::');
-  // parts[0] = 'settings-data-delete', parts[1] = action, parts[2] = invokerId
-  const action = parts[1];
-
-  if (action === 'cancel') {
-    if (!(await assertInvokerOwnership(interaction, parts[2]))) {
-      return;
-    }
-    await interaction.update({ content: 'Deletion cancelled.', embeds: [], components: [] });
+  const parsed = DestructiveCustomIds.parse(interaction.customId);
+  if (parsed === null) {
+    await replyValidationError(interaction, 'Malformed deletion interaction.');
     return;
   }
 
-  if (action !== 'proceed') {
+  if (parsed.action === 'cancel_button') {
+    await handleDestructiveCancel(interaction, 'Deletion cancelled.');
+    return;
+  }
+
+  if (parsed.action !== 'confirm_button') {
     logger.warn({ customId: interaction.customId }, 'Unknown delete button action');
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Unknown interaction.')),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyValidationError(interaction, 'Unknown interaction.');
     return;
   }
 
-  if (!(await assertInvokerOwnership(interaction, parts[2]))) {
-    return;
-  }
-
-  const modal = new ModalBuilder()
-    .setCustomId(`${SETTINGS_DATA_DELETE_PREFIX}::confirm::${interaction.user.id}`)
-    .setTitle('Confirm Account Deletion');
-
-  const confirmInput = new TextInputBuilder()
-    .setCustomId('confirmation_phrase')
-    .setLabel(`Type: ${ACCOUNT_DELETE_CONFIRMATION_PHRASE}`)
-    .setPlaceholder(ACCOUNT_DELETE_CONFIRMATION_PHRASE)
-    .setStyle(TextInputStyle.Short)
-    .setRequired(true)
-    .setMinLength(ACCOUNT_DELETE_CONFIRMATION_PHRASE.length)
-    .setMaxLength(ACCOUNT_DELETE_CONFIRMATION_PHRASE.length + CONFIRMATION_PHRASE_LENGTH_BUFFER);
-
-  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(confirmInput));
-
-  // First (and only) response to the button interaction; no async work above
-  // this line so the 3-second budget stays indivisible.
-  await interaction.showModal(modal);
+  await handleDestructiveConfirmButton(interaction, accountDeleteModalDisplay());
 }
 
 /**
  * Two-step deletion handshake: exchange the typed phrase for a single-use
- * token, then redeem the token to erase the account. Returns the summary on
- * success, or null when either step failed (user-facing error already sent).
+ * token, then redeem the token to erase the account.
  */
 async function executeDeleteHandshake(
   userClient: UserClient,
-  enteredPhrase: string,
-  interaction: ModalSubmitInteraction
-): Promise<{
-  personas: number;
-  characters: number;
-  conversationMessages: number;
-  memories: number;
-  facts: number;
-  characterNames: string[];
-} | null> {
+  userId: string,
+  enteredPhrase: string
+): Promise<DestructiveOperationResult> {
   const tokenResult = await userClient.issueAccountDeleteToken({
     confirmationPhrase: enteredPhrase,
   });
   if (!tokenResult.ok) {
-    await interaction.editReply({
-      content: renderSpec(
+    return {
+      success: false,
+      errorMessage: renderSpec(
         classifyGatewayFailure(tokenResult, 'account deletion', {
           failedAction: 'confirm the deletion',
         })
       ),
-      embeds: [],
-      components: [],
-    });
-    return null;
+    };
   }
 
   const deleteResult = await userClient.deleteAccount({
     deleteToken: tokenResult.data.deleteToken,
   });
   if (!deleteResult.ok) {
-    await interaction.editReply({
-      content: renderSpec(
+    return {
+      success: false,
+      errorMessage: renderSpec(
         classifyGatewayFailure(deleteResult, 'account', { failedAction: 'delete the account' })
       ),
-      embeds: [],
-      components: [],
-    });
-    return null;
+    };
   }
 
-  return deleteResult.data.summary;
-}
-
-/** Handle the typed-phrase modal submission. */
-export async function handleDataDeleteModal(interaction: ModalSubmitInteraction): Promise<void> {
-  const parts = interaction.customId.split('::');
-  // parts[0] = 'settings-data-delete', parts[1] = 'confirm', parts[2] = invokerId
-  if (!(await assertInvokerOwnership(interaction, parts[2]))) {
-    return;
-  }
-
-  const enteredPhrase = interaction.fields.getTextInputValue('confirmation_phrase').trim();
-
-  // Case-insensitive compare matches the api-gateway's own validation.
-  if (enteredPhrase.toUpperCase() !== ACCOUNT_DELETE_CONFIRMATION_PHRASE) {
-    await interaction.reply({
-      content:
-        `Deletion cancelled - confirmation phrase did not match.\n\n` +
-        `You entered: \`${enteredPhrase}\`\nExpected: \`${ACCOUNT_DELETE_CONFIRMATION_PHRASE}\``,
-      flags: MessageFlags.Ephemeral,
-    });
-    if (interaction.message !== null) {
-      // Best-effort cleanup; the ephemeral mismatch reply above already
-      // reached the user, so a failed edit here must not crash the handler.
-      try {
-        await interaction.message.edit({
-          content: 'Deletion cancelled - confirmation phrase did not match.',
-          embeds: [],
-          components: [],
-        });
-      } catch (err) {
-        logger.warn({ err, customId: interaction.customId }, 'Failed to clear delete warning');
-      }
-    }
-    return;
-  }
-
-  // Phrase validated. Ack the modal, clear the warning, then delete.
-  if (!interaction.isFromMessage()) {
-    logger.warn({ customId: interaction.customId }, 'Delete modal submitted without parent');
-    // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: on the phrase-matched path no real async precedes this ack (assertInvokerOwnership is exempt); sawRealAsync leaked from the mismatch branch's message.edit above, which returns before this point.
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Internal error: malformed modal context.')),
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-  // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: this IS the ack-first update() for the phrase-matched path (the handshake runs after it); sawRealAsync leaked from the mismatch branch's message.edit, which returns.
-  await interaction.update({
-    content: 'Deleting your account…',
-    embeds: [],
-    components: [],
-  });
-
-  const { userClient } = clientsFor(interaction);
-  const summary = await executeDeleteHandshake(userClient, enteredPhrase, interaction);
-  if (summary === null) {
-    return;
-  }
-
+  const summary = deleteResult.data.summary;
   const description = [
     'Your account and all associated data have been deleted:',
     '',
@@ -377,11 +242,22 @@ export async function handleDataDeleteModal(interaction: ModalSubmitInteraction)
     'If you message the bot again, a fresh empty account is created automatically.',
   ].join('\n');
 
-  await interaction.editReply({
-    content: '',
-    embeds: [createSuccessEmbed('Account Deleted', description)],
-    components: [],
-  });
+  logger.warn({ userId }, 'ACCOUNT DELETION completed via command');
 
-  logger.warn({ userId: interaction.user.id }, 'ACCOUNT DELETION completed via command');
+  return {
+    success: true,
+    successEmbed: createSuccessEmbed('Account Deleted', description),
+  };
+}
+
+/** Handle the typed-phrase modal submission, routed from settings' destructive branch. */
+export async function handleDataDeleteModal(interaction: ModalSubmitInteraction): Promise<void> {
+  const { userClient } = clientsFor(interaction);
+
+  await handleDestructiveModalSubmit(
+    interaction,
+    ACCOUNT_DELETE_CONFIRMATION_PHRASE,
+    enteredPhrase => executeDeleteHandshake(userClient, interaction.user.id, enteredPhrase),
+    { progressContent: 'Deleting your account…' }
+  );
 }

--- a/services/bot-client/src/commands/settings/index.test.ts
+++ b/services/bot-client/src/commands/settings/index.test.ts
@@ -196,11 +196,12 @@ describe('Settings Command Index', () => {
       expect(groupNames).not.toContain('voices');
     });
 
-    it('should have componentPrefixes for user-defaults, preset-override, and data-delete', () => {
+    it('should have componentPrefixes for user-defaults and preset-override', () => {
+      // Account-delete customIds start with 'settings::' and route natively
+      // by command name — no extra prefix needed since the Tier-B migration.
       expect(settingsCommand.componentPrefixes).toEqual([
         'user-defaults-settings',
         'settings-preset-override',
-        'settings-data-delete',
       ]);
     });
 

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -41,7 +41,7 @@ import { handleBrowse as handleWalletBrowse } from './apikey/browse.js';
 import { handleRemoveKey } from './apikey/remove.js';
 import { handleTestKey } from './apikey/test.js';
 import { handleApikeyModalSubmit } from './apikey/modal.js';
-import { ApikeyCustomIds } from '../../utils/customIds.js';
+import { ApikeyCustomIds, DestructiveCustomIds } from '../../utils/customIds.js';
 
 // Preset handlers
 import {
@@ -63,9 +63,13 @@ import {
   handleDataDelete,
   handleDataDeleteButton,
   handleDataDeleteModal,
-  isDataDeleteInteraction,
-  SETTINGS_DATA_DELETE_PREFIX,
+  SETTINGS_ACCOUNT_DELETE_OPERATION,
 } from './data/delete.js';
+
+/** Account-delete destructive customIds (settings::destructive::...::account-delete...). */
+function isAccountDeleteInteraction(customId: string): boolean {
+  return DestructiveCustomIds.parse(customId)?.operation === SETTINGS_ACCOUNT_DELETE_OPERATION;
+}
 
 // Defaults handlers (user-default config cascade settings)
 import { CATALOG } from '../../ux/catalog/catalog.js';
@@ -173,7 +177,7 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
     return;
   }
 
-  if (isDataDeleteInteraction(interaction.customId)) {
+  if (isAccountDeleteInteraction(interaction.customId)) {
     await handleDataDeleteModal(interaction);
     return;
   }
@@ -195,7 +199,7 @@ async function handleButton(interaction: ButtonInteraction): Promise<void> {
     return;
   }
 
-  if (isDataDeleteInteraction(interaction.customId)) {
+  if (isAccountDeleteInteraction(interaction.customId)) {
     await handleDataDeleteButton(interaction);
     return;
   }
@@ -446,9 +450,5 @@ export default defineCommand({
   handleModal,
   handleButton,
   handleSelectMenu,
-  componentPrefixes: [
-    'user-defaults-settings',
-    PRESET_OVERRIDE_PREFIX,
-    SETTINGS_DATA_DELETE_PREFIX,
-  ],
+  componentPrefixes: ['user-defaults-settings', PRESET_OVERRIDE_PREFIX],
 });

--- a/services/bot-client/src/utils/componentRouter.test.ts
+++ b/services/bot-client/src/utils/componentRouter.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the declarative component-interaction router.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import { createComponentRouter, type ComponentRoute } from './componentRouter.js';
+
+function interaction(customId: string): ButtonInteraction {
+  return { customId } as unknown as ButtonInteraction;
+}
+
+describe('createComponentRouter', () => {
+  it('dispatches to the first matching route with a handler of the right kind', async () => {
+    const first = vi.fn().mockResolvedValue(undefined);
+    const second = vi.fn().mockResolvedValue(undefined);
+    const router = createComponentRouter({
+      routes: [
+        { matches: id => id.startsWith('a::'), onButton: first },
+        { matches: () => true, onButton: second },
+      ],
+    });
+
+    await router.handleButton(interaction('a::x'));
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('skips a matching route that lacks the interaction kind handler', async () => {
+    const buttonOnly = vi.fn().mockResolvedValue(undefined);
+    const modalHandler = vi.fn().mockResolvedValue(undefined);
+    const router = createComponentRouter({
+      routes: [
+        // Matches everything but only handles buttons — a modal must fall through.
+        { matches: () => true, onButton: buttonOnly },
+        { matches: id => id.startsWith('m::'), onModal: modalHandler },
+      ],
+    });
+
+    await router.handleModal(interaction('m::edit') as unknown as ModalSubmitInteraction);
+
+    expect(buttonOnly).not.toHaveBeenCalled();
+    expect(modalHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves table order when multiple routes match', async () => {
+    const calls: string[] = [];
+    const mk = (label: string) =>
+      vi.fn(async () => {
+        calls.push(label);
+      });
+    const router = createComponentRouter({
+      routes: [
+        { matches: id => id.includes('shared-stem'), onButton: mk('specific') },
+        { matches: id => id.includes('shared'), onButton: mk('broad') },
+      ],
+    });
+
+    await router.handleButton(interaction('shared-stem::x'));
+
+    expect(calls).toEqual(['specific']);
+  });
+
+  it('invokes the unrouted fallback when no route claims the interaction', async () => {
+    const unrouted = vi.fn().mockResolvedValue(undefined);
+    const router = createComponentRouter({
+      routes: [{ matches: id => id.startsWith('a::'), onButton: vi.fn() }],
+      unrouted,
+    });
+
+    const i = interaction('unknown::x');
+    await router.handleButton(i);
+
+    expect(unrouted).toHaveBeenCalledWith(i, 'button');
+  });
+
+  it('logs and returns when unrouted and no fallback is provided', async () => {
+    const router = createComponentRouter({
+      routes: [{ matches: () => false, onButton: vi.fn() }],
+    });
+
+    await expect(router.handleButton(interaction('nope'))).resolves.toBeUndefined();
+  });
+
+  it('routes each interaction kind independently over one table', async () => {
+    const onButton = vi.fn().mockResolvedValue(undefined);
+    const onSelect = vi.fn().mockResolvedValue(undefined);
+    const onModal = vi.fn().mockResolvedValue(undefined);
+    const route: ComponentRoute = {
+      matches: id => id.startsWith('multi::'),
+      onButton,
+      onSelect,
+      onModal,
+    };
+    const router = createComponentRouter({ routes: [route] });
+
+    await router.handleButton(interaction('multi::b'));
+    await router.handleSelectMenu(interaction('multi::s') as never);
+    await router.handleModal(interaction('multi::m') as never);
+
+    expect(onButton).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates handler rejections (no swallowing)', async () => {
+    const router = createComponentRouter({
+      routes: [
+        {
+          matches: () => true,
+          onButton: vi.fn().mockRejectedValue(new Error('handler failed')),
+        },
+      ],
+    });
+
+    await expect(router.handleButton(interaction('x'))).rejects.toThrow('handler failed');
+  });
+});

--- a/services/bot-client/src/utils/componentRouter.ts
+++ b/services/bot-client/src/utils/componentRouter.ts
@@ -1,0 +1,100 @@
+/**
+ * Declarative component-interaction router.
+ *
+ * Commands with multiple interactive surfaces (browse, dashboard, destructive
+ * confirms, detail views) previously hand-rolled the same try-prefix-A →
+ * try-prefix-B → fallback dispatch chain in each command's handleButton/
+ * handleSelectMenu/handleModal. This primitive turns that chain into a table:
+ *
+ * ```ts
+ * const router = createComponentRouter({
+ *   routes: [
+ *     { matches: isBrowsePagination, onButton: handleBrowsePagination },
+ *     { matches: DestructiveCustomIds.isDestructive, onButton: ..., onModal: ... },
+ *   ],
+ *   unrouted: async interaction => { ... }, // optional per-command fallback
+ * });
+ * export default defineCommand({ ...router });
+ * ```
+ *
+ * Dispatch semantics:
+ * - Routes are evaluated IN ORDER; the first route whose `matches(customId)`
+ *   is true AND which declares a handler for the interaction kind wins.
+ * - A route that matches but lacks the kind's handler is SKIPPED (its
+ *   predicate may legitimately cover only buttons, not modals).
+ * - No route claiming the interaction invokes `unrouted` when provided,
+ *   else logs a warn. The router adds NO error handling around handlers —
+ *   ack discipline and failure handling stay with the handlers themselves.
+ */
+
+import type {
+  ButtonInteraction,
+  ModalSubmitInteraction,
+  StringSelectMenuInteraction,
+} from 'discord.js';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+
+const logger = createLogger('component-router');
+
+/** One dispatch table entry. Declare only the interaction kinds the surface handles. */
+export interface ComponentRoute {
+  /** Claim predicate over the interaction's customId. */
+  matches: (customId: string) => boolean;
+  onButton?: (interaction: ButtonInteraction) => Promise<void>;
+  onSelect?: (interaction: StringSelectMenuInteraction) => Promise<void>;
+  onModal?: (interaction: ModalSubmitInteraction) => Promise<void>;
+}
+
+/** Any of the three component-interaction kinds the router dispatches. */
+type RoutableInteraction = ButtonInteraction | StringSelectMenuInteraction | ModalSubmitInteraction;
+
+/** The interaction kind being dispatched, passed to the unrouted fallback. */
+export type ComponentKind = 'button' | 'select' | 'modal';
+
+export interface ComponentRouterOptions {
+  /** Ordered dispatch table. */
+  routes: ComponentRoute[];
+  /**
+   * Called when no route claims the interaction. Optional — without it the
+   * router logs a warn and returns (an unrouted modal then surfaces as
+   * Discord's "This interaction failed", so commands whose modals can go
+   * unrouted should provide one that acks with an error reply).
+   */
+  unrouted?: (interaction: RoutableInteraction, kind: ComponentKind) => Promise<void>;
+}
+
+export interface ComponentRouter {
+  handleButton: (interaction: ButtonInteraction) => Promise<void>;
+  handleSelectMenu: (interaction: StringSelectMenuInteraction) => Promise<void>;
+  handleModal: (interaction: ModalSubmitInteraction) => Promise<void>;
+}
+
+/** Build the three CommandHandler-facing handlers from a dispatch table. */
+export function createComponentRouter(options: ComponentRouterOptions): ComponentRouter {
+  const { routes, unrouted } = options;
+
+  async function dispatch(
+    interaction: RoutableInteraction,
+    kind: ComponentKind,
+    pick: (route: ComponentRoute) => ((interaction: never) => Promise<void>) | undefined
+  ): Promise<void> {
+    for (const route of routes) {
+      const handler = pick(route);
+      if (handler !== undefined && route.matches(interaction.customId)) {
+        await (handler as (interaction: RoutableInteraction) => Promise<void>)(interaction);
+        return;
+      }
+    }
+    if (unrouted !== undefined) {
+      await unrouted(interaction, kind);
+      return;
+    }
+    logger.warn({ customId: interaction.customId, kind }, 'Unrouted component interaction');
+  }
+
+  return {
+    handleButton: interaction => dispatch(interaction, 'button', route => route.onButton),
+    handleSelectMenu: interaction => dispatch(interaction, 'select', route => route.onSelect),
+    handleModal: interaction => dispatch(interaction, 'modal', route => route.onModal),
+  };
+}

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.ts
@@ -35,6 +35,7 @@ import {
   type ModalActionRowComponentBuilder,
   type ButtonInteraction,
   type ModalSubmitInteraction,
+  type StringSelectMenuInteraction,
   type InteractionEditReplyOptions,
 } from 'discord.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
@@ -77,6 +78,13 @@ export interface DestructiveConfirmationConfig {
   warningTitle: string;
   /** Warning description shown in the embed. */
   warningDescription: string;
+  /**
+   * Optional embed footer. Flows whose modal-submit step needs display state
+   * that doesn't fit the customId (e.g. purge's personality display name for
+   * the dynamic phrase) stash it here and read it back from
+   * `interaction.message` — restart-safe without server-side sessions.
+   */
+  footerText?: string;
   /** Text shown on the danger button. */
   buttonLabel: string;
   /** Modal title. */
@@ -107,6 +115,9 @@ export function buildDestructiveWarning(config: DestructiveConfirmationConfig): 
     .setTitle(config.warningTitle)
     .setDescription(config.warningDescription)
     .setColor(DISCORD_COLORS.ERROR);
+  if (config.footerText !== undefined) {
+    embed.setFooter({ text: config.footerText });
+  }
 
   const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
@@ -202,6 +213,20 @@ async function assertInvokerOwnership(
   return true;
 }
 
+/**
+ * Ephemeral validation-error reply for malformed or state-lost component
+ * interactions — the shared shape for call sites' own guard paths.
+ */
+export async function replyValidationError(
+  interaction: ButtonInteraction | StringSelectMenuInteraction | ModalSubmitInteraction,
+  message: string
+): Promise<void> {
+  await interaction.reply({
+    content: renderSpec(CATALOG.error.validation(message)),
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
 /** Parse a destructive customId, replying with a validation notice on failure. */
 async function parseOrReject(
   interaction: ButtonInteraction | ModalSubmitInteraction
@@ -209,10 +234,7 @@ async function parseOrReject(
   const parsed = DestructiveCustomIds.parse(interaction.customId);
   if (parsed === null) {
     logger.warn({ customId: interaction.customId }, 'Malformed destructive customId');
-    await interaction.reply({
-      content: renderSpec(CATALOG.error.validation('Malformed confirmation interaction.')),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyValidationError(interaction, 'Malformed confirmation interaction.');
   }
   return parsed;
 }


### PR DESCRIPTION
## Summary

Second slice of UX design-system **Phase 2**: the `createComponentRouter` primitive (the follow-ups row this phase claimed) and the two remaining bespoke typed-phrase flows migrated onto the Tier-B destructive factory from #1697.

### `createComponentRouter` (`utils/componentRouter.ts`)

Turns the hand-rolled try-prefix-A → try-prefix-B dispatch chains into declarative tables: ordered routes of `{matches, onButton?, onSelect?, onModal?}`, first match **with a handler of the right kind** wins (a button-only route never swallows a modal), `unrouted` fallback receiving the interaction kind. No error handling around handlers — ack discipline stays with them. **Memory's chain is the first adoption** (`memory/interactionHandlers.ts` is now a table; the character chain migrates in PR-7 per plan).

### `/memory purge` + `/settings data delete` onto Tier-B

- Both bespoke warning/modal/mismatch/invoker implementations retire onto the #1697 factory: two identical `assertInvokerOwnership` copies deleted, four raw `split('::')` sites gone (G8 progress), both flows gain the derived-modal-routing invariant and the factory's escaped mismatch echo.
- **Phrases are unchanged wire contracts**: purge's `DELETE {NAME} MEMORIES` and account-delete's fixed phrase are gateway-validated server-side; both pass through the explicit `confirmationPhrase` override, and the entered phrase is forwarded verbatim to the token handshakes exactly as before.
- Purge's display-name state rides the new `footerText` config field (restart-safe, no server-side session).
- Retired customId prefixes (`memory-purge`, `settings-data-delete`) removed from `componentPrefixes` — destructive ids start with the command name and route natively. `command-manifest.json` regenerated.
- Incidental degradation fix: purge's old modal built its label as `Type: {phrase}` with **no 45-char cap** — a long character name would make `setLabel` throw. The factory's capped label degrades gracefully instead (placeholder + warning text still show the full phrase).

### Fail-open follow-ups check (from #1697 r3)

Both migrated call sites are `deferralMode: 'ephemeral'` — the fail-open `interactionMetadata` ownership check remains safe; the follow-ups row's trigger has not fired.

### Ride-along

`PurgeMemoriesResponse` type export dropped from common-types (purge's old handshake annotation was its last consumer; knip-flagged after the migration).

## Verification

- `pnpm test` (26/26), `pnpm test:component` (538 passed — manifest snapshot regenerated for the prefix removals), `pnpm quality` all green.
- Purge/delete suites run through the REAL factory (no seam mocks): phrase trimming/case-insensitivity → token forwarding, handshake failure surfaces, cross-user rejection via interactionMetadata, button-time missing-entity guard preserved.
- `ux:literals` unchanged at 101 (below develop's former 102 ceiling).
- In-flight purge/delete confirmations across the deploy boundary die benignly this time for real: the OLD prefixes (`memory-purge::…`) no longer match any route → ephemeral "Unknown interaction" notice; surfaces are ephemeral and short-lived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)