### PR TITLE
fix(bot-client): fail-closed OUTBOUND_DM_ALLOWLIST assertion on non-prod boot

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -76,6 +76,7 @@ import {
   validateDiscordToken,
   validateRedisUrl,
   validateInternalServiceSecret,
+  validateOutboundDmAllowlist,
   logGatewayHealthStatus,
 } from './startup.js';
 import { restoreBotPresence } from './commands/admin/presence.js';
@@ -92,6 +93,7 @@ const envConfig = getConfig();
 // Validate bot-client specific required env vars
 validateDiscordToken();
 validateInternalServiceSecret();
+validateOutboundDmAllowlist();
 
 // Configuration from environment
 const config = {

--- a/services/bot-client/src/startup.test.ts
+++ b/services/bot-client/src/startup.test.ts
@@ -40,6 +40,7 @@ import {
   validateDiscordToken,
   validateRedisUrl,
   validateInternalServiceSecret,
+  validateOutboundDmAllowlist,
   getValidatedServiceSecret,
   logGatewayHealthStatus,
 } from './startup.js';
@@ -82,6 +83,43 @@ describe('Startup Utilities', () => {
           config as ReturnType<typeof import('@tzurot/common-types/config/config').getConfig>
         )
       ).toThrow('DISCORD_TOKEN environment variable is required');
+    });
+  });
+
+  describe('validateOutboundDmAllowlist', () => {
+    const asConfig = (c: Record<string, unknown>) =>
+      c as ReturnType<typeof import('@tzurot/common-types/config/config').getConfig>;
+
+    it('throws on a non-production environment with an unset allowlist', () => {
+      expect(() =>
+        validateOutboundDmAllowlist(
+          asConfig({ NODE_ENV: 'development', OUTBOUND_DM_ALLOWLIST: undefined })
+        )
+      ).toThrow('OUTBOUND_DM_ALLOWLIST must be set on non-production');
+    });
+
+    it('throws on a non-production environment with a whitespace-only allowlist', () => {
+      expect(() =>
+        validateOutboundDmAllowlist(
+          asConfig({ NODE_ENV: 'development', OUTBOUND_DM_ALLOWLIST: '   ' })
+        )
+      ).toThrow('OUTBOUND_DM_ALLOWLIST must be set on non-production');
+    });
+
+    it('does not throw on a non-production environment when the allowlist is set', () => {
+      expect(() =>
+        validateOutboundDmAllowlist(
+          asConfig({ NODE_ENV: 'development', OUTBOUND_DM_ALLOWLIST: '123456789012345678' })
+        )
+      ).not.toThrow();
+    });
+
+    it('does not throw in production even when unset (prod is unrestricted by design)', () => {
+      expect(() =>
+        validateOutboundDmAllowlist(
+          asConfig({ NODE_ENV: 'production', OUTBOUND_DM_ALLOWLIST: undefined })
+        )
+      ).not.toThrow();
     });
   });
 

--- a/services/bot-client/src/startup.ts
+++ b/services/bot-client/src/startup.ts
@@ -47,6 +47,33 @@ export function validateInternalServiceSecret(config = getConfig()): void {
 }
 
 /**
+ * Fail-closed guard for the outbound-DM allowlist. On any NON-production
+ * environment, `OUTBOUND_DM_ALLOWLIST` MUST be set: dev's database is synced
+ * from prod, so an unset allowlist points the dev bot at real prod users — the
+ * exact boot-time DM-burst shape that earned a Discord DM quarantine.
+ * `getOutboundDmAllowlist()` treats unset as "unrestricted" (correct for prod),
+ * so without this assertion a fresh or misconfigured dev deploy silently falls
+ * open. Refuse to boot instead. Prod is intentionally unrestricted and returns
+ * early. The empty-check mirrors `getOutboundDmAllowlist`'s own null condition.
+ *
+ * @throws Error on a non-production environment with an unset/empty allowlist
+ */
+export function validateOutboundDmAllowlist(config = getConfig()): void {
+  if (config.NODE_ENV === 'production') {
+    return;
+  }
+  const raw = config.OUTBOUND_DM_ALLOWLIST;
+  if (raw === undefined || raw.trim() === '') {
+    throw new Error(
+      `OUTBOUND_DM_ALLOWLIST must be set on non-production environments ` +
+        `(NODE_ENV=${config.NODE_ENV}) — the dev database is synced from prod, so ` +
+        `an unset allowlist lets the dev bot DM real prod users. Set it to your ` +
+        `own Discord ID(s), comma-separated.`
+    );
+  }
+}
+
+/**
  * Return the validated `INTERNAL_SERVICE_SECRET` for use in outbound
  * `X-Service-Auth` headers. Pairs with `validateInternalServiceSecret()`
  * which runs at process startup — this helper throws loud at call time


### PR DESCRIPTION
## Makes the dev-bot-DMs-prod-users recurrence structurally impossible

The `OUTBOUND_DM_ALLOWLIST` guard (PR #1650, which stopped the dev bot from
DMing prod users — the Discord-quarantine root cause) is **fail-open**: an unset
allowlist means "unrestricted", correct for prod but dangerous on dev (dev's DB
is synced from prod, so an unset allowlist points the dev bot at real prod
users). Nothing enforced that the var is actually set, so a **fresh or
misconfigured dev environment silently falls open** — the exact concern raised
when considering recreating the dev bot as a new Discord app.

`validateOutboundDmAllowlist()` now refuses to boot when `NODE_ENV != 'production'`
and the allowlist is unset/empty. Prod stays unrestricted by design. This turns
a config-dependent safety property into a code-enforced one.

- Guard: `services/bot-client/src/startup.ts` (mirrors the other `validate*`
  startup checks; injectable `config` param).
- Wired into `index.ts` startup alongside `validateDiscordToken` /
  `validateInternalServiceSecret`.
- Tests: throws on non-prod + unset/whitespace; passes on non-prod + set; passes
  in prod even when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)