### PR TITLE
docs: fresh-mode copy sweep across public surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Tzurot is fully managed via Discord slash commands. For the complete reference (
 - **`/voice`** — TTS/STT provider config, cloned-voice library, per-character resolved-state dashboard (`/voice view`)
 - **`/preset`** + **`/channel`** — Custom LLM presets, channel auto-response activation
 - **`/models`** — Browse and inspect available AI models (capabilities, context window, pricing)
-- **`/memory`** + **`/history`** — Long-term memory browse/search/prune, conversation history management, privacy modes (focus, incognito)
+- **`/memory`** + **`/history`** — Long-term memory browse/search/prune, conversation history management, privacy modes (fresh, incognito)
 - **`/settings`** — Timezone, BYOK API keys, per-character preset overrides, global default settings dashboard, data export/delete
 - **`/notifications`** — Release-notes DM preferences (enable/disable, severity level, DM cleanup)
 - **`/feedback`** — Send feedback to the developer from inside Discord

--- a/docs/legal/PRIVACY_POLICY.md
+++ b/docs/legal/PRIVACY_POLICY.md
@@ -60,7 +60,7 @@ We never sell your data.
 
 ## Your controls
 
-- **Memory**: browse, search, correct, and forget individual memories and facts (`/memory`); batch-delete or purge a character's memories. Honest detail: forgetting removes a memory from use and from view **immediately**, but the underlying row is retained (marked deleted) until it is hard-erased — which happens when you delete the associated persona or character, when you use incognito's retroactive forget, or when you delete your account (`/settings data delete`). **Focus mode** stops memory reads; **incognito mode** stops memory writes for a session, with retroactive (hard-deleting) forget.
+- **Memory**: browse, search, correct, and forget individual memories and facts (`/memory`); batch-delete or purge a character's memories. Honest detail: forgetting removes a memory from use and from view **immediately**, but the underlying row is retained (marked deleted) until it is hard-erased — which happens when you delete the associated persona or character, when you use incognito's retroactive forget, or when you delete your account (`/settings data delete`). **Fresh mode** stops memory reads for a session; **incognito mode** stops memory writes for a session, with retroactive (hard-deleting) forget.
 - **History**: clear your conversation history (`/history clear` — a soft reset, with undo).
 - **Notifications**: release announcements are sent only to accounts that have actually used the bot (a real conversation, a connected key, or an explicit `/notifications` preference — never mere presence in a channel the bot can read), default to breaking-change releases only, and are opt-out (`/notifications disable`, or pick a level).
 - **Keys**: remove a connected API key at any time (immediate hard delete).

--- a/services/website/src/pages/index.astro
+++ b/services/website/src/pages/index.astro
@@ -36,7 +36,7 @@ const features: { emoji: string; title: string; body: string; link?: FeatureLink
   {
     emoji: '🔐',
     title: 'Your data, your rules',
-    body: 'Export everything your account owns or erase it entirely, straight from Discord. BYOK keys are encrypted, memory has focus and incognito modes, and the privacy policy says what actually happens.',
+    body: 'Export everything your account owns or erase it entirely, straight from Discord. BYOK keys are encrypted, memory has fresh and incognito modes, and the privacy policy says what actually happens.',
     link: { href: '/privacy', label: 'Read the privacy policy' },
   },
   {


### PR DESCRIPTION
## What

The Wave-3 breaking rename made `/memory focus` → `/memory fresh`. Three **public-facing** surfaces still described "focus mode" and would ship stale in the beta.174 breaking release:

| Surface | Renders at | Fix |
| --- | --- | --- |
| `docs/legal/PRIVACY_POLICY.md` | `/privacy` | "**Focus mode** stops memory reads" → "**Fresh mode** stops memory reads **for a session**" (matches incognito's session framing) |
| `README.md` | GitHub | privacy-modes bullet `(focus, incognito)` → `(fresh, incognito)` |
| `services/website/src/pages/index.astro` | site root | data card `memory has focus and incognito modes` → `fresh and incognito modes` |

## Why now

This is the release-notes doc sweep for the Wave-3 major-ping beta. The website glob-loads the legal docs and hardcodes the index card, so the staleness is **public** the moment the release deploys — and the fix ships with the release.

## Scope

Copy-only. No behavior change, no logic touched. Found via a case-insensitive `focus` sweep across all user-facing surfaces (`README.md`, `docs/commands.md`, `docs/guides/`, `docs/legal/`, `services/website/src/`); the other `focus` hits were unrelated prose or a CSS `:focus-visible` and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)