### PR TITLE
feat: sync-config completeness gate + release-notes finalize guard (mining R5/R10)

### DIFF
--- a/packages/tooling/src/release/publish.test.ts
+++ b/packages/tooling/src/release/publish.test.ts
@@ -1,15 +1,58 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
-vi.mock('node:fs', () => ({ existsSync: vi.fn(() => true) }));
+vi.mock('node:fs', () => ({ existsSync: vi.fn(() => true), readFileSync: vi.fn(() => '') }));
 
 const mockedExec = vi.mocked(execFileSync);
 const mockedExists = vi.mocked(existsSync);
+const mockedRead = vi.mocked(readFileSync);
 
 // Import AFTER the mocks so the module bindings capture the mocked versions.
-import { isPrereleaseVersion, toTag, findPreviousReleaseTag, publishRelease } from './publish.js';
+import {
+  isPrereleaseVersion,
+  toTag,
+  findPreviousReleaseTag,
+  publishRelease,
+  assertNotesFinalized,
+} from './publish.js';
+
+describe('assertNotesFinalized', () => {
+  it('accepts a finalized compare trailer matching the tag', () => {
+    const notes = 'blah\n**Full Changelog**: https://x/compare/v3.0.0-beta.170...v3.0.0-beta.171';
+    expect(() => assertNotesFinalized(notes, 'v3.0.0-beta.171')).not.toThrow();
+  });
+
+  it('accepts notes with no compare trailer at all (hand-written)', () => {
+    expect(() => assertNotesFinalized('### Features\n- x', 'v3.0.0-beta.171')).not.toThrow();
+  });
+
+  it('rejects the unreplaced ...HEAD draft placeholder', () => {
+    const notes = '**Full Changelog**: https://x/compare/v3.0.0-beta.170...HEAD';
+    expect(() => assertNotesFinalized(notes, 'v3.0.0-beta.171')).toThrow(/HEAD.*placeholder/s);
+  });
+
+  it('rejects a stale notes file naming the previous tag', () => {
+    const notes = '**Full Changelog**: https://x/compare/v3.0.0-beta.169...v3.0.0-beta.170';
+    expect(() => assertNotesFinalized(notes, 'v3.0.0-beta.171')).toThrow(/stale/);
+  });
+
+  it('tolerates trailing markdown/whitespace after the tag', () => {
+    const notes = '**Full Changelog**: https://x/compare/v3.0.0-beta.170...v3.0.0-beta.171\n';
+    expect(() => assertNotesFinalized(notes, 'v3.0.0-beta.171')).not.toThrow();
+  });
+
+  it('ignores a decoy /compare/ link in prose and validates only the trailer line', () => {
+    // A body citing an upstream changelog diff must not be matched instead of
+    // the real "Full Changelog" trailer (which would false-reject).
+    const notes =
+      '### Improvements\n' +
+      '- bumped dep (see https://github.com/up/stream/compare/v1.0.0...v2.0.0)\n\n' +
+      '**Full Changelog**: https://x/compare/v3.0.0-beta.170...v3.0.0-beta.171';
+    expect(() => assertNotesFinalized(notes, 'v3.0.0-beta.171')).not.toThrow();
+  });
+});
 
 describe('isPrereleaseVersion', () => {
   it.each([
@@ -50,6 +93,10 @@ describe('publishRelease', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedExists.mockReturnValue(true);
+    // Default: notes with no compare trailer, so the finalize guard no-ops for
+    // the publish-flow tests that aren't about it (assertNotesFinalized has its
+    // own dedicated cases above).
+    mockedRead.mockReturnValue('### Features\n- something' as never);
   });
 
   /** Collect the (cmd, args) of every non-dry-run exec call. */

--- a/packages/tooling/src/release/publish.ts
+++ b/packages/tooling/src/release/publish.ts
@@ -19,7 +19,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import chalk from 'chalk';
 
 /**
@@ -41,6 +41,48 @@ export interface PublishOptions {
 /** Normalize `3.0.0-beta.155` or `v3.0.0-beta.155` to a `v`-prefixed tag. */
 export function toTag(version: string): string {
   return version.startsWith('v') ? version : `v${version}`;
+}
+
+/**
+ * Guard against publishing an UNFINALIZED or STALE notes file. `existsSync`
+ * already catches a mistyped/nonexistent path; this catches the two content
+ * misses that path-existence can't:
+ *  - `draft-notes` emits `…/compare/vOLD...HEAD` where the human must replace
+ *    `HEAD` with the new tag. Publishing with `HEAD` still present means the
+ *    finalize step was skipped (a recurring release-notes miss).
+ *  - A leftover previous-release notes file names the WRONG new tag in its
+ *    compare trailer — the file exists but is stale.
+ * Only asserts when a `/compare/…` trailer is present (hand-written notes
+ * without one are allowed through — verify-notes covers their PR-ref accuracy).
+ */
+export function assertNotesFinalized(notes: string, tag: string): void {
+  // Anchor to the "**Full Changelog**:" trailer line (05-tooling notes format),
+  // not any `/compare/…` substring — a hand-edited note can cite an upstream
+  // changelog's compare link, and matching that instead would false-reject.
+  const compare = /^\*\*Full Changelog\*\*:.*\/compare\/\S+?\.\.\.(\S+)/m.exec(notes);
+  if (compare === null) {
+    return;
+  }
+  // Strip trailing markdown/punctuation without a regex (avoids a ReDoS-shaped
+  // super-linear pattern). A tag never ends in `)`, `.`, or `,`, so this only
+  // trims trailer noise like a closing paren or sentence period.
+  let newRef = compare[1];
+  while (newRef.length > 0 && ').,'.includes(newRef[newRef.length - 1])) {
+    newRef = newRef.slice(0, -1);
+  }
+  if (newRef === 'HEAD') {
+    throw new Error(
+      `Release notes still contain the draft "...HEAD" compare placeholder.\n` +
+        `Replace HEAD with the new tag (${tag}) in the "**Full Changelog**" line before publishing.`
+    );
+  }
+  if (newRef !== tag) {
+    throw new Error(
+      `Release notes compare trailer targets ${newRef}, but you're publishing ${tag}.\n` +
+        `This looks like a stale notes file from a previous release — regenerate with ` +
+        `pnpm ops release:draft-notes and re-finalize the compare line.`
+    );
+  }
 }
 
 /**
@@ -231,6 +273,7 @@ export function publishRelease(version: string, opts: PublishOptions): void {
         `Prepare notes first (e.g. pnpm ops release:draft-notes > notes.md) and pass --notes-file.`
     );
   }
+  assertNotesFinalized(readFileSync(opts.notesFile, 'utf-8'), tag);
 
   console.log(
     chalk.bold(`Publishing ${tag}`) +

--- a/services/api-gateway/src/services/sync/config/syncTables.test.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.test.ts
@@ -7,9 +7,75 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { SYNC_CONFIG, SYNC_TABLE_ORDER, type SyncTableName } from './syncTables.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  SYNC_CONFIG,
+  SYNC_TABLE_ORDER,
+  EXCLUDED_TABLES,
+  type SyncTableName,
+} from './syncTables.js';
+
+/**
+ * Every DB table (Prisma model) must be a DELIBERATE sync decision — in
+ * SYNC_CONFIG (synced) or EXCLUDED_TABLES (explicitly not, with a reason).
+ * A new table that's in neither silently doesn't sync: exactly the class that
+ * broke prod db-sync when the alias-tier tables landed unclassified. Fails at
+ * authoring time so the classification can't be forgotten. Parsing
+ * schema.prisma (not the Prisma client) keeps this a pure unit test.
+ */
+function schemaTableNames(): string[] {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // config → sync → services → src → api-gateway → services → repo root
+  const schema = readFileSync(
+    join(here, '..', '..', '..', '..', '..', '..', 'prisma', 'schema.prisma'),
+    'utf-8'
+  );
+  const tables: string[] = [];
+  // Assumes each model's closing brace is unindented on its own line (true for
+  // every block in this schema). If a future reformat breaks that, this test
+  // under-counts tables and quietly stops guarding — verify a schema reformat
+  // doesn't drop the completeness assertion.
+  for (const block of schema.matchAll(/\bmodel\s+(\w+)\s*\{([\s\S]*?)\n\}/g)) {
+    const mapped = block[2].match(/@@map\("([^"]+)"\)/);
+    tables.push(mapped ? mapped[1] : block[1]);
+  }
+  return tables;
+}
 
 describe('syncTables Configuration', () => {
+  describe('schema.prisma completeness (every table is a deliberate sync decision)', () => {
+    it('classifies every Prisma model table into SYNC_CONFIG or EXCLUDED_TABLES', () => {
+      const classified = new Set([...Object.keys(SYNC_CONFIG), ...Object.keys(EXCLUDED_TABLES)]);
+      const unclassified = schemaTableNames().filter(t => !classified.has(t));
+      expect(
+        unclassified,
+        `These schema.prisma tables are in NEITHER SYNC_CONFIG nor EXCLUDED_TABLES, ` +
+          `so db-sync silently skips them. Add each to SYNC_CONFIG (+ SYNC_TABLE_ORDER) ` +
+          `if it should sync, or to EXCLUDED_TABLES with a reason if it shouldn't: ` +
+          unclassified.join(', ')
+      ).toEqual([]);
+    });
+
+    it('has no EXCLUDED_TABLES / SYNC_CONFIG entry that no longer maps to a real table', () => {
+      const realTables = new Set(schemaTableNames());
+      const stale = [...Object.keys(SYNC_CONFIG), ...Object.keys(EXCLUDED_TABLES)].filter(
+        t => !realTables.has(t)
+      );
+      expect(
+        stale,
+        `These sync-config entries reference tables not in schema.prisma (renamed/dropped?): ` +
+          stale.join(', ')
+      ).toEqual([]);
+    });
+
+    it('never lists a table in BOTH SYNC_CONFIG and EXCLUDED_TABLES', () => {
+      const both = Object.keys(SYNC_CONFIG).filter(t => t in EXCLUDED_TABLES);
+      expect(both, `Tables in both synced and excluded lists: ${both.join(', ')}`).toEqual([]);
+    });
+  });
+
   describe('SYNC_TABLE_ORDER completeness', () => {
     it('should include all tables from SYNC_CONFIG', () => {
       const configTables = Object.keys(SYNC_CONFIG) as SyncTableName[];

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -33,6 +33,8 @@ export const EXCLUDED_TABLES: Record<string, string> = {
   usage_logs: 'Environment-specific usage tracking',
   import_jobs: 'Transient import job tracking (environment-specific, retryable)',
   export_jobs: 'Transient export job tracking (environment-specific, retryable)',
+  job_results:
+    'Transient per-job delivery state (PENDING_DELIVERY/DELIVERED, auto-cleaned) — environment-specific, never synced',
 
   // Release-notes delivery state (environment-specific: each environment
   // announces its own releases to its own users; syncing would double-blast


### PR DESCRIPTION
## Summary

The two **code gates** from the 2026-07-20 mining synthesis. Both are MISSING-STRUCTURE findings — a manual step with no deterministic backstop.

**R5 — sync-config completeness (finding 4a, owner-requested).** `syncTables.test.ts` now asserts every `schema.prisma` model table is a *deliberate* sync decision: present in `SYNC_CONFIG` (synced) or `EXCLUDED_TABLES` (explicitly not, with a reason). A new table classified into neither silently doesn't sync — the exact class that broke prod db-sync when the alias-tier tables landed. Now a red unit test at authoring time, which is the "hook or some other deterministic measure" the owner asked for. Building it **surfaced one already-unclassified table**: `job_results` (transient per-job delivery state), now excluded with a reason. Also pins no-stale-entry and no-table-in-both-lists.

**R10 — release-notes finalize guard (finding 9 residual).** `release:publish` already fails loudly on a *nonexistent* notes path (`existsSync`). `assertNotesFinalized` adds the two content misses path-existence can't catch:
- the unreplaced `…/compare/vOLD...HEAD` draft placeholder (`draft-notes` emits `HEAD` for the human to replace — publishing with it still there means the finalize step was skipped), and
- a stale notes file whose compare trailer names the *previous* tag.

No-ops on hand-written notes with no compare trailer (`verify-notes` covers their PR-ref accuracy).

## Verification

- R5: 3 completeness tests + the existing 34 sync tests green; the classify test demonstrably discriminated (`job_results` was the sole miss before the exclusion was added).
- R10: 5 `assertNotesFinalized` cases (finalized match, no-trailer, `...HEAD`, stale-tag, trailing-punct) + the existing publish-flow tests green; the fs mock gained `readFileSync`.
- Full pre-push turbo (api-gateway + tooling) + `pnpm quality` green. (A ReDoS-shaped trailing-strip regex was rewritten as a plain-code trim after the lint gate flagged it.)
- Note: the pre-existing "release:* CLI-wiring layer is untested" follow-up (`cold/follow-ups.md`) is now *partially* covered — `assertNotesFinalized` is tested — but the broader CLI-wiring gap it names is out of this slice's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)