### PR TITLE
fix: voice smoke findings — Mistral pagination + MP3 MIME aliases

### DIFF
--- a/packages/common-types/src/constants/media.ts
+++ b/packages/common-types/src/constants/media.ts
@@ -90,6 +90,20 @@ export const VOICE_REFERENCE_LIMITS = {
 } as const;
 
 /**
+ * Nonstandard audio MIME aliases some clients emit, mapped to their canonical
+ * type. Normalized at the intake boundary (`voiceReferenceProcessor`) so
+ * stored and forwarded types are always canonical members of `ALLOWED_TYPES`.
+ * The MP3 family is the repeat offender: `audio/mpeg` is the registered type,
+ * but `audio/mp3`, `audio/mpeg3`, and `audio/x-mpeg-3` all appear in the wild
+ * (Discord attachments carry whatever the uploading client claimed).
+ */
+export const AUDIO_MIME_ALIASES: Record<string, string> = {
+  'audio/mp3': CONTENT_TYPES.AUDIO_MP3,
+  'audio/mpeg3': CONTENT_TYPES.AUDIO_MP3,
+  'audio/x-mpeg-3': CONTENT_TYPES.AUDIO_MP3,
+};
+
+/**
  * Attachment types for multimodal processing
  */
 export enum AttachmentType {

--- a/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
@@ -253,6 +253,15 @@ describe('mistralCloneVoice', () => {
 
 // ===== mistralListVoices ====================================================
 
+/** Build a full window (50 items) of unique voices with the given id prefix. */
+function fullVoicesPage(idPrefix: string): { id: string; name: string; user_id: null }[] {
+  return Array.from({ length: 50 }, (_, i) => ({
+    id: `${idPrefix}-${i}`,
+    name: `voice-${idPrefix}-${i}`,
+    user_id: null,
+  }));
+}
+
 describe('mistralListVoices', () => {
   it('returns the items array mapped to MistralVoiceInfo shape', async () => {
     mockFetch.mockResolvedValueOnce(
@@ -277,11 +286,12 @@ describe('mistralListVoices', () => {
     expect(result.truncated).toBe(false);
   });
 
-  it('uses page_size=50 in the query string', async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse(200, { items: [], total: 0 }));
+  it('uses limit=50 and offset=0 in the query string', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, { items: [] }));
     await mistralListVoices('k');
     const [url] = mockFetch.mock.calls[0];
-    expect(url).toContain('page_size=50');
+    expect(url).toContain('limit=50');
+    expect(url).toContain('offset=0');
   });
 
   it('throws MistralResponseShapeError when items is missing', async () => {
@@ -291,47 +301,33 @@ describe('mistralListVoices', () => {
     await expect(promise).rejects.toThrow(/missing items/);
   });
 
-  it('walks pagination when total_pages > 1 and aggregates results', async () => {
-    // Two pages, 2 items each = 4 total
+  it('walks pagination via offset and aggregates results', async () => {
+    // Full first window (50) then a short second window (2) = 52 total
     mockFetch
-      .mockResolvedValueOnce(
-        jsonResponse(200, {
-          items: [
-            { id: 'p1-v1', name: 'a', user_id: null },
-            { id: 'p1-v2', name: 'b', user_id: null },
-          ],
-          total: 4,
-          total_pages: 2,
-        })
-      )
+      .mockResolvedValueOnce(jsonResponse(200, { items: fullVoicesPage('p1') }))
       .mockResolvedValueOnce(
         jsonResponse(200, {
           items: [
             { id: 'p2-v1', name: 'c', user_id: null },
             { id: 'p2-v2', name: 'd', user_id: null },
           ],
-          total: 4,
-          total_pages: 2,
         })
       );
 
     const result = await mistralListVoices('k');
 
-    expect(result.voices.map(v => v.id)).toEqual(['p1-v1', 'p1-v2', 'p2-v1', 'p2-v2']);
+    expect(result.voices).toHaveLength(52);
+    expect(result.voices.at(-1)?.id).toBe('p2-v2');
     expect(result.truncated).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    // First call requests page 1, second requests page 2
-    expect(mockFetch.mock.calls[0][0]).toContain('page=1');
-    expect(mockFetch.mock.calls[1][0]).toContain('page=2');
+    expect(mockFetch.mock.calls[0][0]).toContain('limit=50&offset=0');
+    expect(mockFetch.mock.calls[1][0]).toContain('limit=50&offset=50');
   });
 
-  it('stops fetching when total_pages indicates we have all items', async () => {
-    // Single page response: total_pages=1, fetch should not loop
+  it('stops fetching after a single short window', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse(200, {
         items: [{ id: 'v1', name: 'only', user_id: null }],
-        total: 1,
-        total_pages: 1,
       })
     );
 
@@ -339,25 +335,33 @@ describe('mistralListVoices', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+  it('dedupes and treats a repeated full window as exhaustive (truncated: false)', async () => {
+    // Provider ignores offset and returns the identical window on every
+    // request. The walker must dedupe by id, stop after the first
+    // no-new-ids window, and NOT set `truncated` — marking it truncated
+    // would make find-by-name refuse to clone permanently.
+    mockFetch.mockResolvedValue(jsonResponse(200, { items: fullVoicesPage('rep') }));
+
+    const result = await mistralListVoices('k');
+
+    expect(result.voices).toHaveLength(50);
+    expect(new Set(result.voices.map(v => v.id)).size).toBe(50);
+    expect(result.truncated).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it('returns truncated: true when pagination cap (VOICE_LIST_MAX_PAGES = 20) is reached', async () => {
-    // Each of 20 pages returns one item with `total_pages = 99` so the walker
-    // never satisfies its early-exit condition (`page >= totalPages`) and runs
-    // out the cap. The provider's find-by-name path uses `truncated: true` to
-    // refuse cloning when no match is found in the prefix — this test pins
-    // the producer side of that contract.
+    // Each of 20 windows returns 50 NEW items, so the walker keeps making
+    // progress until it runs out the cap. The provider's find-by-name path
+    // uses `truncated: true` to refuse cloning when no match is found in
+    // the prefix — this test pins the producer side of that contract.
     for (let i = 0; i < 20; i++) {
-      mockFetch.mockResolvedValueOnce(
-        jsonResponse(200, {
-          items: [{ id: `v-page-${i + 1}`, name: `voice-${i + 1}`, user_id: null }],
-          total: 99 * 50,
-          total_pages: 99,
-        })
-      );
+      mockFetch.mockResolvedValueOnce(jsonResponse(200, { items: fullVoicesPage(`w${i}`) }));
     }
 
     const result = await mistralListVoices('k');
 
-    expect(result.voices).toHaveLength(20);
+    expect(result.voices).toHaveLength(1000);
     expect(result.truncated).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(20);
   });

--- a/services/ai-worker/src/services/voice/MistralTtsClient.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.ts
@@ -11,7 +11,10 @@
  * - `POST /v1/audio/voices` — clone a voice from base64 reference audio.
  *   Mistral SILENTLY DROPS slug/languages/gender/age/tags on creation;
  *   only `name` survives. Cache strategy uses `name` as the find-or-create key.
- * - `GET  /v1/audio/voices?page=N&page_size=50` — paginated list. Walks
+ * - `GET  /v1/audio/voices?limit=50&offset=N` — paginated list. `limit` and
+ *   `offset` are the documented REQUEST params; `page`/`page_size`/
+ *   `total_pages` exist only in the response (sending them as params is
+ *   silently ignored and returns the same window every request). Walks
  *   pagination up to `VOICE_LIST_MAX_PAGES` (20 pages = 1000 voices) before
  *   returning a partial result with a WARN log. The find-by-name path is
  *   resilient to the cap because a missing voice falls through to clone.
@@ -422,22 +425,17 @@ export async function mistralCloneVoice(opts: MistralCloneOptions): Promise<Mist
   };
 }
 
-/** Safety cap on pagination — at page_size=50, this is 1000 voices.
+/** Safety cap on pagination — at limit=50, this is 1000 voices.
  *  Beyond this, something pathological is going on (compromised account
  *  or runaway clone-bug), so the cap prevents an infinite loop on a bad
  *  Mistral response while still covering any realistic legitimate scale. */
 const VOICE_LIST_MAX_PAGES = 20;
 
-interface VoicesPage {
-  items: MistralVoiceInfo[];
-  totalPages: number;
-}
-
-/** Fetch a single page of the voices listing. Internal helper for the
+/** Fetch a single window of the voices listing. Internal helper for the
  *  pagination walker. */
-async function fetchVoicesPage(apiKey: string, page: number): Promise<VoicesPage> {
+async function fetchVoicesPage(apiKey: string, offset: number): Promise<MistralVoiceInfo[]> {
   const response = await mistralFetch(
-    `/audio/voices?page=${page}&page_size=${VOICE_LIST_PAGE_SIZE}`,
+    `/audio/voices?limit=${VOICE_LIST_PAGE_SIZE}&offset=${offset}`,
     {
       method: 'GET',
       headers: { Authorization: `Bearer ${apiKey}` },
@@ -451,21 +449,16 @@ async function fetchVoicesPage(apiKey: string, page: number): Promise<VoicesPage
 
   const json = (await response.json()) as {
     items?: { id: string; name: string; user_id: string | null }[];
-    total?: number;
-    total_pages?: number;
   };
   if (!Array.isArray(json.items)) {
     throw new MistralResponseShapeError('/v1/audio/voices', 'items');
   }
 
-  return {
-    items: json.items.map(item => ({
-      id: item.id,
-      name: item.name,
-      userId: item.user_id,
-    })),
-    totalPages: typeof json.total_pages === 'number' ? json.total_pages : 1,
-  };
+  return json.items.map(item => ({
+    id: item.id,
+    name: item.name,
+    userId: item.user_id,
+  }));
 }
 
 /**
@@ -484,28 +477,49 @@ async function fetchVoicesPage(apiKey: string, page: number): Promise<VoicesPage
 export async function mistralListVoices(
   apiKey: string
 ): Promise<{ voices: MistralVoiceInfo[]; truncated: boolean }> {
-  const all: MistralVoiceInfo[] = [];
-  let page = 1;
+  const byId = new Map<string, MistralVoiceInfo>();
+  let offset = 0;
 
-  while (page <= VOICE_LIST_MAX_PAGES) {
-    const { items, totalPages } = await fetchVoicesPage(apiKey, page);
-    all.push(...items);
+  for (let pageCount = 0; pageCount < VOICE_LIST_MAX_PAGES; pageCount++) {
+    const items = await fetchVoicesPage(apiKey, offset);
 
-    if (page >= totalPages) {
-      return { voices: all, truncated: false };
+    let newItems = 0;
+    for (const item of items) {
+      if (!byId.has(item.id)) {
+        byId.set(item.id, item);
+        newItems++;
+      }
     }
-    page++;
+    offset += items.length;
+
+    // A short page means the listing is exhausted — exhaustive result.
+    if (items.length < VOICE_LIST_PAGE_SIZE) {
+      return { voices: [...byId.values()], truncated: false };
+    }
+    // A full page with zero new ids means the provider is repeating a window
+    // regardless of offset — walking further can't surface anything new. The
+    // visible window IS the account's listing as far as we can ever observe,
+    // so this returns `truncated: false`: marking it truncated would make
+    // find-by-name refuse to clone permanently, while the worst case of
+    // treating it exhaustive (a duplicate clone) is recoverable via purge.
+    if (newItems === 0) {
+      logger.warn(
+        { event: 'mistral.voiceListRepeatedWindow', offset, uniqueCount: byId.size },
+        'Mistral voice list repeated a full page with no new ids — treating visible window as exhaustive'
+      );
+      return { voices: [...byId.values()], truncated: false };
+    }
   }
 
   logger.warn(
     {
       event: 'mistral.voiceListTruncated',
       maxPages: VOICE_LIST_MAX_PAGES,
-      returnedCount: all.length,
+      returnedCount: byId.size,
     },
     'Mistral voice list pagination cap reached — find-by-name will refuse to clone if voice not found in truncated prefix'
   );
-  return { voices: all, truncated: true };
+  return { voices: [...byId.values()], truncated: true };
 }
 
 /**

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
@@ -338,7 +338,7 @@ export class MistralTtsProvider implements TtsProvider {
         return existing.id;
       }
       if (listResult.truncated) {
-        // Voice not found in the first VOICE_LIST_MAX_PAGES * page_size voices,
+        // Voice not found within the pagination cap (VOICE_LIST_MAX_PAGES windows),
         // but there could be more on later pages. Cloning would risk a
         // duplicate. Surface a typed error rather than silently adding to
         // the duplicate count.

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -450,6 +450,28 @@ describe('Voice Management Routes', () => {
       expect(res.body.errors[0]).toContain('elevenlabs');
     });
 
+    it('counts a 404 delete as removed, not failed (voice already gone)', async () => {
+      userWithKeys(['elevenlabs']);
+      let deleteCallCount = 0;
+      setProviderFetchMocks({
+        elevenlabsList: () => jsonOk(elevenLabsVoicesResponse),
+        elevenlabsDelete: () => {
+          deleteCallCount++;
+          // First delete succeeds, second 404s (already absent at the provider)
+          if (deleteCallCount === 1) return { ok: true, status: 200 } as unknown as Response;
+          return { ok: false, status: 404, statusText: 'Not Found' } as unknown as Response;
+        },
+      });
+
+      const res = await request(app).post('/voices/clear');
+
+      expect(res.status).toBe(200);
+      // Already-gone voices satisfy the purge goal — no scary failure output
+      expect(res.body.deleted).toBe(2);
+      expect(res.body.total).toBe(2);
+      expect(res.body.errors).toBeUndefined();
+    });
+
     it('shows actionable message for rate-limited deletions', async () => {
       userWithKeys(['elevenlabs']);
       let deleteCallCount = 0;

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -417,6 +417,7 @@ async function clearVoicesImpl(
   // Bot-client uses GATEWAY_TIMEOUTS.BULK_OPERATION (30s) for this call;
   // gateway timeout would abort but deletions continue server-side.
   let deleted = 0;
+  let alreadyGone = 0;
   const errors: string[] = [];
 
   for (let i = 0; i < voices.length; i += DELETE_BATCH_SIZE) {
@@ -430,6 +431,13 @@ async function clearVoicesImpl(
           throw new Error(`${voice.name}: ${voice.provider} key disappeared mid-clear`);
         }
         const response = await deleteVoiceAtProvider(voice.provider, apiKey, voice.voiceId);
+        if (response.status === 404) {
+          // Already absent at the provider (deleted concurrently, or a stale
+          // listing entry). The purge goal for this voice is met — reporting
+          // it as a failure just alarms the user about a voice that's gone.
+          alreadyGone++;
+          return;
+        }
         if (!response.ok) {
           // Surface actionable messages — "429" alone is meaningless to end users.
           // voice.name is safe to embed: it's tzurot-prefix-filtered (no user-controlled
@@ -453,7 +461,7 @@ async function clearVoicesImpl(
   }
 
   logger.info(
-    { discordUserId, deleted, total: voices.length, errors: errors.length },
+    { discordUserId, deleted, alreadyGone, total: voices.length, errors: errors.length },
     'Cleared cloned voices across providers'
   );
 

--- a/services/api-gateway/src/utils/mistralVoicesClient.test.ts
+++ b/services/api-gateway/src/utils/mistralVoicesClient.test.ts
@@ -31,6 +31,18 @@ function jsonResponse(status: number, body: unknown): Response {
   } as unknown as Response;
 }
 
+/** Build a full page (50 items) of unique voices with the given id prefix. */
+function fullPage(
+  idPrefix: string,
+  namer: (i: number) => string
+): { id: string; name: string; user_id: string }[] {
+  return Array.from({ length: 50 }, (_, i) => ({
+    id: `${idPrefix}-${i}`,
+    name: namer(i),
+    user_id: 'u',
+  }));
+}
+
 beforeEach(() => {
   mockFetch.mockReset();
 });
@@ -44,7 +56,6 @@ describe('listMistralTzurotVoices', () => {
           { id: 'v2', name: 'random-other', user_id: 'u' },
           { id: 'v3', name: 'tzurot-bob', user_id: 'u' },
         ],
-        total_pages: 1,
       })
     );
 
@@ -56,20 +67,20 @@ describe('listMistralTzurotVoices', () => {
       expect(result.totalVoices).toBe(3); // unfiltered count
       expect(result.voices.map(v => v.name)).toEqual(['tzurot-alice', 'tzurot-bob']);
     }
+    // Single short page → no second request
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('walks pagination and aggregates filtered results across pages', async () => {
+  it('walks pagination via limit/offset and aggregates filtered results', async () => {
     mockFetch
       .mockResolvedValueOnce(
         jsonResponse(200, {
-          items: [{ id: 'v1', name: 'tzurot-alice', user_id: 'u' }],
-          total_pages: 2,
+          items: fullPage('p1', i => (i === 0 ? 'tzurot-alice' : `other-${i}`)),
         })
       )
       .mockResolvedValueOnce(
         jsonResponse(200, {
-          items: [{ id: 'v2', name: 'tzurot-bob', user_id: 'u' }],
-          total_pages: 2,
+          items: [{ id: 'p2-0', name: 'tzurot-bob', user_id: 'u' }],
         })
       );
 
@@ -78,10 +89,48 @@ describe('listMistralTzurotVoices', () => {
     expect('voices' in result).toBe(true);
     if ('voices' in result) {
       expect(result.voices.map(v => v.name)).toEqual(['tzurot-alice', 'tzurot-bob']);
+      expect(result.totalVoices).toBe(51);
     }
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0][0]).toContain('page=1');
-    expect(mockFetch.mock.calls[1][0]).toContain('page=2');
+    expect(mockFetch.mock.calls[0][0]).toContain('limit=50&offset=0');
+    expect(mockFetch.mock.calls[1][0]).toContain('limit=50&offset=50');
+  });
+
+  it('stops walking and dedupes when the provider repeats a full page', async () => {
+    // Provider ignores offset and returns the identical window on every
+    // request. The walker must dedupe by id and stop after the first
+    // no-new-ids page instead of collecting 20 copies of each voice.
+    const repeatedWindow = fullPage('rep', i => `tzurot-voice-${i}`);
+    mockFetch.mockResolvedValue(jsonResponse(200, { items: repeatedWindow }));
+
+    const result = await listMistralTzurotVoices('mi-key', 'tzurot-');
+
+    expect('voices' in result).toBe(true);
+    if ('voices' in result) {
+      expect(result.voices).toHaveLength(50);
+      expect(result.totalVoices).toBe(50);
+      expect(new Set(result.voices.map(v => v.voiceId)).size).toBe(50);
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns after the pagination cap when every window keeps producing new ids', async () => {
+    let call = 0;
+    mockFetch.mockImplementation(() => {
+      const window = call++;
+      return Promise.resolve(
+        jsonResponse(200, { items: fullPage(`w${window}`, i => `tzurot-w${window}-${i}`) })
+      );
+    });
+
+    const result = await listMistralTzurotVoices('mi-key', 'tzurot-');
+
+    expect(mockFetch).toHaveBeenCalledTimes(20);
+    expect('voices' in result).toBe(true);
+    if ('voices' in result) {
+      expect(result.voices).toHaveLength(1000);
+      expect(result.totalVoices).toBe(1000);
+    }
   });
 
   it('returns errorResponse on 401', async () => {

--- a/services/api-gateway/src/utils/mistralVoicesClient.ts
+++ b/services/api-gateway/src/utils/mistralVoicesClient.ts
@@ -20,7 +20,7 @@ import { type ErrorResponse, ErrorResponses } from './errorResponses.js';
 
 const logger = createLogger('MistralVoicesClient');
 
-const MISTRAL_VOICES_PAGE_SIZE = 50;
+const MISTRAL_VOICES_PAGE_LIMIT = 50;
 const MISTRAL_VOICES_MAX_PAGES = 20;
 
 const MistralVoiceSchema = z.object({
@@ -31,7 +31,6 @@ const MistralVoiceSchema = z.object({
 
 const MistralVoicesPageSchema = z.object({
   items: z.array(MistralVoiceSchema),
-  total_pages: z.number().optional(),
 });
 
 export interface MistralCloned {
@@ -39,77 +38,112 @@ export interface MistralCloned {
   name: string;
 }
 
+/** Fetch a single window of the voices listing, mapping auth/parse failures
+ *  to the route-facing errorResponse shape. */
+async function fetchMistralVoicesWindow(
+  apiKey: string,
+  offset: number
+): Promise<{ items: z.infer<typeof MistralVoiceSchema>[] } | { errorResponse: ErrorResponse }> {
+  const response = await fetch(
+    `${AI_ENDPOINTS.MISTRAL_BASE_URL}/audio/voices?limit=${MISTRAL_VOICES_PAGE_LIMIT}&offset=${offset}`,
+    {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.EXTERNAL_AUDIO_API_CALL),
+    }
+  );
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      logger.warn({ status: response.status }, 'Mistral rejected API key');
+      return {
+        errorResponse: ErrorResponses.unauthorized(
+          'Mistral API key is invalid or expired. Update it with /settings apikey set'
+        ),
+      };
+    }
+    logger.error(
+      { status: response.status, statusText: response.statusText },
+      'Mistral API error listing voices'
+    );
+    return {
+      errorResponse: ErrorResponses.internalError('Failed to list voices from Mistral'),
+    };
+  }
+
+  const parseResult = MistralVoicesPageSchema.safeParse(await response.json());
+  if (!parseResult.success) {
+    logger.error(
+      { errors: parseResult.error.format() },
+      'Unexpected Mistral voices list response format'
+    );
+    return {
+      errorResponse: ErrorResponses.internalError('Unexpected voices response from Mistral'),
+    };
+  }
+
+  return { items: parseResult.data.items };
+}
+
 /**
  * List all tzurot-prefixed voices in the user's Mistral account, walking
  * pagination. Mirrors the ai-worker's `mistralListVoices` shape but filters
  * by name prefix in api-gateway since that's what the route consumer needs.
+ *
+ * Pagination uses `limit`/`offset` — Mistral's documented request params.
+ * (`page`/`page_size`/`total_pages` exist only in the RESPONSE; sending them
+ * as request params gets silently ignored, returning the same default window
+ * on every request. That shape once inflated a 10-voice account into a
+ * 200-entry listing here.) The seen-id dedupe plus the no-new-ids early exit
+ * keep the walk correct even if the provider repeats a window.
  */
 export async function listMistralTzurotVoices(
   apiKey: string,
   prefix: string
 ): Promise<{ voices: MistralCloned[]; totalVoices: number } | { errorResponse: ErrorResponse }> {
   const all: { voiceId: string; name: string }[] = [];
-  let totalVoices = 0;
-  let page = 1;
+  const seenIds = new Set<string>();
+  let offset = 0;
 
-  while (page <= MISTRAL_VOICES_MAX_PAGES) {
-    const response = await fetch(
-      `${AI_ENDPOINTS.MISTRAL_BASE_URL}/audio/voices?page=${page}&page_size=${MISTRAL_VOICES_PAGE_SIZE}`,
-      {
-        headers: { Authorization: `Bearer ${apiKey}` },
-        signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.EXTERNAL_AUDIO_API_CALL),
-      }
-    );
-
-    if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
-        logger.warn({ status: response.status }, 'Mistral rejected API key');
-        return {
-          errorResponse: ErrorResponses.unauthorized(
-            'Mistral API key is invalid or expired. Update it with /settings apikey set'
-          ),
-        };
-      }
-      logger.error(
-        { status: response.status, statusText: response.statusText },
-        'Mistral API error listing voices'
-      );
-      return {
-        errorResponse: ErrorResponses.internalError('Failed to list voices from Mistral'),
-      };
+  for (let pageCount = 0; pageCount < MISTRAL_VOICES_MAX_PAGES; pageCount++) {
+    const windowResult = await fetchMistralVoicesWindow(apiKey, offset);
+    if ('errorResponse' in windowResult) {
+      return windowResult;
     }
 
-    const parseResult = MistralVoicesPageSchema.safeParse(await response.json());
-    if (!parseResult.success) {
-      logger.error(
-        { errors: parseResult.error.format() },
-        'Unexpected Mistral voices list response format'
-      );
-      return {
-        errorResponse: ErrorResponses.internalError('Unexpected voices response from Mistral'),
-      };
-    }
-
-    const { items, total_pages } = parseResult.data;
-    totalVoices += items.length;
+    const { items } = windowResult;
+    let newItems = 0;
     for (const item of items) {
+      if (seenIds.has(item.id)) {
+        continue;
+      }
+      seenIds.add(item.id);
+      newItems++;
       if (item.name.startsWith(prefix)) {
         all.push({ voiceId: item.id, name: item.name });
       }
     }
+    offset += items.length;
 
-    const pages = total_pages ?? 1;
-    if (page >= pages) {
-      return { voices: all, totalVoices };
+    // A short page means the listing is exhausted. A full page with zero new
+    // ids means the provider is repeating a window — walking further can't
+    // surface anything new, so stop rather than collecting duplicates.
+    if (items.length < MISTRAL_VOICES_PAGE_LIMIT) {
+      return { voices: all, totalVoices: seenIds.size };
     }
-    page++;
+    if (newItems === 0) {
+      logger.warn(
+        { offset, uniqueCount: seenIds.size },
+        'Mistral voice list repeated a full page with no new ids — stopping walk'
+      );
+      return { voices: all, totalVoices: seenIds.size };
+    }
   }
 
   logger.warn(
     { maxPages: MISTRAL_VOICES_MAX_PAGES, returnedCount: all.length },
     'Mistral voice list pagination cap reached'
   );
-  return { voices: all, totalVoices };
+  return { voices: all, totalVoices: seenIds.size };
 }
 
 /**

--- a/services/api-gateway/src/utils/voiceReferenceProcessor.test.ts
+++ b/services/api-gateway/src/utils/voiceReferenceProcessor.test.ts
@@ -110,6 +110,30 @@ describe('processVoiceReferenceData', () => {
     }
   });
 
+  it('normalizes nonstandard MP3 aliases to audio/mpeg', () => {
+    const base64 = Buffer.from('fake-mp3-data').toString('base64');
+
+    for (const alias of ['audio/mp3', 'audio/mpeg3', 'audio/x-mpeg-3']) {
+      const result = processVoiceReferenceData(`data:${alias};base64,${base64}`, 'test');
+      expect(result).not.toBeNull();
+      expect(result!.ok).toBe(true);
+      if (result !== null && result.ok) {
+        expect(result.mimeType).toBe('audio/mpeg');
+      }
+    }
+  });
+
+  it('normalizes MIME type case before validating', () => {
+    const base64 = Buffer.from('fake-wav-data').toString('base64');
+
+    const result = processVoiceReferenceData(`data:Audio/WAV;base64,${base64}`, 'test');
+    expect(result).not.toBeNull();
+    expect(result!.ok).toBe(true);
+    if (result !== null && result.ok) {
+      expect(result.mimeType).toBe('audio/wav');
+    }
+  });
+
   it('returns success for valid OGG data URI', () => {
     const audioBytes = Buffer.from('fake-ogg-data');
     const base64 = audioBytes.toString('base64');

--- a/services/api-gateway/src/utils/voiceReferenceProcessor.ts
+++ b/services/api-gateway/src/utils/voiceReferenceProcessor.ts
@@ -5,7 +5,7 @@
  * Unlike avatars, voice references are stored as-is (no optimization/resizing).
  */
 
-import { VOICE_REFERENCE_LIMITS } from '@tzurot/common-types/constants/media';
+import { AUDIO_MIME_ALIASES, VOICE_REFERENCE_LIMITS } from '@tzurot/common-types/constants/media';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { ErrorResponses, type ErrorResponse } from './errorResponses.js';
 
@@ -60,8 +60,8 @@ export function processVoiceReferenceData(
 
   try {
     // Extract MIME type from data URI
-    const mimeType = extractMimeType(voiceReferenceData);
-    if (mimeType === null) {
+    const rawMimeType = extractMimeType(voiceReferenceData);
+    if (rawMimeType === null) {
       return {
         ok: false,
         error: ErrorResponses.validationError(
@@ -69,6 +69,12 @@ export function processVoiceReferenceData(
         ),
       };
     }
+
+    // Normalize case (MIME types are case-insensitive) and nonstandard
+    // aliases (e.g. `audio/mpeg3` → `audio/mpeg`) so storage and serving
+    // only ever see canonical members of ALLOWED_TYPES.
+    const lowered = rawMimeType.toLowerCase();
+    const mimeType = AUDIO_MIME_ALIASES[lowered] ?? lowered;
 
     // Validate MIME type
     if (!VOICE_REFERENCE_LIMITS.ALLOWED_TYPES.includes(mimeType)) {


### PR DESCRIPTION
## Summary

Two fixes from the Wave-3 dev smoke pass:

**1. Mistral voice listing paginated with the wrong params (both services)**
`GET /v1/audio/voices` takes `limit`/`offset` per Mistral's API reference; `page`/`page_size`/`total_pages` exist only in the response. Both walkers (api-gateway `mistralVoicesClient`, ai-worker `MistralTtsClient`) sent the response fields as request params, which Mistral silently ignored — every request returned the same window. Runtime-confirmed on dev: a 10-voice account listed as 200 entries (`pagination cap reached, returnedCount=200`), `/voice voices purge` reported `deleted=10 total=200 errors=190` (all 404s on duplicate deletes), and the spurious `truncated` flag made the ai-worker's find-by-name path refuse to clone new Mistral voices.

Fix: documented `limit`/`offset` pagination, dedupe-by-id, and a no-new-ids stop guard in both walkers; bulk-clear delete 404s now count as already-gone (log-only counter) instead of user-facing failures. A repeated-window stop returns `truncated: false` — marking it truncated would permanently refuse cloning, while the worst case of treating it exhaustive (a duplicate clone) is recoverable via purge.

**2. `/character voice set` rejected a normal MP3 (`audio/mpeg3`)**
Discord attachments carry whatever MIME type the uploading client claimed; a normal MP3 (verified: MPEG layer III, 320kbps, 23.5s) arrived tagged `audio/mpeg3` and the exact-match allowlist bounced it. Fix: normalize the legacy MP3 alias family (`audio/mp3`, `audio/mpeg3`, `audio/x-mpeg-3`) and MIME case to canonical `audio/mpeg` at the intake boundary (`voiceReferenceProcessor`), so storage and the serving path only ever see canonical members of `ALLOWED_TYPES`.

## Verification

- Gateway: pagination walk asserts `limit=50&offset=0` → `offset=50` across the mocked seam; repeated-window test pins dedupe + 2-call stop; clear-route test pins 404-as-removed (`deleted=2, errors undefined`); alias + case-normalization tests pin `audio/mpeg3 → audio/mpeg`.
- ai-worker: offset-walk, short-window stop, repeated-window (`truncated: false`), and cap-reached (`truncated: true`, 1000 unique voices) all pinned.
- `pnpm test` and `pnpm quality` green locally (full pre-push gate ran on push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)