### PR TITLE
feat(bot-client): shared entity detail-card builder + 6-site retrofit (PR-6)

### DIFF
--- a/services/bot-client/src/commands/deny/detailTypes.ts
+++ b/services/bot-client/src/commands/deny/detailTypes.ts
@@ -5,7 +5,7 @@
  * detail.ts (main handlers) and detailEdit.ts (edit handlers).
  */
 
-import { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
+import { ButtonBuilder, ButtonStyle, ActionRowBuilder, type EmbedBuilder } from 'discord.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import {
   type DenylistEntityType,
@@ -13,6 +13,7 @@ import {
   type DenylistMode,
 } from '@tzurot/common-types/schemas/api/denylist';
 import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
+import { buildEntityDetailCard } from '../../utils/detailCard.js';
 import type { BrowseContext } from '../../utils/dashboard/types.js';
 import type { DenylistEntryResponse } from './browseTypes.js';
 
@@ -60,27 +61,23 @@ export function buildDetailEmbed(
   const modeIcon = entry.mode === 'BLOCK' ? '\u{1F6AB}' : '\u{1F507}';
   const scopeInfo = entry.scope === 'BOT' ? 'Bot-wide' : `${entry.scope}: \`${entry.scopeId}\``;
 
-  const fields = [
-    { name: 'Target', value: target, inline: true },
-    { name: 'Type', value: entry.type, inline: true },
-    { name: '\u200B', value: '\u200B', inline: true },
-    { name: 'Mode', value: `${modeIcon} ${entry.mode}`, inline: true },
-    { name: 'Scope', value: scopeInfo, inline: true },
-    { name: '\u200B', value: '\u200B', inline: true },
-  ];
-
-  if (entry.reason !== null) {
-    fields.push({ name: 'Reason', value: entry.reason, inline: false });
-  }
-
-  return new EmbedBuilder()
-    .setTitle(`${modeIcon} Denylist Entry`)
-    .setColor(entry.mode === 'BLOCK' ? DISCORD_COLORS.ERROR : DISCORD_COLORS.WARNING)
-    .addFields(fields)
-    .setFooter({
-      text: `Added ${formatDateShort(entry.addedAt)} \u2022 ID: ${entry.id}`,
-    })
-    .setTimestamp();
+  return buildEntityDetailCard({
+    title: `${modeIcon} Denylist Entry`,
+    color: entry.mode === 'BLOCK' ? DISCORD_COLORS.ERROR : DISCORD_COLORS.WARNING,
+    // Spacers close each row at 2 cells so Target/Type and Mode/Scope align
+    // vertically in Discord's 3-column field grid.
+    fields: [
+      { name: 'Target', value: target, inline: true },
+      { name: 'Type', value: entry.type, inline: true },
+      'spacer',
+      { name: 'Mode', value: `${modeIcon} ${entry.mode}`, inline: true },
+      { name: 'Scope', value: scopeInfo, inline: true },
+      'spacer',
+      entry.reason !== null && { name: 'Reason', value: entry.reason, inline: false },
+    ],
+    footer: `Added ${formatDateShort(entry.addedAt)} \u2022 ID: ${entry.id}`,
+    timestamp: true,
+  }).embed;
 }
 
 /** Build action buttons for the detail view */

--- a/services/bot-client/src/commands/memory/detail.ts
+++ b/services/bot-client/src/commands/memory/detail.ts
@@ -20,6 +20,7 @@ import { type MemoryItem } from '@tzurot/common-types/schemas/api/memory';
 import { formatDateTimeCompact } from '@tzurot/common-types/utils/dateFormatting';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
+import { buildEntityDetailCard } from '../../utils/detailCard.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
@@ -93,37 +94,26 @@ export function buildDetailEmbed(memory: MemoryItem): {
   embed: EmbedBuilder;
   isTruncated: boolean;
 } {
-  const escapedContent = escapeMarkdown(memory.content);
-  const isTruncated = escapedContent.length > EMBED_DESCRIPTION_SAFE_LIMIT;
+  const { embed, descriptionTruncated } = buildEntityDetailCard({
+    title: `${memory.isLocked ? '🔒 ' : ''}Memory Details`,
+    color: memory.isLocked ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE,
+    description: escapeMarkdown(memory.content),
+    descriptionCap: EMBED_DESCRIPTION_SAFE_LIMIT,
+    truncationNotice: '\n\n*... Content truncated. Click "📄 View Full" to see complete memory.*',
+    fields: [
+      { name: 'Personality', value: escapeMarkdown(memory.personalityName), inline: true },
+      { name: 'Status', value: memory.isLocked ? '🔒 Locked' : '🔓 Unlocked', inline: true },
+      { name: 'Created', value: formatDateTimeCompact(memory.createdAt), inline: true },
+      memory.updatedAt !== memory.createdAt && {
+        name: 'Updated',
+        value: formatDateTimeCompact(memory.updatedAt),
+        inline: true,
+      },
+    ],
+    footer: `Memory ID: ${memory.id.substring(0, 8)}...`,
+  });
 
-  // Truncate if needed, indicating there's more content
-  const displayContent = isTruncated
-    ? escapedContent.substring(0, EMBED_DESCRIPTION_SAFE_LIMIT - 50) +
-      '\n\n*... Content truncated. Click "📄 View Full" to see complete memory.*'
-    : escapedContent;
-
-  const embed = new EmbedBuilder()
-    .setTitle(`${memory.isLocked ? '🔒 ' : ''}Memory Details`)
-    .setColor(memory.isLocked ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE)
-    .setDescription(displayContent);
-
-  embed.addFields(
-    { name: 'Personality', value: escapeMarkdown(memory.personalityName), inline: true },
-    { name: 'Status', value: memory.isLocked ? '🔒 Locked' : '🔓 Unlocked', inline: true },
-    { name: 'Created', value: formatDateTimeCompact(memory.createdAt), inline: true }
-  );
-
-  if (memory.updatedAt !== memory.createdAt) {
-    embed.addFields({
-      name: 'Updated',
-      value: formatDateTimeCompact(memory.updatedAt),
-      inline: true,
-    });
-  }
-
-  embed.setFooter({ text: `Memory ID: ${memory.id.substring(0, 8)}...` });
-
-  return { embed, isTruncated };
+  return { embed, isTruncated: descriptionTruncated };
 }
 
 /**

--- a/services/bot-client/src/commands/memory/factsDetail.test.ts
+++ b/services/bot-client/src/commands/memory/factsDetail.test.ts
@@ -119,6 +119,16 @@ describe('buildFactDetailEmbed', () => {
     expect(corrected.title).toContain('🔒');
     expect(corrected.fields?.find(f => f.name === 'Origin')?.value).toContain('Corrected');
   });
+
+  it('includes Sources only when the fact has source memories', () => {
+    const withSources = buildFactDetailEmbed(createMockFact()).toJSON();
+    expect(withSources.fields?.find(f => f.name === 'Sources')?.value).toBe(
+      '1 conversation memory'
+    );
+
+    const withoutSources = buildFactDetailEmbed(createMockFact({ sourceMemoryIds: [] })).toJSON();
+    expect(withoutSources.fields?.map(f => f.name)).toEqual(['Origin', 'Status', 'Learned']);
+  });
 });
 
 describe('buildFactDetailButtons', () => {

--- a/services/bot-client/src/commands/memory/factsDetail.ts
+++ b/services/bot-client/src/commands/memory/factsDetail.ts
@@ -25,6 +25,7 @@ import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { formatDateTimeCompact } from '@tzurot/common-types/utils/dateFormatting';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
+import { buildEntityDetailCard } from '../../utils/detailCard.js';
 import { buildToolkitModal } from '../../utils/modal/toolkit.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
@@ -80,27 +81,22 @@ export function parseFactActionId(
 
 /** Build the detail embed for a single fact. */
 export function buildFactDetailEmbed(fact: FactItem): EmbedBuilder {
-  const embed = new EmbedBuilder()
-    .setTitle(`${fact.isLocked ? '🔒 ' : ''}Fact Details`)
-    .setColor(fact.isLocked ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE)
-    .setDescription(escapeMarkdown(fact.statement));
-
-  embed.addFields(
-    { name: 'Origin', value: TIER_LABELS[fact.tier] ?? fact.tier, inline: true },
-    { name: 'Status', value: fact.isLocked ? '🔒 Locked' : '🔓 Unlocked', inline: true },
-    { name: 'Learned', value: formatDateTimeCompact(fact.validFrom), inline: true }
-  );
-
-  if (fact.sourceMemoryIds.length > 0) {
-    embed.addFields({
-      name: 'Sources',
-      value: `${fact.sourceMemoryIds.length} conversation ${fact.sourceMemoryIds.length === 1 ? 'memory' : 'memories'}`,
-      inline: true,
-    });
-  }
-
-  embed.setFooter({ text: `Fact ID: ${fact.id.substring(0, 8)}...` });
-  return embed;
+  return buildEntityDetailCard({
+    title: `${fact.isLocked ? '🔒 ' : ''}Fact Details`,
+    color: fact.isLocked ? DISCORD_COLORS.WARNING : DISCORD_COLORS.BLURPLE,
+    description: escapeMarkdown(fact.statement),
+    fields: [
+      { name: 'Origin', value: TIER_LABELS[fact.tier] ?? fact.tier, inline: true },
+      { name: 'Status', value: fact.isLocked ? '🔒 Locked' : '🔓 Unlocked', inline: true },
+      { name: 'Learned', value: formatDateTimeCompact(fact.validFrom), inline: true },
+      fact.sourceMemoryIds.length > 0 && {
+        name: 'Sources',
+        value: `${fact.sourceMemoryIds.length} conversation ${fact.sourceMemoryIds.length === 1 ? 'memory' : 'memories'}`,
+        inline: true,
+      },
+    ],
+    footer: `Fact ID: ${fact.id.substring(0, 8)}...`,
+  }).embed;
 }
 
 /**

--- a/services/bot-client/src/commands/persona/view.test.ts
+++ b/services/bot-client/src/commands/persona/view.test.ts
@@ -166,6 +166,13 @@ describe('handleViewPersona', () => {
     const call = mockEditReply.mock.calls[0][0];
     // Should have components (expand button)
     expect(call.components).toHaveLength(1);
+
+    // The content field renders the truncated preview, not the full text
+    const contentField = call.embeds[0]
+      .toJSON()
+      .fields?.find((f: { name: string }) => f.name.includes('Content'));
+    expect(contentField?.value.endsWith('...')).toBe(true);
+    expect(contentField?.value.length).toBeLessThan(1500);
   });
 
   it('should handle error when fetching details fails', async () => {

--- a/services/bot-client/src/commands/persona/view.ts
+++ b/services/bot-client/src/commands/persona/view.ts
@@ -12,17 +12,17 @@
 
 import {
   MessageFlags,
-  EmbedBuilder,
   ButtonBuilder,
   ButtonStyle,
   ActionRowBuilder,
+  type EmbedBuilder,
   type MessageActionRowComponentBuilder,
   type ButtonInteraction,
 } from 'discord.js';
-import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
+import { buildEntityDetailCard } from '../../utils/detailCard.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
 import { replyError } from '../../utils/dashboard/replyError.js';
@@ -60,53 +60,51 @@ function buildPersonaEmbed(personaDetails: PersonaDetails): {
   embed: EmbedBuilder;
   components: ActionRowBuilder<MessageActionRowComponentBuilder>[];
 } {
-  const embed = new EmbedBuilder()
-    .setTitle('🎭 Your Persona')
-    .setColor(DISCORD_COLORS.BLURPLE)
-    .setTimestamp();
-
-  if (personaDetails.preferredName !== null && personaDetails.preferredName.length > 0) {
-    embed.addFields({
-      name: '📛 Preferred Name',
-      value: personaDetails.preferredName,
-      inline: true,
-    });
-  }
-
-  if (personaDetails.pronouns !== null && personaDetails.pronouns.length > 0) {
-    embed.addFields({ name: '🏷️ Pronouns', value: personaDetails.pronouns, inline: true });
-  }
-
-  const components: ActionRowBuilder<MessageActionRowComponentBuilder>[] = [];
+  // Content is a FIELD (not the description), so its preview truncation and
+  // the coupled expand button stay caller-owned; the shared card handles the
+  // scaffold + conditional fields.
   const contentText = personaDetails.content;
   const hasContent = contentText !== null && contentText.length > 0;
   const isTruncated = hasContent && contentText.length > CONTENT_PREVIEW_LENGTH;
-
-  if (hasContent && contentText !== null) {
-    const content = isTruncated
+  const contentValue = hasContent
+    ? isTruncated
       ? contentText.substring(0, CONTENT_PREVIEW_LENGTH) + '...'
-      : contentText;
-    embed.addFields({ name: CONTENT_FIELD_NAME, value: content, inline: false });
+      : contentText
+    : '*No content set. Use `/persona edit` to add information about yourself.*';
 
-    if (isTruncated) {
-      const expandButton = new ButtonBuilder()
-        .setCustomId(PersonaCustomIds.expand(personaDetails.id, 'content'))
-        .setLabel('Show Full Content')
-        .setStyle(ButtonStyle.Secondary)
-        .setEmoji('📖');
-      components.push(
-        new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(expandButton)
-      );
-    }
-  } else {
-    embed.addFields({
-      name: CONTENT_FIELD_NAME,
-      value: '*No content set. Use `/persona edit` to add information about yourself.*',
-      inline: false,
-    });
+  const { embed } = buildEntityDetailCard({
+    title: '🎭 Your Persona',
+    fields: [
+      personaDetails.preferredName !== null &&
+        personaDetails.preferredName.length > 0 && {
+          name: '📛 Preferred Name',
+          value: personaDetails.preferredName,
+          inline: true,
+        },
+      personaDetails.pronouns !== null &&
+        personaDetails.pronouns.length > 0 && {
+          name: '🏷️ Pronouns',
+          value: personaDetails.pronouns,
+          inline: true,
+        },
+      { name: CONTENT_FIELD_NAME, value: contentValue },
+    ],
+    footer: 'Use /persona edit to update • /settings to change options',
+    timestamp: true,
+  });
+
+  const components: ActionRowBuilder<MessageActionRowComponentBuilder>[] = [];
+  if (isTruncated) {
+    const expandButton = new ButtonBuilder()
+      .setCustomId(PersonaCustomIds.expand(personaDetails.id, 'content'))
+      .setLabel('Show Full Content')
+      .setStyle(ButtonStyle.Secondary)
+      .setEmoji('📖');
+    components.push(
+      new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(expandButton)
+    );
   }
 
-  embed.setFooter({ text: 'Use /persona edit to update • /settings to change options' });
   return { embed, components };
 }
 

--- a/services/bot-client/src/commands/shapes/detail.ts
+++ b/services/bot-client/src/commands/shapes/detail.ts
@@ -6,10 +6,10 @@
  * to stay within Discord's 100-char custom ID limit.
  */
 
-import { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
-import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { ButtonBuilder, ButtonStyle, ActionRowBuilder, type EmbedBuilder } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type UserClient } from '@tzurot/clients';
+import { buildEntityDetailCard } from '../../utils/detailCard.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 import type { BrowseSortType } from '../../utils/browse/constants.js';
 import {
@@ -130,16 +130,17 @@ export async function buildShapeDetailEmbed(
       ? formatCompactExportStatus(jobStatus.latestExport)
       : 'No exports yet';
 
-  const embed = new EmbedBuilder()
-    .setColor(DISCORD_COLORS.BLURPLE)
-    .setTitle(`\uD83D\uDD17 ${slug}`)
-    .setDescription(
+  const { embed } = buildEntityDetailCard({
+    title: `\uD83D\uDD17 ${slug}`,
+    description:
       `\uD83D\uDCE5 **Import**: ${importLine}\n` +
-        `\uD83D\uDCE4 **Export**: ${exportLine}\n\n` +
-        'Select an action below, or refresh to check job progress.'
-    )
-    .setFooter({ text: `slug:${slug}|sort:${sort}` })
-    .setTimestamp();
+      `\uD83D\uDCE4 **Export**: ${exportLine}\n\n` +
+      'Select an action below, or refresh to check job progress.',
+    // Machine-readable navigation state, not display text \u2014 the slug rides
+    // here to stay within Discord's 100-char customId limit.
+    footer: `slug:${slug}|sort:${sort}`,
+    timestamp: true,
+  });
 
   return { embed, components: buildDetailButtons() };
 }

--- a/services/bot-client/src/commands/voice/view.test.ts
+++ b/services/bot-client/src/commands/voice/view.test.ts
@@ -170,6 +170,31 @@ describe('handleVoiceView', () => {
     });
   });
 
+  it('reports an unexpected exception through the classifier', async () => {
+    stub.getVoiceResolution.mockRejectedValue(new Error('boom'));
+    const context = makeContext();
+
+    await handleVoiceView(context as never);
+
+    expect(context.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('voice settings'),
+    });
+  });
+
+  it('renders read-transient copy, never write-uncertainty, on a network-kind failure', async () => {
+    // This handler only READS — omitting operation:'read' would make a
+    // network failure claim "your change may still be applying" for a
+    // change that was never submitted.
+    stub.getVoiceResolution.mockResolvedValue(makeErr(0, 'connection lost'));
+    const context = makeContext();
+
+    await handleVoiceView(context as never);
+
+    const { content } = vi.mocked(context.editReply).mock.calls[0][0] as { content: string };
+    expect(content).toContain("Couldn't load the voice settings");
+    expect(content).not.toContain('may still');
+  });
+
   it('refuses the autocomplete error sentinel without calling the gateway', async () => {
     const apiCheck = await import('../../utils/apiCheck.js');
     vi.mocked(apiCheck.isAutocompleteErrorSentinel).mockReturnValueOnce(true);

--- a/services/bot-client/src/commands/voice/view.ts
+++ b/services/bot-client/src/commands/voice/view.ts
@@ -13,8 +13,7 @@
  * tied to the picked character.
  */
 
-import { EmbedBuilder, escapeMarkdown } from 'discord.js';
-import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { escapeMarkdown } from 'discord.js';
 import { voiceViewOptions } from '@tzurot/common-types/generated/commandOptions';
 import { type TtsResolutionSource } from '@tzurot/common-types/schemas/api/voice-resolution';
 import {
@@ -28,7 +27,10 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
+import { buildEntityDetailCard } from '../../utils/detailCard.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
+import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
+import { renderSpec } from '../../ux/render/render.js';
 
 const logger = createLogger('voice-view');
 
@@ -89,7 +91,14 @@ export async function handleVoiceView(context: DeferredCommandContext): Promise<
 
     if (!result.ok) {
       logger.warn({ userId, personalityId, status: result.status }, 'Failed to resolve voice view');
-      await context.editReply({ content: `❌ Failed to fetch voice settings: ${result.error}` });
+      await context.editReply({
+        content: renderSpec(
+          classifyGatewayFailure(result, 'voice settings', {
+            operation: 'read',
+            failedAction: 'fetch voice settings',
+          })
+        ),
+      });
       return;
     }
 
@@ -105,14 +114,14 @@ export async function handleVoiceView(context: DeferredCommandContext): Promise<
       : stt.provider;
     const sttLine = `**${sttProviderLabel}** _(${sttSourceLabel(stt.source)})_`;
 
-    const embed = new EmbedBuilder()
-      .setTitle(`🎙️ Voice Settings for ${escapeMarkdown(personalityName)}`)
-      .setColor(DISCORD_COLORS.BLURPLE)
-      .addFields(
-        { name: '🔊 TTS (speaks as character)', value: ttsLine, inline: false },
-        { name: '🎤 STT (transcribes your voice)', value: sttLine, inline: false }
-      )
-      .setTimestamp();
+    const { embed } = buildEntityDetailCard({
+      title: `🎙️ Voice Settings for ${escapeMarkdown(personalityName)}`,
+      fields: [
+        { name: '🔊 TTS (speaks as character)', value: ttsLine },
+        { name: '🎤 STT (transcribes your voice)', value: sttLine },
+      ],
+      timestamp: true,
+    });
 
     await context.editReply({ embeds: [embed] });
 
@@ -129,6 +138,13 @@ export async function handleVoiceView(context: DeferredCommandContext): Promise<
     );
   } catch (error) {
     logger.error({ err: error, userId, command: 'Voice View' }, 'Error');
-    await context.editReply({ content: '❌ An error occurred. Please try again later.' });
+    await context.editReply({
+      content: renderSpec(
+        classifyGatewayFailure(error, 'voice settings', {
+          operation: 'read',
+          failedAction: 'fetch voice settings',
+        })
+      ),
+    });
   }
 }

--- a/services/bot-client/src/utils/detailCard.test.ts
+++ b/services/bot-client/src/utils/detailCard.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the entity detail-card scaffold (G5).
+ *
+ * Assertions run over `toJSON()` so discord.js's own component validation
+ * participates in every case.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { buildEntityDetailCard } from './detailCard.js';
+
+interface EmbedJson {
+  title?: string;
+  color?: number;
+  description?: string;
+  fields?: { name: string; value: string; inline?: boolean }[];
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+function toJson(card: ReturnType<typeof buildEntityDetailCard>): EmbedJson {
+  return card.embed.toJSON() as EmbedJson;
+}
+
+describe('buildEntityDetailCard', () => {
+  it('applies defaults: BLURPLE, no footer, no timestamp, no description', () => {
+    const card = buildEntityDetailCard({ title: '📄 Thing Details' });
+    const json = toJson(card);
+
+    expect(json.title).toBe('📄 Thing Details');
+    expect(json.color).toBe(DISCORD_COLORS.BLURPLE);
+    expect(json.description).toBeUndefined();
+    expect(json.fields).toBeUndefined();
+    expect(json.footer).toBeUndefined();
+    expect(json.timestamp).toBeUndefined();
+    expect(card.descriptionTruncated).toBe(false);
+  });
+
+  it('carries state-derived color, footer, and timestamp through', () => {
+    const json = toJson(
+      buildEntityDetailCard({
+        title: '🔒 Thing Details',
+        color: DISCORD_COLORS.WARNING,
+        footer: 'Thing ID: abc12345...',
+        timestamp: true,
+      })
+    );
+
+    expect(json.color).toBe(DISCORD_COLORS.WARNING);
+    expect(json.footer?.text).toBe('Thing ID: abc12345...');
+    expect(json.timestamp).toBeDefined();
+  });
+
+  it('skips null/undefined/false field slots (conditional-field idiom)', () => {
+    const json = toJson(
+      buildEntityDetailCard({
+        title: 'T',
+        fields: [
+          { name: 'Always', value: 'yes', inline: true },
+          null,
+          undefined,
+          false,
+          { name: 'Also', value: 'yes' },
+        ],
+      })
+    );
+
+    expect(json.fields?.map(f => f.name)).toEqual(['Always', 'Also']);
+    // inline defaults to false when omitted
+    expect(json.fields?.[1].inline).toBe(false);
+  });
+
+  it("expands 'spacer' slots into invisible inline grid cells", () => {
+    const json = toJson(
+      buildEntityDetailCard({
+        title: 'T',
+        fields: [
+          { name: 'A', value: '1', inline: true },
+          { name: 'B', value: '2', inline: true },
+          'spacer',
+          { name: 'C', value: '3', inline: true },
+        ],
+      })
+    );
+
+    expect(json.fields?.[2]).toEqual({ name: '\u200B', value: '\u200B', inline: true });
+    expect(json.fields).toHaveLength(4);
+  });
+
+  it('leaves an under-cap description untouched', () => {
+    const card = buildEntityDetailCard({
+      title: 'T',
+      description: 'short content',
+      descriptionCap: 100,
+      truncationNotice: '\n\n*truncated*',
+    });
+
+    expect(toJson(card).description).toBe('short content');
+    expect(card.descriptionTruncated).toBe(false);
+  });
+
+  it('cuts an over-cap description to fit the notice and flips the flag', () => {
+    const card = buildEntityDetailCard({
+      title: 'T',
+      description: 'x'.repeat(120),
+      descriptionCap: 100,
+      truncationNotice: '\n\n*truncated*',
+    });
+    const description = toJson(card).description ?? '';
+
+    expect(card.descriptionTruncated).toBe(true);
+    expect(description.endsWith('\n\n*truncated*')).toBe(true);
+    // cut + notice together stay within the cap
+    expect([...description].length).toBeLessThanOrEqual(100);
+  });
+
+  it('truncates by code point so an astral char at the boundary never splits', () => {
+    const notice = '…';
+    const card = buildEntityDetailCard({
+      title: 'T',
+      description: '🎭'.repeat(60), // 60 code points, 120 UTF-16 units
+      descriptionCap: 50,
+      truncationNotice: notice,
+    });
+    const description = toJson(card).description ?? '';
+
+    expect(card.descriptionTruncated).toBe(true);
+    // No lone surrogate: every remaining char is the full emoji or the notice
+    expect([...description.slice(0, -notice.length)].every(c => c === '🎭')).toBe(true);
+    expect([...description].length).toBe(50);
+  });
+
+  it('treats an empty description as absent', () => {
+    const json = toJson(buildEntityDetailCard({ title: 'T', description: '' }));
+    expect(json.description).toBeUndefined();
+  });
+});

--- a/services/bot-client/src/utils/detailCard.ts
+++ b/services/bot-client/src/utils/detailCard.ts
@@ -1,0 +1,127 @@
+/**
+ * Entity detail-card scaffold (design-system G5).
+ *
+ * One data-driven builder for the single-entity detail embeds (memory, fact,
+ * denylist entry, voice settings, persona, shape). Everything is plain data —
+ * no callbacks: callers derive state-dependent title prefixes, colors, and
+ * footer strings themselves and pass the results in. The value of the seam is
+ * uniformity (empty-field skipping, spacer grids, safe description
+ * truncation) and a single place where list-grammar decisions land; a
+ * non-Discord renderer would swap in behind this signature.
+ *
+ * Deliberately NOT served by this builder: `character/view`'s multi-page
+ * PAGE_BUILDERS system — fitting it would need page-selection, per-field
+ * truncation tracking, and expand-row config (well past the 2-callback
+ * extraction ceiling), so it stays hand-rolled.
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { truncateByCodePoints } from './modal/toolkit.js';
+
+/** One embed field; `inline` defaults to false. */
+export interface DetailCardField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+/**
+ * Field-slot union: `'spacer'` renders an invisible inline cell (zero-width
+ * space) to force 2-per-row grid alignment in Discord's 3-column field
+ * layout; `null`/`undefined`/`false` slots are skipped, so callers can write
+ * conditional fields as `cond && { ... }`.
+ */
+export type DetailCardFieldSlot = DetailCardField | 'spacer' | null | undefined | false;
+
+/**
+ * Description truncation travels as a pair: a cap without a notice would
+ * silently swallow content with no user-visible indicator, so the type
+ * forces both or neither. The notice must be shorter than the cap — the
+ * cut floors at zero, so an over-long notice would itself exceed the cap.
+ */
+type DescriptionTruncation =
+  | {
+      /**
+       * Cap on the description's length in code points. Over-cap content is
+       * cut (surrogate-safe) to leave room for `truncationNotice`, which is
+       * appended, and the returned `descriptionTruncated` flag flips —
+       * callers use it to render a "view full" affordance.
+       */
+      descriptionCap: number;
+      /** Appended when the cap trips. */
+      truncationNotice: string;
+    }
+  | { descriptionCap?: undefined; truncationNotice?: undefined };
+
+export type EntityDetailCardOptions = {
+  /** Full title including any state-derived prefix (e.g. a 🔒 lock marker). */
+  title: string;
+  /** Defaults to BLURPLE; pass a state-derived color to override. */
+  color?: number;
+  description?: string;
+  fields?: DetailCardFieldSlot[];
+  /** Footer text verbatim — callers own the shape (ID, dates, hint, state). */
+  footer?: string;
+  /** Stamp the embed timestamp (off by default). */
+  timestamp?: boolean;
+} & DescriptionTruncation;
+
+export interface EntityDetailCard {
+  embed: EmbedBuilder;
+  descriptionTruncated: boolean;
+}
+
+/** Invisible inline cell backing the `'spacer'` slot. */
+const SPACER_FIELD = { name: '\u200B', value: '\u200B', inline: true } as const;
+
+function resolveDescription(options: EntityDetailCardOptions): {
+  description: string | undefined;
+  truncated: boolean;
+} {
+  const { description, descriptionCap, truncationNotice } = options;
+  if (description === undefined || description.length === 0) {
+    return { description: undefined, truncated: false };
+  }
+  if (descriptionCap === undefined || [...description].length <= descriptionCap) {
+    return { description, truncated: false };
+  }
+  const notice = truncationNotice ?? '';
+  const cut = truncateByCodePoints(description, Math.max(0, descriptionCap - [...notice].length));
+  return { description: cut + notice, truncated: true };
+}
+
+/** Build a single-entity detail embed from plain data. */
+export function buildEntityDetailCard(options: EntityDetailCardOptions): EntityDetailCard {
+  const embed = new EmbedBuilder()
+    .setTitle(options.title)
+    .setColor(options.color ?? DISCORD_COLORS.BLURPLE);
+
+  const { description, truncated } = resolveDescription(options);
+  if (description !== undefined) {
+    embed.setDescription(description);
+  }
+
+  const fields = (options.fields ?? [])
+    .filter(
+      (slot): slot is DetailCardField | 'spacer' =>
+        slot !== null && slot !== undefined && slot !== false
+    )
+    .map(slot =>
+      slot === 'spacer'
+        ? SPACER_FIELD
+        : { name: slot.name, value: slot.value, inline: slot.inline ?? false }
+    );
+  if (fields.length > 0) {
+    embed.addFields(fields);
+  }
+
+  if (options.footer !== undefined && options.footer.length > 0) {
+    embed.setFooter({ text: options.footer });
+  }
+  if (options.timestamp === true) {
+    embed.setTimestamp();
+  }
+
+  return { embed, descriptionTruncated: truncated };
+}


### PR DESCRIPTION
## Summary

UX epic Phase 2, PR-6 (G5): `buildEntityDetailCard` in `utils/detailCard.ts` — one data-driven scaffold for single-entity detail embeds, adopted at **six sites with output shapes preserved** (every pre-existing embed-JSON test passes without modification, including deny's tight field-by-field contract).

### The builder (zero callbacks — everything is plain data)

- **Title / color / footer**: caller-composed strings. Grounding showed four divergent footer shapes across the sites (truncated-ID, full-ID+date, static hint, machine-state) — a footer *callback* would have been the wrong abstraction; a verbatim string is the honest seam.
- **Fields**: slot array with `null`/`undefined`/`false` skipping (conditional fields as `cond && {...}`) and a `'spacer'` sentinel that expands to the invisible inline cell deny uses for 2-per-row grid alignment.
- **Description cap**: optional; over-cap content is cut **by code point** (surrogate-safe) to fit the truncation notice, total provably ≤ cap, and the returned `descriptionTruncated` flag drives memory's `📄 View Full` affordance.
- Reuses `truncateByCodePoints` from the modal toolkit (a neutral home for that helper is a future nicety, noted here rather than churned now).

### Adopted sites

| Site | Notes |
|---|---|
| `memory/detail.ts` | truncation flag preserved; cut point moves from `cap−50` to `cap−notice` (total now provably ≤ cap) and counts code points, not UTF-16 units |
| `memory/factsDetail.ts` | conditional Sources field via the slot idiom |
| `deny/detailTypes.ts` | spacer grid + mode-derived color/title as data |
| `voice/view.ts` | + **catalog-straggler fix**: the last two raw `❌` error literals in any detail site now route through `classifyGatewayFailure` (**ux:literals 101 → 98**) |
| `persona/view.ts` | content is a *field*, so its preview truncation + the coupled expand button stay caller-owned; the card does scaffold + conditional fields |
| `shapes/detail.ts` | description card; machine-state footer passes through verbatim (commented at the site) |

### Deliberately NOT retrofitted: `character/view.ts`

Its PAGE_BUILDERS system needs page-selection, per-field truncation tracking, and dynamic expand-row config — well past the 2-callback extraction ceiling (`02-code-standards.md`), so it stays hand-rolled. The plan's "multi-page variant mined from PAGE_BUILDERS" idea is declined with it; the disposition is recorded in the builder's module JSDoc so the next reader doesn't re-litigate.

## Verified

- `pnpm test` — full suite green (all 19 pre-existing test files over the six sites pass **unchanged**)
- `pnpm quality` — green; ux-literals ratchet improves to 98/102
- New `utils/detailCard.test.ts` (8 cases): defaults, state-derived overrides, slot skipping, spacer expansion, under/over-cap truncation with flag, astral-boundary code-point safety, empty-description absence — all over `toJSON()` so discord.js validation participates
- No command options changed → component-test tier not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)