### PR TITLE
fix(bot-client): honest DM pre-warm tally — count createDM failures

### DIFF
--- a/services/bot-client/src/services/DMCacheWarmer.test.ts
+++ b/services/bot-client/src/services/DMCacheWarmer.test.ts
@@ -76,6 +76,51 @@ describe('DMCacheWarmer', () => {
     await vi.runAllTimersAsync();
   });
 
+  it('warmAwaitable returns true when createDM resolves', async () => {
+    const createDM = vi.fn().mockResolvedValue({});
+    const result = await warmer.warmAwaitable(mockUser('user-1', createDM));
+
+    expect(result).toBe(true);
+    expect(createDM).toHaveBeenCalledTimes(1);
+    expect(warmer.has('user-1')).toBe(true);
+  });
+
+  it('warmAwaitable returns false when createDM rejects (but still memoizes)', async () => {
+    const createDM = vi.fn().mockRejectedValue(new Error('bot quarantined'));
+    const result = await warmer.warmAwaitable(mockUser('user-1', createDM));
+
+    expect(result).toBe(false);
+    // Memoized despite failure — one attempt per process lifetime, same as warm().
+    expect(warmer.has('user-1')).toBe(true);
+  });
+
+  it('warmAwaitable returns the STORED failure on a repeat call, not a hardcoded true', async () => {
+    const createDM = vi.fn().mockRejectedValue(new Error('bot quarantined'));
+    const user = mockUser('user-1', createDM);
+
+    const first = await warmer.warmAwaitable(user);
+    const second = await warmer.warmAwaitable(user);
+
+    // The memo tracks OUTCOME, not just "attempted": a failed user must stay
+    // false on the next call. The race this guards: the live event path warms
+    // (and fails) a user, then the startup prewarmer reaches the same user and
+    // must count them failed, not warmed.
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+    expect(createDM).toHaveBeenCalledTimes(1);
+  });
+
+  it('warmAwaitable returns true for an already-warmed user without a second createDM', async () => {
+    const createDM = vi.fn().mockResolvedValue({});
+    const user = mockUser('user-1', createDM);
+
+    await warmer.warmAwaitable(user);
+    const second = await warmer.warmAwaitable(user);
+
+    expect(second).toBe(true);
+    expect(createDM).toHaveBeenCalledTimes(1);
+  });
+
   it('clear() empties the memo', () => {
     warmer.warm(mockUser('user-1'));
     warmer.warm(mockUser('user-2'));

--- a/services/bot-client/src/services/DMCacheWarmer.ts
+++ b/services/bot-client/src/services/DMCacheWarmer.ts
@@ -14,10 +14,13 @@
  * effect by calling `user.createDM()` proactively whenever we encounter a
  * user via any event channel.
  *
- * The Set memo bounds calls to once-per-user-per-process-lifetime. Set growth
- * is bounded by the number of unique users who interact with the bot during
- * a single process — typically well under 10k for this scale of bot. Process
- * restart clears the memo, matching Discord-side cache lifecycle.
+ * The memo bounds createDM to once-per-user-per-process-lifetime and stores the
+ * ATTEMPT itself (a promise of its outcome), not merely "attempted" — so a
+ * repeat or concurrent caller awaits the same attempt and receives its REAL
+ * result, never a hardcoded success over a prior failure. Growth is bounded by
+ * the number of unique users who interact with the bot during a single process
+ * — typically well under 10k for this scale of bot. Process restart clears the
+ * memo, matching Discord-side cache lifecycle.
  */
 
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -26,39 +29,69 @@ import type { User } from 'discord.js';
 const logger = createLogger('DMCacheWarmer');
 
 export class DMCacheWarmer {
-  private warmedUserIds = new Set<string>();
+  // userId → the single memoized createDM attempt. Storing the PROMISE (not a
+  // bare "attempted" flag) means a repeat call — or a concurrent one, e.g. the
+  // startup prewarmer racing the live event path for the same active user —
+  // awaits the same attempt and gets its true outcome. A prior FAILED attempt
+  // therefore reports false on the next call, never a hardcoded true.
+  private warmAttempts = new Map<string, Promise<boolean>>();
+
+  /**
+   * Idempotently ensure the DM channel for `user` is cached, RETURNING the real
+   * outcome: true if createDM resolved, false if it failed. At most one
+   * createDM() per user per process lifetime; repeat/concurrent callers await
+   * the same memoized attempt and receive its actual result. Use this where the
+   * caller needs an honest success signal (the startup pre-warm tally);
+   * event-path callers use the fire-and-forget `warm`.
+   */
+  warmAwaitable(user: User): Promise<boolean> {
+    const existing = this.warmAttempts.get(user.id);
+    if (existing !== undefined) {
+      return existing;
+    }
+    // Create the attempt (createDM fires synchronously here) and memoize it
+    // BEFORE returning, so a concurrent caller in the same tick reuses it
+    // instead of firing a second createDM.
+    const attempt = this.attemptWarm(user);
+    this.warmAttempts.set(user.id, attempt);
+    return attempt;
+  }
+
+  private async attemptWarm(user: User): Promise<boolean> {
+    try {
+      await user.createDM();
+      return true;
+    } catch (err: unknown) {
+      // DM creation can fail for users with privacy DMs blocked, deleted
+      // accounts, or while the bot itself is quarantined. We just lose the
+      // warming optimization for this user; their DMs would fail dispatch the
+      // same way, but slash-command-based recovery still works as a fallback.
+      logger.debug({ err, userId: user.id }, 'createDM failed during warming');
+      return false;
+    }
+  }
 
   /**
    * Idempotently ensure the DM channel for `user` is cached in Discord.js.
-   * Fire-and-forget: failures are logged but don't propagate.
+   * Fire-and-forget: failures are logged but don't propagate. For event-path
+   * callers that must not block on createDM latency.
    */
   warm(user: User): void {
-    if (this.warmedUserIds.has(user.id)) {
-      return;
-    }
-
-    this.warmedUserIds.add(user.id);
-    void user.createDM().catch((err: unknown) => {
-      // DM creation can fail for users with privacy DMs blocked, deleted
-      // accounts, etc. We just lose the warming optimization for this user;
-      // their DMs would fail dispatch the same way, but slash-command-based
-      // recovery still works as a fallback path.
-      logger.debug({ err, userId: user.id }, 'createDM failed during warming');
-    });
+    void this.warmAwaitable(user);
   }
 
-  /** Number of users currently in the warmed-set memo. */
+  /** Number of users with a memoized warm attempt. */
   get size(): number {
-    return this.warmedUserIds.size;
+    return this.warmAttempts.size;
   }
 
-  /** Test hook: clear the warmed-set memo. */
+  /** Test hook: clear the attempt memo. */
   clear(): void {
-    this.warmedUserIds.clear();
+    this.warmAttempts.clear();
   }
 
-  /** Test hook: check whether a user has been warmed. */
+  /** Test hook: check whether a user has a memoized warm attempt. */
   has(userId: string): boolean {
-    return this.warmedUserIds.has(userId);
+    return this.warmAttempts.has(userId);
   }
 }

--- a/services/bot-client/src/services/StartupDMPrewarmer.test.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.test.ts
@@ -13,13 +13,15 @@ vi.mock('@tzurot/common-types/utils/outboundDmAllowlist', () => ({
   getOutboundDmAllowlist: () => allowlistMock.value,
 }));
 
+// Stable info spy so the completion-tally log ({ warmed, failed }) is assertable.
+const loggerInfoMock = vi.hoisted(() => vi.fn());
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
   );
   return {
     ...actual,
-    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    createLogger: () => ({ debug: vi.fn(), info: loggerInfoMock, warn: vi.fn(), error: vi.fn() }),
   };
 });
 
@@ -38,15 +40,18 @@ function mockUser(id: string): User {
 describe('StartupDMPrewarmer', () => {
   let prewarmer: StartupDMPrewarmer;
   let mockClient: { users: { fetch: ReturnType<typeof vi.fn> } };
-  let mockWarmer: { warm: ReturnType<typeof vi.fn> };
+  let mockWarmer: { warmAwaitable: ReturnType<typeof vi.fn> };
   let mockSleep: ReturnType<typeof vi.fn<(ms: number) => Promise<void>>>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     mockRecentUsers.mockReset();
+    loggerInfoMock.mockReset();
     allowlistMock.value = null;
     mockClient = { users: { fetch: vi.fn() } };
-    mockWarmer = { warm: vi.fn() };
+    // Default: every warm succeeds (createDM resolved). Tests that exercise a
+    // failure override this per call.
+    mockWarmer = { warmAwaitable: vi.fn().mockResolvedValue(true) };
     mockSleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
     prewarmer = new StartupDMPrewarmer({
       client: mockClient as unknown as Client,
@@ -70,7 +75,7 @@ describe('StartupDMPrewarmer', () => {
 
     expect(mockClient.users.fetch).toHaveBeenCalledTimes(1);
     expect(mockClient.users.fetch).toHaveBeenCalledWith('allowed-1');
-    expect(mockWarmer.warm).toHaveBeenCalledTimes(1);
+    expect(mockWarmer.warmAwaitable).toHaveBeenCalledTimes(1);
   });
 
   it('warms each user returned by the recent-users endpoint', async () => {
@@ -89,7 +94,7 @@ describe('StartupDMPrewarmer', () => {
     expect(mockClient.users.fetch).toHaveBeenCalledTimes(2);
     expect(mockClient.users.fetch).toHaveBeenCalledWith('111111111111111111');
     expect(mockClient.users.fetch).toHaveBeenCalledWith('222222222222222222');
-    expect(mockWarmer.warm).toHaveBeenCalledTimes(2);
+    expect(mockWarmer.warmAwaitable).toHaveBeenCalledTimes(2);
     expect(mockSleep).toHaveBeenCalledWith(1000);
   });
 
@@ -118,7 +123,7 @@ describe('StartupDMPrewarmer', () => {
     await prewarmer.run();
 
     expect(mockSleep).not.toHaveBeenCalled();
-    expect(mockWarmer.warm).toHaveBeenCalledTimes(1);
+    expect(mockWarmer.warmAwaitable).toHaveBeenCalledTimes(1);
   });
 
   it('continues when a single user fetch fails (e.g. deleted account)', async () => {
@@ -136,7 +141,25 @@ describe('StartupDMPrewarmer', () => {
     await prewarmer.run();
 
     expect(mockClient.users.fetch).toHaveBeenCalledTimes(3);
-    expect(mockWarmer.warm).toHaveBeenCalledTimes(2);
+    expect(mockWarmer.warmAwaitable).toHaveBeenCalledTimes(2);
+  });
+
+  it('counts createDM failures in the failed tally (honest bot-quarantine accounting)', async () => {
+    mockRecentUsers.mockResolvedValue(
+      okResult({ discordIds: ['111111111111111111', '222222222222222222'], sinceDays: 30 })
+    );
+    mockClient.users.fetch.mockImplementation((id: string) => Promise.resolve(mockUser(id)));
+    // First user's createDM succeeds; the second is refused (e.g. bot quarantined).
+    mockWarmer.warmAwaitable.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await prewarmer.run();
+
+    // The old fire-and-forget path would have logged warmed=2 failed=0; awaiting
+    // the real outcome makes the tally honest about a refused DM.
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      { warmed: 1, failed: 1, elapsedSec: expect.any(Number) },
+      'DM cache pre-warm complete'
+    );
   });
 
   it('skips warming entirely when api-gateway fetch fails on every retry (network errors)', async () => {
@@ -145,7 +168,7 @@ describe('StartupDMPrewarmer', () => {
     await prewarmer.run();
 
     expect(mockClient.users.fetch).not.toHaveBeenCalled();
-    expect(mockWarmer.warm).not.toHaveBeenCalled();
+    expect(mockWarmer.warmAwaitable).not.toHaveBeenCalled();
     // 1 initial attempt + 3 retries = 4 total calls
     expect(mockRecentUsers).toHaveBeenCalledTimes(4);
   });
@@ -158,7 +181,7 @@ describe('StartupDMPrewarmer', () => {
     await prewarmer.run();
 
     expect(mockClient.users.fetch).not.toHaveBeenCalled();
-    expect(mockWarmer.warm).not.toHaveBeenCalled();
+    expect(mockWarmer.warmAwaitable).not.toHaveBeenCalled();
     expect(mockRecentUsers).toHaveBeenCalledTimes(4);
     // Sleep called once per retry delay (3 retries → 3 sleeps; no sleep
     // before the initial attempt or after the final failure).
@@ -178,7 +201,7 @@ describe('StartupDMPrewarmer', () => {
     await prewarmer.run();
 
     expect(mockRecentUsers).toHaveBeenCalledTimes(2);
-    expect(mockWarmer.warm).toHaveBeenCalledTimes(1);
+    expect(mockWarmer.warmAwaitable).toHaveBeenCalledTimes(1);
     expect(mockSleep).toHaveBeenCalledWith(5000); // first retry delay
   });
 
@@ -191,7 +214,7 @@ describe('StartupDMPrewarmer', () => {
     await prewarmer.run();
 
     expect(mockRecentUsers).toHaveBeenCalledTimes(2);
-    expect(mockWarmer.warm).toHaveBeenCalledTimes(1);
+    expect(mockWarmer.warmAwaitable).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/services/bot-client/src/services/StartupDMPrewarmer.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.ts
@@ -3,8 +3,10 @@
  *
  * On bot startup, fetches the list of recently active Discord user IDs from
  * api-gateway (`GET /internal/users/recent`), then walks the list at a slow
- * rate-limited cadence calling `client.users.fetch(id).then(u => warmer.warm(u))`
- * to pre-populate Discord.js's DM channel cache for those users.
+ * rate-limited cadence, awaiting `warmer.warmAwaitable(user)` per user, to
+ * pre-populate Discord.js's DM channel cache for those users. Awaiting (vs the
+ * event path's fire-and-forget `warm`) is what lets the completion tally count
+ * real createDM failures rather than mere attempts.
  *
  * Why slow (1/sec): the Discord.js REST manager processes requests through
  * a queue. Bursting createDM calls would compete with live user-traffic
@@ -111,8 +113,16 @@ export class StartupDMPrewarmer {
       const discordId = discordIds[i];
       try {
         const user = await this.client.users.fetch(discordId);
-        this.warmer.warm(user);
-        warmed += 1;
+        // Await the warm so the tally reflects the REAL createDM outcome: a
+        // quarantined bot (every createDM 403s) now shows warmed=0 failed=N
+        // instead of the fire-and-forget path's misleading warmed=N failed=0.
+        // The loop already paces at RATE_LIMIT_DELAY_MS, so awaiting adds only
+        // the createDM latency, not a new burst.
+        if (await this.warmer.warmAwaitable(user)) {
+          warmed += 1;
+        } else {
+          failed += 1;
+        }
       } catch (err) {
         // Common: deleted accounts (10013), accounts the bot can't see, etc.
         // Logging at debug to avoid noise from expected attrition over a
@@ -129,10 +139,10 @@ export class StartupDMPrewarmer {
     }
 
     const elapsedSec = Math.round((Date.now() - start) / 1000);
-    // `warmed` = users.fetch() succeeded and warm() was invoked. createDM()
-    // inside warm() runs fire-and-forget, so this counts "warming attempted"
-    // not "DM channel definitively cached." `failed` counts users.fetch()
-    // errors only (deleted accounts, etc.).
+    // `warmed` = createDM() actually resolved (DM channel truly cached).
+    // `failed` counts BOTH users.fetch() errors AND createDM() failures
+    // (blocked DMs, deleted accounts, or a bot-level quarantine) — an honest
+    // tally, since it awaits warmAwaitable rather than firing-and-forgetting.
     logger.info({ warmed, failed, elapsedSec }, 'DM cache pre-warm complete');
   }
 


### PR DESCRIPTION
## Summary

The startup DM pre-warm logged `warmed=N failed=0` even when `createDM()` actually 403'd, because `DMCacheWarmer.warm()` fires createDM **fire-and-forget** — the prewarmer counted "warm() invoked", never the real outcome. During a bot-level quarantine (every createDM 403s), the completion log falsely read all-clear.

This is the accounting sibling of the 20026 classification work (#1774): make the quarantine visible instead of hidden.

## What changed

- **`DMCacheWarmer.warmAwaitable(user): Promise<boolean>`** — the same idempotent memo contract (marked before the await; a failed attempt is not retried this process lifetime), but returns whether the DM channel is cached. The event-path `warm()` stays fire-and-forget by delegating to it (`void`).
- **`StartupDMPrewarmer`** — awaits `warmAwaitable` and counts createDM failures into `failed`. The loop already paces at 1/sec, so awaiting adds only createDM latency, not a new boot-burst. A quarantine now logs `warmed=0 failed=N` honestly.

## Tests

- `warmAwaitable` returns true on success, false on createDM rejection (still memoized), true on an already-warmed user (no second createDM). Existing `warm()` tests unchanged (createDM still fires synchronously).
- Prewarmer: a mixed batch (one createDM succeeds, one refused) logs `{ warmed: 1, failed: 1 }` — the drift the old fire-and-forget path hid.

Full pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)