### PR TITLE
feat(bot-client): label-based modal toolkit + create-modal exemplars (PR-5a)

### DIFF
--- a/services/bot-client/src/commands/character/create.test.ts
+++ b/services/bot-client/src/commands/character/create.test.ts
@@ -79,15 +79,15 @@ describe('Character Create', () => {
       );
     });
 
-    it('should include seed fields in modal', async () => {
+    it('should include seed fields in modal as Label-hosted inputs', async () => {
       await handleCreate(mockInteraction);
 
       // Get the ModalBuilder and convert to JSON for inspection
       const modalBuilder = vi.mocked(mockInteraction.showModal).mock.calls[0][0] as {
-        toJSON: () => { components: Array<{ components: Array<{ custom_id: string }> }> };
+        toJSON: () => { components: Array<{ label?: string; component?: { custom_id: string } }> };
       };
       const modalData = modalBuilder.toJSON();
-      const fieldIds = modalData.components.flatMap(row => row.components.map(c => c.custom_id));
+      const fieldIds = modalData.components.map(labelRow => labelRow.component?.custom_id);
 
       expect(fieldIds).toContain('name');
       expect(fieldIds).toContain('slug');

--- a/services/bot-client/src/commands/character/create.ts
+++ b/services/bot-client/src/commands/character/create.ts
@@ -7,15 +7,7 @@
  * 3. Shows dashboard for further editing
  */
 
-import {
-  ModalBuilder,
-  TextInputBuilder,
-  TextInputStyle,
-  ActionRowBuilder,
-  type ModalActionRowComponentBuilder,
-  MessageFlags,
-  type ModalSubmitInteraction,
-} from 'discord.js';
+import { MessageFlags, type ModalSubmitInteraction } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
@@ -39,6 +31,7 @@ import {
   characterSeedFields,
   buildCharacterDashboardOptions,
 } from './config.js';
+import { buildToolkitModal, textFieldFromDefinition } from '../../utils/modal/toolkit.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
@@ -54,22 +47,11 @@ const logger = createLogger('character-create');
  * because this subcommand uses deferralMode: 'modal'.
  */
 export async function handleCreate(context: ModalCommandContext): Promise<void> {
-  const modal = new ModalBuilder()
-    .setCustomId(buildDashboardCustomId('character', 'seed'))
-    .setTitle('Create New Character');
-
-  for (const field of characterSeedFields) {
-    const input = new TextInputBuilder()
-      .setCustomId(field.id)
-      .setLabel(field.label)
-      .setPlaceholder(field.placeholder ?? '')
-      .setStyle(field.style === 'paragraph' ? TextInputStyle.Paragraph : TextInputStyle.Short)
-      .setRequired(field.required ?? false)
-      .setMaxLength(field.maxLength);
-
-    const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(input);
-    modal.addComponents(row);
-  }
+  const modal = buildToolkitModal({
+    customId: buildDashboardCustomId('character', 'seed'),
+    title: 'Create New Character',
+    items: characterSeedFields.map(textFieldFromDefinition),
+  });
 
   await context.showModal(modal);
 }

--- a/services/bot-client/src/commands/preset/create.test.ts
+++ b/services/bot-client/src/commands/preset/create.test.ts
@@ -84,14 +84,14 @@ describe('Preset Create', () => {
       expect(dashboardUtils.buildDashboardCustomId).toHaveBeenCalledWith('preset', 'seed');
     });
 
-    it('should include seed fields in modal', async () => {
+    it('should include seed fields in modal as Label-hosted inputs', async () => {
       await handleCreate(mockContext as unknown as Parameters<typeof handleCreate>[0]);
 
       const modalBuilder = vi.mocked(mockContext.showModal).mock.calls[0][0] as {
-        toJSON: () => { components: Array<{ components: Array<{ custom_id: string }> }> };
+        toJSON: () => { components: Array<{ label?: string; component?: { custom_id: string } }> };
       };
       const modalData = modalBuilder.toJSON();
-      const fieldIds = modalData.components.flatMap(row => row.components.map(c => c.custom_id));
+      const fieldIds = modalData.components.map(labelRow => labelRow.component?.custom_id);
 
       expect(fieldIds).toContain('name');
       expect(fieldIds).toContain('model');

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -7,15 +7,7 @@
  * 3. Shows dashboard for further editing
  */
 
-import {
-  ModalBuilder,
-  TextInputBuilder,
-  TextInputStyle,
-  ActionRowBuilder,
-  type ModalActionRowComponentBuilder,
-  MessageFlags,
-  type ModalSubmitInteraction,
-} from 'discord.js';
+import { MessageFlags, type ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import {
@@ -31,6 +23,7 @@ import {
   presetSeedFields,
   buildPresetDashboardOptions,
 } from './config.js';
+import { buildToolkitModal, textFieldFromDefinition } from '../../utils/modal/toolkit.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createPreset } from './api.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
@@ -49,22 +42,11 @@ export async function handleCreate(context: ModalCommandContext): Promise<void> 
   // No slot option: a preset's vision-capability is derived from its model
   // (`supportsVision`), not chosen at creation. The vision SLOT is picked later
   // when the preset is assigned (set/set-default/global).
-  const modal = new ModalBuilder()
-    .setCustomId(buildDashboardCustomId('preset', 'seed'))
-    .setTitle('Create New Preset');
-
-  for (const field of presetSeedFields) {
-    const input = new TextInputBuilder()
-      .setCustomId(field.id)
-      .setLabel(field.label)
-      .setPlaceholder(field.placeholder ?? '')
-      .setStyle(TextInputStyle.Short)
-      .setRequired(field.required ?? false)
-      .setMaxLength(field.maxLength);
-
-    const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(input);
-    modal.addComponents(row);
-  }
+  const modal = buildToolkitModal({
+    customId: buildDashboardCustomId('preset', 'seed'),
+    title: 'Create New Preset',
+    items: presetSeedFields.map(textFieldFromDefinition),
+  });
 
   await context.showModal(modal);
 }

--- a/services/bot-client/src/utils/modal/toolkit.test.ts
+++ b/services/bot-client/src/utils/modal/toolkit.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the Label-based modal toolkit.
+ *
+ * Build tests assert over `toJSON()` output so discord.js's own component
+ * assertions run — a payload these tests accept is one the library would
+ * actually serialize.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ComponentType } from 'discord.js';
+import {
+  buildToolkitModal,
+  extractSubmission,
+  textFieldFromDefinition,
+  validateSubmission,
+  type ModalItem,
+  type SubmissionFieldReader,
+} from './toolkit.js';
+
+const ITEMS: ModalItem[] = [
+  { kind: 'display', content: 'Pick your settings below.' },
+  {
+    kind: 'text',
+    id: 'name',
+    label: 'Name',
+    description: 'Shown everywhere this entity appears.',
+    required: true,
+    maxLength: 100,
+    placeholder: 'e.g. Lilith',
+  },
+  {
+    kind: 'select',
+    id: 'scope',
+    label: 'Scope',
+    placeholder: 'Choose a scope…',
+    minValues: 1,
+    maxValues: 1,
+    options: [
+      { label: 'Personal', value: 'user', default: true },
+      { label: 'Global', value: 'global', description: 'Bot-owner only' },
+    ],
+  },
+  {
+    kind: 'radio',
+    id: 'mode',
+    label: 'Mode',
+    required: true,
+    options: [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Strict', value: 'strict', default: true },
+    ],
+  },
+  {
+    kind: 'checkboxGroup',
+    id: 'features',
+    label: 'Features',
+    options: [
+      { label: 'Voice', value: 'voice' },
+      { label: 'Images', value: 'images' },
+    ],
+    minValues: 0,
+    maxValues: 2,
+  },
+  { kind: 'checkbox', id: 'public', label: 'Public', default: true },
+  { kind: 'fileUpload', id: 'avatar', label: 'Avatar', minFiles: 1, maxFiles: 1 },
+];
+
+describe('buildToolkitModal', () => {
+  it('renders fields as Labels (with descriptions) and display blocks as Text Display', () => {
+    const modal = buildToolkitModal({
+      customId: 'test::seed',
+      title: 'Create Thing',
+      items: ITEMS,
+    });
+    const json = modal.toJSON();
+
+    expect(json.custom_id).toBe('test::seed');
+    expect(json.title).toBe('Create Thing');
+    expect(json.components).toHaveLength(ITEMS.length);
+
+    const [display, nameLabel] = json.components as [
+      { type: number; content?: string },
+      { type: number; label?: string; description?: string; component?: { type: number } },
+    ];
+    expect(display.type).toBe(ComponentType.TextDisplay);
+    expect(display.content).toBe('Pick your settings below.');
+    expect(nameLabel.type).toBe(ComponentType.Label);
+    expect(nameLabel.label).toBe('Name');
+    expect(nameLabel.description).toBe('Shown everywhere this entity appears.');
+    expect(nameLabel.component?.type).toBe(ComponentType.TextInput);
+  });
+
+  it('carries option metadata and per-kind knobs through to the payload', () => {
+    const json = buildToolkitModal({ customId: 'x', title: 'T', items: ITEMS }).toJSON();
+    const byLabel = new Map(
+      (json.components as { label?: string; component?: Record<string, unknown> }[]).map(c => [
+        c.label,
+        c.component,
+      ])
+    );
+
+    const select = byLabel.get('Scope') as {
+      type: number;
+      placeholder?: string;
+      min_values?: number;
+      max_values?: number;
+      options: { value: string; default?: boolean; description?: string }[];
+    };
+    expect(select.type).toBe(ComponentType.StringSelect);
+    expect(select.placeholder).toBe('Choose a scope…');
+    expect(select.min_values).toBe(1);
+    expect(select.max_values).toBe(1);
+    expect(select.options[0].default).toBe(true);
+    expect(select.options[1].description).toBe('Bot-owner only');
+
+    const radio = byLabel.get('Mode') as {
+      type: number;
+      required?: boolean;
+      options: { value: string; default?: boolean }[];
+    };
+    expect(radio.type).toBe(ComponentType.RadioGroup);
+    expect(radio.required).toBe(true);
+    expect(radio.options.map(o => o.value)).toEqual(['standard', 'strict']);
+    expect(radio.options[1].default).toBe(true);
+
+    const group = byLabel.get('Features') as {
+      type: number;
+      min_values?: number;
+      max_values?: number;
+      options: { value: string }[];
+    };
+    expect(group.type).toBe(ComponentType.CheckboxGroup);
+    expect(group.min_values).toBe(0);
+    expect(group.max_values).toBe(2);
+    expect(group.options.map(o => o.value)).toEqual(['voice', 'images']);
+
+    const checkbox = byLabel.get('Public') as { type: number; default?: boolean };
+    expect(checkbox.type).toBe(ComponentType.Checkbox);
+    expect(checkbox.default).toBe(true);
+
+    const upload = byLabel.get('Avatar') as {
+      type: number;
+      min_values?: number;
+      max_values?: number;
+    };
+    expect(upload.type).toBe(ComponentType.FileUpload);
+    expect(upload.min_values).toBe(1);
+    expect(upload.max_values).toBe(1);
+  });
+
+  it('adapts a dashboard FieldDefinition, carrying length bounds through to the payload', () => {
+    const field = textFieldFromDefinition({
+      id: 'name',
+      label: 'Name',
+      placeholder: 'e.g. Lilith',
+      required: true,
+      style: 'short',
+      minLength: 2,
+      maxLength: 50,
+    });
+    const json = buildToolkitModal({ customId: 'x', title: 'T', items: [field] }).toJSON();
+
+    const input = (json.components as { component?: Record<string, unknown> }[])[0].component as {
+      custom_id: string;
+      min_length?: number;
+      max_length?: number;
+      required?: boolean;
+    };
+    expect(input.custom_id).toBe('name');
+    expect(input.min_length).toBe(2);
+    expect(input.max_length).toBe(50);
+    expect(input.required).toBe(true);
+  });
+
+  it('prefers initialValues over a text field own initialValue and truncates to maxLength', () => {
+    const items: ModalItem[] = [
+      { kind: 'text', id: 'bio', label: 'Bio', maxLength: 5, initialValue: 'original' },
+    ];
+
+    const withOwn = buildToolkitModal({ customId: 'x', title: 'T', items }).toJSON();
+    const withOverride = buildToolkitModal({
+      customId: 'x',
+      title: 'T',
+      items,
+      initialValues: { bio: 'resubmitted' },
+    }).toJSON();
+
+    const valueOf = (json: typeof withOwn): string | undefined =>
+      (json.components as { component?: { value?: string } }[])[0].component?.value;
+    expect(valueOf(withOwn)).toBe('origi');
+    expect(valueOf(withOverride)).toBe('resub');
+  });
+});
+
+describe('extractSubmission', () => {
+  function reader(overrides: Partial<SubmissionFieldReader> = {}): SubmissionFieldReader {
+    return {
+      getTextInputValue: vi.fn(() => 'Lilith'),
+      getStringSelectValues: vi.fn(() => ['user']),
+      getRadioGroup: vi.fn(() => 'strict'),
+      getCheckboxGroup: vi.fn(() => ['voice']),
+      getCheckbox: vi.fn(() => true),
+      ...overrides,
+    };
+  }
+
+  it('reads each interactive kind and skips display + file uploads', () => {
+    const values = extractSubmission(ITEMS, reader());
+
+    expect(values).toEqual({
+      name: 'Lilith',
+      scope: ['user'],
+      mode: 'strict',
+      features: ['voice'],
+      public: true,
+    });
+    expect(values).not.toHaveProperty('avatar');
+  });
+
+  it('skips fields absent from the submission instead of throwing', () => {
+    const values = extractSubmission(
+      ITEMS,
+      reader({
+        getRadioGroup: vi.fn(() => {
+          throw new Error('not present');
+        }),
+      })
+    );
+
+    expect(values).not.toHaveProperty('mode');
+    expect(values.name).toBe('Lilith');
+  });
+});
+
+describe('validateSubmission', () => {
+  const items: ModalItem[] = [
+    { kind: 'text', id: 'name', label: 'Name', required: true, maxLength: 10 },
+    { kind: 'text', id: 'bio', label: 'Bio', minLength: 3, maxLength: 5 },
+    { kind: 'checkbox', id: 'public', label: 'Public' },
+  ];
+
+  it('accepts valid values and ignores non-text kinds', () => {
+    const result = validateSubmission({ name: 'Lilith', bio: 'abc', public: false }, items);
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it('accepts an empty optional text field without running length rules', () => {
+    const result = validateSubmission({ name: 'ok', bio: '' }, items);
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it('flags required, min, and max violations with field labels', () => {
+    const result = validateSubmission({ name: '  ', bio: 'toolong' }, items);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(['Name is required', 'Bio must be at most 5 characters']);
+
+    expect(validateSubmission({ name: 'ok', bio: 'ab' }, items).errors).toEqual([
+      'Bio must be at least 3 characters',
+    ]);
+  });
+});

--- a/services/bot-client/src/utils/modal/toolkit.ts
+++ b/services/bot-client/src/utils/modal/toolkit.ts
@@ -1,0 +1,385 @@
+/**
+ * Label-based modal toolkit (design-system G4/D15).
+ *
+ * The component-era modal API hosts every input inside a Label — which
+ * carries the field's title AND an optional description line (inline docs,
+ * the D15 affordance the legacy ActionRow shape had no room for) — and
+ * adds non-text field kinds: string selects, radio groups, checkbox
+ * groups, single checkboxes, and file uploads. Plain Text Display blocks
+ * interleave as section prose; they are NON-INTERACTIVE, so extraction
+ * skips them.
+ *
+ * This module is the typed vocabulary over that API:
+ *
+ * - `ModalItem` — discriminated union of field kinds + display blocks.
+ * - `buildToolkitModal` — items → a Label-based `ModalBuilder`.
+ * - `extractSubmission` — kind-aware read of a submission into a value
+ *   record (file uploads excluded: attachments aren't string-shaped —
+ *   read them via `interaction.fields.getUploadedFiles`).
+ * - `validateSubmission` — text-kind length/required rules, mirroring the
+ *   dashboard ModalFactory's contract.
+ *
+ * The dashboard's `ModalFactory` (`buildSectionModal`/`buildSimpleModal`)
+ * still renders the legacy ActionRow shape; it migrates onto this module
+ * once Labels are runtime-proven on the create-modal exemplars.
+ */
+
+import {
+  CheckboxBuilder,
+  CheckboxGroupBuilder,
+  CheckboxGroupOptionBuilder,
+  FileUploadBuilder,
+  LabelBuilder,
+  ModalBuilder,
+  RadioGroupBuilder,
+  RadioGroupOptionBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+  TextDisplayBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+} from 'discord.js';
+import type { FieldDefinition } from '../dashboard/types.js';
+
+/** One choice in a select / radio / checkbox-group field. */
+export interface ModalChoice {
+  label: string;
+  value: string;
+  description?: string;
+  default?: boolean;
+}
+
+interface ModalFieldBase {
+  /** Submission key; must be unique within the modal. */
+  id: string;
+  /** Label title shown above the input. */
+  label: string;
+  /** Inline docs rendered under the label (D15). */
+  description?: string;
+  required?: boolean;
+}
+
+export interface TextModalField extends ModalFieldBase {
+  kind: 'text';
+  style?: 'short' | 'paragraph';
+  placeholder?: string;
+  minLength?: number;
+  /** Required — every text field caps its own length (Discord: 1–4000). */
+  maxLength: number;
+  /** Pre-filled value (truncated to maxLength). */
+  initialValue?: string;
+}
+
+export interface SelectModalField extends ModalFieldBase {
+  kind: 'select';
+  options: ModalChoice[];
+  placeholder?: string;
+  minValues?: number;
+  maxValues?: number;
+}
+
+export interface RadioModalField extends ModalFieldBase {
+  kind: 'radio';
+  options: ModalChoice[];
+}
+
+export interface CheckboxGroupModalField extends ModalFieldBase {
+  kind: 'checkboxGroup';
+  options: ModalChoice[];
+  minValues?: number;
+  maxValues?: number;
+}
+
+export interface CheckboxModalField extends ModalFieldBase {
+  kind: 'checkbox';
+  /** Pre-checked state. */
+  default?: boolean;
+}
+
+export interface FileUploadModalField extends ModalFieldBase {
+  kind: 'fileUpload';
+  minFiles?: number;
+  maxFiles?: number;
+}
+
+/** Non-interactive prose block between fields; skipped by extraction. */
+export interface DisplayModalItem {
+  kind: 'display';
+  content: string;
+}
+
+export type ModalField =
+  | TextModalField
+  | SelectModalField
+  | RadioModalField
+  | CheckboxGroupModalField
+  | CheckboxModalField
+  | FileUploadModalField;
+
+export type ModalItem = ModalField | DisplayModalItem;
+
+export interface BuildToolkitModalOptions {
+  customId: string;
+  title: string;
+  items: ModalItem[];
+  /**
+   * Text-field prefills by field id — overrides each field's own
+   * `initialValue`. The preserve-input-on-validation-failure affordance
+   * feeds resubmitted values back through here.
+   */
+  initialValues?: Record<string, string>;
+}
+
+/**
+ * Adapt a dashboard `FieldDefinition` to a text field. Bridges existing
+ * seed-field configs onto the toolkit without reshaping them; the
+ * context-aware `hidden` flag is a dashboard-section concern and is not
+ * carried (seed fields never use it).
+ */
+export function textFieldFromDefinition(field: FieldDefinition): TextModalField {
+  return {
+    kind: 'text',
+    id: field.id,
+    label: field.label,
+    style: field.style,
+    placeholder: field.placeholder,
+    required: field.required,
+    minLength: field.minLength,
+    maxLength: field.maxLength,
+  };
+}
+
+/** Structural shape shared by select/radio/checkbox-group option builders. */
+interface OptionLikeBuilder {
+  setLabel(label: string): this;
+  setValue(value: string): this;
+  setDescription(description: string): this;
+  setDefault(isDefault: boolean): this;
+}
+
+/** Choice list → option builders (shared by select/radio/checkbox-group). */
+function toOptionBuilders<TBuilder extends OptionLikeBuilder>(
+  options: ModalChoice[],
+  make: () => TBuilder
+): TBuilder[] {
+  return options.map(choice => {
+    const builder = make().setLabel(choice.label).setValue(choice.value);
+    if (choice.description !== undefined && choice.description.length > 0) {
+      builder.setDescription(choice.description);
+    }
+    if (choice.default === true) {
+      builder.setDefault(true);
+    }
+    return builder;
+  });
+}
+
+function buildTextInput(
+  field: TextModalField,
+  initialValues?: Record<string, string>
+): TextInputBuilder {
+  const input = new TextInputBuilder()
+    .setCustomId(field.id)
+    .setStyle(field.style === 'paragraph' ? TextInputStyle.Paragraph : TextInputStyle.Short)
+    .setRequired(field.required ?? false)
+    .setMaxLength(field.maxLength);
+  if (field.placeholder !== undefined && field.placeholder.length > 0) {
+    input.setPlaceholder(field.placeholder);
+  }
+  if (field.minLength !== undefined && field.minLength > 0) {
+    input.setMinLength(field.minLength);
+  }
+  const value = initialValues?.[field.id] ?? field.initialValue;
+  if (value !== undefined && value.length > 0) {
+    input.setValue(value.slice(0, field.maxLength));
+  }
+  return input;
+}
+
+function buildSelect(field: SelectModalField): StringSelectMenuBuilder {
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(field.id)
+    .setRequired(field.required ?? false)
+    .addOptions(toOptionBuilders(field.options, () => new StringSelectMenuOptionBuilder()));
+  if (field.placeholder !== undefined && field.placeholder.length > 0) {
+    select.setPlaceholder(field.placeholder);
+  }
+  if (field.minValues !== undefined) {
+    select.setMinValues(field.minValues);
+  }
+  if (field.maxValues !== undefined) {
+    select.setMaxValues(field.maxValues);
+  }
+  return select;
+}
+
+function buildCheckboxGroup(field: CheckboxGroupModalField): CheckboxGroupBuilder {
+  const group = new CheckboxGroupBuilder()
+    .setCustomId(field.id)
+    .setRequired(field.required ?? false)
+    .addOptions(toOptionBuilders(field.options, () => new CheckboxGroupOptionBuilder()));
+  if (field.minValues !== undefined) {
+    group.setMinValues(field.minValues);
+  }
+  if (field.maxValues !== undefined) {
+    group.setMaxValues(field.maxValues);
+  }
+  return group;
+}
+
+function buildRadioGroup(field: RadioModalField): RadioGroupBuilder {
+  return new RadioGroupBuilder()
+    .setCustomId(field.id)
+    .setRequired(field.required ?? false)
+    .addOptions(toOptionBuilders(field.options, () => new RadioGroupOptionBuilder()));
+}
+
+function buildFileUpload(field: FileUploadModalField): FileUploadBuilder {
+  const upload = new FileUploadBuilder().setCustomId(field.id).setRequired(field.required ?? false);
+  if (field.minFiles !== undefined) {
+    upload.setMinValues(field.minFiles);
+  }
+  if (field.maxFiles !== undefined) {
+    upload.setMaxValues(field.maxFiles);
+  }
+  return upload;
+}
+
+/** Attach the field's component to its Label (kind dispatch). */
+function attachComponent(
+  label: LabelBuilder,
+  field: ModalField,
+  initialValues?: Record<string, string>
+): void {
+  switch (field.kind) {
+    case 'text':
+      label.setTextInputComponent(buildTextInput(field, initialValues));
+      break;
+    case 'select':
+      label.setStringSelectMenuComponent(buildSelect(field));
+      break;
+    case 'radio':
+      label.setRadioGroupComponent(buildRadioGroup(field));
+      break;
+    case 'checkboxGroup':
+      label.setCheckboxGroupComponent(buildCheckboxGroup(field));
+      break;
+    case 'checkbox':
+      label.setCheckboxComponent(
+        new CheckboxBuilder().setCustomId(field.id).setDefault(field.default ?? false)
+      );
+      break;
+    case 'fileUpload':
+      label.setFileUploadComponent(buildFileUpload(field));
+      break;
+  }
+}
+
+/** Build a Label-based modal from typed items. */
+export function buildToolkitModal(options: BuildToolkitModalOptions): ModalBuilder {
+  const modal = new ModalBuilder().setCustomId(options.customId).setTitle(options.title);
+
+  for (const item of options.items) {
+    if (item.kind === 'display') {
+      modal.addTextDisplayComponents(new TextDisplayBuilder().setContent(item.content));
+      continue;
+    }
+    const label = new LabelBuilder().setLabel(item.label);
+    if (item.description !== undefined && item.description.length > 0) {
+      label.setDescription(item.description);
+    }
+    attachComponent(label, item, options.initialValues);
+    modal.addLabelComponents(label);
+  }
+
+  return modal;
+}
+
+/**
+ * Structural slice of `ModalSubmitFields` — lets tests stub submissions
+ * without discord.js internals.
+ */
+export interface SubmissionFieldReader {
+  getTextInputValue(customId: string): string;
+  getStringSelectValues(customId: string): readonly string[];
+  getRadioGroup(customId: string, required?: boolean): string | null;
+  getCheckboxGroup(customId: string): readonly string[];
+  getCheckbox(customId: string): boolean;
+}
+
+export type SubmissionValue = string | readonly string[] | boolean | null;
+
+/**
+ * Kind-aware read of a submission. Display blocks are skipped (they are
+ * non-interactive); file uploads are excluded — read attachments via
+ * `interaction.fields.getUploadedFiles(id)`. A field absent from the
+ * submission (e.g. hidden by a future variant) is skipped, matching the
+ * legacy `extractModalValues` contract.
+ */
+export function extractSubmission(
+  items: ModalItem[],
+  fields: SubmissionFieldReader
+): Record<string, SubmissionValue> {
+  const values: Record<string, SubmissionValue> = {};
+  for (const item of items) {
+    if (item.kind === 'display' || item.kind === 'fileUpload') {
+      continue;
+    }
+    try {
+      switch (item.kind) {
+        case 'text':
+          values[item.id] = fields.getTextInputValue(item.id);
+          break;
+        case 'select':
+          values[item.id] = fields.getStringSelectValues(item.id);
+          break;
+        case 'radio':
+          values[item.id] = fields.getRadioGroup(item.id, false);
+          break;
+        case 'checkboxGroup':
+          values[item.id] = fields.getCheckboxGroup(item.id);
+          break;
+        case 'checkbox':
+          values[item.id] = fields.getCheckbox(item.id);
+          break;
+      }
+    } catch {
+      // Field wasn't in the submission — skip it.
+    }
+  }
+  return values;
+}
+
+/**
+ * Validate text-kind values against their length/required rules. Discord
+ * enforces these natively at submit time; this is the defense-in-depth
+ * layer for values that reach the handler through other paths (retry
+ * stashes, tests), mirroring the dashboard ModalFactory's contract.
+ */
+function validateTextField(item: TextModalField, value: SubmissionValue | undefined): string[] {
+  const text = typeof value === 'string' ? value : undefined;
+  if (item.required === true && (text === undefined || text.trim().length === 0)) {
+    return [`${item.label} is required`];
+  }
+  if (text === undefined || text.length === 0) {
+    return [];
+  }
+  const errors: string[] = [];
+  if (item.minLength !== undefined && item.minLength > 0 && text.length < item.minLength) {
+    errors.push(`${item.label} must be at least ${item.minLength} characters`);
+  }
+  if (item.maxLength > 0 && text.length > item.maxLength) {
+    errors.push(`${item.label} must be at most ${item.maxLength} characters`);
+  }
+  return errors;
+}
+
+export function validateSubmission(
+  values: Record<string, SubmissionValue>,
+  items: ModalItem[]
+): { valid: boolean; errors: string[] } {
+  const errors = items
+    .filter((item): item is TextModalField => item.kind === 'text')
+    .flatMap(item => validateTextField(item, values[item.id]));
+  return { valid: errors.length === 0, errors };
+}


### PR DESCRIPTION
## What

First slice of the UX epic's modal wave (PR-5, split D-family: toolkit → site families).

**`utils/modal/toolkit.ts`** — the typed vocabulary over the component-era modal API:
- `ModalItem` discriminated union: text, string-select, radio, checkbox-group, checkbox, file-upload fields + non-interactive Text Display blocks.
- `buildToolkitModal` renders items as **Labels** — field title plus the D15 inline-docs `description` the legacy ActionRow shape had no room for.
- `extractSubmission` reads each kind through the `ModalSubmitFields` getters, skips display blocks (they're non-interactive — the council note), and excludes file uploads (attachments aren't string-shaped; callers use `getUploadedFiles` directly).
- `validateSubmission` carries the text length/required rules as defense-in-depth (Discord enforces natively at submit).
- `textFieldFromDefinition` bridges existing `FieldDefinition[]` seed configs without reshaping them.

Every builder and getter was **probed against the installed discord.js 14.26.5** before use (CheckboxBuilder/RadioGroupBuilder/LabelBuilder/FileUploadBuilder method surfaces, `ModalSubmitFields` getter signatures), and the build tests assert over `toJSON()` so the library's own component assertions gate every payload shape.

**Exemplar adoptions**: `/character create` and `/preset create` seed modals — their hand-rolled ActionRow loops collapse to `buildToolkitModal(fields.map(textFieldFromDefinition))`. Submission handlers unchanged (`getTextInputValue` reads Label-hosted inputs by the same customId).

## Deliberate scope cuts (next slices)

- **Dashboard `ModalFactory` stays on the legacy ActionRow shape** — flipping every dashboard edit modal at once is a big blast radius; the two create modals runtime-prove Labels first (owner smoke on dev), then the factory migrates.
- **Preserve-input-on-validation-failure** ("Try again" re-opens prefilled) — the `initialValues` hook is in place; the retry button + value-stash mechanism is the next slice's lead item.
- Remaining hand-rolled sites migrate per-site-fit after the factory flip.

## Verification

Toolkit unit tests (7: per-kind payload shapes incl. option metadata/defaults, prefill override + truncation, kind-aware extraction with absent-field skip, text validation rules); exemplar tests updated to the Label shape. `pnpm test` + `pnpm quality` green locally. **Owner smoke wanted post-merge on dev**: open `/character create` and `/preset create` — the modals should render with the same fields, now Label-styled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)