### PR TITLE
feat(common-types): branded IsAdmin type guards the isAdmin-vs-canEdit mix-up

### DIFF
--- a/packages/common-types/src/utils/ownerMiddleware.test.ts
+++ b/packages/common-types/src/utils/ownerMiddleware.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { MessageFlags } from 'discord.js';
-import { requireBotOwner } from './ownerMiddleware.js';
+import { requireBotOwner, asIsAdmin } from './ownerMiddleware.js';
 import * as config from '../config/index.js';
 
 // Mock getConfig
@@ -108,5 +108,12 @@ describe('requireBotOwner', () => {
 
     expect(result).toBe(true);
     expect(mockInteraction.reply).not.toHaveBeenCalled();
+  });
+});
+
+describe('asIsAdmin', () => {
+  it('passes the boolean through at runtime (the brand is a compile-time phantom)', () => {
+    expect(asIsAdmin(true)).toBe(true);
+    expect(asIsAdmin(false)).toBe(false);
   });
 });

--- a/packages/common-types/src/utils/ownerMiddleware.ts
+++ b/packages/common-types/src/utils/ownerMiddleware.ts
@@ -10,6 +10,30 @@ import { MessageFlags } from 'discord-api-types/v10';
 import { getConfig } from '../config/index.js';
 
 /**
+ * Branded boolean marking "the current user is the bot owner / admin". Only
+ * {@link isBotOwner} and the explicit {@link asIsAdmin} escape hatch produce it,
+ * so a parameter typed `IsAdmin` (e.g. a dashboard's admin-section gate) CANNOT
+ * be handed a plain boolean like `canEdit` by accident — that is a compile error.
+ * Guards the isAdmin-vs-canEdit confusion class that leaked the bot-owner-only
+ * Admin Settings section to non-admin owners.
+ *
+ * The brand is a compile-time phantom (erased at runtime, survives JSON
+ * round-trips as a plain boolean), so it costs nothing and needs no migration.
+ */
+export type IsAdmin = boolean & { readonly __brand: 'IsAdmin' };
+
+/**
+ * Assert a plain boolean IS an admin flag, producing the branded {@link IsAdmin}.
+ * The ONLY sanctioned construction outside {@link isBotOwner} — for tests and the
+ * rare case where a bot-owner status was already computed/cached as a plain
+ * boolean. Do NOT wrap `canEdit` (true for any character owner, not just admins):
+ * that is exactly the confusion this brand exists to prevent.
+ */
+export function asIsAdmin(value: boolean): IsAdmin {
+  return value as IsAdmin;
+}
+
+/**
  * Check if a Discord ID matches the configured bot owner
  *
  * Used for:
@@ -18,6 +42,11 @@ import { getConfig } from '../config/index.js';
  *
  * @param discordId - Discord user ID to check
  * @returns true if the ID matches BOT_OWNER_ID config
+ *
+ * Returns a plain `boolean` (not the branded {@link IsAdmin}) so the ~40 test
+ * files that mock this function keep working with plain `mockReturnValue(true)`.
+ * Callers that feed a dashboard's admin gate wrap the result in {@link asIsAdmin}
+ * at the call site — that one explicit wrap is what the brand-guard keys on.
  */
 export function isBotOwner(discordId: string): boolean {
   const config = getConfig();

--- a/services/bot-client/src/commands/character/browse.test.ts
+++ b/services/bot-client/src/commands/character/browse.test.ts
@@ -77,6 +77,9 @@ vi.mock('./config.js', () => ({
 const mockIsBotOwner = vi.fn();
 vi.mock('@tzurot/common-types/utils/ownerMiddleware', () => ({
   isBotOwner: (id: string) => mockIsBotOwner(id),
+  // Runtime passthrough — the IsAdmin brand is compile-time only, so the handler's
+  // asIsAdmin(isBotOwner(...)) wrap must not vanish under this mock.
+  asIsAdmin: (v: boolean) => v,
 }));
 
 describe('handleBrowse', () => {

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -23,7 +23,7 @@ import { characterBrowseOptions } from '@tzurot/common-types/generated/commandOp
 import { AUTOCOMPLETE_BADGES } from '@tzurot/common-types/utils/autocompleteFormat';
 import { ENTITY_EMOJI, buildBadgeLegend } from '@tzurot/common-types/constants/uxVocabulary';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { UserClient } from '@tzurot/clients';
 import { clientsFor } from '../../utils/gatewayClients.js';
@@ -477,7 +477,7 @@ export async function handleBrowseSelect(
     // canEdit (true for any character owner). Deriving it from isBotOwner
     // keeps a non-admin owner from seeing an admin section on the initial
     // render (downstream handlers re-verify, but the first paint uses this).
-    const isAdmin = isBotOwner(userId);
+    const isAdmin = asIsAdmin(isBotOwner(userId));
 
     // Create session data with browse context for back navigation
     const sessionData: CharacterSessionData = {

--- a/services/bot-client/src/commands/character/config.test.ts
+++ b/services/bot-client/src/commands/character/config.test.ts
@@ -7,6 +7,7 @@ import { characterSeedFields, getCharacterDashboardConfig } from './config.js';
 import { adminSection } from './sections.js';
 import type { CharacterData } from './characterTypes.js';
 import { DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
+import { asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import { SectionStatus, type DashboardContext } from '../../utils/dashboard/index.js';
 
 /**
@@ -47,7 +48,7 @@ function createTestCharacter(overrides: Partial<CharacterData> = {}): CharacterD
 
 describe('Character Dashboard Configuration', () => {
   // Use the factory function (base config is intentionally unexported)
-  const dashboardConfig = getCharacterDashboardConfig(false, false);
+  const dashboardConfig = getCharacterDashboardConfig(asIsAdmin(false), false);
 
   describe('section structure', () => {
     it('should have exactly 4 sections', () => {
@@ -411,29 +412,29 @@ describe('Character Dashboard Configuration', () => {
 
   describe('getCharacterDashboardConfig', () => {
     it('should return 4 sections for non-admins', () => {
-      const config = getCharacterDashboardConfig(false, false);
+      const config = getCharacterDashboardConfig(asIsAdmin(false), false);
       expect(config.sections).toHaveLength(4);
       const sectionIds = config.sections.map(s => s.id);
       expect(sectionIds).toEqual(['identity', 'biography', 'preferences', 'conversation']);
     });
 
     it('should return 5 sections for admins (including admin section)', () => {
-      const config = getCharacterDashboardConfig(true, false);
+      const config = getCharacterDashboardConfig(asIsAdmin(true), false);
       expect(config.sections).toHaveLength(5);
       const sectionIds = config.sections.map(s => s.id);
       expect(sectionIds).toEqual(['identity', 'biography', 'preferences', 'conversation', 'admin']);
     });
 
     it('should include admin section only for admins', () => {
-      const userConfig = getCharacterDashboardConfig(false, false);
-      const adminConfig = getCharacterDashboardConfig(true, false);
+      const userConfig = getCharacterDashboardConfig(asIsAdmin(false), false);
+      const adminConfig = getCharacterDashboardConfig(asIsAdmin(true), false);
 
       expect(userConfig.sections.find(s => s.id === 'admin')).toBeUndefined();
       expect(adminConfig.sections.find(s => s.id === 'admin')).toBeDefined();
     });
 
     it('should preserve entityType and other config properties', () => {
-      const config = getCharacterDashboardConfig(true, false);
+      const config = getCharacterDashboardConfig(asIsAdmin(true), false);
       expect(config.entityType).toBe('character');
       expect(config.getTitle).toBeDefined();
       expect(config.getDescription).toBeDefined();
@@ -441,22 +442,35 @@ describe('Character Dashboard Configuration', () => {
     });
 
     it('should not include voice-toggle action when hasVoiceReference is false', () => {
-      const config = getCharacterDashboardConfig(false, false);
+      const config = getCharacterDashboardConfig(asIsAdmin(false), false);
       const actionIds = config.actions!.map(a => a.id);
       expect(actionIds).not.toContain('voice-toggle');
       expect(actionIds).toContain('voice'); // Change Voice always shown
     });
 
     it('should include voice-toggle action when hasVoiceReference is true', () => {
-      const config = getCharacterDashboardConfig(false, true);
+      const config = getCharacterDashboardConfig(asIsAdmin(false), true);
       const actionIds = config.actions!.map(a => a.id);
       expect(actionIds).toContain('voice-toggle');
       expect(actionIds).toContain('voice');
     });
+
+    it('rejects a plain boolean (the canEdit mix-up) at compile time — the IsAdmin guard', () => {
+      // canEdit is true for ANY character owner, not just bot admins. Passing it
+      // as the admin gate leaked the Admin Settings section (the bug this brand
+      // prevents). A plain boolean must NOT satisfy the IsAdmin parameter — the
+      // suppression directive below turns into an unused-directive compile error
+      // if the type ever starts accepting it, which is what pins the guard.
+      const canEdit: boolean = true;
+      // @ts-expect-error - a plain boolean must not satisfy the IsAdmin brand
+      getCharacterDashboardConfig(canEdit, false);
+      // asIsAdmin is the explicit, review-visible way to opt a boolean in.
+      expect(getCharacterDashboardConfig(asIsAdmin(canEdit), false).sections).toHaveLength(5);
+    });
   });
 
   describe('Admin section', () => {
-    const adminConfig = getCharacterDashboardConfig(true, false);
+    const adminConfig = getCharacterDashboardConfig(asIsAdmin(true), false);
     const adminSection = adminConfig.sections.find(s => s.id === 'admin')!;
 
     it('should have slug field', () => {

--- a/services/bot-client/src/commands/character/config.ts
+++ b/services/bot-client/src/commands/character/config.ts
@@ -7,6 +7,7 @@
 
 import { DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
 import { formatDateShort } from '@tzurot/common-types/utils/dateFormatting';
+import type { IsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import {
   type DashboardConfig,
   type ActionButtonOptions,
@@ -125,12 +126,15 @@ const baseCharacterDashboardConfig: DashboardConfig<CharacterData> = {
  * Use this instead of `baseCharacterDashboardConfig` directly so that admin-only
  * sections and voice-dependent actions are correctly included/excluded.
  *
- * @param isAdmin - Whether the current user is a bot owner (adds admin section)
+ * @param isAdmin - Branded {@link IsAdmin} (from `isBotOwner`) — adds the
+ *   bot-owner-only admin section. Requiring the brand (not a plain boolean)
+ *   makes passing `canEdit` here a compile error — that mix-up leaked the admin
+ *   section to non-admin owners.
  * @param hasVoiceReference - Whether the character has a voice reference uploaded
  *   (adds "Toggle Voice" action when true)
  */
 export function getCharacterDashboardConfig(
-  isAdmin: boolean,
+  isAdmin: IsAdmin,
   hasVoiceReference: boolean
 ): DashboardConfig<CharacterData> {
   const sections = [identitySection, biographySection, preferencesSection, conversationSection];

--- a/services/bot-client/src/commands/character/create.ts
+++ b/services/bot-client/src/commands/character/create.ts
@@ -10,7 +10,7 @@
 import { MessageFlags, type ModalBuilder, type ModalSubmitInteraction } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import { normalizeSlugForUser, suggestSlugExample } from '@tzurot/common-types/utils/slugUtils';
 import {
   SLUG_PATTERN,
@@ -144,7 +144,7 @@ export async function handleSeedModalSubmit(
     // User just created this character, so they own it (createCharacter
     // grafts canEdit: true — the create response has no such field)
     // New characters never have a voice reference yet (hasVoiceReference: false)
-    const isAdmin = isBotOwner(interaction.user.id);
+    const isAdmin = asIsAdmin(isBotOwner(interaction.user.id));
     const dashboardConfig = getCharacterDashboardConfig(isAdmin, character.hasVoiceReference);
     const embed = buildDashboardEmbed(dashboardConfig, character);
     const components = buildDashboardComponents(

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -15,7 +15,7 @@ import {
 } from 'discord.js';
 import { getConfig, type EnvConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import {
   buildDashboardEmbed,
   buildDashboardComponents,
@@ -111,7 +111,7 @@ async function handleSectionModalSubmit(
 
   // SECURITY: Re-verify admin status for admin section edits
   // Never trust session data - always check server-side
-  const isAdmin = isBotOwner(interaction.user.id);
+  const isAdmin = asIsAdmin(isBotOwner(interaction.user.id));
   if (sectionId === 'admin' && !isAdmin) {
     logger.warn(
       { userId: interaction.user.id, entityId, sectionId },
@@ -222,7 +222,7 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
   // rest of the section context (dashboardConfig, data, DashboardContext)
   // is resolved inside resolveCharacterSectionContext so the select-menu
   // path shares its preamble with the truncation-warning button handlers.
-  const isAdmin = isBotOwner(interaction.user.id);
+  const isAdmin = asIsAdmin(isBotOwner(interaction.user.id));
 
   // Handle section edit selection
   if (value.startsWith('edit-')) {

--- a/services/bot-client/src/commands/character/dashboardActions.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.ts
@@ -13,7 +13,7 @@
 import { MessageFlags, type StringSelectMenuInteraction } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import {
   buildDashboardEmbed,
   buildDashboardComponents,
@@ -42,7 +42,7 @@ export async function refreshDashboardAfterUpdate(
   entityId: string,
   updated: CharacterData
 ): Promise<void> {
-  const isAdmin = isBotOwner(interaction.user.id);
+  const isAdmin = asIsAdmin(isBotOwner(interaction.user.id));
   const dashboardConfig = getCharacterDashboardConfig(isAdmin, updated.hasVoiceReference);
 
   const sessionManager = getSessionManager();

--- a/services/bot-client/src/commands/character/dashboardButtons.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.ts
@@ -7,7 +7,7 @@
 
 import type { ButtonInteraction } from 'discord.js';
 import { getConfig } from '@tzurot/common-types/config/config';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import {
   buildDashboardEmbed,
   buildDashboardComponents,
@@ -64,7 +64,7 @@ export async function handleRefreshButton(
     return;
   }
 
-  const isAdmin = isBotOwner(interaction.user.id);
+  const isAdmin = asIsAdmin(isBotOwner(interaction.user.id));
   const dashboardConfig = getCharacterDashboardConfig(isAdmin, character.hasVoiceReference);
 
   // Preserve browseContext from existing session

--- a/services/bot-client/src/commands/character/edit.ts
+++ b/services/bot-client/src/commands/character/edit.ts
@@ -7,7 +7,7 @@
 import { type EnvConfig } from '@tzurot/common-types/config/config';
 import { characterEditOptions } from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
   buildDashboardEmbed,
@@ -63,7 +63,7 @@ export async function handleEdit(
     }
 
     // Check if user is a bot admin (for admin-only sections)
-    const isAdmin = isBotOwner(userId);
+    const isAdmin = asIsAdmin(isBotOwner(userId));
     const dashboardConfig = getCharacterDashboardConfig(isAdmin, character.hasVoiceReference);
 
     // Build and send dashboard

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -28,7 +28,7 @@ import { CATALOG } from '../../ux/catalog/catalog.js';
 import { renderSpec } from '../../ux/render/render.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import {
   type DashboardConfig,
   type DashboardContext,
@@ -82,7 +82,7 @@ export function findCharacterSection(
   sectionId: string,
   userId: string
 ): CharacterSectionSync | null {
-  const isAdmin = isBotOwner(userId);
+  const isAdmin = asIsAdmin(isBotOwner(userId));
   const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
   const section = dashboardConfig.sections.find(s => s.id === sectionId);
   if (!section) {

--- a/services/bot-client/src/commands/character/viewEdit.test.ts
+++ b/services/bot-client/src/commands/character/viewEdit.test.ts
@@ -43,6 +43,9 @@ vi.mock('./config.js', () => ({
 const mockIsBotOwner = vi.fn();
 vi.mock('@tzurot/common-types/utils/ownerMiddleware', () => ({
   isBotOwner: (id: string) => mockIsBotOwner(id),
+  // Runtime passthrough — the IsAdmin brand is compile-time only, so the handler's
+  // asIsAdmin(isBotOwner(...)) wrap must not vanish under this mock.
+  asIsAdmin: (v: boolean) => v,
 }));
 
 // reply.js is deliberately NOT mocked: the error-delivery seam (editReply

--- a/services/bot-client/src/commands/character/viewEdit.ts
+++ b/services/bot-client/src/commands/character/viewEdit.ts
@@ -13,7 +13,7 @@
 import { MessageFlags, type ButtonInteraction } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { isBotOwner, asIsAdmin } from '@tzurot/common-types/utils/ownerMiddleware';
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { classifyGatewayFailure } from '../../ux/catalog/classify.js';
 import { replySpec, ackUpdate, ackDeferReply } from '../../ux/render/reply.js';
@@ -74,7 +74,7 @@ export async function handleViewEdit(
     // canEdit (which is true for any character owner). Every other
     // dashboard-opening path derives it from isBotOwner — matching here keeps
     // a non-admin owner from seeing an admin section on the initial render.
-    const isAdmin = isBotOwner(interaction.user.id);
+    const isAdmin = asIsAdmin(isBotOwner(interaction.user.id));
     const dashboardConfig = getCharacterDashboardConfig(isAdmin, character.hasVoiceReference);
     const embed = buildDashboardEmbed(dashboardConfig, character);
     const sessionData: CharacterSessionData = { ...character, _isAdmin: isAdmin };


### PR DESCRIPTION
## Problem

`getCharacterDashboardConfig`'s first parameter gates the **bot-owner-only** Admin Settings section — but it was typed plain `boolean`. So `getCharacterDashboardConfig(character.canEdit, …)` type-checked, and `canEdit` is true for **any** character owner, not just admins. That leaked the admin section to non-admin owners. The bug shipped twice (`browse.ts` and, briefly, `viewEdit.ts` in #1755).

This is the compile-time sibling to #1756's runtime fix: eliminate the confusion class with a type, so the mix-up can't be written.

## Fix

- **Branded type** in `common-types/utils/ownerMiddleware.ts`: `type IsAdmin = boolean & { readonly __brand: 'IsAdmin' }`, plus an explicit `asIsAdmin(value: boolean): IsAdmin` constructor (the only sanctioned way to make one).
- `getCharacterDashboardConfig(isAdmin: IsAdmin, …)` now **requires** the brand. A plain boolean — `character.canEdit`, a literal `true` — is a **compile error** there. Only `asIsAdmin(isBotOwner(...))` satisfies it.
- The 8 dashboard-opening call sites derive `const isAdmin = asIsAdmin(isBotOwner(...))` — that one explicit wrap is the seam the brand keys on. (`isBotOwner` deliberately keeps returning plain `boolean` so its ~40 test mocks stay untouched — branding *its* return would have churned 39 `mockReturnValue` sites for no extra safety.)

## Why this is stronger than a lint rule

Both `canEdit` and `isAdmin` are `boolean`, so no lint rule or grep can tell them apart at a call site. The type system can — once one side is branded, the compiler rejects the other at every call site, current and future, with no allowlist and no maintenance.

## Verification

- **A `@ts-expect-error` test pins the guard** (`config.test.ts`): `getCharacterDashboardConfig(canEdit /* boolean */, false)` must fail to compile — if the type ever starts accepting a plain boolean, the directive goes unused and `typecheck:spec` fails. (Fun detour: my first draft's *doc comment* contained `// @ts-expect-error …` at a line start, which TS parsed as a real directive — reworded.)
- `asIsAdmin` runtime-passthrough test in common-types; the two seam-test mocks (`viewEdit`/`browse`) gained an `asIsAdmin` passthrough so the compile-time brand doesn't vanish at runtime under the mock.
- Compile-time only, no migration (the brand is a phantom, erased at runtime, survives JSON round-trips as a plain boolean).
- `pnpm --filter bot-client test` (5823) + `pnpm --filter @tzurot/common-types test` (2579) + `pnpm quality` all green; bot-client / api-gateway / ai-worker / identity all typecheck clean (branding is scoped to the config gate, not `isBotOwner`'s 39 consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)