### PR TITLE
feat: phase 3 PR-5 — verb/option renames + selector standardization

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,7 +27,7 @@ TTS + STT provider selection and cloned-voice library lifecycle. Per-character T
 | `/voice` | `view <character>`                             | Resolved TTS + STT for a character (with cascade source) |
 |          | `tts list set clear set-default clear-default` | Per-character + user-default TTS provider config         |
 |          | `stt set clear`                                | Transcription provider preference (user-scoped)          |
-|          | `voices browse delete clear`                   | Cloned-voice library lifecycle                           |
+|          | `voices browse delete purge`                   | Cloned-voice library lifecycle                           |
 
 ## Presets & Channels
 
@@ -55,7 +55,7 @@ TTS + STT provider selection and cloned-voice library lifecycle. Per-character T
 
 | Command          | Subcommands                                         | Purpose                                                                                                                                                                                                                                                                                                            |
 | ---------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `/settings`      | `timezone` (`set` `get`)                            | Timezone for timestamps                                                                                                                                                                                                                                                                                            |
+| `/settings`      | `timezone` (`set` `view`)                           | Timezone for timestamps                                                                                                                                                                                                                                                                                            |
 |                  | `apikey` (`set` `browse` `remove` `test`)           | BYOK API key management                                                                                                                                                                                                                                                                                            |
 |                  | `defaults` (`edit`)                                 | User default settings dashboard                                                                                                                                                                                                                                                                                    |
 |                  | `data` (`export` `delete`)                          | Data rights: export everything your account owns (ZIP, 24h link) or permanently erase the account (typed confirmation)                                                                                                                                                                                             |

--- a/docs/reference/standards/FOLDER_STRUCTURE.md
+++ b/docs/reference/standards/FOLDER_STRUCTURE.md
@@ -210,8 +210,8 @@ commands/settings/
 ├── timezone/                   # /settings timezone <subcommand>
 │   ├── set.ts                  # /settings timezone set
 │   ├── set.test.ts
-│   ├── get.ts                  # /settings timezone get
-│   └── get.test.ts
+│   ├── view.ts                 # /settings timezone view
+│   └── view.test.ts
 ├── apikey/                     # /settings apikey <subcommand>
 │   ├── set.ts                  # /settings apikey set
 │   └── remove.ts               # /settings apikey remove

--- a/packages/common-types/src/constants/uxVocabulary.test.ts
+++ b/packages/common-types/src/constants/uxVocabulary.test.ts
@@ -89,6 +89,17 @@ describe('buildBadgeLegend', () => {
   });
 });
 
+describe('SELECTOR_DESCRIPTION', () => {
+  it('every selector phrase uses the §4.2 "Which …" form and stays unique', async () => {
+    const { SELECTOR_DESCRIPTION } = await import('./uxVocabulary.js');
+    const values = Object.values(SELECTOR_DESCRIPTION);
+    for (const value of values) {
+      expect(value).toMatch(/^Which [a-z]/i);
+    }
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
 describe('UX_SENTINELS', () => {
   it('pins the sanctioned sentinel strings', () => {
     expect(UX_SENTINELS.NOT_SET).toBe('_Not set_');

--- a/packages/common-types/src/constants/uxVocabulary.ts
+++ b/packages/common-types/src/constants/uxVocabulary.ts
@@ -72,6 +72,21 @@ export function entityTitle(kind: UxEntityKind, title: string): string {
 }
 
 /**
+ * Unified selector-option descriptions (§4.2): one shared phrasing per
+ * selector noun — "Which character", never five variants of "Character to
+ * update/edit/view". Qualified sites append an em-dash clause
+ * (`${SELECTOR_DESCRIPTION.character} — or "all" …`).
+ */
+export const SELECTOR_DESCRIPTION = {
+  character: 'Which character',
+  preset: 'Which preset',
+  globalPreset: 'Which global preset',
+  persona: 'Which persona',
+  voice: 'Which voice',
+  ttsConfig: 'Which TTS config',
+} as const;
+
+/**
  * Display sentinels (§2.5/D6) — the ONLY sanctioned empty-value strings.
  * `_Not configured_`, `—`, `_none_`, `None`, and `N/A` are retired.
  */

--- a/packages/common-types/src/generated/commandOptions.ts
+++ b/packages/common-types/src/generated/commandOptions.ts
@@ -46,10 +46,10 @@ export const adminKickOptions = defineTypedOptions({
 });
 
 /**
- * /admin usage <period>
+ * /admin usage <timeframe>
  */
 export const adminUsageOptions = defineTypedOptions({
-  period: { type: 'string', required: false },
+  timeframe: { type: 'string', required: false },
 });
 
 /**
@@ -64,10 +64,10 @@ export const adminBroadcastOptions = defineTypedOptions({
 });
 
 /**
- * /admin cleanup <days, target>
+ * /admin cleanup <timeframe, target>
  */
 export const adminCleanupOptions = defineTypedOptions({
-  days: { type: 'integer', required: false },
+  timeframe: { type: 'integer', required: false },
   target: { type: 'string', required: false },
 });
 
@@ -363,11 +363,11 @@ export const memoryFocusStatusOptions = defineTypedOptions({
 });
 
 /**
- * /memory incognito enable <character, duration>
+ * /memory incognito enable <character, timeframe>
  */
 export const memoryIncognitoEnableOptions = defineTypedOptions({
   character: { type: 'string', required: true },
-  duration: { type: 'string', required: true },
+  timeframe: { type: 'string', required: true },
 });
 
 /**
@@ -612,11 +612,11 @@ export const settingsApikeyTestOptions = defineTypedOptions({
 // =============================================================================
 
 /**
- * /shapes import <slug, import_type>
+ * /shapes import <slug, import-type>
  */
 export const shapesImportOptions = defineTypedOptions({
   slug: { type: 'string', required: true },
-  import_type: { type: 'string', required: false },
+  'import-type': { type: 'string', required: false },
 });
 
 /**

--- a/packages/tooling/src/eslint/builder-import-allowlist.ts
+++ b/packages/tooling/src/eslint/builder-import-allowlist.ts
@@ -123,7 +123,7 @@ export const BUILDER_IMPORT_ALLOWLIST: Readonly<Record<string, readonly string[]
   'services/bot-client/src/commands/voice/tts/guestModeValidation.ts': ['EmbedBuilder'],
   'services/bot-client/src/commands/voice/tts/set-default.ts': ['EmbedBuilder'],
   'services/bot-client/src/commands/voice/tts/set.ts': ['EmbedBuilder'],
-  'services/bot-client/src/commands/voice/voices/clear.ts': ['EmbedBuilder'],
+  'services/bot-client/src/commands/voice/voices/purge.ts': ['EmbedBuilder'],
   'services/bot-client/src/commands/voice/voices/delete.ts': ['EmbedBuilder'],
 };
 

--- a/packages/tooling/src/eslint/raw-content-allowlist.test.ts
+++ b/packages/tooling/src/eslint/raw-content-allowlist.test.ts
@@ -14,7 +14,7 @@ describe('allowlist contract (shrink-only)', () => {
     // Shrinking (migrating copy onto ux/catalog) passes without touching this
     // pin; new raw copy fails it. Lower the ceiling opportunistically when
     // the total drops.
-    expect(rawContentBudgetTotal()).toBeLessThanOrEqual(168);
+    expect(rawContentBudgetTotal()).toBeLessThanOrEqual(166);
   });
 
   it('contains no stale entries — every allowlisted file still exists', () => {

--- a/packages/tooling/src/eslint/raw-content-allowlist.ts
+++ b/packages/tooling/src/eslint/raw-content-allowlist.ts
@@ -71,7 +71,6 @@ export const RAW_CONTENT_ALLOWLIST: Readonly<Record<string, number>> = {
   'services/bot-client/src/commands/settings/apikey/browse.ts': 2,
   'services/bot-client/src/commands/settings/apikey/test.ts': 3,
   'services/bot-client/src/commands/settings/data/export.ts': 3,
-  'services/bot-client/src/commands/settings/timezone/get.ts': 2,
   'services/bot-client/src/commands/settings/timezone/set.ts': 2,
   'services/bot-client/src/commands/shapes/browse.ts': 4,
   'services/bot-client/src/commands/shapes/detailHandlers.ts': 7,
@@ -85,7 +84,7 @@ export const RAW_CONTENT_ALLOWLIST: Readonly<Record<string, number>> = {
   'services/bot-client/src/commands/voice/tts/clear.ts': 2,
   'services/bot-client/src/commands/voice/tts/set-default.ts': 2,
   'services/bot-client/src/commands/voice/tts/set.ts': 2,
-  'services/bot-client/src/commands/voice/voices/clear.ts': 1,
+  'services/bot-client/src/commands/voice/voices/purge.ts': 1,
 };
 
 /** Total grandfathered literals — the shrink-only ceiling pinned by the test. */

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -66,7 +66,7 @@
           {
             "type": 1,
             "name": "servers",
-            "description": "List all servers the bot is in",
+            "description": "Browse all servers the bot is in",
             "options": []
           },
           {
@@ -104,8 +104,8 @@
                     "value": "30d"
                   }
                 ],
-                "name": "period",
-                "description": "Time period for stats",
+                "name": "timeframe",
+                "description": "Time window for stats",
                 "required": false
               }
             ]
@@ -172,8 +172,8 @@
                 "max_value": 365,
                 "min_value": 1,
                 "type": 4,
-                "name": "days",
-                "description": "Keep history from the last N days (default: 30)",
+                "name": "timeframe",
+                "description": "Time window in days — keep history newer than this (default: 30)",
                 "required": false
               },
               {
@@ -320,7 +320,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to activate",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -405,7 +405,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to edit",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -419,7 +419,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to view",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -438,7 +438,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "Character to inspect (omit to see all your aliases)",
+                    "description": "Which character (omit to see all your aliases)",
                     "required": false
                   }
                 ]
@@ -452,7 +452,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "Character the alias points to",
+                    "description": "Which character the alias points to",
                     "required": true
                   },
                   {
@@ -524,7 +524,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to update",
+                "description": "Which character",
                 "required": true
               },
               {
@@ -544,7 +544,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to update",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -558,7 +558,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to update",
+                "description": "Which character",
                 "required": true
               },
               {
@@ -572,13 +572,13 @@
           {
             "type": 1,
             "name": "voice-clear",
-            "description": "Remove a character voice reference and disable TTS",
+            "description": "Clear a character's voice reference and disable TTS",
             "options": [
               {
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to update",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -617,7 +617,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to export",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -637,7 +637,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to chat with",
+                "description": "Which character",
                 "required": true
               },
               {
@@ -690,7 +690,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to chime in",
+                "description": "Which character",
                 "required": true
               },
               {
@@ -710,7 +710,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to manage",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -724,7 +724,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Character to override settings for",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -1052,14 +1052,14 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to clear history for",
+                "description": "Which character",
                 "required": true
               },
               {
                 "autocomplete": true,
                 "type": 3,
                 "name": "persona",
-                "description": "The persona to use (defaults to your active persona)",
+                "description": "Which persona (defaults to your active persona)",
                 "required": false
               }
             ]
@@ -1073,14 +1073,14 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to restore history for",
+                "description": "Which character",
                 "required": true
               },
               {
                 "autocomplete": true,
                 "type": 3,
                 "name": "persona",
-                "description": "The persona to use (defaults to your active persona)",
+                "description": "Which persona (defaults to your active persona)",
                 "required": false
               }
             ]
@@ -1094,14 +1094,14 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to view stats for",
+                "description": "Which character",
                 "required": true
               },
               {
                 "autocomplete": true,
                 "type": 3,
                 "name": "persona",
-                "description": "The persona to use (defaults to your active persona)",
+                "description": "Which persona (defaults to your active persona)",
                 "required": false
               }
             ]
@@ -1115,7 +1115,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to delete history for",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -1181,7 +1181,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to view stats for",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -1195,7 +1195,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Filter by character (optional)",
+                "description": "Which character — omit for all",
                 "required": false
               }
             ]
@@ -1209,7 +1209,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character whose facts to manage",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -1229,7 +1229,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Filter by character (optional)",
+                "description": "Which character — omit for all",
                 "required": false
               },
               {
@@ -1251,7 +1251,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to delete memories for",
+                "description": "Which character",
                 "required": true
               },
               {
@@ -1293,7 +1293,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "The character to purge all memories for",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -1312,7 +1312,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to enable focus mode for",
+                    "description": "Which character",
                     "required": true
                   }
                 ]
@@ -1326,7 +1326,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to disable focus mode for",
+                    "description": "Which character",
                     "required": true
                   }
                 ]
@@ -1340,7 +1340,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to check status for",
+                    "description": "Which character",
                     "required": true
                   }
                 ]
@@ -1361,7 +1361,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "Character or \"all\" for global incognito",
+                    "description": "Which character — or \"all\" for global incognito",
                     "required": true
                   },
                   {
@@ -1384,7 +1384,7 @@
                         "value": "forever"
                       }
                     ],
-                    "name": "duration",
+                    "name": "timeframe",
                     "description": "How long to stay in incognito mode",
                     "required": true
                   }
@@ -1399,7 +1399,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "Character or \"all\" to disable global incognito",
+                    "description": "Which character — or \"all\" to disable global incognito",
                     "required": true
                   }
                 ]
@@ -1419,7 +1419,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "Character or \"all\" for all characters",
+                    "description": "Which character — or \"all\" for all characters",
                     "required": true
                   },
                   {
@@ -1647,7 +1647,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "persona",
-                "description": "The persona to set as default",
+                "description": "Which persona",
                 "required": true
               }
             ]
@@ -1666,14 +1666,14 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to override",
+                    "description": "Which character",
                     "required": true
                   },
                   {
                     "autocomplete": true,
                     "type": 3,
                     "name": "persona",
-                    "description": "The persona to use (or create new)",
+                    "description": "Which persona — or a new name to create one",
                     "required": true
                   }
                 ]
@@ -1687,7 +1687,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to clear override for",
+                    "description": "Which character",
                     "required": true
                   }
                 ]
@@ -1788,7 +1788,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "preset",
-                "description": "Preset to edit",
+                "description": "Which preset",
                 "required": true
               }
             ]
@@ -1802,7 +1802,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "preset",
-                "description": "Preset to export",
+                "description": "Which preset",
                 "required": true
               }
             ]
@@ -1840,7 +1840,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "preset",
-                    "description": "Global preset to set as default",
+                    "description": "Which global preset",
                     "required": true
                   },
                   {
@@ -1870,7 +1870,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "preset",
-                    "description": "Global preset to set as free tier default",
+                    "description": "Which global preset",
                     "required": true
                   },
                   {
@@ -1913,14 +1913,14 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to override",
+                    "description": "Which character",
                     "required": true
                   },
                   {
                     "autocomplete": true,
                     "type": 3,
                     "name": "preset",
-                    "description": "The preset to use",
+                    "description": "Which preset",
                     "required": true
                   },
                   {
@@ -1944,13 +1944,13 @@
               {
                 "type": 1,
                 "name": "clear",
-                "description": "Remove preset override for a character",
+                "description": "Clear the preset override for a character",
                 "options": [
                   {
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to clear",
+                    "description": "Which character",
                     "required": true
                   },
                   {
@@ -1980,7 +1980,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "preset",
-                    "description": "The preset to use as default",
+                    "description": "Which preset",
                     "required": true
                   },
                   {
@@ -2069,7 +2069,7 @@
               },
               {
                 "type": 1,
-                "name": "get",
+                "name": "view",
                 "description": "Show your current timezone",
                 "options": []
               }
@@ -2275,7 +2275,7 @@
                     "value": "memory_only"
                   }
                 ],
-                "name": "import_type",
+                "name": "import-type",
                 "description": "Import type (default: full)",
                 "required": false
               }
@@ -2349,7 +2349,7 @@
                 "autocomplete": true,
                 "type": 3,
                 "name": "character",
-                "description": "Which character to inspect",
+                "description": "Which character",
                 "required": true
               }
             ]
@@ -2374,14 +2374,14 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to override",
+                    "description": "Which character",
                     "required": true
                   },
                   {
                     "autocomplete": true,
                     "type": 3,
                     "name": "tts",
-                    "description": "The TTS config to use",
+                    "description": "Which TTS config",
                     "required": true
                   }
                 ]
@@ -2389,13 +2389,13 @@
               {
                 "type": 1,
                 "name": "clear",
-                "description": "Remove TTS config override for a character",
+                "description": "Clear the TTS override for a character",
                 "options": [
                   {
                     "autocomplete": true,
                     "type": 3,
                     "name": "character",
-                    "description": "The character to clear",
+                    "description": "Which character",
                     "required": true
                   }
                 ]
@@ -2409,7 +2409,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "tts",
-                    "description": "The TTS config to use as default",
+                    "description": "Which TTS config",
                     "required": true
                   }
                 ]
@@ -2482,15 +2482,15 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "voice",
-                    "description": "The voice to delete",
+                    "description": "Which voice",
                     "required": true
                   }
                 ]
               },
               {
                 "type": 1,
-                "name": "clear",
-                "description": "Delete all Tzurot cloned voices",
+                "name": "purge",
+                "description": "Permanently delete ALL Tzurot cloned voices",
                 "options": []
               }
             ]

--- a/services/bot-client/src/commands/admin/cleanup.test.ts
+++ b/services/bot-client/src/commands/admin/cleanup.test.ts
@@ -96,7 +96,7 @@ describe('handleCleanup', () => {
           }),
           getBoolean: vi.fn(() => null),
           getInteger: vi.fn((name: string) => {
-            if (name === 'days') return days;
+            if (name === 'timeframe') return days;
             return null;
           }),
         },
@@ -110,7 +110,7 @@ describe('handleCleanup', () => {
       commandName: 'admin',
       isEphemeral: true,
       getOption: vi.fn((name: string) => {
-        if (name === 'days') return days;
+        if (name === 'timeframe') return days;
         if (name === 'target') return target;
         return null;
       }),

--- a/services/bot-client/src/commands/admin/cleanup.ts
+++ b/services/bot-client/src/commands/admin/cleanup.ts
@@ -19,7 +19,7 @@ const logger = createLogger('admin-cleanup');
 
 export async function handleCleanup(context: DeferredCommandContext): Promise<void> {
   const options = adminCleanupOptions(context.interaction);
-  const daysToKeep = options.days() ?? CLEANUP_DEFAULTS.DAYS_TO_KEEP_HISTORY;
+  const daysToKeep = options.timeframe() ?? CLEANUP_DEFAULTS.DAYS_TO_KEEP_HISTORY;
   // Discord's slash-command option type comes through as `string`, but the
   // server schema enums to ('history' | 'tombstones' | 'all'). The slash
   // command itself only exposes those three choices to users, so the cast

--- a/services/bot-client/src/commands/admin/index.test.ts
+++ b/services/bot-client/src/commands/admin/index.test.ts
@@ -99,7 +99,7 @@ describe('admin command', () => {
       expect(serversSubcommand).toBeDefined();
       if (serversSubcommand && 'name' in serversSubcommand && 'description' in serversSubcommand) {
         expect(serversSubcommand.name).toBe('servers');
-        expect(serversSubcommand.description).toBe('List all servers the bot is in');
+        expect(serversSubcommand.description).toBe('Browse all servers the bot is in');
       }
     });
 

--- a/services/bot-client/src/commands/admin/index.ts
+++ b/services/bot-client/src/commands/admin/index.ts
@@ -230,6 +230,13 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
  * Export command definition using defineCommand for type safety
  * Category is injected by CommandHandler based on folder structure
  */
+/** §4.2 `timeframe` choice set for /admin usage (G11: named constant, not inline). */
+const USAGE_TIMEFRAME_CHOICES: { name: string; value: string }[] = [
+  { name: 'Last 24 hours', value: '24h' },
+  { name: 'Last 7 days', value: '7d' },
+  { name: 'Last 30 days', value: '30d' },
+];
+
 export default defineCommand({
   data: new SlashCommandBuilder()
     .setName('admin')
@@ -255,7 +262,7 @@ export default defineCommand({
         )
     )
     .addSubcommand(subcommand =>
-      subcommand.setName('servers').setDescription('List all servers the bot is in')
+      subcommand.setName('servers').setDescription('Browse all servers the bot is in')
     )
     .addSubcommand(subcommand =>
       subcommand
@@ -275,14 +282,10 @@ export default defineCommand({
         .setDescription('View API usage statistics')
         .addStringOption(option =>
           option
-            .setName('period')
-            .setDescription('Time period for stats')
+            .setName('timeframe')
+            .setDescription('Time window for stats')
             .setRequired(false)
-            .addChoices(
-              { name: 'Last 24 hours', value: '24h' },
-              { name: 'Last 7 days', value: '7d' },
-              { name: 'Last 30 days', value: '30d' }
-            )
+            .addChoices(...USAGE_TIMEFRAME_CHOICES)
         )
     )
     .addSubcommand(subcommand =>
@@ -332,9 +335,12 @@ export default defineCommand({
         .setName('cleanup')
         .setDescription('Clean up old conversation history and tombstones')
         .addIntegerOption(option =>
+          // Unlike the enum-window `timeframe`s (usage, incognito, memory
+          // delete), cleanup's is a RAW DAY COUNT — arbitrary N-days is real
+          // admin utility a fixed choice set would destroy (§4.2/D10 call).
           option
-            .setName('days')
-            .setDescription('Keep history from the last N days (default: 30)')
+            .setName('timeframe')
+            .setDescription('Time window in days — keep history newer than this (default: 30)')
             .setRequired(false)
             .setMinValue(1)
             .setMaxValue(365)

--- a/services/bot-client/src/commands/admin/usage.test.ts
+++ b/services/bot-client/src/commands/admin/usage.test.ts
@@ -96,14 +96,14 @@ describe('handleUsage', () => {
     vi.restoreAllMocks();
   });
 
-  function createMockContext(period: string | null = null): DeferredCommandContext {
+  function createMockContext(timeframe: string | null = null): DeferredCommandContext {
     const mockEditReply = vi.fn().mockResolvedValue(undefined);
     return {
       interaction: {
         user: { id: 'user-123' },
         options: {
           getString: vi.fn((name: string) => {
-            if (name === 'period') return period;
+            if (name === 'timeframe') return timeframe;
             return null;
           }),
           getBoolean: vi.fn(() => null),
@@ -119,7 +119,7 @@ describe('handleUsage', () => {
       commandName: 'admin',
       isEphemeral: true,
       getOption: vi.fn((name: string) => {
-        if (name === 'period') return period;
+        if (name === 'timeframe') return timeframe;
         return null;
       }),
       getRequiredOption: vi.fn(),

--- a/services/bot-client/src/commands/admin/usage.ts
+++ b/services/bot-client/src/commands/admin/usage.ts
@@ -18,7 +18,7 @@ const logger = createLogger('admin-usage');
 
 export async function handleUsage(context: DeferredCommandContext): Promise<void> {
   const options = adminUsageOptions(context.interaction);
-  const periodOption = options.period();
+  const periodOption = options.timeframe();
   const timeframe =
     periodOption !== undefined && periodOption !== null && periodOption.length > 0
       ? periodOption

--- a/services/bot-client/src/commands/channel/index.ts
+++ b/services/bot-client/src/commands/channel/index.ts
@@ -21,6 +21,7 @@ import {
   type ButtonInteraction,
   type ModalSubmitInteraction,
 } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import {
   defineCommand,
@@ -131,7 +132,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to activate')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )

--- a/services/bot-client/src/commands/character/index.ts
+++ b/services/bot-client/src/commands/character/index.ts
@@ -10,6 +10,7 @@
  */
 
 import { SlashCommandBuilder, type AutocompleteInteraction } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { getConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { defineCommand } from '../../utils/defineCommand.js';
@@ -43,7 +44,6 @@ import {
 const logger = createLogger('character-command');
 
 /** Shared description for subcommands that modify a character */
-const CHARACTER_TO_UPDATE_DESC = 'Character to update';
 
 /**
  * Create character router with mixed deferral modes
@@ -144,7 +144,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Character to edit')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -156,7 +156,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Character to view')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -172,7 +172,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('Character to inspect (omit to see all your aliases)')
+                .setDescription(`${SELECTOR_DESCRIPTION.character} (omit to see all your aliases)`)
                 .setAutocomplete(true)
             )
         )
@@ -183,7 +183,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('Character the alias points to')
+                .setDescription(`${SELECTOR_DESCRIPTION.character} the alias points to`)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -231,7 +231,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription(CHARACTER_TO_UPDATE_DESC)
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -249,7 +249,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription(CHARACTER_TO_UPDATE_DESC)
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -261,7 +261,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription(CHARACTER_TO_UPDATE_DESC)
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -275,11 +275,11 @@ export default defineCommand({
     .addSubcommand(subcommand =>
       subcommand
         .setName('voice-clear')
-        .setDescription('Remove a character voice reference and disable TTS')
+        .setDescription("Clear a character's voice reference and disable TTS")
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription(CHARACTER_TO_UPDATE_DESC)
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -314,7 +314,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Character to export')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -329,7 +329,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Character to chat with')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -386,7 +386,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Character to chime in')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -406,7 +406,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Character to manage')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -418,7 +418,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Character to override settings for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -15,6 +15,7 @@ import {
   type ButtonInteraction,
   type ModalSubmitInteraction,
 } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { defineCommand } from '../../utils/defineCommand.js';
 import { createSubcommandContextRouter } from '../../utils/subcommandContextRouter.js';
@@ -42,7 +43,7 @@ import { createSuccessEmbed } from '../../utils/commandHelpers.js';
 const logger = createLogger('history-command');
 
 const HARD_DELETE_OPERATION = 'hard-delete';
-const PERSONA_OPTION_DESCRIPTION = 'The persona to use (defaults to your active persona)';
+const PERSONA_OPTION_DESCRIPTION = 'Which persona (defaults to your active persona)';
 
 /**
  * Context-aware subcommand router
@@ -245,7 +246,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to clear history for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -264,7 +265,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to restore history for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -283,7 +284,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to view stats for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -305,7 +306,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to delete history for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )

--- a/services/bot-client/src/commands/memory/incognito.test.ts
+++ b/services/bot-client/src/commands/memory/incognito.test.ts
@@ -94,8 +94,9 @@ describe('Memory Incognito Handlers', () => {
         options: {
           getString: (name: string, _required?: boolean) => {
             if (name === 'character') return options.character ?? 'lilith';
-            if (name === 'duration') return options.duration ?? '1h';
-            if (name === 'timeframe') return options.timeframe ?? '15m';
+            // Both enable (duration semantics) and forget (window semantics)
+            // now share the §4.2 `timeframe` option name.
+            if (name === 'timeframe') return options.duration ?? options.timeframe ?? '1h';
             return null;
           },
         },

--- a/services/bot-client/src/commands/memory/incognito.ts
+++ b/services/bot-client/src/commands/memory/incognito.ts
@@ -123,7 +123,7 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
   const { userClient } = clientsFor(context.interaction);
   const options = memoryIncognitoEnableOptions(context.interaction);
   const personalityInput = options.character();
-  const duration = options.duration() as IncognitoDuration;
+  const duration = options.timeframe() as IncognitoDuration;
 
   try {
     const resolved = await resolveIncognitoTargetOrReply(context, userClient, personalityInput);

--- a/services/bot-client/src/commands/memory/index.ts
+++ b/services/bot-client/src/commands/memory/index.ts
@@ -18,6 +18,7 @@
  */
 
 import { SlashCommandBuilder, type AutocompleteInteraction } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { defineCommand } from '../../utils/defineCommand.js';
 import type {
@@ -122,6 +123,22 @@ async function autocomplete(interaction: AutocompleteInteraction): Promise<void>
  *
  * deferralMode: 'ephemeral' means all subcommands receive DeferredCommandContext.
  */
+/** §4.2 `timeframe` choice sets (G11: named constants, not inline; sets differ per domain). */
+const DELETE_TIMEFRAME_CHOICES: { name: string; value: string }[] = [
+  { name: 'Last 24 hours', value: '24h' },
+  { name: 'Last 7 days', value: '7d' },
+  { name: 'Last 30 days', value: '30d' },
+  { name: 'Last year', value: '1y' },
+  { name: 'All time', value: 'all' },
+];
+
+const INCOGNITO_TIMEFRAME_CHOICES: { name: string; value: string }[] = [
+  { name: '30 minutes', value: '30m' },
+  { name: '1 hour', value: '1h' },
+  { name: '4 hours', value: '4h' },
+  { name: 'Until manually disabled', value: 'forever' },
+];
+
 export default defineCommand({
   deferralMode: 'ephemeral',
   data: new SlashCommandBuilder()
@@ -134,7 +151,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to view stats for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -146,7 +163,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Filter by character (optional)')
+            .setDescription(`${SELECTOR_DESCRIPTION.character} — omit for all`)
             .setRequired(false)
             .setAutocomplete(true)
         )
@@ -158,7 +175,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character whose facts to manage')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -176,7 +193,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Filter by character (optional)')
+            .setDescription(`${SELECTOR_DESCRIPTION.character} — omit for all`)
             .setRequired(false)
             .setAutocomplete(true)
         )
@@ -196,7 +213,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to delete memories for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -205,13 +222,7 @@ export default defineCommand({
             .setName('timeframe')
             .setDescription('Only delete memories from this time period (e.g., 7d, 30d, 1y)')
             .setRequired(false)
-            .addChoices(
-              { name: 'Last 24 hours', value: '24h' },
-              { name: 'Last 7 days', value: '7d' },
-              { name: 'Last 30 days', value: '30d' },
-              { name: 'Last year', value: '1y' },
-              { name: 'All time', value: 'all' }
-            )
+            .addChoices(...DELETE_TIMEFRAME_CHOICES)
         )
     )
     .addSubcommand(subcommand =>
@@ -221,7 +232,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to purge all memories for')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -237,7 +248,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('The character to enable focus mode for')
+                .setDescription(SELECTOR_DESCRIPTION.character)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -249,7 +260,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('The character to disable focus mode for')
+                .setDescription(SELECTOR_DESCRIPTION.character)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -261,7 +272,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('The character to check status for')
+                .setDescription(SELECTOR_DESCRIPTION.character)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -278,21 +289,16 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('Character or "all" for global incognito')
+                .setDescription(`${SELECTOR_DESCRIPTION.character} — or "all" for global incognito`)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
             .addStringOption(option =>
               option
-                .setName('duration')
+                .setName('timeframe')
                 .setDescription('How long to stay in incognito mode')
                 .setRequired(true)
-                .addChoices(
-                  { name: '30 minutes', value: '30m' },
-                  { name: '1 hour', value: '1h' },
-                  { name: '4 hours', value: '4h' },
-                  { name: 'Until manually disabled', value: 'forever' }
-                )
+                .addChoices(...INCOGNITO_TIMEFRAME_CHOICES)
             )
         )
         .addSubcommand(subcommand =>
@@ -302,7 +308,9 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('Character or "all" to disable global incognito')
+                .setDescription(
+                  `${SELECTOR_DESCRIPTION.character} — or "all" to disable global incognito`
+                )
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -317,7 +325,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('Character or "all" for all characters')
+                .setDescription(`${SELECTOR_DESCRIPTION.character} — or "all" for all characters`)
                 .setRequired(true)
                 .setAutocomplete(true)
             )

--- a/services/bot-client/src/commands/persona/index.ts
+++ b/services/bot-client/src/commands/persona/index.ts
@@ -25,6 +25,7 @@ import {
   type ButtonInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { personaEditOptions } from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { defineCommand } from '../../utils/defineCommand.js';
@@ -287,7 +288,9 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('persona')
-            .setDescription('Which persona to edit (optional, defaults to your default)')
+            .setDescription(
+              `${SELECTOR_DESCRIPTION.persona} to edit (optional, defaults to your default)`
+            )
             .setRequired(false)
             .setAutocomplete(true)
         )
@@ -305,7 +308,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('persona')
-            .setDescription('The persona to set as default')
+            .setDescription(SELECTOR_DESCRIPTION.persona)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -321,14 +324,14 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('The character to override')
+                .setDescription(SELECTOR_DESCRIPTION.character)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
             .addStringOption(option =>
               option
                 .setName('persona')
-                .setDescription('The persona to use (or create new)')
+                .setDescription(`${SELECTOR_DESCRIPTION.persona} — or a new name to create one`)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -340,7 +343,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('The character to clear override for')
+                .setDescription(SELECTOR_DESCRIPTION.character)
                 .setRequired(true)
                 .setAutocomplete(true)
             )

--- a/services/bot-client/src/commands/preset/index.ts
+++ b/services/bot-client/src/commands/preset/index.ts
@@ -25,6 +25,7 @@ import {
   type ButtonInteraction,
   type ModalSubmitInteraction,
 } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { CONFIG_SLOT_OPTION_DESCRIPTION } from '@tzurot/common-types/constants/ai';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { handleModalRetry, isModalRetryInteraction } from '../../utils/modal/retry.js';
@@ -274,7 +275,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('preset')
-            .setDescription('Preset to edit')
+            .setDescription(SELECTOR_DESCRIPTION.preset)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -286,7 +287,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('preset')
-            .setDescription('Preset to export')
+            .setDescription(SELECTOR_DESCRIPTION.preset)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -313,7 +314,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('preset')
-                .setDescription('Global preset to set as default')
+                .setDescription(SELECTOR_DESCRIPTION.globalPreset)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -332,7 +333,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('preset')
-                .setDescription('Global preset to set as free tier default')
+                .setDescription(SELECTOR_DESCRIPTION.globalPreset)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -361,14 +362,14 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('The character to override')
+                .setDescription(SELECTOR_DESCRIPTION.character)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
             .addStringOption(option =>
               option
                 .setName('preset')
-                .setDescription('The preset to use')
+                .setDescription(SELECTOR_DESCRIPTION.preset)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -383,11 +384,11 @@ export default defineCommand({
         .addSubcommand(subcommand =>
           subcommand
             .setName('clear')
-            .setDescription('Remove preset override for a character')
+            .setDescription('Clear the preset override for a character')
             .addStringOption(option =>
               option
                 .setName('character')
-                .setDescription('The character to clear')
+                .setDescription(SELECTOR_DESCRIPTION.character)
                 .setRequired(true)
                 .setAutocomplete(true)
             )
@@ -406,7 +407,7 @@ export default defineCommand({
             .addStringOption(option =>
               option
                 .setName('preset')
-                .setDescription('The preset to use as default')
+                .setDescription(SELECTOR_DESCRIPTION.preset)
                 .setRequired(true)
                 .setAutocomplete(true)
             )

--- a/services/bot-client/src/commands/settings/index.test.ts
+++ b/services/bot-client/src/commands/settings/index.test.ts
@@ -18,8 +18,8 @@ vi.mock('./timezone/set.js', () => ({
   handleTimezoneSet: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('./timezone/get.js', () => ({
-  handleTimezoneGet: vi.fn().mockResolvedValue(undefined),
+vi.mock('./timezone/view.js', () => ({
+  handleTimezoneView: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock apikey handlers
@@ -103,7 +103,7 @@ describe('Settings Command Index', () => {
       const subcommands = (
         (timezoneGroup as { options?: Array<{ name: string }> })?.options ?? []
       ).map(s => s.name);
-      expect(subcommands).toContain('get');
+      expect(subcommands).toContain('view');
       expect(subcommands).toContain('set');
     });
 
@@ -196,13 +196,13 @@ describe('Settings Command Index', () => {
     }
 
     describe('timezone group', () => {
-      it('should route to timezone get handler', async () => {
-        const { handleTimezoneGet } = await import('./timezone/get.js');
-        const context = createMockContext('timezone', 'get');
+      it('should route to timezone view handler', async () => {
+        const { handleTimezoneView } = await import('./timezone/view.js');
+        const context = createMockContext('timezone', 'view');
 
         await execute(context);
 
-        expect(handleTimezoneGet).toHaveBeenCalledWith(context);
+        expect(handleTimezoneView).toHaveBeenCalledWith(context);
       });
 
       it('should route to timezone set handler', async () => {

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -3,7 +3,7 @@
  *
  * Consolidates user settings in one place:
  *
- * - /settings timezone get|set - Manage timezone
+ * - /settings timezone view|set - Manage timezone
  * - /settings apikey set|browse|remove|test - Manage API keys (BYOK)
  * - /settings defaults edit - Manage global default settings (config cascade)
  *
@@ -28,7 +28,7 @@ import { replyValidationError } from '../../utils/confirmation/confirmDestructiv
 
 // Timezone handlers
 import { handleTimezoneSet } from './timezone/set.js';
-import { handleTimezoneGet } from './timezone/get.js';
+import { handleTimezoneView } from './timezone/view.js';
 
 // API key handlers (moved from /wallet)
 import { handleSetKey } from './apikey/set.js';
@@ -71,7 +71,7 @@ const logger = createLogger('settings-command');
 const timezoneRouter = createTypedSubcommandRouter(
   {
     set: handleTimezoneSet,
-    get: handleTimezoneGet,
+    view: handleTimezoneView,
   },
   { logger, logPrefix: '[Settings/Timezone]' }
 );
@@ -213,7 +213,7 @@ export default defineCommand({
             )
         )
         .addSubcommand(subcommand =>
-          subcommand.setName('get').setDescription('Show your current timezone')
+          subcommand.setName('view').setDescription('Show your current timezone')
         )
     )
     // API key subcommand group

--- a/services/bot-client/src/commands/settings/timezone/view.test.ts
+++ b/services/bot-client/src/commands/settings/timezone/view.test.ts
@@ -1,12 +1,12 @@
 /**
- * Tests for Timezone Get Handler
+ * Tests for Timezone View Handler
  *
  * Note: This command uses editReply() because interactions are deferred
  * at the top level in index.ts. Ephemerality is set by deferReply().
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleTimezoneGet } from './get.js';
+import { handleTimezoneView } from './view.js';
 import { mockGetTimezoneResponse } from '@tzurot/test-factories';
 import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
 import type { UserClient } from '@tzurot/clients';
@@ -67,7 +67,7 @@ vi.mock('../../../utils/commandHelpers.js', () => ({
     mockCreateInfoEmbed(...(args as [string, string | undefined])),
 }));
 
-describe('handleTimezoneGet', () => {
+describe('handleTimezoneView', () => {
   const mockEditReply = vi.fn();
 
   beforeEach(() => {
@@ -83,7 +83,7 @@ describe('handleTimezoneGet', () => {
       user: { id: '123456789', username: 'testuser' },
       interaction: {} as never,
       editReply: mockEditReply,
-    } as unknown as Parameters<typeof handleTimezoneGet>[0];
+    } as unknown as Parameters<typeof handleTimezoneView>[0];
   }
 
   it('should get timezone successfully', async () => {
@@ -91,7 +91,7 @@ describe('handleTimezoneGet', () => {
       makeOk(mockGetTimezoneResponse({ timezone: 'America/New_York', isDefault: false }))
     );
 
-    await handleTimezoneGet(createMockContext());
+    await handleTimezoneView(createMockContext());
 
     expect(stub.getTimezone).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
@@ -106,7 +106,7 @@ describe('handleTimezoneGet', () => {
       makeOk(mockGetTimezoneResponse({ timezone: 'UTC', isDefault: true }))
     );
 
-    await handleTimezoneGet(createMockContext());
+    await handleTimezoneView(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
@@ -122,20 +122,33 @@ describe('handleTimezoneGet', () => {
   it('should handle API error', async () => {
     stub.getTimezone.mockResolvedValue(makeErr(500, 'Server error'));
 
-    await handleTimezoneGet(createMockContext());
+    await handleTimezoneView(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ Failed to get timezone. Please try again later.',
+      content: '❌ Server error',
     });
+  });
+
+  it('renders read-shaped copy on a timeout — never a write-outcome claim', async () => {
+    // kind 'timeout' hits the read/write branch the http-kind pins bypass; a
+    // pure GET must never render "your change may still be applying".
+    stub.getTimezone.mockResolvedValue(makeErr(0, 'timed out', undefined, 'timeout'));
+
+    const context = createMockContext();
+    await handleTimezoneView(context);
+
+    const call = vi.mocked(context.editReply).mock.calls[0][0] as { content: string };
+    expect(call.content).not.toContain('may still be applying');
+    expect(call.content).not.toContain('was saved');
   });
 
   it('should handle exceptions', async () => {
     stub.getTimezone.mockRejectedValue(new Error('Network error'));
 
-    await handleTimezoneGet(createMockContext());
+    await handleTimezoneView(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ An error occurred. Please try again later.',
+      content: '❌ Failed to fetch your timezone. Please try again.',
     });
   });
 });

--- a/services/bot-client/src/commands/settings/timezone/view.ts
+++ b/services/bot-client/src/commands/settings/timezone/view.ts
@@ -1,6 +1,6 @@
 /**
- * Timezone Get Handler
- * Handles /settings timezone get command
+ * Timezone View Handler
+ * Handles /settings timezone view command
  */
 
 import { TIMEZONE_DISCORD_CHOICES } from '@tzurot/common-types/constants/timezone';
@@ -9,13 +9,15 @@ import type { DeferredCommandContext } from '../../../utils/commandContext/types
 import { clientsFor } from '../../../utils/gatewayClients.js';
 import { createInfoEmbed } from '../../../utils/commandHelpers.js';
 import { getCurrentTimeInTimezone } from './utils.js';
+import { classifyGatewayFailure } from '../../../ux/catalog/classify.js';
+import { renderSpec } from '../../../ux/render/render.js';
 
-const logger = createLogger('timezone-get');
+const logger = createLogger('timezone-view');
 
 /**
- * Handle /settings timezone get
+ * Handle /settings timezone view
  */
-export async function handleTimezoneGet(context: DeferredCommandContext): Promise<void> {
+export async function handleTimezoneView(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
 
   try {
@@ -24,7 +26,14 @@ export async function handleTimezoneGet(context: DeferredCommandContext): Promis
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to get timezone');
-      await context.editReply({ content: '❌ Failed to get timezone. Please try again later.' });
+      await context.editReply({
+        content: renderSpec(
+          classifyGatewayFailure(result, 'timezone', {
+            operation: 'read',
+            failedAction: 'fetch your timezone',
+          })
+        ),
+      });
       return;
     }
 
@@ -49,7 +58,14 @@ export async function handleTimezoneGet(context: DeferredCommandContext): Promis
 
     await context.editReply({ embeds: [embed] });
   } catch (error) {
-    logger.error({ err: error, userId, command: 'Timezone Get' }, 'Error');
-    await context.editReply({ content: '❌ An error occurred. Please try again later.' });
+    logger.error({ err: error, userId, command: 'Timezone View' }, 'Error');
+    await context.editReply({
+      content: renderSpec(
+        classifyGatewayFailure(error, 'timezone', {
+          operation: 'read',
+          failedAction: 'fetch your timezone',
+        })
+      ),
+    });
   }
 }

--- a/services/bot-client/src/commands/shapes/import.test.ts
+++ b/services/bot-client/src/commands/shapes/import.test.ts
@@ -43,7 +43,7 @@ describe('handleImport', () => {
     vi.resetAllMocks();
     mockGetString.mockImplementation((name: string) => {
       if (name === 'slug') return 'test-character';
-      if (name === 'import_type') return null;
+      if (name === 'import-type') return null;
       return null;
     });
     stub = {

--- a/services/bot-client/src/commands/shapes/import.ts
+++ b/services/bot-client/src/commands/shapes/import.ts
@@ -13,6 +13,7 @@ import {
   ActionRowBuilder,
   type MessageComponentInteraction,
 } from 'discord.js';
+import { shapesImportOptions } from '@tzurot/common-types/generated/commandOptions';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { renderSpec } from '../../ux/render/render.js';
@@ -113,7 +114,7 @@ export async function handleImport(context: DeferredCommandContext): Promise<voi
     return;
   }
   const slug = rawSlug.trim().toLowerCase();
-  const importTypeRaw = context.interaction.options.getString('import_type') ?? 'full';
+  const importTypeRaw = shapesImportOptions(context.interaction)['import-type']() ?? 'full';
   const importType: 'full' | 'memory_only' =
     importTypeRaw === 'memory_only' ? 'memory_only' : 'full';
 

--- a/services/bot-client/src/commands/shapes/index.ts
+++ b/services/bot-client/src/commands/shapes/index.ts
@@ -47,6 +47,12 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
   await handleShapesModalSubmit(interaction);
 }
 
+/** Import-type choice set (G11: named constant; values are wire/API vocabulary). */
+const IMPORT_TYPE_CHOICES: { name: string; value: string }[] = [
+  { name: 'Full Character', value: 'full' },
+  { name: 'Memory Only', value: 'memory_only' },
+];
+
 export default defineCommand({
   deferralMode: 'ephemeral',
   subcommandDeferralModes: {
@@ -77,12 +83,9 @@ export default defineCommand({
         )
         .addStringOption(option =>
           option
-            .setName('import_type')
+            .setName('import-type')
             .setDescription('Import type (default: full)')
-            .addChoices(
-              { name: 'Full Character', value: 'full' },
-              { name: 'Memory Only', value: 'memory_only' }
-            )
+            .addChoices(...IMPORT_TYPE_CHOICES)
         )
     )
     .addSubcommand(subcommand =>

--- a/services/bot-client/src/commands/voice/index.test.ts
+++ b/services/bot-client/src/commands/voice/index.test.ts
@@ -49,11 +49,11 @@ vi.mock('./voices/delete.js', () => ({
   handleDeleteVoice: vi.fn(),
   handleVoiceAutocomplete: vi.fn(),
 }));
-vi.mock('./voices/clear.js', () => ({
-  handleClearVoices: vi.fn(),
-  handleVoiceClearButton: vi.fn(),
-  handleVoiceClearModal: vi.fn(),
-  VOICE_CLEAR_OPERATION: 'voice-clear',
+vi.mock('./voices/purge.js', () => ({
+  handlePurgeVoices: vi.fn(),
+  handleVoicePurgeButton: vi.fn(),
+  handleVoicePurgeModal: vi.fn(),
+  VOICE_PURGE_OPERATION: 'voice-purge',
 }));
 
 import { handleTtsBrowse } from './tts/browse.js';
@@ -69,10 +69,10 @@ import {
 } from './voices/browse.js';
 import { handleDeleteVoice, handleVoiceAutocomplete } from './voices/delete.js';
 import {
-  handleClearVoices,
-  handleVoiceClearButton,
-  handleVoiceClearModal,
-} from './voices/clear.js';
+  handlePurgeVoices,
+  handleVoicePurgeButton,
+  handleVoicePurgeModal,
+} from './voices/purge.js';
 
 describe('Voice Command', () => {
   const mockEditReply = vi.fn();
@@ -118,7 +118,7 @@ describe('Voice Command', () => {
       const voicesSubcommands = ((voices as { options?: { name: string }[] }).options ?? [])
         .map(s => s.name)
         .sort();
-      expect(voicesSubcommands).toEqual(['browse', 'clear', 'delete']);
+      expect(voicesSubcommands).toEqual(['browse', 'delete', 'purge']);
     });
   });
 
@@ -165,10 +165,10 @@ describe('Voice Command', () => {
       expect(handleDeleteVoice).toHaveBeenCalledOnce();
     });
 
-    it('routes /voice voices clear to handleClearVoices', async () => {
-      const ctx = createMockContext('clear', 'voices');
+    it('routes /voice voices purge to handlePurgeVoices', async () => {
+      const ctx = createMockContext('purge', 'voices');
       await execute(ctx as any);
-      expect(handleClearVoices).toHaveBeenCalledOnce();
+      expect(handlePurgeVoices).toHaveBeenCalledOnce();
     });
 
     it('replies with error on unknown subcommand group', async () => {
@@ -229,13 +229,13 @@ describe('Voice Command', () => {
       expect(handleVoiceBrowsePagination).toHaveBeenCalledOnce();
     });
 
-    it('routes destructive voice-clear customIds to handleVoiceClearButton', async () => {
+    it('routes destructive voice-purge customIds to handleVoicePurgeButton', async () => {
       vi.mocked(isVoiceBrowseInteraction).mockReturnValue(false);
       const interaction = {
-        customId: 'voice::destructive::confirm_button::voice-clear::all',
+        customId: 'voice::destructive::confirm_button::voice-purge::all',
       };
       await handleButton!(interaction as any);
-      expect(handleVoiceClearButton).toHaveBeenCalledOnce();
+      expect(handleVoicePurgeButton).toHaveBeenCalledOnce();
     });
 
     it('does not route destructive customIds for unrelated operations', async () => {
@@ -244,23 +244,23 @@ describe('Voice Command', () => {
         customId: 'voice::destructive::confirm_button::other-op::all',
       };
       await handleButton!(interaction as any);
-      expect(handleVoiceClearButton).not.toHaveBeenCalled();
+      expect(handleVoicePurgeButton).not.toHaveBeenCalled();
     });
   });
 
   describe('handleModal', () => {
-    it('routes destructive voice-clear modal customIds to handleVoiceClearModal', async () => {
+    it('routes destructive voice-purge modal customIds to handleVoicePurgeModal', async () => {
       const interaction = {
-        customId: 'voice::destructive::modal_submit::voice-clear::all',
+        customId: 'voice::destructive::modal_submit::voice-purge::all',
       };
       await handleModal!(interaction as any);
-      expect(handleVoiceClearModal).toHaveBeenCalledOnce();
+      expect(handleVoicePurgeModal).toHaveBeenCalledOnce();
     });
 
     it('does not route non-destructive modal customIds', async () => {
       const interaction = { customId: 'settings::apikey::modal' };
       await handleModal!(interaction as any);
-      expect(handleVoiceClearModal).not.toHaveBeenCalled();
+      expect(handleVoicePurgeModal).not.toHaveBeenCalled();
     });
   });
 

--- a/services/bot-client/src/commands/voice/index.ts
+++ b/services/bot-client/src/commands/voice/index.ts
@@ -5,7 +5,7 @@
  *
  * - /voice tts browse|set|clear|set-default|clear-default — TTS provider config (per-character + user-default)
  * - /voice stt set|clear — transcription provider preference (user-scoped; STT is speaker-bound)
- * - /voice voices browse|delete|clear — cloned-voice lifecycle
+ * - /voice voices browse|delete|purge — cloned-voice lifecycle
  * - /voice view <character> — unified TTS+STT+voices dashboard
  */
 
@@ -16,6 +16,7 @@ import {
   type ModalSubmitInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { renderSpec } from '../../ux/render/render.js';
@@ -56,11 +57,11 @@ import {
 } from './voices/browse.js';
 import { handleDeleteVoice, handleVoiceAutocomplete } from './voices/delete.js';
 import {
-  handleClearVoices,
-  handleVoiceClearButton,
-  handleVoiceClearModal,
-  VOICE_CLEAR_OPERATION,
-} from './voices/clear.js';
+  handlePurgeVoices,
+  handleVoicePurgeButton,
+  handleVoicePurgeModal,
+  VOICE_PURGE_OPERATION,
+} from './voices/purge.js';
 
 import { buildVoiceTtsSubcommandGroup } from './tts/subcommandBuilder.js';
 import { buildVoiceVoicesSubcommandGroup } from './voices/subcommandBuilder.js';
@@ -93,7 +94,7 @@ const voicesRouter = createTypedSubcommandRouter(
   {
     browse: handleBrowseVoices,
     delete: handleDeleteVoice,
-    clear: handleClearVoices,
+    purge: handlePurgeVoices,
   },
   { logger, logPrefix: '[Voice/Voices]' }
 );
@@ -173,8 +174,8 @@ async function handleButton(interaction: ButtonInteraction): Promise<void> {
 
   if (DestructiveCustomIds.isDestructive(interaction.customId)) {
     const parsed = DestructiveCustomIds.parse(interaction.customId);
-    if (parsed?.operation === VOICE_CLEAR_OPERATION) {
-      await handleVoiceClearButton(interaction);
+    if (parsed?.operation === VOICE_PURGE_OPERATION) {
+      await handleVoicePurgeButton(interaction);
       return;
     }
   }
@@ -185,8 +186,8 @@ async function handleButton(interaction: ButtonInteraction): Promise<void> {
 async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
   if (DestructiveCustomIds.isDestructive(interaction.customId)) {
     const parsed = DestructiveCustomIds.parse(interaction.customId);
-    if (parsed?.operation === VOICE_CLEAR_OPERATION) {
-      await handleVoiceClearModal(interaction);
+    if (parsed?.operation === VOICE_PURGE_OPERATION) {
+      await handleVoicePurgeModal(interaction);
       return;
     }
   }
@@ -214,7 +215,7 @@ export default defineCommand({
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('Which character to inspect')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )

--- a/services/bot-client/src/commands/voice/tts/subcommandBuilder.ts
+++ b/services/bot-client/src/commands/voice/tts/subcommandBuilder.ts
@@ -12,6 +12,7 @@
  */
 
 import type { SlashCommandSubcommandGroupBuilder } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 
 export function buildVoiceTtsSubcommandGroup(
   group: SlashCommandSubcommandGroupBuilder
@@ -29,14 +30,14 @@ export function buildVoiceTtsSubcommandGroup(
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to override')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
         .addStringOption(option =>
           option
             .setName('tts')
-            .setDescription('The TTS config to use')
+            .setDescription(SELECTOR_DESCRIPTION.ttsConfig)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -44,11 +45,11 @@ export function buildVoiceTtsSubcommandGroup(
     .addSubcommand(subcommand =>
       subcommand
         .setName('clear')
-        .setDescription('Remove TTS config override for a character')
+        .setDescription('Clear the TTS override for a character')
         .addStringOption(option =>
           option
             .setName('character')
-            .setDescription('The character to clear')
+            .setDescription(SELECTOR_DESCRIPTION.character)
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -60,7 +61,7 @@ export function buildVoiceTtsSubcommandGroup(
         .addStringOption(option =>
           option
             .setName('tts')
-            .setDescription('The TTS config to use as default')
+            .setDescription(SELECTOR_DESCRIPTION.ttsConfig)
             .setRequired(true)
             .setAutocomplete(true)
         )

--- a/services/bot-client/src/commands/voice/voices/browse.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.ts
@@ -131,7 +131,7 @@ function buildVoiceBrowsePage(
       name: '💡 Management',
       value: [
         '`/voice voices delete <voice>` - Remove a single voice',
-        '`/voice voices clear` - Remove all Tzurot voices',
+        '`/voice voices purge` - Permanently delete all Tzurot voices',
       ].join('\n'),
       inline: false,
     });

--- a/services/bot-client/src/commands/voice/voices/purge.test.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for Voice Clear Handler
+ * Tests for Voice Purge Handler
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -9,11 +9,11 @@ import type {
   ModalSubmitInteraction,
 } from 'discord.js';
 import {
-  handleClearVoices,
-  handleVoiceClearButton,
-  handleVoiceClearModal,
-  VOICE_CLEAR_OPERATION,
-} from './clear.js';
+  handlePurgeVoices,
+  handleVoicePurgeButton,
+  handleVoicePurgeModal,
+  VOICE_PURGE_OPERATION,
+} from './purge.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
 import type { UserClient } from '@tzurot/clients';
@@ -76,7 +76,7 @@ vi.mock('../../../utils/customIds.js', () => ({
   },
 }));
 
-describe('handleClearVoices', () => {
+describe('handlePurgeVoices', () => {
   const mockEditReply = vi.fn();
 
   beforeEach(() => {
@@ -106,7 +106,7 @@ describe('handleClearVoices', () => {
       deleteReply: vi.fn(),
       getOption: vi.fn(),
       getRequiredOption: vi.fn(),
-      getSubcommand: vi.fn().mockReturnValue('clear'),
+      getSubcommand: vi.fn().mockReturnValue('purge'),
       getSubcommandGroup: vi.fn().mockReturnValue('voices'),
     } as unknown as DeferredCommandContext;
   }
@@ -123,12 +123,12 @@ describe('handleClearVoices', () => {
       })
     );
 
-    await handleClearVoices(createMockContext());
+    await handlePurgeVoices(createMockContext());
 
     expect(mockBuildDestructiveWarning).toHaveBeenCalledWith(
       expect.objectContaining({
         entityType: 'cloned voices',
-        operation: VOICE_CLEAR_OPERATION,
+        operation: VOICE_PURGE_OPERATION,
       })
     );
     expect(mockEditReply).toHaveBeenCalled();
@@ -146,7 +146,7 @@ describe('handleClearVoices', () => {
       })
     );
 
-    await handleClearVoices(createMockContext());
+    await handlePurgeVoices(createMockContext());
 
     const callArg = mockBuildDestructiveWarning.mock.calls[0]?.[0] as
       { entityName?: string } | undefined;
@@ -158,10 +158,10 @@ describe('handleClearVoices', () => {
   it('should show message when no voices to clear', async () => {
     stub.listVoices.mockResolvedValue(makeOk({ voices: [], totalVoices: 5, tzurotCount: 0 }));
 
-    await handleClearVoices(createMockContext());
+    await handlePurgeVoices(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: 'No Tzurot voices to clear.',
+      content: 'No Tzurot voices to purge.',
     });
     expect(mockBuildDestructiveWarning).not.toHaveBeenCalled();
   });
@@ -169,7 +169,7 @@ describe('handleClearVoices', () => {
   it('should handle API error', async () => {
     stub.listVoices.mockResolvedValue(makeErr(404, 'ElevenLabs API key not found'));
 
-    await handleClearVoices(createMockContext());
+    await handlePurgeVoices(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
       content: '❌ ElevenLabs API key not found',
@@ -179,41 +179,41 @@ describe('handleClearVoices', () => {
   it('should handle exceptions', async () => {
     stub.listVoices.mockRejectedValue(new Error('Network error'));
 
-    await handleClearVoices(createMockContext());
+    await handlePurgeVoices(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: '❌ Failed to clear your voices. Please try again.',
+      content: '❌ Failed to purge your voices. Please try again.',
     });
   });
 });
 
-describe('handleVoiceClearButton', () => {
+describe('handleVoicePurgeButton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should handle cancel button', async () => {
     const interaction = {
-      customId: `voice::destructive::cancel_button::${VOICE_CLEAR_OPERATION}::all`,
+      customId: `voice::destructive::cancel_button::${VOICE_PURGE_OPERATION}::all`,
     } as unknown as ButtonInteraction;
 
-    await handleVoiceClearButton(interaction);
+    await handleVoicePurgeButton(interaction);
 
-    expect(mockHandleDestructiveCancel).toHaveBeenCalledWith(interaction, 'Voice clear cancelled.');
+    expect(mockHandleDestructiveCancel).toHaveBeenCalledWith(interaction, 'Voice purge cancelled.');
   });
 
   it('should handle confirm button', async () => {
     const interaction = {
-      customId: `voice::destructive::confirm_button::${VOICE_CLEAR_OPERATION}::all`,
+      customId: `voice::destructive::confirm_button::${VOICE_PURGE_OPERATION}::all`,
     } as unknown as ButtonInteraction;
 
-    await handleVoiceClearButton(interaction);
+    await handleVoicePurgeButton(interaction);
 
     expect(mockHandleDestructiveConfirmButton).toHaveBeenCalled();
   });
 });
 
-describe('handleVoiceClearModal', () => {
+describe('handleVoicePurgeModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     stub.clearVoices.mockReset();
@@ -221,11 +221,11 @@ describe('handleVoiceClearModal', () => {
 
   it('should handle modal submit', async () => {
     const interaction = {
-      customId: `voice::destructive::modal_submit::${VOICE_CLEAR_OPERATION}::all`,
+      customId: `voice::destructive::modal_submit::${VOICE_PURGE_OPERATION}::all`,
       user: { id: 'user-123' },
     } as unknown as ModalSubmitInteraction;
 
-    await handleVoiceClearModal(interaction);
+    await handleVoicePurgeModal(interaction);
 
     expect(mockHandleDestructiveModalSubmit).toHaveBeenCalled();
   });
@@ -244,11 +244,11 @@ describe('handleVoiceClearModal', () => {
       data: { deleted: 3, total: 3 },
     });
     const interaction = {
-      customId: `voice::destructive::modal_submit::${VOICE_CLEAR_OPERATION}::all`,
+      customId: `voice::destructive::modal_submit::${VOICE_PURGE_OPERATION}::all`,
       user: { id: 'user-123' },
     } as unknown as ModalSubmitInteraction;
 
-    await handleVoiceClearModal(interaction);
+    await handleVoicePurgeModal(interaction);
 
     expect(stub.clearVoices).toHaveBeenCalled();
   });

--- a/services/bot-client/src/commands/voice/voices/purge.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.ts
@@ -1,6 +1,8 @@
 /**
- * Voice Clear Handler
- * Deletes ALL tzurot-prefixed voices with destructive confirmation.
+ * Voice Purge Handler
+ * Handles /voice voices purge — destroys ALL tzurot-prefixed voices behind a
+ * typed-phrase destructive confirmation (§4.1: `purge` is the destroy-all
+ * verb; `clear` never destroys entities).
  *
  * `source: 'voice'` in the warning config is load-bearing: it prefixes the
  * customIds `voice::destructive::...` so CommandHandler routes confirm/
@@ -28,25 +30,29 @@ import {
 import { DestructiveCustomIds } from '../../../utils/customIds.js';
 import { invalidateVoiceCache } from './voiceCache.js';
 
-const logger = createLogger('voice-voices-clear');
+const logger = createLogger('voice-voices-purge');
 
-/** Shared failedAction verb for the clear-voices classify paths. */
-const CLEAR_VOICES_ACTION = 'clear your voices';
+/** Shared failedAction verb for the purge-voices classify paths. */
+const PURGE_VOICES_ACTION = 'purge your voices';
 
-/** Operation name for destructive confirmation custom IDs */
-export const VOICE_CLEAR_OPERATION = 'voice-clear';
+/**
+ * Operation name for destructive confirmation custom IDs. Renamed with the
+ * subcommand (unlike browse prefixes, destructive confirms are minutes-lived
+ * and an unmatched in-flight confirm fails CLOSED — the user just re-runs).
+ */
+export const VOICE_PURGE_OPERATION = 'voice-purge';
 
 /**
  * Entity name shared by the warning config and the modal-submit validation so
  * the dynamic confirmation phrase can't drift between the two.
  */
-const VOICE_CLEAR_ENTITY_NAME = 'all your Tzurot voices';
+const VOICE_PURGE_ENTITY_NAME = 'all your Tzurot voices';
 
 /**
- * Handle /voice voices clear
- * Shows destructive confirmation before clearing all tzurot voices
+ * Handle /voice voices purge
+ * Shows destructive confirmation before purging all tzurot voices
  */
-export async function handleClearVoices(context: DeferredCommandContext): Promise<void> {
+export async function handlePurgeVoices(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
 
   try {
@@ -56,14 +62,14 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
     if (!result.ok) {
       await context.editReply({
         content: renderSpec(
-          classifyGatewayFailure(result, 'voices', { failedAction: CLEAR_VOICES_ACTION })
+          classifyGatewayFailure(result, 'voices', { failedAction: PURGE_VOICES_ACTION })
         ),
       });
       return;
     }
 
     if (result.data.voices.length === 0) {
-      await context.editReply({ content: 'No Tzurot voices to clear.' });
+      await context.editReply({ content: 'No Tzurot voices to purge.' });
       return;
     }
 
@@ -77,12 +83,12 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
     const count = result.data.voices.length;
     const config = createHardDeleteConfig({
       entityType: 'cloned voices',
-      entityName: VOICE_CLEAR_ENTITY_NAME,
+      entityName: VOICE_PURGE_ENTITY_NAME,
       additionalWarning:
         'This will remove all auto-cloned voices from your audio provider accounts.\n' +
         'They will be re-cloned automatically when needed.',
       source: 'voice',
-      operation: VOICE_CLEAR_OPERATION,
+      operation: VOICE_PURGE_OPERATION,
       entityId: 'all',
     });
 
@@ -94,35 +100,35 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
     logger.error({ err: error, userId }, 'Unexpected error');
     await context.editReply({
       content: renderSpec(
-        classifyGatewayFailure(error, 'voices', { failedAction: CLEAR_VOICES_ACTION })
+        classifyGatewayFailure(error, 'voices', { failedAction: PURGE_VOICES_ACTION })
       ),
     });
   }
 }
 
 /**
- * Handle confirm button for voice-clear operation.
+ * Handle confirm button for voice-purge operation.
  *
  * Display-only: the modal's routing customId is derived from the button's own
  * customId inside the factory. (The previous config-rebuild here carried
  * `source: 'settings'`, which routed the modal to /settings — whose handleModal
- * has no voice-clear branch — silently dropping the typed confirmation.)
+ * has no voice-purge branch — silently dropping the typed confirmation.)
  */
-export async function handleVoiceClearConfirmButton(interaction: ButtonInteraction): Promise<void> {
+export async function handleVoicePurgeConfirmButton(interaction: ButtonInteraction): Promise<void> {
   await handleDestructiveConfirmButton(
     interaction,
-    hardDeleteModalDisplay(VOICE_CLEAR_ENTITY_NAME)
+    hardDeleteModalDisplay(VOICE_PURGE_ENTITY_NAME)
   );
 }
 
 /**
- * Handle modal submit for voice-clear operation
+ * Handle modal submit for voice-purge operation
  */
-export async function handleVoiceClearModalSubmit(
+export async function handleVoicePurgeModalSubmit(
   interaction: ModalSubmitInteraction
 ): Promise<void> {
   const userId = interaction.user.id;
-  const { confirmationPhrase } = hardDeleteModalDisplay(VOICE_CLEAR_ENTITY_NAME);
+  const { confirmationPhrase } = hardDeleteModalDisplay(VOICE_PURGE_ENTITY_NAME);
 
   const executeOperation = async (): Promise<DestructiveOperationResult> => {
     const { userClient } = clientsFor(interaction);
@@ -132,7 +138,7 @@ export async function handleVoiceClearModalSubmit(
       return {
         success: false,
         errorMessage: renderSpec(
-          classifyGatewayFailure(result, 'voices', { failedAction: CLEAR_VOICES_ACTION })
+          classifyGatewayFailure(result, 'voices', { failedAction: PURGE_VOICES_ACTION })
         ),
       };
     }
@@ -140,7 +146,7 @@ export async function handleVoiceClearModalSubmit(
     const { deleted, total, errors } = result.data;
 
     const embed = new EmbedBuilder()
-      .setTitle('🗑️ Voices Cleared')
+      .setTitle('🗑️ Voices Purged')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setTimestamp();
 
@@ -164,45 +170,45 @@ export async function handleVoiceClearModalSubmit(
     // Invalidate autocomplete cache so deleted voices don't appear in /voice voices delete
     invalidateVoiceCache(userId);
 
-    logger.info({ userId, deleted, total }, 'Cleared voices');
+    logger.info({ userId, deleted, total }, 'Purged voices');
 
     return { success: true, successEmbed: embed };
   };
 
   await handleDestructiveModalSubmit(interaction, confirmationPhrase, executeOperation, {
-    progressContent: 'Clearing voices…',
+    progressContent: 'Purging voices…',
   });
 }
 
 /**
- * Route button interactions for voice-clear destructive confirmation
+ * Route button interactions for voice-purge destructive confirmation
  */
-export async function handleVoiceClearButton(interaction: ButtonInteraction): Promise<void> {
+export async function handleVoicePurgeButton(interaction: ButtonInteraction): Promise<void> {
   const parsed = DestructiveCustomIds.parse(interaction.customId);
   if (parsed === null) {
     return;
   }
 
   if (parsed.action === 'cancel_button') {
-    await handleDestructiveCancel(interaction, 'Voice clear cancelled.');
+    await handleDestructiveCancel(interaction, 'Voice purge cancelled.');
     return;
   }
 
   if (parsed.action === 'confirm_button') {
-    await handleVoiceClearConfirmButton(interaction);
+    await handleVoicePurgeConfirmButton(interaction);
   }
 }
 
 /**
- * Route modal interactions for voice-clear destructive confirmation
+ * Route modal interactions for voice-purge destructive confirmation
  */
-export async function handleVoiceClearModal(interaction: ModalSubmitInteraction): Promise<void> {
+export async function handleVoicePurgeModal(interaction: ModalSubmitInteraction): Promise<void> {
   const parsed = DestructiveCustomIds.parse(interaction.customId);
   if (parsed === null) {
     return;
   }
 
   if (parsed.action === 'modal_submit') {
-    await handleVoiceClearModalSubmit(interaction);
+    await handleVoicePurgeModalSubmit(interaction);
   }
 }

--- a/services/bot-client/src/commands/voice/voices/subcommandBuilder.test.ts
+++ b/services/bot-client/src/commands/voice/voices/subcommandBuilder.test.ts
@@ -8,7 +8,7 @@ import { SlashCommandBuilder } from 'discord.js';
 import { buildVoiceVoicesSubcommandGroup } from './subcommandBuilder.js';
 
 describe('buildVoiceVoicesSubcommandGroup', () => {
-  it('attaches the 3 expected subcommands (browse / delete / clear)', () => {
+  it('attaches the 3 expected subcommands (browse / delete / purge)', () => {
     const builder = new SlashCommandBuilder().setName('test').setDescription('test');
     builder.addSubcommandGroup(group => buildVoiceVoicesSubcommandGroup(group));
 
@@ -22,7 +22,7 @@ describe('buildVoiceVoicesSubcommandGroup', () => {
     const subcommandNames = (voicesGroup?.options as Array<{ name: string }> | undefined)?.map(
       s => s.name
     );
-    expect(subcommandNames).toEqual(['browse', 'delete', 'clear']);
+    expect(subcommandNames).toEqual(['browse', 'delete', 'purge']);
   });
 
   it('delete subcommand requires the voice option with autocomplete', () => {
@@ -37,8 +37,7 @@ describe('buildVoiceVoicesSubcommandGroup', () => {
       voicesGroup?.options as Array<{ name: string; options?: unknown[] }> | undefined
     )?.find(s => s.name === 'delete');
     const opts = deleteSubcommand?.options as
-      | Array<{ name: string; required?: boolean; autocomplete?: boolean }>
-      | undefined;
+      Array<{ name: string; required?: boolean; autocomplete?: boolean }> | undefined;
 
     expect(opts?.length).toBe(1);
     expect(opts?.[0].name).toBe('voice');
@@ -46,7 +45,7 @@ describe('buildVoiceVoicesSubcommandGroup', () => {
     expect(opts?.[0].autocomplete).toBe(true);
   });
 
-  it('browse and clear subcommands take no options', () => {
+  it('browse and purge subcommands take no options', () => {
     const builder = new SlashCommandBuilder().setName('test').setDescription('test');
     builder.addSubcommandGroup(group => buildVoiceVoicesSubcommandGroup(group));
 
@@ -55,10 +54,9 @@ describe('buildVoiceVoicesSubcommandGroup', () => {
       (o): o is typeof o & { options?: unknown[] } => o.name === 'voices'
     );
     const subcommands = voicesGroup?.options as
-      | Array<{ name: string; options?: unknown[] }>
-      | undefined;
+      Array<{ name: string; options?: unknown[] }> | undefined;
 
     expect(subcommands?.find(s => s.name === 'browse')?.options ?? []).toEqual([]);
-    expect(subcommands?.find(s => s.name === 'clear')?.options ?? []).toEqual([]);
+    expect(subcommands?.find(s => s.name === 'purge')?.options ?? []).toEqual([]);
   });
 });

--- a/services/bot-client/src/commands/voice/voices/subcommandBuilder.ts
+++ b/services/bot-client/src/commands/voice/voices/subcommandBuilder.ts
@@ -1,12 +1,13 @@
 /**
  * Voices subcommand group builder for /voice.
  *
- * Cloned-voice lifecycle operations: browse, delete (one), clear (all).
+ * Cloned-voice lifecycle operations: browse, delete (one), purge (all).
  * Schema preserved verbatim from the legacy /settings voices group; only
  * the parent command moved (settings → voice).
  */
 
 import type { SlashCommandSubcommandGroupBuilder } from 'discord.js';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 
 export function buildVoiceVoicesSubcommandGroup(
   group: SlashCommandSubcommandGroupBuilder
@@ -24,12 +25,12 @@ export function buildVoiceVoicesSubcommandGroup(
         .addStringOption(option =>
           option
             .setName('voice')
-            .setDescription('The voice to delete')
+            .setDescription(SELECTOR_DESCRIPTION.voice)
             .setRequired(true)
             .setAutocomplete(true)
         )
     )
     .addSubcommand(subcommand =>
-      subcommand.setName('clear').setDescription('Delete all Tzurot cloned voices')
+      subcommand.setName('purge').setDescription('Permanently delete ALL Tzurot cloned voices')
     );
 }

--- a/services/bot-client/src/handlers/CommandHandler.component.test.ts
+++ b/services/bot-client/src/handlers/CommandHandler.component.test.ts
@@ -271,14 +271,14 @@ describe('CommandHandler (component)', () => {
       // source: 'voice' (not 'settings') so destructive confirm/cancel/modal
       // interactions route to /voice's handleButton + handleModal. Using
       // source: 'settings' silently fails because /settings.handleButton
-      // no longer dispatches voice-clear after the /voice consolidation.
+      // no longer dispatches voice-purge after the /voice consolidation.
       const voiceCommand = handler.getCommand('voice');
       expect(voiceCommand?.handleButton).toBeDefined();
 
       const handleButtonSpy = vi.spyOn(voiceCommand!, 'handleButton');
 
       const interaction = createMockButtonInteraction(
-        'voice::destructive::confirm_button::voice-clear::all'
+        'voice::destructive::confirm_button::voice-purge::all'
       );
       await handler.handleComponentInteraction(interaction);
 

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
@@ -36,7 +36,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
     "type": 1,
   },
   {
-    "description": "List all servers the bot is in",
+    "description": "Browse all servers the bot is in",
     "description_localizations": undefined,
     "name": "servers",
     "name_localizations": undefined,
@@ -89,11 +89,11 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
             "value": "30d",
           },
         ],
-        "description": "Time period for stats",
+        "description": "Time window for stats",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
-        "name": "period",
+        "name": "timeframe",
         "name_localizations": undefined,
         "required": false,
         "type": 3,
@@ -187,11 +187,11 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": undefined,
         "choices": undefined,
-        "description": "Keep history from the last N days (default: 30)",
+        "description": "Time window in days — keep history newer than this (default: 30)",
         "description_localizations": undefined,
         "max_value": 365,
         "min_value": 1,
-        "name": "days",
+        "name": "timeframe",
         "name_localizations": undefined,
         "required": false,
         "type": 4,
@@ -371,7 +371,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to activate",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -465,7 +465,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to edit",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -486,7 +486,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to view",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -513,7 +513,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Character to inspect (omit to see all your aliases)",
+            "description": "Which character (omit to see all your aliases)",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -534,7 +534,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Character the alias points to",
+            "description": "Which character the alias points to",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -642,7 +642,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to update",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -671,7 +671,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to update",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -692,7 +692,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to update",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -713,7 +713,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
     "type": 1,
   },
   {
-    "description": "Remove a character voice reference and disable TTS",
+    "description": "Clear a character's voice reference and disable TTS",
     "description_localizations": undefined,
     "name": "voice-clear",
     "name_localizations": undefined,
@@ -721,7 +721,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to update",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -775,7 +775,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to export",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -804,7 +804,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to chat with",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -882,7 +882,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to chime in",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -911,7 +911,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to manage",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -932,7 +932,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Character to override settings for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1317,7 +1317,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to clear history for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1329,7 +1329,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The persona to use (defaults to your active persona)",
+        "description": "Which persona (defaults to your active persona)",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1350,7 +1350,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to restore history for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1362,7 +1362,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The persona to use (defaults to your active persona)",
+        "description": "Which persona (defaults to your active persona)",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1383,7 +1383,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to view stats for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1395,7 +1395,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The persona to use (defaults to your active persona)",
+        "description": "Which persona (defaults to your active persona)",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1416,7 +1416,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to delete history for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1459,7 +1459,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to view stats for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1480,7 +1480,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Filter by character (optional)",
+        "description": "Which character — omit for all",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1501,7 +1501,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character whose facts to manage",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1534,7 +1534,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Filter by character (optional)",
+        "description": "Which character — omit for all",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1567,7 +1567,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to delete memories for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1626,7 +1626,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The character to purge all memories for",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -1653,7 +1653,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to enable focus mode for",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1674,7 +1674,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to disable focus mode for",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1695,7 +1695,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to check status for",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1725,7 +1725,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Character or "all" for global incognito",
+            "description": "Which character — or "all" for global incognito",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1762,7 +1762,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
-            "name": "duration",
+            "name": "timeframe",
             "name_localizations": undefined,
             "required": true,
             "type": 3,
@@ -1779,7 +1779,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Character or "all" to disable global incognito",
+            "description": "Which character — or "all" to disable global incognito",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1808,7 +1808,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Character or "all" for all characters",
+            "description": "Which character — or "all" for all characters",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2059,7 +2059,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "The persona to set as default",
+        "description": "Which persona",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -2086,7 +2086,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to override",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2098,7 +2098,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The persona to use (or create new)",
+            "description": "Which persona — or a new name to create one",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2119,7 +2119,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to clear override for",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2238,7 +2238,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Preset to edit",
+        "description": "Which preset",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -2259,7 +2259,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Preset to export",
+        "description": "Which preset",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -2311,7 +2311,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Global preset to set as default",
+            "description": "Which global preset",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2355,7 +2355,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Global preset to set as free tier default",
+            "description": "Which global preset",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2416,7 +2416,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to override",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2428,7 +2428,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The preset to use",
+            "description": "Which preset",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2464,7 +2464,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
         "type": 1,
       },
       {
-        "description": "Remove preset override for a character",
+        "description": "Clear the preset override for a character",
         "description_localizations": undefined,
         "name": "clear",
         "name_localizations": undefined,
@@ -2472,7 +2472,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to clear",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2516,7 +2516,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The preset to use as default",
+            "description": "Which preset",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -2621,7 +2621,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "description": "Show your current timezone",
         "description_localizations": undefined,
-        "name": "get",
+        "name": "view",
         "name_localizations": undefined,
         "options": [],
         "type": 1,
@@ -2879,7 +2879,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
-        "name": "import_type",
+        "name": "import-type",
         "name_localizations": undefined,
         "required": false,
         "type": 3,
@@ -2953,7 +2953,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": true,
         "choices": undefined,
-        "description": "Which character to inspect",
+        "description": "Which character",
         "description_localizations": undefined,
         "max_length": undefined,
         "min_length": undefined,
@@ -2988,7 +2988,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to override",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -3000,7 +3000,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The TTS config to use",
+            "description": "Which TTS config",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -3013,7 +3013,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
         "type": 1,
       },
       {
-        "description": "Remove TTS config override for a character",
+        "description": "Clear the TTS override for a character",
         "description_localizations": undefined,
         "name": "clear",
         "name_localizations": undefined,
@@ -3021,7 +3021,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The character to clear",
+            "description": "Which character",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -3042,7 +3042,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The TTS config to use as default",
+            "description": "Which TTS config",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -3142,7 +3142,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The voice to delete",
+            "description": "Which voice",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -3155,9 +3155,9 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
         "type": 1,
       },
       {
-        "description": "Delete all Tzurot cloned voices",
+        "description": "Permanently delete ALL Tzurot cloned voices",
         "description_localizations": undefined,
-        "name": "clear",
+        "name": "purge",
         "name_localizations": undefined,
         "options": [],
         "type": 1,

--- a/services/bot-client/src/handlers/commandManifest.test.ts
+++ b/services/bot-client/src/handlers/commandManifest.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { SELECTOR_DESCRIPTION } from '@tzurot/common-types/constants/uxVocabulary';
 import { CommandHandler } from './CommandHandler.js';
 import { CATEGORY_CONFIG } from '../commands/help/index.js';
 import type { Command } from '../types.js';
@@ -108,5 +109,59 @@ describe('command manifest', () => {
     await expect(JSON.stringify(manifest, null, 2) + '\n').toMatchFileSnapshot(
       '../../command-manifest.json'
     );
+  });
+
+  it('every entity-selector option uses the §4.2 SELECTOR_DESCRIPTION phrasing', () => {
+    // Selector-phrasing drift arrives through shapes a source grep misses
+    // (inline literals, pre-existing named constants, novel phrasings).
+    // Grep-by-expected-phrasing cannot prove completeness; walking the LIVE
+    // command tree can — this is the structural guard for §4.2.
+    const BASES: Record<string, string> = {
+      character: SELECTOR_DESCRIPTION.character,
+      preset: SELECTOR_DESCRIPTION.preset,
+      persona: SELECTOR_DESCRIPTION.persona,
+      voice: SELECTOR_DESCRIPTION.voice,
+      tts: SELECTOR_DESCRIPTION.ttsConfig,
+    };
+    // /deny keeps its bespoke wording until its planned redesign rebuilds
+    // that surface (raw-ID target + scope-conditional options — a different
+    // shape); remove this exemption when it lands.
+    const EXEMPT_COMMANDS = new Set(['deny']);
+
+    interface OptionNode {
+      type: number;
+      name: string;
+      description?: string;
+      options?: OptionNode[];
+    }
+    const violations: string[] = [];
+    const walk = (options: OptionNode[] | undefined, path: string): void => {
+      for (const opt of options ?? []) {
+        if (opt.type === 1 || opt.type === 2) {
+          walk(opt.options, `${path} ${opt.name}`);
+        } else if (opt.name in BASES) {
+          const base = BASES[opt.name];
+          const desc = opt.description ?? '';
+          // Base form, a qualified `${base} — …` clause, or a `${base} (…)`
+          // parenthetical are conforming; anything else is drift. GLOBAL
+          // preset's "Which global preset" is its own registry entry.
+          const ok =
+            desc === base ||
+            desc.startsWith(`${base} `) ||
+            desc === SELECTOR_DESCRIPTION.globalPreset;
+          if (!ok) {
+            violations.push(`${path} [${opt.name}]: ${desc}`);
+          }
+        }
+      }
+    };
+    for (const cmd of handler.getCommands().values()) {
+      if (EXEMPT_COMMANDS.has(cmd.data.name)) {
+        continue;
+      }
+      const json = cmd.data.toJSON() as { options?: OptionNode[] };
+      walk(json.options, `/${cmd.data.name}`);
+    }
+    expect(violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

The breaking batch's grammar sweep (D9, D10, G11, §4.1–4.3): two subcommand renames, three option-name standardizations, choice-set constants, and the selector-description unification — codified as registry constants so the phrasing structurally cannot drift.

## Renames

- **`/voice voices clear` → `purge`** (D9): `clear` never destroys entities in the §4.1 verb table; `purge` is the destroy-all verb behind the typed-phrase confirm. File/handlers/tests renamed wholesale (`handlePurgeVoices` etc.), copy updated ("Voices Purged", "Purging voices…"). **Wire decision — deliberately opposite of PR-4's frozen prefix**: the destructive operation token renames too (`'voice-clear'` → `'voice-purge'`), because typed-phrase confirms are minutes-lived ephemerals and an unmatched in-flight confirm **fails closed** (the user re-runs the command) — the safe direction for a destructive flow, and it avoids permanent naming debt. The gateway route `/api/user/voices/clear` is deliberately unchanged (internal wire contract, not user surface).
- **`/settings timezone get` → `view`** (§4.1: `view` = read one entity in full). Rides the burn-down: its two raw error literals migrate onto `classifyGatewayFailure`, deleting the allowlist entry — ceiling **168 → 166** (purge's entry re-keys at 1).

## D10 `timeframe` + G11 constants

All three census sites standardize on `timeframe`: admin usage (`period`), admin cleanup (`days` — **stays an integer**; arbitrary N-days is genuine admin utility a choice set would destroy, so the unit moves into the description), and incognito (`duration`). Choice sets become named constants per the deny exemplar (`USAGE_TIMEFRAME_CHOICES`, `DELETE_TIMEFRAME_CHOICES`, `INCOGNITO_TIMEFRAME_CHOICES`, `IMPORT_TYPE_CHOICES`) — sets stay per-domain, the NAME is the standard. `shapes import_type` → `import-type` (values unchanged — wire vocabulary).

## §4.2 selector unification — now a registry constant

The census found ~30 description variants ("Character to edit/view/export/manage/chat with/chime in…"). All unify on **`SELECTOR_DESCRIPTION`** — a new uxVocabulary registry map (`character: 'Which character'`, plus preset/global preset/persona/voice/TTS config) referenced across nine command files; qualified sites template off it (`` `${SELECTOR_DESCRIPTION.character} — or "all" for global incognito` ``). SonarJS's duplicate-string warning on the raw sweep is what pushed this from strings to constants — the lint rule accidentally enforced the spec's own single-phrasing intent.

## §4.1/§4.3 alignment

- Clear-verb subcommands stop describing themselves as "Remove…" (preset override clear, TTS override clear, character voice-clear); `admin servers` "List…" → "Browse…".
- §4.3 verified: zero user-visible "personality" strings remain (the codification already held).

## Blast radius (checklist discharged)

- Codegen regenerated (77 schemas; new accessors `timeframe()`/`['import-type']`), check-mode green.
- Manifest + component snapshots updated deliberately; the diffs are exactly the renames + description changes.
- Builder + raw-content allowlists re-keyed/shrunk; `CATEGORY_CONFIG` untouched; `componentPrefixes` unchanged (only the destructive operation token moved, see above).
- Interaction mocks in six test files updated to the new option names; the incognito mock's two now-colliding branches merged with a comment.
- Docs: `commands.md` rows, `FOLDER_STRUCTURE.md` example. Three-vocabulary sweep (command literal / file path / tracker pointers) run repo-wide — the PR-4 lesson applied.
- Parameter ordering verified at every touched definition (required-first holds).

## Verification

Full suite 26/26 turbo tasks; bot-client 5782; component tier 40/40; `pnpm quality` green end-to-end (gate-parity 27/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)