### PR TITLE
feat(bot-client): browse filter-toggle wave — shared builder + adoption (PR-4b-1)

### DIFF
--- a/services/bot-client/src/commands/channel/browse.test.ts
+++ b/services/bot-client/src/commands/channel/browse.test.ts
@@ -161,6 +161,59 @@ describe('handleBrowse', () => {
       embeds: expect.any(Array),
       components: expect.any(Array),
     });
+
+    // Non-owners never see the all-servers toggle — the 'all' filter is
+    // bot-owner-only, and a rendered-but-gated button is a dead affordance.
+    const call = mockEditReply.mock.calls[0][0] as {
+      components: { toJSON: () => { components: { custom_id?: string; label?: string }[] } }[];
+    };
+    const buttons = call.components.flatMap(row => row.toJSON().components);
+    expect(buttons.find(button => button.label === 'Filter: All Servers')).toBeUndefined();
+  });
+
+  it('renders the all-servers toggle for the bot owner with sort threaded and page reset', async () => {
+    const { isBotOwner } = await import('@tzurot/common-types/utils/ownerMiddleware');
+    vi.mocked(isBotOwner).mockReturnValue(true);
+    stub.listUserChannels.mockResolvedValue(
+      ok({
+        settings: [
+          {
+            channelId: 'channel-1',
+            guildId: 'guild-123',
+            personalityId: 'personality-1',
+            personalityName: 'Test Personality',
+            personalitySlug: 'test-personality',
+            createdAt: '2025-06-15T12:00:00.000Z',
+          },
+        ],
+      })
+    );
+
+    const context = createMockContext();
+    await handleBrowse(context);
+
+    const call = mockEditReply.mock.calls[0][0] as {
+      components: { toJSON: () => { components: { custom_id?: string; label?: string }[] } }[];
+    };
+    const buttons = call.components.flatMap(row => row.toJSON().components);
+    const toggle = buttons.find(button => button.label === 'Filter: All Servers');
+    expect(toggle?.custom_id).toBe('channel::browse::0::all::date::');
+  });
+
+  it('renders the empty all-servers view without crashing (zero activations bot-wide)', async () => {
+    const { isBotOwner } = await import('@tzurot/common-types/utils/ownerMiddleware');
+    vi.mocked(isBotOwner).mockReturnValue(true);
+    stub.listUserChannels.mockResolvedValue(ok({ settings: [] }));
+
+    const context = createMockContext(null, 'all');
+    await handleBrowse(context);
+
+    const call = mockEditReply.mock.calls[0][0] as {
+      embeds: { toJSON: () => { description?: string; footer?: { text: string } } }[];
+    };
+    const embed = call.embeds[0].toJSON();
+    expect(embed.description).toContain('No activated channels in any server');
+    expect(embed.footer?.text).toContain('0 total');
   });
 
   it('should reject all filter for non-bot-owners', async () => {

--- a/services/bot-client/src/commands/channel/browse.ts
+++ b/services/bot-client/src/commands/channel/browse.ts
@@ -12,7 +12,6 @@
 
 import {
   type ButtonInteraction,
-  type TextChannel,
   type Client,
   EmbedBuilder,
   type ButtonBuilder,
@@ -21,6 +20,7 @@ import {
 } from 'discord.js';
 import {
   buildBrowseButtons as buildSharedBrowseButtons,
+  buildFilterToggleButton,
   createBrowseCustomIdHelpers,
   joinFooter,
   formatSortNatural,
@@ -33,28 +33,32 @@ import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { renderSpec } from '../../ux/render/render.js';
 import { channelBrowseOptions } from '@tzurot/common-types/generated/commandOptions';
 import { type ChannelSettings } from '@tzurot/common-types/schemas/api/channel';
-import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
 import { type UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
-import { createListComparator, type ListSortType } from '../../utils/listSorting.js';
-import { CHANNELS_PER_PAGE, CHANNELS_PER_PAGE_ALL_SERVERS, type GuildPage } from './listTypes.js';
+import {
+  CHANNELS_PER_PAGE,
+  FILTER_TOGGLE_DISPLAY,
+  VALID_CHANNEL_FILTERS,
+  type ChannelBrowseFilter,
+  type GuildPage,
+} from './listTypes.js';
+import {
+  buildGuildPages,
+  filterByQuery,
+  formatChannelSettings,
+  sortChannelSettings,
+} from './browseHelpers.js';
 
 const logger = createLogger('channel-browse');
-
-/** Browse filter options */
-type ChannelBrowseFilter = 'current' | 'all';
-
-/** Valid filters for channel browse */
-const VALID_FILTERS = ['current', 'all'] as const;
 
 /** Browse customId helpers using shared factory */
 const browseHelpers = createBrowseCustomIdHelpers<ChannelBrowseFilter>({
   prefix: 'channel',
-  validFilters: VALID_FILTERS,
+  validFilters: VALID_CHANNEL_FILTERS,
 });
 
 /** Default sort type */
@@ -68,136 +72,26 @@ export function isChannelBrowseInteraction(customId: string): boolean {
 }
 
 /**
- * Format a single channel settings entry for display
+ * Build pagination and sort buttons using shared utility, plus the
+ * in-place filter toggle (current ↔ all servers). The 'all' filter is
+ * bot-owner-only, so the toggle only renders for the owner — showing it
+ * to everyone else would be a dead affordance (the pagination handler
+ * gates the click, leaving a button that visibly does nothing).
  */
-function formatChannelSettings(settings: ChannelSettings): string {
-  const channelMention = `<#${settings.channelId}>`;
-  const activatedDate = formatDateShort(settings.createdAt);
-  const safeName = escapeMarkdown(settings.personalityName ?? 'Unknown');
-  return `${channelMention} → **${safeName}** (\`${settings.personalitySlug}\`)\n  _Activated: ${activatedDate}_`;
+interface ChannelBrowseButtonsOptions {
+  currentPage: number;
+  totalPages: number;
+  filter: ChannelBrowseFilter;
+  currentSort: BrowseSortType;
+  query: string | null;
+  showFilterToggle: boolean;
 }
 
-/**
- * Create a channel comparator with access to client cache for name lookups.
- */
-function createChannelComparator(
-  client: Client
-): (sortType: ListSortType) => (a: ChannelSettings, b: ChannelSettings) => number {
-  const getChannelName = (s: ChannelSettings): string => {
-    const channel = client.channels.cache.get(s.channelId) as TextChannel | undefined;
-    return channel?.name ?? s.channelId;
-  };
-
-  return createListComparator<ChannelSettings>(getChannelName, s => s.createdAt);
-}
-
-/**
- * Sort channel settings by the specified sort type.
- */
-function sortChannelSettings(
-  settings: ChannelSettings[],
-  sortType: BrowseSortType,
-  client: Client,
-  isAllServers = false
-): ChannelSettings[] {
-  const sorted = [...settings];
-  const comparator = createChannelComparator(client);
-
-  const getGuildName = (s: ChannelSettings): string => {
-    if (s.guildId === null) {
-      return 'zzz_unknown';
-    }
-    const guild = client.guilds.cache.get(s.guildId);
-    return guild?.name ?? s.guildId;
-  };
-
-  if (isAllServers) {
-    sorted.sort((a, b) => {
-      const guildCompare = getGuildName(a).localeCompare(getGuildName(b));
-      if (guildCompare !== 0) {
-        return guildCompare;
-      }
-      return comparator(sortType)(a, b);
-    });
-  } else {
-    sorted.sort(comparator(sortType));
-  }
-
-  return sorted;
-}
-
-/**
- * Filter channel settings by query
- */
-function filterByQuery(settings: ChannelSettings[], query: string | null): ChannelSettings[] {
-  if (query === null || query.length === 0) {
-    return settings;
-  }
-
-  const lowerQuery = query.toLowerCase();
-  return settings.filter(
-    s =>
-      (s.personalityName?.toLowerCase().includes(lowerQuery) ?? false) ||
-      (s.personalitySlug?.toLowerCase().includes(lowerQuery) ?? false)
-  );
-}
-
-/**
- * Build guild-aware pages for all-servers view
- */
-function buildGuildPages(activations: ChannelSettings[], client: Client): GuildPage[] {
-  const pages: GuildPage[] = [];
-
-  const guildGroups: { guildId: string; guildName: string; settings: ChannelSettings[] }[] = [];
-  let currentGroup: (typeof guildGroups)[0] | null = null;
-
-  for (const activation of activations) {
-    const guildId = activation.guildId ?? 'unknown';
-    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- explicit null check required
-    if (currentGroup === null || currentGroup.guildId !== guildId) {
-      const guild = guildId !== 'unknown' ? client.guilds.cache.get(guildId) : undefined;
-      const guildName: string = guild?.name ?? `Unknown Server (${guildId})`;
-      currentGroup = { guildId, guildName, settings: [] };
-      guildGroups.push(currentGroup);
-    }
-    currentGroup.settings.push(activation);
-  }
-
-  for (const group of guildGroups) {
-    const totalChannels = group.settings.length;
-    let offset = 0;
-
-    while (offset < totalChannels) {
-      const pageSettings = group.settings.slice(offset, offset + CHANNELS_PER_PAGE_ALL_SERVERS);
-      const isContinuation = offset > 0;
-      const isComplete = offset + pageSettings.length >= totalChannels;
-
-      pages.push({
-        guildId: group.guildId,
-        guildName: group.guildName,
-        settings: pageSettings,
-        isContinuation,
-        isComplete,
-      });
-
-      offset += CHANNELS_PER_PAGE_ALL_SERVERS;
-    }
-  }
-
-  return pages;
-}
-
-/**
- * Build pagination and sort buttons using shared utility
- */
 function buildBrowseButtons(
-  currentPage: number,
-  totalPages: number,
-  filter: ChannelBrowseFilter,
-  currentSort: BrowseSortType,
-  query: string | null
+  options: ChannelBrowseButtonsOptions
 ): ReturnType<typeof buildSharedBrowseButtons> {
-  return buildSharedBrowseButtons({
+  const { currentPage, totalPages, filter, currentSort, query, showFilterToggle } = options;
+  const row = buildSharedBrowseButtons({
     currentPage,
     totalPages,
     filter,
@@ -206,6 +100,19 @@ function buildBrowseButtons(
     buildCustomId: browseHelpers.build,
     buildInfoId: browseHelpers.buildInfo,
   });
+  if (showFilterToggle) {
+    row.addComponents(
+      buildFilterToggleButton({
+        filters: VALID_CHANNEL_FILTERS,
+        display: FILTER_TOGGLE_DISPLAY,
+        current: filter,
+        buildCustomId: browseHelpers.build,
+        sort: currentSort,
+        query,
+      })
+    );
+  }
+  return row;
 }
 
 /**
@@ -267,6 +174,22 @@ function buildEmbedAllServers(
   totalChannels: number,
   query: string | null
 ): EmbedBuilder {
+  // Zero activations anywhere: without this guard, safePage clamps to -1
+  // and guildPages[-1] throws. The always-rendered filter toggle makes
+  // this path directly reachable (toggle to All Servers on an empty bot).
+  if (guildPages.length === 0) {
+    return new EmbedBuilder()
+      .setTitle('📍 Channel Browser')
+      .setColor(DISCORD_COLORS.BLURPLE)
+      .setDescription(
+        query !== null
+          ? '_No channels match your search in any server._'
+          : '_No activated channels in any server._\n\nUse `/channel activate` to set up auto-responses.'
+      )
+      .setFooter({ text: '0 total across all servers' })
+      .setTimestamp();
+  }
+
   const totalPages = guildPages.length;
   const safePage = Math.min(Math.max(0, page), totalPages - 1);
   const guildPage = guildPages[safePage];
@@ -316,6 +239,8 @@ interface BuildBrowsePageOptions {
   sortType: BrowseSortType;
   query: string | null;
   client: Client;
+  /** Owner-only affordance: the all-servers toggle renders only for the bot owner. */
+  showFilterToggle: boolean;
 }
 
 /**
@@ -326,7 +251,7 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
   components: ActionRowBuilder<ButtonBuilder>[];
   totalPages: number;
 } {
-  const { activations, page, filter, sortType, query, client } = options;
+  const { activations, page, filter, sortType, query, client, showFilterToggle } = options;
   const isAllServers = filter === 'all';
 
   if (isAllServers) {
@@ -335,9 +260,18 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
     const embed = buildEmbedAllServers(guildPages, page, sortType, activations.length, query);
     const components: ActionRowBuilder<ButtonBuilder>[] = [];
 
-    if (totalPages > 1 || activations.length > 0) {
-      components.push(buildBrowseButtons(page, totalPages, filter, sortType, query));
-    }
+    // Always render: the filter toggle must stay reachable even when this
+    // view is empty (the other filter's view may not be).
+    components.push(
+      buildBrowseButtons({
+        currentPage: page,
+        totalPages,
+        filter,
+        currentSort: sortType,
+        query,
+        showFilterToggle,
+      })
+    );
 
     return { embed, components, totalPages };
   }
@@ -346,9 +280,18 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
   const embed = buildEmbedSingleGuild(activations, page, sortType, query);
   const components: ActionRowBuilder<ButtonBuilder>[] = [];
 
-  if (totalPages > 1 || activations.length > 0) {
-    components.push(buildBrowseButtons(page, totalPages, filter, sortType, query));
-  }
+  // Always render: the filter toggle must stay reachable even when this
+  // view is empty (the other filter's view may not be).
+  components.push(
+    buildBrowseButtons({
+      currentPage: page,
+      totalPages,
+      filter,
+      currentSort: sortType,
+      query,
+      showFilterToggle,
+    })
+  );
 
   return { embed, components, totalPages };
 }
@@ -472,6 +415,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
       sortType: DEFAULT_SORT,
       query,
       client: interaction.client,
+      showFilterToggle: isBotOwner(context.user.id),
     });
 
     await context.editReply({ embeds: [embed], components });
@@ -550,6 +494,7 @@ export async function handleBrowsePagination(
       sortType: sort,
       query,
       client: interaction.client,
+      showFilterToggle: isBotOwner(userId),
     });
 
     await interaction.editReply({ embeds: [embed], components });

--- a/services/bot-client/src/commands/channel/browseHelpers.test.ts
+++ b/services/bot-client/src/commands/channel/browseHelpers.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the channel browse pure helpers (row formatting, query
+ * filtering, guild-page chunking for the all-servers view).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Client } from 'discord.js';
+import type { ChannelSettings } from '@tzurot/common-types/schemas/api/channel';
+import { buildGuildPages, filterByQuery, formatChannelSettings } from './browseHelpers.js';
+
+function makeSettings(overrides: Partial<ChannelSettings>): ChannelSettings {
+  return {
+    channelId: '111',
+    guildId: 'g-1',
+    personalityId: 'p-1',
+    personalityName: 'Lilith',
+    personalitySlug: 'lilith',
+    createdAt: '2026-07-18T00:00:00.000Z',
+    ...overrides,
+  } as ChannelSettings;
+}
+
+function makeClient(guildNames: Record<string, string>): Client {
+  return {
+    guilds: {
+      cache: {
+        get: (id: string) => (guildNames[id] !== undefined ? { name: guildNames[id] } : undefined),
+      },
+    },
+  } as unknown as Client;
+}
+
+describe('formatChannelSettings', () => {
+  it('renders mention, escaped name, slug, and activation date', () => {
+    const line = formatChannelSettings(makeSettings({ personalityName: 'Li*lith' }));
+    expect(line).toContain('<#111>');
+    expect(line).toContain('Li\\*lith');
+    expect(line).toContain('`lilith`');
+    expect(line).toContain('Activated:');
+  });
+});
+
+describe('filterByQuery', () => {
+  it('matches personality name case-insensitively and passes null query through', () => {
+    const rows = [
+      makeSettings({ personalityName: 'Lilith' }),
+      makeSettings({ channelId: '222', personalityName: 'Sapphomet', personalitySlug: 'sapph' }),
+    ];
+    expect(filterByQuery(rows, 'lil')).toHaveLength(1);
+    expect(filterByQuery(rows, null)).toHaveLength(2);
+  });
+});
+
+describe('buildGuildPages', () => {
+  it('groups consecutive same-guild rows into pages with resolved names', () => {
+    const rows = [
+      makeSettings({ guildId: 'g-1' }),
+      makeSettings({ channelId: '222', guildId: 'g-1' }),
+      makeSettings({ channelId: '333', guildId: 'g-2' }),
+    ];
+    const pages = buildGuildPages(rows, makeClient({ 'g-1': 'Alpha', 'g-2': 'Beta' }));
+
+    expect(pages).toHaveLength(2);
+    expect(pages[0].guildName).toBe('Alpha');
+    expect(pages[0].settings).toHaveLength(2);
+    expect(pages[1].guildName).toBe('Beta');
+  });
+
+  it('labels unresolvable guilds and splits oversized guilds into continuations', () => {
+    const many = Array.from({ length: 10 }, (_, index) =>
+      makeSettings({ channelId: `c-${index}`, guildId: 'g-x' })
+    );
+    const pages = buildGuildPages(many, makeClient({}));
+
+    expect(pages[0].guildName).toContain('Unknown Server');
+    // 10 channels at 8-per-page → a continuation page.
+    expect(pages).toHaveLength(2);
+    expect(pages[1].isContinuation).toBe(true);
+  });
+});

--- a/services/bot-client/src/commands/channel/browseHelpers.ts
+++ b/services/bot-client/src/commands/channel/browseHelpers.ts
@@ -1,0 +1,134 @@
+/**
+ * Channel browse pure helpers: row formatting, sorting, query filtering,
+ * and the guild-page chunking for the all-servers view.
+ */
+
+import { escapeMarkdown, type Client, type TextChannel } from 'discord.js';
+import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
+import type { ChannelSettings } from '@tzurot/common-types/schemas/api/channel';
+import { createListComparator, type ListSortType } from '../../utils/listSorting.js';
+import type { BrowseSortType } from '../../utils/browse/index.js';
+import { CHANNELS_PER_PAGE_ALL_SERVERS, type GuildPage } from './listTypes.js';
+
+/**
+ * Format a single channel settings entry for display
+ */
+export function formatChannelSettings(settings: ChannelSettings): string {
+  const channelMention = `<#${settings.channelId}>`;
+  const activatedDate = formatDateShort(settings.createdAt);
+  const safeName = escapeMarkdown(settings.personalityName ?? 'Unknown');
+  return `${channelMention} → **${safeName}** (\`${settings.personalitySlug}\`)\n  _Activated: ${activatedDate}_`;
+}
+
+/**
+ * Create a channel comparator with access to client cache for name lookups.
+ */
+export function createChannelComparator(
+  client: Client
+): (sortType: ListSortType) => (a: ChannelSettings, b: ChannelSettings) => number {
+  const getChannelName = (s: ChannelSettings): string => {
+    const channel = client.channels.cache.get(s.channelId) as TextChannel | undefined;
+    return channel?.name ?? s.channelId;
+  };
+
+  return createListComparator<ChannelSettings>(getChannelName, s => s.createdAt);
+}
+
+/**
+ * Sort channel settings by the specified sort type.
+ */
+export function sortChannelSettings(
+  settings: ChannelSettings[],
+  sortType: BrowseSortType,
+  client: Client,
+  isAllServers = false
+): ChannelSettings[] {
+  const sorted = [...settings];
+  const comparator = createChannelComparator(client);
+
+  const getGuildName = (s: ChannelSettings): string => {
+    if (s.guildId === null) {
+      return 'zzz_unknown';
+    }
+    const guild = client.guilds.cache.get(s.guildId);
+    return guild?.name ?? s.guildId;
+  };
+
+  if (isAllServers) {
+    sorted.sort((a, b) => {
+      const guildCompare = getGuildName(a).localeCompare(getGuildName(b));
+      if (guildCompare !== 0) {
+        return guildCompare;
+      }
+      return comparator(sortType)(a, b);
+    });
+  } else {
+    sorted.sort(comparator(sortType));
+  }
+
+  return sorted;
+}
+
+/**
+ * Filter channel settings by query
+ */
+export function filterByQuery(
+  settings: ChannelSettings[],
+  query: string | null
+): ChannelSettings[] {
+  if (query === null || query.length === 0) {
+    return settings;
+  }
+
+  const lowerQuery = query.toLowerCase();
+  return settings.filter(
+    s =>
+      (s.personalityName?.toLowerCase().includes(lowerQuery) ?? false) ||
+      (s.personalitySlug?.toLowerCase().includes(lowerQuery) ?? false)
+  );
+}
+
+/**
+ * Build guild-aware pages for all-servers view
+ */
+export function buildGuildPages(activations: ChannelSettings[], client: Client): GuildPage[] {
+  const pages: GuildPage[] = [];
+
+  const guildGroups: { guildId: string; guildName: string; settings: ChannelSettings[] }[] = [];
+  let currentGroup: (typeof guildGroups)[0] | null = null;
+
+  for (const activation of activations) {
+    const guildId = activation.guildId ?? 'unknown';
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- explicit null check required
+    if (currentGroup === null || currentGroup.guildId !== guildId) {
+      const guild = guildId !== 'unknown' ? client.guilds.cache.get(guildId) : undefined;
+      const guildName: string = guild?.name ?? `Unknown Server (${guildId})`;
+      currentGroup = { guildId, guildName, settings: [] };
+      guildGroups.push(currentGroup);
+    }
+    currentGroup.settings.push(activation);
+  }
+
+  for (const group of guildGroups) {
+    const totalChannels = group.settings.length;
+    let offset = 0;
+
+    while (offset < totalChannels) {
+      const pageSettings = group.settings.slice(offset, offset + CHANNELS_PER_PAGE_ALL_SERVERS);
+      const isContinuation = offset > 0;
+      const isComplete = offset + pageSettings.length >= totalChannels;
+
+      pages.push({
+        guildId: group.guildId,
+        guildName: group.guildName,
+        settings: pageSettings,
+        isContinuation,
+        isComplete,
+      });
+
+      offset += CHANNELS_PER_PAGE_ALL_SERVERS;
+    }
+  }
+
+  return pages;
+}

--- a/services/bot-client/src/commands/channel/listTypes.ts
+++ b/services/bot-client/src/commands/channel/listTypes.ts
@@ -2,6 +2,8 @@
  * Channel List Types and Constants
  */
 
+import type { FilterToggleDisplay } from '../../utils/browse/filterRowBuilder.js';
+
 import type { ChannelSettings } from '@tzurot/common-types/schemas/api/channel';
 
 /** Channels per page for pagination (single guild mode) */
@@ -23,3 +25,14 @@ export interface GuildPage {
   /** True if this is the last page for this guild */
   isComplete: boolean;
 }
+
+/** Browse filter: the invoking server only, or every server the bot shares. */
+export type ChannelBrowseFilter = 'current' | 'all';
+
+export const VALID_CHANNEL_FILTERS = ['current', 'all'] as const;
+
+/** In-place filter toggle display (§3.1 affordance). */
+export const FILTER_TOGGLE_DISPLAY: Record<ChannelBrowseFilter, FilterToggleDisplay> = {
+  current: { label: 'Filter: This Server', shortLabel: 'This Server', emoji: '\u{1F4CD}' },
+  all: { label: 'Filter: All Servers', shortLabel: 'All Servers', emoji: '\u{1F310}' },
+};

--- a/services/bot-client/src/commands/character/aliasBrowse.ts
+++ b/services/bot-client/src/commands/character/aliasBrowse.ts
@@ -18,8 +18,6 @@
  */
 
 import {
-  ButtonBuilder,
-  ButtonStyle,
   escapeMarkdown,
   MessageFlags,
   type ButtonInteraction,
@@ -31,7 +29,6 @@ import {
   ALIAS_FILTERS,
   applyFilter,
   fetchAliasRows,
-  nextAliasFilter,
   type AliasFilter,
   type AliasRow,
 } from './aliasData.js';
@@ -41,6 +38,8 @@ import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   buildBrowseListEmbed,
   buildBrowseSelectMenu,
+  buildFilterToggleButton,
+  type FilterToggleDisplay,
   buildSimplePaginationButtons,
   createBrowseCustomIdHelpers,
   truncateForSelect,
@@ -99,10 +98,10 @@ function parseRemoveCustomId(
   return { page, filter: filterRaw as AliasFilter, query: query === '' ? null : query };
 }
 
-const FILTER_TOGGLE_DISPLAY: Record<AliasFilter, { label: string; emoji: string }> = {
-  all: { label: 'Filter: All', emoji: '📋' },
-  mine: { label: 'Filter: Mine', emoji: '🔒' },
-  global: { label: 'Filter: Global', emoji: '🌐' },
+const FILTER_TOGGLE_DISPLAY: Record<AliasFilter, FilterToggleDisplay> = {
+  all: { label: 'Filter: All', shortLabel: 'All', emoji: '📋' },
+  mine: { label: 'Filter: Mine', shortLabel: 'Mine', emoji: '🔒' },
+  global: { label: 'Filter: Global', shortLabel: 'Global', emoji: '🌐' },
 };
 
 function scopeBadge(row: AliasRow): string {
@@ -188,8 +187,7 @@ export async function renderAliasBrowse(
     filterActive: filter !== 'all',
     footerSegments: [
       pluralize(filtered.length, { singular: 'alias', plural: 'aliases' }),
-      filter !== 'all' &&
-        formatFilterLabeled(FILTER_TOGGLE_DISPLAY[filter].label.replace('Filter: ', '')),
+      filter !== 'all' && formatFilterLabeled(FILTER_TOGGLE_DISPLAY[filter].shortLabel),
       fetched.data.truncated && 'list truncated',
     ],
     badgeLegend: myMode ? 'Global 🌐 · Personal 🔒 · Shadowed ⚠️' : 'Global 🌐 · Personal 🔒',
@@ -225,31 +223,20 @@ export async function renderAliasBrowse(
     buildCustomId: aliasHelpers.build,
     buildInfoId: aliasHelpers.buildInfo,
   });
-  // The first in-place FILTER toggle (owner-adopted design affordance):
-  // one Primary button whose customId is the same pagination coordinate
-  // set with only the filter advanced — and the page reset to 0, since a
-  // narrower filter renumbers the list.
-  const toggleDisplay = FILTER_TOGGLE_DISPLAY[nextAliasFilter(filter)];
+  // The in-place FILTER toggle (owner-adopted design affordance), via the
+  // shared builder this pilot's usage was generalized into.
   buttonRow.addComponents(
-    buildFilterToggleButton(
-      toggleDisplay,
-      aliasHelpers.build(0, nextAliasFilter(filter), 'name', query)
-    )
+    buildFilterToggleButton({
+      filters: ALIAS_FILTERS,
+      display: FILTER_TOGGLE_DISPLAY,
+      current: filter,
+      buildCustomId: aliasHelpers.build,
+      query,
+    })
   );
   components.push(buttonRow);
 
   await target.editReply({ content: '', embeds: [embed], components });
-}
-
-function buildFilterToggleButton(
-  display: { label: string; emoji: string },
-  customId: string
-): ButtonBuilder {
-  return new ButtonBuilder()
-    .setCustomId(customId)
-    .setLabel(display.label)
-    .setEmoji(display.emoji)
-    .setStyle(ButtonStyle.Primary);
 }
 
 function describeAliasFailure(status: number, error: string): string {

--- a/services/bot-client/src/commands/character/aliasData.test.ts
+++ b/services/bot-client/src/commands/character/aliasData.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { applyFilter, nextAliasFilter, type AliasRow } from './aliasData.js';
+import { applyFilter, type AliasRow } from './aliasData.js';
 
 const rows: AliasRow[] = [
   { alias: 'a', scope: 'user', shadowed: false, character: { name: null, slug: 's' } },
@@ -11,14 +11,6 @@ const rows: AliasRow[] = [
 ];
 
 describe('alias data model', () => {
-  describe('nextAliasFilter (the first in-place filter toggle)', () => {
-    it('cycles all → mine → global → all', () => {
-      expect(nextAliasFilter('all')).toBe('mine');
-      expect(nextAliasFilter('mine')).toBe('global');
-      expect(nextAliasFilter('global')).toBe('all');
-    });
-  });
-
   describe('applyFilter', () => {
     it('narrows to the selected scope and passes everything for all', () => {
       expect(applyFilter(rows, 'all')).toHaveLength(2);

--- a/services/bot-client/src/commands/character/aliasData.ts
+++ b/services/bot-client/src/commands/character/aliasData.ts
@@ -1,7 +1,7 @@
 /**
  * Alias browse data model: the normalized row shape both endpoints map
- * into, the scope-filter vocabulary, and the filter-cycle function behind
- * the design system's first in-place filter toggle.
+ * into and the scope-filter vocabulary (the toggle cycle itself lives in
+ * the shared browse filterRowBuilder).
  */
 
 import type { AliasScope } from '@tzurot/common-types/schemas/api/personality';
@@ -75,10 +75,4 @@ export function applyFilter(rows: AliasRow[], filter: AliasFilter): AliasRow[] {
     return rows.filter(row => row.scope === 'global');
   }
   return rows;
-}
-
-/** The design system's first in-place filter toggle: all → mine → global. */
-export function nextAliasFilter(filter: AliasFilter): AliasFilter {
-  const index = ALIAS_FILTERS.indexOf(filter);
-  return ALIAS_FILTERS[(index + 1) % ALIAS_FILTERS.length];
 }

--- a/services/bot-client/src/commands/character/browse.test.ts
+++ b/services/bot-client/src/commands/character/browse.test.ts
@@ -158,6 +158,15 @@ describe('handleBrowse', () => {
       ],
       components: expect.any(Array),
     });
+
+    // The in-place filter toggle rides the button row: same coordinates,
+    // filter advanced one step (all → mine), page reset to 0.
+    const call = vi.mocked(mockEditReply).mock.calls[0][0] as unknown as {
+      components: { toJSON: () => { components: { custom_id?: string; label?: string }[] } }[];
+    };
+    const allButtons = call.components.flatMap(row => row.toJSON().components);
+    const toggle = allButtons.find(button => button.label === 'Filter: Mine');
+    expect(toggle?.custom_id).toBe('character::browse::0::mine::date::');
   });
 
   it('should filter by mine (owned only)', async () => {

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -51,6 +51,7 @@ import {
   buildBrowseButtons as buildSharedBrowseButtons,
   buildBrowseListEmbed,
   buildBrowseSelectMenu,
+  buildFilterToggleButton,
   createBrowseCustomIdHelpers,
   pluralize,
   formatFilterLabeled,
@@ -65,6 +66,9 @@ import {
   buildFilterLine,
   buildEmptyStateLines,
   FILTER_LABELS,
+  FILTER_TOGGLE_DISPLAY,
+  buildCharacterDescription,
+  formatCharacterSelectLabel,
 } from './browseHelpers.js';
 
 const logger = createLogger('character-browse');
@@ -99,30 +103,8 @@ export function isCharacterBrowseSelectInteraction(customId: string): boolean {
 }
 
 /**
- * Format a character for the select menu — returns the unprefixed
- * label (numbering is added by the buildBrowseSelectMenu factory).
- */
-function formatCharacterSelectLabel(item: ListItem): string {
-  const char = item.char;
-  const visibility = char.isPublic ? '🌐' : '🔒';
-  const ownBadge = item.isOwn ? '✏️' : '';
-  return `${visibility}${ownBadge} ${char.displayName ?? char.name}`;
-}
-
-/**
- * Build the description for a character's select menu option.
- * Slug-prefixed identifier with an optional ownership marker.
- */
-function buildCharacterDescription(item: ListItem): string {
-  let description = `/${item.char.slug}`;
-  if (item.isOwn) {
-    description += ' (yours)';
-  }
-  return description;
-}
-
-/**
- * Build pagination buttons using shared utility
+ * Build pagination buttons using shared utility, plus the in-place filter
+ * toggle (all → mine → public — same coordinates, filter advanced, page 0).
  */
 function buildBrowseButtons(
   currentPage: number,
@@ -131,7 +113,7 @@ function buildBrowseButtons(
   currentSort: CharacterBrowseSortType,
   query: string | null
 ): ReturnType<typeof buildSharedBrowseButtons> {
-  return buildSharedBrowseButtons({
+  const row = buildSharedBrowseButtons({
     currentPage,
     totalPages,
     filter,
@@ -140,6 +122,17 @@ function buildBrowseButtons(
     buildCustomId: browseHelpers.build,
     buildInfoId: browseHelpers.buildInfo,
   });
+  row.addComponents(
+    buildFilterToggleButton({
+      filters: VALID_FILTERS,
+      display: FILTER_TOGGLE_DISPLAY,
+      current: filter,
+      buildCustomId: browseHelpers.build,
+      sort: currentSort,
+      query,
+    })
+  );
+  return row;
 }
 
 /** Options for buildBrowsePage */
@@ -236,10 +229,10 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
     components.push(selectRow);
   }
 
-  // Add pagination buttons if multiple pages or items exist
-  if (totalPages > 1 || allItems.length > 0) {
-    components.push(buildBrowseButtons(renderedPage, totalPages, filter, sortType, query));
-  }
+  // The button row always renders on filter-bearing browses (alias-pilot
+  // norm): the filter toggle must stay reachable even on an empty filtered
+  // list — it's the way back out. Pagination buttons disable at one page.
+  components.push(buildBrowseButtons(renderedPage, totalPages, filter, sortType, query));
 
   return { embed, components };
 }

--- a/services/bot-client/src/commands/character/browseHelpers.ts
+++ b/services/bot-client/src/commands/character/browseHelpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { escapeMarkdown } from 'discord.js';
+import type { FilterToggleDisplay } from '../../utils/browse/filterRowBuilder.js';
 import { createListComparator } from '../../utils/listSorting.js';
 import type { CharacterBrowseFilter, CharacterBrowseSortType } from './config.js';
 import type { CharacterData } from './characterTypes.js';
@@ -199,4 +200,34 @@ export function buildEmptyStateLines(
     }
   }
   return lines;
+}
+
+/** In-place filter toggle display (§3.1 affordance; emoji match the legend). */
+export const FILTER_TOGGLE_DISPLAY: Record<CharacterBrowseFilter, FilterToggleDisplay> = {
+  all: { label: 'Filter: All', shortLabel: 'All', emoji: '📋' },
+  mine: { label: 'Filter: Mine', shortLabel: 'Mine', emoji: '✏️' },
+  public: { label: 'Filter: Public', shortLabel: 'Public', emoji: '🌐' },
+};
+
+/**
+ * Format a character for the select menu — returns the unprefixed
+ * label (numbering is added by the buildBrowseSelectMenu factory).
+ */
+export function formatCharacterSelectLabel(item: ListItem): string {
+  const char = item.char;
+  const visibility = char.isPublic ? '🌐' : '🔒';
+  const ownBadge = item.isOwn ? '✏️' : '';
+  return `${visibility}${ownBadge} ${char.displayName ?? char.name}`;
+}
+
+/**
+ * Build the description for a character's select menu option.
+ * Slug-prefixed identifier with an optional ownership marker.
+ */
+export function buildCharacterDescription(item: ListItem): string {
+  let description = `/${item.char.slug}`;
+  if (item.isOwn) {
+    description += ' (yours)';
+  }
+  return description;
 }

--- a/services/bot-client/src/commands/deny/browse.test.ts
+++ b/services/bot-client/src/commands/deny/browse.test.ts
@@ -106,7 +106,6 @@ vi.mock('../../utils/browse/index.js', async importOriginal => {
       browsePrefix: 'deny::browse',
       browseSelectPrefix: 'deny::browse-select',
     })),
-    buildBrowseButtons: vi.fn(() => ({ type: 'action-row', components: [] })),
     createBrowseSortToggle: vi.fn(
       (overrides?: {
         sortByName?: { label: string; emoji: string };
@@ -319,7 +318,7 @@ describe('handleBrowse', () => {
       embeds: expect.arrayContaining([
         expect.objectContaining({
           data: expect.objectContaining({
-            description: expect.stringContaining('No denylist entries found'),
+            description: expect.stringContaining('The denylist is empty'),
           }),
         }),
       ]),
@@ -345,7 +344,7 @@ describe('handleBrowse', () => {
     const call = vi.mocked(context.editReply).mock.calls[0][0] as {
       embeds: { data: { footer: { text: string } } }[];
     };
-    expect(call.embeds[0].data.footer.text).toContain('users only');
+    expect(call.embeds[0].data.footer.text).toContain('filtered by: Users');
   });
 
   it('should filter by guild type', async () => {
@@ -357,7 +356,7 @@ describe('handleBrowse', () => {
     const call = vi.mocked(context.editReply).mock.calls[0][0] as {
       embeds: { data: { footer: { text: string } } }[];
     };
-    expect(call.embeds[0].data.footer.text).toContain('guilds only');
+    expect(call.embeds[0].data.footer.text).toContain('filtered by: Guilds');
   });
 
   it('should default to all filter', async () => {
@@ -369,7 +368,7 @@ describe('handleBrowse', () => {
     const call = vi.mocked(context.editReply).mock.calls[0][0] as {
       embeds: { data: { footer: { text: string } } }[];
     };
-    expect(call.embeds[0].data.footer.text).toContain('all types');
+    expect(call.embeds[0].data.footer.text).not.toContain('filtered by:');
   });
 
   it('should handle API error', async () => {
@@ -414,7 +413,7 @@ describe('handleBrowse', () => {
     const call = vi.mocked(context.editReply).mock.calls[0][0] as {
       embeds: { data: { description: string } }[];
     };
-    expect(call.embeds[0].data.description).toContain('**MUTE**');
+    expect(call.embeds[0].data.description).toContain('\u{1F507}');
   });
 
   it('should not show mode badge for BLOCK-mode entries', async () => {
@@ -426,7 +425,7 @@ describe('handleBrowse', () => {
     const call = vi.mocked(context.editReply).mock.calls[0][0] as {
       embeds: { data: { description: string } }[];
     };
-    expect(call.embeds[0].data.description).not.toContain('**MUTE**');
+    expect(call.embeds[0].data.description).not.toContain('\u{1F507}');
     expect(call.embeds[0].data.description).not.toContain('**BLOCK**');
   });
 
@@ -465,7 +464,9 @@ describe('handleBrowse', () => {
       components: unknown[];
     };
     // No browse buttons and no select menu
-    expect(call.components.length).toBe(0);
+    // The button row always renders (filter toggle stays reachable); only
+    // the select menu drops on an empty list.
+    expect(call.components.length).toBe(1);
   });
 });
 
@@ -532,7 +533,7 @@ describe('handleBrowsePagination', () => {
     const call = vi.mocked(interaction.editReply).mock.calls[0][0] as {
       embeds: { data: { footer: { text: string } } }[];
     };
-    expect(call.embeds[0].data.footer.text).toContain('users only');
+    expect(call.embeds[0].data.footer.text).toContain('filtered by: Users');
   });
 
   it('should silently handle API error', async () => {
@@ -629,13 +630,13 @@ describe('buildBrowseResponse', () => {
     expect(result.embed).toBeDefined();
     expect(result.components).toBeDefined();
     // Should only show USER entries (2 of 3)
-    expect(result.embed.data.footer?.text).toContain('users only');
+    expect(result.embed.data.footer?.text).toContain('filtered by: Users');
   });
 
   it('should handle all filter', () => {
     const result = buildBrowseResponse(sampleEntries, 0, 'all', 'name');
 
-    expect(result.embed.data.footer?.text).toContain('all types');
+    expect(result.embed.data.footer?.text).not.toContain('filtered by:');
     expect(result.embed.data.footer?.text).toContain('by target ID');
   });
 });

--- a/services/bot-client/src/commands/deny/browse.ts
+++ b/services/bot-client/src/commands/deny/browse.ts
@@ -7,8 +7,8 @@
  */
 
 import {
-  EmbedBuilder,
   escapeMarkdown,
+  type EmbedBuilder,
   type ButtonInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
@@ -22,16 +22,17 @@ import { requireBotOwnerContext } from '../../utils/commandContext/index.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   buildBrowseButtons,
+  buildBrowseListEmbed,
   buildBrowseSelectMenu,
+  buildFilterToggleButton,
   createBrowseCustomIdHelpers,
   createBrowseSortToggle,
-  calculatePaginationState,
   ITEMS_PER_PAGE,
-  joinFooter,
   pluralize,
-  formatFilterParens,
+  formatFilterLabeled,
   formatSortNatural,
   type BrowseSortType,
+  type FilterToggleDisplay,
   type BrowseActionRow,
 } from '../../utils/browse/index.js';
 
@@ -59,19 +60,12 @@ export function isDenyBrowseSelectInteraction(customId: string): boolean {
   return browseHelpers.isBrowseSelect(customId);
 }
 
-/** Format a single entry for embed display */
-function formatEntry(entry: DenylistEntryResponse, index: number): string {
-  const num = String(index + 1);
-  const target =
-    entry.type === 'USER'
-      ? `<@${entry.discordId}> (\`${entry.discordId}\`)`
-      : `\`${entry.discordId}\` (Guild)`;
-  const scopeInfo = entry.scope === 'BOT' ? 'Bot-wide' : `${entry.scope}:${entry.scopeId}`;
-  const modeBadge = entry.mode === 'MUTE' ? ' · **MUTE**' : '';
-  const date = formatDateShort(entry.addedAt);
-  const reason = entry.reason !== null ? `\n   _${escapeMarkdown(entry.reason)}_` : '';
-  return `${num}. ${target}\n   ${scopeInfo}${modeBadge} · Added ${date}${reason}`;
-}
+/** In-place filter toggle display (§3.1 affordance). */
+const FILTER_TOGGLE_DISPLAY: Record<DenyBrowseFilter, FilterToggleDisplay> = {
+  all: { label: 'Filter: All', shortLabel: 'All', emoji: '📋' },
+  user: { label: 'Filter: Users', shortLabel: 'Users', emoji: '👤' },
+  guild: { label: 'Filter: Guilds', shortLabel: 'Guilds', emoji: '🏢' },
+};
 
 /**
  * Format entry for select menu label (unprefixed).
@@ -112,66 +106,54 @@ function filterByType(
   return entries.filter(e => e.type === typeValue);
 }
 
-/** Build the browse page embed and components */
+/** Build the browse page embed and components on the shared list builder. */
 function buildBrowsePage(
   entries: DenylistEntryResponse[],
   page: number,
   filter: DenyBrowseFilter,
   sort: BrowseSortType
 ): { embed: EmbedBuilder; components: BrowseActionRow[] } {
-  const { safePage, totalPages, startIndex, endIndex } = calculatePaginationState(
-    entries.length,
-    ITEMS_PER_PAGE,
-    page
-  );
-
-  const pageEntries = entries.slice(startIndex, endIndex);
-
-  const embed = new EmbedBuilder()
-    .setTitle('\u{1F6AB} Denylist Browser')
-    .setColor(DISCORD_COLORS.ERROR)
-    .setTimestamp();
-
-  if (pageEntries.length === 0) {
-    embed.setDescription('_No denylist entries found._');
-  } else {
-    const lines = pageEntries.map((e, i) => formatEntry(e, startIndex + i));
-    embed.setDescription(lines.join('\n\n'));
-  }
-
-  const filterLabel = filter === 'all' ? 'all types' : `${filter}s only`;
-  embed.setFooter({
-    text: joinFooter(
-      `${pluralize(entries.length, { singular: 'entry', plural: 'entries' })} ${formatFilterParens(filterLabel)}`,
-      sort === 'date' ? formatSortNatural('date') : formatSortNatural('target ID')
-    ),
-  });
+  const { embed, pageItems, startIndex, totalPages, safePage } =
+    buildBrowseListEmbed<DenylistEntryResponse>({
+      entityEmoji: '\u{1F6AB}',
+      titleNoun: 'Denylist',
+      items: entries,
+      page,
+      itemsPerPage: ITEMS_PER_PAGE,
+      formatRow: entry => ({
+        badges:
+          (entry.type === 'USER' ? '\u{1F464}' : '\u{1F3E2}') +
+          (entry.mode === 'MUTE' ? '\u{1F507}' : ''),
+        // Users render as a live mention with the raw id as techId; guilds
+        // only have the raw id, which becomes the name itself.
+        name: entry.type === 'USER' ? `<@${entry.discordId}>` : entry.discordId,
+        techId: entry.type === 'USER' ? entry.discordId : undefined,
+        metadata: [
+          entry.scope === 'BOT' ? 'Bot-wide' : `${entry.scope}:${entry.scopeId}`,
+          `Added ${formatDateShort(entry.addedAt)}`,
+          ...(entry.reason !== null ? [escapeMarkdown(entry.reason)] : []),
+        ],
+      }),
+      empty: {
+        noItems: 'The denylist is empty \u2014 add entries with `/deny add`.',
+        noMatch: 'No entries match this filter \u2014 toggle it to see all.',
+      },
+      filterActive: filter !== 'all',
+      footerSegments: [
+        pluralize(entries.length, { singular: 'entry', plural: 'entries' }),
+        // Derived from the toggle display so button and footer can't drift.
+        filter !== 'all' && formatFilterLabeled(FILTER_TOGGLE_DISPLAY[filter].shortLabel),
+        sort === 'date' ? formatSortNatural('date') : formatSortNatural('target ID'),
+      ],
+      badgeLegend: 'User \u{1F464} \u00B7 Guild \u{1F3E2} \u00B7 Muted \u{1F507}',
+      color: DISCORD_COLORS.ERROR,
+    });
 
   const components: BrowseActionRow[] = [];
-  if (entries.length > 0) {
-    components.push(
-      buildBrowseButtons({
-        currentPage: safePage,
-        totalPages,
-        filter,
-        currentSort: sort,
-        query: null,
-        buildCustomId: browseHelpers.build,
-        buildInfoId: browseHelpers.buildInfo,
-        // Deny entries are keyed by ID (not name), so override the
-        // default 'Sort A-Z' label to reflect that. The rest of the
-        // default BrowseSortType toggle (toggling between 'name' and
-        // 'date', the emoji choices) is preserved.
-        sortToggle: createBrowseSortToggle({
-          sortByName: { label: 'Sort by ID', emoji: '🔤' },
-        }),
-      })
-    );
-  }
 
-  // Add select menu for entry detail view
+  // Select first, buttons second — the design system's composition order.
   const selectRow = buildBrowseSelectMenu<DenylistEntryResponse>({
-    items: pageEntries,
+    items: pageItems,
     customId: browseHelpers.buildSelect(safePage, filter, sort, null),
     placeholder: 'Select an entry to view/edit...',
     startIndex,
@@ -184,6 +166,36 @@ function buildBrowsePage(
   if (selectRow !== null) {
     components.push(selectRow);
   }
+
+  // The button row always renders on filter-bearing browses (alias-pilot
+  // norm): the filter toggle stays reachable even on an empty filtered list.
+  const buttonRow = buildBrowseButtons({
+    currentPage: safePage,
+    totalPages,
+    filter,
+    currentSort: sort,
+    query: null,
+    buildCustomId: browseHelpers.build,
+    buildInfoId: browseHelpers.buildInfo,
+    // Deny entries are keyed by ID (not name), so override the
+    // default 'Sort A-Z' label to reflect that. The rest of the
+    // default BrowseSortType toggle (toggling between 'name' and
+    // 'date', the emoji choices) is preserved.
+    sortToggle: createBrowseSortToggle({
+      sortByName: { label: 'Sort by ID', emoji: '\u{1F524}' },
+    }),
+  });
+  buttonRow.addComponents(
+    buildFilterToggleButton({
+      filters: VALID_FILTERS,
+      display: FILTER_TOGGLE_DISPLAY,
+      current: filter,
+      buildCustomId: browseHelpers.build,
+      sort,
+      query: null,
+    })
+  );
+  components.push(buttonRow);
 
   return { embed, components };
 }

--- a/services/bot-client/src/commands/deny/browseRebuilder.test.ts
+++ b/services/bot-client/src/commands/deny/browseRebuilder.test.ts
@@ -75,7 +75,6 @@ vi.mock('../../utils/browse/index.js', async importOriginal => {
       browsePrefix: 'deny::browse',
       browseSelectPrefix: 'deny::browse-select',
     })),
-    buildBrowseButtons: vi.fn(() => ({ type: 'action-row', components: [] })),
     createBrowseSortToggle: vi.fn(() => ({
       next: (current: string) => (current === 'date' ? 'name' : 'date'),
       labelFor: () => ({ label: 'Sort', emoji: '🔤' }),

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -270,8 +270,17 @@ describe('handleBrowse', () => {
     });
 
     const components = mockEditReply.mock.calls[0][0].components;
-    expect(components).toHaveLength(1); // Just select menu, no pagination
+    // Select menu + the always-rendered button row (pagination disabled at
+    // one page; the two filter toggles live there).
+    expect(components).toHaveLength(2);
     expect(components[0].components[0].data.custom_id).toBe('preset::browse-select::0::all.all::');
+    const buttons = components[1].toJSON().components as { custom_id: string; label?: string }[];
+    // The two-dimensional in-place filter: per-axis cycle toggles, each
+    // holding the other axis constant, page reset to 0.
+    const scopeToggle = buttons.find(button => button.label === 'Scope: Global');
+    const capabilityToggle = buttons.find(button => button.label === 'Type: Text');
+    expect(scopeToggle?.custom_id).toBe('preset::browse::0::global.all::');
+    expect(capabilityToggle?.custom_id).toBe('preset::browse::0::all.text::');
   });
 
   it('shows both kinds by default (vision badged) and filters by capability', async () => {

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -36,6 +36,7 @@ import {
   buildBrowseButtons as buildSharedBrowseButtons,
   buildBrowseListEmbed,
   buildBrowseSelectMenu,
+  buildFilterToggleButton,
   createBrowseCustomIdHelpers,
   pluralize,
   formatFilterLabeled,
@@ -52,9 +53,14 @@ import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { renderSpec } from '../../ux/render/render.js';
 import {
+  CAPABILITY_TOGGLE_DISPLAY,
   composeBrowseFilter,
   describeFilter,
+  filterPresets,
+  SCOPE_TOGGLE_DISPLAY,
   splitBrowseFilter,
+  PRESET_CAPABILITY_FILTERS,
+  PRESET_SCOPE_FILTERS,
   VALID_PRESET_FILTERS,
   type PresetBrowseFilter,
   type PresetCapabilityFilter,
@@ -129,61 +135,12 @@ function buildPresetDescription(preset: LlmConfigSummary, isGuestMode: boolean):
 }
 
 /**
- * Apply the scope + capability axes + search query — all client-side. Browse
- * fetches every config; capability ('vision'/'text') is a
- * model-`supportsVision` check applied here, not a fetch-scope parameter.
- */
-function filterPresets(
-  presets: LlmConfigSummary[],
-  scope: PresetScopeFilter,
-  capability: PresetCapabilityFilter,
-  query: string | null,
-  isGuestMode: boolean
-): LlmConfigSummary[] {
-  let filtered = presets;
-
-  // Capability axis: the model's vision capability ('vision' = vision-capable,
-  // 'text' = text-only, 'all' = no filter).
-  if (capability === 'vision') {
-    filtered = filtered.filter(c => c.supportsVision);
-  } else if (capability === 'text') {
-    filtered = filtered.filter(c => !c.supportsVision);
-  }
-
-  switch (scope) {
-    case 'global':
-      filtered = filtered.filter(c => c.isGlobal);
-      break;
-    case 'mine':
-      filtered = filtered.filter(c => c.isOwned);
-      break;
-    case 'free':
-      // Audience-aware: a guest's 'free' scope means "what I can use for
-      // free" and includes the conditionally-free piggyback model.
-      filtered = filtered.filter(c => isFreeModelForUser(c.model, isGuestMode));
-      break;
-    case 'all':
-    default:
-      // No scope filter
-      break;
-  }
-
-  // Apply search query
-  if (query !== null && query.length > 0) {
-    const lowerQuery = query.toLowerCase();
-    filtered = filtered.filter(
-      c =>
-        c.name.toLowerCase().includes(lowerQuery) ||
-        c.model.toLowerCase().includes(lowerQuery) ||
-        (c.description?.toLowerCase().includes(lowerQuery) ?? false)
-    );
-  }
-
-  return filtered;
-}
-
-/**
- * Build pagination buttons using shared utility (no sort toggle for presets)
+ * Build pagination buttons (no sort toggle for presets) plus the
+ * two-dimensional in-place filter: one cycle toggle PER AXIS, each holding
+ * the other axis constant in the composite `scope.capability` token. Two
+ * buttons beat a filter select here — the 12 composite states would make an
+ * unwieldy select, and per-axis cycling matches the design system's toggle
+ * affordance. Row budget: 3 pagination + 2 toggles = Discord's 5-button max.
  */
 function buildBrowseButtons(
   currentPage: number,
@@ -191,7 +148,8 @@ function buildBrowseButtons(
   filter: PresetBrowseFilter,
   query: string | null
 ): ReturnType<typeof buildSharedBrowseButtons> {
-  return buildSharedBrowseButtons({
+  const { scope, capability } = splitBrowseFilter(filter);
+  const row = buildSharedBrowseButtons({
     currentPage,
     totalPages,
     filter,
@@ -201,6 +159,25 @@ function buildBrowseButtons(
     buildInfoId: browseHelpers.buildInfo,
     showSortToggle: false, // Presets don't have sort toggle
   });
+  row.addComponents(
+    buildFilterToggleButton({
+      filters: PRESET_SCOPE_FILTERS,
+      display: SCOPE_TOGGLE_DISPLAY,
+      current: scope,
+      buildCustomId: (page, nextScope, _sort, q) =>
+        browseHelpers.build(page, composeBrowseFilter(nextScope, capability), 'name', q),
+      query,
+    }),
+    buildFilterToggleButton({
+      filters: PRESET_CAPABILITY_FILTERS,
+      display: CAPABILITY_TOGGLE_DISPLAY,
+      current: capability,
+      buildCustomId: (page, nextCapability, _sort, q) =>
+        browseHelpers.build(page, composeBrowseFilter(scope, nextCapability), 'name', q),
+      query,
+    })
+  );
+  return row;
 }
 
 /**
@@ -285,10 +262,11 @@ function buildBrowsePage(
     components.push(selectRow);
   }
 
-  // Add pagination buttons if multiple pages
-  if (totalPages > 1) {
-    components.push(buildBrowseButtons(safePage, totalPages, filter, query));
-  }
+  // The button row always renders on filter-bearing browses (alias-pilot
+  // norm): the filter toggles must stay reachable even on a single page —
+  // and ESPECIALLY on an empty filtered list, where the toggle is the way
+  // back out. Pagination buttons disable themselves at one page.
+  components.push(buildBrowseButtons(safePage, totalPages, filter, query));
 
   return { embed, components };
 }

--- a/services/bot-client/src/commands/preset/browseFilter.test.ts
+++ b/services/bot-client/src/commands/preset/browseFilter.test.ts
@@ -8,6 +8,7 @@ import {
   describeFilter,
   splitBrowseFilter,
   VALID_PRESET_FILTERS,
+  filterPresets,
 } from './browseFilter.js';
 
 describe('composeBrowseFilter', () => {
@@ -67,5 +68,30 @@ describe('describeFilter', () => {
 
   it('joins both axes with a middot when both are narrowed', () => {
     expect(describeFilter('mine', 'text')).toBe('My Presets · Text-only Models');
+  });
+});
+
+describe('filterPresets', () => {
+  const presets = [
+    {
+      name: 'GlobalVision',
+      model: 'x/model-a',
+      isGlobal: true,
+      isOwned: false,
+      supportsVision: true,
+    },
+    { name: 'MineText', model: 'x/model-b', isGlobal: false, isOwned: true, supportsVision: false },
+  ] as never[];
+
+  it('narrows by scope and capability independently', () => {
+    expect(filterPresets(presets, 'global', 'all', null, false)).toHaveLength(1);
+    expect(filterPresets(presets, 'all', 'vision', null, false)).toHaveLength(1);
+    expect(filterPresets(presets, 'mine', 'text', null, false)).toHaveLength(1);
+    expect(filterPresets(presets, 'global', 'text', null, false)).toHaveLength(0);
+  });
+
+  it('applies the search query over name and model', () => {
+    expect(filterPresets(presets, 'all', 'all', 'minetext', false)).toHaveLength(1);
+    expect(filterPresets(presets, 'all', 'all', 'model-', false)).toHaveLength(2);
   });
 });

--- a/services/bot-client/src/commands/preset/browseFilter.ts
+++ b/services/bot-client/src/commands/preset/browseFilter.ts
@@ -9,16 +9,18 @@
  * the encoding; everything else passes the composite around verbatim.
  */
 
-import { MODEL_SLOTS } from '@tzurot/common-types/constants/ai';
+import { isFreeModelForUser, MODEL_SLOTS } from '@tzurot/common-types/constants/ai';
+import type { FilterToggleDisplay } from '../../utils/browse/filterRowBuilder.js';
+import { type LlmConfigSummary } from '@tzurot/common-types/schemas/api/llm-config';
 
 // Single source of truth for each axis: the runtime arrays drive the types
 // (`typeof[number]`) AND the customId factory's validation, so the two can't
 // drift. Adding a scope/capability value here updates both with no second edit.
-const PRESET_SCOPE_FILTERS = ['all', 'global', 'mine', 'free'] as const;
+export const PRESET_SCOPE_FILTERS = ['all', 'global', 'mine', 'free'] as const;
 // The capability values reuse MODEL_SLOTS ('text'/'vision') as the encoded
 // tokens so the customId format is unchanged from when this axis was a config
 // `kind` — but they're now interpreted as a model-capability filter.
-const PRESET_CAPABILITY_FILTERS = ['all', ...MODEL_SLOTS] as const;
+export const PRESET_CAPABILITY_FILTERS = ['all', ...MODEL_SLOTS] as const;
 
 /** Scope axis of the browse filter (independent of capability). */
 export type PresetScopeFilter = (typeof PRESET_SCOPE_FILTERS)[number];
@@ -96,3 +98,71 @@ export function describeFilter(
   }
   return parts.length > 0 ? parts.join(' · ') : null;
 }
+
+/**
+ * Apply the scope + capability axes + search query — all client-side. Browse
+ * fetches every config; capability ('vision'/'text') is a
+ * model-`supportsVision` check applied here, not a fetch-scope parameter.
+ */
+export function filterPresets(
+  presets: LlmConfigSummary[],
+  scope: PresetScopeFilter,
+  capability: PresetCapabilityFilter,
+  query: string | null,
+  isGuestMode: boolean
+): LlmConfigSummary[] {
+  let filtered = presets;
+
+  // Capability axis: the model's vision capability ('vision' = vision-capable,
+  // 'text' = text-only, 'all' = no filter).
+  if (capability === 'vision') {
+    filtered = filtered.filter(c => c.supportsVision);
+  } else if (capability === 'text') {
+    filtered = filtered.filter(c => !c.supportsVision);
+  }
+
+  switch (scope) {
+    case 'global':
+      filtered = filtered.filter(c => c.isGlobal);
+      break;
+    case 'mine':
+      filtered = filtered.filter(c => c.isOwned);
+      break;
+    case 'free':
+      // Audience-aware: a guest's 'free' scope means "what I can use for
+      // free" and includes the conditionally-free piggyback model.
+      filtered = filtered.filter(c => isFreeModelForUser(c.model, isGuestMode));
+      break;
+    case 'all':
+    default:
+      // No scope filter
+      break;
+  }
+
+  // Apply search query
+  if (query !== null && query.length > 0) {
+    const lowerQuery = query.toLowerCase();
+    filtered = filtered.filter(
+      c =>
+        c.name.toLowerCase().includes(lowerQuery) ||
+        c.model.toLowerCase().includes(lowerQuery) ||
+        (c.description?.toLowerCase().includes(lowerQuery) ?? false)
+    );
+  }
+
+  return filtered;
+}
+
+/** Per-axis toggle displays for the two-dimensional in-place filter. */
+export const SCOPE_TOGGLE_DISPLAY: Record<PresetScopeFilter, FilterToggleDisplay> = {
+  all: { label: 'Scope: All', shortLabel: 'All', emoji: '📋' },
+  global: { label: 'Scope: Global', shortLabel: 'Global', emoji: '🌐' },
+  mine: { label: 'Scope: Mine', shortLabel: 'Mine', emoji: '✏️' },
+  free: { label: 'Scope: Free', shortLabel: 'Free', emoji: '🆓' },
+};
+
+export const CAPABILITY_TOGGLE_DISPLAY: Record<PresetCapabilityFilter, FilterToggleDisplay> = {
+  all: { label: 'Type: All', shortLabel: 'All', emoji: '📋' },
+  text: { label: 'Type: Text', shortLabel: 'Text', emoji: '💬' },
+  vision: { label: 'Type: Vision', shortLabel: 'Vision', emoji: '👁️' },
+};

--- a/services/bot-client/src/utils/browse/filterRowBuilder.test.ts
+++ b/services/bot-client/src/utils/browse/filterRowBuilder.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the in-place filter toggle builder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ButtonStyle } from 'discord.js';
+import { buildFilterToggleButton, nextFilter } from './filterRowBuilder.js';
+
+const FILTERS = ['all', 'mine', 'global'] as const;
+type Filter = (typeof FILTERS)[number];
+
+const DISPLAY = {
+  all: { label: 'Filter: All', shortLabel: 'All', emoji: '📋' },
+  mine: { label: 'Filter: Mine', shortLabel: 'Mine', emoji: '🔒' },
+  global: { label: 'Filter: Global', shortLabel: 'Global', emoji: '🌐' },
+} as const;
+
+function buildCustomId(page: number, filter: Filter, _sort: string, query: string | null): string {
+  return `x::browse::${page}::${filter}::${query ?? ''}`;
+}
+
+describe('nextFilter', () => {
+  it('cycles through the list and wraps', () => {
+    expect(nextFilter(FILTERS, 'all')).toBe('mine');
+    expect(nextFilter(FILTERS, 'mine')).toBe('global');
+    expect(nextFilter(FILTERS, 'global')).toBe('all');
+  });
+});
+
+describe('buildFilterToggleButton', () => {
+  it('targets the NEXT filter with page reset to 0 and preserved query', () => {
+    const button = buildFilterToggleButton({
+      filters: FILTERS,
+      display: DISPLAY,
+      current: 'all',
+      buildCustomId,
+      query: 'some-slug',
+    }).toJSON() as { custom_id: string; label: string; style: number };
+
+    // Page 0 (a narrower filter renumbers the list), filter advanced, query kept.
+    expect(button.custom_id).toBe('x::browse::0::mine::some-slug');
+    expect(button.label).toBe('Filter: Mine');
+    expect(button.style).toBe(ButtonStyle.Primary);
+  });
+
+  it("labels with the TARGET filter's display, not the current one", () => {
+    const button = buildFilterToggleButton({
+      filters: FILTERS,
+      display: DISPLAY,
+      current: 'global',
+      buildCustomId,
+      query: null,
+    }).toJSON() as { custom_id: string; label: string };
+
+    expect(button.custom_id).toBe('x::browse::0::all::');
+    expect(button.label).toBe('Filter: All');
+  });
+});

--- a/services/bot-client/src/utils/browse/filterRowBuilder.ts
+++ b/services/bot-client/src/utils/browse/filterRowBuilder.ts
@@ -1,0 +1,74 @@
+/**
+ * In-place filter toggle — the design system's filter affordance for
+ * ≤3-value filters (spec §3.1 "filter/sort where applicable").
+ *
+ * Mechanism generalized from the alias-browse pilot: the toggle is ONE
+ * Primary button whose customId is the browse's own pagination coordinates
+ * with only the filter advanced to the next cycle value — no dedicated
+ * handler, the pagination handler re-renders at the parsed coordinates.
+ * The page always resets to 0 because a narrower filter renumbers the
+ * list. The button's label/emoji show the TARGET filter (what clicking
+ * switches to), mirroring the sort toggle's convention.
+ *
+ * Multi-dimensional filters (more values, or several axes) overflow a
+ * cycle button — those surfaces keep their slash-option filter or use a
+ * select; this builder deliberately supports only the flat cycle.
+ */
+
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
+import type { BrowseSortType } from './constants.js';
+
+export interface FilterToggleDisplay {
+  /** Button label, e.g. 'Filter: Mine'. */
+  label: string;
+  /**
+   * The filter's bare name for footers/prose (e.g. 'Mine') — a structured
+   * field so footer text derives without string surgery on the label.
+   */
+  shortLabel: string;
+  /** Button emoji, set separately per the 04-discord button rule. */
+  emoji: string;
+}
+
+export interface FilterToggleConfig<TFilter extends string> {
+  /** Cycle order; clicking advances current → next (wrapping). */
+  filters: readonly TFilter[];
+  /** Display per filter, used for the TARGET filter the button switches to. */
+  display: Record<TFilter, FilterToggleDisplay>;
+  current: TFilter;
+  /**
+   * The browse's own coordinate builder (the customId factory's `build`).
+   * Sortless factories ignore the sort argument.
+   */
+  buildCustomId: (
+    page: number,
+    filter: TFilter,
+    sort: BrowseSortType,
+    query: string | null
+  ) => string;
+  /** Carried through for sortful browses; sortless ones may omit. */
+  sort?: BrowseSortType;
+  query: string | null;
+}
+
+/** Advance a filter one step through the cycle, wrapping at the end. */
+export function nextFilter<TFilter extends string>(
+  filters: readonly TFilter[],
+  current: TFilter
+): TFilter {
+  const index = filters.indexOf(current);
+  return filters[(index + 1) % filters.length];
+}
+
+/** Build the in-place filter toggle button for a browse's button row. */
+export function buildFilterToggleButton<TFilter extends string>(
+  config: FilterToggleConfig<TFilter>
+): ButtonBuilder {
+  const target = nextFilter(config.filters, config.current);
+  const display = config.display[target];
+  return new ButtonBuilder()
+    .setCustomId(config.buildCustomId(0, target, config.sort ?? 'name', config.query))
+    .setLabel(display.label)
+    .setEmoji(display.emoji)
+    .setStyle(ButtonStyle.Primary);
+}

--- a/services/bot-client/src/utils/browse/index.ts
+++ b/services/bot-client/src/utils/browse/index.ts
@@ -49,6 +49,14 @@ export {
   type BuildBrowseSelectMenuOptions,
 } from './selectMenuBuilder.js';
 
+// In-place filter toggle (≤3-value filters; spec §3.1)
+export {
+  buildFilterToggleButton,
+  nextFilter,
+  type FilterToggleConfig,
+  type FilterToggleDisplay,
+} from './filterRowBuilder.js';
+
 // Footer helpers
 export {
   FOOTER_DELIMITER,

--- a/services/bot-client/src/utils/browse/listEmbedBuilder.test.ts
+++ b/services/bot-client/src/utils/browse/listEmbedBuilder.test.ts
@@ -172,6 +172,22 @@ describe('buildBrowseListEmbed', () => {
     );
   });
 
+  it('never stacks a second blank when the preamble already ends with one (regression)', () => {
+    // The own-empty + others-present combo: the empty-state CTA block in the
+    // preamble carries its own trailing spacer, and the first row's group
+    // header separator used to add another — a double blank line.
+    const { embed } = buildBrowseListEmbed<Item>({
+      ...baseOptions,
+      items: [{ name: 'Other', group: '**🌐 Public Characters (1)**' }],
+      preamble: ["You haven't created any characters yet — `/character create`.", ''],
+    });
+
+    expect(embed.data.description).toContain(
+      '`/character create`.\n\n**🌐 Public Characters (1)**'
+    );
+    expect(embed.data.description).not.toContain('\n\n\n');
+  });
+
   it('honors a nameMarkup override without double-bolding', () => {
     const { embed } = buildBrowseListEmbed<Item>({
       ...baseOptions,

--- a/services/bot-client/src/utils/browse/listEmbedBuilder.ts
+++ b/services/bot-client/src/utils/browse/listEmbedBuilder.ts
@@ -111,7 +111,10 @@ function renderMetadataLine(segments: string[]): string {
 /** Render one §2.4 row (plus its optional group header) into lines. */
 function renderRow(spec: BrowseRowSpec, rowNumber: number, lines: string[]): void {
   if (spec.groupHeader !== undefined) {
-    if (lines.length > 0) {
+    // Separator before a header that follows content — but never stack a
+    // second blank when the preceding line (e.g. a preamble CTA's own
+    // trailing spacer) already is one.
+    if (lines.length > 0 && lines[lines.length - 1] !== '') {
       lines.push('');
     }
     lines.push(spec.groupHeader);


### PR DESCRIPTION
## Summary

First of two PR-4b slices: the pilot's in-place filter toggle generalizes into the design system and lands on every ≤3-value-filter browse, plus the deny retrofit and the #1700 r3 blank-line fix. (Slice 2 — the mechanical no-filter retrofits across ~9 surfaces — follows separately.)

### The shared toggle (`utils/browse/filterRowBuilder.ts`)

`nextFilter` cycle + `buildFilterToggleButton`: one Primary button whose customId is the browse's own pagination coordinates with only the filter advanced (page reset to 0, since a narrower filter renumbers the list; label/emoji show the TARGET filter, mirroring the sort toggle's convention). Extracted from the alias pilot's real usage per the owner's design-affordance adoption; the pilot migrates onto it as first consumer.

### Adoption

- **character browse**: all→mine→public toggle (row budget: 4 pagination/sort + toggle = 5 exactly).
- **channel browse**: current↔all-servers toggle. **Builder retrofit deliberately declined** for its embeds — the all-servers mode paginates BY GUILD with dynamic titles and variable page sizes (continuations), which the uniform list builder cannot express; forcing it would be the Wrong Abstraction (cascade-route precedent). Its pure helpers (guild-page chunking, row formatting, sort/filter) extracted to `browseHelpers.ts` with direct tests.
- **preset browse — the multi-dimensional decision (plan: "decide once at PR-4b")**: two per-axis cycle toggles (scope 4-cycle × capability 3-cycle) over a filter select. Rationale: the 12 composite `scope.capability` states make a select unwieldy, a second select row next to the entity select is confusing, per-axis cycling matches the toggle affordance, and the row fits exactly (3 pagination + 2 toggles = Discord's 5). Each toggle holds the other axis constant via `composeBrowseFilter` closures. Filter logic + displays moved to `browseFilter.ts` (cohesion + the max-lines cap).
- **deny browse**: FULL retrofit onto `buildBrowseListEmbed` — §2.4 row grammar (👤/🏢 scope badges + 🔇 muted in the badge run, mention-as-name with raw-id techId for users), D19 empty states with CTAs, word-first legend, footer via segments, select-first component ordering — plus the all/users/guilds toggle alongside its existing sort toggle.

### Always-render rule

Filter-bearing browses now always push the button row (alias-pilot norm): the toggle must stay reachable on a single page and *especially* on an empty filtered list — it's the way back out. Pagination buttons disable themselves at one page. (No-filter browses keep their conditional; that's slice 2's territory.)

### Fixes

- `listEmbedBuilder`: the group-header separator no longer stacks a second blank line when the preamble's CTA already ends with one — the own-empty + others-present regression from #1700 r3, now pinned by test.

## Verification (ran, not just read)

- New: filterRowBuilder unit tests (cycle + target-labeling + page-reset pins), channel browseHelpers direct tests (guild chunking incl. continuations + unknown-guild labeling), blank-line regression test.
- Updated: character toggle customId pin, preset both-toggle customId pins, deny suite reworked to the new grammar (33 tests; two test-only `buildBrowseButtons` stub mocks removed so the real ActionRowBuilder runs).
- `pnpm test` / `pnpm test:component` / `pnpm quality` all green from repo root; ux:literals unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)