### PR TITLE
fix(bot-client): post-edit delete-button loss + Close-button removal (owner smoke findings)

### DIFF
--- a/docs/reference/standards/SLASH_COMMAND_UX.md
+++ b/docs/reference/standards/SLASH_COMMAND_UX.md
@@ -125,7 +125,7 @@ Use the Dashboard pattern for **complex entities with multiple editable fields**
 2. Entity created → Dashboard embed appears
    ├── Shows current values with status indicators
    ├── Select menu to choose section to edit
-   └── Action buttons (refresh, close, special actions)
+   └── Action buttons (refresh, special actions — no Close; native dismiss covers ephemerals)
 
 3. User selects section → Section modal opens
    └── Pre-filled with current values (max 5 fields)
@@ -141,7 +141,6 @@ const embed = buildDashboardEmbed(config, entityData);
 
 // Edit menu + action buttons
 const components = buildDashboardComponents(config, entityId, entityData, {
-  showClose: true,
   showRefresh: true,
 });
 

--- a/services/bot-client/src/commands/character/api.test.ts
+++ b/services/bot-client/src/commands/character/api.test.ts
@@ -440,6 +440,21 @@ describe('Character API Client', () => {
       expect(result.shadowedAliases).toEqual([]);
     });
 
+    it('carries the response canEdit through — dropping it hid permission-gated buttons post-edit', async () => {
+      stub.updatePersonality.mockResolvedValue({
+        ok: true,
+        data: {
+          success: true,
+          personality: makePersonality({ slug: 'test-char' }),
+          canEdit: true,
+        },
+      });
+
+      const result = await updateCharacter('test-char', { name: 'X' }, asClient(stub), mockConfig);
+
+      expect(result.character.canEdit).toBe(true);
+    });
+
     it('should throw error on update failure', async () => {
       stub.updatePersonality.mockResolvedValue({
         ok: false,

--- a/services/bot-client/src/commands/character/api.ts
+++ b/services/bot-client/src/commands/character/api.ts
@@ -293,7 +293,7 @@ export async function updateCharacter(
   data: Partial<CharacterData>,
   userClient: UserClient,
   _config: EnvConfig
-): Promise<{ character: CharacterData; shadowedAliases: string[] }> {
+): Promise<{ character: FetchedCharacter; shadowedAliases: string[] }> {
   const result = await userClient.updatePersonality(slug, omitEmptyRequiredText(data));
 
   if (!result.ok) {
@@ -309,7 +309,10 @@ export async function updateCharacter(
   }
 
   return {
-    character: toCharacterData(result.data.personality),
+    // canEdit rides the update response (same schema as GET) — dropping it
+    // made the post-edit dashboard re-render lose its permission-gated
+    // buttons (Delete) until a refresh re-fetched the flag.
+    character: { ...toCharacterData(result.data.personality), canEdit: result.data.canEdit },
     // Present only after a rename that shadows GLOBAL aliases (warn-don't-block).
     shadowedAliases: result.data.shadowedAliases ?? [],
   };

--- a/services/bot-client/src/commands/character/browse.test.ts
+++ b/services/bot-client/src/commands/character/browse.test.ts
@@ -67,7 +67,6 @@ vi.mock('./config.js', () => ({
     sections: [],
   }),
   buildCharacterDashboardOptions: vi.fn().mockReturnValue({
-    showClose: true,
     showBack: false,
     showRefresh: true,
     showDelete: false,

--- a/services/bot-client/src/commands/character/config.ts
+++ b/services/bot-client/src/commands/character/config.ts
@@ -42,9 +42,9 @@ export interface CharacterSessionData extends CharacterData {
 /**
  * Build dashboard action button options based on character state.
  *
- * Controls which dashboard chrome buttons (close, back, refresh, delete)
- * are visible. Close and Back are mutually exclusive: Back appears when
- * the dashboard was opened from a browse list, Close appears otherwise.
+ * Controls which dashboard chrome buttons (back, refresh, delete) are
+ * visible. Back appears when the dashboard was opened from a browse list;
+ * there is no Close (D18 — native dismiss covers ephemeral dashboards).
  *
  * @param data - Current character data (needs canEdit and browseContext)
  * @returns Action button visibility flags for buildDashboardComponents
@@ -52,7 +52,6 @@ export interface CharacterSessionData extends CharacterData {
 export function buildCharacterDashboardOptions(data: CharacterData): ActionButtonOptions {
   const hasBackContext = data.browseContext !== undefined;
   return {
-    showClose: !hasBackContext, // Only show close if not from browse
     showBack: hasBackContext, // Show back if opened from browse
     showRefresh: true,
     showDelete: data.canEdit, // Only show delete for owned characters

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -211,6 +211,7 @@ describe('Character Dashboard', () => {
 
       vi.mocked(api.updateCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'uuid',
           name: 'Test',
           slug: 'test-char',
@@ -245,6 +246,16 @@ describe('Character Dashboard', () => {
       await handleModalSubmit(mockInteraction, mockConfig);
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
+
+      // Regression: the post-edit re-render must keep permission-gated
+      // buttons — the update response's canEdit drives showDelete, and
+      // dropping it hid Delete until a manual refresh re-fetched the flag.
+      expect(dashboardUtils.buildDashboardComponents).toHaveBeenCalledWith(
+        expect.anything(),
+        'test-char',
+        expect.anything(),
+        expect.objectContaining({ showDelete: true })
+      );
     });
 
     it('sends an ephemeral ⚠️ followUp when a rename shadows global aliases', async () => {
@@ -262,6 +273,7 @@ describe('Character Dashboard', () => {
 
       vi.mocked(api.updateCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'uuid',
           name: 'Lila',
           slug: 'test-char',
@@ -369,6 +381,7 @@ describe('Character Dashboard', () => {
 
       vi.mocked(api.updateCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'uuid',
           name: 'Test',
           slug: 'test-char',
@@ -631,6 +644,7 @@ describe('Character Dashboard', () => {
 
       vi.mocked(api.updateCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'uuid',
           name: 'Test',
           slug: 'test-char',

--- a/services/bot-client/src/commands/character/dashboardActions.test.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.test.ts
@@ -323,5 +323,24 @@ describe('Dashboard Actions', () => {
         })
       );
     });
+
+    it('prefers the update response canEdit over a stale session value', async () => {
+      const mockInteraction = createMockInteraction();
+      // Fresh response says the user can no longer edit; the stale session
+      // still claims true — the authoritative response value must win
+      // (`??` falls back only on null/undefined, never on false).
+      const updated = { ...createMockCharacter(), canEdit: false };
+      const mockSession = { data: { canEdit: true } };
+      vi.mocked(dashboardUtils.getSessionManager().get).mockResolvedValue(mockSession as never);
+
+      await refreshDashboardAfterUpdate(mockInteraction, 'test-char', updated);
+
+      expect(dashboardUtils.getSessionManager().update).toHaveBeenCalledWith(
+        'user-123',
+        'character',
+        'test-char',
+        expect.objectContaining({ canEdit: false })
+      );
+    });
   });
 });

--- a/services/bot-client/src/commands/character/dashboardActions.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.ts
@@ -55,7 +55,7 @@ export async function refreshDashboardAfterUpdate(
     ...updated,
     // updateCharacter now carries the server's canEdit; the session value
     // is only a fallback for callers passing a bare CharacterData.
-    canEdit: (updated as { canEdit?: boolean }).canEdit ?? session?.data?.canEdit,
+    canEdit: updated.canEdit ?? session?.data?.canEdit,
     _isAdmin: isAdmin,
     browseContext: session?.data?.browseContext,
   };

--- a/services/bot-client/src/commands/character/dashboardActions.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.ts
@@ -53,7 +53,9 @@ export async function refreshDashboardAfterUpdate(
 
   const sessionData: CharacterSessionData = {
     ...updated,
-    canEdit: session?.data?.canEdit,
+    // updateCharacter now carries the server's canEdit; the session value
+    // is only a fallback for callers passing a bare CharacterData.
+    canEdit: (updated as { canEdit?: boolean }).canEdit ?? session?.data?.canEdit,
     _isAdmin: isAdmin,
     browseContext: session?.data?.browseContext,
   };

--- a/services/bot-client/src/commands/character/edit.test.ts
+++ b/services/bot-client/src/commands/character/edit.test.ts
@@ -147,7 +147,7 @@ describe('Character Edit Handler', () => {
         expect.anything(),
         'my-char',
         mockCharacter,
-        expect.objectContaining({ showClose: true, showRefresh: true })
+        expect.objectContaining({ showRefresh: true })
       );
       expect(mockContext.editReply).toHaveBeenCalledWith({
         embeds: expect.any(Array),

--- a/services/bot-client/src/commands/persona/config.ts
+++ b/services/bot-client/src/commands/persona/config.ts
@@ -191,7 +191,6 @@ export const PERSONA_DASHBOARD_CONFIG: DashboardConfig<FlattenedPersonaData> = {
 export function buildPersonaDashboardOptions(data: FlattenedPersonaData): ActionButtonOptions {
   const hasBackContext = data.browseContext !== undefined;
   return {
-    showClose: !hasBackContext, // Only show close if not from browse
     showBack: hasBackContext, // Show back if opened from browse
     showRefresh: true,
     showDelete: !data.isDefault, // Can't delete default persona

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -55,7 +55,6 @@ vi.mock('./config.js', () => ({
   flattenPresetData: (data: Record<string, unknown>) => ({ ...data, isOwned: data.isOwned }),
   buildPresetDashboardOptions: vi.fn().mockReturnValue({
     showBack: false,
-    showClose: true,
     showRefresh: true,
     showClone: true,
     showDelete: false,

--- a/services/bot-client/src/commands/preset/config.ts
+++ b/services/bot-client/src/commands/preset/config.ts
@@ -240,13 +240,12 @@ export const PRESET_DASHBOARD_CONFIG: DashboardConfig<FlattenedPresetData> = {
 
 /**
  * Build dashboard button options including toggle-global and delete for owned presets.
- * Shows back button when opened from browse, close button when opened directly.
+ * Shows back button when opened from browse; no Close (D18 — native dismiss).
  */
 export function buildPresetDashboardOptions(data: FlattenedPresetData): ActionButtonOptions {
   const hasBrowseContext = data.browseContext !== undefined;
   return {
     showBack: hasBrowseContext,
-    showClose: !hasBrowseContext,
     showRefresh: true,
     showClone: true,
     // Use server-computed canDelete so bot-owner/admin can delete any preset,

--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -310,7 +310,6 @@ describe('Preset Dashboard Buttons', () => {
       const data = createMockFlattenedPreset({ browseContext: undefined });
       const options = buildPresetDashboardOptions(data);
 
-      expect(options.showClose).toBe(true);
       expect(options.showBack).toBe(false);
     });
 
@@ -321,7 +320,6 @@ describe('Preset Dashboard Buttons', () => {
       const options = buildPresetDashboardOptions(data);
 
       expect(options.showBack).toBe(true);
-      expect(options.showClose).toBe(false);
     });
   });
 

--- a/services/bot-client/src/commands/preset/edit.test.ts
+++ b/services/bot-client/src/commands/preset/edit.test.ts
@@ -114,7 +114,6 @@ describe('handleEdit', () => {
       'preset-123',
       expect.objectContaining({ id: 'preset-123', name: 'Test Preset' }),
       expect.objectContaining({
-        showClose: true,
         showRefresh: true,
         showDelete: true, // isOwned is true
         showClone: true,

--- a/services/bot-client/src/commands/settings/defaults/edit.test.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.test.ts
@@ -222,7 +222,7 @@ describe('User Default Settings Dashboard', () => {
       expect(embedJson.footer.text).toContain('Page 1/3 · Memory');
     });
 
-    it('should include select menu and close button', async () => {
+    it('should include select menu and pagination row', async () => {
       const context = createMockContext();
       stub.resolveUserDefaults.mockResolvedValue({ ok: true, data: mockResolveDefaultsResponse });
 

--- a/services/bot-client/src/utils/dashboard/DashboardBuilder.test.ts
+++ b/services/bot-client/src/utils/dashboard/DashboardBuilder.test.ts
@@ -146,15 +146,15 @@ describe('DashboardBuilder', () => {
       expect(button.label).toBe('Refresh');
     });
 
-    it('should add close button when showClose is true', () => {
+    it('never renders a Close button (D18 — native dismiss covers it)', () => {
       const config = createTestConfig();
-      const options: ActionButtonOptions = { showClose: true };
-      const row = buildActionButtons(config, 'entity-123', options);
+      const row = buildActionButtons(config, 'entity-123', {
+        showRefresh: true,
+        showDelete: true,
+      });
 
-      expect(row.components).toHaveLength(1);
-      const button = getButtonData(row, 0);
-      expect(button.custom_id).toBe('test-entity::close::entity-123');
-      expect(button.label).toBe('Close');
+      const labels = row.components.map(component => (component.data as { label?: string }).label);
+      expect(labels).not.toContain('Close');
     });
 
     it('should add delete button when showDelete is true', () => {
@@ -216,20 +216,18 @@ describe('DashboardBuilder', () => {
         expect(button.emoji).toEqual(expect.objectContaining({ name: '🔒' }));
       });
 
-      it('should position toggle button between refresh and close', () => {
+      it('should position toggle button after refresh', () => {
         const config = createTestConfig();
         const options: ActionButtonOptions = {
           showRefresh: true,
-          showClose: true,
           toggleGlobal: { isGlobal: false, isOwned: true },
         };
         const row = buildActionButtons(config, 'entity-123', options);
 
-        // Order should be: Refresh, Toggle, Close
-        expect(row.components).toHaveLength(3);
+        // Order should be: Refresh, Toggle
+        expect(row.components).toHaveLength(2);
         expect(getButtonData(row, 0).label).toBe('Refresh');
         expect(getButtonData(row, 1).label).toBe('Make Global');
-        expect(getButtonData(row, 2).label).toBe('Close');
       });
     });
 
@@ -237,16 +235,14 @@ describe('DashboardBuilder', () => {
       const config = createTestConfig();
       const options: ActionButtonOptions = {
         showRefresh: true,
-        showClose: true,
         showDelete: true,
       };
       const row = buildActionButtons(config, 'entity-123', options);
 
-      // Order: Refresh, Close, Delete
-      expect(row.components).toHaveLength(3);
+      // Order: Refresh, Delete (destructive last).
+      expect(row.components).toHaveLength(2);
       expect(getButtonData(row, 0).label).toBe('Refresh');
-      expect(getButtonData(row, 1).label).toBe('Close');
-      expect(getButtonData(row, 2).label).toBe('Delete');
+      expect(getButtonData(row, 1).label).toBe('Delete');
     });
   });
 
@@ -260,7 +256,7 @@ describe('DashboardBuilder', () => {
 
     it('should return menu and button rows when options provided', () => {
       const config = createTestConfig();
-      const options: ActionButtonOptions = { showClose: true };
+      const options: ActionButtonOptions = { showRefresh: true };
       const components = buildDashboardComponents(config, 'entity-123', testEntity, options);
 
       expect(components).toHaveLength(2);

--- a/services/bot-client/src/utils/dashboard/DashboardBuilder.ts
+++ b/services/bot-client/src/utils/dashboard/DashboardBuilder.ts
@@ -134,7 +134,6 @@ export function buildEditMenu<T>(
  */
 export interface ActionButtonOptions {
   showDelete?: boolean;
-  showClose?: boolean;
   showRefresh?: boolean;
   showClone?: boolean;
   /** Show "Back to Browse" button instead of close (when opened from browse) */
@@ -201,15 +200,10 @@ export function buildActionButtons<T>(
     );
   }
 
-  if (options?.showClose === true) {
-    row.addComponents(
-      new ButtonBuilder()
-        .setCustomId(buildDashboardCustomId(config.entityType, 'close', entityId))
-        .setLabel('Close')
-        .setStyle(ButtonStyle.Secondary)
-        .setEmoji('✖️')
-    );
-  }
+  // No Close button (D18): ephemeral dashboards need no explicit Close —
+  // Discord's native dismiss covers it and the session TTL handles
+  // teardown. The 'close' ACTION stays routable for messages rendered
+  // before the removal.
 
   if (options?.showDelete === true) {
     row.addComponents(
@@ -241,7 +235,6 @@ export function buildDashboardComponents<T>(
   // Add action buttons if any options are enabled
   const hasButtonOptions =
     options?.showDelete === true ||
-    options?.showClose === true ||
     options?.showRefresh === true ||
     options?.showBack === true ||
     options?.showClone === true ||

--- a/services/bot-client/src/utils/dashboard/refreshHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/refreshHandler.test.ts
@@ -164,7 +164,7 @@ describe('refreshHandler', () => {
     it('should use buildOptions when provided', async () => {
       const data = { name: 'Test' };
       const fetchFn = vi.fn().mockResolvedValue(data);
-      const buildOptions = vi.fn().mockReturnValue({ showClose: true, showRefresh: true });
+      const buildOptions = vi.fn().mockReturnValue({ showDelete: true, showRefresh: true });
 
       const handler = createRefreshHandler({
         entityType: 'preset',
@@ -188,7 +188,7 @@ describe('refreshHandler', () => {
         mockConfig,
         'entity-abc',
         data,
-        { showClose: true, showRefresh: true }
+        { showDelete: true, showRefresh: true }
       );
     });
 

--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.test.ts
@@ -485,7 +485,7 @@ describe('SettingsDashboardBuilder', () => {
       const message = buildOverviewMessage(config, session);
 
       expect(message.embeds).toHaveLength(1);
-      expect(message.components).toHaveLength(2); // select menu + close button
+      expect(message.components).toHaveLength(1); // select menu only (no Close — D18)
     });
   });
 
@@ -682,20 +682,16 @@ describe('SettingsDashboardBuilder', () => {
       expect(lastButtons[2].disabled).toBe(true); // last page → Next disabled
     });
 
-    it('overview message swaps Close for the pagination row on paged configs only', () => {
+    it('overview renders pagination on paged configs and NO second row on flat (D18)', () => {
       const paged = buildOverviewMessage(pagedConfig(), pagedSession(0));
       const secondRow = paged.components[1].toJSON();
       const labels = (secondRow.components as APIButtonComponentWithCustomId[]).map(b => b.label);
       expect(labels).toContain('Prev');
       expect(labels).not.toContain('Close');
 
-      // Flat config keeps today's Close button.
+      // Flat config: select menu only — native dismiss replaces Close.
       const flat = buildOverviewMessage(createTestConfig(), createTestSession());
-      const flatSecond = flat.components[1].toJSON();
-      const flatLabels = (flatSecond.components as APIButtonComponentWithCustomId[]).map(
-        b => b.label
-      );
-      expect(flatLabels).toEqual(['Close']);
+      expect(flat.components).toHaveLength(1);
     });
 
     it('select menu scopes to the current page', () => {

--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.ts
@@ -30,7 +30,6 @@ import {
   buildEnumButtons,
   buildEditButtons,
   buildBackButton,
-  buildCloseButton,
   buildBooleanButtons,
   buildPaginationRow,
 } from './settingsButtonBuilders.js';
@@ -321,17 +320,17 @@ export function buildOverviewMessage(
   const embed = buildOverviewEmbed(config, session);
   const selectMenu = buildSettingsSelectMenu(config, session);
 
-  // Paged dashboards: the pagination row replaces Close (D18 — ephemeral
-  // dashboards need no explicit Close; native dismiss suffices, and the Redis
-  // session TTL handles teardown). Flat dashboards keep today's Close button.
-  const secondRow =
-    config.pages !== undefined && config.pages.length > 0
-      ? buildPaginationRow(config, session)
-      : buildCloseButton(config, session);
+  // No Close row (D18 complete): ephemeral dashboards need no explicit
+  // Close — native dismiss suffices and the Redis session TTL handles
+  // teardown. The 'close' action stays routable for pre-removal messages.
+  const components: ActionRowBuilder<MessageActionRowComponentBuilder>[] = [selectMenu];
+  if (config.pages !== undefined && config.pages.length > 0) {
+    components.push(buildPaginationRow(config, session));
+  }
 
   return {
     embeds: [embed],
-    components: [selectMenu, secondRow],
+    components,
   };
 }
 

--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.test.ts
@@ -277,7 +277,7 @@ describe('SettingsDashboardHandler', () => {
       expect(embedJson.title).toBe('Test Settings');
     });
 
-    it('should include select menu and close button', async () => {
+    it('should include the select menu only (no Close — D18)', async () => {
       const config = createTestConfig();
       const data = createTestData();
       const interaction = createMockInteraction();
@@ -291,7 +291,7 @@ describe('SettingsDashboardHandler', () => {
       });
 
       const editReplyCall = interaction.editReply.mock.calls[0][0];
-      expect(editReplyCall.components).toHaveLength(2);
+      expect(editReplyCall.components).toHaveLength(1);
     });
   });
 

--- a/services/bot-client/src/utils/dashboard/settings/settingsButtonBuilders.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsButtonBuilders.test.ts
@@ -11,7 +11,6 @@ import {
   buildEnumButtons,
   buildEditButtons,
   buildBackButton,
-  buildCloseButton,
 } from './settingsButtonBuilders.js';
 import {
   type SettingDefinition,
@@ -439,20 +438,6 @@ describe('settingsButtonBuilders', () => {
       expect(buttons).toHaveLength(1);
       expect(buttons[0].label).toBe('Back to Overview');
       expect(buttons[0].custom_id).toBe('test-settings::back::test-entity');
-    });
-  });
-
-  describe('buildCloseButton', () => {
-    it('should create close button with correct custom ID', () => {
-      const config = createTestConfig();
-      const session = createTestSession();
-
-      const row = buildCloseButton(config, session);
-      const buttons = getButtons(row);
-
-      expect(buttons).toHaveLength(1);
-      expect(buttons[0].label).toBe('Close');
-      expect(buttons[0].custom_id).toBe('test-settings::close::test-entity');
     });
   });
 });

--- a/services/bot-client/src/utils/dashboard/settings/settingsButtonBuilders.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsButtonBuilders.ts
@@ -1,6 +1,6 @@
 /**
  * Settings dashboard button-row builders — the per-setting-type control rows
- * (tri-state / boolean / enum / edit) and the navigation rows (back / close /
+ * (tri-state / boolean / enum / edit) and the navigation rows (back /
  * pagination). Extracted from SettingsDashboardBuilder to keep it within the
  * max-lines budget; the Builder's message assemblers compose these.
  */
@@ -284,26 +284,6 @@ export function buildBackButton(
       .setCustomId(buildSettingsCustomId(config.entityType, 'back', session.entityId))
       .setLabel('Back to Overview')
       .setEmoji('⬅️')
-      .setStyle(ButtonStyle.Secondary)
-  );
-
-  return row;
-}
-
-/**
- * Build close button row for overview
- */
-export function buildCloseButton(
-  config: SettingsDashboardConfig,
-  session: SettingsDashboardSession
-): ActionRowBuilder<MessageActionRowComponentBuilder> {
-  const row = new ActionRowBuilder<MessageActionRowComponentBuilder>();
-
-  row.addComponents(
-    new ButtonBuilder()
-      .setCustomId(buildSettingsCustomId(config.entityType, 'close', session.entityId))
-      .setLabel('Close')
-      .setEmoji('✖️')
       .setStyle(ButtonStyle.Secondary)
   );
 


### PR DESCRIPTION
## What

Both findings from the owner's dev smoke, as two commits:

**1. `fix`: delete button vanished after editing a character** (refresh brought it back). Root cause: `fetchCharacter` attaches the server's `canEdit` flag but `updateCharacter` discarded it — even though the update response uses the same schema and always carries it. The post-edit re-render computed `showDelete` from `undefined`, and worse, wrote the canEdit-less data back into the shared session, defeating `dashboardActions`' session-fallback workaround for every subsequent toggle. Fix at the source: `updateCharacter` returns `FetchedCharacter` (canEdit included), which heals every consumer at once; the actions path now prefers the authoritative response value. Seam pinned: the post-edit `buildDashboardComponents` call must receive `showDelete: true`.

**2. `feat`: Close buttons removed everywhere** (owner call — they duplicate Discord's native dismiss on ephemeral messages). This completes D18 ahead of PR-7's schedule:
- `ActionButtonOptions.showClose` + its button deleted from the generic dashboard builder; the three entity configs (character/persona/preset) stop requesting it.
- The flat settings overview loses its Close-only second row (select menu only now); paged overviews keep their pagination row; `buildCloseButton` deleted with its only consumer.
- **The `close` action stays routable everywhere** — messages rendered before this change keep working; only the rendering is gone.

## Verification

- Regression tests: `updateCharacter` canEdit carry (api.test), post-edit `showDelete: true` seam (dashboard.test), never-renders-Close pin (DashboardBuilder.test), flat-overview single-row pin (SettingsDashboardBuilder.test).
- Full `pnpm test` (5,719 bot-client among 26 packages) + `pnpm quality` green.
- **Owner smoke post-merge**: edit a character section → Delete stays put; dashboards show no Close anywhere; an OLD message's Close button (pre-deploy) still dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)