### PR TITLE
feat(bot-client): retention 1d — pure-client command activity stamp

### DIFF
--- a/packages/clients/src/clients/_generated/service-client.ts
+++ b/packages/clients/src/clients/_generated/service-client.ts
@@ -140,6 +140,18 @@ export class ServiceClient {
     });
   }
 
+  async stampUserActivity(input: z.input<typeof ROUTE_MANIFEST.stampUserActivity.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.stampUserActivity.output>>> {
+    const fullPath = '/api/internal/users/activity';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'POST',
+      path: fullPath,
+      body: input,
+      outputSchema: ROUTE_MANIFEST.stampUserActivity.output,
+    });
+  }
+
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -39,6 +39,8 @@ import {
   ConversationSyncResponseSchema,
   DmSessionSetRequestSchema,
   DmSessionSetResponseSchema,
+  StampUserActivityRequestSchema,
+  StampUserActivityResponseSchema,
   LoadPersonalityInternalResponseSchema,
   MessagePersonalityResponseSchema,
   PersistAssistantMessageRequestSchema,
@@ -189,6 +191,22 @@ export const internalRoutes = {
     id: 'setDmSession',
     input: DmSessionSetRequestSchema,
     output: DmSessionSetResponseSchema,
+    serviceOnly: true,
+  },
+
+  /**
+   * POST /api/internal/users/activity
+   * Fire-and-forget retention activity stamp for pure-client slash commands
+   * (e.g. /help) that never reach the gateway; refreshes last_active_at and
+   * clears dm_undeliverable_since for the user.
+   */
+  stampUserActivity: {
+    audience: 'internal',
+    method: 'post',
+    path: '/users/activity',
+    id: 'stampUserActivity',
+    input: StampUserActivityRequestSchema,
+    output: StampUserActivityResponseSchema,
     serviceOnly: true,
   },
 

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -4,6 +4,8 @@ import {
   RecentUsersResponseSchema,
   DmSessionSetRequestSchema,
   DmSessionSetResponseSchema,
+  StampUserActivityRequestSchema,
+  StampUserActivityResponseSchema,
   MessagePersonalityResponseSchema,
   PersistAssistantMessageRequestSchema,
   PersistAssistantMessageResponseSchema,
@@ -147,6 +149,33 @@ describe('DmSessionSetRequestSchema and DmSessionSetResponseSchema', () => {
 
   it('request rejects missing channelId', () => {
     expect(DmSessionSetRequestSchema.safeParse({ personalitySlug: 'lila' }).success).toBe(false);
+  });
+});
+
+describe('StampUserActivityRequestSchema and StampUserActivityResponseSchema', () => {
+  it('request accepts a valid Discord snowflake', () => {
+    expect(
+      StampUserActivityRequestSchema.safeParse({ discordId: '123456789012345678' }).success
+    ).toBe(true);
+  });
+
+  it('request rejects a non-snowflake discordId', () => {
+    expect(StampUserActivityRequestSchema.safeParse({ discordId: 'not-a-snowflake' }).success).toBe(
+      false
+    );
+  });
+
+  it('request rejects a missing discordId', () => {
+    expect(StampUserActivityRequestSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('response accepts stamped true and false', () => {
+    expect(StampUserActivityResponseSchema.safeParse({ stamped: true }).success).toBe(true);
+    expect(StampUserActivityResponseSchema.safeParse({ stamped: false }).success).toBe(true);
+  });
+
+  it('response rejects a non-boolean stamped', () => {
+    expect(StampUserActivityResponseSchema.safeParse({ stamped: 'yes' }).success).toBe(false);
   });
 });
 

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -33,6 +33,24 @@ export const RecentUsersResponseSchema = z.object({
 });
 
 // ============================================================================
+// POST /internal/users/activity
+// Fire-and-forget activity stamp for pure-client slash commands (e.g. /help)
+// that never otherwise reach the gateway. Refreshes last_active_at and clears
+// dm_undeliverable_since for the user, keyed by Discord ID (best-effort; a
+// no-op when the user isn't provisioned yet). Mirrors the getOrCreateUser
+// activity stamp — a raw UPDATE, so updated_at stays off the sync LWW resolver.
+// ============================================================================
+
+export const StampUserActivityRequestSchema = z.object({
+  discordId: DiscordSnowflakeSchema,
+});
+
+export const StampUserActivityResponseSchema = z.object({
+  /** True when a user row was updated; false when the user isn't provisioned yet. */
+  stamped: z.boolean(),
+});
+
+// ============================================================================
 // POST /internal/channel/dm-session/set
 // Records active personality in a DM session. Called by bot-client after a
 // multi-tag reply selects a personality; the gateway stores it so subsequent

--- a/packages/tooling/coverage-topology.json
+++ b/packages/tooling/coverage-topology.json
@@ -2186,6 +2186,20 @@
       ]
     },
     {
+      "id": "client:api-gateway:stampUserActivity",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /users/activity",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
       "id": "client:api-gateway:startAccountExport",
       "kind": "http-route",
       "producer": "client",

--- a/packages/tooling/src/codegen/handler-paths.ts
+++ b/packages/tooling/src/codegen/handler-paths.ts
@@ -133,6 +133,7 @@ const PATH_MAP: Readonly<Record<string, string>> = {
 
   // Internal
   recentUsers: '../internal/usersRecent.js',
+  stampUserActivity: '../internal/usersActivity.js',
   listPersonalityAliases: PERSONALITY_ALIASES_PATH,
   addPersonalityAlias: PERSONALITY_ALIASES_PATH,
   removePersonalityAlias: PERSONALITY_ALIASES_PATH,

--- a/services/api-gateway/src/routes/_generated/mounts.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.ts
@@ -38,6 +38,7 @@ import { handleAiConfirmDelivery } from '../ai/confirmDelivery.js';
 import { handleReleaseBroadcastPending, handleReleaseBroadcastDeliveries } from '../internal/releaseBroadcast.js';
 import { handleReleaseBroadcastReconcile } from '../internal/releaseReconcile.js';
 import { handleSetDmSession } from '../internal/dmSessionSet.js';
+import { handleStampUserActivity } from '../internal/usersActivity.js';
 import { handleLookupPersonalityFromMessage } from '../user/conversationLookup.js';
 import { handlePersistAssistantMessage } from '../internal/conversationAssistantMessage.js';
 import { handlePersistUserMessage } from '../internal/conversationUserMessage.js';
@@ -115,6 +116,7 @@ export function mountInternalRoutes(app: Express, deps: RouteDeps): void {
   app.post('/api/internal/ai/transcribe', handleAiTranscribe(deps));
   app.post('/api/internal/release-broadcast/reconcile', handleReleaseBroadcastReconcile(deps));
   app.post('/api/internal/channel/dm-session/set', handleSetDmSession(deps));
+  app.post('/api/internal/users/activity', handleStampUserActivity(deps));
   app.get('/api/internal/conversation/message-personality', handleLookupPersonalityFromMessage(deps));
   app.post('/api/internal/conversation/assistant-message', handlePersistAssistantMessage(deps));
   app.post('/api/internal/conversation/user-message', handlePersistUserMessage(deps));

--- a/services/api-gateway/src/routes/conformance/fixtures/internal.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/internal.ts
@@ -291,6 +291,12 @@ export const internalFixtures: Record<string, ConformanceEntry> = {
     // The provisioned actor row itself is the "recent user" — zero extra seed.
   },
 
+  stampUserActivity: {
+    // The provisioned actor row is the stamp target — no extra DB seed. Passing
+    // the actor's own discordId exercises the success path (stamped: true).
+    seed: ctx => Promise.resolve({ body: { discordId: ctx.actorDiscordId } }),
+  },
+
   secretRotationStatus: {
     // Empty ledger is a valid (pre-seed) state; the route returns
     // entries: [] + overdueCount: 0 — zero seed needed.

--- a/services/api-gateway/src/routes/internal/usersActivity.test.ts
+++ b/services/api-gateway/src/routes/internal/usersActivity.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for POST /internal/users/activity
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { handleStampUserActivity } from './usersActivity.js';
+import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const VALID_DISCORD_ID = '123456789012345678';
+
+describe('POST /internal/users/activity', () => {
+  let mockPrisma: { $executeRaw: ReturnType<typeof vi.fn> };
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = { $executeRaw: vi.fn() };
+    app = express();
+    app.use(express.json());
+    app.post(
+      '/internal/users/activity',
+      handleStampUserActivity({
+        ...stubRouteResolvers(),
+        prisma: mockPrisma as unknown as PrismaClient,
+      })
+    );
+  });
+
+  it('stamps last_active_at + clears dm_undeliverable_since by discord_id, off updated_at', async () => {
+    mockPrisma.$executeRaw.mockResolvedValue(1); // one row updated
+
+    const response = await request(app)
+      .post('/internal/users/activity')
+      .send({ discordId: VALID_DISCORD_ID });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ stamped: true });
+
+    // The retention signals cross the seam as a RAW UPDATE keyed by discord_id;
+    // updated_at must stay untouched (it's the dev<->prod sync LWW resolver).
+    const [template, discordId] = mockPrisma.$executeRaw.mock.calls[0] as [string[], string];
+    const sql = template.join('');
+    expect(sql).toContain('last_active_at');
+    expect(sql).toContain('dm_undeliverable_since');
+    expect(sql).toContain('discord_id');
+    expect(sql).not.toContain('updated_at');
+    expect(discordId).toBe(VALID_DISCORD_ID);
+  });
+
+  it('reports stamped:false when the user is not provisioned yet (0 rows updated)', async () => {
+    mockPrisma.$executeRaw.mockResolvedValue(0); // no matching row — pure-client-only user
+
+    const response = await request(app)
+      .post('/internal/users/activity')
+      .send({ discordId: VALID_DISCORD_ID });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ stamped: false });
+  });
+
+  it('rejects a non-snowflake discordId with Zod validation', async () => {
+    const response = await request(app)
+      .post('/internal/users/activity')
+      .send({ discordId: 'not-a-snowflake' });
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing discordId', async () => {
+    const response = await request(app).post('/internal/users/activity').send({});
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/routes/internal/usersActivity.ts
+++ b/services/api-gateway/src/routes/internal/usersActivity.ts
@@ -1,0 +1,56 @@
+/**
+ * POST /internal/users/activity
+ *
+ * Service-only endpoint. Records a "the user is active" signal for slash
+ * commands that never otherwise reach the gateway — pure-client commands like
+ * /help render entirely bot-side, so without this their use would never refresh
+ * the retention clock. Stamps the same pair the getOrCreateUser provisioning
+ * path maintains: refresh last_active_at and clear dm_undeliverable_since
+ * (activity is proof of reach), keyed by Discord ID.
+ *
+ * Best-effort: a raw UPDATE that no-ops (0 rows) when the user isn't
+ * provisioned yet — a pure-client-only user has no row and no data to track, so
+ * "not found" is a legitimate outcome, not an error. Raw SQL (not the Prisma
+ * client) so `updated_at` (the dev<->prod sync LWW resolver) stays untouched —
+ * identical reasoning to the UserService.getOrCreateUser lastActiveAt stamp.
+ *
+ * Authentication: X-Service-Auth is enforced upstream by the global
+ * requireServiceAuth() in api-gateway/src/index.ts, which gates every
+ * /internal/* route. Requests without a valid service secret never reach here.
+ */
+
+import { type Response, type RequestHandler } from 'express';
+import { StampUserActivityRequestSchema } from '@tzurot/common-types/schemas/api/internal';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { asyncHandler } from '../../utils/asyncHandler.js';
+import { sendCustomSuccess } from '../../utils/responseHelpers.js';
+import { sendZodError } from '../../utils/zodHelpers.js';
+import type { RouteDeps } from '../routeDeps.js';
+
+const logger = createLogger('internal-users-activity');
+
+/** POST /api/internal/users/activity — refresh the caller's retention activity signal. */
+export const handleStampUserActivity = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req, res: Response) => {
+    const parseResult = StampUserActivityRequestSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      sendZodError(res, parseResult.error);
+      return;
+    }
+    const { discordId } = parseResult.data;
+
+    // Raw UPDATE (not the Prisma client): last_active_at and
+    // dm_undeliverable_since are retention signals that must NOT bump
+    // updated_at (the dev<->prod sync LWW resolver) — see
+    // UserService.getOrCreateUser for the full rationale. `$executeRaw` returns
+    // the affected-row count, which is 0 when the user isn't provisioned yet
+    // (a legitimate no-op, not an error).
+    const affected = await prisma.$executeRaw`
+      UPDATE users SET last_active_at = NOW(), dm_undeliverable_since = NULL WHERE discord_id = ${discordId}
+    `;
+
+    logger.debug({ discordId, stamped: affected > 0 }, 'Stamped pure-client user activity');
+    sendCustomSuccess(res, { stamped: affected > 0 });
+  });
+};

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -24,6 +24,7 @@ import {
   clearAllChannelSettingsCache,
   confirmDelivery,
   healthCheck,
+  stampUserActivity,
 } from './utils/gatewayServiceCalls.js';
 import { WebhookManager } from './utils/WebhookManager.js';
 import { getServiceClient } from './utils/gatewayClients.js';
@@ -405,6 +406,16 @@ client.on(Events.InteractionCreate, interaction => {
           logger.warn({ commandName: interaction.commandName }, 'Unknown command');
           return;
         }
+
+        // Retention: pure-client commands (e.g. /help) render bot-side and never
+        // reach the gateway, so stamp activity here for every chat-input command.
+        // Fire-and-forget — the wrapper logs on failure and never throws; the
+        // redundant stamp for gateway-reaching commands (which already stamp via
+        // getOrCreateUser) is a harmless idempotent NOW-write. Not awaited: the
+        // stamp must never delay or fail the 3-second ack path.
+        void stampUserActivity(interaction.user.id).catch(() => {
+          /* wrapper already logs; swallow so a rejection can't become unhandled */
+        });
 
         // All commands use the typed context pattern with deferralMode metadata
         await handleCommandWithContext(interaction, command);

--- a/services/bot-client/src/utils/gatewayServiceCalls.test.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.test.ts
@@ -15,6 +15,7 @@ const mockServiceClient = {
   setDmSession: vi.fn(),
   lookupPersonalityFromMessage: vi.fn(),
   updateDiagnosticResponseIds: vi.fn(),
+  stampUserActivity: vi.fn(),
   aiGenerate: vi.fn(),
   aiConfirmDelivery: vi.fn(),
   releaseBroadcastPending: vi.fn(),
@@ -35,6 +36,7 @@ import {
   setDmSessionPersonality,
   lookupPersonalityFromMessage,
   updateDiagnosticResponseIds,
+  stampUserActivity,
   generate,
   confirmDelivery,
   filterPendingDeliveries,
@@ -169,6 +171,17 @@ describe('fire-and-forget helpers', () => {
     await expect(updateDiagnosticResponseIds('req-1', ['m1', 'm2'])).resolves.toBeUndefined();
     expect(mockServiceClient.updateDiagnosticResponseIds).toHaveBeenCalledWith('req-1', {
       responseMessageIds: ['m1', 'm2'],
+    });
+  });
+
+  it('stampUserActivity forwards the discordId as { discordId } and never throws on failure', async () => {
+    mockServiceClient.stampUserActivity.mockResolvedValue(err(500));
+    // Seam assertion: the wrapper must forward the raw snowflake as the request
+    // body shape the endpoint expects, and a failed stamp must not surface to
+    // the fire-and-forget caller.
+    await expect(stampUserActivity('123456789012345678')).resolves.toBeUndefined();
+    expect(mockServiceClient.stampUserActivity).toHaveBeenCalledWith({
+      discordId: '123456789012345678',
     });
   });
 

--- a/services/bot-client/src/utils/gatewayServiceCalls.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.ts
@@ -215,6 +215,19 @@ export async function updateDiagnosticResponseIds(
 }
 
 /**
+ * Refresh the caller's retention activity signal for a pure-client slash command
+ * — one that renders entirely bot-side (e.g. /help) and never otherwise reaches
+ * the gateway. Best-effort: logs on failure, never throws. The interaction path
+ * must neither wait on nor fail for this (called fire-and-forget from the funnel).
+ */
+export async function stampUserActivity(discordId: string): Promise<void> {
+  const result = await getServiceClient().stampUserActivity({ discordId });
+  if (!result.ok) {
+    logger.warn({ discordId, status: result.status }, 'Failed to stamp user activity');
+  }
+}
+
+/**
  * Submit an async AI generation job. Returns the job/request IDs immediately;
  * the result is delivered later via the Redis result stream (JobTracker).
  * Throws on failure — the chat path needs to surface submission errors.


### PR DESCRIPTION
## Retention Phase 1d — closes the pure-client gap (Phase 1 tracking complete)

Final slice of retention Phase 1. Slash commands that render entirely bot-side
(e.g. `/help`) never reach the gateway, so their use never refreshed the
retention clock. This wires a fire-and-forget activity stamp so pure-client
command use counts. 1a/1b/1c are merged; this completes the tracking substrate.

### What it does
- **New endpoint** `POST /api/internal/users/activity` (`usersActivity.ts`):
  raw `UPDATE users SET last_active_at = NOW(), dm_undeliverable_since = NULL
  WHERE discord_id = $1` — best-effort (no-op / `stamped: false` when the user
  isn't provisioned yet), service-auth only. Raw SQL keeps the retention
  columns off `updated_at` (the dev↔prod sync LWW resolver), same as the 1b
  `getOrCreateUser` stamp.
- **bot-client** fires it fire-and-forget from the `InteractionCreate` funnel
  for every `isChatInputCommand()`, not awaited (must never touch the 3-second
  ack budget). The wrapper logs on failure and never throws.

### Design call: fire for all commands, not just pure-client
The owner **counts `/help` as usage**. There is **no property** on the command
shape that distinguishes pure-client from gateway-reaching commands (verified:
`CommandDefinition`/`Command` only carry `category`, a UX grouping, not a
transport class). So firing for every chat-input command is the simple, robust
choice — `/help` is covered, and the redundant stamp for gateway commands
(which already stamp via `getOrCreateUser`) is a harmless idempotent NOW-write.
The alternative — a `pureClient` marker — adds a footgun (a new pure-client
command silently not counting) for a near-empty cohort, so I didn't add it.

### Plumbing
Manifest entry (`clients/routes/internal.ts`) + regenerated `ServiceClient`
method and mount; codegen `PATH_MAP` entry; conformance fixture; schema tests;
handler test (stamp/no-op/reject); wrapper seam test; topology artifact refreshed.

### Verification
- `pnpm test` (26 packages) + `pnpm quality` — both green.
- Conformance component runner replays the new fixture against PGLite — green
  (seed uses the provisioned actor's discordId → `stamped: true`).
- No migration (reuses the 1a columns).

### Runtime note
Invisible by design. Runtime confirmation is the debug log line
(`Stamped pure-client user activity`) on the first real `/help` in dev/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)