### PR TITLE
docs(rules): sync-tracked-table updated_at raw-SQL rule

### DIFF
--- a/.claude/rules/03-database.md
+++ b/.claude/rules/03-database.md
@@ -55,6 +55,12 @@ const results = await prisma.$queryRaw<SimilarMemory[]>`
 
 Corollary for removals: `idx_scan = 0` alone never justifies a drop. Verify no query exists (raw AND Prisma) — an index backing a real query on a still-small table shows 0 scans only because the planner seq-scans; it becomes load-bearing as the table grows. PK/unique indexes are constraints, never drop candidates.
 
+## Sync-Tracked Tables & `updated_at` (dev↔prod LWW)
+
+`DatabaseSyncService` reconciles dev↔prod rows by **last-write-wins on `updated_at`** (`syncTables.ts`). Any Prisma client-level write (`update`/`updateMany`/`upsert`) auto-bumps `@updatedAt` — so a **high-frequency or non-semantic** write (an activity stamp, a counter, a `last_seen`) makes that env's row "win" the next sync and can silently clobber the other env's genuine edits.
+
+**Rule**: write high-frequency/non-semantic columns on a sync-tracked table via **raw SQL** (`$executeRaw`) — it bypasses `@updatedAt`, leaving `updated_at` for genuine, sync-worthy state changes only. Reference: the retention `lastActiveAt`/`dmUndeliverableSince` stamps write via `$executeRaw` for exactly this reason.
+
 ## Migrations
 
 ### The One True Workflow


### PR DESCRIPTION
## Captures the 1b/1c retention lesson as a durable constraint

Retention 1b's review caught a real data-corruption bug: an `updateMany`
activity stamp auto-bumped `users.updated_at` via `@updatedAt`, which
`DatabaseSyncService` uses as the dev↔prod last-write-wins conflict resolver —
so an hourly-per-active-user stamp would silently make one env "win" and clobber
the other's edits on sync. It was fixed by writing via `$executeRaw` (both 1b
`lastActiveAt` and 1c `dmUndeliverableSince` do this).

That fix lived only in code comments at the two sites. This adds a short section
to `03-database.md` so the next stamp/counter/`last_seen` on a sync-tracked table
doesn't repeat it: **write high-frequency/non-semantic columns via raw SQL** so
they don't bump `updated_at`.

Rules line budget: 2229/2270 — comfortably under.

(Filed as a follow-up during 1b; promoting it here as a beta.175 ride-along.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)