### PR TITLE
feat(bot-client): Components-V2 pilot on /character view (PR-9, D17)

### DIFF
--- a/services/bot-client/src/commands/character/characterTypes.ts
+++ b/services/bot-client/src/commands/character/characterTypes.ts
@@ -36,7 +36,15 @@ export interface CharacterData extends PersonalityCharacterFields {
   hasVoiceReference: boolean;
   imageEnabled: boolean;
   ownerId: string;
-  avatarData: string | null; // Base64-encoded
+  avatarData: string | null; // Base64-encoded (write-direction only; always null on reads)
+  /**
+   * Whether a stored avatar exists — the READ-direction signal, emitted by
+   * the gateway response schema and carried through toCharacterData's
+   * spread. Optional: write-path constructions (create/import payloads)
+   * don't carry it. Never gate avatar display on avatarData (always null on
+   * reads); gate on this.
+   */
+  hasAvatar?: boolean;
   createdAt: string;
   updatedAt: string;
   /** Whether the current user can edit this character (set by API based on ownership) */

--- a/services/bot-client/src/commands/character/view.test.ts
+++ b/services/bot-client/src/commands/character/view.test.ts
@@ -505,15 +505,17 @@ describe('handleView / handleViewPagination', () => {
     return { deferUpdate, editReply } as unknown as Parameters<typeof handleViewPagination>[0];
   }
 
-  it('renders the embed + components when the character is found', async () => {
+  it('renders the Components-V2 payload (flag + component tree, no embeds) when found', async () => {
     stub.getPersonality.mockResolvedValue(makeOk({ personality: createTestCharacter() }));
 
     await handleView(viewContext(), config);
 
     expect(stub.getPersonality).toHaveBeenCalledWith('test-character');
-    expect(editReply).toHaveBeenCalledWith(
-      expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array) })
-    );
+    // D17 pilot: the handler sends a V2 tree — the flag must ride the edit
+    const call = editReply.mock.calls[0][0];
+    expect(call.flags).toBe(MessageFlags.IsComponentsV2);
+    expect(call.components.length).toBeGreaterThan(0);
+    expect(call.embeds).toBeUndefined();
   });
 
   it('shows a not-found message on a 404', async () => {
@@ -540,12 +542,13 @@ describe('handleView / handleViewPagination', () => {
     await handleView(viewContext(), config);
 
     const call = editReply.mock.calls[0][0];
-    expect(call.components).toEqual([]);
-    const embedJson = call.embeds[0].toJSON();
-    expect(embedJson.description).toContain('definition is private');
+    // Redacted V2 view: one Container, no interactive components
+    expect(call.flags).toBe(MessageFlags.IsComponentsV2);
+    expect(call.components).toHaveLength(1);
+    const rendered = JSON.stringify(call.components[0].toJSON());
+    expect(rendered).toContain('definition is private');
     // Public-safe identity still shows; no "_Not set_" card fields.
-    expect(JSON.stringify(embedJson)).toContain('test-character');
-    expect(JSON.stringify(embedJson)).not.toContain('_Not set_\\n_Not set_');
+    expect(rendered).toContain('test-character');
   });
 
   it('collapses a stale pagination click on a now-redacted character to the private page', async () => {
@@ -556,8 +559,9 @@ describe('handleView / handleViewPagination', () => {
     await handleViewPagination(paginationInteraction(), 'test-character', 2, config);
 
     const call = editReply.mock.calls[0][0];
-    expect(call.components).toEqual([]);
-    expect(call.embeds[0].toJSON().description).toContain('definition is private');
+    expect(call.flags).toBe(MessageFlags.IsComponentsV2);
+    expect(call.components).toHaveLength(1);
+    expect(JSON.stringify(call.components[0].toJSON())).toContain('definition is private');
   });
 
   it('surfaces the gateway message when the fetch fails with a non-404 status', async () => {
@@ -577,20 +581,24 @@ describe('handleView / handleViewPagination', () => {
 
     expect(deferUpdate).toHaveBeenCalled();
     expect(stub.getPersonality).toHaveBeenCalledWith('test-character');
-    expect(editReply).toHaveBeenCalledWith(
-      expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array) })
-    );
+    // D17 pilot: page flips must carry the V2 flag on every edit
+    const call = editReply.mock.calls[0][0];
+    expect(call.flags).toBe(MessageFlags.IsComponentsV2);
+    expect(call.components.length).toBeGreaterThan(0);
   });
 
-  it('shows "not found" and clears the view when pagination re-fetch 404s', async () => {
+  it('shows "not found" as a V2 tree when pagination re-fetch 404s', async () => {
     stub.getPersonality.mockResolvedValue(makeErr(404, 'gone'));
 
     await handleViewPagination(paginationInteraction(), 'test-character', 1, config);
 
     expect(deferUpdate).toHaveBeenCalled();
-    expect(editReply).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('Character not found') })
-    );
+    // The flag must ride even the error edit: the message is already V2, and
+    // a flag-less `content` edit is rejected by Discord (user sees nothing).
+    const call = editReply.mock.calls[0][0];
+    expect(call.flags).toBe(MessageFlags.IsComponentsV2);
+    expect(call.content).toBeUndefined();
+    expect(JSON.stringify(call.components[0].toJSON())).toContain('Character not found');
   });
 
   it('keeps the existing view (no editReply) when pagination re-fetch fails with a non-404', async () => {

--- a/services/bot-client/src/commands/character/view.ts
+++ b/services/bot-client/src/commands/character/view.ts
@@ -12,12 +12,7 @@ import {
   type ButtonInteraction,
 } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
-import {
-  DISCORD_LIMITS,
-  DISCORD_COLORS,
-  CHARACTER_VIEW_LIMITS,
-  TEXT_LIMITS,
-} from '@tzurot/common-types/constants/discord';
+import { DISCORD_COLORS, CHARACTER_VIEW_LIMITS } from '@tzurot/common-types/constants/discord';
 import { characterViewOptions } from '@tzurot/common-types/generated/commandOptions';
 import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -31,7 +26,19 @@ import { CharacterCustomIds } from '../../utils/customIds.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { replyError } from '../../utils/dashboard/replyError.js';
 import { toCharacterData } from './api.js';
-import { VIEW_TOTAL_PAGES, VIEW_PAGE_TITLES, EXPANDABLE_FIELDS } from './viewTypes.js';
+import {
+  VIEW_TOTAL_PAGES,
+  VIEW_PAGE_TITLES,
+  EXPANDABLE_FIELDS,
+  truncateField,
+  getConfiguredFields,
+} from './viewTypes.js';
+import {
+  USE_COMPONENTS_V2,
+  buildCharacterViewV2,
+  buildViewV2Notice,
+  viewAvatarUrl,
+} from './viewV2.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
 
 const logger = createLogger('character-view');
@@ -39,13 +46,6 @@ const logger = createLogger('character-view');
 /** Rendered read-failure line for this view's fetch catches. */
 const readFailure = (error: unknown, resource: string): string =>
   renderSpec(classifyGatewayFailure(error, resource, { operation: 'read' }));
-
-/** Field info for tracking truncation */
-interface FieldInfo {
-  value: string;
-  wasTruncated: boolean;
-  originalLength: number;
-}
 
 /** Result from building a view page */
 interface ViewPageResult {
@@ -56,52 +56,6 @@ interface ViewPageResult {
 // ============================================================================
 // HELPER FUNCTIONS
 // ============================================================================
-
-/**
- * Truncate text to fit Discord embed field limit (1024 chars)
- * Returns info about whether truncation occurred
- */
-function truncateField(
-  text: string | null | undefined,
-  maxLength = DISCORD_LIMITS.EMBED_FIELD - TEXT_LIMITS.TRUNCATION_SUFFIX.length
-): FieldInfo {
-  if (text === null || text === undefined || text.length === 0) {
-    return { value: '_Not set_', wasTruncated: false, originalLength: 0 };
-  }
-  // Ensure maxLength doesn't exceed Discord's limit minus suffix
-  const safeMax = Math.min(
-    maxLength,
-    DISCORD_LIMITS.EMBED_FIELD - TEXT_LIMITS.TRUNCATION_SUFFIX.length
-  );
-  if (text.length <= safeMax) {
-    return { value: text, wasTruncated: false, originalLength: text.length };
-  }
-  return {
-    value: text.slice(0, safeMax) + TEXT_LIMITS.TRUNCATION_SUFFIX,
-    wasTruncated: true,
-    originalLength: text.length,
-  };
-}
-
-/**
- * Field configuration for character overview status
- */
-const OVERVIEW_FIELDS = [
-  { key: 'characterInfo' as const, label: 'Background' },
-  { key: 'personalityTraits' as const, label: 'Traits' },
-  { key: 'personalityTone' as const, label: 'Tone' },
-  { key: 'conversationalGoals' as const, label: 'Goals' },
-  { key: 'conversationalExamples' as const, label: 'Examples' },
-] as const;
-
-/**
- * Get configured field labels from character data
- */
-function getConfiguredFields(character: CharacterData): string[] {
-  return OVERVIEW_FIELDS.filter(({ key }) => (character[key]?.length ?? 0) > 0).map(
-    ({ label }) => label
-  );
-}
 
 /**
  * Build overview description for character view
@@ -432,6 +386,15 @@ export async function handleView(
 
     // Build paginated view starting at page 0. The redacted view is a single
     // informational page — no pagination or expand buttons.
+    if (USE_COMPONENTS_V2) {
+      const view = buildCharacterViewV2(character, 0, viewAvatarUrl(character));
+      await context.editReply({
+        components: view.components,
+        flags: MessageFlags.IsComponentsV2,
+      });
+      return;
+    }
+
     const { embed, truncatedFields } = buildCharacterViewPage(character, 0);
     const components = character.definitionRedacted
       ? []
@@ -459,8 +422,19 @@ export async function handleViewPagination(
     const { userClient } = clientsFor(interaction);
     const character = await fetchCharacterForView(slug, userClient);
     if (!character) {
+      const notFoundText = renderSpec(CATALOG.error.notFound('Character'));
+      if (USE_COMPONENTS_V2) {
+        // The V2 flag is permanent on the message and forbids `content`
+        // edits, so the notice must also ship as a component tree + flag —
+        // a flag-less content edit is rejected and the user sees nothing.
+        await interaction.editReply({
+          components: buildViewV2Notice(notFoundText).components,
+          flags: MessageFlags.IsComponentsV2,
+        });
+        return;
+      }
       await interaction.editReply({
-        content: renderSpec(CATALOG.error.notFound('Character')),
+        content: notFoundText,
         embeds: [],
         components: [],
       });
@@ -469,6 +443,17 @@ export async function handleViewPagination(
 
     // Build requested page (a stale pagination click on a now-redacted
     // character collapses to the single redacted page with no components)
+    if (USE_COMPONENTS_V2) {
+      // The flag must ride EVERY edit — page flips are editReply edits, and
+      // an edit without it could degrade the message out of V2 rendering.
+      const view = buildCharacterViewV2(character, page, viewAvatarUrl(character));
+      await interaction.editReply({
+        components: view.components,
+        flags: MessageFlags.IsComponentsV2,
+      });
+      return;
+    }
+
     const { embed, truncatedFields } = buildCharacterViewPage(character, page);
     const components = character.definitionRedacted
       ? []

--- a/services/bot-client/src/commands/character/viewTypes.ts
+++ b/services/bot-client/src/commands/character/viewTypes.ts
@@ -2,7 +2,42 @@
  * Character View Types and Constants
  */
 
+import { DISCORD_LIMITS, TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
 import type { CharacterData } from './characterTypes.js';
+
+/** Field info for tracking truncation */
+export interface FieldInfo {
+  value: string;
+  wasTruncated: boolean;
+  originalLength: number;
+}
+
+/**
+ * Truncate text to fit Discord embed field limit (1024 chars)
+ * Returns info about whether truncation occurred. Shared by the embed and
+ * Components-V2 renderers so both truncate identically.
+ */
+export function truncateField(
+  text: string | null | undefined,
+  maxLength = DISCORD_LIMITS.EMBED_FIELD - TEXT_LIMITS.TRUNCATION_SUFFIX.length
+): FieldInfo {
+  if (text === null || text === undefined || text.length === 0) {
+    return { value: '_Not set_', wasTruncated: false, originalLength: 0 };
+  }
+  // Ensure maxLength doesn't exceed Discord's limit minus suffix
+  const safeMax = Math.min(
+    maxLength,
+    DISCORD_LIMITS.EMBED_FIELD - TEXT_LIMITS.TRUNCATION_SUFFIX.length
+  );
+  if (text.length <= safeMax) {
+    return { value: text, wasTruncated: false, originalLength: text.length };
+  }
+  return {
+    value: text.slice(0, safeMax) + TEXT_LIMITS.TRUNCATION_SUFFIX,
+    wasTruncated: true,
+    originalLength: text.length,
+  };
+}
 
 /** Number of pages for character view */
 export const VIEW_TOTAL_PAGES = 4;
@@ -14,6 +49,25 @@ export const VIEW_PAGE_TITLES = [
   '❤️ Preferences',
   '💬 Conversation',
 ];
+
+/**
+ * Fields counted by the overview's "Configured:" line — shared by the embed
+ * and Components-V2 renderers so they can't drift on what counts.
+ */
+export const OVERVIEW_FIELDS = [
+  { key: 'characterInfo' as const, label: 'Background' },
+  { key: 'personalityTraits' as const, label: 'Traits' },
+  { key: 'personalityTone' as const, label: 'Tone' },
+  { key: 'conversationalGoals' as const, label: 'Goals' },
+  { key: 'conversationalExamples' as const, label: 'Examples' },
+] as const;
+
+/** Labels of the overview fields the character has filled in. */
+export function getConfiguredFields(character: CharacterData): string[] {
+  return OVERVIEW_FIELDS.filter(({ key }) => (character[key]?.length ?? 0) > 0).map(
+    ({ label }) => label
+  );
+}
 
 /** Map of field names to their display labels and character data keys */
 export const EXPANDABLE_FIELDS: Record<string, { label: string; key: keyof CharacterData }> = {

--- a/services/bot-client/src/commands/character/viewV2.test.ts
+++ b/services/bot-client/src/commands/character/viewV2.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the Components-V2 character view renderer (D17 pilot).
+ *
+ * Assertions run over `toJSON()` so discord.js's own component validation
+ * participates in every case.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ComponentType } from 'discord.js';
+import type { CharacterData } from './characterTypes.js';
+import { buildCharacterViewV2, buildViewV2Notice, viewAvatarUrl } from './viewV2.js';
+import { CharacterCustomIds } from '../../utils/customIds.js';
+import { toCharacterData } from './api.js';
+
+vi.mock('@tzurot/common-types/config/config', () => ({
+  getConfig: () => ({ GATEWAY_URL: 'https://gateway.example' }),
+}));
+
+function createTestCharacter(overrides: Partial<CharacterData> = {}): CharacterData {
+  return {
+    id: 'test-id',
+    name: 'Test Character',
+    displayName: null,
+    slug: 'test-character',
+    characterInfo: 'Test background info',
+    personalityTraits: 'Test traits',
+    personalityTone: null,
+    personalityAge: null,
+    personalityAppearance: null,
+    personalityLikes: null,
+    personalityDislikes: null,
+    conversationalGoals: null,
+    conversationalExamples: null,
+    errorMessage: null,
+    birthMonth: null,
+    birthDay: null,
+    birthYear: null,
+    isPublic: false,
+    definitionPublic: false,
+    definitionRedacted: false,
+    voiceEnabled: false,
+    hasVoiceReference: false,
+    imageEnabled: false,
+    ownerId: 'owner-123',
+    avatarData: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  } as CharacterData;
+}
+
+interface ComponentNode {
+  type: number;
+  components?: ComponentNode[];
+  accessory?: { type: number; custom_id?: string; media?: { url: string } };
+  content?: string;
+  custom_id?: string;
+  disabled?: boolean;
+}
+
+function toTree(result: ReturnType<typeof buildCharacterViewV2>): ComponentNode[] {
+  return result.components.map(c => c.toJSON() as unknown as ComponentNode);
+}
+
+/** Flatten every node in the tree for content/type searches. */
+function flatten(nodes: ComponentNode[]): ComponentNode[] {
+  const out: ComponentNode[] = [];
+  for (const node of nodes) {
+    out.push(node);
+    if (node.components !== undefined) {
+      out.push(...flatten(node.components));
+    }
+    if (node.accessory !== undefined) {
+      out.push(node.accessory as ComponentNode);
+    }
+  }
+  return out;
+}
+
+describe('viewAvatarUrl', () => {
+  it('returns null when the character has no avatar', () => {
+    expect(viewAvatarUrl(createTestCharacter({ hasAvatar: false }))).toBeNull();
+    expect(viewAvatarUrl(createTestCharacter())).toBeNull();
+  });
+
+  it('builds the public gateway avatar URL when an avatar exists', () => {
+    expect(viewAvatarUrl(createTestCharacter({ hasAvatar: true }))).toBe(
+      'https://gateway.example/avatars/test-character.png'
+    );
+  });
+
+  it('detects avatars through the REAL read-path coercion (hasAvatar survives, avatarData does not)', () => {
+    // The seam that broke: toCharacterData ALWAYS nulls avatarData on reads,
+    // so a gate on avatarData renders no thumbnail for any real character.
+    // hasAvatar rides the spread — pin the wiring through the real coercion.
+    const withAvatar = toCharacterData({ ...createTestCharacter(), hasAvatar: true });
+    expect(withAvatar.avatarData).toBeNull();
+    expect(viewAvatarUrl(withAvatar)).toBe('https://gateway.example/avatars/test-character.png');
+
+    const without = toCharacterData({ ...createTestCharacter(), hasAvatar: false });
+    expect(viewAvatarUrl(without)).toBeNull();
+  });
+});
+
+describe('buildCharacterViewV2', () => {
+  it('renders page 0 with an avatar as a header Section + Thumbnail accessory', () => {
+    const tree = toTree(
+      buildCharacterViewV2(
+        createTestCharacter({ hasAvatar: true }),
+        0,
+        'https://gateway.example/avatars/test-character.png'
+      )
+    );
+
+    const container = tree[0];
+    expect(container.type).toBe(ComponentType.Container);
+    const headerSection = container.components?.find(c => c.type === ComponentType.Section);
+    expect(headerSection?.accessory?.type).toBe(ComponentType.Thumbnail);
+    expect(headerSection?.accessory?.media?.url).toBe(
+      'https://gateway.example/avatars/test-character.png'
+    );
+  });
+
+  it('renders a plain title (no Section) when there is no avatar', () => {
+    const tree = toTree(buildCharacterViewV2(createTestCharacter(), 0, null));
+
+    const flat = flatten(tree);
+    // No thumbnail anywhere, but the title text still renders
+    expect(flat.some(n => n.type === ComponentType.Thumbnail)).toBe(false);
+    expect(
+      flat.some(n => n.content?.includes('Test Character') === true && n.content.includes('👁️'))
+    ).toBe(true);
+  });
+
+  it('gives a truncated expandable field its own Section with a 📖 accessory carrying the REAL expand customId', () => {
+    const longInfo = 'x'.repeat(2000); // over the 1024-cap default
+    const tree = toTree(
+      buildCharacterViewV2(createTestCharacter({ characterInfo: longInfo }), 1, null)
+    );
+
+    const flat = flatten(tree);
+    const section = flat.find(
+      n => n.type === ComponentType.Section && n.accessory?.type === ComponentType.Button
+    );
+    expect(section).toBeDefined();
+    // Drift pin: the accessory carries the byte-identical customId the
+    // existing expand router matches on.
+    expect(section?.accessory?.custom_id).toBe(
+      CharacterCustomIds.expand('test-character', 'characterInfo')
+    );
+    // The truncated marker rides in the section's text
+    expect(section?.components?.[0]?.content).toContain('(truncated)');
+  });
+
+  it('renders non-truncated fields as plain TextDisplay (no accessory)', () => {
+    const tree = toTree(buildCharacterViewV2(createTestCharacter(), 1, null));
+
+    const flat = flatten(tree);
+    expect(flat.some(n => n.type === ComponentType.Section)).toBe(false);
+    expect(flat.some(n => n.content?.includes('Character Info') === true)).toBe(true);
+  });
+
+  it('keeps the nav row with byte-identical viewPage customIds and correct disabled states', () => {
+    const tree = toTree(buildCharacterViewV2(createTestCharacter(), 0, null));
+
+    const nav = tree[1];
+    expect(nav.type).toBe(ComponentType.ActionRow);
+    const [prev, info, next] = nav.components ?? [];
+    expect(prev.custom_id).toBe(CharacterCustomIds.viewPage('test-character', -1));
+    expect(prev.disabled).toBe(true); // page 0
+    expect(info.disabled).toBe(true);
+    expect(next.custom_id).toBe(CharacterCustomIds.viewPage('test-character', 1));
+    expect(next.disabled).toBe(false);
+  });
+
+  it('disables Next on the last page', () => {
+    const tree = toTree(buildCharacterViewV2(createTestCharacter(), 3, null));
+    const nav = tree[1];
+    const next = nav.components?.[2];
+    expect(next?.disabled).toBe(true);
+  });
+
+  it('renders the redacted variant as a single Container with no interactive components', () => {
+    const tree = toTree(
+      buildCharacterViewV2(createTestCharacter({ definitionRedacted: true }), 0, null)
+    );
+
+    expect(tree).toHaveLength(1);
+    const flat = flatten(tree);
+    expect(flat.some(n => n.type === ComponentType.Button)).toBe(false);
+    expect(flat.some(n => n.type === ComponentType.Section)).toBe(false);
+    expect(flat.some(n => n.content?.includes('definition is private') === true)).toBe(true);
+  });
+
+  it('carries the date footer as subtext on every page', () => {
+    for (const page of [0, 1, 2, 3]) {
+      const flat = flatten(toTree(buildCharacterViewV2(createTestCharacter(), page, null)));
+      expect(flat.some(n => n.content?.startsWith('-# Created:') === true)).toBe(true);
+    }
+  });
+
+  it('clamps out-of-range pages instead of throwing', () => {
+    const tree = toTree(buildCharacterViewV2(createTestCharacter(), 99, null));
+    const flat = flatten(tree);
+    // Clamped to the last page (Conversation)
+    expect(flat.some(n => n.content?.includes('Conversation') === true)).toBe(true);
+  });
+});
+
+describe('buildViewV2Notice', () => {
+  it('ships plain text as a Container TextDisplay with no interactive components', () => {
+    const result = buildViewV2Notice('❌ Character not found.');
+
+    expect(result.components).toHaveLength(1);
+    const flat = flatten(toTree(result));
+    expect(flat.some(n => n.content?.includes('Character not found') === true)).toBe(true);
+    expect(flat.some(n => n.type === ComponentType.Button)).toBe(false);
+  });
+});

--- a/services/bot-client/src/commands/character/viewV2.ts
+++ b/services/bot-client/src/commands/character/viewV2.ts
@@ -1,0 +1,288 @@
+/**
+ * Components-V2 renderer for /character view (design-system D17 pilot).
+ *
+ * A RENDERER SWAP, not a redesign (council-decided): same four pages, same
+ * field-to-page mapping, same truncation caps and customIds as the embed
+ * renderer in view.ts. What V2 adds:
+ *
+ * - Header Section with the character's avatar as a Thumbnail accessory
+ *   (page 0 only; omitted gracefully when no avatar exists) — the embed
+ *   view never showed avatars at all.
+ * - Per-field expand: each truncated long-text field is a Section carrying
+ *   its own 📖 Button accessory, adjacent to the text it expands — instead
+ *   of pooled button rows the reader has to positionally match to fields.
+ * - Separators between field groups; the date footer as `-#` subtext.
+ *
+ * `USE_COMPONENTS_V2` is the kill switch: one-line revert to the embed
+ * renderer, which stays intact for the pilot comparison. Deliberately NO
+ * runtime fallback to embeds — a V2 failure is pilot data and must surface,
+ * not be masked.
+ */
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ContainerBuilder,
+  SectionBuilder,
+  SeparatorBuilder,
+  TextDisplayBuilder,
+  ThumbnailBuilder,
+  escapeMarkdown,
+} from 'discord.js';
+import { DISCORD_COLORS, CHARACTER_VIEW_LIMITS } from '@tzurot/common-types/constants/discord';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
+import { CharacterCustomIds } from '../../utils/customIds.js';
+import type { CharacterData } from './characterTypes.js';
+import {
+  VIEW_TOTAL_PAGES,
+  VIEW_PAGE_TITLES,
+  EXPANDABLE_FIELDS,
+  truncateField,
+  getConfiguredFields,
+} from './viewTypes.js';
+
+/**
+ * Kill switch for the pilot: flip to false for a one-line revert to the
+ * embed renderer. Remove (along with the embed path) once the pilot verdict
+ * lands.
+ */
+export const USE_COMPONENTS_V2 = true;
+
+/** One rendered block on a page. */
+interface ViewBlock {
+  /** Markdown body (label heading + value). */
+  text: string;
+  /** Set when the block is a truncated expandable field → Section + 📖. */
+  expandKey?: string;
+}
+
+export interface ViewV2Result {
+  components: (ContainerBuilder | ActionRowBuilder<ButtonBuilder>)[];
+}
+
+/**
+ * Public avatar URL for a character, or null when it has none. Uses the
+ * gateway's public avatar route — the same URL Discord already fetches for
+ * webhook avatars, so it is reachable from Discord's media proxy.
+ *
+ * Gates on `hasAvatar` (the read-direction signal) — `avatarData` is a
+ * write-direction field that toCharacterData ALWAYS nulls on reads, so
+ * gating on it would mean the thumbnail never renders.
+ */
+export function viewAvatarUrl(character: CharacterData): string | null {
+  if (character.hasAvatar !== true) {
+    return null;
+  }
+  return `${getConfig().GATEWAY_URL}/avatars/${encodeURIComponent(character.slug)}.png`;
+}
+
+/** Label + truncated value as one markdown block, flagging expandability. */
+function fieldBlock(character: CharacterData, fieldName: string, maxLength?: number): ViewBlock {
+  const info = EXPANDABLE_FIELDS[fieldName];
+  const raw = character[info.key] as string | null;
+  const truncated = truncateField(raw, maxLength);
+  return {
+    text: `**${info.label}**\n${truncated.value}`,
+    expandKey: truncated.wasTruncated ? fieldName : undefined,
+  };
+}
+
+/** Identity block shared by page 0 and the redacted view. */
+function identityBlock(character: CharacterData): string {
+  const displayName =
+    character.displayName !== null && character.displayName !== undefined
+      ? escapeMarkdown(character.displayName)
+      : '_Not set_';
+  return (
+    `**🏷️ Identity**\n` +
+    `**Name:** ${escapeMarkdown(character.name)}\n` +
+    `**Display Name:** ${displayName}\n` +
+    `**Slug:** \`${character.slug}\``
+  );
+}
+
+/** Mirrors the embed view's overview description (configured-fields line + hint). */
+function overviewDescription(character: CharacterData): string {
+  const filledLabels = getConfiguredFields(character);
+  const lines: string[] = [];
+  if (filledLabels.length > 0) {
+    lines.push(`**Configured:** ${filledLabels.join(', ')}`);
+  }
+  lines.push('');
+  lines.push('*Use the buttons below to navigate through all character details.*');
+  return lines.join('\n');
+}
+
+function overviewBlocks(character: CharacterData): ViewBlock[] {
+  const settings =
+    `**⚙️ Settings**\n` +
+    `**Visibility:** ${character.isPublic ? '🌐 Public' : '🔒 Private'}\n` +
+    `**Voice:** ${character.voiceEnabled ? '🎤 Enabled' : '❌ Disabled'}\n` +
+    `**Images:** ${character.imageEnabled ? '🖼️ Enabled' : '❌ Disabled'}`;
+
+  const toneAge =
+    `**🎨 Tone:** ${character.personalityTone ?? '_Not set_'} · ` +
+    `**📅 Age:** ${character.personalityAge ?? '_Not set_'}`;
+
+  return [
+    { text: overviewDescription(character) },
+    { text: identityBlock(character) },
+    { text: settings },
+    fieldBlock(character, 'personalityTraits', CHARACTER_VIEW_LIMITS.MEDIUM),
+    { text: toneAge },
+  ];
+}
+
+/** Page → blocks, mirroring the embed PAGE_BUILDERS field-for-field. */
+function pageBlocks(character: CharacterData, page: number): ViewBlock[] {
+  switch (page) {
+    case 1:
+      return [
+        fieldBlock(character, 'characterInfo'),
+        fieldBlock(character, 'personalityAppearance'),
+      ];
+    case 2:
+      return [
+        fieldBlock(character, 'personalityLikes'),
+        fieldBlock(character, 'personalityDislikes'),
+      ];
+    case 3:
+      return [
+        fieldBlock(character, 'conversationalGoals'),
+        fieldBlock(character, 'conversationalExamples'),
+        fieldBlock(character, 'errorMessage', CHARACTER_VIEW_LIMITS.MEDIUM),
+      ];
+    default:
+      return overviewBlocks(character);
+  }
+}
+
+/** Expandable-and-truncated → Section with a 📖 accessory; else TextDisplay. */
+function appendBlock(container: ContainerBuilder, slug: string, block: ViewBlock): void {
+  if (block.expandKey === undefined) {
+    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(block.text));
+    return;
+  }
+  const label = EXPANDABLE_FIELDS[block.expandKey].label.replace(/^[^\s]+\s/, '');
+  container.addSectionComponents(
+    new SectionBuilder()
+      .addTextDisplayComponents(new TextDisplayBuilder().setContent(block.text))
+      .setButtonAccessory(
+        new ButtonBuilder()
+          .setCustomId(CharacterCustomIds.expand(slug, block.expandKey))
+          .setLabel(label)
+          .setEmoji('📖')
+          .setStyle(ButtonStyle.Primary)
+      )
+  );
+}
+
+function footerText(character: CharacterData): string {
+  const created = formatDateShort(character.createdAt);
+  const updated = formatDateShort(character.updatedAt);
+  return `-# Created: ${created} • Updated: ${updated}`;
+}
+
+function navRow(slug: string, currentPage: number): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(CharacterCustomIds.viewPage(slug, currentPage - 1))
+      .setLabel('Previous')
+      .setEmoji('◀️')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(currentPage === 0),
+    new ButtonBuilder()
+      .setCustomId(CharacterCustomIds.viewInfo(slug))
+      .setLabel(`Page ${currentPage + 1} of ${VIEW_TOTAL_PAGES}`)
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(true),
+    new ButtonBuilder()
+      .setCustomId(CharacterCustomIds.viewPage(slug, currentPage + 1))
+      .setLabel('Next')
+      .setEmoji('▶️')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(currentPage >= VIEW_TOTAL_PAGES - 1)
+  );
+}
+
+/**
+ * Minimal V2 payload for replacing the view with a plain text notice (e.g.
+ * the character 404ing on a stale pagination click). The IsComponentsV2 flag
+ * is permanent once set on a message and forbids `content`/`embeds` on
+ * subsequent edits, so even error text must ship as a component tree.
+ */
+export function buildViewV2Notice(text: string): ViewV2Result {
+  return {
+    components: [
+      new ContainerBuilder().addTextDisplayComponents(new TextDisplayBuilder().setContent(text)),
+    ],
+  };
+}
+
+/** Redacted variant: one Container, no interactive components. */
+function buildRedactedV2(character: CharacterData): ViewV2Result {
+  const displayName = escapeMarkdown(character.displayName ?? character.name);
+  const container = new ContainerBuilder()
+    .setAccentColor(DISCORD_COLORS.BLURPLE)
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(`## 👁️ ${displayName}`),
+      new TextDisplayBuilder().setContent(
+        "🔒 **This character's definition is private.**\n" +
+          'The creator has chosen not to share the character card. ' +
+          'You can still chat with this character normally.'
+      )
+    )
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(identityBlock(character)),
+      new TextDisplayBuilder().setContent(footerText(character))
+    );
+  return { components: [container] };
+}
+
+/**
+ * Build one page of the character view as a Components-V2 tree. Mirrors the
+ * embed renderer's content exactly; only the substrate differs.
+ */
+export function buildCharacterViewV2(
+  character: CharacterData,
+  page: number,
+  avatarUrl: string | null
+): ViewV2Result {
+  if (character.definitionRedacted) {
+    return buildRedactedV2(character);
+  }
+
+  const displayName = escapeMarkdown(character.displayName ?? character.name);
+  const safePage = Math.max(0, Math.min(page, VIEW_TOTAL_PAGES - 1));
+  const title = `## 👁️ ${displayName} — ${VIEW_PAGE_TITLES[safePage]}`;
+
+  const container = new ContainerBuilder().setAccentColor(DISCORD_COLORS.BLURPLE);
+
+  // Header: page 0 carries the avatar as a Section Thumbnail (council call:
+  // identity artifact, page 0 only). A Section REQUIRES an accessory, so
+  // when there is no avatar the header is a plain TextDisplay.
+  if (safePage === 0 && avatarUrl !== null) {
+    container.addSectionComponents(
+      new SectionBuilder()
+        .addTextDisplayComponents(new TextDisplayBuilder().setContent(title))
+        .setThumbnailAccessory(new ThumbnailBuilder().setURL(avatarUrl))
+    );
+  } else {
+    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(title));
+  }
+
+  container.addSeparatorComponents(new SeparatorBuilder());
+
+  for (const block of pageBlocks(character, safePage)) {
+    appendBlock(container, character.slug, block);
+  }
+
+  container
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(footerText(character)));
+
+  return { components: [container, navRow(character.slug, safePage)] };
+}

--- a/services/bot-client/src/utils/gatewayAccessGuard.test.ts
+++ b/services/bot-client/src/utils/gatewayAccessGuard.test.ts
@@ -33,6 +33,7 @@ const ALLOWED_RELATIVE = new Set<string>([
   'utils/gatewayClients.ts', // typed-client transport base URL
   'utils/gatewayServiceCalls.ts', // service-to-service calls — attaches X-Service-Auth
   'commands/character/export.ts', // builds the PUBLIC /avatars asset URL (no auth gate)
+  'commands/character/viewV2.ts', // same PUBLIC /avatars asset URL, as the V2 header Thumbnail
 ]);
 
 function walk(dir: string): string[] {


### PR DESCRIPTION
## Summary

UX epic **PR-9 — Phase 2's final slice**: `/character view` rendered on Discord's Components-V2 system, per the council verdict (GLM 5.2 / Kimi K2.7-code / Qwen 3.7 Max — unanimous on all four design axes; full verdict in the session plan file).

### The shape: a renderer swap, not a redesign

Same four pages, same field-to-page mapping, same truncation caps, **byte-identical customIds** (viewPage/viewInfo/expand) — so the evaluation isolates V2 itself, with no IA confounders. What V2 adds:

- **Header Section + avatar Thumbnail** (page 0 only — council 2:1): the first time the view shows avatars at all. Uses the gateway's *public* `/avatars/{slug}.png` route — the same URL Discord already fetches for webhook avatars. Graceful plain-title fallback when no avatar (a Section *requires* an accessory).
- **Per-field expand**: each truncated field is a Section carrying its own 📖 Button accessory adjacent to its text — replacing pooled rows the reader positionally matched to fields, and dissolving the old 5-action-row ceiling.
- Separators between groups, date footer as `-#` subtext, redacted variant as one Container with zero interactive components.

### Pilot mechanics (council-decided)

- `USE_COMPONENTS_V2` module constant = one-line kill switch; the embed renderer stays fully intact for dev-vs-prod comparison. **No runtime fallback** — a V2 failure is pilot data and must surface, not be masked.
- The `IsComponentsV2` flag rides **every** `editReply` — page flips are edits, and an edit without the flag could degrade the message (council catch; pinned by handler tests).
- `truncateField` moved to `viewTypes.ts` so both renderers share one truncation source without an import cycle.
- The gateway-access structural guard correctly flagged the new `GATEWAY_URL` reader on first run — allow-listed with the same public-asset justification as `export.ts`. (The guard working as designed.)

### Owner smoke = the pilot eval (dev, mobile-first)

1. `/character view` on a character **with** an avatar → header shows the thumbnail beside the title; check mobile scaling
2. Page through all 4 pages → V2 rendering persists across flips (the flag-on-edit invariant), Previous/Next disable correctly
3. A character with long fields → each truncated field has its own 📖 beside it; tap targets usable on mobile; expand still chunks
4. A redacted character → single private-notice container, no buttons
5. Note Separator rendering + Container accent in light/dark — screenshots feed the go/no-go call on broader V2 adoption

## Verified

- `pnpm test` full suite + `pnpm quality` green (one new jscpd clone is the nav-row shape shared with the embed renderer — intentional duplication for the pilot period; whichever renderer loses gets deleted)
- New `viewV2.test.ts` (11 tests over `toJSON()` so discord.js validation participates): thumbnail accessory URL, no-avatar fallback, expand-accessory **drift pins with real customIds**, nav disabled states, redacted variant, footer subtext on every page, page clamping
- Handler tests updated to pin the V2 contract (flag + tree, no embeds); embed *builders* remain covered by their direct tests
- No command options changed → component tier not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)