### PR TITLE
fix(ci): make claude hooks cwd-independent

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/skill-eval.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/skill-eval.sh"
           }
         ]
       }
@@ -16,15 +16,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/pr-merge-review-check.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/pr-merge-review-check.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/git-commit-filter-guard.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/git-commit-filter-guard.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/develop-code-commit-guard.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/develop-code-commit-guard.sh"
           }
         ]
       }
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/session-start.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/session-start.sh"
           }
         ]
       }
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/eslint-on-edit.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/eslint-on-edit.sh"
           }
         ]
       },
@@ -54,11 +54,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/pr-monitor-reminder.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/pr-monitor-reminder.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/release-finalize-reminder.sh"
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/release-finalize-reminder.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Owner-spotted from the session log: a spray of `PreToolUse`/`PostToolUse` hook errors — `.claude/hooks/<name>.sh: No such file or directory`. Root cause: all 8 hook commands in `.claude/settings.json` resolve their script path against the **current working directory**, and the assistant's persistent shell frequently sits in a package subdir (`services/bot-client`) for targeted test runs.

**This was a protection gap, not just noise**: for any tool call made from a subdir, the guards silently skipped — the merge-review gate, the commit filter guard, the develop-commit guard, and the PR-monitor reminder simply didn't run. Every "the hook caught X" success this session happened to occur with the shell at the repo root.

## Fix

Each hook command becomes:

```
cd "${CLAUDE_PROJECT_DIR:-.}" && .claude/hooks/<name>.sh
```

- With `CLAUDE_PROJECT_DIR` (which Claude Code sets for hook execution), the hook runs at the repo root from **any** cwd — which also fixes cwd-relative operations *inside* the scripts (e.g. the guards' `git` invocations; scripts that already used absolute paths, like the merge gate's ack file, were unaffected by this class).
- The `:-.` fallback means an environment without the variable degrades to exactly today's behavior — strictly no worse.

**Runtime-probed both halves before shipping** (from `services/bot-client`): with the var set the hook executes (exit 0); without it, the old "No such file" reproduces.

Note: the settings reload on session start — currently-running sessions keep the old resolution until restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
