### PR TITLE
chore(deps): force adm-zip >=0.6.0 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
       "*eslint*"
     ],
     "overrides": {
+      "adm-zip@<0.6.0": ">=0.6.0",
       "undici": "^6.27.0",
       "path-to-regexp@>=8.0.0 <8.4.0": ">=8.4.0",
       "ioredis": "^5.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  adm-zip@<0.6.0: '>=0.6.0'
   undici: ^6.27.0
   path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.0'
   ioredis: ^5.11.1
@@ -3507,9 +3508,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.18:
-    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -9870,7 +9871,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  adm-zip@0.5.18: {}
+  adm-zip@0.6.0: {}
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
@@ -11967,13 +11968,13 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.18
+      adm-zip: 0.6.0
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 
   onnxruntime-node@1.27.0:
     dependencies:
-      adm-zip: 0.5.18
+      adm-zip: 0.6.0
       global-agent: 4.1.3
       onnxruntime-common: 1.27.0
 


### PR DESCRIPTION
## Summary

Closes the repo's only open Dependabot alert (#135, high — path-traversal class in adm-zip <0.6.0). The dependency is transitive via `onnxruntime-node`, which unpacks only its own install artifacts — never user-supplied ZIPs — so exposure was already indirect (triaged as such on the board); the pnpm override removes the vulnerable version from the tree entirely rather than arguing about reachability.

- `adm-zip@<0.6.0 → >=0.6.0` in the root `pnpm.overrides` (matches the existing override style); lockfile now resolves 0.6.0 everywhere (zero 0.5.x entries).
- Verified: `@tzurot/embeddings` (the onnxruntime consumer) test suite green on the new resolution; full `pnpm test` + `pnpm quality` green.

Board Quick Win discharged; intended to ride the upcoming beta cut so the release ships with a clean security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)