### PR TITLE
feat: classify Discord 20026 as a distinct bot-level DM failure

### DIFF
--- a/packages/common-types/src/schemas/api/broadcast.test.ts
+++ b/packages/common-types/src/schemas/api/broadcast.test.ts
@@ -154,6 +154,7 @@ describe('ReleaseBroadcastDeliveriesResponseSchema', () => {
         sent: 117,
         failedPermanent: 2,
         failedTransient: 1,
+        failedBotLevel: 0,
         optedOut: 0,
       },
     });
@@ -169,9 +170,23 @@ describe('BroadcastCompletionSummarySchema', () => {
       sent: 117,
       failedPermanent: 0,
       failedTransient: 0,
+      failedBotLevel: 4,
       optedOut: 0,
     });
     expect(result.success).toBe(true);
+  });
+
+  it('requires failedBotLevel (its own bucket, distinct from the failure buckets)', async () => {
+    const { BroadcastCompletionSummarySchema } = await import('./broadcast.js');
+    expect(
+      BroadcastCompletionSummarySchema.safeParse({
+        version: 'v3.0.0-beta.167',
+        sent: 1,
+        failedPermanent: 0,
+        failedTransient: 0,
+        optedOut: 0,
+      }).success
+    ).toBe(false);
   });
 
   it('rejects negative counts and a missing version', async () => {
@@ -182,6 +197,7 @@ describe('BroadcastCompletionSummarySchema', () => {
         sent: -1,
         failedPermanent: 0,
         failedTransient: 0,
+        failedBotLevel: 0,
         optedOut: 0,
       }).success
     ).toBe(false);
@@ -190,6 +206,7 @@ describe('BroadcastCompletionSummarySchema', () => {
         sent: 1,
         failedPermanent: 0,
         failedTransient: 0,
+        failedBotLevel: 0,
         optedOut: 0,
       }).success
     ).toBe(false);
@@ -209,6 +226,7 @@ describe('internal route inputs', () => {
   it('deliveries: accepts terminal outcomes and rejects pending', () => {
     expect(DeliveryOutcomeSchema.safeParse('sent').success).toBe(true);
     expect(DeliveryOutcomeSchema.safeParse('failed_permanent').success).toBe(true);
+    expect(DeliveryOutcomeSchema.safeParse('failed_bot_level').success).toBe(true);
     expect(DeliveryOutcomeSchema.safeParse('pending').success).toBe(false);
 
     const result = ReleaseBroadcastDeliveriesInputSchema.safeParse({

--- a/packages/common-types/src/schemas/api/broadcast.ts
+++ b/packages/common-types/src/schemas/api/broadcast.ts
@@ -83,7 +83,16 @@ export const ReleaseBroadcastPendingResponseSchema = z.object({
 // ============================================================================
 
 /** Terminal delivery outcomes the worker may report (pending is not reportable). */
-export const DeliveryOutcomeSchema = z.enum(['sent', 'failed_transient', 'failed_permanent']);
+export const DeliveryOutcomeSchema = z.enum([
+  'sent',
+  'failed_transient',
+  'failed_permanent',
+  // Bot-level failure (Discord 20026 — bot quarantined/limited, cannot create
+  // DMs). Terminal, but the recipient is reachable, so it is neither a permanent
+  // nor a transient failure: it never feeds the auto-disable streak or the
+  // retention undeliverable stamp, and it is tallied in its own bucket.
+  'failed_bot_level',
+]);
 
 export type DeliveryOutcome = z.infer<typeof DeliveryOutcomeSchema>;
 
@@ -121,6 +130,13 @@ export const BroadcastCompletionSummarySchema = z.object({
   /** Genuine delivery failures ONLY — resweep eligibility exclusions are not here. */
   failedPermanent: z.number().int().min(0),
   failedTransient: z.number().int().min(0),
+  /**
+   * Rows that failed because the BOT is quarantined/limited (Discord 20026),
+   * not because the recipient is unreachable. Kept out of both failure buckets:
+   * the users are reachable, so this must not read as delivery ill-health nor
+   * feed the per-user auto-disable streak.
+   */
+  failedBotLevel: z.number().int().min(0),
   /**
    * Rows terminalized by the incomplete-broadcast resweep because the user
    * was no longer eligible (opted out / raised their level). Administrative

--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -11,7 +11,7 @@ CREATE EXTENSION IF NOT EXISTS "vector";
 CREATE TYPE "notify_level" AS ENUM ('major', 'minor', 'patch');
 
 -- CreateEnum
-CREATE TYPE "delivery_status" AS ENUM ('pending', 'sent', 'failed_transient', 'failed_permanent');
+CREATE TYPE "delivery_status" AS ENUM ('pending', 'sent', 'failed_transient', 'failed_permanent', 'failed_bot_level');
 
 -- CreateEnum
 CREATE TYPE "feedback_status" AS ENUM ('new', 'read', 'archived');

--- a/prisma/migrations/20260723185140_add_bot_level_delivery_status/migration.sql
+++ b/prisma/migrations/20260723185140_add_bot_level_delivery_status/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "delivery_status" ADD VALUE 'failed_bot_level';
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memory_facts_embedding";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1016,6 +1016,12 @@ enum DeliveryStatus {
   sent
   failed_transient
   failed_permanent
+  /// Bot-level failure (Discord 20026 — the bot is quarantined/limited and
+  /// cannot create DMs). Terminal like the failed_* siblings, but the recipient
+  /// is reachable — the BOT is not — so it must never feed the user's
+  /// auto-disable streak or the retention dm_undeliverable_since stamp. Reported
+  /// separately in the blast tally instead of inflating either failure bucket.
+  failed_bot_level
 
   @@map("delivery_status")
 }

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
@@ -396,6 +396,7 @@ describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
       sent: 2,
       failedPermanent: 1,
       failedTransient: 0,
+      failedBotLevel: 0,
       optedOut: 0,
     });
   });
@@ -424,7 +425,36 @@ describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
       sent: 3,
       failedPermanent: 1,
       failedTransient: 0,
+      failedBotLevel: 0,
       optedOut: 2,
+    });
+  });
+
+  it('counts failed_bot_level rows in their own bucket, not permanent or transient', async () => {
+    mockPrisma.releaseDeliveryLog.count.mockResolvedValueOnce(0);
+    mockPrisma.releaseDeliveryLog.groupBy.mockResolvedValueOnce([
+      { status: 'sent', errorCode: null, _count: { _all: 1 } },
+      { status: 'failed_bot_level', errorCode: '20026', _count: { _all: 5 } },
+    ]);
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'sent' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+      summary?: unknown;
+    };
+    // The bot-quarantine rows are reachable users — kept out of both failure
+    // buckets so neither number reads as recipient ill-health.
+    expect(payload.summary).toEqual({
+      version: 'v-test',
+      sent: 1,
+      failedPermanent: 0,
+      failedTransient: 0,
+      failedBotLevel: 5,
+      optedOut: 0,
     });
   });
 

--- a/services/api-gateway/src/services/releaseBroadcast.ts
+++ b/services/api-gateway/src/services/releaseBroadcast.ts
@@ -278,6 +278,7 @@ export async function computeCompletionSummary(
       group => group.status === 'failed_permanent' && group.errorCode !== 'opted_out'
     ),
     failedTransient: countWhere(group => group.status === 'failed_transient'),
+    failedBotLevel: countWhere(group => group.status === 'failed_bot_level'),
     optedOut: countWhere(
       group => group.status === 'failed_permanent' && group.errorCode === 'opted_out'
     ),

--- a/services/api-gateway/src/services/releaseReconcile.test.ts
+++ b/services/api-gateway/src/services/releaseReconcile.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { BroadcastCompletionSummary } from '@tzurot/common-types/schemas/api/broadcast';
 import type { Queue } from 'bullmq';
 
 const announceMock = vi.hoisted(() => vi.fn());
@@ -196,8 +197,9 @@ describe('sweepIncompleteBroadcasts', () => {
       sent: 4,
       failedPermanent: 1,
       failedTransient: 0,
+      failedBotLevel: 0,
       optedOut: 0,
-    });
+    } satisfies BroadcastCompletionSummary);
   });
 
   afterEach(() => {

--- a/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.test.ts
+++ b/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DiscordAPIError, type Client } from 'discord.js';
 import { JobType } from '@tzurot/common-types/constants/queue';
 import type { ReleaseBroadcastRecipient } from '@tzurot/common-types/types/jobs';
+import type { BroadcastCompletionSummary } from '@tzurot/common-types/schemas/api/broadcast';
 import type { Job } from 'bullmq';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -137,6 +138,32 @@ describe('createReleaseDmProcessor', () => {
     ]);
     expect(deps.report).toHaveBeenNthCalledWith(2, RELEASE_ID, [
       { deliveryLogId: LOG_B, status: 'sent', sentMessageId: 'sent-b' },
+    ]);
+    expect(result).toEqual({ sent: 1, failed: 1, skipped: 0 });
+  });
+
+  it('classifies a 20026 as failed_bot_level (bot quarantined, recipient reachable)', async () => {
+    const quarantined = new DiscordAPIError(
+      { code: 20026, message: 'This application cannot send DMs' },
+      20026,
+      403,
+      'POST',
+      'url',
+      {}
+    );
+    const deps = makeDeps(userId =>
+      userId === '111111111111111111'
+        ? Promise.reject(quarantined)
+        : Promise.resolve({ id: 'sent-b' })
+    );
+    const processor = createReleaseDmProcessor(deps);
+
+    const result = await processor(asJob(makePayload()));
+
+    // Its own terminal status — never failed_permanent (would feed auto-disable)
+    // nor failed_transient (would count as recipient ill-health).
+    expect(deps.report).toHaveBeenNthCalledWith(1, RELEASE_ID, [
+      { deliveryLogId: LOG_A, status: 'failed_bot_level', errorCode: '20026' },
     ]);
     expect(result).toEqual({ sent: 1, failed: 1, skipped: 0 });
   });
@@ -290,13 +317,16 @@ describe('createReleaseDmProcessor', () => {
   });
 
   describe('completion ops report', () => {
+    // `satisfies` makes the compiler break this fixture when the summary shape
+    // moves (per 02-code-standards §8 — type your mock payloads).
     const SUMMARY = {
       version: 'adhoc-test',
       sent: 5,
       failedPermanent: 1,
       failedTransient: 0,
+      failedBotLevel: 0,
       optedOut: 2,
-    };
+    } satisfies BroadcastCompletionSummary;
 
     it('posts one owner-channel embed when a report flips the blast to completed', async () => {
       const deps = makeDeps();
@@ -317,6 +347,27 @@ describe('createReleaseDmProcessor', () => {
       expect(embed.data.description).toContain('5 sent');
       expect(embed.data.description).toContain('1 permanent-failed');
       expect(embed.data.description).toContain('2 excluded (opted out mid-blast)');
+      // No quarantine this blast — the bot-level note stays absent.
+      expect(embed.data.description).not.toContain('bot-quarantined');
+    });
+
+    it('names bot-quarantined failures plainly when the bot is limited', async () => {
+      const quarantinedSummary = {
+        ...SUMMARY,
+        failedBotLevel: 3,
+      } satisfies BroadcastCompletionSummary;
+      const deps = makeDeps();
+      deps.report
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ completed: true, summary: quarantinedSummary });
+      const processor = createReleaseDmProcessor(deps);
+
+      await processor(asJob(makePayload()));
+
+      const embed = postOwnerChannelEmbedMock.mock.calls[0][1] as {
+        data: { description?: string };
+      };
+      expect(embed.data.description).toContain('3 bot-quarantined');
     });
 
     it('posts nothing when no report claims completion (including lost-report undefined)', async () => {

--- a/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.ts
+++ b/services/bot-client/src/services/releaseDm/setupReleaseDmWorker.ts
@@ -54,6 +54,13 @@ const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTi
 /** Discord "Unknown Message" — the previous DM is already gone; goal state reached. */
 const UNKNOWN_MESSAGE_CODE = 10008;
 
+/** Classified failure kind → ledger status. bot_level is its own terminal outcome. */
+const DELIVERY_STATUS_BY_KIND = {
+  permanent: 'failed_permanent',
+  bot_level: 'failed_bot_level',
+  transient: 'failed_transient',
+} as const satisfies Record<ReturnType<typeof classifyDmError>['kind'], DeliveryReport['status']>;
+
 /**
  * Best-effort delete of the user's prior release DM so the channel holds at
  * most one release note. Never blocks the send: a failure just leaves the
@@ -115,7 +122,7 @@ async function sendOne(
       'Broadcast DM failed'
     );
     return {
-      status: classified.kind === 'permanent' ? 'failed_permanent' : 'failed_transient',
+      status: DELIVERY_STATUS_BY_KIND[classified.kind],
       errorCode: dmErrorCode(classified),
       deletedPreviousDeliveryLogId,
     };
@@ -194,13 +201,17 @@ async function postBlastCompletionReport(
 ): Promise<void> {
   const optedOutNote =
     summary.optedOut > 0 ? `, ${summary.optedOut} excluded (opted out mid-blast)` : '';
+  // Only surfaced when the bot is quarantined (Discord 20026) — a bot-level
+  // failure, not the recipients', so it reads separately from the failure buckets.
+  const botLevelNote =
+    summary.failedBotLevel > 0 ? `, ${summary.failedBotLevel} bot-quarantined` : '';
   const embed = new EmbedBuilder()
     .setColor(DISCORD_COLORS.SUCCESS)
     .setTitle('📣 Release blast completed')
     .setDescription(
       `**${summary.version}** — ${summary.sent} sent, ` +
         `${summary.failedPermanent} permanent-failed, ` +
-        `${summary.failedTransient} transient-failed${optedOutNote}`
+        `${summary.failedTransient} transient-failed${botLevelNote}${optedOutNote}`
     )
     .setTimestamp();
   await postOwnerChannelEmbed(client, embed);

--- a/services/bot-client/src/utils/dmErrorClassifier.test.ts
+++ b/services/bot-client/src/utils/dmErrorClassifier.test.ts
@@ -29,6 +29,11 @@ describe('classifyDmError', () => {
     expect(result).toEqual({ kind: 'permanent', code: 50278 });
   });
 
+  it('classifies 20026 (bot quarantined) as bot_level, not permanent or transient', () => {
+    const result = classifyDmError(makeDiscordError(20026));
+    expect(result).toEqual({ kind: 'bot_level', code: 20026 });
+  });
+
   it('classifies other Discord API errors as transient', () => {
     const result = classifyDmError(makeDiscordError(0, 500));
     expect(result.kind).toBe('transient');
@@ -48,6 +53,10 @@ describe('classifyDmError', () => {
 describe('dmErrorCode', () => {
   it('uses the numeric code for permanent failures', () => {
     expect(dmErrorCode({ kind: 'permanent', code: 50007 })).toBe('50007');
+  });
+
+  it('uses the numeric code for bot_level failures', () => {
+    expect(dmErrorCode({ kind: 'bot_level', code: 20026 })).toBe('20026');
   });
 
   it('caps transient causes at the ledger column width', () => {

--- a/services/bot-client/src/utils/dmErrorClassifier.ts
+++ b/services/bot-client/src/utils/dmErrorClassifier.ts
@@ -8,6 +8,11 @@
  *     permanents auto-disable the user's notifications server-side.
  *   - `failed_transient`: infrastructure hiccup (rate limit, network, 5xx) —
  *     a future retry sweep may re-attempt.
+ *   - `bot_level`: the BOT is quarantined/limited (Discord 20026) and cannot
+ *     create DMs. The recipient is perfectly reachable — the bot is not — so
+ *     this is neither the user's fault nor an infra hiccup: it must never feed
+ *     the recipient's auto-disable streak or the retention undeliverable stamp,
+ *     and it is tallied in its own bucket rather than either failure bucket.
  *
  * Mirrors typingErrorClassifier's discriminated-union shape.
  */
@@ -15,7 +20,9 @@
 import { DiscordAPIError } from 'discord.js';
 
 export type DmErrorClass =
-  { kind: 'permanent'; code: number } | { kind: 'transient'; cause: string };
+  | { kind: 'permanent'; code: number }
+  | { kind: 'bot_level'; code: number }
+  | { kind: 'transient'; cause: string };
 
 // Discord API error codes meaning "this user is unreachable, forever."
 const DM_PERMANENT_CODES = new Set<number>([
@@ -26,10 +33,20 @@ const DM_PERMANENT_CODES = new Set<number>([
   //       without it fails identically every release.
 ]);
 
+// Discord API error codes meaning "the BOT can't DM (quarantined / limited)."
+// The recipient is reachable; retrying won't help while the bot is flagged, and
+// it must never be charged to the recipient (auto-disable / undeliverable stamp).
+const DM_BOT_LEVEL_CODES = new Set<number>([
+  20026, // Bot quarantined / limited by Discord — createDM is refused bot-wide.
+]);
+
 export function classifyDmError(error: unknown): DmErrorClass {
   if (error instanceof DiscordAPIError) {
     if (typeof error.code === 'number' && DM_PERMANENT_CODES.has(error.code)) {
       return { kind: 'permanent', code: error.code };
+    }
+    if (typeof error.code === 'number' && DM_BOT_LEVEL_CODES.has(error.code)) {
+      return { kind: 'bot_level', code: error.code };
     }
     // 429s and 5xx-class API errors are retryable infrastructure states.
     return { kind: 'transient', cause: `discord-${String(error.code)}` };
@@ -48,5 +65,6 @@ export function classifyDmError(error: unknown): DmErrorClass {
 
 /** Ledger error-code string for a classified failure (fits VarChar(50)). */
 export function dmErrorCode(classified: DmErrorClass): string {
-  return classified.kind === 'permanent' ? String(classified.code) : classified.cause.slice(0, 50);
+  // permanent + bot_level both carry a numeric code; only transient carries a cause.
+  return classified.kind === 'transient' ? classified.cause.slice(0, 50) : String(classified.code);
 }

--- a/services/bot-client/src/utils/gatewayServiceCalls.test.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.test.ts
@@ -5,6 +5,7 @@ import {
   AudioTooLongError,
   SttUnavailableError,
 } from '@tzurot/common-types/utils/errors';
+import type { BroadcastCompletionSummary } from '@tzurot/common-types/schemas/api/broadcast';
 
 // Mock the ServiceClient factory + the service-secret accessor so the helpers
 // run without real config/network. (The context write-path helpers live in
@@ -222,8 +223,9 @@ describe('fire-and-forget helpers', () => {
       sent: 3,
       failedPermanent: 0,
       failedTransient: 1,
+      failedBotLevel: 0,
       optedOut: 0,
-    };
+    } satisfies BroadcastCompletionSummary;
     mockServiceClient.releaseBroadcastDeliveries.mockResolvedValue(
       ok({ updated: 1, autoDisabledUserIds: [], completed: true, summary })
     );


### PR DESCRIPTION
## Summary

A release-DM that fails with **Discord 20026** means the **bot** is quarantined/limited and cannot create DMs — the recipient is perfectly reachable. Today the classifier funnels 20026 into `failed_transient`, so a quarantined blast reports "N transient-failed", and (worse) a 20026 sitting next to a real permanent failure could feed the recipient's two-consecutive-permanents **auto-disable** streak.

This introduces a distinct terminal outcome so the bot's problem is never charged to the user.

## User-visible change

The release-blast owner-channel embed gains a **"N bot-quarantined"** line (shown only when > 0). No other user-facing change. Everything else is internal ledger accounting.

## What changed (cross-service, additive)

- **`prisma/schema.prisma`** — new `DeliveryStatus` enum value `failed_bot_level` → **additive migration** (`ALTER TYPE ... ADD VALUE`), premigrate-safe, no maintenance window. PGLite test schema regenerated.
- **common-types** — `DeliveryOutcomeSchema` accepts `failed_bot_level`; `BroadcastCompletionSummarySchema` gains a `failedBotLevel` bucket.
- **bot-client `dmErrorClassifier`** — third `bot_level` kind for Discord 20026 (sibling of permanent/transient), numeric code to the ledger.
- **bot-client worker** — maps `bot_level` → `failed_bot_level` via a data-driven status map; the ops embed names it plainly.
- **api-gateway `computeCompletionSummary`** — counts `failed_bot_level` in its own bucket.

## Why it's safe by construction (verified via the flow, not just intent)

`failed_bot_level` is neither `failed_permanent` nor a *prior* permanent, so it **cannot** reach `recordPermanentFailure` (the retention `dm_undeliverable_since` stamp) or `maybeAutoDisable` (the auto-disable streak keys on `status === 'failed_permanent'`). A quarantined blast therefore never marks reachable users undeliverable or disables their notifications. It's terminal (not retried) — appropriate for a durable quarantine.

## Tests

- Classifier: 20026 → `bot_level` (not permanent/transient); `dmErrorCode` → `'20026'`.
- Worker: 20026 send failure → reported `failed_bot_level`; embed surfaces "N bot-quarantined" and stays silent when zero.
- Gateway: a `failed_bot_level` groupBy row lands in `failedBotLevel`, not either failure bucket.
- Schema: `DeliveryOutcomeSchema` accepts the value; summary requires `failedBotLevel`.
- Untyped summary fixtures typed with `satisfies BroadcastCompletionSummary` (02-code-standards §8) so the next shape change breaks the compiler, not runtime.

Full pre-push gate green (turbo build/lint/test across 16 packages, typecheck:spec, depcruise, guards).

## Migration note

This is the **second additive migration** in the beta.175 range (after the retention columns). Both premigrate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)