### PR TITLE
feat(tooling): Phase 3 PR-0 — ESLint guards (modal ban, button order, UX boundary)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,6 +95,20 @@ const COMPONENT_ROUTING_RULES = [
   },
 ];
 
+// UX design-system enforcement (Phase 3 / machinery §4.5): modal construction
+// is factory-owned. The Phase 2 modal wave migrated every hand-rolled site onto
+// the modal toolkit / dashboard ModalFactory / destructive-confirmation
+// factory; this selector keeps the class dead. The three factory modules
+// themselves carry justified eslint-disable suppressions at their single
+// construction sites.
+const MODAL_FACTORY_RULES = [
+  {
+    selector: "NewExpression[callee.name='ModalBuilder']",
+    message:
+      "Don't construct ModalBuilder directly — modals are factory-owned. Use buildToolkitModal (utils/modal/toolkit.ts), the dashboard ModalFactory, or the destructive-confirmation factory; if none fits, extend the toolkit rather than hand-rolling.",
+  },
+];
+
 // Forward-safety: in the envelope-building path (contextBuilder/ +
 // MessageContextBuilder), the trigger `message`'s content-bearing fields are
 // EMPTY for a native Discord forward — the real content lives in
@@ -355,6 +369,7 @@ export default tseslint.config(
         ...IDENTITY_PROVISIONING_RULES,
         ...SEND_TYPING_RULES,
         ...COMPONENT_ROUTING_RULES,
+        ...MODAL_FACTORY_RULES,
       ],
 
       // ============================================================================
@@ -418,6 +433,16 @@ export default tseslint.config(
       // `.claude/rules/04-discord.md`. 'error' because a violation is a real bug —
       // the user gets no response.
       '@tzurot/component-handler-ack-first': 'error',
+
+      // UX boundary (design-system Phase 3 / G10): command files must not
+      // value-import discord.js message-UI builders — they compose the shared
+      // ux/ builders. Grandfathered sites live in the shrink-only allowlist
+      // (packages/tooling/src/eslint/builder-import-allowlist.ts).
+      '@tzurot/no-discord-builders-in-commands': 'error',
+
+      // Danger-styled buttons come last in a hand-built action row (the
+      // confirmation factories own the order for factory-built rows).
+      '@tzurot/button-order-danger-last': 'error',
 
       // ============================================================================
       // SONARJS RULES - Additional code quality checks

--- a/packages/tooling/src/eslint/builder-import-allowlist.test.ts
+++ b/packages/tooling/src/eslint/builder-import-allowlist.test.ts
@@ -1,0 +1,32 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { BUILDER_IMPORT_ALLOWLIST, allowlistPairCount } from './builder-import-allowlist.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+describe('allowlist contract (shrink-only)', () => {
+  it('never grows past the grandfathered ceiling', () => {
+    // Shrinking (migrating a file off hand-built UI) passes without touching
+    // this pin; adding a file or symbol fails it. Lower the ceiling
+    // opportunistically when the count drops.
+    expect(allowlistPairCount()).toBeLessThanOrEqual(84);
+  });
+
+  it('contains no stale entries — every allowlisted file still exists', () => {
+    const stale = Object.keys(BUILDER_IMPORT_ALLOWLIST).filter(
+      relPath => !existsSync(path.join(repoRoot, relPath))
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it('lists every symbol set sorted and non-empty', () => {
+    for (const [file, symbols] of Object.entries(BUILDER_IMPORT_ALLOWLIST)) {
+      expect(symbols.length, `${file} has an empty symbol set — remove the entry`).toBeGreaterThan(
+        0
+      );
+      expect([...symbols].sort(), `${file} symbols should stay sorted`).toEqual([...symbols]);
+    }
+  });
+});

--- a/packages/tooling/src/eslint/builder-import-allowlist.ts
+++ b/packages/tooling/src/eslint/builder-import-allowlist.ts
@@ -1,0 +1,133 @@
+/**
+ * Grandfathered discord.js builder VALUE-imports in bot-client command files —
+ * the shrink-only allowlist behind `@tzurot/no-discord-builders-in-commands`.
+ *
+ * Contract:
+ *   - An entry permits a command file to keep importing exactly the listed
+ *     builder symbols as VALUES (type-only imports are always allowed and are
+ *     not tracked here).
+ *   - SHRINK-ONLY: entries are removed as files migrate onto the shared ux/
+ *     builders (listEmbedBuilder, buildEntityDetailCard, ModalFactory/toolkit,
+ *     confirmation factories). Adding an entry — or a new symbol to an existing
+ *     entry — means new hand-built Discord UI outside the design system; extend
+ *     the shared builders instead. The colocated test pins the ceiling so
+ *     growth fails loudly.
+ *   - Paths are repo-relative with forward slashes; the rule matches them as
+ *     suffixes of the linted file's normalized absolute path, so the check is
+ *     cwd-independent (lint-staged runs eslint from varying cwds).
+ *
+ * `SlashCommandBuilder`/`ContextMenuCommandBuilder` are NOT restricted —
+ * command DEFINITIONS legitimately live in command files. The restricted set
+ * is the message-UI builders (embeds, action rows, buttons, selects, modals,
+ * Components-V2 primitives).
+ */
+
+export const BUILDER_IMPORT_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
+  'services/bot-client/src/commands/admin/broadcast.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/admin/db-sync.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/admin/health.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/admin/metrics.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/admin/servers.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/channel/browse.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/character/browse.ts': ['ActionRowBuilder', 'ButtonBuilder'],
+  'services/bot-client/src/commands/character/import.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/character/view.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/character/viewV2.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'ContainerBuilder',
+    'SectionBuilder',
+    'SeparatorBuilder',
+    'TextDisplayBuilder',
+    'ThumbnailBuilder',
+  ],
+  'services/bot-client/src/commands/deny/detailTypes.ts': ['ActionRowBuilder', 'ButtonBuilder'],
+  'services/bot-client/src/commands/feedback/index.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/help/index.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/inspect/browse.ts': ['ActionRowBuilder', 'ButtonBuilder'],
+  'services/bot-client/src/commands/inspect/components.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'StringSelectMenuBuilder',
+  ],
+  'services/bot-client/src/commands/inspect/embed.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/inspect/extendedViews.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/inspect/memoryInspectorState.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+  ],
+  'services/bot-client/src/commands/inspect/views.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/memory/detail.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/memory/detailModals.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/memory/factsDetail.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/models/card.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/persona/view.ts': ['ActionRowBuilder', 'ButtonBuilder'],
+  'services/bot-client/src/commands/preset/global/globalPresetHelpers.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/preset/import.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/apikey/modal.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/apikey/remove.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/apikey/test.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/data/export.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/preset/clear-default.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/preset/guestModeValidation.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/preset/set-default.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/settings/preset/set.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/shapes/auth.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/shapes/detail.ts': ['ActionRowBuilder', 'ButtonBuilder'],
+  'services/bot-client/src/commands/shapes/detailHandlers.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/shapes/errorRecovery.ts': ['ActionRowBuilder', 'ButtonBuilder'],
+  'services/bot-client/src/commands/shapes/export.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/shapes/import.ts': [
+    'ActionRowBuilder',
+    'ButtonBuilder',
+    'EmbedBuilder',
+  ],
+  'services/bot-client/src/commands/shapes/logout.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/shapes/modal.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/shapes/status.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/stt/clear.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/stt/set.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/tts/clear-default.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/tts/guestModeValidation.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/tts/set-default.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/tts/set.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/voices/clear.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/voices/delete.ts': ['EmbedBuilder'],
+};
+
+/** Total (file, symbol) pairs — the shrink-only ceiling pinned by the test. */
+export function allowlistPairCount(): number {
+  return Object.values(BUILDER_IMPORT_ALLOWLIST).reduce((sum, syms) => sum + syms.length, 0);
+}

--- a/packages/tooling/src/eslint/button-order-danger-last.test.ts
+++ b/packages/tooling/src/eslint/button-order-danger-last.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import rule from './button-order-danger-last.js';
+
+const linter = new Linter({ configType: 'flat' });
+
+function lint(code: string): Linter.LintMessage[] {
+  return linter.verify(code, [
+    {
+      languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      plugins: { test: { rules: { 'button-order-danger-last': rule } } },
+      rules: { 'test/button-order-danger-last': 'error' },
+    },
+  ]);
+}
+
+const DANGER =
+  "new ButtonBuilder().setCustomId('d').setLabel('Delete').setStyle(ButtonStyle.Danger)";
+const SAFE =
+  "new ButtonBuilder().setCustomId('c').setLabel('Cancel').setStyle(ButtonStyle.Secondary)";
+
+describe('rule metadata', () => {
+  it('has problem type and the dangerBeforeSafe message', () => {
+    expect(rule.meta?.type).toBe('problem');
+    expect(rule.meta?.messages?.dangerBeforeSafe).toBeDefined();
+  });
+});
+
+describe('violations', () => {
+  it('flags Danger preceding a non-Danger sibling in addComponents', () => {
+    const messages = lint(`row.addComponents(${DANGER}, ${SAFE});`);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].messageId).toBe('dangerBeforeSafe');
+  });
+
+  it('flags the array-argument call shape', () => {
+    const messages = lint(`row.addComponents([${DANGER}, ${SAFE}]);`);
+    expect(messages).toHaveLength(1);
+  });
+
+  it('flags setComponents too', () => {
+    const messages = lint(`row.setComponents(${DANGER}, ${SAFE});`);
+    expect(messages).toHaveLength(1);
+  });
+
+  it('detects the style through interleaved fluent methods', () => {
+    const messages = lint(
+      `row.addComponents(new ButtonBuilder().setStyle(ButtonStyle.Danger).setEmoji('🗑️').setLabel('Delete'), ${SAFE});`
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it('reports each offending Danger button once', () => {
+    const messages = lint(`row.addComponents(${DANGER}, ${DANGER}, ${SAFE});`);
+    expect(messages).toHaveLength(2);
+  });
+});
+
+describe('allowed shapes', () => {
+  it('allows Danger last', () => {
+    const messages = lint(`row.addComponents(${SAFE}, ${DANGER});`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows a lone Danger button', () => {
+    const messages = lint(`row.addComponents(${DANGER});`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows consecutive Danger buttons with nothing after', () => {
+    const messages = lint(`row.addComponents(${SAFE}, ${DANGER}, ${DANGER});`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does not flag when the later sibling style is not statically visible', () => {
+    // Variables are invisible to the rule — documented limitation; the
+    // factories own those shapes.
+    const messages = lint(`row.addComponents(${DANGER}, cancelButton);`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does not flag variables preceding an inline Danger', () => {
+    const messages = lint(`row.addComponents(confirmButton, ${DANGER});`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('ignores unrelated addComponents calls (selects, inputs)', () => {
+    const messages = lint("row.addComponents(new StringSelectMenuBuilder().setCustomId('s'));");
+    expect(messages).toHaveLength(0);
+  });
+
+  it('ignores non-component method calls', () => {
+    const messages = lint(`list.push(${DANGER}, ${SAFE});`);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('ignores buttons without a visible style', () => {
+    const messages = lint(
+      "row.addComponents(new ButtonBuilder().setCustomId('a'), new ButtonBuilder().setCustomId('b'));"
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('resolves a double setStyle to the LAST-executed call (runtime winner)', () => {
+    // Danger then Secondary: the builder ends up Secondary — correctly ordered.
+    const messages = lint(
+      `row.addComponents(new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x').setStyle(ButtonStyle.Secondary), ${SAFE});`
+    );
+    expect(messages).toHaveLength(0);
+  });
+});
+
+describe('double setStyle violation', () => {
+  it('flags when the last-executed style is Danger and a safe sibling follows', () => {
+    const messages = lint(
+      `row.addComponents(new ButtonBuilder().setStyle(ButtonStyle.Secondary).setLabel('x').setStyle(ButtonStyle.Danger), ${SAFE});`
+    );
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/packages/tooling/src/eslint/button-order-danger-last.ts
+++ b/packages/tooling/src/eslint/button-order-danger-last.ts
@@ -1,0 +1,143 @@
+/**
+ * ESLint Rule: button-order-danger-last
+ *
+ * Enforces the design-system button-order standard (spec §3 / 04-discord.md
+ * "Standard Button Order"): within one action row, a Danger-styled button is
+ * always LAST — destructive actions never sit to the left of safe ones.
+ * Hand-rolled rows drift into Danger-first ordering when built ad hoc; the
+ * confirmation factories own the order for factory-built rows, and this rule
+ * keeps the class dead for hand-built ones.
+ *
+ * What is flagged: inside a single `addComponents(...)` / `setComponents(...)`
+ * argument list (or a single array literal argument), an INLINE
+ * `new ButtonBuilder()…` chain whose `.setStyle(ButtonStyle.Danger)` precedes
+ * a sibling inline chain with a statically-visible non-Danger style.
+ *
+ * Known limitation (deliberate): buttons built into variables and passed by
+ * name (`addComponents(confirm, cancel)`) are invisible to this rule — style
+ * resolution would need cross-statement data flow. The sanctioned factories
+ * (confirmAction/confirmDestructive/buildBrowseButtons) own those shapes and
+ * are order-correct by construction; the rule guards the inline hand-rolled
+ * shape, which is where the historical violations lived.
+ */
+
+import type { Rule } from 'eslint';
+import type { Node } from 'estree';
+
+const COMPONENT_METHODS = new Set(['addComponents', 'setComponents']);
+
+interface MemberNode {
+  type: string;
+  object?: MemberNode & { name?: string };
+  property?: { type: string; name?: string };
+  callee?: MemberNode;
+  arguments?: Node[];
+}
+
+/** The ButtonStyle member name from a `.setStyle(ButtonStyle.X)` argument, or null. */
+function styleArgumentName(arg: MemberNode | undefined): string | null {
+  const isStyleMember =
+    arg?.type === 'MemberExpression' &&
+    arg.object?.type === 'Identifier' &&
+    arg.object.name === 'ButtonStyle' &&
+    arg.property?.type === 'Identifier';
+  return isStyleMember ? (arg.property?.name ?? null) : null;
+}
+
+/**
+ * The statically-visible ButtonStyle of an inline `new ButtonBuilder()…` chain,
+ * or null when the expression is not such a chain / carries no visible style.
+ * Walks the fluent chain: CallExpression(MemberExpression(...)) down to a
+ * NewExpression of ButtonBuilder, collecting `.setStyle(ButtonStyle.X)`.
+ */
+function inlineButtonStyle(expr: Node): string | null {
+  let node = expr as unknown as MemberNode;
+  let style: string | null = null;
+  let sawButtonBuilderNew = false;
+
+  while (node !== undefined && node !== null) {
+    if (node.type === 'NewExpression') {
+      const callee = node.callee as unknown as { name?: string } | undefined;
+      sawButtonBuilderNew = callee?.name === 'ButtonBuilder';
+      break;
+    }
+    if (node.type !== 'CallExpression' || node.callee?.type !== 'MemberExpression') {
+      break;
+    }
+    const member = node.callee;
+    if (member.property?.type === 'Identifier' && member.property.name === 'setStyle') {
+      // The outer→inner walk visits the LAST-executed setStyle first — and the
+      // last call wins at runtime (it's a plain field set) — so the first hit
+      // is authoritative; never overwrite it with an earlier-executed one.
+      const found = styleArgumentName(node.arguments?.[0]);
+      if (found !== null && style === null) {
+        style = found;
+      }
+    }
+    node = member.object as MemberNode;
+  }
+
+  return sawButtonBuilderNew ? style : null;
+}
+
+function checkSequence(context: Rule.RuleContext, elements: Node[]): void {
+  const styles = elements.map(inlineButtonStyle);
+  for (let i = 0; i < styles.length; i++) {
+    if (styles[i] !== 'Danger') {
+      continue;
+    }
+    const laterNonDanger = styles.some((style, j) => j > i && style !== null && style !== 'Danger');
+    if (laterNonDanger) {
+      context.report({
+        node: elements[i] as unknown as Rule.Node,
+        messageId: 'dangerBeforeSafe',
+      });
+    }
+  }
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Danger-styled buttons come last in an action row — a destructive button must not precede a non-Danger sibling',
+      recommended: true,
+    },
+    messages: {
+      dangerBeforeSafe:
+        'Danger-styled button precedes a non-Danger sibling in the same row — destructive actions are always LAST (04-discord.md "Standard Button Order"). Reorder the arguments, or use the confirmation factories which own the order.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const call = node as unknown as MemberNode;
+        if (
+          call.callee?.type !== 'MemberExpression' ||
+          call.callee.property?.type !== 'Identifier' ||
+          call.callee.property.name === undefined ||
+          !COMPONENT_METHODS.has(call.callee.property.name)
+        ) {
+          return;
+        }
+        const args = call.arguments ?? [];
+        // Both call shapes are legal discord.js: addComponents(a, b, c) and
+        // addComponents([a, b, c]) — normalize to one element sequence.
+        const first = args[0] as unknown as { type?: string; elements?: Node[] } | undefined;
+        if (args.length === 1 && first?.type === 'ArrayExpression') {
+          checkSequence(
+            context,
+            (first.elements ?? []).filter((e): e is Node => e !== null)
+          );
+        } else {
+          checkSequence(context, args);
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/tooling/src/eslint/index.ts
+++ b/packages/tooling/src/eslint/index.ts
@@ -20,6 +20,8 @@
 
 import noSingletonExport from './no-singleton-export.js';
 import componentHandlerAckFirst from './component-handler-ack-first.js';
+import noDiscordBuildersInCommands from './no-discord-builders-in-commands.js';
+import buttonOrderDangerLast from './button-order-danger-last.js';
 
 const plugin = {
   meta: {
@@ -29,6 +31,8 @@ const plugin = {
   rules: {
     'no-singleton-export': noSingletonExport,
     'component-handler-ack-first': componentHandlerAckFirst,
+    'no-discord-builders-in-commands': noDiscordBuildersInCommands,
+    'button-order-danger-last': buttonOrderDangerLast,
   },
 };
 

--- a/packages/tooling/src/eslint/no-discord-builders-in-commands.test.ts
+++ b/packages/tooling/src/eslint/no-discord-builders-in-commands.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import tseslint from 'typescript-eslint';
+import rule from './no-discord-builders-in-commands.js';
+
+// import-type syntax needs the typescript-eslint parser; no type program required.
+const linter = new Linter({ configType: 'flat' });
+
+function lint(code: string, filename: string): Linter.LintMessage[] {
+  return linter.verify(
+    code,
+    [
+      {
+        files: ['**/*.ts'],
+        languageOptions: {
+          parser: tseslint.parser as unknown as Linter.Parser,
+          ecmaVersion: 2022,
+          sourceType: 'module',
+        },
+        plugins: {
+          test: { rules: { 'no-discord-builders-in-commands': rule } },
+        },
+        rules: { 'test/no-discord-builders-in-commands': 'error' },
+      },
+    ],
+    filename
+  );
+}
+
+// Relative filenames: the flat-config Linter only applies configs to files
+// under its basePath (the cwd), so absolute fixture paths would match nothing.
+const COMMANDS = 'services/bot-client/src/commands';
+
+describe('rule metadata', () => {
+  it('has problem type and the restrictedBuilder message', () => {
+    expect(rule.meta?.type).toBe('problem');
+    expect(rule.meta?.messages?.restrictedBuilder).toBeDefined();
+  });
+});
+
+describe('flagging value imports in command files', () => {
+  it('flags a restricted builder value import in a non-allowlisted file', () => {
+    const messages = lint(
+      "import { EmbedBuilder } from 'discord.js';",
+      `${COMMANDS}/history/stats.ts`
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].messageId).toBe('restrictedBuilder');
+  });
+
+  it('flags only the restricted symbols in a mixed import', () => {
+    const messages = lint(
+      "import { ButtonBuilder, MessageFlags, ChatInputCommandInteraction } from 'discord.js';",
+      `${COMMANDS}/history/stats.ts`
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('ButtonBuilder');
+  });
+
+  it('flags a symbol NOT in the grandfathered set of an allowlisted file', () => {
+    // admin/broadcast.ts is allowlisted for EmbedBuilder only.
+    const messages = lint(
+      "import { EmbedBuilder, ButtonBuilder } from 'discord.js';",
+      `${COMMANDS}/admin/broadcast.ts`
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('ButtonBuilder');
+  });
+
+  it('flags Components-V2 builders outside the pilot allowlist entry', () => {
+    const messages = lint(
+      "import { ContainerBuilder } from 'discord.js';",
+      `${COMMANDS}/persona/view.ts`
+    );
+    expect(messages).toHaveLength(1);
+  });
+});
+
+describe('allowed shapes', () => {
+  it('allows a grandfathered (file, symbol) pair', () => {
+    const messages = lint(
+      "import { EmbedBuilder } from 'discord.js';",
+      `${COMMANDS}/admin/broadcast.ts`
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows type-only import declarations', () => {
+    const messages = lint(
+      "import type { EmbedBuilder } from 'discord.js';",
+      `${COMMANDS}/history/stats.ts`
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows inline type specifiers', () => {
+    const messages = lint(
+      "import { type EmbedBuilder, MessageFlags } from 'discord.js';",
+      `${COMMANDS}/history/stats.ts`
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows SlashCommandBuilder — command definitions belong in command files', () => {
+    const messages = lint(
+      "import { SlashCommandBuilder, ContextMenuCommandBuilder } from 'discord.js';",
+      `${COMMANDS}/history/index.ts`
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('ignores files outside the commands tree', () => {
+    const messages = lint(
+      "import { EmbedBuilder } from 'discord.js';",
+      'services/bot-client/src/utils/browse/listEmbedBuilder.ts'
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('ignores imports from modules other than discord.js', () => {
+    const messages = lint(
+      "import { EmbedBuilder } from './localShim.js';",
+      `${COMMANDS}/history/stats.ts`
+    );
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/packages/tooling/src/eslint/no-discord-builders-in-commands.ts
+++ b/packages/tooling/src/eslint/no-discord-builders-in-commands.ts
@@ -1,0 +1,114 @@
+/**
+ * ESLint Rule: no-discord-builders-in-commands
+ *
+ * The UX-boundary guard (design-system machinery §4.5/G10): command files must
+ * not hand-build Discord message UI — embeds, action rows, buttons, selects,
+ * modals, Components-V2 primitives — they compose the shared ux/ builders
+ * (listEmbedBuilder, buildEntityDetailCard, ModalFactory/toolkit, confirmation
+ * factories) instead. Hand-built UI in a command file is exactly how the
+ * pre-design-system drift accumulated (17 hand-built browse embeds, 11
+ * hand-rolled modals, 4 confirmation implementations).
+ *
+ * What is flagged: a VALUE import of a restricted `*Builder` symbol from
+ * 'discord.js' in a file under `services/bot-client/src/commands/`, unless the
+ * (file, symbol) pair is grandfathered in `builder-import-allowlist.ts`
+ * (shrink-only — see its header contract).
+ *
+ * What is NOT flagged:
+ *   - Type-only imports (`import type { EmbedBuilder }` / `{ type EmbedBuilder }`)
+ *     — types can't construct UI; command files legitimately type parameters
+ *     with builder types.
+ *   - `SlashCommandBuilder` / `ContextMenuCommandBuilder` — command DEFINITIONS
+ *     belong in command files; the boundary covers message UI only.
+ *   - Files outside `commands/` — the shared builders themselves live in
+ *     utils/ and ux/ and obviously construct builders.
+ *
+ * A module-level depcruise boundary ("commands must not import discord.js")
+ * is deliberately NOT the mechanism: 147 command files import interaction
+ * TYPES legitimately, and depcruise cannot see symbol granularity. The
+ * import-symbol rule is the feasible 80/20; the types-from-common-types
+ * refactor that would enable a module boundary is a trigger-gated backlog
+ * idea (`backlog/cold/ideas.md`).
+ */
+
+import type { Rule } from 'eslint';
+import { BUILDER_IMPORT_ALLOWLIST } from './builder-import-allowlist.js';
+
+/** Message-UI builder symbols the boundary restricts. */
+const RESTRICTED_BUILDER =
+  /^(?:Embed|ActionRow|Button|StringSelectMenu|UserSelectMenu|RoleSelectMenu|ChannelSelectMenu|MentionableSelectMenu|Modal|TextInput|Container|Section|TextDisplay|MediaGallery|Separator|Thumbnail|FileUpload|Label)Builder$/;
+
+const COMMANDS_MARKER = 'services/bot-client/src/commands/';
+
+/**
+ * The repo-relative path of the linted file (forward slashes), or null when
+ * the file is not under the commands tree. Suffix-matching from the marker
+ * keeps the rule cwd-independent (lint-staged invokes eslint from varying
+ * working directories).
+ */
+function commandsRelativePath(filename: string): string | null {
+  const normalized = filename.replace(/\\/g, '/');
+  const at = normalized.indexOf(COMMANDS_MARKER);
+  return at === -1 ? null : normalized.slice(at);
+}
+
+interface ImportSpecifierNode {
+  type: string;
+  importKind?: string;
+  imported?: { type: string; name?: string };
+  local?: { name?: string };
+}
+
+interface ImportDeclarationNode {
+  source: { value?: unknown };
+  importKind?: string;
+  specifiers: ImportSpecifierNode[];
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow value-importing discord.js message-UI builders in command files — compose the shared ux/ builders instead',
+      recommended: true,
+    },
+    messages: {
+      restrictedBuilder:
+        "'{{symbol}}' is a Discord message-UI builder; command files compose the shared builders (listEmbedBuilder, buildEntityDetailCard, ModalFactory/toolkit, confirmation factories) instead of hand-building UI. If the shared builders genuinely cannot express this surface, extend them — do not add to the shrink-only allowlist without that conversation.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const relPath = commandsRelativePath(context.filename);
+    if (relPath === null || relPath.endsWith('.test.ts')) {
+      return {};
+    }
+    const allowed = new Set(BUILDER_IMPORT_ALLOWLIST[relPath] ?? []);
+
+    return {
+      ImportDeclaration(node) {
+        const decl = node as unknown as ImportDeclarationNode;
+        if (decl.source.value !== 'discord.js' || decl.importKind === 'type') {
+          return;
+        }
+        for (const spec of decl.specifiers) {
+          if (spec.type !== 'ImportSpecifier' || spec.importKind === 'type') {
+            continue;
+          }
+          const name = spec.imported?.name;
+          if (name !== undefined && RESTRICTED_BUILDER.test(name) && !allowed.has(name)) {
+            context.report({
+              node: spec as unknown as Rule.Node,
+              messageId: 'restrictedBuilder',
+              data: { symbol: name },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/services/bot-client/src/commands/help/categoryConfig.test.ts
+++ b/services/bot-client/src/commands/help/categoryConfig.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Completeness gate for CATEGORY_CONFIG (design-system §5.3a).
+ *
+ * CommandHandler derives each command's help category from its top-level
+ * folder name (capitalized — see deriveCategory). A folder without a
+ * CATEGORY_CONFIG entry silently falls into "📦 Other", which is exactly the
+ * kind of drift a rename or a new command folder introduces. This test makes
+ * the config↔folders sync mechanical in BOTH directions: every folder has an
+ * entry, and every entry (except the "Other" fallback and this Help folder's
+ * own) corresponds to a real folder.
+ */
+
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { CATEGORY_CONFIG } from './index.js';
+
+const commandsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Mirrors CommandHandler's deriveCategory transform (first char upper). */
+function folderToCategory(folder: string): string {
+  return folder.charAt(0).toUpperCase() + folder.slice(1);
+}
+
+function commandFolders(): string[] {
+  return readdirSync(commandsDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name);
+}
+
+describe('CATEGORY_CONFIG completeness', () => {
+  it('has an entry for every command folder — nothing falls into "Other"', () => {
+    const missing = commandFolders()
+      .map(folderToCategory)
+      .filter(category => CATEGORY_CONFIG[category] === undefined);
+    expect(missing).toEqual([]);
+  });
+
+  it('has no stale entries — every category (except the Other fallback) is a real folder', () => {
+    const folders = new Set(commandFolders().map(folderToCategory));
+    const stale = Object.keys(CATEGORY_CONFIG).filter(
+      category => category !== 'Other' && !folders.has(category)
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it('assigns a unique display order to every category', () => {
+    const orders = Object.values(CATEGORY_CONFIG).map(config => config.order);
+    expect(new Set(orders).size).toBe(orders.length);
+  });
+});

--- a/services/bot-client/src/commands/memory/detailModals.ts
+++ b/services/bot-client/src/commands/memory/detailModals.ts
@@ -120,14 +120,14 @@ function buildTruncationWarningEmbed(memory: MemoryItem): EmbedBuilder {
 function buildTruncationButtons(memoryId: string): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
+      .setCustomId(buildMemoryActionId('cancel-edit', memoryId))
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
       .setCustomId(buildMemoryActionId(EDIT_TRUNCATED_ACTION, memoryId))
       .setLabel('Edit with Truncation')
       .setStyle(ButtonStyle.Danger)
-      .setEmoji('✂️'),
-    new ButtonBuilder()
-      .setCustomId(buildMemoryActionId('cancel-edit', memoryId))
-      .setLabel('Cancel')
-      .setStyle(ButtonStyle.Secondary)
+      .setEmoji('✂️')
   );
 }
 

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.ts
@@ -151,6 +151,7 @@ export function buildConfirmationModal(
   parsed: DestructiveParseResult,
   display: DestructiveModalDisplay
 ): ModalBuilder {
+  // eslint-disable-next-line no-restricted-syntax -- Tier-B typed-phrase confirmation factory: the modal customId MUST derive from the button's parsed segments (routing-continuity invariant), which the toolkit deliberately doesn't model
   const modal = new ModalBuilder()
     .setCustomId(DestructiveCustomIds.modalSubmitFromParsed(parsed))
     .setTitle(display.modalTitle);

--- a/services/bot-client/src/utils/dashboard/settings/SettingsModalFactory.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsModalFactory.ts
@@ -40,6 +40,7 @@ export function buildSettingEditModal(
   setting: SettingDefinition,
   currentValue: unknown
 ): ModalBuilder {
+  // eslint-disable-next-line no-restricted-syntax -- settings-dashboard modal factory: single-input modal whose customId encodes the settings routing contract; not expressible via the toolkit's item union
   const modal = new ModalBuilder()
     .setCustomId(buildSettingsCustomId(entityType, 'modal', entityId, setting.id))
     .setTitle(`Edit ${setting.label}`);

--- a/services/bot-client/src/utils/modal/toolkit.ts
+++ b/services/bot-client/src/utils/modal/toolkit.ts
@@ -208,6 +208,7 @@ function attachComponent(
 
 /** Build a Label-based modal from typed items. */
 export function buildToolkitModal(options: BuildToolkitModalOptions): ModalBuilder {
+  // eslint-disable-next-line no-restricted-syntax -- THE modal toolkit's single construction site; every other module builds modals through this function
   const modal = new ModalBuilder().setCustomId(options.customId).setTitle(options.title);
 
   for (const item of options.items) {


### PR DESCRIPTION
## Summary

Wave 0 of the UX epic's Phase 3 (plan approved 2026-07-20; council-resequenced **guards-first** — enforcement lands over already-conformant code BEFORE the phase's big refactors can regress it):

- **`MODAL_FACTORY_RULES`** (`no-restricted-syntax`): bans direct `new ModalBuilder()` — modals are factory-owned (Phase 2's modal wave left zero hand-rolled sites). The three factory homes (toolkit, SettingsModalFactory, confirmDestructive) carry justified suppressions.
- **`@tzurot/button-order-danger-last`** (custom rule): in a hand-built action row, a Danger button must not precede a non-Danger sibling. Inline-chain analysis only (documented limitation — variables belong to the factories, which own order by construction).
- **`@tzurot/no-discord-builders-in-commands`** (custom rule): the UX boundary — command files must not VALUE-import discord.js message-UI builders; they compose the shared ux/ builders. Grandfathered state lives in a **shrink-only per-file × per-symbol allowlist** (51 files / 84 pairs; ceiling + staleness + sortedness pinned by tests). Type-only imports and `SlashCommandBuilder`/`ContextMenuCommandBuilder` are exempt. A module-level depcruise boundary was evaluated and rejected: 147 command files import interaction *types* legitimately; the types-from-common-types refactor enabling it is a trigger-gated backlog idea.
- **Category completeness gate** (`categoryConfig.test.ts`): every command folder must have a `CATEGORY_CONFIG` entry (kills the silent "📦 Other" fallthrough), every entry must be a real folder, orders unique — mechanizes the config's own "keep in sync" comment ahead of Phase 3's folder moves.

## The rule earned its keep on landing

`button-order-danger-last` caught a **real pre-existing violation** on its first full-tree run: `memory/detailModals.ts`'s truncation confirm had Danger before Cancel (a site the Phase 2 four-site sweep missed). Fixed in its own commit — Cancel leads, destructive last.

## Verified

- `pnpm test` green from root (bot-client 5781; tooling 1581 incl. 30 new rule tests).
- `pnpm quality` green end-to-end (both new rules active over the whole tree; gate-parity clean).
- Rule tests probe the flat-config Linter with the real typescript-eslint parser (type-only import shapes exercised against the compiled rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)