### PR TITLE
feat: promise-ledger + cwd-drift warn-hooks (session-mining R2/R11)

### DIFF
--- a/.claude/hooks/cwd-drift-guard.probe.sh
+++ b/.claude/hooks/cwd-drift-guard.probe.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Fixture check for cwd-drift-guard.sh — run after ANY edit to the hook.
+# Asserts the exit-code table over the shapes that matter: only a bare git
+# command with a repo-root-relative pathspec, run from a drifted subdir cwd,
+# blocks; everything else (git -C, at-root, pnpm, no-pathspec, subdir-local
+# path) passes.
+#
+# Colocated with the hook — it IS the hook's verification mechanism, a bash
+# exit-code harness over a bash hook, run manually on hook edits.
+#
+# Usage: .claude/hooks/cwd-drift-guard.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/cwd-drift-guard.sh"
+export CLAUDE_PROJECT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+ROOT="$CLAUDE_PROJECT_DIR"
+
+fail=0
+check() { # $1=expected_exit $2=label $3=json
+  echo "$3" | "$HOOK" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" != "$1" ]; then
+    echo "FAIL [$got≠$1]: $2"
+    fail=1
+  else
+    echo "ok   [$got]: $2"
+  fi
+}
+
+check 2 "drift + repo-root-relative pathspec" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 2 "drift + bare root-file pathspec (CURRENT.md)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add CURRENT.md\"},\"cwd\":\"$ROOT/services/bot-client\"}"
+check 0 "git -C is root-anchored" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $ROOT add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 0 "shell at repo root (no drift)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT\"}"
+check 0 "pnpm from a subdir is legitimate" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"pnpm --filter @tzurot/tooling test\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 0 "git with no pathspec (status)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 0 "subdir-local pathspec (no repo-root prefix)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 0 "path-like substring only INSIDE a quoted commit message (not a pathspec)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m \\\"docs: update packages/tooling/README\\\"\"},\"cwd\":\"$ROOT/services/bot-client\"}"
+check 0 "self-correcting: leading cd to root before the git command" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd \\\"\$CLAUDE_PROJECT_DIR\\\" && git add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 2 "drift + .github pathspec (allowlist completeness)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add .github/workflows/ci.yml\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 0 "no cwd in payload (fail-safe)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add packages/tooling/src/x.ts\"}}"
+check 0 "non-Bash tool" \
+  "{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"x\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+
+[ "$fail" = 0 ] && echo "ALL PASS" || { echo "FAILURES"; exit 1; }

--- a/.claude/hooks/cwd-drift-guard.sh
+++ b/.claude/hooks/cwd-drift-guard.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# PreToolUse(Bash) hook: block a `git` command that references a repo-root-
+# relative pathspec while the persistent shell has drifted into a subdirectory.
+# That exact shape (`git add packages/x/y.ts` run from inside `packages/x`)
+# resolves to `packages/x/packages/x/y.ts` → "did not match any files", AFTER
+# the tests it was gating already passed. It bit four times in one session and
+# again while fixing an unrelated hook.
+#
+# Deliberately NARROW — only the always-wrong shape blocks:
+#   - shell cwd != repo root (drift), AND
+#   - a bare `git` (no `-C` root anchor), AND
+#   - a pathspec that looks repo-root-relative (services/, packages/, …).
+# `pnpm` from a subdir is legitimate (resolves the nearest package) and never
+# blocks; `git -C <root>` is the sanctioned cross-cwd form and never blocks;
+# `git status`/`git log` with no pathspec never block.
+#
+# FAIL-SAFE: if the payload carries no cwd, or cwd == root, exit 0 (allow).
+# The hook can only ever ADD a block on an unambiguous mistake.
+
+set -uo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$CMD" ] && exit 0
+
+# The shell's persistent cwd, as reported in the hook payload. Absent → allow.
+SHELL_CWD=$(jq -r '.cwd // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$SHELL_CWD" ] && exit 0
+
+ROOT="${CLAUDE_PROJECT_DIR:-}"
+[ -z "$ROOT" ] && exit 0
+# No drift → nothing to guard. Normalize trailing slashes before comparing.
+[ "${SHELL_CWD%/}" = "${ROOT%/}" ] && exit 0
+# Drift outside the repo entirely (some other project) → not our concern.
+case "${SHELL_CWD%/}/" in
+  "${ROOT%/}/"*) ;;
+  *) exit 0 ;;
+esac
+
+# A command that OPENS with `cd …` deliberately sets its own cwd, so the
+# persistent-shell cwd this guard reads is no longer what git runs against —
+# `cd "$CLAUDE_PROJECT_DIR" && git add packages/x` self-corrects to root. Bail
+# out (fail-open) rather than false-block on a self-correcting command.
+case "$(printf '%s' "$CMD" | sed -E 's/^[[:space:]]+//')" in
+  cd\ *) exit 0 ;;
+esac
+
+# Cheap short-circuit: only git commands with a repo-root-relative-looking
+# pathspec are candidates. `-C` anywhere means the command is root-anchored.
+case "$CMD" in
+  *git\ -C\ *|*git\ --git-dir*) exit 0 ;;
+esac
+if ! grep -qE '(^|[[:space:]&|;])git[[:space:]]' <<<"$CMD"; then
+  exit 0
+fi
+# Strip quoted spans BEFORE the pathspec scan — a commit message like
+# `git commit -m "docs: update packages/tooling/README"` contains a path-like
+# substring that is NOT a pathspec argument, and matching it would false-block
+# (violating this hook's "only ever block an unambiguous mistake" contract).
+# Same quote-stripping precedent as git-commit-filter-guard.
+SCAN=$(sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g" <<<"$CMD")
+# Repo-root-relative DIR-prefixed pathspec (the always-wrong drift shape)...
+if ! grep -qE '(^|[[:space:]])(services|packages|backlog|docs|prisma|scripts|\.claude|\.github|\.husky)/' <<<"$SCAN"; then
+  # ...or a bare root-file pathspec (CURRENT.md/BACKLOG.md — files, so no
+  # trailing slash; the dir alternation above can't catch these).
+  grep -qE '(^|[[:space:]])(CURRENT|BACKLOG)\.md($|[[:space:]])' <<<"$SCAN" || exit 0
+fi
+
+REL="${SHELL_CWD#"${ROOT%/}"/}"
+cat >&2 << MSG
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+CWD-DRIFT GUARD — command blocked
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+The persistent shell is in a subdirectory ('$REL'), but this git
+command references a repo-root-relative pathspec. It will resolve
+against the subdir ('$REL/$REL/...') and fail with "did not match
+any files" — AFTER any tests in the chain already ran.
+
+Per /tzurot-git-workflow § command-shape rules, use either:
+  - git -C "\$CLAUDE_PROJECT_DIR" <subcommand> <paths>   (root-anchored), or
+  - run the git step in its own call from the repo root.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MSG
+exit 2

--- a/.claude/hooks/promise-ledger-check.probe.sh
+++ b/.claude/hooks/promise-ledger-check.probe.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Fixture check for promise-ledger-check.sh — run after ANY edit to the hook.
+# Asserts the exit-code table over synthetic transcripts: a deferred-work
+# promise with no same-turn backlog write (and no backlog-file mention) blocks;
+# a same-turn write, a backlog-file mention, a process-action promise, and a
+# no-promise close all pass. The stop_hook_active re-stop always passes.
+#
+# Colocated with the hook — the transcript-parsing python is the fragile part;
+# this harness pins its behavior on hook edits.
+#
+# Usage: .claude/hooks/promise-ledger-check.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/promise-ledger-check.sh"
+export CLAUDE_PROJECT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Build a transcript: one user turn + optional Edit(file) + a final text block.
+mktx() { # $1=out $2=text $3=edited_file(optional)
+  : > "$1"
+  echo '{"type":"user","isMeta":null,"message":{"content":"go"}}' >> "$1"
+  [ -n "${3:-}" ] && printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"%s"}}]}}\n' "$3" >> "$1"
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":%s}]}}\n' "$(printf '%s' "$2" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" >> "$1"
+}
+
+fail=0
+check() { # $1=expected_exit $2=label $3=transcript $4=stop_active
+  echo "{\"stop_hook_active\":${4:-false},\"transcript_path\":\"$3\"}" | "$HOOK" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" != "$1" ]; then echo "FAIL [$got≠$1]: $2"; fail=1; else echo "ok   [$got]: $2"; fi
+}
+
+mktx "$TMP/a.jsonl" "Filed the export nit. I'll add the sync gate later once the schema settles."
+check 2 "promise + unrelated 'Filed' word, no write" "$TMP/a.jsonl"
+
+mktx "$TMP/b.jsonl" "I'll add the sync gate later once the schema settles." "$CLAUDE_PROJECT_DIR/backlog/cold/follow-ups.md"
+check 0 "promise + same-turn backlog write" "$TMP/b.jsonl"
+
+mktx "$TMP/c.jsonl" "All merged. I'll merge #1732 once CI passes."
+check 0 "process-action promise (merge once CI)" "$TMP/c.jsonl"
+
+mktx "$TMP/d.jsonl" "Done — the fix is in and tests are green. Anything else?"
+check 0 "no promise" "$TMP/d.jsonl"
+
+mktx "$TMP/e.jsonl" "Good idea — let's not forget the ratchet trend work."
+check 2 "let's-not-forget, no write" "$TMP/e.jsonl"
+
+mktx "$TMP/f.jsonl" "I'll circle back to the browse retrofit after this PR. Tracked in follow-ups.md already."
+check 0 "promise but names a backlog file" "$TMP/f.jsonl"
+
+mktx "$TMP/h.jsonl" "I will add the sync gate later once the schema settles."
+check 2 "full-form 'I will' promise (not just the contraction), no write" "$TMP/h.jsonl"
+
+check 0 "stop_hook_active re-stop always allows" "$TMP/a.jsonl" true
+
+# Finding 2: a transcript with NO genuine user turn must fail strict — an
+# unfiled promise still fires (no earlier backlog write gets credited).
+{
+  echo '{"type":"user","isMeta":true,"message":{"content":[{"type":"tool_result","content":"x"}]}}'
+  echo '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"'"$CLAUDE_PROJECT_DIR"'/backlog/cold/follow-ups.md"}}]}}'
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":%s}]}}\n' \
+    "$(printf '%s' "I'll add the sync gate later." | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+} > "$TMP/g.jsonl"
+check 2 "no genuine user turn → strict: earlier backlog write NOT credited" "$TMP/g.jsonl"
+
+[ "$fail" = 0 ] && echo "ALL PASS" || { echo "FAILURES"; exit 1; }

--- a/.claude/hooks/promise-ledger-check.sh
+++ b/.claude/hooks/promise-ledger-check.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Stop hook: when the agent tries to end a turn whose final message makes a
+# deferred-work promise ("I'll file that later", "follow-up after this PR")
+# WITHOUT a same-turn write to a backlog file or CURRENT.md, block the stop
+# once and remind — the promise ledger dies in chat otherwise, and the owner
+# ends up asking "what's the plan for those?" a session later.
+#
+# Enforcement geometry mirrors the origin-vocabulary merge gate: a deterministic
+# scan of the ASSISTANT'S OWN output, blocking once until acknowledged. The
+# `stop_hook_active` flag makes it fire at most once per turn-end — if the
+# promise is already tracked, or is a process action that needs no backlog
+# entry, the agent notes that and stops again (the second stop is allowed).
+#
+# Trigger is deliberately narrow (deferred-WORK verbs + a deferral marker) to
+# keep false positives low; the same-turn backlog-write gate suppresses the
+# common "promised AND filed in the same breath" case.
+#
+# 06-backlog.md § "The promise ledger — file at the moment of utterance".
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Already blocked once this turn-end → allow the stop (no infinite loop).
+ACTIVE=$(jq -r '.stop_hook_active // false' <<<"$INPUT" 2>/dev/null || echo "false")
+[ "$ACTIVE" = "true" ] && exit 0
+
+TRANSCRIPT=$(jq -r '.transcript_path // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ] && exit 0
+
+VERDICT=$(TRANSCRIPT="$TRANSCRIPT" python3 << 'PYEOF'
+import json, os, re, sys
+
+path = os.environ["TRANSCRIPT"]
+try:
+    lines = open(path, encoding="utf-8").read().splitlines()
+except OSError:
+    print("ok"); sys.exit()
+
+# Walk from the end to the last GENUINE user message (a user turn carrying real
+# text, not a tool_result envelope) — that bounds the current turn.
+def is_genuine_user(entry):
+    if entry.get("type") != "user" or entry.get("isMeta"):
+        return False
+    content = entry.get("message", {}).get("content")
+    if isinstance(content, str):
+        return len(content.strip()) > 0
+    if isinstance(content, list):
+        return any(b.get("type") == "text" for b in content)
+    return False
+
+records = []
+for ln in lines:
+    ln = ln.strip()
+    if not ln:
+        continue
+    try:
+        records.append(json.loads(ln))
+    except json.JSONDecodeError:
+        continue
+
+turn_start = None
+for i in range(len(records) - 1, -1, -1):
+    if is_genuine_user(records[i]):
+        turn_start = i
+        break
+
+# If the turn boundary can't be found, fail toward STRICT: an empty turn means
+# wrote_backlog stays False, so an unfiled promise still fires (rather than
+# crediting a backlog write from some earlier point in the session and silently
+# defeating the same-turn check). The final message is scanned regardless.
+turn = records[turn_start:] if turn_start is not None else []
+
+BACKLOG_RE = re.compile(r"(^|/)(backlog/|CURRENT\.md|BACKLOG\.md)")
+
+# (a) same-turn backlog writes. LIMITATION: only direct Edit/Write/MultiEdit in
+# THIS transcript count — a backlog file written by a delegated subagent (Agent
+# tool) lands in a different transcript and won't be seen here; the closing
+# message must then name the backlog file to take the escape hatch below.
+wrote_backlog = any(
+    block.get("type") == "tool_use"
+    and block.get("name") in ("Edit", "Write", "MultiEdit")
+    and BACKLOG_RE.search(str(block.get("input", {}).get("file_path", "")))
+    for entry in turn
+    if entry.get("type") == "assistant"
+    for block in (entry.get("message", {}).get("content", []) or [])
+)
+
+# (b) the final assistant text = last text block ANYWHERE (robust to the
+# boundary-not-found case; it's always the closing message we read to end).
+final_text = ""
+for entry in records:
+    if entry.get("type") != "assistant":
+        continue
+    for block in entry.get("message", {}).get("content", []) or []:
+        if block.get("type") == "text":
+            final_text = block.get("text", "")
+
+if wrote_backlog or not final_text.strip():
+    print("ok"); sys.exit()
+
+# Escape hatch: the message names an actual backlog FILE where it's tracked.
+# Deliberately filename-based, not a bare "filed/tracked" word — the word form
+# false-negatived "Filed the export nit. I'll add the gate later" (the "filed"
+# was about a different thing; the promise was still unfiled). False positives
+# here cost one acknowledged turn; false negatives defeat the hook — bias to fire.
+TEXT_TRACK_RE = re.compile(
+    r"(backlog/|follow-ups\.md|ideas\.md|now\.md|active-epic\.md|epic-log\.md|queue\.md|CURRENT\.md|BACKLOG\.md)",
+    re.I,
+)
+if TEXT_TRACK_RE.search(final_text):
+    print("ok"); sys.exit()
+
+# Deferred-WORK promise: a work verb + a deferral marker, reasonably close.
+# Narrow on purpose — "I'll merge once CI passes" (process, not backlogged
+# work) lacks a work verb here and is correctly ignored.
+PROMISE = re.compile(
+    r"\b(?:I['’]?ll|I\s+will)\s+(?:\w+\s+){0,3}?"
+    r"(add|fix|file|handle|implement|build|write|create|update|migrate|refactor|clean\s*up|revisit|circle\s+back)"
+    r"\b.{0,60}?\b(later|after\s+(this|the)|once\b|next\s+session|tomorrow|down\s+the\s+line|follow[-\s]?up)",
+    re.I | re.S,
+)
+ALT = re.compile(
+    r"\b(let['’]?s\s+not\s+forget|as\s+a\s+follow[-\s]?up|in\s+a\s+follow[-\s]?up\s+PR)\b",
+    re.I,
+)
+if PROMISE.search(final_text) or ALT.search(final_text):
+    print("promise")
+else:
+    print("ok")
+PYEOF
+) || exit 0
+
+[ "$VERDICT" != "promise" ] && exit 0
+
+cat >&2 << 'MSG'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PROMISE LEDGER — deferred-work promise without a same-turn backlog write
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Your closing message defers work ("I'll … later" / "follow-up …") but
+no backlog/**/*.md or CURRENT.md write happened this turn. Per
+06-backlog.md § promise ledger, a promise that lives only in chat
+dies at the next compaction.
+
+Do ONE of:
+  - File it now (cold/follow-ups.md row, or now.md), then stop; or
+  - If it's already tracked or is a process action that needs no
+    backlog entry, say where/why in one line and stop again (this
+    gate fires only once per turn — the next stop proceeds).
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,20 @@
           {
             "type": "command",
             "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/develop-code-commit-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/cwd-drift-guard.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/promise-ledger-check.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Two deterministic hooks from the 2026-07-20 mining synthesis. Both address findings where a **rule already existed and was still violated** across the mined corpora — the fix is a scan of a deterministic signal, not another rule.

**`promise-ledger-check.sh` (Stop hook, R2 / finding 3)** — blocks a turn-end **once** when the agent's final message defers work (`I'll … later`, `follow-up after this PR`, `let's not forget`) without a same-turn write to a backlog file or CURRENT.md. `stop_hook_active` guarantees at-most-once firing: the agent files the item (or notes where it's already tracked / that it's a process action) and stops again, which proceeds. Same enforcement geometry as the origin-vocabulary merge gate — a scan of the agent's *own* output — which the synthesis found **held across all three corpora** where the rule-only version failed. `06-backlog.md` § promise ledger was violated in all three.

**`cwd-drift-guard.sh` (PreToolUse Bash, R11 / tier-3)** — blocks the narrow *always-wrong* shape: a bare `git` command with a repo-root-relative pathspec run while the persistent shell has drifted into a subdir (resolves to `subdir/subdir/…` → "did not match any files", after the tests in the chain already ran). Bit 4× in one session, and again while fixing an unrelated hook. **Fail-safe**: no `cwd` in payload, at-root, `git -C`, `git status`, and `pnpm`-from-subdir all pass — it can only ever add a block on an unambiguous mistake.

## Verification

- Colocated probe scripts (`*.probe.sh`, following `develop-code-commit-guard.probe.sh` precedent) pin both exit-code tables against synthetic payloads/transcripts: **cwd-drift 12/12, promise-ledger 9/9, ALL PASS**.
- The promise-hook probe includes the false-negative case that shaped the design: `"Filed the export nit. I'll add the gate later"` must block (the "Filed" is about a different thing) — which is why the escape hatch is backlog-*filename*-based, not a bare "filed/tracked" word.
- Settings reload at session start, so both arm next session (no effect on this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
