### PR TITLE
feat(bot-client): shared browse list-embed builder + character/preset adoption (UX Phase 2, PR-2)

### DIFF
--- a/backlog/now.md
+++ b/backlog/now.md
@@ -26,6 +26,7 @@ _Recently resolved items move to the GitHub release notes at ship time — this 
 
 _Small tasks that can be done between major features. Good for momentum._
 
+- 🐛 `[FIX]` **DuplicateDetectionFlow P2002 flake — recurrence trigger FIRED 2026-07-18** (first seen #1568, filed-on-recurrence per its note; second hit: #1699 CI, `mixed chronological order` case) — `generateConversationHistoryUuid(channelId, personalityId, personaId, createdAt)` collides when a test inserts two rows in the same millisecond. Fix shape: the test passes explicit distinct timestamps per insert (test-only change in `DuplicateDetectionFlow.component.test.ts` / its history seeding helper); consider whether OTHER component tests seed history the same racy way. Filed 2026-07-18.
 - 🧹 `[CHORE]` **Dependabot #135: `adm-zip` <0.6.0 (high, crafted-ZIP 4GB alloc)** — transitive via `onnxruntime-node` (embeddings runtime; adm-zip unpacks onnxruntime's own install artifacts, never user-supplied ZIPs → not reachable from Discord input, low in-context risk). Fix: pnpm `overrides` entry pinning `adm-zip@^0.6.0` + embeddings tests green; or ride the next onnxruntime bump if Dependabot opens one. Filed 2026-07-18.
 
 

--- a/services/bot-client/src/commands/character/browse.test.ts
+++ b/services/bot-client/src/commands/character/browse.test.ts
@@ -152,7 +152,7 @@ describe('handleBrowse', () => {
       embeds: [
         expect.objectContaining({
           data: expect.objectContaining({
-            title: '📚 Character Browser',
+            title: '🎭 Characters',
           }),
         }),
       ],
@@ -385,7 +385,7 @@ describe('handleBrowse', () => {
         embeds: expect.arrayContaining([
           expect.objectContaining({
             data: expect.objectContaining({
-              description: expect.stringContaining("You don't have any characters yet"),
+              description: expect.stringContaining("You haven't created any characters yet"),
             }),
           }),
         ]),
@@ -430,8 +430,13 @@ describe('handleBrowse', () => {
     const context = createMockContext(null, 'mine');
     await handleBrowse(context, mockConfig);
 
+    // A fully-empty list renders EXACTLY ONE message — the builder's
+    // filter-aware empty state; the own-section CTA must not stack on top
+    // (the duplicated/contradictory-empty-state regression).
     const embedData = mockEditReply.mock.calls[0][0].embeds[0].data;
-    expect(embedData.description).toContain("You don't have any characters yet");
+    expect(embedData.description).toContain('No characters match');
+    expect(embedData.description).not.toContain("You don't have any characters yet");
+    expect(embedData.description).not.toContain('📝 Your Characters (0)');
   });
 
   it('should handle API errors gracefully', async () => {

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -13,12 +13,12 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
-  EmbedBuilder,
+  type EmbedBuilder,
+  escapeMarkdown,
   type ButtonInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
 import { type EnvConfig, getConfig } from '@tzurot/common-types/config/config';
-import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { characterBrowseOptions } from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
@@ -49,9 +49,9 @@ import {
 } from '../../utils/dashboard/index.js';
 import {
   buildBrowseButtons as buildSharedBrowseButtons,
+  buildBrowseListEmbed,
   buildBrowseSelectMenu,
   createBrowseCustomIdHelpers,
-  joinFooter,
   pluralize,
   formatFilterLabeled,
   formatSortNatural,
@@ -64,7 +64,6 @@ import {
   createListItems,
   buildFilterLine,
   buildEmptyStateLines,
-  renderPageItems,
   FILTER_LABELS,
 } from './browseHelpers.js';
 
@@ -162,49 +161,59 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
 } {
   const { allItems, ownCount, page, filter, sortType, query } = options;
 
-  const totalPages = Math.max(1, Math.ceil(allItems.length / CHARACTERS_PER_PAGE));
-  const safePage = Math.min(Math.max(0, page), totalPages - 1);
-
-  const startIdx = safePage * CHARACTERS_PER_PAGE;
-  const endIdx = Math.min(startIdx + CHARACTERS_PER_PAGE, allItems.length);
-  const pageItems = allItems.slice(startIdx, endIdx);
-
-  // Build description lines
-  const lines: string[] = [];
-
+  // Preamble: search/filter context + the own-section-empty CTA. The CTA is
+  // preamble (not the builder's empty state) because it renders ABOVE other
+  // users' rows — but ONLY when the list has content: on a fully-empty list
+  // the builder's D19 empty state is the single message, and stacking the
+  // CTA on top of it would duplicate/contradict it (the old code's
+  // `lines.length === 0` guard, carried over to the split).
+  const preamble: string[] = [];
   const filterLine = buildFilterLine(query, filter);
   if (filterLine !== null) {
-    lines.push(filterLine);
+    preamble.push(filterLine);
+  }
+  if (allItems.length > 0) {
+    // Clamp before the page===0 check — callers pre-clamp today, but the
+    // guard must not depend on that. Mirrors the builder's own clamp: the
+    // two must stay in sync if itemsPerPage semantics ever change.
+    const totalPages = Math.max(1, Math.ceil(allItems.length / CHARACTERS_PER_PAGE));
+    const clampedPage = Math.min(Math.max(0, page), totalPages - 1);
+    const hasOthersInList = !allItems[0].isOwn;
+    preamble.push(...buildEmptyStateLines(clampedPage, ownCount, filter, hasOthersInList));
   }
 
-  const hasOthersOnPage = pageItems.length > 0 && !pageItems[0].isOwn;
-  const emptyLines = buildEmptyStateLines(safePage, ownCount, filter, hasOthersOnPage);
-  lines.push(...emptyLines);
-
-  // Check if no results at all
-  if (allItems.length === 0 && lines.length === 0 && (query !== null || filter !== 'all')) {
-    lines.push('_No characters match your search._');
-  }
-
-  // Render page items
-  const itemLines = renderPageItems(pageItems, lines.length);
-  lines.push(...itemLines);
-
-  // Build embed
-  const embed = new EmbedBuilder()
-    .setTitle('📚 Character Browser')
-    .setColor(DISCORD_COLORS.BLURPLE)
-    .setDescription(lines.join('\n') || 'No characters found.')
-    .setTimestamp();
-
-  // Footer with legend
-  embed.setFooter({
-    text: joinFooter(
+  const {
+    embed,
+    pageItems,
+    startIndex,
+    totalPages,
+    safePage: renderedPage,
+  } = buildBrowseListEmbed<ListItem>({
+    entityEmoji: '\u{1F3AD}',
+    titleNoun: 'Characters',
+    items: allItems,
+    page,
+    itemsPerPage: CHARACTERS_PER_PAGE,
+    preamble,
+    formatRow: item => ({
+      groupHeader: item.groupHeader,
+      badges: `${item.char.isPublic ? '\u{1F310}' : '\u{1F512}'}${item.isOwn ? '\u270F\uFE0F' : ''}`,
+      name: escapeMarkdown(item.char.displayName ?? item.char.name),
+      // Slugs are typed in @mentions — the §2.4 case where the tech-id
+      // belongs in the row.
+      techId: item.char.slug,
+    }),
+    empty: {
+      noItems: "You haven't created any characters yet — start with `/character create`.",
+      noMatch: 'No characters match — clear the search or filter to see all.',
+    },
+    filterActive: query !== null || filter !== 'all',
+    footerSegments: [
       pluralize(allItems.length, { singular: 'character', plural: 'characters' }),
       filter !== 'all' && formatFilterLabeled(FILTER_LABELS[filter]),
       sortType === 'date' ? formatSortNatural('date') : formatSortVerbatim('Sorted alphabetically'),
-      '\uD83C\uDF10 Public \uD83D\uDD12 Private'
-    ),
+    ],
+    badgeLegend: 'Public \u{1F310} · Private \u{1F512} · Yours \u270F\uFE0F',
   });
 
   // Build components
@@ -213,9 +222,9 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
   // Add select menu — factory returns null on empty pageItems
   const selectRow = buildBrowseSelectMenu<ListItem>({
     items: pageItems,
-    customId: browseHelpers.buildSelect(safePage, filter, sortType, query),
+    customId: browseHelpers.buildSelect(renderedPage, filter, sortType, query),
     placeholder: 'Select a character to view/edit...',
-    startIndex: startIdx,
+    startIndex,
     formatItem: item => ({
       label: formatCharacterSelectLabel(item),
       // Use slug as value to fetch full character data on selection
@@ -229,7 +238,7 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
 
   // Add pagination buttons if multiple pages or items exist
   if (totalPages > 1 || allItems.length > 0) {
-    components.push(buildBrowseButtons(safePage, totalPages, filter, sortType, query));
+    components.push(buildBrowseButtons(renderedPage, totalPages, filter, sortType, query));
   }
 
   return { embed, components };

--- a/services/bot-client/src/commands/character/browseHelpers.ts
+++ b/services/bot-client/src/commands/character/browseHelpers.ts
@@ -30,15 +30,6 @@ const characterComparator = createListComparator<CharacterData>(
   c => c.updatedAt
 );
 
-/**
- * Format a character line for the list
- */
-function formatCharacterLine(c: CharacterData): string {
-  const visibility = c.isPublic ? '🌐' : '🔒';
-  const displayName = escapeMarkdown(c.displayName ?? c.name);
-  return `${visibility} **${displayName}** (\`${c.slug}\`)`;
-}
-
 /** Filter labels for display */
 export const FILTER_LABELS: Record<CharacterBrowseFilter, string> = {
   all: 'All',
@@ -206,26 +197,6 @@ export function buildEmptyStateLines(
     if (hasOthersOnPage) {
       lines.push('');
     }
-  }
-  return lines;
-}
-
-/**
- * Render page items with their group headers
- */
-export function renderPageItems(pageItems: ListItem[], existingLinesLength: number): string[] {
-  const lines: string[] = [];
-  for (const item of pageItems) {
-    if (item.groupHeader !== undefined) {
-      // Add separator before "Other Users" section if coming from own chars
-      const totalLines = existingLinesLength + lines.length;
-      const lastLine = lines.length > 0 ? lines[lines.length - 1] : '';
-      if (!item.isOwn && totalLines > 0 && !lastLine.startsWith('**🌐')) {
-        lines.push('');
-      }
-      lines.push(item.groupHeader);
-    }
-    lines.push(formatCharacterLine(item.char));
   }
   return lines;
 }

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -262,7 +262,7 @@ describe('handleBrowse', () => {
       embeds: [
         expect.objectContaining({
           data: expect.objectContaining({
-            title: '🔧 Preset Browser',
+            title: '⚙️ Presets',
           }),
         }),
       ],
@@ -472,7 +472,9 @@ describe('handleBrowse', () => {
     await handleBrowse(context);
 
     const embedData = mockEditReply.mock.calls[0][0].embeds[0].data;
-    expect(embedData.description).toContain('No presets match your search');
+    expect(embedData.description).toContain(
+      'No presets match — clear the search or filter to see all.'
+    );
   });
 
   it('should handle API error', async () => {

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -10,7 +10,7 @@
  */
 
 import {
-  EmbedBuilder,
+  type EmbedBuilder,
   escapeMarkdown,
   MessageFlags,
   type ButtonInteraction,
@@ -34,9 +34,9 @@ import {
 import {
   ITEMS_PER_PAGE,
   buildBrowseButtons as buildSharedBrowseButtons,
+  buildBrowseListEmbed,
   buildBrowseSelectMenu,
   createBrowseCustomIdHelpers,
-  joinFooter,
   pluralize,
   formatFilterLabeled,
   type BrowseActionRow,
@@ -183,21 +183,6 @@ function filterPresets(
 }
 
 /**
- * Format a preset line with badges
- */
-function formatPresetLine(c: LlmConfigSummary, isGuestMode: boolean, index: number): string {
-  const badgeStr = presetBadgeArray(c, isGuestMode).join('');
-  const shortModel = shortModelName(c.model);
-  const safeName = escapeMarkdown(c.name);
-
-  // In guest mode, dim paid presets
-  const nameStyle =
-    isGuestMode && !isFreeTierEligibleModel(c.model) ? `~~${safeName}~~` : `**${safeName}**`;
-
-  return `${index + 1}. ${badgeStr} ${nameStyle}\n   └ \`${shortModel}\``;
-}
-
-/**
  * Build pagination buttons using shared utility (no sort toggle for presets)
  */
 function buildBrowseButtons(
@@ -230,57 +215,56 @@ function buildBrowsePage(
 ): { embed: EmbedBuilder; components: BrowseActionRow[] } {
   const { scope, capability } = splitBrowseFilter(filter);
   const filtered = filterPresets(allPresets, scope, capability, query, isGuestMode);
-  const totalPages = Math.max(1, Math.ceil(filtered.length / ITEMS_PER_PAGE));
-  const safePage = Math.min(Math.max(0, page), totalPages - 1);
 
-  const startIdx = safePage * ITEMS_PER_PAGE;
-  const endIdx = Math.min(startIdx + ITEMS_PER_PAGE, filtered.length);
-  const pageItems = filtered.slice(startIdx, endIdx);
-
-  const embed = new EmbedBuilder()
-    .setTitle('🔧 Preset Browser')
-    .setColor(isGuestMode ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE)
-    .setTimestamp();
-
-  // Build description
-  const lines: string[] = [];
-
-  // Guest mode warning
+  // Preamble: guest-mode warning + search/filter context.
+  const preamble: string[] = [];
   if (isGuestMode) {
-    lines.push(
-      '⚠️ **Guest Mode** - Limited to free models (🆓). Use `/settings apikey set` for full access.\n'
+    preamble.push(
+      '\u26A0\uFE0F **Guest Mode** - Limited to free models (\u{1F193}). Use `/settings apikey set` for full access.\n'
     );
   }
-
-  // Search/filter info
   const activeFilterLabel = describeFilter(scope, capability);
   if (query !== null) {
-    lines.push(`🔍 Searching: "${query}" • Filter: ${activeFilterLabel ?? 'All'}\n`);
+    preamble.push(`\u{1F50D} Searching: "${query}" \u2022 Filter: ${activeFilterLabel ?? 'All'}\n`);
   } else if (activeFilterLabel !== null) {
-    lines.push(`Filter: ${activeFilterLabel}\n`);
+    preamble.push(`Filter: ${activeFilterLabel}\n`);
   }
 
-  // Preset list
-  if (pageItems.length === 0) {
-    lines.push('_No presets match your search._');
-  } else {
-    for (let i = 0; i < pageItems.length; i++) {
-      lines.push(formatPresetLine(pageItems[i], isGuestMode, startIdx + i));
-    }
-  }
-
-  embed.setDescription(lines.join('\n'));
-
-  // Footer with legend
   const freeCount = filtered.filter(c => isFreeModelForUser(c.model, isGuestMode)).length;
   const visionCount = filtered.filter(c => c.supportsVision).length;
-  embed.setFooter({
-    text: joinFooter(
-      pluralize(filtered.length, { singular: 'preset', plural: 'presets' }),
-      activeFilterLabel !== null && formatFilterLabeled(activeFilterLabel),
-      `🌐 Global  🔒 Private  👤 Other user  👁️ Vision (${visionCount})  ⭐ Default  🆓 Free (${freeCount})`
-    ),
-  });
+
+  const { embed, pageItems, startIndex, totalPages, safePage } =
+    buildBrowseListEmbed<LlmConfigSummary>({
+      entityEmoji: '\u2699\uFE0F',
+      titleNoun: 'Presets',
+      items: filtered,
+      page,
+      itemsPerPage: ITEMS_PER_PAGE,
+      preamble,
+      formatRow: preset => {
+        const safeName = escapeMarkdown(preset.name);
+        const dimmed = isGuestMode && !isFreeTierEligibleModel(preset.model);
+        return {
+          badges: presetBadgeArray(preset, isGuestMode).join(''),
+          name: safeName,
+          // Guest-mode dims paid presets — the one styling exception (§2.4).
+          nameMarkup: dimmed ? `~~${safeName}~~` : undefined,
+          // Preset ids are detail-view territory, not typed anywhere — no techId.
+          metadata: [`\`${shortModelName(preset.model)}\``],
+        };
+      },
+      empty: {
+        noItems: 'No presets exist yet \u2014 create one with `/preset create`.',
+        noMatch: 'No presets match \u2014 clear the search or filter to see all.',
+      },
+      filterActive: query !== null || activeFilterLabel !== null,
+      color: isGuestMode ? DISCORD_COLORS.WARNING : undefined,
+      footerSegments: [
+        pluralize(filtered.length, { singular: 'preset', plural: 'presets' }),
+        activeFilterLabel !== null && formatFilterLabeled(activeFilterLabel),
+      ],
+      badgeLegend: `Global \u{1F310} \u00B7 Private \u{1F512} \u00B7 Other user \u{1F464} \u00B7 Vision \u{1F441}\uFE0F (${visionCount}) \u00B7 Default \u2B50 \u00B7 Free \u{1F193} (${freeCount})`,
+    });
 
   // Build components
   const components: BrowseActionRow[] = [];
@@ -290,7 +274,7 @@ function buildBrowsePage(
     items: pageItems,
     customId: browseHelpers.buildSelect(safePage, filter, 'name', query),
     placeholder: 'Select a preset to view...',
-    startIndex: startIdx,
+    startIndex,
     formatItem: preset => ({
       label: `${buildPresetBadges(preset, isGuestMode)}${preset.name}`,
       value: preset.id,

--- a/services/bot-client/src/utils/browse/index.ts
+++ b/services/bot-client/src/utils/browse/index.ts
@@ -60,3 +60,11 @@ export {
   formatPageIndicator,
   type NounSpec,
 } from './footer.js';
+
+// Shared list-embed builder (§2.4 row grammar, §2.1 titles, D19 empty states)
+export {
+  buildBrowseListEmbed,
+  type BrowseRowSpec,
+  type BrowseListEmbedOptions,
+  type BrowseListEmbedResult,
+} from './listEmbedBuilder.js';

--- a/services/bot-client/src/utils/browse/listEmbedBuilder.test.ts
+++ b/services/bot-client/src/utils/browse/listEmbedBuilder.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the shared browse list-embed builder (§2.4/§3.1, D19).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { buildBrowseListEmbed, type BrowseRowSpec } from './listEmbedBuilder.js';
+
+interface Item {
+  name: string;
+  slug?: string;
+  group?: string;
+}
+
+function rowFor(item: Item): BrowseRowSpec {
+  return {
+    groupHeader: item.group,
+    badges: '🌐',
+    name: item.name,
+    techId: item.slug,
+    metadata: undefined,
+  };
+}
+
+const baseOptions = {
+  entityEmoji: '🎭',
+  titleNoun: 'Characters',
+  itemsPerPage: 2,
+  page: 0,
+  formatRow: rowFor,
+  empty: { noItems: 'You have none yet — start with `/character create`.' },
+};
+
+describe('buildBrowseListEmbed', () => {
+  it('renders the §2.1 title grammar and BLURPLE default color', () => {
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'Lilith', slug: 'lilith' }],
+    });
+
+    expect(embed.data.title).toBe('🎭 Characters');
+    expect(embed.data.color).toBe(DISCORD_COLORS.BLURPLE);
+  });
+
+  it('renders §2.4 rows: bold number, badges, bold name, backticked tech-id', () => {
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'Lilith', slug: 'lilith' }],
+    });
+
+    expect(embed.data.description).toContain('**1.** 🌐 **Lilith** (`lilith`)');
+  });
+
+  it('omits the tech-id segment when none is provided', () => {
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'Fast Preset' }],
+    });
+
+    expect(embed.data.description).toContain('**1.** 🌐 **Fast Preset**');
+    expect(embed.data.description).not.toContain('(`');
+  });
+
+  it('numbers rows by ABSOLUTE index so they match the select menu numbering', () => {
+    const items: Item[] = [{ name: 'A' }, { name: 'B' }, { name: 'C' }];
+    const { embed, startIndex, pageItems, safePage, totalPages } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items,
+      page: 1,
+    });
+
+    expect(safePage).toBe(1);
+    expect(totalPages).toBe(2);
+    expect(startIndex).toBe(2);
+    expect(pageItems).toEqual([{ name: 'C' }]);
+    expect(embed.data.description).toContain('**3.** 🌐 **C**');
+  });
+
+  it('clamps an out-of-range page into bounds', () => {
+    const { safePage, pageItems } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'A' }],
+      page: 99,
+    });
+
+    expect(safePage).toBe(0);
+    expect(pageItems).toEqual([{ name: 'A' }]);
+  });
+
+  it('renders the └ metadata line and truncates it at the density cap', () => {
+    const long = 'x'.repeat(100);
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'A' }],
+      formatRow: () => ({ name: 'A', metadata: ['model-x', long] }),
+    });
+
+    const metaLine = (embed.data.description ?? '').split('\n').find(l => l.startsWith('   └ '));
+    expect(metaLine).toBeDefined();
+    expect(metaLine).toContain('model-x · ');
+    expect(metaLine).toContain('…');
+    expect((metaLine ?? '').length).toBeLessThanOrEqual('   └ '.length + 72);
+  });
+
+  it('interleaves group headers with a separating blank line', () => {
+    const items: Item[] = [
+      { name: 'Mine', group: '**📝 Your Characters (1)**' },
+      { name: 'Theirs', group: "**🌐 Other Users' Characters (1)**" },
+    ];
+    const { embed } = buildBrowseListEmbed<Item>({ ...baseOptions, items });
+
+    const description = embed.data.description ?? '';
+    expect(description).toContain('**📝 Your Characters (1)**\n**1.** 🌐 **Mine**');
+    // Second header gets a blank-line separator before it.
+    expect(description).toContain("\n\n**🌐 Other Users' Characters (1)**\n**2.** 🌐 **Theirs**");
+  });
+
+  it('renders the D19 empty state with the CTA when the list is empty', () => {
+    const { embed } = buildBrowseListEmbed<Item>({ ...baseOptions, items: [] });
+
+    expect(embed.data.description).toContain('start with `/character create`');
+  });
+
+  it('prefers the filter-aware empty state when a filter is active', () => {
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [],
+      filterActive: true,
+      empty: {
+        noItems: 'none yet',
+        noMatch: 'No private characters match — clear the filter to see all.',
+      },
+    });
+
+    expect(embed.data.description).toContain('clear the filter to see all');
+  });
+
+  it('joins footer segments and appends the badge legend last', () => {
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'A' }],
+      footerSegments: ['3 characters', false, 'Sorted by date'],
+      badgeLegend: 'Public 🌐 · Private 🔒',
+    });
+
+    expect(embed.data.footer?.text).toBe('3 characters • Sorted by date • Public 🌐 · Private 🔒');
+  });
+
+  it('renders preamble lines above the list', () => {
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'A' }],
+      preamble: ['🔍 Searching: "li"'],
+    });
+
+    expect(embed.data.description?.startsWith('🔍 Searching: "li"')).toBe(true);
+  });
+
+  it('separates the preamble from the FIRST group header with a blank line (intentional)', () => {
+    // Deliberate visual upgrade over the old per-command rendering, which
+    // only separated the others-section header: context (preamble) and
+    // content (the list) now always get one blank line between them,
+    // uniformly across every browse surface.
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'Mine', group: '**📝 Your Characters (1)**' }],
+      preamble: ['🔍 Searching: "mine"'],
+    });
+
+    expect(embed.data.description).toContain(
+      '🔍 Searching: "mine"\n\n**📝 Your Characters (1)**\n**1.**'
+    );
+  });
+
+  it('honors a nameMarkup override without double-bolding', () => {
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'Paid' }],
+      formatRow: () => ({ name: 'Paid', nameMarkup: '~~Paid~~' }),
+    });
+
+    expect(embed.data.description).toContain('**1.** ~~Paid~~');
+    expect(embed.data.description).not.toContain('**Paid**');
+  });
+});

--- a/services/bot-client/src/utils/browse/listEmbedBuilder.ts
+++ b/services/bot-client/src/utils/browse/listEmbedBuilder.ts
@@ -1,0 +1,171 @@
+/**
+ * Shared browse list-embed builder (design-system spec §2.4/§3.1, D19).
+ *
+ * Every browse command previously hand-built its list embed with drifting
+ * grammar (numbered vs unnumbered rows, ad-hoc empty states, freelance
+ * titles). This builder owns the invariants:
+ *
+ * - Title grammar `{entity emoji} {Plural noun}` (§2.1) — browse titles are
+ *   the entity's identity, not a "Browser" suffix.
+ * - Row grammar `**{n}.** {badges} **{name}** (\`{tech-id}\`)` with an
+ *   optional `└`-prefixed metadata second line, ` · `-separated (§2.4).
+ *   Numbering always matches the select menu's numbering (same startIndex).
+ * - Tech-id renders only when the caller provides one — reserved for ids
+ *   users type elsewhere (character slugs); detail-view-only ids stay off
+ *   the list (§2.4 council catch).
+ * - Metadata density guardrail: the `└` line truncates with `…` so a row
+ *   survives a narrow phone viewport (§2.4).
+ * - Empty states are designed surfaces (D19): one orientation sentence plus
+ *   a CTA, with a filter-aware variant when emptiness came from filtering.
+ * - Informational surfaces are BLURPLE (§2.3); state renders via badges.
+ *
+ * The builder owns the embed only. Select menus, pagination buttons, and
+ * customIds stay with the existing browse factories — compose the result's
+ * `pageItems`/`startIndex` into `buildBrowseSelectMenu` so row numbers and
+ * select numbers can never drift.
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { joinFooter } from './footer.js';
+
+/**
+ * Metadata (`└` line) density cap. Long metadata wraps into multi-line rows
+ * on phones, burying the row numbering the select menu depends on.
+ */
+const MAX_METADATA_LENGTH = 72;
+
+/** One rendered row. The caller escapes user-controlled text (names). */
+export interface BrowseRowSpec {
+  /**
+   * Optional section header rendered above this row — grouped lists
+   * (character browse's own/others sections) interleave headers with rows.
+   * The builder inserts a blank line before a header that follows content.
+   */
+  groupHeader?: string;
+  /** Badge glyph run rendered before the name (state, per §2.2). */
+  badges?: string;
+  /** Display name (markdown-escaped by the caller); the builder bolds it. */
+  name: string;
+  /**
+   * Pre-styled name markup override for the rare style exception (e.g.
+   * guest-mode strikethrough). When present, `name` is not rendered.
+   */
+  nameMarkup?: string;
+  /** Technical id — only for ids users type elsewhere. */
+  techId?: string;
+  /** Metadata segments for the `└` line, joined with ' · '. */
+  metadata?: string[];
+}
+
+export interface BrowseListEmbedOptions<T> {
+  /** Entity emoji (§2.1 registry) — the entity's stable identity. */
+  entityEmoji: string;
+  /** Plural noun for the title (e.g. 'Characters' → `🎭 Characters`). */
+  titleNoun: string;
+  /** The full filtered item list (all pages). */
+  items: T[];
+  /** Requested 0-based page; clamped into range. */
+  page: number;
+  itemsPerPage: number;
+  /** Row renderer; absoluteIndex is 0-based across the whole list. */
+  formatRow: (item: T, absoluteIndex: number) => BrowseRowSpec;
+  /** Context lines above the list (search/filter line, mode warnings). */
+  preamble?: string[];
+  /** D19 designed empty states. */
+  empty: {
+    /** Zero items, no filter/query: orientation + CTA (`/command` inline). */
+    noItems: string;
+    /** Zero items WITH a filter/query active; falls back to noItems. */
+    noMatch?: string;
+  };
+  /** Whether a filter or query is narrowing the list (selects noMatch). */
+  filterActive?: boolean;
+  /** Footer segments, joined via joinFooter (falsy segments dropped). */
+  footerSegments?: (string | false | null | undefined)[];
+  /** Word-first badge legend (§2.2) — always the footer's last segment. */
+  badgeLegend?: string;
+  /** Embed color; BLURPLE default (§2.3 — info surfaces are BLURPLE). */
+  color?: number;
+}
+
+export interface BrowseListEmbedResult<T> {
+  embed: EmbedBuilder;
+  /** The page's item slice — feed to buildBrowseSelectMenu. */
+  pageItems: T[];
+  /** Absolute index of the first page item — the select's startIndex. */
+  startIndex: number;
+  totalPages: number;
+  /** The clamped page actually rendered. */
+  safePage: number;
+}
+
+/** Truncate the joined metadata line to the density cap. */
+function renderMetadataLine(segments: string[]): string {
+  const joined = segments.join(' · ');
+  const capped =
+    joined.length > MAX_METADATA_LENGTH ? `${joined.slice(0, MAX_METADATA_LENGTH - 1)}…` : joined;
+  return `   └ ${capped}`;
+}
+
+/** Render one §2.4 row (plus its optional group header) into lines. */
+function renderRow(spec: BrowseRowSpec, rowNumber: number, lines: string[]): void {
+  if (spec.groupHeader !== undefined) {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(spec.groupHeader);
+  }
+  const badges = spec.badges !== undefined && spec.badges.length > 0 ? `${spec.badges} ` : '';
+  const nameMarkup = spec.nameMarkup ?? `**${spec.name}**`;
+  const techId = spec.techId !== undefined ? ` (\`${spec.techId}\`)` : '';
+  lines.push(`**${rowNumber}.** ${badges}${nameMarkup}${techId}`);
+  if (spec.metadata !== undefined && spec.metadata.length > 0) {
+    lines.push(renderMetadataLine(spec.metadata));
+  }
+}
+
+/**
+ * Build the browse list embed. Pagination math is owned here so the caller
+ * can't slice one range and number another.
+ */
+export function buildBrowseListEmbed<T>(
+  options: BrowseListEmbedOptions<T>
+): BrowseListEmbedResult<T> {
+  const { items, itemsPerPage, formatRow } = options;
+
+  const totalPages = Math.max(1, Math.ceil(items.length / itemsPerPage));
+  const safePage = Math.min(Math.max(0, options.page), totalPages - 1);
+  const startIndex = safePage * itemsPerPage;
+  const pageItems = items.slice(startIndex, startIndex + itemsPerPage);
+
+  const lines: string[] = [];
+  for (const line of options.preamble ?? []) {
+    lines.push(line);
+  }
+
+  if (items.length === 0) {
+    const emptyLine =
+      options.filterActive === true
+        ? (options.empty.noMatch ?? options.empty.noItems)
+        : options.empty.noItems;
+    lines.push(emptyLine);
+  } else {
+    pageItems.forEach((item, i) => {
+      renderRow(formatRow(item, startIndex + i), startIndex + i + 1, lines);
+    });
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle(`${options.entityEmoji} ${options.titleNoun}`)
+    .setColor(options.color ?? DISCORD_COLORS.BLURPLE)
+    .setDescription(lines.join('\n'))
+    .setTimestamp();
+
+  const footer = joinFooter(...(options.footerSegments ?? []), options.badgeLegend);
+  if (footer.length > 0) {
+    embed.setFooter({ text: footer });
+  }
+
+  return { embed, pageItems, startIndex, totalPages, safePage };
+}


### PR DESCRIPTION
## Summary

Third slice of UX design-system **Phase 2**: the shared browse list-embed builder (G9), adopted on the two exemplar browses. This is the pilot's direct runway — the `/character alias` redesign (PR-4) renders its browse through this builder.

### `utils/browse/listEmbedBuilder.ts`

Owns the invariants each browse hand-rolled with drift:
- **§2.1 title grammar** — `{entity emoji} {Plural}` (`🎭 Characters`, `⚙️ Presets`); "Browser" suffixes retire on adopted surfaces.
- **§2.4 row grammar** — `**{n}.** {badges} **{name}** (\`{tech-id}\`)` with an optional `└` metadata line (` · `-joined, density-capped with `…`). **Numbering is absolute and owned by the same math that slices the page**, so list numbers and select-menu numbers structurally cannot drift — character browse's rows were previously unnumbered while its select was numbered.
- **Tech-id discipline** — rendered only where users type the id elsewhere (character slugs yes; preset ids stay in the detail view, per the §2.4 council catch).
- **D19 empty states** — designed surfaces with a CTA, plus a filter-aware variant ("clear the search or filter to see all").
- **§2.2 word-first badge legend** as the footer's final segment via the existing `joinFooter`.
- Group-header interleaving supports character browse's own/others sections unchanged.

### Adoption

- **Character browse**: `🎭 Characters`, numbered rows with slug tech-ids, `Yours ✏️` joins the legend, empty/no-match states upgraded. Grouping and the own-section CTA preamble preserved.
- **Preset browse**: `⚙️ Presets`, guest-mode dimming via the `nameMarkup` escape hatch, model name as `└` metadata, word-first legend. Badge glyphs themselves are unchanged on both surfaces — the §2.2 registry sweep is Phase 3.
- Retired: `renderPageItems`, `formatCharacterLine`, `formatPresetLine` (builder owns rendering). Remaining ~11 browses retrofit in the committed PR-4b sweep.

### Honest plan deviation

The planned **filter-button-row builder was cut**: grounding showed no browse hand-builds filter buttons (filters are slash options everywhere; the only browse buttons are the shared pagination/sort set). Building it would have been speculative code with zero consumers. Recorded in the plan; if a filter-row need materializes in the retrofit sweep, it gets built against a real consumer.

### Ride-along

DuplicateDetectionFlow P2002 flake filed as a Quick Win — its file-on-recurrence trigger fired on #1699's CI run (same-millisecond deterministic conversation-history UUID collision in test seeding).

## Verification

- `pnpm test` (26/26), `pnpm test:component` (all green), `pnpm quality` green.
- New builder has 12 dedicated tests (title/row/tech-id/absolute-numbering/clamping/metadata-cap/group-headers/empty-states/footer-legend/preamble/nameMarkup).
- Character + preset browse suites updated to the new titles/copy and pass (1010 tests across the touched areas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)