### PR TITLE
feat: retention Phase 2 PR-A — flag plumbing + schema

### DIFF
--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -37,10 +37,25 @@ CREATE TABLE "users" (
     "notify_auto_disabled_at" TIMESTAMP(3),
     "last_active_at" TIMESTAMP(3),
     "dm_undeliverable_since" TIMESTAMP(3),
+    "discord_account_gone_at" TIMESTAMP(3),
+    "retention_exempt" BOOLEAN NOT NULL DEFAULT false,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "retention_purge_log" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "target_discord_id" VARCHAR(20) NOT NULL,
+    "purged_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "run_context" TEXT,
+    "deletion_counts" JSONB NOT NULL,
+    "db_outcome" VARCHAR(16) NOT NULL,
+    "off_db_reconciled" VARCHAR(16) NOT NULL DEFAULT 'pending',
+
+    CONSTRAINT "retention_purge_log_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -213,6 +228,7 @@ CREATE TABLE "personalities" (
     "voice_reference_data" BYTEA,
     "voice_reference_type" VARCHAR(50),
     "config_defaults" JSONB,
+    "original_owner_discord_id" VARCHAR(20),
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
 

--- a/prisma/migrations/20260724051854_retention_phase2_flags/migration.sql
+++ b/prisma/migrations/20260724051854_retention_phase2_flags/migration.sql
@@ -1,0 +1,25 @@
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memory_facts_embedding";
+
+-- AlterTable
+ALTER TABLE "personalities" ADD COLUMN     "original_owner_discord_id" VARCHAR(20);
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "discord_account_gone_at" TIMESTAMP(3),
+ADD COLUMN     "retention_exempt" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "retention_purge_log" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "target_discord_id" VARCHAR(20) NOT NULL,
+    "purged_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "run_context" TEXT,
+    "deletion_counts" JSONB NOT NULL,
+    "db_outcome" VARCHAR(16) NOT NULL,
+    "off_db_reconciled" VARCHAR(16) NOT NULL DEFAULT 'pending',
+
+    CONSTRAINT "retention_purge_log_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,21 @@ model User {
   /// user is never left flagged unreachable (an inactive user stops clearing it,
   /// which is exactly the retention cohort). Reads guard with != null.
   dmUndeliverableSince  DateTime?                  @map("dm_undeliverable_since")
+  /// State machine (sibling of dmUndeliverableSince, a stronger signal): NULL
+  /// until a release DM permanently fails with Discord 10013 (Unknown User =
+  /// the account is DELETED, not merely unreachable). Set to the first-failure
+  /// time; never advances while non-null. A deleted account cannot clear it via
+  /// activity, so it persists — the retention purge branch (Phase 2) treats a
+  /// persisted gone-account as immediate-purge-eligible (skips the 180-day
+  /// inactivity wait). Kept DISTINCT from dmUndeliverableSince because 10013
+  /// warrants a different, faster purge policy than 50278/50007. Reads guard
+  /// with != null.
+  discordAccountGoneAt  DateTime?                  @map("discord_account_gone_at")
+  /// Operator-set exemption: when true, the retention purge job never selects
+  /// this user (test/burner/VIP/pending-dispute accounts). Distinct from
+  /// isSuperuser (which grants admin powers — the wrong lever for an exemption).
+  /// Never set by any automated path; owner-controlled. Default false.
+  retentionExempt       Boolean                    @default(false) @map("retention_exempt")
   createdAt             DateTime                   @default(now()) @map("created_at")
   updatedAt             DateTime                   @updatedAt @map("updated_at")
   releaseDeliveries     ReleaseDeliveryLog[]
@@ -105,6 +120,34 @@ model User {
   @@index([defaultTtsConfigId])
   @@index([defaultPersonaId])
   @@map("users")
+}
+
+/// Audit + off-DB reconciliation ledger for retention purges (Retention Phase 2,
+/// D14). One row per purged account. Deliberately NO relation to users — the
+/// purge deletes the user row, so target_discord_id is a plain string record.
+/// Doubles as the off-DB retry queue: a row whose off_db_reconciled is not
+/// 'done' is picked up by the reconciliation sweep (its backing index ships
+/// with that query in the purge PR, per index-ships-with-its-query).
+model RetentionPurgeLog {
+  /// DB-generated (gen_random_uuid) rather than the app-generated deterministic
+  /// UUIDs most models use — this is a pure non-relational audit ledger, nothing
+  /// needs the id before insert, so there is no determinism requirement.
+  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  /// The purged user's Discord snowflake (the user row itself is deleted).
+  targetDiscordId String   @map("target_discord_id") @db.VarChar(20)
+  purgedAt        DateTime @default(now()) @map("purged_at")
+  /// Operator/run label identifying who or what triggered the purge run.
+  runContext      String?  @map("run_context")
+  /// Per-table deletion counts (the AccountDeletionSummary shape).
+  deletionCounts  Json     @map("deletion_counts")
+  /// 'success' once the erasure transaction committed; 'failed' otherwise.
+  dbOutcome       String   @map("db_outcome") @db.VarChar(16)
+  /// Off-DB cleanup (avatar unlink / Redis eviction / cache broadcast)
+  /// reconciliation state: 'pending' | 'done' | 'failed'. A non-'done' row is
+  /// the retry queue for the off-DB reconciliation sweep.
+  offDbReconciled String   @default("pending") @map("off_db_reconciled") @db.VarChar(16)
+
+  @@map("retention_purge_log")
 }
 
 /// Tracks API usage per user for monitoring, billing, and abuse prevention.
@@ -372,6 +415,13 @@ model Personality {
   voiceReferenceType     String? @map("voice_reference_type") @db.VarChar(50)
   /// JSONB config cascade defaults (personality tier). Validated against ConfigOverridesSchema at runtime.
   configDefaults         Json?   @map("config_defaults")
+  /// Orphan-bucket provenance (Retention Phase 2, D11): NULL for normally-owned
+  /// characters. Set to the ORIGINAL owner's Discord ID when a retention purge
+  /// re-homes a character with cross-user reach to the "Orphaned Characters"
+  /// sentinel owner (instead of deleting it out from under active users). Lets a
+  /// later reclamation flow hand ownership back if the original owner returns.
+  /// Reads guard with != null.
+  originalOwnerDiscordId String? @map("original_owner_discord_id") @db.VarChar(20)
 
   createdAt               DateTime                        @default(now()) @map("created_at")
   updatedAt               DateTime                        @updatedAt @map("updated_at")

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
@@ -56,6 +56,13 @@ function makeDeps(): RouteDeps {
   return { prisma: mockPrisma as unknown as PrismaClient } as unknown as RouteDeps;
 }
 
+/** True if any $executeRaw call's SQL skeleton contains `substr`. */
+function executeRawSqlIncludes(substr: string): boolean {
+  return (mockPrisma.$executeRaw as ReturnType<typeof vi.fn>).mock.calls.some(call =>
+    (call[0] as TemplateStringsArray).join(' ').includes(substr)
+  );
+}
+
 function createMockReqRes(body: Record<string, unknown>) {
   const req = { body, params: { releaseId: RELEASE_ID } } as unknown as Request;
   const res = {
@@ -241,6 +248,82 @@ describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
     expect(payload.autoDisabledUserIds).toEqual([USER_A]);
   });
 
+  it('stamps discord_account_gone_at (NOT dm_undeliverable_since) on a 10013 deleted-account failure', async () => {
+    mockPrisma.releaseDeliveryLog.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.releaseDeliveryLog.count.mockResolvedValue(1); // pending remains → no completion flip
+    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
+    mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce({ status: 'sent' }); // no auto-disable
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '10013' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    // 10013 = deleted account → the DISTINCT gone-account stamp (its own
+    // first-failure guard), not the 50278/50007 unreachable stamp.
+    expect(executeRawSqlIncludes('discord_account_gone_at = NOW()')).toBe(true);
+    expect(executeRawSqlIncludes('dm_undeliverable_since = NOW()')).toBe(false);
+  });
+
+  it('clears dm_undeliverable_since for the sent set (blast-success clear)', async () => {
+    mockPrisma.releaseDeliveryLog.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.releaseDeliveryLog.count.mockResolvedValue(1); // pending remains → no completion flip
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'sent', sentMessageId: 'm-1' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    // A reached-again user (rejoined a server so THIS blast landed but never
+    // otherwise interacted) gets their stale unreachable flag cleared, batched
+    // over the sent set — otherwise the purge branch would route them to
+    // unreachable-purge-without-notice.
+    expect(executeRawSqlIncludes('dm_undeliverable_since = NULL')).toBe(true);
+  });
+
+  it('swallows a failed blast-success clear without failing the batch', async () => {
+    mockPrisma.releaseDeliveryLog.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.releaseDeliveryLog.count.mockResolvedValue(1); // pending remains → no completion flip
+    // The clear is best-effort: delivery rows are already committed, so a raw-SQL
+    // failure must not 500 the batch. A sent-only result routes $executeRaw solely
+    // to the clear, so this rejection exercises exactly its catch — the batch must
+    // still report its success payload.
+    mockPrisma.$executeRaw.mockRejectedValueOnce(new Error('db unavailable'));
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      results: [{ deliveryLogId: LOG_A, status: 'sent', sentMessageId: 'm-1' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      updated: 1,
+      autoDisabledUserIds: [],
+      completed: false,
+    });
+  });
+
+  it('stamps NO retention signal on an unrecognized permanent-failure code', async () => {
+    mockPrisma.releaseDeliveryLog.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.releaseDeliveryLog.count.mockResolvedValue(1);
+    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
+    mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce(null);
+    const handler = handleReleaseBroadcastDeliveries(makeDeps());
+    const { req, res } = createMockReqRes({
+      // Neither a per-user unreachable code (50278/50007) nor deleted-account
+      // (10013) → stamps nothing. Guards the if/else-if from silently growing a
+      // branch that stamps unconditionally (a wrong stamp = wrong purge later).
+      results: [{ deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '99999' }],
+    });
+
+    await handler(req, res, vi.fn());
+
+    expect(executeRawSqlIncludes('dm_undeliverable_since = NOW()')).toBe(false);
+    expect(executeRawSqlIncludes('discord_account_gone_at = NOW()')).toBe(false);
+  });
+
   it('does NOT auto-disable when the previous delivery was non-permanent (counter resets)', async () => {
     mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
     mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce({ status: 'sent' });
@@ -332,21 +415,6 @@ describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
     expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
     const [template] = mockPrisma.$executeRaw.mock.calls[0] as [string[], string];
     expect(template.join('')).toContain('dm_undeliverable_since');
-  });
-
-  it('does NOT stamp dm_undeliverable_since on a non-unreachable permanent code (e.g. 10013)', async () => {
-    // 10013 = deleted account: a distinct, stronger signal handled in the Phase 2
-    // purge branch, NOT the 180-day undeliverable clock. Only 50278/50007 stamp.
-    mockPrisma.releaseDeliveryLog.findUnique.mockResolvedValueOnce({ userId: USER_A });
-    mockPrisma.releaseDeliveryLog.findFirst.mockResolvedValueOnce(null);
-    const handler = handleReleaseBroadcastDeliveries(makeDeps());
-    const { req, res } = createMockReqRes({
-      results: [{ deliveryLogId: LOG_A, status: 'failed_permanent', errorCode: '10013' }],
-    });
-
-    await handler(req, res, vi.fn());
-
-    expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
   });
 
   it('swallows an undeliverable-stamp failure and keeps processing the rest of the batch', async () => {

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.ts
@@ -96,12 +96,13 @@ async function maybeAutoDisable(
  * call auto-disabled them (so the caller can report it), else null.
  *
  * Retention: 50278 = user left every shared server; 50007 = DMs closed or bot
- * blocked. NEVER 20026 (bot-wide quarantine — would false-flag every recipient)
- * or 10013 (deleted account — a distinct, stronger signal deferred to the Phase
- * 2 purge branch). The `dm_undeliverable_since IS NULL` guard records the FIRST
- * failure only (never advances a live streak); raw SQL keeps the column off
- * updated_at, the dev<->prod sync LWW resolver — same reasoning as the
- * getOrCreateUser lastActiveAt stamp.
+ * blocked, both → dm_undeliverable_since. 10013 = deleted account (a distinct,
+ * stronger signal) → discord_account_gone_at, kept separate because a gone
+ * account warrants a faster purge policy (immediate, not the 180-day wait).
+ * NEVER 20026 (bot-wide quarantine — would false-flag every recipient). Each
+ * `... IS NULL` guard records the FIRST failure only (never advances a live
+ * streak); raw SQL keeps the columns off updated_at, the dev<->prod sync LWW
+ * resolver — same reasoning as the getOrCreateUser lastActiveAt stamp.
  *
  * Best-effort, never fatal (mirrors the getOrCreateUser stamp's swallow): these
  * are non-critical signals that self-heal on the next release blast (a still-
@@ -130,6 +131,11 @@ async function recordPermanentFailure(
         UPDATE users SET dm_undeliverable_since = NOW()
         WHERE id = ${row.userId}::uuid AND dm_undeliverable_since IS NULL
       `;
+    } else if (errorCode === '10013') {
+      await prisma.$executeRaw`
+        UPDATE users SET discord_account_gone_at = NOW()
+        WHERE id = ${row.userId}::uuid AND discord_account_gone_at IS NULL
+      `;
     }
     return (await maybeAutoDisable(prisma, deliveryLogId, row.userId)) ? row.userId : null;
   } catch (err) {
@@ -138,6 +144,39 @@ async function recordPermanentFailure(
       'Permanent-failure side-effects (undeliverable stamp / auto-disable) failed; non-fatal'
     );
     return null;
+  }
+}
+
+/**
+ * D10 (blast-success clear): a successful delivery proves the user is reachable
+ * again — clear any stale dm_undeliverable_since (e.g. they went undeliverable,
+ * rejoined a server so THIS blast reached them, but never otherwise interacted,
+ * so the getOrCreateUser activity-clear never fired). Batched over the sent set
+ * in one UPDATE; raw SQL keeps the write off updated_at (the sync LWW resolver);
+ * the IS NOT NULL guard makes it a targeted clear, not a per-row no-op each
+ * blast. Best-effort — the delivery rows are already committed, so a throw here
+ * must not 500 the batch (same swallow rationale as recordPermanentFailure).
+ */
+async function clearUndeliverableForSent(
+  prisma: PrismaClient,
+  sentDeliveryLogIds: string[]
+): Promise<void> {
+  if (sentDeliveryLogIds.length === 0) {
+    return;
+  }
+  try {
+    await prisma.$executeRaw`
+      UPDATE users SET dm_undeliverable_since = NULL
+      WHERE dm_undeliverable_since IS NOT NULL
+        AND id IN (
+          SELECT user_id FROM release_delivery_log WHERE id = ANY(${sentDeliveryLogIds}::uuid[])
+        )
+    `;
+  } catch (err) {
+    logger.warn(
+      { err, count: sentDeliveryLogIds.length },
+      'Blast-success undeliverable clear failed; non-fatal'
+    );
   }
 }
 
@@ -154,6 +193,7 @@ export const handleReleaseBroadcastDeliveries = (deps: RouteDeps): RequestHandle
 
     let updated = 0;
     const autoDisabledUserIds: string[] = [];
+    const sentDeliveryLogIds: string[] = [];
 
     for (const result of parseResult.data.results) {
       // The worker deleted this user's PRIOR release DM before sending —
@@ -184,6 +224,10 @@ export const handleReleaseBroadcastDeliveries = (deps: RouteDeps): RequestHandle
       }
       updated += 1;
 
+      if (result.status === 'sent') {
+        sentDeliveryLogIds.push(result.deliveryLogId);
+      }
+
       if (result.status === 'failed_permanent') {
         const autoDisabledUserId = await recordPermanentFailure(
           prisma,
@@ -195,6 +239,8 @@ export const handleReleaseBroadcastDeliveries = (deps: RouteDeps): RequestHandle
         }
       }
     }
+
+    await clearUndeliverableForSent(prisma, sentDeliveryLogIds);
 
     const summary = await stampCompletionIfFinal(prisma, releaseId, now);
     const completed = summary !== undefined;

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -52,6 +52,8 @@ export const EXCLUDED_TABLES: Record<string, string> = {
   // Operational state
   secret_rotations:
     'Environment-local secret-rotation ledger — each env rotates (and nags) on its own clock',
+  retention_purge_log:
+    'Environment-local retention purge audit + off-DB reconciliation ledger — each env purges its own userbase',
 };
 
 export interface TableSyncConfig {


### PR DESCRIPTION
## Retention Phase 2 — PR-A (flag plumbing + schema)

First PR of the retention purge line. Additive schema + delivery-handler prerequisites — **no purge yet**; this lands the signals the purge job (PR-C/D) will read.

**Design:** [`inactivity-retention-purge-phase2.md`](https://github.com/lbds137/tzurot/blob/develop/docs/proposals/backlog/inactivity-retention-purge-phase2.md) (D10–D14), ACCEPTED. Prerequisite Phase 1.5 (#1778) already merged.

### Schema (all additive → premigrate-safe)
- **`users.discord_account_gone_at`** (D13) — the 10013 deleted-account signal, distinct from `dm_undeliverable_since`.
- **`users.retention_exempt`** (D12, `@default(false)`) — operator never-purge flag (test/burner/VIP), distinct from `is_superuser`.
- **`personalities.original_owner_discord_id`** (D11) — orphan-bucket provenance for the sentinel-reassignment path.
- **`retention_purge_log`** table (D14) — purge audit trail + off-DB reconciliation queue (`off_db_reconciled`). No FK to `users` (the row is deleted); added to `EXCLUDED_TABLES` (per-env, not synced).

### Delivery-handler behaviors (`handleReleaseBroadcastDeliveries`)
- **D10 blast-success clear** — a `sent` delivery clears the user's stale `dm_undeliverable_since`, batched over the sent set. Correctness prerequisite: a rejoined-reachable user (undeliverable → rejoined a server → this blast reached them → never otherwise interacted) must not route to the unreachable-purge-without-notice branch.
- **D13 10013 stamp** — a release DM failing with Discord 10013 stamps `discord_account_gone_at` (first-failure-guarded), kept separate from 50278/50007's `dm_undeliverable_since` because a *gone* account warrants a faster purge policy than an *unreachable* one.

### Verified
- Release-broadcast tests green (35), including new seam tests asserting the 10013 stamp SQL and the blast-clear SQL cross the `$executeRaw` boundary (§7) — the blast-clear test caught a missing wire during development.
- Migration applied to local dev + PGLite schema regenerated. `EXCLUDED_TABLES` coverage test updated for the new table. `pnpm quality` green (typecheck/lint/depcruise/knip/cpd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)