### PR TITLE
feat(bot-client): persona create lands in the edit dashboard

### DIFF
--- a/services/bot-client/src/commands/persona/create.test.ts
+++ b/services/bot-client/src/commands/persona/create.test.ts
@@ -15,10 +15,13 @@ vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: clientsForMock,
 }));
 
-// The retry affordance stashes submitted values in a dashboard session
+// The retry affordance stashes submitted values in a dashboard session,
+// and the success path lands in the edit dashboard.
 const sessionSetMock = vi.hoisted(() => vi.fn());
 vi.mock('../../utils/dashboard/index.js', () => ({
   getSessionManager: () => ({ set: sessionSetMock }),
+  buildDashboardEmbed: vi.fn().mockReturnValue({ mock: 'embed' }),
+  buildDashboardComponents: vi.fn().mockReturnValue([{ mock: 'components' }]),
 }));
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -145,9 +148,22 @@ describe('handleCreateModalSubmit', () => {
     // result lands via editReply, never a bare reply.
     expect(mockDeferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
     expect(mockReply).not.toHaveBeenCalled();
-    expect(mockEditReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('Persona "Work Persona" created'),
-    });
+
+    // Success lands in the edit dashboard (consistent with character/preset
+    // creates), not a text confirmation.
+    expect(mockEditReply).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array) })
+    );
+
+    // Seam: the dashboard session must be created against the reply message
+    // so the dashboard's components route on interaction.
+    expect(sessionSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'persona',
+        messageId: 'message-123',
+        data: expect.objectContaining({ name: 'Work Persona' }),
+      })
+    );
   });
 
   it('should surface a name-collision message instead of a generic error', async () => {

--- a/services/bot-client/src/commands/persona/create.ts
+++ b/services/bot-client/src/commands/persona/create.ts
@@ -18,6 +18,17 @@ import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import { buildPersonaModalFields } from './utils/modalBuilder.js';
 import { buildToolkitModal } from '../../utils/modal/toolkit.js';
 import { replyWithModalRetry } from '../../utils/modal/retry.js';
+import {
+  buildDashboardEmbed,
+  buildDashboardComponents,
+  getSessionManager,
+} from '../../utils/dashboard/index.js';
+import {
+  PERSONA_DASHBOARD_CONFIG,
+  flattenPersonaData,
+  buildPersonaDashboardOptions,
+  type FlattenedPersonaData,
+} from './config.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { CATALOG } from '../../ux/catalog/catalog.js';
@@ -153,32 +164,30 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
 
     const { persona } = result.data;
 
+    // Land in the edit dashboard — the same post-create flow character and
+    // preset creates use — instead of a text confirmation.
+    const flattenedData = flattenPersonaData(persona);
+    const embed = buildDashboardEmbed(PERSONA_DASHBOARD_CONFIG, flattenedData);
+    const components = buildDashboardComponents(
+      PERSONA_DASHBOARD_CONFIG,
+      persona.id,
+      flattenedData,
+      buildPersonaDashboardOptions(flattenedData)
+    );
+
+    const reply = await interaction.editReply({ embeds: [embed], components });
+
+    const sessionManager = getSessionManager();
+    await sessionManager.set<FlattenedPersonaData>({
+      userId: discordId,
+      entityType: 'persona', // Matches command name for component routing
+      entityId: persona.id,
+      data: flattenedData,
+      messageId: reply.id,
+      channelId: interaction.channelId ?? '',
+    });
+
     logger.info({ userId: discordId, personaId: persona.id, personaName }, 'Created new persona');
-
-    // Build response
-    const details: string[] = [];
-    if (persona.description !== null) {
-      details.push(`📋 Description: ${persona.description}`);
-    }
-    if (persona.preferredName !== null) {
-      details.push(`📛 Name: ${persona.preferredName}`);
-    }
-    if (persona.pronouns !== null) {
-      details.push(`🏷️ Pronouns: ${persona.pronouns}`);
-    }
-    if (persona.content !== null && persona.content.length > 0) {
-      details.push(
-        `📝 Content: ${persona.content.substring(0, 100)}${persona.content.length > 100 ? '...' : ''}`
-      );
-    }
-
-    let response = `✅ **Persona "${personaName}" created!**`;
-    if (details.length > 0) {
-      response += `\n\n${details.join('\n')}`;
-    }
-    response += '\n\nUse `/persona browse` to see all your personas.';
-
-    await interaction.editReply({ content: response });
   } catch (error) {
     logger.error({ err: error, userId: discordId }, 'Failed to create persona');
     // Post-defer: deferReply ran (and succeeded) before the try, so the


### PR DESCRIPTION
## Summary

Owner smoke feedback: `/persona create` replied with a text blob ("✅ Persona created! ... Use /persona browse") while `/character create` and `/preset create` open the edit dashboard — inconsistent post-create flows. The success path now mirrors the siblings exactly: flatten → `PERSONA_DASHBOARD_CONFIG` embed + components → dashboard session keyed to the reply message, so the fresh persona is immediately editable in place (routing works out of the box — `entityType: 'persona'` matches the command name).

No extra fetch needed: `createPersona` already returns full `PersonaDetails`, the exact shape `flattenPersonaData` takes.

**Deliberately unchanged**: the override-create flow keeps its text confirmation — its result is an override *binding* for a character, not a standalone edit target, so landing in the persona dashboard would lose the override context.

## Verified

- `pnpm test` full suite green, `pnpm quality` green
- Success-path test now pins the dashboard landing (embeds + components) AND the session seam (entityType/messageId/data) instead of the old text assertion
- Retry-affordance failure paths untouched (their tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)