### PR TITLE
fix(bot-client): V2 pilot eval feedback — public avatar URL + Tone/Age split

### DIFF
--- a/packages/common-types/src/schemas/api/personality.test.ts
+++ b/packages/common-types/src/schemas/api/personality.test.ts
@@ -630,6 +630,7 @@ describe('Personality API Contract Tests', () => {
       imageEnabled: false,
       ownerId: '44444444-4444-5444-8444-444444444444',
       hasAvatar: true,
+      avatarUrl: 'https://public.example/avatars/test-character-1737385800000.png',
       hasVoiceReference: false,
       customFields: null,
       createdAt: '2025-01-15T12:00:00.000Z',
@@ -638,6 +639,24 @@ describe('Personality API Contract Tests', () => {
 
     it('should validate complete personality data', () => {
       const result = PersonalityFullSchema.safeParse(validFull);
+      expect(result.success).toBe(true);
+    });
+
+    it('avatarUrl survives the parse (strip-mode deletes undeclared fields)', () => {
+      // The pin that matters for the V2 thumbnail: an undeclared field would
+      // parse fine and silently vanish — the bot would render no avatar with
+      // every unit test green.
+      const result = PersonalityFullSchema.safeParse(validFull);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.avatarUrl).toBe(
+          'https://public.example/avatars/test-character-1737385800000.png'
+        );
+      }
+    });
+
+    it('accepts null avatarUrl (no avatar)', () => {
+      const result = PersonalityFullSchema.safeParse({ ...validFull, avatarUrl: null });
       expect(result.success).toBe(true);
     });
 
@@ -707,6 +726,7 @@ describe('Personality API Contract Tests', () => {
       imageEnabled: false,
       ownerId: '44444444-4444-5444-8444-444444444444',
       hasAvatar: false,
+      avatarUrl: null,
       hasVoiceReference: false,
       customFields: null,
       createdAt: '2025-01-15T12:00:00.000Z',
@@ -752,6 +772,7 @@ describe('Personality API Contract Tests', () => {
       imageEnabled: false,
       ownerId: '44444444-4444-5444-8444-444444444444',
       hasAvatar: false,
+      avatarUrl: null,
       hasVoiceReference: false,
       customFields: null,
       createdAt: '2025-01-15T12:00:00.000Z',

--- a/packages/common-types/src/schemas/api/personality.ts
+++ b/packages/common-types/src/schemas/api/personality.ts
@@ -73,6 +73,15 @@ export const PersonalityFullSchema = z.object({
   imageEnabled: z.boolean(),
   ownerId: z.string(),
   hasAvatar: z.boolean(),
+  /**
+   * Public, cache-busting avatar URL, or null when the character has none.
+   * Derived GATEWAY-side (identity's deriveAvatarUrl over PUBLIC_GATEWAY_URL)
+   * because bot-client's own GATEWAY_URL is the internal hostname — a URL
+   * built from it renders as a broken image when Discord's media proxy is
+   * the fetcher (thumbnails), even though the bot's own fetches succeed.
+   * Must be DECLARED here or strip-mode deletes it (see customFields note).
+   */
+  avatarUrl: z.string().nullable(),
   hasVoiceReference: z.boolean(),
   // Must be DECLARED here or the typed client's Zod parse (default strip mode)
   // silently drops it from every response — the gateway sends it, but an

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -21,3 +21,7 @@ export {
 export { resolveRoutingContext, type RoutingContextDeps } from './RoutingContextResolver.js';
 export { type PersonaPromptData, PersonaResolver } from './resolvers/index.js';
 export { PersonalityService } from './personality/index.js';
+// Canonical public avatar-URL derivation (PUBLIC_GATEWAY_URL + cache-busting
+// timestamp). Exported so gateway responses and webhook payloads share ONE
+// URL shape — hand-built variants have shipped unreachable internal URLs.
+export { deriveAvatarUrl } from './personality/PersonalityDefaults.js';

--- a/packages/test-factories/src/personality.ts
+++ b/packages/test-factories/src/personality.ts
@@ -49,6 +49,7 @@ function createBasePersonality(overrides?: Partial<PersonalityFull>): Personalit
     imageEnabled: false,
     ownerId: DEFAULT_OWNER_ID,
     hasAvatar: false,
+    avatarUrl: null,
     hasVoiceReference: false,
     customFields: null,
     createdAt: now,

--- a/services/api-gateway/src/routes/user/personality/formatters.test.ts
+++ b/services/api-gateway/src/routes/user/personality/formatters.test.ts
@@ -2,8 +2,17 @@
  * Tests for personality response formatters
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { formatPersonalityResponse, REDACTABLE_CARD_FIELDS } from './formatters.js';
+
+// deriveAvatarUrl reads PUBLIC_GATEWAY_URL at call time — pin it so the
+// expected avatarUrl below is deterministic regardless of .env.test.
+beforeEach(() => {
+  vi.stubEnv('PUBLIC_GATEWAY_URL', 'https://public.example');
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 function createMockPersonality(overrides: Record<string, unknown> = {}) {
   return {
@@ -71,6 +80,8 @@ describe('formatPersonalityResponse', () => {
       imageEnabled: true,
       ownerId: 'owner-123',
       hasAvatar: true,
+      // Public URL, cache-busted with the fixture's own updatedAt epoch
+      avatarUrl: `https://public.example/avatars/test-bot-${new Date('2026-02-01T00:00:00Z').getTime()}.png`,
       hasVoiceReference: false,
       customFields: { key: 'value' },
       systemPromptId: 'prompt-123',
@@ -137,6 +148,26 @@ describe('formatPersonalityResponse', () => {
     const personality = createMockPersonality({ avatarData: null });
     const result = formatPersonalityResponse(personality, { redact: false });
     expect(result.hasAvatar).toBe(false);
+  });
+
+  it('emits null avatarUrl when the character has no avatar (a derived URL would 404 → broken thumbnail)', () => {
+    const personality = createMockPersonality({ avatarData: null });
+    const result = formatPersonalityResponse(personality, { redact: false });
+    expect(result.avatarUrl).toBeNull();
+  });
+
+  it('keeps avatarUrl visible when redacted — avatar presence is not a card field', () => {
+    const result = formatPersonalityResponse(createMockPersonality(), { redact: true });
+    expect(result.avatarUrl).toContain('https://public.example/avatars/test-bot-');
+  });
+
+  it('falls back to GATEWAY_URL when PUBLIC_GATEWAY_URL is unset (local dev)', () => {
+    // stubEnv(undefined) DELETES the var — an empty string would NOT take
+    // the ?? fallback in deriveAvatarUrl and would yield null instead.
+    vi.stubEnv('PUBLIC_GATEWAY_URL', undefined);
+    vi.stubEnv('GATEWAY_URL', 'http://localhost:3000');
+    const result = formatPersonalityResponse(createMockPersonality(), { redact: false });
+    expect(result.avatarUrl).toContain('http://localhost:3000/avatars/test-bot-');
   });
 
   it('should set hasAvatar to true when avatarData is present', () => {

--- a/services/api-gateway/src/routes/user/personality/formatters.ts
+++ b/services/api-gateway/src/routes/user/personality/formatters.ts
@@ -10,6 +10,10 @@ import {
   type PersonalityCharacterFields,
 } from '@tzurot/common-types/schemas/api/personality';
 import { type Prisma } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { deriveAvatarUrl } from '@tzurot/identity';
+
+const logger = createLogger('personality-formatter');
 
 type PersonalityFromDb = Prisma.PersonalityGetPayload<{
   select: typeof PERSONALITY_DETAIL_SELECT;
@@ -65,6 +69,9 @@ export interface PersonalityResponse extends Omit<PersonalityCharacterFields, Re
   imageEnabled: boolean;
   ownerId: string;
   hasAvatar: boolean;
+  /** Public cache-busting avatar URL (null = no avatar). Derived here, where
+   *  PUBLIC_GATEWAY_URL exists — bot-client's GATEWAY_URL is internal-only. */
+  avatarUrl: string | null;
   hasVoiceReference: boolean;
   // Matches PersonalityFullSchema's declared shape — the create/update
   // schemas only ever store records in the Json? column.
@@ -116,6 +123,10 @@ export function formatPersonalityResponse(
     imageEnabled: personality.imageEnabled,
     ownerId: personality.ownerId,
     hasAvatar: personality.avatarData !== null,
+    avatarUrl:
+      personality.avatarData !== null
+        ? (deriveAvatarUrl(personality.slug, personality.updatedAt, logger) ?? null)
+        : null,
     // voiceReferenceType (not voiceReferenceData) is the proxy — PERSONALITY_DETAIL_SELECT
     // excludes the blob column to avoid loading up to 10MB into memory on every query.
     hasVoiceReference: personality.voiceReferenceType !== null,

--- a/services/bot-client/src/commands/character/characterTypes.ts
+++ b/services/bot-client/src/commands/character/characterTypes.ts
@@ -38,6 +38,14 @@ export interface CharacterData extends PersonalityCharacterFields {
   ownerId: string;
   avatarData: string | null; // Base64-encoded (write-direction only; always null on reads)
   /**
+   * Public cache-busting avatar URL from the API (null = no avatar).
+   * Gateway-derived where the public base URL is configured — never rebuild
+   * it from bot-client's own gateway base env var, which is the internal
+   * hostname and renders as a broken image when Discord's media proxy is
+   * the fetcher.
+   */
+  avatarUrl?: string | null;
+  /**
    * Whether a stored avatar exists — the READ-direction signal, emitted by
    * the gateway response schema and carried through toCharacterData's
    * spread. Optional: write-path constructions (create/import payloads)

--- a/services/bot-client/src/commands/character/viewV2.test.ts
+++ b/services/bot-client/src/commands/character/viewV2.test.ts
@@ -5,16 +5,12 @@
  * participates in every case.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ComponentType } from 'discord.js';
 import type { CharacterData } from './characterTypes.js';
 import { buildCharacterViewV2, buildViewV2Notice, viewAvatarUrl } from './viewV2.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import { toCharacterData } from './api.js';
-
-vi.mock('@tzurot/common-types/config/config', () => ({
-  getConfig: () => ({ GATEWAY_URL: 'https://gateway.example' }),
-}));
 
 function createTestCharacter(overrides: Partial<CharacterData> = {}): CharacterData {
   return {
@@ -78,26 +74,34 @@ function flatten(nodes: ComponentNode[]): ComponentNode[] {
 }
 
 describe('viewAvatarUrl', () => {
-  it('returns null when the character has no avatar', () => {
-    expect(viewAvatarUrl(createTestCharacter({ hasAvatar: false }))).toBeNull();
+  it('returns null when the API provides no avatar URL', () => {
+    expect(viewAvatarUrl(createTestCharacter({ avatarUrl: null }))).toBeNull();
     expect(viewAvatarUrl(createTestCharacter())).toBeNull();
   });
 
-  it('builds the public gateway avatar URL when an avatar exists', () => {
-    expect(viewAvatarUrl(createTestCharacter({ hasAvatar: true }))).toBe(
-      'https://gateway.example/avatars/test-character.png'
-    );
+  it('returns the API-provided public URL verbatim — never rebuilds it locally', () => {
+    // The URL must be gateway-derived: bot-client's own GATEWAY_URL is the
+    // internal hostname, and a URL built from it rendered as a broken image
+    // (Discord's media proxy is the fetcher, not the bot).
+    expect(
+      viewAvatarUrl(
+        createTestCharacter({ avatarUrl: 'https://public.example/avatars/test-character-123.png' })
+      )
+    ).toBe('https://public.example/avatars/test-character-123.png');
   });
 
-  it('detects avatars through the REAL read-path coercion (hasAvatar survives, avatarData does not)', () => {
-    // The seam that broke: toCharacterData ALWAYS nulls avatarData on reads,
-    // so a gate on avatarData renders no thumbnail for any real character.
-    // hasAvatar rides the spread — pin the wiring through the real coercion.
-    const withAvatar = toCharacterData({ ...createTestCharacter(), hasAvatar: true });
+  it('carries the avatar URL through the REAL read-path coercion (avatarUrl survives, avatarData does not)', () => {
+    // The seam that broke twice: toCharacterData ALWAYS nulls avatarData on
+    // reads, and a schema-undeclared field would be strip-deleted before the
+    // bot ever saw it. Pin the wiring through the real coercion.
+    const withAvatar = toCharacterData({
+      ...createTestCharacter(),
+      avatarUrl: 'https://public.example/avatars/test-character-123.png',
+    });
     expect(withAvatar.avatarData).toBeNull();
-    expect(viewAvatarUrl(withAvatar)).toBe('https://gateway.example/avatars/test-character.png');
+    expect(viewAvatarUrl(withAvatar)).toBe('https://public.example/avatars/test-character-123.png');
 
-    const without = toCharacterData({ ...createTestCharacter(), hasAvatar: false });
+    const without = toCharacterData({ ...createTestCharacter(), avatarUrl: null });
     expect(viewAvatarUrl(without)).toBeNull();
   });
 });
@@ -190,6 +194,28 @@ describe('buildCharacterViewV2', () => {
     expect(flat.some(n => n.type === ComponentType.Button)).toBe(false);
     expect(flat.some(n => n.type === ComponentType.Section)).toBe(false);
     expect(flat.some(n => n.content?.includes('definition is private') === true)).toBe(true);
+  });
+
+  it('renders Tone and Age as separate blocks, never one joined line (owner eval finding)', () => {
+    const flat = flatten(
+      toTree(
+        buildCharacterViewV2(
+          createTestCharacter({
+            personalityTone: 'a very long tone paragraph that would scrunch anything joined to it',
+            personalityAge: 'sounds about fifty',
+          }),
+          0,
+          null
+        )
+      )
+    );
+
+    const toneNode = flat.find(n => n.content?.startsWith('**🎨 Tone**') === true);
+    const ageNode = flat.find(n => n.content?.startsWith('**📅 Age**') === true);
+    expect(toneNode?.content).toContain('a very long tone paragraph');
+    expect(ageNode?.content).toContain('sounds about fifty');
+    // Age must not ride the tail of the Tone block.
+    expect(toneNode?.content).not.toContain('Age');
   });
 
   it('carries the date footer as subtext on every page', () => {

--- a/services/bot-client/src/commands/character/viewV2.ts
+++ b/services/bot-client/src/commands/character/viewV2.ts
@@ -31,7 +31,6 @@ import {
   escapeMarkdown,
 } from 'discord.js';
 import { DISCORD_COLORS, CHARACTER_VIEW_LIMITS } from '@tzurot/common-types/constants/discord';
-import { getConfig } from '@tzurot/common-types/config/config';
 import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import type { CharacterData } from './characterTypes.js';
@@ -63,19 +62,15 @@ export interface ViewV2Result {
 }
 
 /**
- * Public avatar URL for a character, or null when it has none. Uses the
- * gateway's public avatar route — the same URL Discord already fetches for
- * webhook avatars, so it is reachable from Discord's media proxy.
- *
- * Gates on `hasAvatar` (the read-direction signal) — `avatarData` is a
- * write-direction field that toCharacterData ALWAYS nulls on reads, so
- * gating on it would mean the thumbnail never renders.
+ * Public avatar URL for a character, or null when it has none. Consumes the
+ * API's gateway-derived `avatarUrl` — the thumbnail is fetched by DISCORD's
+ * media proxy, so it needs the PUBLIC gateway host, which only the gateway
+ * process knows (bot-client's own gateway base URL is the internal hostname
+ * and produced a broken image here; export.ts can use it only because the
+ * BOT does that fetch itself).
  */
 export function viewAvatarUrl(character: CharacterData): string | null {
-  if (character.hasAvatar !== true) {
-    return null;
-  }
-  return `${getConfig().GATEWAY_URL}/avatars/${encodeURIComponent(character.slug)}.png`;
+  return character.avatarUrl ?? null;
 }
 
 /** Label + truncated value as one markdown block, flagging expandability. */
@@ -122,16 +117,19 @@ function overviewBlocks(character: CharacterData): ViewBlock[] {
     `**Voice:** ${character.voiceEnabled ? '🎤 Enabled' : '❌ Disabled'}\n` +
     `**Images:** ${character.imageEnabled ? '🖼️ Enabled' : '❌ Disabled'}`;
 
-  const toneAge =
-    `**🎨 Tone:** ${character.personalityTone ?? '_Not set_'} · ` +
-    `**📅 Age:** ${character.personalityAge ?? '_Not set_'}`;
+  // Tone and Age are SEPARATE blocks, mirroring the embed view's separate
+  // inline fields — a mid-line `·` join scrunched Age onto the tail of an
+  // arbitrarily long Tone paragraph (owner eval finding).
+  const tone = `**🎨 Tone**\n${character.personalityTone ?? '_Not set_'}`;
+  const age = `**📅 Age**\n${character.personalityAge ?? '_Not set_'}`;
 
   return [
     { text: overviewDescription(character) },
     { text: identityBlock(character) },
     { text: settings },
     fieldBlock(character, 'personalityTraits', CHARACTER_VIEW_LIMITS.MEDIUM),
-    { text: toneAge },
+    { text: tone },
+    { text: age },
   ];
 }
 

--- a/services/bot-client/src/utils/gatewayAccessGuard.test.ts
+++ b/services/bot-client/src/utils/gatewayAccessGuard.test.ts
@@ -32,8 +32,7 @@ const ALLOWED_RELATIVE = new Set<string>([
   'utils/serviceFetch.ts', // blessed infra fetch (/health, /metrics) — attaches X-Service-Auth
   'utils/gatewayClients.ts', // typed-client transport base URL
   'utils/gatewayServiceCalls.ts', // service-to-service calls — attaches X-Service-Auth
-  'commands/character/export.ts', // builds the PUBLIC /avatars asset URL (no auth gate)
-  'commands/character/viewV2.ts', // same PUBLIC /avatars asset URL, as the V2 header Thumbnail
+  'commands/character/export.ts', // fetches the /avatars asset ITSELF (bot-side fetch — internal URL is fine)
 ]);
 
 function walk(dir: string): string[] {


### PR DESCRIPTION
## Summary

The owner's V2 pilot eval (mobile, maxed-out character) found two issues; both fixed.

**1. Header thumbnail rendered as a broken image.** Runtime-confirmed root cause: `viewAvatarUrl` built the URL from bot-client's `GATEWAY_URL`, which on Railway is the **internal** hostname — `export.ts` gets away with it because the *bot* performs that fetch over the internal network, but a Thumbnail is fetched by **Discord's media proxy**, from outside. (Verified against dev env: bot-client has only the internal var; api-gateway holds `PUBLIC_GATEWAY_URL`.)

Fix follows the pattern the *working* webhook avatars already use: derive server-side, consume client-side.
- `PersonalityFullSchema` gains `avatarUrl` (required, nullable — all four user personality routes emit via the shared formatter, so no optional weakening). Declared-in-schema, so strip-mode can't silently delete it.
- `formatPersonalityResponse` derives it via identity's canonical `deriveAvatarUrl` (public base + cache-busting `updatedAt` timestamp, so avatar changes bust Discord's CDN) — and emits **null when no avatar exists**, since a derived URL for a missing avatar would 404 into the same broken-image state.
- `viewAvatarUrl` consumes the field verbatim; the hand-built URL (and its `getConfig` read) is gone, and viewV2 is removed from the gateway-access-guard allowlist.

**2. Age scrunched onto the tail of the Tone paragraph.** The overview joined Tone and Age with a mid-line `·` — unreadable when Tone is a 900-char paragraph. They're now separate blocks, mirroring the embed view's separate fields.

## Verification

- Seam pins per the class history (this field's shape has now bitten twice): schema-parse survival test, carriage through the REAL `toCharacterData` coercion, formatter emission incl. no-avatar null, redaction-safe case, and the `PUBLIC_GATEWAY_URL → GATEWAY_URL` fallback (with the empty-string-vs-unset `??` trap documented).
- Tone/Age separation pinned (`toneNode` must not contain Age).
- Full pre-push turbo across all 14 affected packages green; `pnpm quality` green. The typed test-factory caught the interface change at compile time, exactly as designed.
- Owner re-smoke needed post-deploy: the thumbnail should now render (and the URL carries a timestamp, so no stale-cache confusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)