### PR TITLE
fix(bot-client): character create dashboard shows Delete (canEdit graft)

### DIFF
--- a/services/bot-client/src/commands/character/api.test.ts
+++ b/services/bot-client/src/commands/character/api.test.ts
@@ -373,6 +373,10 @@ describe('Character API Client', () => {
 
       expect(stub.createPersonality).toHaveBeenCalledWith(input);
       expect(result.character.slug).toBe('new-character');
+      // Creator owns the new character — the graft drives the dashboard's
+      // Delete button (showDelete: data.canEdit); the create response itself
+      // carries no canEdit field.
+      expect(result.character.canEdit).toBe(true);
       // No shadowedAliases in the response → empty ride-along, never undefined.
       expect(result.shadowedAliases).toEqual([]);
     });

--- a/services/bot-client/src/commands/character/api.ts
+++ b/services/bot-client/src/commands/character/api.ts
@@ -264,7 +264,7 @@ export async function createCharacter(
   },
   userClient: UserClient,
   _config: EnvConfig
-): Promise<{ character: CharacterData; shadowedAliases: string[] }> {
+): Promise<{ character: FetchedCharacter; shadowedAliases: string[] }> {
   const result = await userClient.createPersonality(data);
 
   if (!result.ok) {
@@ -279,7 +279,11 @@ export async function createCharacter(
   }
 
   return {
-    character: toCharacterData(result.data.personality),
+    // The create response carries no canEdit field (it would always be true:
+    // you own what you just created) — graft it so the dashboard's
+    // showDelete derivation sees an owned character, matching the
+    // fetch/update paths.
+    character: { ...toCharacterData(result.data.personality), canEdit: true },
     // Warn-don't-block ride-along: GLOBAL aliases the new name/slug shadows.
     shadowedAliases: result.data.shadowedAliases ?? [],
   };

--- a/services/bot-client/src/commands/character/create.test.ts
+++ b/services/bot-client/src/commands/character/create.test.ts
@@ -127,6 +127,7 @@ describe('Character Create', () => {
 
       vi.mocked(api.createCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'new-uuid',
           name: 'Test Character',
           slug: 'test-character',
@@ -299,6 +300,7 @@ describe('Character Create', () => {
 
       vi.mocked(api.createCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'new-uuid',
           name: 'Test',
           slug: 'valid-slug-123',
@@ -352,6 +354,7 @@ describe('Character Create', () => {
 
       vi.mocked(api.createCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'new-uuid',
           name: 'New Character',
           slug: 'new-character',
@@ -487,6 +490,7 @@ describe('Character Create', () => {
 
       vi.mocked(api.createCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'new-uuid',
           name: 'Test',
           slug: 'test-slug',
@@ -550,6 +554,7 @@ describe('Character Create', () => {
 
       vi.mocked(api.createCharacter).mockResolvedValue({
         character: {
+          canEdit: true,
           id: 'new-uuid',
           name: 'Lila',
           slug: 'lila-slug',

--- a/services/bot-client/src/commands/character/create.ts
+++ b/services/bot-client/src/commands/character/create.ts
@@ -141,7 +141,8 @@ export async function handleSeedModalSubmit(
 
     // Build and send dashboard
     // Use slug as entityId (not UUID) because fetchCharacter expects slug
-    // User just created this character, so they own it (canEdit: true from API)
+    // User just created this character, so they own it (createCharacter
+    // grafts canEdit: true — the create response has no such field)
     // New characters never have a voice reference yet (hasVoiceReference: false)
     const isAdmin = isBotOwner(interaction.user.id);
     const dashboardConfig = getCharacterDashboardConfig(isAdmin, character.hasVoiceReference);


### PR DESCRIPTION
## Summary

Owner smoke finding — the exact sibling of the update-path bug fixed in #1717: `createCharacter` returned `toCharacterData(...)` **without** `canEdit`, so the post-create dashboard derived `showDelete` from `undefined` and rendered no Delete button until the first edit (whose response, fixed in #1717, carries `canEdit: true`) repaired the session.

The create response schema has no `canEdit` field — and adding one would carry no information: it would always be `true`, since you own what you just created. So the client grafts it, matching the fetch/update paths, with the invariant stated at the graft site.

**Class sweep** (exhaustive, per the fix-all-instances posture): all `toCharacterData` call sites checked — `fetchCharacter` grafts from the response ✓, `updateCharacter` grafts from the response ✓ (#1717), `createCharacter` now grafts `true` ✓, `export.ts` and `view.ts` render no edit actions and need no graft. Persona create's Delete derivation (`!isDefault`) was verified unaffected.

## Verified

- `pnpm test` + `pnpm quality` green
- `api.test.ts` pins `result.character.canEdit === true` on create — the seam that drives `showDelete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)