### PR TITLE
feat(bot-client): Phase 3 PR-2a — character/persona vocabulary adoption

### DIFF
--- a/packages/common-types/src/constants/uxVocabulary.test.ts
+++ b/packages/common-types/src/constants/uxVocabulary.test.ts
@@ -64,6 +64,16 @@ describe('buildBadgeLegend', () => {
     expect(buildBadgeLegend(['ACTIVE', 'FREE'])).toBe('Active ✅ · Free 🆓');
     expect(buildBadgeLegend([])).toBe('');
   });
+
+  it('accepts surface-specific word overrides while the glyph stays registry-locked', () => {
+    expect(
+      buildBadgeLegend([
+        { key: 'GLOBAL', word: 'Global' },
+        { key: 'OWNED', word: 'Personal' },
+        'SHADOWED',
+      ])
+    ).toBe('Global 🌐 · Personal 🔒 · Shadowed ⚠️');
+  });
 });
 
 describe('UX_SENTINELS', () => {

--- a/packages/common-types/src/constants/uxVocabulary.ts
+++ b/packages/common-types/src/constants/uxVocabulary.ts
@@ -30,7 +30,8 @@ export type UxEntityKind =
   | 'voice'
   | 'apiKey'
   | 'denial'
-  | 'shapes';
+  | 'shapes'
+  | 'alias';
 
 /**
  * Entity emoji registry (§2.1) — one glyph per entity, everywhere.
@@ -55,6 +56,9 @@ export const ENTITY_EMOJI: Readonly<Record<UxEntityKind, string>> = {
   apiKey: '💳',
   denial: '🚫',
   shapes: '🔗',
+  // Post-spec entity: character aliases became a first-class browsable surface
+  // after the spec's table was authored; 🏷️ was established with that surface.
+  alias: '🏷️',
 } as const;
 
 /**
@@ -103,12 +107,27 @@ export const BADGE_LEGEND_WORDS: Readonly<Record<keyof typeof AUTOCOMPLETE_BADGE
 export type BadgeKey = keyof typeof AUTOCOMPLETE_BADGES;
 
 /**
+ * A legend entry: a badge key (uses the standard word), or a key with a
+ * surface-specific word override — for surfaces whose domain vocabulary
+ * differs from the standard word (alias tiers say "Global/Personal" where the
+ * registry says "Public/Private"). The GLYPH always comes from the registry;
+ * only the word may vary, so glyph drift stays impossible.
+ */
+export type LegendEntry = BadgeKey | { key: BadgeKey; word: string };
+
+/**
  * Build a word-first badge legend (§2.2): `Private 🔒 · Locked 🔐` — for
  * exactly the badges present on the surface, in the caller's order. Replaces
  * hand-written `badgeLegend` strings so wording and glyphs can't drift from
  * the registry. Word-first keeps the legend scannable on mobile; keep the
  * badge list to what the embed actually renders.
  */
-export function buildBadgeLegend(badges: readonly BadgeKey[]): string {
-  return badges.map(key => `${BADGE_LEGEND_WORDS[key]} ${AUTOCOMPLETE_BADGES[key]}`).join(' · ');
+export function buildBadgeLegend(badges: readonly LegendEntry[]): string {
+  return badges
+    .map(entry => {
+      const key = typeof entry === 'string' ? entry : entry.key;
+      const word = typeof entry === 'string' ? BADGE_LEGEND_WORDS[key] : entry.word;
+      return `${word} ${AUTOCOMPLETE_BADGES[key]}`;
+    })
+    .join(' · ');
 }

--- a/services/bot-client/src/commands/character/aliasBrowse.ts
+++ b/services/bot-client/src/commands/character/aliasBrowse.ts
@@ -25,6 +25,12 @@ import {
   type StringSelectMenuInteraction,
 } from 'discord.js';
 import type { AliasScope } from '@tzurot/common-types/schemas/api/personality';
+import { AUTOCOMPLETE_BADGES } from '@tzurot/common-types/utils/autocompleteFormat';
+import {
+  ENTITY_EMOJI,
+  buildBadgeLegend,
+  type LegendEntry,
+} from '@tzurot/common-types/constants/uxVocabulary';
 import {
   ALIAS_FILTERS,
   applyFilter,
@@ -105,8 +111,20 @@ const FILTER_TOGGLE_DISPLAY: Record<AliasFilter, FilterToggleDisplay> = {
 };
 
 function scopeBadge(row: AliasRow): string {
-  const base = row.scope === 'global' ? '🌐' : '🔒';
-  return row.shadowed ? `${base}⚠️` : base;
+  const base = row.scope === 'global' ? AUTOCOMPLETE_BADGES.GLOBAL : AUTOCOMPLETE_BADGES.OWNED;
+  return row.shadowed ? `${base}${AUTOCOMPLETE_BADGES.SHADOWED}` : base;
+}
+
+/**
+ * Legend in the alias domain's words — Global/Personal (the filter toggle's
+ * vocabulary), overriding the registry's standard Public/Private.
+ */
+function aliasLegend(myMode: boolean): string {
+  const base: LegendEntry[] = [
+    { key: 'GLOBAL', word: 'Global' },
+    { key: 'OWNED', word: 'Personal' },
+  ];
+  return buildBadgeLegend(myMode ? [...base, 'SHADOWED'] : base);
 }
 
 interface BrowseCoords {
@@ -165,7 +183,7 @@ export async function renderAliasBrowse(
   }
 
   const { embed, pageItems, startIndex, totalPages, safePage } = buildBrowseListEmbed<AliasRow>({
-    entityEmoji: '🏷️',
+    entityEmoji: ENTITY_EMOJI.alias,
     titleNoun: 'Aliases',
     items: filtered,
     page: coords.page,
@@ -190,7 +208,7 @@ export async function renderAliasBrowse(
       filter !== 'all' && formatFilterLabeled(FILTER_TOGGLE_DISPLAY[filter].shortLabel),
       fetched.data.truncated && 'list truncated',
     ],
-    badgeLegend: myMode ? 'Global 🌐 · Personal 🔒 · Shadowed ⚠️' : 'Global 🌐 · Personal 🔒',
+    badgeLegend: aliasLegend(myMode),
   });
 
   const components: BrowseActionRow[] = [];
@@ -330,8 +348,8 @@ async function handleAliasSelect(interaction: StringSelectMenuInteraction): Prom
       ? 'This global alias resolves for everyone.'
       : 'This personal alias only affects you.';
   const { embed, components } = buildConfirmAction({
-    title: '🏷️ Remove Alias?',
-    description: `Remove ${row.scope === 'global' ? '🌐' : '🔒'} \`@${escapeMarkdown(row.alias)}\` from **${escapeMarkdown(characterDisplay)}**?\n${scopeNote}`,
+    title: `${ENTITY_EMOJI.alias} Remove Alias?`,
+    description: `Remove ${row.scope === 'global' ? AUTOCOMPLETE_BADGES.GLOBAL : AUTOCOMPLETE_BADGES.OWNED} \`@${escapeMarkdown(row.alias)}\` from **${escapeMarkdown(characterDisplay)}**?\n${scopeNote}`,
     confirmCustomId: buildRemoveCustomId(RM_YES_PREFIX, coords.page, coords.filter, coords.query),
     cancelCustomId: buildRemoveCustomId(RM_NO_PREFIX, coords.page, coords.filter, coords.query),
     confirmLabel: 'Remove Alias',

--- a/services/bot-client/src/commands/character/autocomplete.test.ts
+++ b/services/bot-client/src/commands/character/autocomplete.test.ts
@@ -195,7 +195,7 @@ describe('handleAutocomplete', () => {
 
     expect(mockRespond).toHaveBeenCalledWith([
       { name: '🔒 MyChar (my-char)', value: 'my-char' },
-      { name: '📖 Public Bot (public-char)', value: 'public-char' },
+      { name: '👥 Public Bot (public-char)', value: 'public-char' },
     ]);
   });
 
@@ -369,7 +369,7 @@ describe('handleAutocomplete', () => {
     expect(mockRespond).toHaveBeenCalledWith([
       { name: '🔒 Private (private-owned)', value: 'private-owned' },
       { name: '🌐 Public (public-owned)', value: 'public-owned' },
-      { name: '📖 Other (public-other)', value: 'public-other' },
+      { name: '👥 Other (public-other)', value: 'public-other' },
     ]);
   });
 });

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -20,6 +20,8 @@ import {
 } from 'discord.js';
 import { type EnvConfig, getConfig } from '@tzurot/common-types/config/config';
 import { characterBrowseOptions } from '@tzurot/common-types/generated/commandOptions';
+import { AUTOCOMPLETE_BADGES } from '@tzurot/common-types/utils/autocompleteFormat';
+import { ENTITY_EMOJI, buildBadgeLegend } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { UserClient } from '@tzurot/clients';
@@ -182,7 +184,7 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
     totalPages,
     safePage: renderedPage,
   } = buildBrowseListEmbed<ListItem>({
-    entityEmoji: '\u{1F3AD}',
+    entityEmoji: ENTITY_EMOJI.character,
     titleNoun: 'Characters',
     items: allItems,
     page,
@@ -190,7 +192,7 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
     preamble,
     formatRow: item => ({
       groupHeader: item.groupHeader,
-      badges: `${item.char.isPublic ? '\u{1F310}' : '\u{1F512}'}${item.isOwn ? '\u270F\uFE0F' : ''}`,
+      badges: `${item.char.isPublic ? AUTOCOMPLETE_BADGES.PUBLIC : AUTOCOMPLETE_BADGES.OWNED}${item.isOwn ? AUTOCOMPLETE_BADGES.EDITABLE : ''}`,
       name: escapeMarkdown(item.char.displayName ?? item.char.name),
       // Slugs are typed in @mentions — the §2.4 case where the tech-id
       // belongs in the row.
@@ -206,7 +208,7 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
       filter !== 'all' && formatFilterLabeled(FILTER_LABELS[filter]),
       sortType === 'date' ? formatSortNatural('date') : formatSortVerbatim('Sorted alphabetically'),
     ],
-    badgeLegend: 'Public \u{1F310} · Private \u{1F512} · Yours \u270F\uFE0F',
+    badgeLegend: buildBadgeLegend(['PUBLIC', 'OWNED', 'EDITABLE']),
   });
 
   // Build components

--- a/services/bot-client/src/commands/character/view.ts
+++ b/services/bot-client/src/commands/character/view.ts
@@ -14,6 +14,7 @@ import {
 import { type EnvConfig } from '@tzurot/common-types/config/config';
 import { DISCORD_COLORS, CHARACTER_VIEW_LIMITS } from '@tzurot/common-types/constants/discord';
 import { characterViewOptions } from '@tzurot/common-types/generated/commandOptions';
+import { UX_SENTINELS } from '@tzurot/common-types/constants/uxVocabulary';
 import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { GatewayApiError, type UserClient } from '@tzurot/clients';
@@ -86,7 +87,7 @@ function buildOverviewPage(
       name: '🏷️ Identity',
       value:
         `**Name:** ${escapeMarkdown(character.name)}\n` +
-        `**Display Name:** ${character.displayName !== null && character.displayName !== undefined ? escapeMarkdown(character.displayName) : '_Not set_'}\n` +
+        `**Display Name:** ${character.displayName !== null && character.displayName !== undefined ? escapeMarkdown(character.displayName) : UX_SENTINELS.NOT_SET}\n` +
         `**Slug:** \`${character.slug}\``,
       inline: false,
     },
@@ -107,8 +108,8 @@ function buildOverviewPage(
   embed.addFields({ name: '🎭 Personality Traits', value: traits.value, inline: false });
 
   embed.addFields(
-    { name: '🎨 Tone', value: character.personalityTone ?? '_Not set_', inline: true },
-    { name: '📅 Age', value: character.personalityAge ?? '_Not set_', inline: true }
+    { name: '🎨 Tone', value: character.personalityTone ?? UX_SENTINELS.NOT_SET, inline: true },
+    { name: '📅 Age', value: character.personalityAge ?? UX_SENTINELS.NOT_SET, inline: true }
   );
 }
 
@@ -213,11 +214,14 @@ export function buildRedactedViewPage(character: CharacterData): ViewPageResult 
       name: '🏷️ Identity',
       value:
         `**Name:** ${escapeMarkdown(character.name)}\n` +
-        `**Display Name:** ${character.displayName !== null && character.displayName !== undefined ? escapeMarkdown(character.displayName) : '_Not set_'}\n` +
+        `**Display Name:** ${character.displayName !== null && character.displayName !== undefined ? escapeMarkdown(character.displayName) : UX_SENTINELS.NOT_SET}\n` +
         `**Slug:** \`${character.slug}\``,
       inline: false,
     });
 
+  // Static dates by necessity: embed FOOTERS don't render <t:> markup, so
+  // the §2.5 dynamic-timestamp rule can't apply here (same carve-out class
+  // as file exports).
   const created = formatDateShort(character.createdAt);
   const updated = formatDateShort(character.updatedAt);
   embed.setFooter({ text: `Created: ${created} • Updated: ${updated}` });
@@ -502,7 +506,7 @@ export async function handleExpandField(
     // Get the full content
     const content = character[fieldInfo.key] as string | null;
     if (content === null || content === undefined || content.length === 0) {
-      await interaction.editReply(`${fieldInfo.label}\n\n_Not set_`);
+      await interaction.editReply(`${fieldInfo.label}\n\n${UX_SENTINELS.NOT_SET}`);
       return;
     }
 

--- a/services/bot-client/src/commands/character/viewTypes.ts
+++ b/services/bot-client/src/commands/character/viewTypes.ts
@@ -3,6 +3,7 @@
  */
 
 import { DISCORD_LIMITS, TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
+import { UX_SENTINELS } from '@tzurot/common-types/constants/uxVocabulary';
 import type { CharacterData } from './characterTypes.js';
 
 /** Field info for tracking truncation */
@@ -22,7 +23,7 @@ export function truncateField(
   maxLength = DISCORD_LIMITS.EMBED_FIELD - TEXT_LIMITS.TRUNCATION_SUFFIX.length
 ): FieldInfo {
   if (text === null || text === undefined || text.length === 0) {
-    return { value: '_Not set_', wasTruncated: false, originalLength: 0 };
+    return { value: UX_SENTINELS.NOT_SET, wasTruncated: false, originalLength: 0 };
   }
   // Ensure maxLength doesn't exceed Discord's limit minus suffix
   const safeMax = Math.min(

--- a/services/bot-client/src/commands/character/viewV2.test.ts
+++ b/services/bot-client/src/commands/character/viewV2.test.ts
@@ -221,7 +221,10 @@ describe('buildCharacterViewV2', () => {
   it('carries the date footer as subtext on every page', () => {
     for (const page of [0, 1, 2, 3]) {
       const flat = flatten(toTree(buildCharacterViewV2(createTestCharacter(), page, null)));
-      expect(flat.some(n => n.content?.startsWith('-# Created:') === true)).toBe(true);
+      const footer = flat.find(n => n.content?.startsWith('-# Created:') === true);
+      expect(footer).toBeDefined();
+      // Dynamic Discord timestamps (§2.5) — TextDisplay renders <t:> markup.
+      expect(footer?.content).toMatch(/<t:\d+:D>/);
     }
   });
 

--- a/services/bot-client/src/commands/character/viewV2.ts
+++ b/services/bot-client/src/commands/character/viewV2.ts
@@ -31,7 +31,8 @@ import {
   escapeMarkdown,
 } from 'discord.js';
 import { DISCORD_COLORS, CHARACTER_VIEW_LIMITS } from '@tzurot/common-types/constants/discord';
-import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
+import { UX_SENTINELS } from '@tzurot/common-types/constants/uxVocabulary';
+import { formatDiscordTimestamp } from '@tzurot/common-types/utils/dateFormatting';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import type { CharacterData } from './characterTypes.js';
 import {
@@ -89,7 +90,7 @@ function identityBlock(character: CharacterData): string {
   const displayName =
     character.displayName !== null && character.displayName !== undefined
       ? escapeMarkdown(character.displayName)
-      : '_Not set_';
+      : UX_SENTINELS.NOT_SET;
   return (
     `**🏷️ Identity**\n` +
     `**Name:** ${escapeMarkdown(character.name)}\n` +
@@ -120,8 +121,8 @@ function overviewBlocks(character: CharacterData): ViewBlock[] {
   // Tone and Age are SEPARATE blocks, mirroring the embed view's separate
   // inline fields — a mid-line `·` join scrunched Age onto the tail of an
   // arbitrarily long Tone paragraph (owner eval finding).
-  const tone = `**🎨 Tone**\n${character.personalityTone ?? '_Not set_'}`;
-  const age = `**📅 Age**\n${character.personalityAge ?? '_Not set_'}`;
+  const tone = `**🎨 Tone**\n${character.personalityTone ?? UX_SENTINELS.NOT_SET}`;
+  const age = `**📅 Age**\n${character.personalityAge ?? UX_SENTINELS.NOT_SET}`;
 
   return [
     { text: overviewDescription(character) },
@@ -178,8 +179,10 @@ function appendBlock(container: ContainerBuilder, slug: string, block: ViewBlock
 }
 
 function footerText(character: CharacterData): string {
-  const created = formatDateShort(character.createdAt);
-  const updated = formatDateShort(character.updatedAt);
+  // TextDisplay content renders markdown — dynamic timestamps work here,
+  // unlike classic embed footers (see view.ts).
+  const created = formatDiscordTimestamp(character.createdAt, 'D');
+  const updated = formatDiscordTimestamp(character.updatedAt, 'D');
   return `-# Created: ${created} • Updated: ${updated}`;
 }
 

--- a/services/bot-client/src/commands/persona/browse.ts
+++ b/services/bot-client/src/commands/persona/browse.ts
@@ -11,6 +11,8 @@ import {
   type ButtonInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
+import { AUTOCOMPLETE_BADGES } from '@tzurot/common-types/utils/autocompleteFormat';
+import { ENTITY_EMOJI, buildBadgeLegend } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
@@ -79,7 +81,7 @@ function sortPersonas(personas: PersonaSummary[], sortType: BrowseSortType): Per
  * (numbering is added by the buildBrowseSelectMenu factory).
  */
 function formatPersonaSelectLabel(persona: PersonaSummary): string {
-  const defaultBadge = persona.isDefault ? '⭐' : '';
+  const defaultBadge = persona.isDefault ? AUTOCOMPLETE_BADGES.DEFAULT : '';
   const nameBadge =
     persona.preferredName !== null &&
     persona.preferredName !== undefined &&
@@ -125,13 +127,13 @@ function buildBrowsePage(
 
   const { embed, pageItems, startIndex, totalPages, safePage } =
     buildBrowseListEmbed<PersonaSummary>({
-      entityEmoji: '👤',
+      entityEmoji: ENTITY_EMOJI.persona,
       titleNoun: 'Personas',
       items: sortedPersonas,
       page,
       itemsPerPage: ITEMS_PER_PAGE,
       formatRow: persona => ({
-        badges: persona.isDefault ? '⭐' : undefined,
+        badges: persona.isDefault ? AUTOCOMPLETE_BADGES.DEFAULT : undefined,
         name: escapeMarkdown(persona.name),
         metadata:
           persona.preferredName !== null &&
@@ -149,7 +151,7 @@ function buildBrowsePage(
           ? formatSortNatural('date')
           : formatSortVerbatim('Sorted alphabetically'),
       ],
-      badgeLegend: 'Default ⭐',
+      badgeLegend: buildBadgeLegend(['DEFAULT']),
     });
 
   // Build components

--- a/services/bot-client/src/commands/persona/config.ts
+++ b/services/bot-client/src/commands/persona/config.ts
@@ -9,6 +9,7 @@
  */
 
 import { DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
+import { entityTitle } from '@tzurot/common-types/constants/uxVocabulary';
 import {
   SectionStatus,
   type SectionDefinition,
@@ -159,7 +160,7 @@ const identitySection: SectionDefinition<FlattenedPersonaData> = {
  */
 export const PERSONA_DASHBOARD_CONFIG: DashboardConfig<FlattenedPersonaData> = {
   entityType: 'persona', // Matches command name - no componentPrefixes needed!
-  getTitle: data => `👤 Persona: ${data.name}`,
+  getTitle: data => entityTitle('persona', `Persona: ${data.name}`),
   getDescription: data => {
     const badges: string[] = [];
     if (data.isDefault) {

--- a/services/bot-client/src/commands/persona/view.test.ts
+++ b/services/bot-client/src/commands/persona/view.test.ts
@@ -113,7 +113,8 @@ describe('handleViewPersona', () => {
       embeds: [
         expect.objectContaining({
           data: expect.objectContaining({
-            title: '🎭 Your Persona',
+            // 👤 = persona entity glyph; 🎭 belongs to characters (§2.1)
+            title: '👤 Your Persona',
           }),
         }),
       ],

--- a/services/bot-client/src/commands/persona/view.ts
+++ b/services/bot-client/src/commands/persona/view.ts
@@ -19,6 +19,7 @@ import {
   type MessageActionRowComponentBuilder,
   type ButtonInteraction,
 } from 'discord.js';
+import { entityTitle, UX_SENTINELS } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
@@ -73,7 +74,9 @@ function buildPersonaEmbed(personaDetails: PersonaDetails): {
     : '*No content set. Use `/persona edit` to add information about yourself.*';
 
   const { embed } = buildEntityDetailCard({
-    title: '🎭 Your Persona',
+    // 🎭 is the CHARACTER entity's glyph — the persona view carries the
+    // persona register's 👤 (spec §2.1 reassignment).
+    title: entityTitle('persona', 'Your Persona'),
     fields: [
       personaDetails.preferredName !== null &&
         personaDetails.preferredName.length > 0 && {
@@ -193,7 +196,7 @@ export async function handleExpandContent(
 
     const content = result.data.persona.content;
     if (content === null || content.length === 0) {
-      await interaction.editReply('📝 Content\n\n_Not set_');
+      await interaction.editReply(`📝 Content\n\n${UX_SENTINELS.NOT_SET}`);
       return;
     }
 

--- a/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
@@ -205,7 +205,7 @@ describe('handleAutocomplete', () => {
       ]);
     });
 
-    it('should show 📖 icon for public personalities not owned', async () => {
+    it('should show 👥 icon for public personalities not owned', async () => {
       // Cast to handle getFocused(true) return type
       vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
         name: 'character',
@@ -227,9 +227,9 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      // 📖 = not owned (read-only)
+      // 👥 = owned by another user
       expect(mockInteraction.respond).toHaveBeenCalledWith([
-        { name: '📖 Shared Bot (sharedbot)', value: 'p1' },
+        { name: '👥 Shared Bot (sharedbot)', value: 'p1' },
       ]);
     });
 

--- a/services/bot-client/src/utils/autocomplete/personalityAutocomplete.test.ts
+++ b/services/bot-client/src/utils/autocomplete/personalityAutocomplete.test.ts
@@ -347,7 +347,7 @@ describe('handlePersonalityAutocomplete', () => {
       expect(mockRespond).toHaveBeenCalledWith([
         { name: '🌐 Public Owned (public-owned)', value: 'public-owned' },
         { name: '🔒 Private Owned (private-owned)', value: 'private-owned' },
-        { name: '📖 Public Not Owned (public-not-owned)', value: 'public-not-owned' },
+        { name: '👥 Public Not Owned (public-not-owned)', value: 'public-not-owned' },
       ]);
     });
 
@@ -448,14 +448,14 @@ describe('getVisibilityIcon', () => {
     expect(getVisibilityIcon(true, false)).toBe('🔒');
   });
 
-  it('should return 📖 (READ_ONLY) for cannot edit (public read-only)', () => {
-    // 📖 = someone else's public personality
-    expect(getVisibilityIcon(false, true)).toBe('📖');
+  it('should return 👥 (OWNED_BY_OTHER) for cannot edit (public read-only)', () => {
+    // 👥 = someone else's public personality
+    expect(getVisibilityIcon(false, true)).toBe('👥');
   });
 
-  it('should return 📖 (READ_ONLY) for cannot edit even if private', () => {
+  it('should return 👥 (OWNED_BY_OTHER) for cannot edit even if private', () => {
     // This case shouldn't happen in practice (private + cannot edit)
     // but the function should still handle it
-    expect(getVisibilityIcon(false, false)).toBe('📖');
+    expect(getVisibilityIcon(false, false)).toBe('👥');
   });
 });

--- a/services/bot-client/src/utils/autocomplete/personalityAutocomplete.ts
+++ b/services/bot-client/src/utils/autocomplete/personalityAutocomplete.ts
@@ -7,7 +7,7 @@
  * Uses standardized badges from @tzurot/common-types:
  * - 🌐 PUBLIC = User's public personality (can edit)
  * - 🔒 OWNED = User's private personality (can edit)
- * - 📖 READ_ONLY = Someone else's public personality
+ * - 👥 OWNED_BY_OTHER = Someone else's public personality
  */
 
 import type { AutocompleteInteraction } from 'discord.js';
@@ -126,12 +126,12 @@ export async function handlePersonalityAutocomplete(
       // Determine scope badge based on permissions
       // 🌐 PUBLIC = can edit + public (user's shared personality)
       // 🔒 OWNED = can edit + private (user's private personality)
-      // 📖 READ_ONLY = cannot edit (someone else's public personality)
+      // 👥 OWNED_BY_OTHER = cannot edit (someone else's public personality)
       const scopeBadge = p.permissions.canEdit
         ? p.isPublic
           ? AUTOCOMPLETE_BADGES.PUBLIC
           : AUTOCOMPLETE_BADGES.OWNED
-        : AUTOCOMPLETE_BADGES.READ_ONLY;
+        : AUTOCOMPLETE_BADGES.OWNED_BY_OTHER;
 
       return formatAutocompleteOption({
         name: displayName,
@@ -165,7 +165,7 @@ export async function handlePersonalityAutocomplete(
  * Uses standardized badges from AUTOCOMPLETE_BADGES:
  * - 🌐 PUBLIC = can edit + public
  * - 🔒 OWNED = can edit + private
- * - 📖 READ_ONLY = cannot edit
+ * - 👥 OWNED_BY_OTHER = cannot edit
  *
  * @param canEdit - Whether the user can edit this personality (from permissions.canEdit)
  * @param isPublic - Whether the personality is public
@@ -175,5 +175,5 @@ export function getVisibilityIcon(canEdit: boolean, isPublic: boolean): string {
   if (canEdit) {
     return isPublic ? AUTOCOMPLETE_BADGES.PUBLIC : AUTOCOMPLETE_BADGES.OWNED;
   }
-  return AUTOCOMPLETE_BADGES.READ_ONLY;
+  return AUTOCOMPLETE_BADGES.OWNED_BY_OTHER;
 }


### PR DESCRIPTION
## Summary

First adoption sweep of the vocabulary registry (Phase 3 Wave 1) — the character + persona families, each file visited once for ALL vocabulary classes per the council's by-module split:

- **Registry adoption**: browse `entityEmoji` args (character 🎭, persona 👤, alias 🏷️) and row badges (`PUBLIC`/`OWNED`/`EDITABLE`, `DEFAULT`, alias scope+`SHADOWED`) now come from the registry; hand-written badge legends replaced by `buildBadgeLegend`.
- **User-visible glyph changes (all spec-decided)**: the persona view's title 🎭→👤 (the §2.1 reassignment — roleplay belongs to characters); the shared personality autocomplete's not-editable badge 📖→👥 (deprecated `READ_ONLY` retired from live paths).
- **Registry extensions** (common-types commit): `alias` joins `ENTITY_EMOJI` (post-spec entity from the Phase 2 pilot), and `buildBadgeLegend` gains per-entry word overrides — the alias surface keeps its Global/Personal tier vocabulary while glyphs stay registry-locked.
- **Sentinels**: every `_Not set_` literal in the family binds to `UX_SENTINELS.NOT_SET`.
- **Timestamps**: viewV2's footer dates become dynamic `<t:...:D>` (TextDisplay renders markdown). Classic embed footers (view.ts, character dashboard config) deliberately KEEP static dates with the constraint documented in-code — Discord renders no `<t:>` markup in embed footers, the same carve-out class as file exports.

## Verified

- `pnpm test` green from root (bot-client 5788); `pnpm quality` green end-to-end.
- Six test pins updated to the new intended glyphs (📖→👥 ×4 files, 🎭→👤 persona view) — behavior changes are the PR's purpose, not regressions.
- Post-sweep grep: zero raw `_Not set_'` literals remain in the family (one prose comment mention stays, correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)