### PR TITLE
refactor(bot-client): use crypto.randomInt for the random character pick

### DIFF
--- a/services/bot-client/src/services/character/randomPick.test.ts
+++ b/services/bot-client/src/services/character/randomPick.test.ts
@@ -34,7 +34,19 @@ vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({ userClient: {} })),
 }));
 
+// Partial-mock node:crypto so the random pick index is controllable while every
+// other crypto function (used transitively) keeps its real implementation.
+vi.mock('node:crypto', async importActual => ({
+  ...(await importActual<typeof import('node:crypto')>()),
+  randomInt: vi.fn(),
+}));
+
+import { randomInt } from 'node:crypto';
 import { resolveCharacterSlug, finalizeDeferredReply } from './randomPick.js';
+
+// randomInt is overloaded (sync → number, async-callback → void); pin the sync
+// form so mockReturnValue takes a number rather than the callback overload's void.
+const mockedRandomInt = vi.mocked(randomInt as (max: number) => number);
 
 const makeSummary = (
   slug: string,
@@ -58,11 +70,12 @@ const makeContext = (): DeferredCommandContext =>
     deleteReply: vi.fn().mockResolvedValue(undefined),
   }) as unknown as DeferredCommandContext;
 
-// File-scope hooks: cover both describe blocks. `restoreAllMocks` is
-// load-bearing because tests use `vi.spyOn(Math, 'random')` which would
-// otherwise leak across suites and into other test files.
+// File-scope hooks: cover both describe blocks. randomInt is reset to a stable
+// default (index 0) each test so an untargeted pick is deterministic; the two
+// indexing tests override it. `restoreAllMocks` keeps any spies from leaking.
 beforeEach(() => {
   vi.clearAllMocks();
+  mockedRandomInt.mockReturnValue(0);
 });
 
 afterEach(() => {
@@ -116,15 +129,15 @@ describe('resolveCharacterSlug', () => {
     expect(result).toEqual({ kind: 'slug', slug: 'only-one', randomPick: true });
   });
 
-  it('uses Math.random output to index into the pool', async () => {
+  it('uses randomInt output to index into the pool', async () => {
     const pool = ['a', 'b', 'c', 'd'].map(s => makeSummary(s));
     mockGetCachedPersonalities.mockResolvedValue({ kind: 'ok', value: pool });
-    // 0.75 * 4 = 3 → index 3 → slug 'd'
-    vi.spyOn(Math, 'random').mockReturnValue(0.75);
+    mockedRandomInt.mockReturnValue(3); // index 3 → slug 'd'
 
     const result = await resolveCharacterSlug(null, makeContext());
 
     expect(result).toEqual({ kind: 'slug', slug: 'd', randomPick: true });
+    expect(mockedRandomInt).toHaveBeenCalledWith(4); // pool length, half-open upper bound
   });
 
   it('with excludePrivate=true, filters out non-public personalities before picking', async () => {
@@ -136,8 +149,7 @@ describe('resolveCharacterSlug', () => {
         makeSummary('public-two', { isPublic: true }),
       ],
     });
-    // index 1 of 2 candidates → 'public-two'
-    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    mockedRandomInt.mockReturnValue(1); // index 1 of 2 candidates → 'public-two'
 
     const result = await resolveCharacterSlug(null, makeContext(), { excludePrivate: true });
 
@@ -185,7 +197,7 @@ describe('resolveCharacterSlug', () => {
         makeSummary('not-mine-other', { isPublic: true, isOwned: false }),
       ],
     });
-    vi.spyOn(Math, 'random').mockReturnValue(0); // pick index 0 of survivors
+    mockedRandomInt.mockReturnValue(0); // pick index 0 of survivors
 
     const result = await resolveCharacterSlug(null, makeContext(), { onlyMine: true });
 
@@ -202,7 +214,7 @@ describe('resolveCharacterSlug', () => {
         makeSummary('mine-public-2', { isPublic: true, isOwned: true }),
       ],
     });
-    vi.spyOn(Math, 'random').mockReturnValue(0); // pick index 0 of survivors
+    mockedRandomInt.mockReturnValue(0); // pick index 0 of survivors
 
     const result = await resolveCharacterSlug(null, makeContext(), {
       onlyMine: true,

--- a/services/bot-client/src/services/character/randomPick.ts
+++ b/services/bot-client/src/services/character/randomPick.ts
@@ -8,6 +8,7 @@
  * reply for the explicit-pick path (`/chat`, `/chime-in`).
  */
 
+import { randomInt } from 'node:crypto';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
@@ -105,9 +106,11 @@ export async function resolveCharacterSlug(
       ),
     };
   }
-  // Index lands in [0, length-1] — Math.random() is half-open so floor() never
-  // hits length itself; the length>0 guard above keeps the denominator safe.
-  const picked = candidates[Math.floor(Math.random() * candidates.length)];
+  // The pick is pure UX (which accessible persona responds), not a security
+  // decision. randomInt(max) returns a secure integer in [0, max) — used over
+  // Math.random so the insecure-randomness analyzer flag stays quiet without a
+  // per-relocation suppression; the length>0 guard above keeps max valid.
+  const picked = candidates[randomInt(candidates.length)];
   return { kind: 'slug', slug: picked.slug, randomPick: true };
 }
 


### PR DESCRIPTION
## What

Swaps the random-character-pick from `Math.floor(Math.random() * n)` to `crypto.randomInt(n)` in `randomPick.ts`.

## Why

CodeQL's `js/insecure-randomness` rule flags the `Math.random()` pick. It's a **false positive** — choosing which accessible persona responds to `/random` / `/chime-in` is pure UX, not a security decision (the pool is the user's own + public personalities). It was dismissed once (alert #77), but the Wave-3 turn-engine extraction (#1749) **relocated** the code, so CodeQL's large-diff analysis lost the dismissal and re-flagged it as "new" on the **beta.174 release PR (#1761)**, blocking the release CodeQL check.

Rather than re-dismiss the same alert on every relocation (Sisyphean, per owner call), this **satisfies the analyzer permanently**: `crypto.randomInt(n)` returns a secure integer in `[0, n)`. Cost is nil for a one-off pick; **behavior is unchanged** (still a uniform pick over the accessible pool).

## Scope

- `randomPick.ts`: one-line swap + import; comment documents it's UX-not-security.
- `randomPick.test.ts`: the two indexing tests now mock `node:crypto`'s `randomInt` (partial mock — real crypto otherwise) instead of `Math.random`; a typed `mockedRandomInt` pins the sync overload.

**This unblocks the release CodeQL check** — once merged, #1761's CodeQL re-runs against develop with the `Math.random` gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)