### PR TITLE
feat(bot-client): migrate dashboard ModalFactory onto the Label toolkit (PR-5b)

### DIFF
--- a/services/bot-client/src/utils/dashboard/ModalFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/ModalFactory.test.ts
@@ -58,7 +58,13 @@ function getModalComponents(modal: ReturnType<typeof buildSectionModal>) {
 function getTextInput(modal: ReturnType<typeof buildSectionModal>, index: number): any {
   const components = getModalComponents(modal);
 
-  return (components[index] as any)?.components?.[0];
+  // Label-based shape: each top-level component is a Label carrying the
+  // field's title plus the hosted input. Merge the Label's `label` onto
+  // the input view so assertions keep reading the user-visible title.
+  const labelRow = components[index] as any;
+  return labelRow?.component !== undefined
+    ? { ...labelRow.component, label: labelRow.label }
+    : undefined;
 }
 
 describe('ModalFactory', () => {

--- a/services/bot-client/src/utils/dashboard/ModalFactory.ts
+++ b/services/bot-client/src/utils/dashboard/ModalFactory.ts
@@ -3,15 +3,20 @@
  *
  * Creates modals for dashboard section editing with pre-filled values.
  * Reusable across /character, /profile, /preset, etc.
+ *
+ * Rendering is delegated to the Label-based modal toolkit
+ * (`utils/modal/toolkit.ts`): each text field renders inside a Label
+ * component rather than the legacy ActionRow shape. Submission reading is
+ * unchanged — `getTextInputValue` resolves by customId regardless of the
+ * hosting component.
  */
 
+import { type ModalBuilder } from 'discord.js';
 import {
-  ModalBuilder,
-  TextInputBuilder,
-  TextInputStyle,
-  ActionRowBuilder,
-  type ModalActionRowComponentBuilder,
-} from 'discord.js';
+  buildToolkitModal,
+  textFieldFromDefinition,
+  truncateByCodePoints,
+} from '../modal/toolkit.js';
 import {
   type DashboardConfig,
   type SectionDefinition,
@@ -20,6 +25,24 @@ import {
   buildDashboardCustomId,
   resolveContextAware,
 } from './types.js';
+
+/** Discord caps modals at five top-level components. */
+const MAX_MODAL_FIELDS = 5;
+
+/** Collect string prefills for the given fields from an entity record. */
+function collectInitialValues<T extends Record<string, unknown>>(
+  fields: FieldDefinition[],
+  currentData: T
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const field of fields) {
+    const currentValue = currentData[field.id];
+    if (currentValue !== undefined && currentValue !== null && typeof currentValue === 'string') {
+      values[field.id] = truncateByCodePoints(currentValue, field.maxLength);
+    }
+  }
+  return values;
+}
 
 /**
  * Build a modal for editing a dashboard section
@@ -37,10 +60,6 @@ export function buildSectionModal<T extends Record<string, unknown>>(
   currentData: T,
   context?: DashboardContext
 ): ModalBuilder {
-  const modal = new ModalBuilder()
-    .setCustomId(buildDashboardCustomId(config.entityType, 'modal', entityId, section.id))
-    .setTitle(`Edit ${section.label.replace(/^[^\w\s]+\s*/, '')}`); // Remove leading emoji
-
   // Filter out hidden fields when context is provided
   let visibleFields = section.fields;
   if (context !== undefined) {
@@ -49,57 +68,14 @@ export function buildSectionModal<T extends Record<string, unknown>>(
     );
   }
 
-  // Add fields (max 5 per Discord limit)
-  const fieldsToAdd = visibleFields.slice(0, 5);
+  const fieldsToAdd = visibleFields.slice(0, MAX_MODAL_FIELDS);
 
-  for (const field of fieldsToAdd) {
-    const textInput = buildTextInput(field, currentData);
-    const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(textInput);
-    modal.addComponents(row);
-  }
-
-  return modal;
-}
-
-/**
- * Build a text input component for a field
- */
-function buildTextInput<T extends Record<string, unknown>>(
-  field: FieldDefinition,
-  currentData: T
-): TextInputBuilder {
-  const input = new TextInputBuilder()
-    .setCustomId(field.id)
-    .setLabel(field.label)
-    .setStyle(field.style === 'paragraph' ? TextInputStyle.Paragraph : TextInputStyle.Short)
-    .setRequired(field.required ?? false);
-
-  // Set placeholder if provided
-  if (field.placeholder !== undefined && field.placeholder.length > 0) {
-    input.setPlaceholder(field.placeholder);
-  }
-
-  // `maxLength` is required on `FieldDefinition`, so no style-based
-  // fallback is needed — every field provides its own cap. A `maxLength: 0`
-  // typo would cause Discord to reject the modal at render time (API
-  // requires 1–4000), which is the intended fail-fast behavior; the
-  // `> 0` guard in `validateModalValues` is defense-in-depth for
-  // post-submission validation paths that run on pre-existing data.
-  input.setMaxLength(field.maxLength);
-
-  if (field.minLength !== undefined && field.minLength > 0) {
-    input.setMinLength(field.minLength);
-  }
-
-  // Pre-fill with current value if it exists
-  const currentValue = currentData[field.id];
-  if (currentValue !== undefined && currentValue !== null && typeof currentValue === 'string') {
-    // Discord modals require value to be within length constraints
-    const truncatedValue = currentValue.slice(0, field.maxLength);
-    input.setValue(truncatedValue);
-  }
-
-  return input;
+  return buildToolkitModal({
+    customId: buildDashboardCustomId(config.entityType, 'modal', entityId, section.id),
+    title: `Edit ${section.label.replace(/^[^\w\s]+\s*/, '')}`, // Remove leading emoji
+    items: fieldsToAdd.map(textFieldFromDefinition),
+    initialValues: collectInitialValues(fieldsToAdd, currentData),
+  });
 }
 
 /**
@@ -113,39 +89,12 @@ export function buildSimpleModal(
   fields: FieldDefinition[],
   initialValues?: Record<string, string>
 ): ModalBuilder {
-  const modal = new ModalBuilder().setCustomId(customId).setTitle(title);
-
-  // Add fields (max 5 per Discord limit)
-  const fieldsToAdd = fields.slice(0, 5);
-
-  for (const field of fieldsToAdd) {
-    const input = new TextInputBuilder()
-      .setCustomId(field.id)
-      .setLabel(field.label)
-      .setStyle(field.style === 'paragraph' ? TextInputStyle.Paragraph : TextInputStyle.Short)
-      .setRequired(field.required ?? false);
-
-    if (field.placeholder !== undefined && field.placeholder.length > 0) {
-      input.setPlaceholder(field.placeholder);
-    }
-
-    input.setMaxLength(field.maxLength);
-
-    if (field.minLength !== undefined && field.minLength > 0) {
-      input.setMinLength(field.minLength);
-    }
-
-    // Pre-fill if initial value provided
-    const initialValue = initialValues?.[field.id];
-    if (initialValue !== undefined && initialValue.length > 0) {
-      input.setValue(initialValue.slice(0, field.maxLength));
-    }
-
-    const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(input);
-    modal.addComponents(row);
-  }
-
-  return modal;
+  return buildToolkitModal({
+    customId,
+    title,
+    items: fields.slice(0, MAX_MODAL_FIELDS).map(textFieldFromDefinition),
+    initialValues,
+  });
 }
 
 /**

--- a/services/bot-client/src/utils/dashboard/settings/SettingsModalFactory.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsModalFactory.ts
@@ -12,6 +12,7 @@ import {
   ActionRowBuilder,
   type ModalActionRowComponentBuilder,
 } from 'discord.js';
+import { truncateByCodePoints } from '../../modal/toolkit.js';
 import { Duration, DurationParseError } from '@tzurot/common-types/utils/Duration';
 import { type SettingDefinition, buildSettingsCustomId, SettingType } from './types.js';
 
@@ -62,7 +63,7 @@ export function buildSettingEditModal(
   // throws in TextInputBuilder validation.
   const valueStr = formatValueForInput(currentValue);
   if (valueStr.length > 0) {
-    input.setValue(valueStr.slice(0, maxLength));
+    input.setValue(truncateByCodePoints(valueStr, maxLength));
   }
 
   input.setMaxLength(maxLength);

--- a/services/bot-client/src/utils/modal/toolkit.test.ts
+++ b/services/bot-client/src/utils/modal/toolkit.test.ts
@@ -12,10 +12,10 @@ import {
   buildToolkitModal,
   extractSubmission,
   textFieldFromDefinition,
+  truncateByCodePoints,
   validateSubmission,
-  type ModalItem,
-  type SubmissionFieldReader,
 } from './toolkit.js';
+import type { ModalItem, SubmissionFieldReader } from './types.js';
 
 const ITEMS: ModalItem[] = [
   { kind: 'display', content: 'Pick your settings below.' },
@@ -218,17 +218,36 @@ describe('extractSubmission', () => {
   });
 
   it('skips fields absent from the submission instead of throwing', () => {
+    const notFound = Object.assign(new Error('not found'), {
+      code: 'ModalSubmitInteractionFieldNotFound',
+    });
     const values = extractSubmission(
       ITEMS,
       reader({
         getRadioGroup: vi.fn(() => {
-          throw new Error('not present');
+          throw notFound;
         }),
       })
     );
 
     expect(values).not.toHaveProperty('mode');
     expect(values.name).toBe('Lilith');
+  });
+
+  it('rethrows non-absence errors (e.g. a kind/type mismatch) instead of swallowing them', () => {
+    const mismatch = Object.assign(new Error('expected text input'), {
+      code: 'ModalSubmitInteractionFieldType',
+    });
+    expect(() =>
+      extractSubmission(
+        ITEMS,
+        reader({
+          getTextInputValue: vi.fn(() => {
+            throw mismatch;
+          }),
+        })
+      )
+    ).toThrow('expected text input');
   });
 });
 
@@ -257,5 +276,17 @@ describe('validateSubmission', () => {
     expect(validateSubmission({ name: 'ok', bio: 'ab' }, items).errors).toEqual([
       'Bio must be at least 3 characters',
     ]);
+  });
+});
+
+describe('truncateByCodePoints', () => {
+  it('caps by code point so astral emoji never split', () => {
+    expect(truncateByCodePoints('abc', 5)).toBe('abc');
+    expect(truncateByCodePoints('abcdef', 5)).toBe('abcde');
+    // 4 ASCII + butterfly (astral): cap at 5 keeps the whole emoji...
+    expect(truncateByCodePoints('abcd🦋ef', 5)).toBe('abcd🦋');
+    // ...and cap at 4 drops it entirely rather than leaving half a pair.
+    expect(truncateByCodePoints('abcd🦋ef', 4)).toBe('abcd');
+    expect(truncateByCodePoints('abcd🦋ef', 4)).not.toContain('\uFFFD');
   });
 });

--- a/services/bot-client/src/utils/modal/toolkit.ts
+++ b/services/bot-client/src/utils/modal/toolkit.ts
@@ -9,19 +9,16 @@
  * interleave as section prose; they are NON-INTERACTIVE, so extraction
  * skips them.
  *
- * This module is the typed vocabulary over that API:
+ * The type vocabulary lives in `types.ts`; this module owns the behavior:
  *
- * - `ModalItem` — discriminated union of field kinds + display blocks.
  * - `buildToolkitModal` — items → a Label-based `ModalBuilder`.
  * - `extractSubmission` — kind-aware read of a submission into a value
  *   record (file uploads excluded: attachments aren't string-shaped —
  *   read them via `interaction.fields.getUploadedFiles`).
  * - `validateSubmission` — text-kind length/required rules, mirroring the
  *   dashboard ModalFactory's contract.
- *
- * The dashboard's `ModalFactory` (`buildSectionModal`/`buildSimpleModal`)
- * still renders the legacy ActionRow shape; it migrates onto this module
- * once Labels are runtime-proven on the create-modal exemplars.
+ * - `truncateByCodePoints` — the shared prefill-truncation helper (cuts by
+ *   code point so a surrogate pair never splits at the cap).
  */
 
 import {
@@ -40,94 +37,28 @@ import {
   TextInputStyle,
 } from 'discord.js';
 import type { FieldDefinition } from '../dashboard/types.js';
+import type {
+  BuildToolkitModalOptions,
+  CheckboxGroupModalField,
+  FileUploadModalField,
+  ModalChoice,
+  ModalField,
+  ModalItem,
+  RadioModalField,
+  SelectModalField,
+  SubmissionFieldReader,
+  SubmissionValue,
+  TextModalField,
+} from './types.js';
 
-/** One choice in a select / radio / checkbox-group field. */
-export interface ModalChoice {
-  label: string;
-  value: string;
-  description?: string;
-  default?: boolean;
-}
-
-interface ModalFieldBase {
-  /** Submission key; must be unique within the modal. */
-  id: string;
-  /** Label title shown above the input. */
-  label: string;
-  /** Inline docs rendered under the label (D15). */
-  description?: string;
-  required?: boolean;
-}
-
-export interface TextModalField extends ModalFieldBase {
-  kind: 'text';
-  style?: 'short' | 'paragraph';
-  placeholder?: string;
-  minLength?: number;
-  /** Required — every text field caps its own length (Discord: 1–4000). */
-  maxLength: number;
-  /** Pre-filled value (truncated to maxLength). */
-  initialValue?: string;
-}
-
-export interface SelectModalField extends ModalFieldBase {
-  kind: 'select';
-  options: ModalChoice[];
-  placeholder?: string;
-  minValues?: number;
-  maxValues?: number;
-}
-
-export interface RadioModalField extends ModalFieldBase {
-  kind: 'radio';
-  options: ModalChoice[];
-}
-
-export interface CheckboxGroupModalField extends ModalFieldBase {
-  kind: 'checkboxGroup';
-  options: ModalChoice[];
-  minValues?: number;
-  maxValues?: number;
-}
-
-export interface CheckboxModalField extends ModalFieldBase {
-  kind: 'checkbox';
-  /** Pre-checked state. */
-  default?: boolean;
-}
-
-export interface FileUploadModalField extends ModalFieldBase {
-  kind: 'fileUpload';
-  minFiles?: number;
-  maxFiles?: number;
-}
-
-/** Non-interactive prose block between fields; skipped by extraction. */
-export interface DisplayModalItem {
-  kind: 'display';
-  content: string;
-}
-
-export type ModalField =
-  | TextModalField
-  | SelectModalField
-  | RadioModalField
-  | CheckboxGroupModalField
-  | CheckboxModalField
-  | FileUploadModalField;
-
-export type ModalItem = ModalField | DisplayModalItem;
-
-export interface BuildToolkitModalOptions {
-  customId: string;
-  title: string;
-  items: ModalItem[];
-  /**
-   * Text-field prefills by field id — overrides each field's own
-   * `initialValue`. The preserve-input-on-validation-failure affordance
-   * feeds resubmitted values back through here.
-   */
-  initialValues?: Record<string, string>;
+/**
+ * Truncate to `max` code points — safe for astral-plane characters
+ * (emoji, some CJK) that a UTF-16 `.slice` would cut mid-surrogate. No
+ * ellipsis: callers truncate EDITABLE prefill content, not display text.
+ */
+export function truncateByCodePoints(value: string, max: number): string {
+  const codePoints = [...value];
+  return codePoints.length > max ? codePoints.slice(0, max).join('') : value;
 }
 
 /**
@@ -191,7 +122,7 @@ function buildTextInput(
   }
   const value = initialValues?.[field.id] ?? field.initialValue;
   if (value !== undefined && value.length > 0) {
-    input.setValue(value.slice(0, field.maxLength));
+    input.setValue(truncateByCodePoints(value, field.maxLength));
   }
   return input;
 }
@@ -296,20 +227,6 @@ export function buildToolkitModal(options: BuildToolkitModalOptions): ModalBuild
 }
 
 /**
- * Structural slice of `ModalSubmitFields` — lets tests stub submissions
- * without discord.js internals.
- */
-export interface SubmissionFieldReader {
-  getTextInputValue(customId: string): string;
-  getStringSelectValues(customId: string): readonly string[];
-  getRadioGroup(customId: string, required?: boolean): string | null;
-  getCheckboxGroup(customId: string): readonly string[];
-  getCheckbox(customId: string): boolean;
-}
-
-export type SubmissionValue = string | readonly string[] | boolean | null;
-
-/**
  * Kind-aware read of a submission. Display blocks are skipped (they are
  * non-interactive); file uploads are excluded — read attachments via
  * `interaction.fields.getUploadedFiles(id)`. A field absent from the
@@ -343,8 +260,13 @@ export function extractSubmission(
           values[item.id] = fields.getCheckbox(item.id);
           break;
       }
-    } catch {
-      // Field wasn't in the submission — skip it.
+    } catch (error) {
+      // Only "field absent from the submission" is skippable (hidden
+      // variants, partial submissions). Anything else — notably a
+      // kind/type mismatch — is a wiring bug and must surface.
+      if ((error as { code?: string }).code !== 'ModalSubmitInteractionFieldNotFound') {
+        throw error;
+      }
     }
   }
   return values;

--- a/services/bot-client/src/utils/modal/types.ts
+++ b/services/bot-client/src/utils/modal/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Modal toolkit type vocabulary (design-system G4/D15).
+ *
+ * The discriminated `ModalItem` union describes everything a Label-based
+ * modal can host: text inputs, string selects, radio groups, checkbox
+ * groups, single checkboxes, file uploads, and non-interactive Text
+ * Display prose blocks. Builders/extractors live in `toolkit.ts`.
+ */
+
+/** One choice in a select / radio / checkbox-group field. */
+export interface ModalChoice {
+  label: string;
+  value: string;
+  description?: string;
+  default?: boolean;
+}
+
+interface ModalFieldBase {
+  /** Submission key; must be unique within the modal. */
+  id: string;
+  /** Label title shown above the input. */
+  label: string;
+  /** Inline docs rendered under the label (D15). */
+  description?: string;
+  required?: boolean;
+}
+
+export interface TextModalField extends ModalFieldBase {
+  kind: 'text';
+  style?: 'short' | 'paragraph';
+  placeholder?: string;
+  minLength?: number;
+  /** Required — every text field caps its own length (Discord: 1–4000). */
+  maxLength: number;
+  /** Pre-filled value (truncated to maxLength). */
+  initialValue?: string;
+}
+
+export interface SelectModalField extends ModalFieldBase {
+  kind: 'select';
+  options: ModalChoice[];
+  placeholder?: string;
+  minValues?: number;
+  maxValues?: number;
+}
+
+export interface RadioModalField extends ModalFieldBase {
+  kind: 'radio';
+  options: ModalChoice[];
+}
+
+export interface CheckboxGroupModalField extends ModalFieldBase {
+  kind: 'checkboxGroup';
+  options: ModalChoice[];
+  minValues?: number;
+  maxValues?: number;
+}
+
+export interface CheckboxModalField extends ModalFieldBase {
+  kind: 'checkbox';
+  /** Pre-checked state. */
+  default?: boolean;
+}
+
+export interface FileUploadModalField extends ModalFieldBase {
+  kind: 'fileUpload';
+  minFiles?: number;
+  maxFiles?: number;
+}
+
+/** Non-interactive prose block between fields; skipped by extraction. */
+export interface DisplayModalItem {
+  kind: 'display';
+  content: string;
+}
+
+export type ModalField =
+  | TextModalField
+  | SelectModalField
+  | RadioModalField
+  | CheckboxGroupModalField
+  | CheckboxModalField
+  | FileUploadModalField;
+
+export type ModalItem = ModalField | DisplayModalItem;
+
+export interface BuildToolkitModalOptions {
+  customId: string;
+  title: string;
+  items: ModalItem[];
+  /**
+   * Text-field prefills by field id — overrides each field's own
+   * `initialValue`. The preserve-input-on-validation-failure affordance
+   * feeds resubmitted values back through here.
+   */
+  initialValues?: Record<string, string>;
+}
+
+/**
+ * Structural slice of `ModalSubmitFields` — lets tests stub submissions
+ * without discord.js internals.
+ */
+export interface SubmissionFieldReader {
+  getTextInputValue(customId: string): string;
+  getStringSelectValues(customId: string): readonly string[];
+  getRadioGroup(customId: string, required?: boolean): string | null;
+  getCheckboxGroup(customId: string): readonly string[];
+  getCheckbox(customId: string): boolean;
+}
+
+export type SubmissionValue = string | readonly string[] | boolean | null;


### PR DESCRIPTION
## What

The modal wave's second slice — the runtime gate cleared when the owner smoke-verified Label modals on both create exemplars, so the dashboard `ModalFactory` now renders through the toolkit:

- `buildSectionModal` / `buildSimpleModal` keep their signatures, customIds, titles, hidden-field filtering, and the 5-field cap — but render Label-hosted inputs via `buildToolkitModal`. **Every dashboard edit modal moves to the component-era shape in one flip.** Submission handlers are untouched (`getTextInputValue` resolves by customId regardless of the hosting component — same property that made the exemplar flip safe).
- `extractModalValues` / `validateModalValues` stay as-is (many callers, unchanged contract).

**Hardening trio** (filed from #1711 r2 + #1713's release review, promoted here on its named trigger):
- `extractSubmission`'s catch narrows to `ModalSubmitInteractionFieldNotFound` (error code probed against the installed discord.js) — a kind/type mismatch now surfaces instead of silently producing a missing key. Rethrow pinned by test.
- `truncateByCodePoints` replaces all four UTF-16 prefill `.slice` copies (toolkit, ModalFactory ×2 via `collectInitialValues`, SettingsModalFactory) — the browse builder's surrogate-split fix, now applied across modals. Boundary-emoji tests included.
- The toolkit's type vocabulary splits to `utils/modal/types.ts` (toolkit.ts was 385/400 pre-migration).

## Scope notes

- SettingsModalFactory gets ONLY the truncation swap — its Label flip is a separate surface with its own session machinery and stays out of this slice.
- The remaining trio item (non-text validation defense-in-depth) stays filed: its trigger is the first non-text field consumer, which hasn't landed yet.

## Verification

`ModalFactory.test.ts`'s single ActionRow-unwrap helper flipped to the Label shape (label read from the wrapper) — all 26 pass unchanged otherwise; settings suite 50/50; toolkit 11/11 incl. the new rethrow + boundary-truncation tests. Full `pnpm test` (5,710 bot-client) + `pnpm quality` green. **Owner smoke suggestion post-merge**: open any dashboard section edit (e.g. `/character edit` → a section) on dev — same fields, Label-styled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)