### PR TITLE
feat(api-gateway): retention 1c — dmUndeliverableSince stamp + clear-on-activity

### DIFF
--- a/packages/identity/src/UserService.test.ts
+++ b/packages/identity/src/UserService.test.ts
@@ -198,14 +198,17 @@ describe('UserService', () => {
 
       await userService.getOrCreateUser('123456', 'testuser');
 
-      // The stamp crosses the seam as a RAW UPDATE of last_active_at ONLY — it
-      // must NOT touch updated_at (that column is the dev<->prod sync's
+      // The stamp crosses the seam as a RAW UPDATE of the retention columns ONLY
+      // — it must NOT touch updated_at (that column is the dev<->prod sync's
       // last-write-wins resolver; bumping it hourly would clobber dev edits).
       // findUnique returns an existing user, so no creation query fires —
       // $executeRaw is the stamp alone, keyed by the provisioned user id.
+      // The same write clears dm_undeliverable_since: activity proves reach, so
+      // an active user is never left flagged unreachable.
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
       const [template, userId] = mockPrisma.$executeRaw.mock.calls[0] as [string[], string];
       expect(template.join('')).toContain('last_active_at');
+      expect(template.join('')).toContain('dm_undeliverable_since');
       expect(template.join('')).not.toContain('updated_at');
       expect(userId).toBe('active-user-id');
     });

--- a/packages/identity/src/UserService.ts
+++ b/packages/identity/src/UserService.ts
@@ -185,12 +185,18 @@ export class UserService {
       // ~hourly per active user would make prod rows always "win" and silently
       // clobber dev-only edits on the next sync. `lastActiveAt` is a SEPARATE
       // column precisely to keep retention tracking off `updated_at`'s
-      // semantics; a raw UPDATE writes only `last_active_at` and leaves
+      // semantics; a raw UPDATE writes only the retention columns and leaves
       // `updated_at` untouched. A raw UPDATE on a mid-flight-deleted row matches
       // 0 rows without throwing, matching the TOCTOU cache guard below.
+      //
+      // The same stamp also CLEARS dm_undeliverable_since: activity is proof of
+      // reach, so an active user is never left flagged unreachable. Both are
+      // retention signals maintained together on this one activity seam — the
+      // release-blast path sets the flag, any provisioning clears it (a later
+      // failure re-stamps fresh, since the clear resets the first-failure guard).
       try {
         await this.prisma.$executeRaw`
-          UPDATE users SET last_active_at = NOW() WHERE id = ${user.id}::uuid
+          UPDATE users SET last_active_at = NOW(), dm_undeliverable_since = NULL WHERE id = ${user.id}::uuid
         `;
       } catch (stampError) {
         logger.warn({ err: stampError, discordId }, 'Failed to stamp lastActiveAt (non-fatal)');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,9 +70,10 @@ model User {
   /// permanently fails with a per-user unreachable code (Discord 50278 = left
   /// every shared server, 50007 = DMs closed or bot blocked); stays fixed
   /// through the unreachable streak, never advancing while already non-null.
-  /// Cleared back to NULL on the user's next deliberate use (same seams that
-  /// clear notifyAutoDisabledAt). Reads guard with != null. The stamp + clear
-  /// write path lands in a later PR — currently always NULL.
+  /// Cleared back to NULL on the user's next activity — folded into the same
+  /// getOrCreateUser cache-miss stamp that maintains lastActiveAt, so any active
+  /// user is never left flagged unreachable (an inactive user stops clearing it,
+  /// which is exactly the retention cohort). Reads guard with != null.
   dmUndeliverableSince  DateTime?                  @map("dm_undeliverable_since")
   createdAt             DateTime                   @default(now()) @map("created_at")
   updatedAt             DateTime                   @updatedAt @map("updated_at")

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
@@ -35,6 +35,9 @@ const mockPrisma = {
   user: {
     update: vi.fn(),
   },
+  // Retention undeliverable stamp writes via raw SQL (keeps updated_at off the
+  // sync LWW resolver). Default resolves so the happy path needs no per-test setup.
+  $executeRaw: vi.fn().mockResolvedValue(1),
 };
 
 import {
@@ -293,6 +296,80 @@ describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
     await handler(req, res, vi.fn());
 
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('stamps dm_undeliverable_since (first-failure guard) on a 50278 permanent failure', async () => {
+    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
+    mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce(null); // no auto-disable
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '50278' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    // The undeliverable clock starts via a raw UPDATE keyed by the user id, with
+    // a `dm_undeliverable_since IS NULL` guard so only the FIRST failure records
+    // (never advancing a live streak) and updated_at stays untouched.
+    expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+    const [template, userId] = mockPrisma.$executeRaw.mock.calls[0] as [string[], string];
+    expect(template.join('')).toContain('dm_undeliverable_since');
+    expect(template.join('')).toContain('IS NULL');
+    expect(template.join('')).not.toContain('updated_at');
+    expect(userId).toBe(USER_A);
+  });
+
+  it('stamps dm_undeliverable_since on a 50007 permanent failure', async () => {
+    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
+    mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce(null);
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '50007' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+    const [template] = mockPrisma.$executeRaw.mock.calls[0] as [string[], string];
+    expect(template.join('')).toContain('dm_undeliverable_since');
+  });
+
+  it('does NOT stamp dm_undeliverable_since on a non-unreachable permanent code (e.g. 10013)', async () => {
+    // 10013 = deleted account: a distinct, stronger signal handled in the Phase 2
+    // purge branch, NOT the 180-day undeliverable clock. Only 50278/50007 stamp.
+    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
+    mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce(null);
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '10013' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('swallows an undeliverable-stamp failure and keeps processing the rest of the batch', async () => {
+    // The row's terminal transition already committed before the stamp runs, so
+    // a thrown stamp must NOT 500 the batch — that would strand this row on
+    // retry (its pending guard already flipped) AND skip every later row. The
+    // side-effects are best-effort; swallow + continue.
+    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
+    mockPrisma.$executeRaw.mockRejectedValueOnce(new Error('db blip'));
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [
+        { deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '50278' },
+        { deliveryLogId: LOG_B, status: 'sent' },
+      ],
+    });
+
+    // No throw propagates (pre-fix this rejected); both rows transition — the
+    // later, unrelated row must still be processed.
+    await handler(req, res, vi.fn());
+
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0] as { updated: number };
+    expect(payload.updated).toBe(2);
   });
 
   it('stamps completedAt when no pending rows remain and carries the summary tally', async () => {

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.ts
@@ -89,6 +89,58 @@ async function maybeAutoDisable(
   return true;
 }
 
+/**
+ * Handle a freshly-transitioned permanent-failure row: start the retention
+ * undeliverable clock (per-user unreachable codes only) and escalate to
+ * auto-disable on a second consecutive failure. Returns the userId IFF this
+ * call auto-disabled them (so the caller can report it), else null.
+ *
+ * Retention: 50278 = user left every shared server; 50007 = DMs closed or bot
+ * blocked. NEVER 20026 (bot-wide quarantine — would false-flag every recipient)
+ * or 10013 (deleted account — a distinct, stronger signal deferred to the Phase
+ * 2 purge branch). The `dm_undeliverable_since IS NULL` guard records the FIRST
+ * failure only (never advances a live streak); raw SQL keeps the column off
+ * updated_at, the dev<->prod sync LWW resolver — same reasoning as the
+ * getOrCreateUser lastActiveAt stamp.
+ *
+ * Best-effort, never fatal (mirrors the getOrCreateUser stamp's swallow): these
+ * are non-critical signals that self-heal on the next release blast (a still-
+ * unreachable user fails again and re-stamps). The caller has ALREADY committed
+ * this row's terminal transition before calling us, so a thrown error here would
+ * both 500 the whole batch (asyncHandler → unrelated later rows never process)
+ * AND permanently strand this row — a retry's `status: 'pending'` guard now
+ * matches 0, so it skips the row entirely and its stamp/escalation are lost for
+ * good. Swallow + log instead; return null (no auto-disable reported).
+ */
+async function recordPermanentFailure(
+  prisma: PrismaClient,
+  deliveryLogId: string,
+  errorCode: string | undefined
+): Promise<string | null> {
+  try {
+    const row = await prisma.releaseDeliveryLog.findUnique({
+      where: { id: deliveryLogId },
+      select: { userId: true },
+    });
+    if (row === null) {
+      return null;
+    }
+    if (errorCode === '50278' || errorCode === '50007') {
+      await prisma.$executeRaw`
+        UPDATE users SET dm_undeliverable_since = NOW()
+        WHERE id = ${row.userId}::uuid AND dm_undeliverable_since IS NULL
+      `;
+    }
+    return (await maybeAutoDisable(prisma, deliveryLogId, row.userId)) ? row.userId : null;
+  } catch (err) {
+    logger.warn(
+      { err, deliveryLogId },
+      'Permanent-failure side-effects (undeliverable stamp / auto-disable) failed; non-fatal'
+    );
+    return null;
+  }
+}
+
 /** POST /api/internal/release-broadcast/:releaseId/deliveries */
 export const handleReleaseBroadcastDeliveries = (deps: RouteDeps): RequestHandler => {
   const { prisma } = deps;
@@ -133,12 +185,13 @@ export const handleReleaseBroadcastDeliveries = (deps: RouteDeps): RequestHandle
       updated += 1;
 
       if (result.status === 'failed_permanent') {
-        const row = await prisma.releaseDeliveryLog.findUnique({
-          where: { id: result.deliveryLogId },
-          select: { userId: true },
-        });
-        if (row !== null && (await maybeAutoDisable(prisma, result.deliveryLogId, row.userId))) {
-          autoDisabledUserIds.push(row.userId);
+        const autoDisabledUserId = await recordPermanentFailure(
+          prisma,
+          result.deliveryLogId,
+          result.errorCode
+        );
+        if (autoDisabledUserId !== null) {
+          autoDisabledUserIds.push(autoDisabledUserId);
         }
       }
     }


### PR DESCRIPTION
## Retention Phase 1c — the DM-undeliverable half of the tracking substrate

Third slice of retention Phase 1 (tracking only, no purge). Sets and clears the
`dmUndeliverableSince` signal the future purge job will read. 1a (columns +
backfill, #1764) and 1b (lastActiveAt forward stamp, #1765) are already merged.

### What it does
- **Stamp** (`releaseBroadcast.ts`): the release-blast delivery handler starts
  the undeliverable clock when a per-user unreachable code lands — Discord
  `50278` (left every shared server) or `50007` (DMs closed/blocked). Raw SQL
  with a `dm_undeliverable_since IS NULL` first-failure guard: records the
  **first** failure only (never advances a live streak), and keeps the column
  off `updated_at` (the dev↔prod sync LWW resolver) — same reasoning as the 1b
  `lastActiveAt` stamp. **Not** stamped on `20026` (bot-wide quarantine → would
  false-flag every recipient) or `10013` (deleted account → a distinct, stronger
  signal deferred to Phase 2's purge branch).
- **Clear** (`UserService.getOrCreateUser`): folded into the 1b activity stamp
  (rides the same UPDATE). Activity proves reach, so an active user is never left
  flagged; an inactive one stops clearing it — exactly the retention cohort.

### Divergence from the approved plan (read the code, moved the target)
The plan named the **three `notifyAutoDisabledAt`-clear seams** for the clear.
Reading the code superseded that:
1. Those seams guard on `notifyAutoDisabledAt != null` (set only after **two**
   consecutive failures), so appending the clear there would **miss
   single-failure users** (`dmUndeliverableSince` set, `notifyAutoDisabledAt`
   still null).
2. The activity stamp already fires on **every** provisioning — one place,
   complete, no extra round-trip, and cohesive (both retention signals
   maintained on one seam).

Schema doc for `dmUndeliverableSince` updated to describe the actual clear
mechanism. `recordPermanentFailure` extracted to keep the delivery handler under
the cognitive-complexity limit.

### Deferred (Phase 2 follow-up)
Clearing on a later **successful** blast delivery (the rejoined-but-never-
interacts edge). Only matters once the purge branch reads the flag, and Phase 2
finalizes the reachable/unreachable branch semantics anyway. Will be filed in
`backlog/cold/follow-ups.md`.

### Verification
- `pnpm --filter @tzurot/identity test` — 176 green (stamp test now asserts the
  clear rides the same UPDATE).
- `pnpm --filter @tzurot/api-gateway test releaseBroadcast` — 19 green (new:
  stamp fires on 50278/50007, **not** on 10013; first-failure `IS NULL` guard;
  `updated_at` untouched).
- `pnpm test` (26 packages) + `pnpm quality` — both green.
- Schema change is comment-only (pglite-schema regen was a no-op) — no migration.

### Runtime note
Phase 1 is invisible by design — no user-visible surface to smoke. The runtime
confirmation is the next **prod** release blast stamping `dm_undeliverable_since`
(dev outbound DM is quarantined, so a live dev DM-fail can't be exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)