### PR TITLE
docs: session-mining operationalizations — receipt/sweep/confidence triggers

### DIFF
--- a/.claude/hooks/skill-eval.sh
+++ b/.claude/hooks/skill-eval.sh
@@ -47,8 +47,13 @@ if echo "$PROMPT" | grep -qiE 'doc.*audit|audit.*doc|documentation.*fresh|stale.
     RELEVANT_SKILLS="$RELEVANT_SKILLS tzurot-doc-audit"
 fi
 
-# Bug remediation → tzurot-bug-remediation skill
-if echo "$PROMPT" | grep -qiE 'keeps? (biting|happening|recurring)|recurring bug|regress(ed|ion)|why didn.t.*tests? catch|root.?cause'; then
+# Bug remediation → tzurot-bug-remediation skill. Two trigger families:
+# (a) recurrence language (a "fixed" class came back), and (b) the FIRST-fix
+# moment for a path-specific UI/flow bug — the skill's first-fix sibling-sweep
+# only helps if the skill loads THEN, not just on recurrence (the phrasing here
+# mirrors the owner's smoke-report shape: "delete button doesn't show up after
+# creation", "only shows up after edit").
+if echo "$PROMPT" | grep -qiE 'keeps? (biting|happening|recurring)|recurring bug|regress(ed|ion)|why didn.t.*tests? catch|root.?cause|(delete|edit|create|browse|view|save|submit) (button|flow|screen|dialog|modal)|does(n.?t| not) (show|appear|render)|only (shows?|appears?).*(after|on)'; then
     RELEVANT_SKILLS="$RELEVANT_SKILLS tzurot-bug-remediation"
 fi
 

--- a/.claude/rules/09-interaction-style.md
+++ b/.claude/rules/09-interaction-style.md
@@ -17,6 +17,8 @@ Rules about how to interact with the user during sessions. These supplement, not
 
 When a user message contains a question, answer it BEFORE advancing your own agenda — the release flow, the next task, or a re-ask of your own pending question. Multi-part messages get every part addressed; enumerate the parts if that's what it takes. Skipping an embedded question forces the user to halt the work and re-ask ("can you answer my webhook question first?", "did you see my question?" — both real).
 
+**Two mechanical checkpoints** (the rule alone kept being violated under monitor-notification interleave — these attach it to deterministic moments): (a) a user message that arrives **mid-turn** gets an explicit one-line receipt at the TOP of the next reply, restating the ask before continuing — this also surfaces a harness-swallowed message within one turn; (b) before **ending any turn**, re-scan the user's last message for question marks and enumerated parts, and either answer each or name which remain pending. "Did you see my earlier question / recommendation?" recurred across every mined corpus — the fix is checking at these two points, not trying harder to remember.
+
 ## User Directives Are Immutable Session State
 
 Once the user has made a call — a release gate ("I want them fixed before the release is cut"), a scope decision, a design choice — do not re-propose the alternative in later turns. Re-litigating forces escalation ("I'm not budging on that"). Genuinely new information may justify surfacing the tradeoff once more, explicitly framed as new information; convenience or effort never does.

--- a/.claude/skills/tzurot-bug-remediation/SKILL.md
+++ b/.claude/skills/tzurot-bug-remediation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-bug-remediation
-description: 'The recurring-bug remediation protocol: runtime evidence → root cause → exhaustive class sweep → seam-tier regression test → structural guard. Invoke with /tzurot-bug-remediation when a bug recurs, a "fixed" class regresses, or the owner says a failure "keeps biting".'
-lastUpdated: '2026-07-05'
+description: 'The recurring-bug remediation protocol: runtime evidence → root cause → exhaustive class sweep → seam-tier regression test → structural guard. Invoke with /tzurot-bug-remediation when a bug recurs, a "fixed" class regresses, the owner says a failure "keeps biting", OR at the FIRST fix of a path-specific UI/flow bug (create/edit/browse/view/delete) — to sweep sibling flows before declaring it fixed.'
+lastUpdated: '2026-07-20'
 ---
 
 # Bug Remediation Protocol
@@ -11,6 +11,8 @@ previously-"fixed" class regresses, or when the owner signals class-level pain
 ("keeps biting me", "this happens a lot", "why didn't tests catch it"). The
 protocol exists because under-remediation recurs in a fixed shape: a symptom
 patch on the one visible instance, a mocked unit test, and the class returns.
+
+**Also fires at the FIRST fix of any path-specific UI/flow bug** — a bug on one of a component family's parallel flows (create / edit / browse / view / delete). Before declaring it fixed: sweep every sibling flow of the same family for the same class, and label the claim **code-read-only** until the owner's runtime smoke confirms it. This class was lost repeatedly by waiting for recurrence: a `canEdit`/delete-button bug fixed on the edit path returned on the _create_ path one smoke round later; an avatar-seam bug "fixed" pre-merge was still broken at runtime. The recurrence trigger below is the backstop; this first-fix sweep is the cheaper catch.
 
 The five steps run IN ORDER. Skipping one is how the bug comes back.
 

--- a/.claude/skills/tzurot-docs/SKILL.md
+++ b/.claude/skills/tzurot-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-docs
 description: 'Session workflow procedures. Invoke with /tzurot-docs for session start/end, CURRENT.md and backlog management.'
-lastUpdated: '2026-07-05'
+lastUpdated: '2026-07-20'
 ---
 
 # Documentation & Session Workflow
@@ -25,7 +25,8 @@ The backlog is HOT/COLD split — load only the HOT surface at start (see `BACKL
 4. **Run both BACKLOG gates** (see `.claude/rules/06-backlog.md`):
    - **Additions gate**: every promised backlog item from this session's plans is actually written to the appropriate `backlog/**/*.md` file
    - **Removals gate**: every item that shipped in this session's merged PRs is removed from its backlog file. `grep -r backlog/` (recursive — includes `cold/`) against the session's PR titles and scope terms; delete matches. This gate most often gets skipped, producing backlog rot. (Removal is for _shipped_ or _genuinely obsolete_ items only — never time-based pruning; aging escalates, it doesn't delete.)
-5. Commit with `wip:` prefix if session ended with incomplete work
+5. **Structural sweep**: name any failure that occurred twice-or-more this session and its disposition — rule / skill / hook / explicitly none-needed with the reason. "Nothing recurred" must be stated, not implied. The gap this closes is self-_initiation_: once the owner asks "do we need a rule/hook?" the response is reliably fast, so the miss is noticing at the moment of the second occurrence, not building. (`/tzurot-session-mining` is the periodic backstop; this is the per-session one.)
+6. Commit with `wip:` prefix if session ended with incomplete work
 
 ## Work Tracking Files
 

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-07-16'
+lastUpdated: '2026-07-20'
 ---
 
 # Git Workflow Procedures
@@ -191,6 +191,13 @@ raise confidence?" — answer it before being asked, as part of proposing the cu
 - For minor features, offer **observability-instead-of-smoke** ("logging is in
   place to check the first real use") as a first-class alternative to another
   manual round.
+- **The smoke request IS the CURRENT.md write** — never ask the owner to
+  smoke-test anything that isn't already a CURRENT.md checklist item with its
+  own status line. Asking in chat shorthand forces "remind me what to test?"
+  (recurred: the ask lived only in chat and scrolled away).
+- **Each smoke item carries a confidence tier** (canonical definition in
+  `/tzurot-testing` § Human-Verification Requests) — offer the owner only the
+  _needs-smoke_ tier, never the _high_ tier CI + review already cover.
 - Never cite "soaked in dev" as safety evidence (see /tzurot-deployment).
 
 ### 1. Version Bump
@@ -213,6 +220,14 @@ Write release notes following the Conventional Changelog format defined in `.cla
 **Source of truth**: `git log v<previous-tag>..HEAD --no-merges` — NOT CURRENT.md.
 CURRENT.md tracks session work; release notes track what shipped between tags.
 Using CURRENT.md caused duplicate entries in beta.94 (items from beta.93 re-listed).
+
+**Backlog sweep — same pass, same commit as the notes.** The release range
+enumerates every shipped PR anyway, which is the one deterministic moment the
+full shipped-list exists. For each PR in the range, grep `backlog/` (recursive,
+incl. `cold/`) for the item's topic and strike/remove the shipped entries. This
+mechanizes 06-backlog's session-end removal gate at the moment it's nearly free
+— removal-at-ship keeps being missed, which is what leaves the board stale
+enough that the owner's memory has to catch it ("didn't we already do X?").
 
 ```bash
 # 1. Find the previous release tag

--- a/.claude/skills/tzurot-testing/SKILL.md
+++ b/.claude/skills/tzurot-testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-testing
 description: 'Testing procedures. Invoke with /tzurot-testing for test execution, coverage audits, and debugging test failures.'
-lastUpdated: '2026-07-03'
+lastUpdated: '2026-07-20'
 ---
 
 # Testing Procedures
@@ -215,6 +215,14 @@ be answerable from the file). Justify every case — a bloated matrix wastes the
 user's time; each case states what it uniquely proves. After the user reports,
 close the loop with runtime evidence (logs) when the user-visible outcome can't
 prove the new code path ran.
+
+**Each checklist item carries a confidence tier** — _high_ (CI + review +
+blast-radius cover it; ships without a manual round) or _needs-smoke_ (with the
+one-line reason confidence is limited: runtime-unverified path, mobile
+rendering, a failure sequence tests can't reach). Surface only the needs-smoke
+tier for the owner to run — they don't want to hand-test high-confidence
+changes ("what's the level of confidence… I don't feel like testing them unless
+confidence is limited").
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary

Five one-line-to-paragraph additions to existing load-bearing surfaces, from the 2026-07-20 cross-corpus session-mining synthesis (`mined-corpus/reports/SYNTHESIS-2026-07-20.md`, machine-local). Every one is a **compliance-failure** finding — a rule/skill that already existed and was still violated across the mined corpora — so these are **trigger sentences attached to deterministic moments**, not rule restatements (the synthesis explicitly rejected restatements).

| R | Surface | Change | Finding |
|---|---------|--------|---------|
| R1 | `09-interaction-style.md` | mid-turn message receipt + end-of-turn question re-scan | "did you see my question?" recurred in all 3 corpora |
| R3 | `tzurot-bug-remediation` | fires at FIRST fix of path-specific UI bugs — sibling-flow sweep + code-read-only labeling | canEdit/avatar classes returned at sibling paths one smoke round after the "fix" |
| R7 | `tzurot-git-workflow` + `tzurot-testing` | smoke-request IS the CURRENT.md write; per-item confidence tiers (owner tests only needs-smoke) | "remind me what to test?" / "confidence in their changes?" |
| R8 | `tzurot-git-workflow` | release-time backlog sweep in the notes pass | removal-at-ship keeps being missed → board staleness |
| R9 | `tzurot-docs` | session-end structural sweep (name twice-recurring failures + disposition) | owner keeps having to ask "do we need a rule/hook?" |

The hooks (R2 promise-ledger, R11 cwd-drift) and code gates (R5 sync-completeness, R10 notes-path) ride separate PRs. Owner decisions (observability promotion, ratchet-trend) already landed as backlog moves on develop.

## Verification

Docs/skill-only; pre-push line-budget + backlog + workflow-sync green. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)