### PR TITLE
feat(bot-client): preserve-input retry affordance for create modals (PR-5c)

### DIFF
--- a/services/bot-client/src/commands/character/create.test.ts
+++ b/services/bot-client/src/commands/character/create.test.ts
@@ -190,7 +190,24 @@ describe('Character Create', () => {
       await handleSeedModalSubmit(mockInteraction, mockConfig);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('Invalid slug format')
+        expect.objectContaining({
+          content: expect.stringContaining('Invalid slug format'),
+          components: expect.any(Array),
+        })
+      );
+
+      // Seam: the submitted values must reach the retry stash so the
+      // Try-again button can reopen the modal prefilled.
+      const sessionSet = vi.mocked(dashboardUtils.getSessionManager)().set;
+      expect(sessionSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: 'modal-retry',
+          messageId: 'message-123',
+          data: {
+            kind: 'seed',
+            values: expect.objectContaining({ slug: 'Invalid Slug!' }),
+          },
+        })
       );
     });
 
@@ -214,7 +231,10 @@ describe('Character Create', () => {
       // Pre-#slug-alignment this passed client validation and died at the
       // gateway with a raw 400; now it fails here with the friendly message.
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('start with a letter')
+        expect.objectContaining({
+          content: expect.stringContaining('start with a letter'),
+          components: expect.any(Array),
+        })
       );
     });
 
@@ -237,7 +257,10 @@ describe('Character Create', () => {
       await handleSeedModalSubmit(mockInteraction, mockConfig);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('3–50 characters')
+        expect.objectContaining({
+          content: expect.stringContaining('3–50 characters'),
+          components: expect.any(Array),
+        })
       );
     });
 
@@ -259,7 +282,10 @@ describe('Character Create', () => {
       await handleSeedModalSubmit(mockInteraction, mockConfig);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('3–50 characters')
+        expect.objectContaining({
+          content: expect.stringContaining('3–50 characters'),
+          components: expect.any(Array),
+        })
       );
     });
 
@@ -399,7 +425,10 @@ describe('Character Create', () => {
       await handleSeedModalSubmit(mockInteraction, mockConfig);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('already exists')
+        expect.objectContaining({
+          content: expect.stringContaining('already exists'),
+          components: expect.any(Array),
+        })
       );
     });
 

--- a/services/bot-client/src/commands/character/create.ts
+++ b/services/bot-client/src/commands/character/create.ts
@@ -7,7 +7,7 @@
  * 3. Shows dashboard for further editing
  */
 
-import { MessageFlags, type ModalSubmitInteraction } from 'discord.js';
+import { MessageFlags, type ModalBuilder, type ModalSubmitInteraction } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
@@ -32,6 +32,7 @@ import {
   buildCharacterDashboardOptions,
 } from './config.js';
 import { buildToolkitModal, textFieldFromDefinition } from '../../utils/modal/toolkit.js';
+import { replyWithModalRetry } from '../../utils/modal/retry.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
@@ -46,14 +47,32 @@ const logger = createLogger('character-create');
  * Receives ModalCommandContext (has showModal method!)
  * because this subcommand uses deferralMode: 'modal'.
  */
-export async function handleCreate(context: ModalCommandContext): Promise<void> {
-  const modal = buildToolkitModal({
+/** Seed modal builder — shared by create and the retry affordance. */
+export function buildCharacterSeedModal(initialValues?: Record<string, string>): ModalBuilder {
+  return buildToolkitModal({
     customId: buildDashboardCustomId('character', 'seed'),
     title: 'Create New Character',
     items: characterSeedFields.map(textFieldFromDefinition),
+    initialValues,
   });
+}
 
-  await context.showModal(modal);
+export async function handleCreate(context: ModalCommandContext): Promise<void> {
+  await context.showModal(buildCharacterSeedModal());
+}
+
+/** Validation-failure reply + prefill stash (shared D15 helper). */
+async function replyWithRetry(
+  interaction: ModalSubmitInteraction,
+  content: string,
+  values: Record<string, string>
+): Promise<void> {
+  await replyWithModalRetry(interaction, {
+    commandPrefix: 'character',
+    kind: 'seed',
+    content,
+    values,
+  });
 }
 
 /**
@@ -74,22 +93,26 @@ export async function handleSeedModalSubmit(
   // enforces, so a digit-leading slug fails here with a friendly message
   // instead of a raw 400 after submit.
   if (!SLUG_PATTERN.test(values.slug)) {
-    await interaction.editReply(
+    await replyWithRetry(
+      interaction,
       renderSpec(
         CATALOG.error.validation(
           `Invalid slug format. ${SLUG_REQUIREMENTS_MESSAGE}\nExample: \`${suggestSlugExample(values.name)}\``
         )
-      )
+      ),
+      values
     );
     return;
   }
   if (values.slug.length < SLUG_MIN_LENGTH || values.slug.length > DISCORD_LIMITS.SLUG_MAX_LENGTH) {
-    await interaction.editReply(
+    await replyWithRetry(
+      interaction,
       renderSpec(
         CATALOG.error.validation(
           `Slug must be ${SLUG_MIN_LENGTH}–${DISCORD_LIMITS.SLUG_MAX_LENGTH} characters (yours is ${values.slug.length}).`
         )
-      )
+      ),
+      values
     );
     return;
   }
@@ -156,12 +179,14 @@ export async function handleSeedModalSubmit(
 
     // Check for duplicate slug error
     if (error instanceof Error && error.message.includes('409')) {
-      await interaction.editReply(
+      await replyWithRetry(
+        interaction,
         renderSpec(
           CATALOG.error.validation(
             `A character with slug \`${normalizedSlug}\` already exists.\nPlease choose a different slug.`
           )
-        )
+        ),
+        values
       );
       return;
     }

--- a/services/bot-client/src/commands/character/interactionRouting.test.ts
+++ b/services/bot-client/src/commands/character/interactionRouting.test.ts
@@ -53,6 +53,13 @@ vi.mock('./overrides.js', () => ({
   isCharacterOverridesInteraction: (id: string) => overrides.matches(id) as boolean,
 }));
 
+const retryHandle = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/modal/retry.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/modal/retry.js')>();
+  return { ...actual, handleModalRetry: retryHandle };
+});
+vi.mock('./create.js', () => ({ buildCharacterSeedModal: vi.fn() }));
+
 const dashboard = {
   select: vi.fn(),
   button: vi.fn(),
@@ -69,6 +76,8 @@ import {
   handleButton,
   handleCharacterModal as handleModal,
 } from './interactionRouting.js';
+import { buildModalRetryRow } from '../../utils/modal/retry.js';
+import { buildCharacterSeedModal } from './create.js';
 
 function interaction(customId: string): { customId: string } {
   return { customId };
@@ -112,6 +121,28 @@ describe('character interaction routing', () => {
 
     expect(overrides.button).toHaveBeenCalled();
     expect(dashboard.button).not.toHaveBeenCalled();
+  });
+
+  it('routes the REAL retry-button customId to handleModalRetry (builder↔guard drift pin)', async () => {
+    // Built from the actual button builder so a prefix typo in EITHER
+    // buildModalRetryRow or isModalRetryInteraction breaks this test.
+    const row = buildModalRetryRow('character').toJSON() as {
+      components: { custom_id: string }[];
+    };
+    await handleButton(interaction(row.components[0].custom_id) as ButtonInteraction);
+
+    expect(retryHandle).toHaveBeenCalled();
+    expect(dashboard.button).not.toHaveBeenCalled();
+
+    // Seam: exercise the captured rebuild closure — 'seed' must hit THIS
+    // command's builder with the stashed values; unknown kinds return null.
+    const rebuild = retryHandle.mock.calls[0][1] as (
+      kind: string,
+      values: Record<string, string>
+    ) => unknown;
+    rebuild('seed', { name: 'Lilith' });
+    expect(vi.mocked(buildCharacterSeedModal)).toHaveBeenCalledWith({ name: 'Lilith' });
+    expect(rebuild('retired-kind', {})).toBeNull();
   });
 
   it('falls through unmatched ids to the edit dashboard', async () => {

--- a/services/bot-client/src/commands/character/interactionRouting.ts
+++ b/services/bot-client/src/commands/character/interactionRouting.ts
@@ -12,6 +12,8 @@ import {
   type StringSelectMenuInteraction,
   type ButtonInteraction,
 } from 'discord.js';
+import { handleModalRetry, isModalRetryInteraction } from '../../utils/modal/retry.js';
+import { buildCharacterSeedModal } from './create.js';
 import { getConfig } from '@tzurot/common-types/config/config';
 import {
   handleBrowsePagination,
@@ -89,6 +91,16 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
   // Alias browse surface (pagination, filter toggle, remove confirm/cancel)
   if (isCharacterAliasInteraction(interaction.customId)) {
     await aliasComponentRouter.handleButton(interaction);
+    return;
+  }
+
+  // Try-again for a failed create-modal submission (prefilled reopen).
+  if (isModalRetryInteraction(interaction.customId, 'character')) {
+    await handleModalRetry(
+      interaction,
+      (kind, values) => (kind === 'seed' ? buildCharacterSeedModal(values) : null),
+      '/character create'
+    );
     return;
   }
 

--- a/services/bot-client/src/commands/preset/create.test.ts
+++ b/services/bot-client/src/commands/preset/create.test.ts
@@ -171,8 +171,23 @@ describe('Preset Create', () => {
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith({
         content: '❌ Preset name is required.',
+        components: expect.any(Array),
       });
       expect(api.createPreset).not.toHaveBeenCalled();
+
+      // Seam: the submitted values must reach the retry stash so the
+      // Try-again button can reopen the modal prefilled.
+      const sessionSet = vi.mocked(dashboardUtils.getSessionManager)().set;
+      expect(sessionSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: 'modal-retry',
+          messageId: 'message-123',
+          data: {
+            kind: 'seed',
+            values: expect.objectContaining({ model: 'anthropic/claude-sonnet-4' }),
+          },
+        })
+      );
     });
 
     it('should reject empty model', async () => {
@@ -190,6 +205,7 @@ describe('Preset Create', () => {
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith({
         content: '❌ Model ID is required.',
+        components: expect.any(Array),
       });
       expect(api.createPreset).not.toHaveBeenCalled();
     });
@@ -271,6 +287,7 @@ describe('Preset Create', () => {
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith({
         content: expect.stringContaining('already exists'),
+        components: expect.any(Array),
       });
     });
 

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -7,7 +7,7 @@
  * 3. Shows dashboard for further editing
  */
 
-import { MessageFlags, type ModalSubmitInteraction } from 'discord.js';
+import { MessageFlags, type ModalBuilder, type ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import {
@@ -24,11 +24,13 @@ import {
   buildPresetDashboardOptions,
 } from './config.js';
 import { buildToolkitModal, textFieldFromDefinition } from '../../utils/modal/toolkit.js';
+import { replyWithModalRetry } from '../../utils/modal/retry.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createPreset } from './api.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { replySpec } from '../../ux/render/reply.js';
+import { renderSpec } from '../../ux/render/render.js';
 
 const logger = createLogger('preset-create');
 
@@ -42,13 +44,31 @@ export async function handleCreate(context: ModalCommandContext): Promise<void> 
   // No slot option: a preset's vision-capability is derived from its model
   // (`supportsVision`), not chosen at creation. The vision SLOT is picked later
   // when the preset is assigned (set/set-default/global).
-  const modal = buildToolkitModal({
+  await context.showModal(buildPresetSeedModal());
+}
+
+/** Seed modal builder — shared by create and the retry affordance. */
+export function buildPresetSeedModal(initialValues?: Record<string, string>): ModalBuilder {
+  return buildToolkitModal({
     customId: buildDashboardCustomId('preset', 'seed'),
     title: 'Create New Preset',
     items: presetSeedFields.map(textFieldFromDefinition),
+    initialValues,
   });
+}
 
-  await context.showModal(modal);
+/** Validation-failure reply + prefill stash (shared D15 helper). */
+async function replyWithRetry(
+  interaction: ModalSubmitInteraction,
+  content: string,
+  values: Record<string, string>
+): Promise<void> {
+  await replyWithModalRetry(interaction, {
+    commandPrefix: 'preset',
+    kind: 'seed',
+    content,
+    values,
+  });
 }
 
 /**
@@ -64,12 +84,20 @@ export async function handleSeedModalSubmit(interaction: ModalSubmitInteraction)
 
   // Validate required fields
   if (!values.name || values.name.trim().length === 0) {
-    await replySpec(interaction, CATALOG.error.validation('Preset name is required.'));
+    await replyWithRetry(
+      interaction,
+      renderSpec(CATALOG.error.validation('Preset name is required.')),
+      values
+    );
     return;
   }
 
   if (!values.model || values.model.trim().length === 0) {
-    await replySpec(interaction, CATALOG.error.validation('Model ID is required.'));
+    await replyWithRetry(
+      interaction,
+      renderSpec(CATALOG.error.validation('Model ID is required.')),
+      values
+    );
     return;
   }
 
@@ -120,11 +148,14 @@ export async function handleSeedModalSubmit(interaction: ModalSubmitInteraction)
 
     // Check for duplicate name error (match structured format to avoid false positives)
     if (error instanceof Error && error.message.includes(': 409 ')) {
-      await replySpec(
+      await replyWithRetry(
         interaction,
-        CATALOG.error.validation(
-          `A preset with name "${values.name}" already exists.\nPlease choose a different name.`
-        )
+        renderSpec(
+          CATALOG.error.validation(
+            `A preset with name "${values.name}" already exists.\nPlease choose a different name.`
+          )
+        ),
+        values
       );
       return;
     }

--- a/services/bot-client/src/commands/preset/index.test.ts
+++ b/services/bot-client/src/commands/preset/index.test.ts
@@ -36,14 +36,21 @@ vi.mock('./browse.js', () => ({
   handleBrowsePagination: vi.fn(),
   isPresetBrowseInteraction: vi.fn(),
 }));
-vi.mock('./create.js', () => ({ handleCreate: vi.fn() }));
+vi.mock('./create.js', () => ({ handleCreate: vi.fn(), buildPresetSeedModal: vi.fn() }));
+const presetRetryHandle = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/modal/retry.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/modal/retry.js')>();
+  return { ...actual, handleModalRetry: presetRetryHandle };
+});
 // Note: delete is now handled via the dashboard, not a standalone command
 
 // Mock global subcommand handlers
 vi.mock('./global/set-default.js', () => ({ handleGlobalSetDefault: vi.fn() }));
 vi.mock('./global/free-default.js', () => ({ handleGlobalSetFreeDefault: vi.fn() }));
 
-import { handleBrowse } from './browse.js';
+import { handleBrowse, isPresetBrowseInteraction } from './browse.js';
+import { buildPresetSeedModal } from './create.js';
+import { buildModalRetryRow } from '../../utils/modal/retry.js';
 import { handleCreate } from './create.js';
 import { handleGlobalSetDefault } from './global/set-default.js';
 import { handleGlobalSetFreeDefault } from './global/free-default.js';
@@ -153,5 +160,29 @@ describe('Preset Command', () => {
 
       expect(handleGlobalSetFreeDefault).toHaveBeenCalledWith(context);
     });
+  });
+});
+
+describe('button dispatch', () => {
+  it('routes the REAL retry-button customId to handleModalRetry (builder↔guard drift pin)', async () => {
+    vi.mocked(isPresetBrowseInteraction).mockReturnValue(false);
+    const row = buildModalRetryRow('preset').toJSON() as { components: { custom_id: string }[] };
+    const interaction = { customId: row.components[0].custom_id } as never;
+
+    await presetCommand.handleButton?.(interaction);
+
+    expect(presetRetryHandle).toHaveBeenCalled();
+
+    // Seam: exercise the captured rebuild closure — 'seed' must hit THIS
+    // command's builder with the stashed values; unknown kinds return null.
+    const rebuild = presetRetryHandle.mock.calls[0][1] as (
+      kind: string,
+      values: Record<string, string>
+    ) => unknown;
+    rebuild('seed', { model: 'anthropic/claude-sonnet-4' });
+    expect(vi.mocked(buildPresetSeedModal)).toHaveBeenCalledWith({
+      model: 'anthropic/claude-sonnet-4',
+    });
+    expect(rebuild('retired-kind', {})).toBeNull();
   });
 });

--- a/services/bot-client/src/commands/preset/index.ts
+++ b/services/bot-client/src/commands/preset/index.ts
@@ -25,6 +25,7 @@ import {
 } from 'discord.js';
 import { CONFIG_SLOT_OPTION_DESCRIPTION } from '@tzurot/common-types/constants/ai';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { handleModalRetry, isModalRetryInteraction } from '../../utils/modal/retry.js';
 import { defineCommand } from '../../utils/defineCommand.js';
 import { createTypedSubcommandRouter } from '../../utils/subcommandRouter.js';
 import { createMixedModeSubcommandRouter } from '../../utils/mixedModeSubcommandRouter.js';
@@ -40,7 +41,7 @@ import {
   handleBrowseSelect,
   isPresetBrowseSelectInteraction,
 } from './browse.js';
-import { handleCreate } from './create.js';
+import { handleCreate, buildPresetSeedModal } from './create.js';
 import { handleEdit } from './edit.js';
 import { handleExport } from './export.js';
 import { handleImport } from './import.js';
@@ -138,6 +139,16 @@ async function button(interaction: ButtonInteraction): Promise<void> {
   // Handle browse pagination
   if (isPresetBrowseInteraction(interaction.customId)) {
     await handleBrowsePagination(interaction);
+    return;
+  }
+
+  // Try-again for a failed create-modal submission (prefilled reopen).
+  if (isModalRetryInteraction(interaction.customId, 'preset')) {
+    await handleModalRetry(
+      interaction,
+      (kind, values) => (kind === 'seed' ? buildPresetSeedModal(values) : null),
+      '/preset create'
+    );
     return;
   }
 

--- a/services/bot-client/src/utils/modal/retry.test.ts
+++ b/services/bot-client/src/utils/modal/retry.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the preserve-input-on-validation-failure affordance.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ButtonInteraction, ModalBuilder } from 'discord.js';
+import {
+  buildModalRetryRow,
+  isModalRetryInteraction,
+  replyWithModalRetry,
+  stashModalRetry,
+  handleModalRetry,
+} from './retry.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const sessionManagerMock = {
+  set: vi.fn(),
+  findByMessageId: vi.fn(),
+};
+vi.mock('../dashboard/index.js', () => ({
+  getSessionManager: () => sessionManagerMock,
+}));
+
+const showModalMock = vi.hoisted(() => vi.fn());
+vi.mock('../dashboard/showModalWithTimeoutCatch.js', () => ({
+  showModalWithTimeoutCatch: showModalMock,
+}));
+
+function makeInteraction(): ButtonInteraction {
+  return {
+    customId: 'character::modal-retry',
+    user: { id: 'user-1' },
+    message: { id: 'reply-1' },
+    reply: vi.fn(),
+  } as unknown as ButtonInteraction;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildModalRetryRow / isModalRetryInteraction', () => {
+  it('builds a Try-again button whose customId the guard recognizes', () => {
+    const row = buildModalRetryRow('character').toJSON() as {
+      components: { custom_id: string; label?: string }[];
+    };
+    expect(row.components[0].custom_id).toBe('character::modal-retry');
+    expect(row.components[0].label).toBe('Try again');
+
+    expect(isModalRetryInteraction('character::modal-retry', 'character')).toBe(true);
+    expect(isModalRetryInteraction('character::modal-retry', 'preset')).toBe(false);
+    expect(isModalRetryInteraction('character::browse::0::all::', 'character')).toBe(false);
+  });
+});
+
+describe('stashModalRetry', () => {
+  it('stores the values in a message-id-keyed session', async () => {
+    await stashModalRetry({
+      userId: 'user-1',
+      channelId: 'chan-1',
+      messageId: 'reply-1',
+      kind: 'seed',
+      values: { name: 'Lilith', slug: 'bad slug!' },
+    });
+
+    expect(sessionManagerMock.set).toHaveBeenCalledWith({
+      userId: 'user-1',
+      entityType: 'modal-retry',
+      entityId: 'reply-1',
+      data: { kind: 'seed', values: { name: 'Lilith', slug: 'bad slug!' } },
+      messageId: 'reply-1',
+      channelId: 'chan-1',
+    });
+  });
+});
+
+describe('replyWithModalRetry', () => {
+  it('sends the button-carrying reply and stashes the values in one call', async () => {
+    const editReply = vi.fn().mockResolvedValue({ id: 'reply-9' });
+    const interaction = {
+      editReply,
+      user: { id: 'user-1' },
+      channelId: null,
+    };
+
+    await replyWithModalRetry(interaction as never, {
+      commandPrefix: 'character',
+      kind: 'seed',
+      content: '❌ nope',
+      values: { name: 'Lilith' },
+    });
+
+    expect(editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '❌ nope', components: expect.any(Array) })
+    );
+    expect(sessionManagerMock.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'modal-retry',
+        entityId: 'reply-9',
+        channelId: '',
+        data: { kind: 'seed', values: { name: 'Lilith' } },
+      })
+    );
+  });
+});
+
+describe('handleModalRetry', () => {
+  const modal = { fake: 'modal' } as unknown as ModalBuilder;
+
+  it('rebuilds the modal with the stashed values and shows it through the timeout catch', async () => {
+    sessionManagerMock.findByMessageId.mockResolvedValue({
+      userId: 'user-1',
+      data: { kind: 'seed', values: { name: 'Lilith' } },
+    });
+    const rebuild = vi.fn(() => modal);
+    const interaction = makeInteraction();
+
+    await handleModalRetry(interaction, rebuild, '/character create');
+
+    expect(sessionManagerMock.findByMessageId).toHaveBeenCalledWith('reply-1');
+    expect(rebuild).toHaveBeenCalledWith('seed', { name: 'Lilith' });
+    expect(showModalMock).toHaveBeenCalledWith(
+      interaction,
+      modal,
+      expect.objectContaining({ source: 'handleModalRetry', sectionId: 'seed' }),
+      expect.any(String)
+    );
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('degrades to the session-expired reply when the stash is gone', async () => {
+    sessionManagerMock.findByMessageId.mockResolvedValue(null);
+    const interaction = makeInteraction();
+
+    await handleModalRetry(interaction, vi.fn(), '/character create');
+
+    expect(showModalMock).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('/character create') })
+    );
+  });
+
+  it("rejects another user's click on the button", async () => {
+    sessionManagerMock.findByMessageId.mockResolvedValue({
+      userId: 'someone-else',
+      data: { kind: 'seed', values: {} },
+    });
+    const interaction = makeInteraction();
+
+    await handleModalRetry(interaction, vi.fn(), '/character create');
+
+    expect(showModalMock).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalled();
+  });
+
+  it('degrades when no rebuilder exists for the stashed kind', async () => {
+    sessionManagerMock.findByMessageId.mockResolvedValue({
+      userId: 'user-1',
+      data: { kind: 'retired-kind', values: {} },
+    });
+    const interaction = makeInteraction();
+
+    await handleModalRetry(interaction, () => null, '/character create');
+
+    expect(showModalMock).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/utils/modal/retry.ts
+++ b/services/bot-client/src/utils/modal/retry.ts
@@ -1,0 +1,174 @@
+/**
+ * Preserve-input-on-validation-failure (design-system D15 affordance).
+ *
+ * When a modal submission fails app-side validation, the modal is already
+ * closed and Discord offers no way to reopen it prefilled — historically
+ * the user's input was simply lost. This module standardizes the recovery:
+ *
+ *   1. The submit handler attaches a "Try again" button to its error reply
+ *      (`buildModalRetryRow`) and stashes the submitted values in a
+ *      dashboard session keyed by that reply's message id
+ *      (`stashModalRetry`) — values can be kilobytes, so they live in
+ *      Redis, never in the customId.
+ *   2. The button handler (`handleModalRetry`) looks the stash up by
+ *      `interaction.message.id` and re-shows the modal with
+ *      `initialValues` fed back through the toolkit.
+ *
+ * The pre-show Redis lookup eats into the 3-second budget, which is
+ * exactly the case `showModalWithTimeoutCatch` exists for (Discord
+ * forbids deferring before `showModal`).
+ */
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags,
+  type ButtonInteraction,
+  type ModalBuilder,
+  type ModalSubmitInteraction,
+} from 'discord.js';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { getSessionManager } from '../dashboard/index.js';
+import { ackWithTimeoutCatch } from '../dashboard/ackWithTimeoutCatch.js';
+import { showModalWithTimeoutCatch } from '../dashboard/showModalWithTimeoutCatch.js';
+import { CATALOG } from '../../ux/catalog/catalog.js';
+import { renderSpec } from '../../ux/render/render.js';
+
+/** One string, three roles: logger name, customId action, session type. */
+const MODAL_RETRY = 'modal-retry';
+
+const logger = createLogger(MODAL_RETRY);
+
+/** Action segment in the retry button's customId. */
+const MODAL_RETRY_ACTION = MODAL_RETRY;
+
+/** Session entity type for retry stashes (message-id keyed). */
+const RETRY_ENTITY_TYPE = MODAL_RETRY;
+
+/** Stash payload: which modal to rebuild, with what prefills. */
+export interface ModalRetryStash {
+  /** Consumer-defined modal kind (e.g. 'seed'). */
+  kind: string;
+  values: Record<string, string>;
+}
+
+/** The "Try again" row attached to a validation-failure reply. */
+export function buildModalRetryRow(commandPrefix: string): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${commandPrefix}::${MODAL_RETRY_ACTION}`)
+      .setLabel('Try again')
+      .setEmoji('🔁')
+      .setStyle(ButtonStyle.Secondary)
+  );
+}
+
+/** Guard for the retry button under a given command prefix. */
+export function isModalRetryInteraction(customId: string, commandPrefix: string): boolean {
+  return customId === `${commandPrefix}::${MODAL_RETRY_ACTION}`;
+}
+
+/**
+ * Stash submitted values against the error reply's message id. Sessions
+ * inherit the dashboard TTL (15 min) — past that, retry degrades to the
+ * session-expired reply.
+ */
+export async function stashModalRetry(options: {
+  userId: string;
+  channelId: string;
+  /** The error reply's message id — the retry button lives on it. */
+  messageId: string;
+  kind: string;
+  values: Record<string, string>;
+}): Promise<void> {
+  await getSessionManager().set<ModalRetryStash>({
+    userId: options.userId,
+    entityType: RETRY_ENTITY_TYPE,
+    entityId: options.messageId,
+    data: { kind: options.kind, values: options.values },
+    messageId: options.messageId,
+    channelId: options.channelId,
+  });
+}
+
+/**
+ * Send a validation-failure reply carrying the Try-again button and stash
+ * the submitted values against that reply — the one-call form consumers
+ * use so the affordance can't be half-wired (button without stash or
+ * vice versa).
+ */
+export async function replyWithModalRetry(
+  interaction: Pick<ModalSubmitInteraction, 'editReply' | 'user' | 'channelId'>,
+  options: {
+    commandPrefix: string;
+    kind: string;
+    content: string;
+    values: Record<string, string>;
+  }
+): Promise<void> {
+  const reply = await interaction.editReply({
+    content: options.content,
+    components: [buildModalRetryRow(options.commandPrefix)],
+  });
+  await stashModalRetry({
+    userId: interaction.user.id,
+    // Metadata only — SessionManager never gates findByMessageId on it,
+    // so the DM/thread null case degrades to '' harmlessly.
+    channelId: interaction.channelId ?? '',
+    messageId: reply.id,
+    kind: options.kind,
+    values: options.values,
+  });
+}
+
+/**
+ * Rebuild the modal for a stashed kind with the stashed prefills. Return
+ * `null` for an unknown kind (stale stash across a deploy that renamed
+ * kinds) — degrades to the session-expired reply.
+ */
+export type ModalRetryRebuilder = (
+  kind: string,
+  values: Record<string, string>
+) => ModalBuilder | null;
+
+/**
+ * Handle a retry-button click: stash lookup by message id, then re-show
+ * the modal prefilled. The lookup is pre-ack async work — the show is
+ * routed through the timeout-catch wrapper per the 04-discord rule.
+ */
+export async function handleModalRetry(
+  interaction: ButtonInteraction,
+  rebuild: ModalRetryRebuilder,
+  retryCommandHint: string
+): Promise<void> {
+  const stash = await getSessionManager().findByMessageId<ModalRetryStash>(interaction.message.id);
+
+  const diag = {
+    source: 'handleModalRetry',
+    userId: interaction.user.id,
+    entityId: interaction.message.id,
+    sectionId: stash?.data.kind ?? 'expired',
+  };
+  const expiredReply = (): Promise<unknown> =>
+    interaction.reply({
+      content: renderSpec(CATALOG.progress.sessionExpired(retryCommandHint)),
+      flags: MessageFlags.Ephemeral,
+    });
+
+  if (stash?.userId !== interaction.user.id) {
+    // Expired (or, on a non-ephemeral surface, someone else's button).
+    // The stash lookup already spent budget — timeout-catch the ack.
+    await ackWithTimeoutCatch(interaction, expiredReply, diag, retryCommandHint);
+    return;
+  }
+
+  const modal = rebuild(stash.data.kind, stash.data.values);
+  if (modal === null) {
+    logger.warn({ kind: stash.data.kind }, 'No rebuilder for stashed modal kind');
+    await ackWithTimeoutCatch(interaction, expiredReply, diag, retryCommandHint);
+    return;
+  }
+
+  await showModalWithTimeoutCatch(interaction, modal, diag, 'Please click Try again once more.');
+}


### PR DESCRIPTION
## What

The modal wave's slice ③ — the D15 preserve-input-on-validation-failure standard:

- **`utils/modal/retry.ts`**: `buildModalRetryRow` (Try-again button on the error reply) · `stashModalRetry` (submitted values in a message-id-keyed dashboard session — the fact-browse precedent; values can be kilobytes so they live in Redis, never the customId, and no token machinery is needed since the button lives on the stash's own message) · `handleModalRetry` (lookup → rebuild prefilled via the toolkit's `initialValues` hook → show).
- **3-second-rule compliance**: the pre-show stash lookup is precisely the async-before-`showModal` case, so the show routes through `showModalWithTimeoutCatch` and the degraded replies (expired stash, wrong user, unknown kind) through `ackWithTimeoutCatch`. Honest note: my first version used bare `interaction.reply` for the error paths and the `component-handler-ack-first` lint rule blocked it — the structural guard working exactly as designed.
- **Consumers**: all five create-modal failure paths (character slug format/length/409, preset name/model/409). Routing branches added in character's `interactionRouting` and preset's button router.
- Wrong-user clicks and stale kinds (stash surviving a deploy that renamed kinds) degrade to the session-expired reply with the re-run hint.

## Scope note

Dashboard *section* edit modals keep their current behavior — their validation failures re-render inside the dashboard flow and their migration is the site-family wave's business.

## Verification

Retry module: 6 tests (button/guard shape, stash payload, prefilled re-show through the wrapper, expired/wrong-user/unknown-kind degradations). Consumer failure-path tests updated to the content+button reply shape. Full `pnpm test` + `pnpm quality` green. **Owner smoke**: `/character create` with an invalid slug (e.g. `Bad Slug!`) → error with Try again → click → modal reopens with all four fields intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)