### PR TITLE
chore: bump version to 3.0.0-beta.169

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "description": "Next-generation Discord AI bot with customizable personalities",
   "type": "module",

--- a/packages/cache-invalidation/package.json
+++ b/packages/cache-invalidation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/cache-invalidation",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Redis pub/sub cache-invalidation services: a generic base + per-domain invalidators (personality, llm/tts/stt config, persona, api-key, channel-activation, denylist)",

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/clients",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Typed HTTP clients + route manifest for the Tzurot gateway API",

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/common-types",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Shared types and validation schemas for Tzurot",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/config-resolver",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Resolves effective LLM/TTS/STT configuration from the user/personality/global override cascade",

--- a/packages/conversation-history/package.json
+++ b/packages/conversation-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/conversation-history",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Prisma-backed conversation persistence: history retrieval, channel sync, and reference-image-description writes",

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/embeddings",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Local embedding service using bge-small-en-v1.5 for semantic similarity",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/identity",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "User / persona / personality provisioning + routing-context resolution (Prisma-backed identity services)",

--- a/packages/test-factories/package.json
+++ b/packages/test-factories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/test-factories",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Validated mock-data factories for Tzurot tests (built on @tzurot/common-types schemas)",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/test-utils",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Shared test utilities for Tzurot services",

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/tooling",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "description": "Internal tooling and CLI for Tzurot monorepo operations",
   "type": "module",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/scripts",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Utility scripts for Tzurot development and operations",

--- a/services/ai-worker/package.json
+++ b/services/ai-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/ai-worker",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "AI processing worker service for Tzurot bot",

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/api-gateway",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "API gateway service for Tzurot bot",

--- a/services/bot-client/package.json
+++ b/services/bot-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/bot-client",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Discord client service for Tzurot bot",

--- a/services/website/package.json
+++ b/services/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/website",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Public website for Tzurot (tzurot.org) — landing page + legal documents",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tzurot/e2e",
-  "version": "3.0.0-beta.168",
+  "version": "3.0.0-beta.169",
   "private": true,
   "type": "module",
   "description": "Integration + contract tests for Tzurot services (run via the root `pnpm test:integration`; see vitest.integration.config.ts).",


### PR DESCRIPTION
Mechanical version bump for the beta.169 cut (17 package.json files, version field only). Routed through a PR per the develop code-commit guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)