### PR TITLE
fix(api-gateway): flush propagated sync deletes before upserts

### DIFF
--- a/services/api-gateway/src/services/DatabaseSyncService.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.test.ts
@@ -1069,6 +1069,71 @@ describe('DatabaseSyncService', () => {
       expect(result.deletionsTruncated).toBe(false);
     });
 
+    it('flushes propagated DELETEs before upserts (delete-then-recreate under a new id)', async () => {
+      // Delete-then-recreate under a new id: an alias removed on dev and
+      // re-added under its deterministic id queues a prod-bound DELETE (old
+      // random-id row, tombstoned) AND a prod-bound INSERT (new id, same
+      // lower(alias)).
+      // With writes first, the INSERT 23505s the partial unique
+      // personality_aliases_global_alias_unique while the doomed row still
+      // holds the slot, rolling back the whole write transaction. Deletes
+      // must vacate unique slots first.
+      const oldId = '13656360-2291-437e-9c91-000000000001'; // prod's random-id row
+      const newId = '2ef6438e-2309-5e06-9f98-000000000002'; // dev's deterministic row
+      const executed: string[] = [];
+
+      devClient.$queryRawUnsafe.mockImplementation(async query => {
+        if (String(query).includes('FROM "personality_aliases"')) {
+          return [
+            {
+              id: newId,
+              personality_id: '4f9b0f66-0000-4000-8000-0000000000f2',
+              alias: 'emberlynn',
+              created_at: new Date('2026-07-18T00:00:00Z'),
+            },
+          ];
+        }
+        return [];
+      });
+      prodClient.$queryRawUnsafe.mockImplementation(async query => {
+        if (String(query).includes('FROM "personality_aliases"')) {
+          return [
+            {
+              id: oldId,
+              personality_id: '4f9b0f66-0000-4000-8000-0000000000f2',
+              alias: 'emberlynn',
+              created_at: new Date('2026-07-01T00:00:00Z'),
+            },
+          ];
+        }
+        return [];
+      });
+      devClient.syncTombstone.findMany
+        .mockResolvedValueOnce([
+          {
+            tableName: 'personality_aliases',
+            rowPk: oldId,
+            deletedAt: new Date('2026-07-18T22:00:00Z'),
+          },
+        ])
+        .mockResolvedValue([]);
+      prodClient.$executeRawUnsafe.mockImplementation(async (query: unknown) => {
+        executed.push(String(query));
+        return 1;
+      });
+
+      await service.sync({ dryRun: false });
+
+      const deleteIndex = executed.findIndex(q => q.includes('DELETE FROM "personality_aliases"'));
+      const insertIndex = executed.findIndex(q => q.includes('INSERT INTO "personality_aliases"'));
+      expect(deleteIndex, 'the tombstoned row must be deleted').toBeGreaterThanOrEqual(0);
+      expect(insertIndex, 'the replacement row must be inserted').toBeGreaterThanOrEqual(0);
+      expect(
+        deleteIndex,
+        'the DELETE must vacate the unique slot BEFORE the replacement INSERT'
+      ).toBeLessThan(insertIndex);
+    });
+
     it('caps row-level deletion detail at 500 and flags the truncation loudly', async () => {
       // 501 tombstoned one-sided rows: the response-size backstop must slice
       // the detail to 500 and set the flag, while the per-table stats keep

--- a/services/api-gateway/src/services/DatabaseSyncService.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.ts
@@ -257,10 +257,17 @@ export class DatabaseSyncService {
       // rationale on naming them explicitly) so circular NOT NULL FKs
       // can insert atomically.
       if (!options.dryRun) {
-        await this.flushWrites(this.devClient, devBoundWrites, 'dev');
-        await this.flushWrites(this.prodClient, prodBoundWrites, 'prod');
-        // Propagated deletions run AFTER the upserts, per table in reverse
-        // FK order, fail-soft per table (see flushPendingDeletes).
+        // Propagated deletions run BEFORE the upserts (per table in reverse
+        // FK order, fail-soft per table — see flushPendingDeletes): a
+        // tombstoned row must vacate its unique slots before a replacement
+        // row with a DIFFERENT id but the same natural key lands. The
+        // delete-then-recreate pattern (e.g. an alias removed and re-added
+        // under its deterministic id) otherwise 23505s the whole write
+        // transaction against text-level uniques like
+        // personality_aliases_global_alias_unique, since the upsert's
+        // ON CONFLICT arbiter is the PK only. Deletes-first is FK-safe:
+        // a queued write can't depend on a tombstoned parent — the source
+        // side's cascade would have removed the child with it.
         const devDeletes = await flushPendingDeletes(
           this.devClient,
           devBoundDeletes,
@@ -273,6 +280,8 @@ export class DatabaseSyncService {
           'prod',
           warnings
         );
+        await this.flushWrites(this.devClient, devBoundWrites, 'dev');
+        await this.flushWrites(this.prodClient, prodBoundWrites, 'prod');
         reconcileDeletedStats(stats, devDeletes.counts, prodDeletes.counts);
         // Prune ONLY after a fully-clean delete pass: a failed propagation's
         // tombstone must survive past retention or the protected row silently

--- a/services/api-gateway/src/services/sync/utils/syncTombstoneUtils.ts
+++ b/services/api-gateway/src/services/sync/utils/syncTombstoneUtils.ts
@@ -101,7 +101,10 @@ export async function loadSyncTombstones(
  * remaining tables still process. Known accepted edge: a propagated persona
  * delete hits users.default_persona_id ON DELETE RESTRICT only when the two
  * sides' user rows diverge; the warning surfaces it and the row survives
- * until reconciled.
+ * until reconciled. This edge fires a little more often now that deletes
+ * flush BEFORE upserts (a same-run write that would clear the reference
+ * hasn't landed yet — RESTRICT checks fire immediately and can't be
+ * deferred); still self-heals on the next run once the write is in.
  *
  * @returns per-table deleted counts
  */


### PR DESCRIPTION
## Problem

Prod db-sync has been failing every run with HTTP 500 / Postgres 23505 on `personality_aliases_global_alias_unique`.

Root cause: the `emberlynn` alias was deleted and re-added on dev, which mints a **new deterministic id** (the v5 seed includes the alias text, but the old prod row predates deterministic ids). Prod still holds the old row (tombstone-doomed, queued for deletion), while the sync flushes **writes before deletes**. The incoming INSERT has a different PK but the same `lower(alias)` natural key — and the upsert's `ON CONFLICT` arbiter is the PK only — so it collides with the doomed row's text-level unique and rolls back prod's entire write transaction. Prod data is unharmed; the sync just can't complete.

## Fix

Reorder the flush phase: propagated deletions (dev then prod) now run **before** upserts. A tombstoned row vacates its unique slots before the replacement row with a different id lands.

FK-safety of the new order: a queued write can't depend on a tombstoned parent — the source side's cascade removed the child together with the parent, so the delete pass never strands an incoming write.

## Verification

- New ordering test pins `deleteIndex < insertIndex` in the executed query sequence for the delete-then-recreate shape (dev re-adds an alias under a new id while prod holds the old id + a dev tombstone).
- Full `DatabaseSyncService` suite green; `pnpm test` + `pnpm quality` green.

Note: this reaches prod at the next release. The immediate prod unblock (manual delete of the doomed row) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)