### PR TITLE
chore(tooling): weekly-audit hygiene — per-metric security, cpd step, broadcast verb

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -58,6 +58,15 @@ jobs:
       - name: Build packages
         run: pnpm --filter './packages/*' build
 
+      # The cpd ratchet-margin bullet reads jscpd's JSON report from disk;
+      # without this step it degrades to "unavailable (no jscpd report)".
+      # continue-on-error: raw jscpd exits non-zero past its own threshold —
+      # a report-only margin must never abort the audit before the aggregator
+      # runs (same isolation rationale as the Discord-delivery step below).
+      - name: Generate jscpd report
+        continue-on-error: true
+        run: pnpm cpd
+
       - name: Run audit-health aggregator
         id: health
         env:

--- a/packages/tooling/src/audits/health-extras.test.ts
+++ b/packages/tooling/src/audits/health-extras.test.ts
@@ -53,7 +53,10 @@ describe('collectSecuritySurface', () => {
 
     const surface = collectSecuritySurface();
 
-    expect(surface).toEqual({ available: true, dependabotPrs: 3, dependabotAlerts: 1 });
+    expect(surface).toEqual({
+      dependabotPrs: { available: true, count: 3 },
+      dependabotAlerts: { available: true, count: 1 },
+    });
     // The args crossing the subprocess seam are the contract — a silently
     // reworded --jq filter would count the wrong thing while still "passing".
     expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
@@ -93,9 +96,16 @@ describe('collectSecuritySurface', () => {
 
     const surface = collectSecuritySurface();
 
+    // BOTH metrics degrade independently with the same diagnostic.
     expect(surface).toEqual({
-      available: false,
-      reason: 'To get started with GitHub CLI, please run: gh auth login',
+      dependabotPrs: {
+        available: false,
+        reason: 'To get started with GitHub CLI, please run: gh auth login',
+      },
+      dependabotAlerts: {
+        available: false,
+        reason: 'To get started with GitHub CLI, please run: gh auth login',
+      },
     });
   });
 
@@ -109,7 +119,7 @@ describe('collectSecuritySurface', () => {
       throw error;
     });
 
-    const result = collectSecuritySurface();
+    const result = collectSecuritySurface().dependabotPrs;
 
     expect(result.available).toBe(false);
     if (!result.available) {
@@ -121,7 +131,7 @@ describe('collectSecuritySurface', () => {
   it('degrades to unavailable when gh emits something non-numeric', () => {
     vi.mocked(execFileSync).mockReturnValue('not a count');
 
-    const surface = collectSecuritySurface();
+    const surface = collectSecuritySurface().dependabotAlerts;
 
     expect(surface.available).toBe(false);
     if (!surface.available) {
@@ -251,7 +261,8 @@ describe('collectHealthExtras', () => {
     await withTmpRepo({}, async rootDir => {
       const extras = collectHealthExtras(rootDir);
 
-      expect(extras.security.available).toBe(false);
+      expect(extras.security.dependabotPrs.available).toBe(false);
+      expect(extras.security.dependabotAlerts.available).toBe(false);
       // One degraded bullet per ratchet (lines, cpd, mutation).
       expect(extras.marginBullets).toHaveLength(3);
       expect(extras.docsOrphans).toEqual({ totalDocs: 0, orphans: [] });
@@ -262,7 +273,10 @@ describe('collectHealthExtras', () => {
 describe('formatHealthExtras', () => {
   it('renders the three H3 sections with orphan paths listed', () => {
     const extras: HealthExtras = {
-      security: { available: true, dependabotPrs: 2, dependabotAlerts: 0 },
+      security: {
+        dependabotPrs: { available: true, count: 2 },
+        dependabotAlerts: { available: true, count: 0 },
+      },
       marginBullets: ['lines rules: 1900/2150 (250 headroom, live measure)'],
       docsOrphans: { totalDocs: 40, orphans: ['docs/reference/lost-runbook.md'] },
     };
@@ -281,21 +295,31 @@ describe('formatHealthExtras', () => {
 
   it('renders degraded sections honestly', () => {
     const extras: HealthExtras = {
-      security: { available: false, reason: 'gh auth missing' },
+      security: {
+        dependabotPrs: { available: true, count: 2 },
+        dependabotAlerts: { available: false, reason: 'HTTP 403: Resource not accessible' },
+      },
       marginBullets: ['cpd: unavailable (no jscpd report on disk — run `pnpm cpd` first)'],
       docsOrphans: { unavailable: 'permission denied' },
     };
 
     const text = formatHealthExtras(extras);
 
-    expect(text).toContain('- security: unavailable (gh auth missing)');
+    // The mixed state is the CI reality: PR count works, alerts API 403s.
+    expect(text).toContain('- Dependabot PRs open: 2');
+    expect(text).toContain(
+      '- Dependabot alerts open: unavailable (HTTP 403: Resource not accessible)'
+    );
     expect(text).toContain('- cpd: unavailable');
     expect(text).toContain('- docs-orphan scan: unavailable (permission denied)');
   });
 
   it('reports a clean docs tree as zero orphans', () => {
     const extras: HealthExtras = {
-      security: { available: false, reason: 'x' },
+      security: {
+        dependabotPrs: { available: false, reason: 'x' },
+        dependabotAlerts: { available: false, reason: 'x' },
+      },
       marginBullets: [],
       docsOrphans: { totalDocs: 40, orphans: [] },
     };

--- a/packages/tooling/src/audits/health-extras.ts
+++ b/packages/tooling/src/audits/health-extras.ts
@@ -31,9 +31,21 @@ import {
 import { parseMutationBaseline } from '../test/mutation-check.js';
 import { scanDocsOrphans, type DocsOrphanResult } from './docs-orphan-scan.js';
 
-export type SecuritySurface =
-  | { available: true; dependabotPrs: number; dependabotAlerts: number }
-  | { available: false; reason: string };
+/** One security metric, degraded independently of its siblings. */
+export type SecurityCount =
+  { available: true; count: number } | { available: false; reason: string };
+
+/**
+ * Per-metric availability (not all-or-nothing): in CI, GITHUB_TOKEN can list
+ * Dependabot PRs but structurally CANNOT read the Dependabot-alerts API — no
+ * workflow `permissions:` scope grants it (`security-events` covers code/
+ * secret scanning only). A shared try/catch would let the always-403 alerts
+ * call discard the PR count that succeeds.
+ */
+export interface SecuritySurface {
+  dependabotPrs: SecurityCount;
+  dependabotAlerts: SecurityCount;
+}
 
 /** Budget for each gh subprocess — a hung gh must degrade, not stall health. */
 const GH_TIMEOUT_MS = 30 * 1000;
@@ -71,14 +83,24 @@ function describeGhFailure(error: unknown): string {
   return error instanceof Error ? error.message.split('\n')[0] : String(error);
 }
 
+/** Run one gh count, degrading to an unavailable-with-reason on any throw. */
+function safeGhCount(args: string[]): SecurityCount {
+  try {
+    return { available: true, count: runGhCount(args) };
+  } catch (error) {
+    return { available: false, reason: describeGhFailure(error) };
+  }
+}
+
 /**
- * Count open Dependabot PRs + alerts. Never throws — some environments
- * (local checkouts without gh auth) legitimately can't answer, and the
- * security section must degrade rather than break the whole report.
+ * Count open Dependabot PRs + alerts, each degrading independently. Never
+ * throws — some environments (local checkouts without gh auth, CI tokens
+ * without alerts access) legitimately can't answer one or both, and the
+ * security section must degrade per-metric rather than break the report.
  */
 export function collectSecuritySurface(): SecuritySurface {
-  try {
-    const dependabotPrs = runGhCount([
+  return {
+    dependabotPrs: safeGhCount([
       'pr',
       'list',
       '--author',
@@ -89,17 +111,14 @@ export function collectSecuritySurface(): SecuritySurface {
       'number',
       '--jq',
       'length',
-    ]);
-    const dependabotAlerts = runGhCount([
+    ]),
+    dependabotAlerts: safeGhCount([
       'api',
       'repos/{owner}/{repo}/dependabot/alerts',
       '--jq',
       '[.[] | select(.state=="open")] | length',
-    ]);
-    return { available: true, dependabotPrs, dependabotAlerts };
-  } catch (error) {
-    return { available: false, reason: describeGhFailure(error) };
-  }
+    ]),
+  };
 }
 
 /**
@@ -212,6 +231,13 @@ export function collectHealthExtras(rootDir: string): HealthExtras {
   return { security: collectSecuritySurface(), marginBullets, docsOrphans };
 }
 
+/** Render one security metric as its report bullet. */
+function securityBullet(label: string, metric: SecurityCount): string {
+  return metric.available
+    ? `- ${label}: ${metric.count}`
+    : `- ${label}: unavailable (${metric.reason})`;
+}
+
 /**
  * Render the extras as markdown-flavored plain text, matching the section
  * shape of `formatHealthReport` (H3 sections after the tool bullets).
@@ -220,12 +246,8 @@ export function formatHealthExtras(extras: HealthExtras): string {
   const lines: string[] = [];
 
   lines.push('### Security surface (report-only)');
-  if (extras.security.available) {
-    lines.push(`- Dependabot PRs open: ${extras.security.dependabotPrs}`);
-    lines.push(`- Dependabot alerts open: ${extras.security.dependabotAlerts}`);
-  } else {
-    lines.push(`- security: unavailable (${extras.security.reason})`);
-  }
+  lines.push(securityBullet('Dependabot PRs open', extras.security.dependabotPrs));
+  lines.push(securityBullet('Dependabot alerts open', extras.security.dependabotAlerts));
 
   lines.push('');
   lines.push('### Ratchet margins (report-only)');

--- a/packages/tooling/src/audits/health.test.ts
+++ b/packages/tooling/src/audits/health.test.ts
@@ -279,7 +279,9 @@ describe('runHealth', () => {
       .mock.calls.flat()
       .map(arg => String(arg))
       .join('\n');
-    expect(output).toContain('- security: unavailable');
+    // Per-metric degradation: each security bullet carries its own reason.
+    expect(output).toContain('- Dependabot PRs open: unavailable');
+    expect(output).toContain('- Dependabot alerts open: unavailable');
     expect(report.overall).toBe('ok');
     expect(process.exitCode).toBeUndefined();
   });

--- a/packages/tooling/src/dev/commandsAuditChecks.ts
+++ b/packages/tooling/src/dev/commandsAuditChecks.ts
@@ -59,6 +59,10 @@ const KNOWN_SUBCOMMAND_NAMES = new Set<string>([
   'template',
   // /notifications threshold verb (set the minimum release weight worth a DM)
   'level',
+  // /admin release-notification blast (deliberate verb: pushes the release DM
+  // to opted-in users; not a rename candidate — "send"/"notify" would collide
+  // with nothing and describe less)
+  'broadcast',
   // /character chat-mode verbs (chat / random / chime-in) — deliberate, established
   'chat',
   'random',


### PR DESCRIPTION
## Summary

Triage of today's weekly audit WARN (owner-shared report). Three fixes, one deliberate non-fix:

1. **Security section — per-metric degradation.** The report showed `security: unavailable (HTTP 403)`. Root cause: one shared try/catch around both `gh` calls, and the Dependabot-**alerts** API call structurally always 403s under `GITHUB_TOKEN` (no workflow `permissions:` scope grants alerts read — `security-events` covers code/secret scanning only), discarding the Dependabot-**PR** count that succeeds. Now each metric degrades independently: CI reports the PR count plus an honest `alerts: unavailable (<reason>)`.
2. **cpd margin — missing workflow step.** The aggregator reads jscpd's report from disk; the workflow never generated one, so the margin always degraded. Added the `pnpm cpd` step before the aggregator.
3. **`broadcast` → KNOWN_SUBCOMMAND_NAMES.** Deliberate verb (`/admin broadcast`, the release-notification blast); justification comment included.
4. **NOT fixed on purpose: the `character alias` vocabulary warning.** That warning is the audit correctly flagging the nonconforming surface whose deviation promoted the UX epic — the PR-4 pilot redesign dissolves it into a subcommand group (`browse`/`add`/`remove`, all known verbs). Suppressing it now would mask the exact thing the epic exists to fix. It will show as 1 warning on main until the pilot ships.

Also explains the report's "1 finding vs 2 local": the scheduled workflow audits the default branch (main), which doesn't have #1695's alias yet.

## Verification

- `pnpm test` (26/26) + `pnpm quality` green; `pnpm ops commands:audit` locally now reports exactly the intended 1 remaining warning (alias).
- health-extras/health tests updated to the per-metric shape, including the mixed CI-reality case (PR count present + alerts 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)