### PR TITLE
feat(api-gateway): retention Phase 2 PR-C — cohort preview (read-only)

### DIFF
--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -64,6 +64,29 @@ Commands for analyzing and managing pgvector memories:
 
 **Use case:** After migrations or data imports, check for and clean up duplicate memory embeddings.
 
+## Retention Commands
+
+Data-minimization tooling for the inactivity retention/purge epic:
+
+| Command                                                       | Description                                                               |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `pnpm ops retention:preview --env dev`                        | Report the purge-eligible cohort + character impact (**read-only**)       |
+| `pnpm ops retention:backfill-last-active --env dev --dry-run` | Report which users' `last_active_at` would advance                        |
+| `pnpm ops retention:backfill-last-active --env dev`           | Seed `last_active_at` from historical activity (forward-only, idempotent) |
+| `pnpm ops retention:backfill-last-active --env prod --force`  | Skip the production confirmation prompt                                   |
+
+**`retention:preview` is safe to run against prod** — it mutates nothing and has
+no confirmation prompt. It reads the cohort from the gateway
+(`GET /internal/retention/preview`) rather than querying locally, so the report
+reflects exactly the eligibility predicate a purge would act on. It needs the
+Railway CLI logged in (credentials come from the `api-gateway` service's
+variables).
+
+A user is purge-eligible when they are **unreachable** (DMs permanently failed,
+or their Discord account is gone) **and** inactive past the retention window.
+The bot owner and any `retention_exempt` account — including the Orphaned
+Characters sentinel — are always excluded.
+
 ## Context Commands
 
 Quick codebase state for AI session startup:

--- a/packages/clients/src/clients/_generated/service-client.ts
+++ b/packages/clients/src/clients/_generated/service-client.ts
@@ -261,6 +261,20 @@ export class ServiceClient {
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */
+  async retentionPreview(): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.retentionPreview.output>>> {
+    const fullPath = '/api/internal/retention/preview';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'GET',
+      path: fullPath,
+      outputSchema: ROUTE_MANIFEST.retentionPreview.output,
+    });
+  }
+
+  /**
+   * @safeRead Server-side has no observable mutation — safe to cache client-side.
+   */
   async getModels(options: { inputModality?: string; outputModality?: string; search?: string; limit?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.getModels.output>>> {
     const fullPath = '/api/internal/models' + buildQueryString([['inputModality', options.inputModality], ['outputModality', options.outputModality], ['search', options.search], ['limit', options.limit]]);
     return callGateway({

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -48,6 +48,7 @@ import {
   PersistUserMessageRequestSchema,
   PersistUserMessageResponseSchema,
   RecentUsersResponseSchema,
+  RetentionPreviewResponseSchema,
   RoutingContextRequestSchema,
   RoutingContextResponseSchema,
   SecretRotationStatusResponseSchema,
@@ -354,6 +355,24 @@ export const internalRoutes = {
     path: '/secret-rotations',
     id: 'secretRotationStatus',
     output: SecretRotationStatusResponseSchema,
+    serviceOnly: true,
+    meta: { safeRead: true },
+  },
+
+  /**
+   * GET /api/internal/retention/preview
+   * The purge-eligible cohort (Retention Phase 2, D2/D3) with per-user
+   * character impact and the circuit-breaker annotation. READ-ONLY — it
+   * reports; the purge itself is a separate, later endpoint. Consumed by the
+   * `pnpm ops retention:preview` CLI and (later) the daily owner-channel nag,
+   * both reading the same predicate so their counts can never drift.
+   */
+  retentionPreview: {
+    audience: 'internal',
+    method: 'get',
+    path: '/retention/preview',
+    id: 'retentionPreview',
+    output: RetentionPreviewResponseSchema,
     serviceOnly: true,
     meta: { safeRead: true },
   },

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -18,6 +18,8 @@ import {
   RoutingContextResponseSchema,
   SecretRotationEntrySchema,
   SecretRotationStatusResponseSchema,
+  RetentionPreviewUserSchema,
+  RetentionPreviewResponseSchema,
 } from './internal.js';
 
 describe('DiscordSnowflakeSchema', () => {
@@ -643,5 +645,70 @@ describe('SecretRotationEntrySchema', () => {
   it('requires every field (no partial ledger rows on the wire)', () => {
     const { overdueDays: _dropped, ...partial } = entry;
     expect(SecretRotationEntrySchema.safeParse(partial).success).toBe(false);
+  });
+});
+
+describe('RetentionPreviewUserSchema', () => {
+  const user = {
+    discordId: '900000000000000071',
+    inactiveSince: '2025-01-01T00:00:00.000Z',
+    reason: 'unreachable' as const,
+    ownedCharacters: { toDelete: 2, toReHome: 1 },
+  };
+
+  it('accepts both eligibility reasons', () => {
+    expect(RetentionPreviewUserSchema.safeParse(user).success).toBe(true);
+    expect(RetentionPreviewUserSchema.safeParse({ ...user, reason: 'account_gone' }).success).toBe(
+      true
+    );
+  });
+
+  it('rejects an unknown reason (the purge branches on it)', () => {
+    expect(RetentionPreviewUserSchema.safeParse({ ...user, reason: 'inactive' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects a non-snowflake discordId and negative character counts', () => {
+    expect(RetentionPreviewUserSchema.safeParse({ ...user, discordId: 'nope' }).success).toBe(
+      false
+    );
+    expect(
+      RetentionPreviewUserSchema.safeParse({
+        ...user,
+        ownedCharacters: { toDelete: -1, toReHome: 0 },
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('RetentionPreviewResponseSchema', () => {
+  const response = {
+    users: [],
+    totals: {
+      eligibleCount: 0,
+      userbaseCount: 270,
+      percentOfUserbase: 0,
+      charactersToDelete: 0,
+      charactersToReHome: 0,
+      breakerWarning: false,
+    },
+  };
+
+  it('accepts an empty cohort (the healthy steady state)', () => {
+    expect(RetentionPreviewResponseSchema.safeParse(response).success).toBe(true);
+  });
+
+  it('accepts a fractional percentage (one decimal place)', () => {
+    const parsed = RetentionPreviewResponseSchema.safeParse({
+      ...response,
+      totals: { ...response.totals, eligibleCount: 26, percentOfUserbase: 9.6 },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('requires the breaker flag (a missing warning must not read as false)', () => {
+    const { breakerWarning: _dropped, ...totals } = response.totals;
+    expect(RetentionPreviewResponseSchema.safeParse({ ...response, totals }).success).toBe(false);
   });
 });

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -293,3 +293,41 @@ export const SecretRotationStatusResponseSchema = z.object({
   entries: z.array(SecretRotationEntrySchema),
   overdueCount: z.number().int().nonnegative(),
 });
+
+// ============================================================================
+// GET /internal/retention/preview — purge-eligible cohort (Retention Phase 2)
+// ============================================================================
+
+/**
+ * One purge-eligible user, with what would happen to the characters they own.
+ * Read-only reporting: the preview mutates nothing.
+ */
+export const RetentionPreviewUserSchema = z.object({
+  discordId: DiscordSnowflakeSchema,
+  /** Inactivity anchor as ISO — last_active_at, or created_at when never stamped. */
+  inactiveSince: z.string().datetime(),
+  /** `account_gone` (Discord 10013) is the stronger signal and wins when both are set. */
+  reason: z.enum(['unreachable', 'account_gone']),
+  ownedCharacters: z.object({
+    /** Nobody else has data on them — deleted with the account. */
+    toDelete: z.number().int().nonnegative(),
+    /** Other users have data on them — re-homed to the orphan sentinel (D11). */
+    toReHome: z.number().int().nonnegative(),
+  }),
+});
+
+export const RetentionPreviewResponseSchema = z.object({
+  users: z.array(RetentionPreviewUserSchema),
+  totals: z.object({
+    eligibleCount: z.number().int().nonnegative(),
+    userbaseCount: z.number().int().nonnegative(),
+    /** Cohort as a percentage of the userbase, one decimal place. */
+    percentOfUserbase: z.number().nonnegative(),
+    charactersToDelete: z.number().int().nonnegative(),
+    charactersToReHome: z.number().int().nonnegative(),
+    /** Cohort exceeds the breaker's warning share — review before purging. */
+    breakerWarning: z.boolean(),
+  }),
+});
+
+export type RetentionPreviewResponse = z.infer<typeof RetentionPreviewResponseSchema>;

--- a/packages/tooling/coverage-topology.json
+++ b/packages/tooling/coverage-topology.json
@@ -1906,6 +1906,20 @@
       ]
     },
     {
+      "id": "client:api-gateway:retentionPreview",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /retention/preview",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
       "id": "client:api-gateway:routingContextCreate",
       "kind": "http-route",
       "producer": "client",

--- a/packages/tooling/src/codegen/handler-paths.ts
+++ b/packages/tooling/src/codegen/handler-paths.ts
@@ -139,6 +139,7 @@ const PATH_MAP: Readonly<Record<string, string>> = {
   removePersonalityAlias: PERSONALITY_ALIASES_PATH,
   listMyAliases: PERSONALITY_ALIASES_PATH,
   secretRotationStatus: '../internal/secretRotationStatus.js',
+  retentionPreview: '../internal/retentionPreview.js',
   getModels: '../internal/models.js',
   setDmSession: '../internal/dmSessionSet.js',
   lookupPersonalityFromMessage: '../user/conversationLookup.js',

--- a/packages/tooling/src/commands/retention.ts
+++ b/packages/tooling/src/commands/retention.ts
@@ -31,4 +31,15 @@ export function registerRetentionCommands(cli: CAC): void {
         force: options.force,
       });
     });
+
+  cli
+    .command(
+      'retention:preview',
+      'Report the purge-eligible cohort and its character impact (read-only)'
+    )
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
+    .action(async (options: { env?: Environment }) => {
+      const { retentionPreview } = await import('../retention/preview.js');
+      await retentionPreview({ env: options.env ?? 'dev' });
+    });
 }

--- a/packages/tooling/src/retention/preview.test.ts
+++ b/packages/tooling/src/retention/preview.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { retentionPreviewMock, getClientMock } = vi.hoisted(() => ({
+  retentionPreviewMock: vi.fn(),
+  getClientMock: vi.fn(),
+}));
+
+vi.mock('../utils/env-runner.js', () => ({
+  validateEnvironment: vi.fn(),
+  showEnvironmentBanner: vi.fn(),
+}));
+vi.mock('../utils/gateway-client.js', () => ({ getServiceClientForEnv: getClientMock }));
+
+import { retentionPreview, renderPreview } from './preview.js';
+
+const EMPTY_TOTALS = {
+  eligibleCount: 0,
+  userbaseCount: 100,
+  percentOfUserbase: 0,
+  charactersToDelete: 0,
+  charactersToReHome: 0,
+  breakerWarning: false,
+};
+
+const COHORT = {
+  users: [
+    {
+      discordId: '900000000000000001',
+      inactiveSince: '2025-01-01T00:00:00.000Z',
+      reason: 'unreachable' as const,
+      ownedCharacters: { toDelete: 1, toReHome: 2 },
+    },
+    {
+      discordId: '900000000000000002',
+      inactiveSince: '2025-02-01T00:00:00.000Z',
+      reason: 'account_gone' as const,
+      ownedCharacters: { toDelete: 0, toReHome: 0 },
+    },
+  ],
+  totals: {
+    eligibleCount: 2,
+    userbaseCount: 20,
+    percentOfUserbase: 10,
+    charactersToDelete: 1,
+    charactersToReHome: 2,
+    breakerWarning: false,
+  },
+};
+
+describe('retentionPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    getClientMock.mockReturnValue({ retentionPreview: retentionPreviewMock });
+  });
+
+  it('fetches the cohort from the gateway for the requested env', async () => {
+    retentionPreviewMock.mockResolvedValue({ ok: true, data: { users: [], totals: EMPTY_TOTALS } });
+
+    await retentionPreview({ env: 'prod' });
+
+    // The env crosses the seam into the client factory, and the command reads
+    // the cohort from the gateway (never a local re-derivation of the predicate).
+    expect(getClientMock).toHaveBeenCalledWith('prod');
+    expect(retentionPreviewMock).toHaveBeenCalledOnce();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('exits non-zero with the actionable message when credentials can not be resolved', async () => {
+    // Railway CLI not logged in / missing variable. Without the catch this
+    // surfaces as an unhandled rejection instead of the friendly exit path.
+    getClientMock.mockImplementation(() => {
+      throw new Error('Check that the Railway CLI is logged in');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(retentionPreview({ env: 'prod' })).resolves.toBeUndefined();
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Railway CLI is logged in'));
+    expect(retentionPreviewMock).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('exits non-zero on a gateway failure instead of reporting an empty cohort', async () => {
+    // Silent-empty on failure would read as "nobody is eligible" — the most
+    // dangerous possible misreport for a purge preview.
+    retentionPreviewMock.mockResolvedValue({
+      ok: false,
+      kind: 'http',
+      error: 'Unauthorized',
+      status: 401,
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await retentionPreview({ env: 'dev' });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unauthorized'));
+    errorSpy.mockRestore();
+  });
+});
+
+describe('renderPreview', () => {
+  it('reports the empty cohort as the healthy state', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    renderPreview({ users: [], totals: EMPTY_TOTALS });
+
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('No users are purge-eligible');
+    logSpy.mockRestore();
+  });
+
+  it('prints each user, both reasons, and the character split', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    renderPreview(COHORT);
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('900000000000000001');
+    expect(output).toContain('900000000000000002');
+    expect(output).toContain('Discord account deleted');
+    expect(output).toContain('2 would be re-homed');
+    expect(output).toContain('Read-only');
+    logSpy.mockRestore();
+  });
+
+  it('surfaces the breaker warning with the percentage', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    renderPreview({
+      ...COHORT,
+      totals: { ...COHORT.totals, percentOfUserbase: 40, breakerWarning: true },
+    });
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Circuit-breaker warning');
+    expect(output).toContain('40%');
+    logSpy.mockRestore();
+  });
+});

--- a/packages/tooling/src/retention/preview.ts
+++ b/packages/tooling/src/retention/preview.ts
@@ -1,0 +1,110 @@
+/**
+ * `pnpm ops retention:preview` — the purge-eligible cohort, read-only.
+ *
+ * Reports who would be purged (unreachable/gone AND inactive past the retention
+ * window), what would happen to the characters they own, and how large the
+ * cohort is relative to the userbase. It mutates NOTHING — there is deliberately
+ * no confirmation prompt, and it is safe to run against prod.
+ *
+ * The cohort comes from the gateway (`GET /internal/retention/preview`) rather
+ * than a local query, so the operator reviews exactly the predicate the purge
+ * will act on — re-deriving it here would fork the definition.
+ */
+
+import chalk from 'chalk';
+import type { RetentionPreviewResponse } from '@tzurot/common-types/schemas/api/internal';
+import {
+  type Environment,
+  validateEnvironment,
+  showEnvironmentBanner,
+} from '../utils/env-runner.js';
+import { getServiceClientForEnv } from '../utils/gateway-client.js';
+
+export interface RetentionPreviewOptions {
+  env: Environment;
+}
+
+/** Human-readable eligibility reason. */
+const REASON_LABEL: Record<RetentionPreviewResponse['users'][number]['reason'], string> = {
+  unreachable: 'DMs closed / left every shared server',
+  account_gone: 'Discord account deleted',
+};
+
+/** Print the cohort report. Exported for testing without the transport. */
+export function renderPreview(preview: RetentionPreviewResponse): void {
+  const { users, totals } = preview;
+
+  if (users.length === 0) {
+    console.log(
+      chalk.green('\nNo users are purge-eligible — nobody is both unreachable and inactive.')
+    );
+    return;
+  }
+
+  console.log(chalk.bold('\nPurge-eligible cohort:'));
+  for (const user of users) {
+    const inactiveSince = user.inactiveSince.slice(0, 10);
+    const characters =
+      user.ownedCharacters.toDelete + user.ownedCharacters.toReHome === 0
+        ? 'no characters'
+        : `${user.ownedCharacters.toDelete} to delete, ${user.ownedCharacters.toReHome} to re-home`;
+    console.log(
+      `  ${user.discordId}  inactive since ${inactiveSince}  ` +
+        `${chalk.dim(REASON_LABEL[user.reason])}  ${chalk.dim(`(${characters})`)}`
+    );
+  }
+
+  console.log(chalk.bold('\nTotals:'));
+  console.log(
+    `  eligible: ${totals.eligibleCount} of ${totals.userbaseCount} users ` +
+      `(${totals.percentOfUserbase}% of the userbase)`
+  );
+  console.log(
+    `  characters: ${totals.charactersToDelete} would be deleted, ` +
+      `${totals.charactersToReHome} would be re-homed to the Orphaned Characters bucket`
+  );
+
+  if (totals.breakerWarning) {
+    console.log(
+      chalk.red(
+        `\n⚠️  Circuit-breaker warning: the cohort is ${totals.percentOfUserbase}% of the userbase. ` +
+          'That is large enough to be a tracking-signal glitch rather than genuine churn — ' +
+          'confirm the numbers before purging anything.'
+      )
+    );
+  }
+
+  console.log(chalk.dim('\nRead-only — nothing was deleted.'));
+}
+
+/** Entry point for `pnpm ops retention:preview`. */
+export async function retentionPreview(options: RetentionPreviewOptions): Promise<void> {
+  const { env } = options;
+  validateEnvironment(env);
+  showEnvironmentBanner(env);
+
+  // No prod-confirm: the command is read-only by construction (D5).
+  // Credential resolution can throw (Railway CLI not logged in, missing
+  // variable) — surface it the same way as a failed call rather than as an
+  // unhandled rejection.
+  let client;
+  try {
+    client = getServiceClientForEnv(env);
+  } catch (error) {
+    console.error(chalk.red(`\n${error instanceof Error ? error.message : 'Unknown error'}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await client.retentionPreview();
+
+  if (!result.ok) {
+    console.error(
+      chalk.red(`\nFailed to fetch the retention preview (${result.kind}): ${result.error}`)
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  renderPreview(result.data);
+}

--- a/packages/tooling/src/utils/gateway-client.test.ts
+++ b/packages/tooling/src/utils/gateway-client.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('child_process', () => ({ execFileSync: execFileSyncMock }));
+
+import { getServiceClientForEnv } from './gateway-client.js';
+
+const RAILWAY_VARS = {
+  PUBLIC_GATEWAY_URL: 'https://api-gateway-development.up.railway.app',
+  RAILWAY_PUBLIC_DOMAIN: 'api-gateway-development.up.railway.app',
+  INTERNAL_SERVICE_SECRET: 'secret-value',
+};
+
+describe('getServiceClientForEnv', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    execFileSyncMock.mockReturnValue(JSON.stringify(RAILWAY_VARS));
+  });
+
+  it('reads the gateway credentials from the api-gateway Railway service', () => {
+    const client = getServiceClientForEnv('dev');
+
+    expect(client).toBeDefined();
+    // Array args (never string interpolation) and the mapped Railway env name.
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'railway',
+      ['variables', '--environment', 'development', '--service', 'api-gateway', '--json'],
+      expect.objectContaining({ encoding: 'utf-8' })
+    );
+  });
+
+  it('maps prod to the production Railway environment', () => {
+    getServiceClientForEnv('prod');
+
+    expect(execFileSyncMock.mock.calls[0][1]).toContain('production');
+  });
+
+  it('falls back to the public domain when PUBLIC_GATEWAY_URL is unset', () => {
+    const { PUBLIC_GATEWAY_URL: _dropped, ...withoutUrl } = RAILWAY_VARS;
+    execFileSyncMock.mockReturnValue(JSON.stringify(withoutUrl));
+
+    // Constructs without throwing — the bare domain gets an https:// scheme.
+    expect(() => getServiceClientForEnv('dev')).not.toThrow();
+  });
+
+  it('throws an actionable error naming the missing secret', () => {
+    execFileSyncMock.mockReturnValue(
+      JSON.stringify({ PUBLIC_GATEWAY_URL: RAILWAY_VARS.PUBLIC_GATEWAY_URL })
+    );
+
+    // An opaque 401 later is much worse than a named variable now.
+    expect(() => getServiceClientForEnv('dev')).toThrow(/INTERNAL_SERVICE_SECRET/);
+    expect(() => getServiceClientForEnv('dev')).toThrow(/api-gateway/);
+  });
+
+  it('reads local credentials from the ambient env, not Railway', () => {
+    const prevUrl = process.env.PUBLIC_GATEWAY_URL;
+    const prevSecret = process.env.INTERNAL_SERVICE_SECRET;
+    process.env.PUBLIC_GATEWAY_URL = 'http://localhost:3000';
+    process.env.INTERNAL_SERVICE_SECRET = 'local-secret';
+    try {
+      expect(getServiceClientForEnv('local')).toBeDefined();
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    } finally {
+      process.env.PUBLIC_GATEWAY_URL = prevUrl;
+      process.env.INTERNAL_SERVICE_SECRET = prevSecret;
+    }
+  });
+
+  it('throws when the local gateway URL is unset', () => {
+    const prevUrl = process.env.PUBLIC_GATEWAY_URL;
+    const prevGateway = process.env.GATEWAY_URL;
+    delete process.env.PUBLIC_GATEWAY_URL;
+    delete process.env.GATEWAY_URL;
+    try {
+      expect(() => getServiceClientForEnv('local')).toThrow(/PUBLIC_GATEWAY_URL/);
+    } finally {
+      process.env.PUBLIC_GATEWAY_URL = prevUrl;
+      process.env.GATEWAY_URL = prevGateway;
+    }
+  });
+});

--- a/packages/tooling/src/utils/gateway-client.ts
+++ b/packages/tooling/src/utils/gateway-client.ts
@@ -1,0 +1,100 @@
+/**
+ * Build a service-auth `ServiceClient` for an environment's api-gateway.
+ *
+ * Most ops commands talk to the database directly (`getPrismaForEnv`). Some
+ * can't: work whose logic lives BEHIND the gateway — the retention cohort
+ * predicate, and later the account purge, whose off-DB cleanup (avatar unlink,
+ * Redis eviction, cache broadcast) only the gateway can perform. Re-deriving
+ * that logic in the CLI would fork it; calling the gateway keeps one
+ * implementation.
+ *
+ * Credentials come from the same place the gateway itself gets them — the
+ * Railway service variables — so there is nothing extra for an operator to
+ * configure. Note it must be the PUBLIC url: `*.railway.internal` resolves only
+ * inside Railway's network, never from a developer machine.
+ */
+
+import { execFileSync } from 'child_process';
+import chalk from 'chalk';
+import { ServiceClient } from '@tzurot/clients';
+import { type Environment, getRailwayEnvName } from './env-runner.js';
+
+/** The Railway service that serves the internal API. */
+const GATEWAY_SERVICE = 'api-gateway';
+
+/**
+ * Read the variables set on a Railway service. Wraps the CLI/parse failure in
+ * an actionable message (mirrors `getRailwayDatabaseUrl`): the raw failure here
+ * is a child_process error whose most common cause — "not logged in" — is
+ * invisible in the default output.
+ */
+function readServiceVariables(env: Environment, service: string): Record<string, string> {
+  try {
+    // execFileSync with ARRAY args — never string interpolation (shell-injection).
+    const output = execFileSync(
+      'railway',
+      ['variables', '--environment', getRailwayEnvName(env), '--service', service, '--json'],
+      { stdio: 'pipe', encoding: 'utf-8' }
+    );
+    return JSON.parse(output) as Record<string, string>;
+  } catch (error) {
+    throw new Error(
+      `Failed to read Railway variables for the ${service} service in ${getRailwayEnvName(env)}: ` +
+        `${error instanceof Error ? error.message : 'Unknown error'}. ` +
+        'Check that the Railway CLI is logged in (`railway whoami`) and linked to this project.',
+      { cause: error }
+    );
+  }
+}
+
+function requireVar(vars: Record<string, string>, keys: string[], env: Environment): string {
+  for (const key of keys) {
+    const value = vars[key];
+    if (value !== undefined && value.length > 0) {
+      return value;
+    }
+  }
+  throw new Error(
+    `${keys.join(' / ')} not set on the ${GATEWAY_SERVICE} service in Railway ${getRailwayEnvName(env)}. ` +
+      `Set it in the Railway dashboard (or check you're linked to the right project).`
+  );
+}
+
+/**
+ * A `ServiceClient` pointed at the given environment's gateway.
+ *
+ * `local` reads the ambient env (the repo `.env` the CLI already loads);
+ * `dev`/`prod` read the gateway service's Railway variables. Throws with an
+ * actionable message naming the missing variable rather than failing later as
+ * an opaque 401/ENOTFOUND.
+ */
+export function getServiceClientForEnv(env: Environment): ServiceClient {
+  if (env === 'local') {
+    const baseUrl = process.env.PUBLIC_GATEWAY_URL ?? process.env.GATEWAY_URL;
+    const serviceSecret = process.env.INTERNAL_SERVICE_SECRET;
+    if (baseUrl === undefined || baseUrl.length === 0) {
+      throw new Error(
+        'PUBLIC_GATEWAY_URL (or GATEWAY_URL) not set — is the local gateway running?'
+      );
+    }
+    if (serviceSecret === undefined || serviceSecret.length === 0) {
+      throw new Error('INTERNAL_SERVICE_SECRET not set in your local environment');
+    }
+    return new ServiceClient({ baseUrl, serviceSecret });
+  }
+
+  console.log(chalk.dim(`Fetching gateway credentials from Railway ${getRailwayEnvName(env)}...`));
+  const vars = readServiceVariables(env, GATEWAY_SERVICE);
+  // RAILWAY_PUBLIC_DOMAIN is the bare host, so it needs the scheme prepended;
+  // PUBLIC_GATEWAY_URL is already a full url and is preferred.
+  const publicUrl = vars.PUBLIC_GATEWAY_URL;
+  const baseUrl =
+    publicUrl !== undefined && publicUrl.length > 0
+      ? publicUrl
+      : `https://${requireVar(vars, ['RAILWAY_PUBLIC_DOMAIN'], env)}`;
+
+  return new ServiceClient({
+    baseUrl,
+    serviceSecret: requireVar(vars, ['INTERNAL_SERVICE_SECRET'], env),
+  });
+}

--- a/services/api-gateway/src/routes/_generated/mounts.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.ts
@@ -47,6 +47,7 @@ import { handleLoadPersonalityInternal } from '../internal/personalityLoad.js';
 import { handleRoutingContextCreate } from '../internal/routingContextCreate.js';
 import { handleRecentUsers } from '../internal/usersRecent.js';
 import { handleSecretRotationStatus } from '../internal/secretRotationStatus.js';
+import { handleRetentionPreview } from '../internal/retentionPreview.js';
 import { handleGetModels } from '../internal/models.js';
 import { handleGetDenylistCache, handleAddDenylistEntry, handleListDenylistEntries, handleRemoveDenylistEntry } from '../admin/denylist.js';
 import { handleUpdateDiagnosticResponseIds, handleGetRecentDiagnostics, handleGetDiagnosticByMessage, handleGetDiagnosticByResponse, handleGetDiagnosticByRequestId } from '../admin/diagnostic.js';
@@ -125,6 +126,7 @@ export function mountInternalRoutes(app: Express, deps: RouteDeps): void {
   app.post('/api/internal/v1/routing-context', handleRoutingContextCreate(deps));
   app.get('/api/internal/users/recent', handleRecentUsers(deps));
   app.get('/api/internal/secret-rotations', handleSecretRotationStatus(deps));
+  app.get('/api/internal/retention/preview', handleRetentionPreview(deps));
   app.get('/api/internal/models', handleGetModels(deps));
   app.get('/api/internal/denylist/cache', handleGetDenylistCache(deps));
   app.get('/api/internal/admin-settings', handleGetAdminSettings(deps));

--- a/services/api-gateway/src/routes/conformance/fixtures/internal.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/internal.ts
@@ -302,6 +302,12 @@ export const internalFixtures: Record<string, ConformanceEntry> = {
     // entries: [] + overdueCount: 0 — zero seed needed.
   },
 
+  retentionPreview: {
+    // An empty cohort is the healthy steady state (and the conformance actor is
+    // recent + reachable, so it can't be eligible): the route returns
+    // users: [] with zeroed totals — zero seed needed.
+  },
+
   getModels: {
     // No DB seed: the catalog comes from the harness's fake modelCache.
     query: { search: 'claude', limit: '10' },

--- a/services/api-gateway/src/routes/internal/retentionPreview.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionPreview.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { RetentionPreviewResponseSchema } from '@tzurot/common-types/schemas/api/internal';
+
+const buildPreviewMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/asyncHandler.js', () => ({ asyncHandler: vi.fn(fn => fn) }));
+vi.mock('../../services/retention/RetentionPurgeService.js', () => ({
+  // Plain function: constructable (arrows are not).
+  RetentionPurgeService: function MockRetentionPurgeService() {
+    return { buildPreview: buildPreviewMock };
+  },
+}));
+
+import { handleRetentionPreview } from './retentionPreview.js';
+import type { RouteDeps } from '../routeDeps.js';
+
+const PREVIEW = {
+  users: [
+    {
+      discordId: '900000000000000001',
+      inactiveSince: '2025-01-01T00:00:00.000Z',
+      reason: 'unreachable' as const,
+      ownedCharacters: { toDelete: 1, toReHome: 2 },
+    },
+  ],
+  totals: {
+    eligibleCount: 1,
+    userbaseCount: 100,
+    percentOfUserbase: 1,
+    charactersToDelete: 1,
+    charactersToReHome: 2,
+    breakerWarning: false,
+  },
+};
+
+function createMockReqRes() {
+  const req = {} as Request;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return { req, res };
+}
+
+describe('GET /internal/retention/preview', () => {
+  it('returns the service preview in the manifest-declared shape', async () => {
+    buildPreviewMock.mockResolvedValue(PREVIEW);
+    const { req, res } = createMockReqRes();
+
+    await handleRetentionPreview({} as RouteDeps)(req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload).toEqual(PREVIEW);
+    // The wire body must satisfy the contract the generated client parses with.
+    expect(RetentionPreviewResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('returns an empty cohort without erroring', async () => {
+    buildPreviewMock.mockResolvedValue({
+      users: [],
+      totals: {
+        eligibleCount: 0,
+        userbaseCount: 100,
+        percentOfUserbase: 0,
+        charactersToDelete: 0,
+        charactersToReHome: 0,
+        breakerWarning: false,
+      },
+    });
+    const { req, res } = createMockReqRes();
+
+    await handleRetentionPreview({} as RouteDeps)(req, res, vi.fn());
+
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.users).toEqual([]);
+    expect(RetentionPreviewResponseSchema.safeParse(payload).success).toBe(true);
+  });
+});

--- a/services/api-gateway/src/routes/internal/retentionPreview.ts
+++ b/services/api-gateway/src/routes/internal/retentionPreview.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/internal/retention/preview
+ *
+ * The purge-eligible cohort (Retention Phase 2, D2/D3): who has gone
+ * unreachable AND inactive past the retention window, what would happen to the
+ * characters they own, and how large the cohort is relative to the userbase.
+ *
+ * READ-ONLY — this route selects and reports; it deletes nothing. It shares
+ * `RetentionPurgeService`'s single eligibility predicate with the (later) purge
+ * and nag, so the number an operator reviews here is by construction the same
+ * set the purge would act on.
+ *
+ * Service-auth protected like every internal route. Consumed by
+ * `pnpm ops retention:preview`.
+ */
+
+import { type Request, type Response, type RequestHandler } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { RetentionPreviewResponseSchema } from '@tzurot/common-types/schemas/api/internal';
+import { asyncHandler } from '../../utils/asyncHandler.js';
+import { sendContractSuccess } from '../../utils/responseHelpers.js';
+import { RetentionPurgeService } from '../../services/retention/RetentionPurgeService.js';
+import type { RouteDeps } from '../routeDeps.js';
+
+/** GET /api/internal/retention/preview — read-only purge-eligible cohort. */
+export const handleRetentionPreview = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (_req: Request, res: Response) => {
+    const preview = await new RetentionPurgeService(prisma).buildPreview();
+    sendContractSuccess(res, RetentionPreviewResponseSchema, preview, StatusCodes.OK);
+  });
+};

--- a/services/api-gateway/src/services/AccountDeletionService.ts
+++ b/services/api-gateway/src/services/AccountDeletionService.ts
@@ -24,10 +24,11 @@ import {
   ACCOUNT_DELETE_CONFIRMATION_PHRASE,
   type OwnedCharacterImpactSchema,
 } from '@tzurot/common-types/schemas/api/account';
-import { type PrismaClient, type Prisma } from '@tzurot/common-types/services/prisma';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { z } from 'zod';
 import { ensureOrphanSentinel } from './OrphanSentinelBootstrap.js';
+import { findCrossUserReachIds } from './retention/crossUserReach.js';
 
 const logger = createLogger('AccountDeletionService');
 
@@ -138,40 +139,6 @@ export class AccountDeletionService {
     return new Map(rows.map(row => [row.personalityId, row.otherUsers]));
   }
 
-  /**
-   * Owned characters with CROSS-USER reach (Retention Phase 2, D11): another
-   * user — a persona owner other than the departed one — has a memory,
-   * conversation-history row, OR fact scoped to the character. These are the
-   * characters a retention purge re-homes to the sentinel instead of deleting,
-   * so the other users keep using them. Broadens `fetchOtherUserReach`'s
-   * memories-only signal to all three personality-scoped tables (council). The
-   * INNER JOINs drop world/orphan rows with a null `persona_id` — reach is
-   * about another USER, not un-owned content. Returns the ids to re-home.
-   */
-  private async partitionOwnedByReach(
-    tx: Prisma.TransactionClient,
-    userId: string,
-    ownedIds: string[]
-  ): Promise<string[]> {
-    const rows = await tx.$queryRaw<{ personalityId: string }[]>`
-      SELECT DISTINCT reach.personality_id AS "personalityId"
-      FROM (
-        SELECT m.personality_id FROM memories m
-          JOIN personas p ON m.persona_id = p.id
-          WHERE m.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
-        UNION ALL
-        SELECT ch.personality_id FROM conversation_history ch
-          JOIN personas p ON ch.persona_id = p.id
-          WHERE ch.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
-        UNION ALL
-        SELECT f.personality_id FROM memory_facts f
-          JOIN personas p ON f.persona_id = p.id
-          WHERE f.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
-      ) reach
-    `;
-    return rows.map(row => row.personalityId);
-  }
-
   async preview(userId: string): Promise<AccountDeletePreview> {
     // Intentionally unbounded (exception to the bounded-findMany rule): the
     // deletion scope must cover the COMPLETE owned set — a paginated page
@@ -261,7 +228,7 @@ export class AccountDeletionService {
         // other-user data is never touched (D11).
         let deletedCharacters = ownedCharacters;
         if (mode === 'retention' && sentinelId !== null && ownedIds.length > 0) {
-          const reHomeIds = await this.partitionOwnedByReach(tx, userId, ownedIds);
+          const reHomeIds = await findCrossUserReachIds(tx, userId, ownedIds);
           if (reHomeIds.length > 0) {
             // Prisma client write (NOT raw SQL) so `@updatedAt` bumps: personalities
             // is a sync-tracked table and re-home is a SEMANTIC ownership change that

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Component test: the eligibility predicate over REAL PGLite. Seeds a user for
+ * every arm of D4 — eligible via each unreachable signal, plus one excluded by
+ * each exemption — and asserts the cohort is EXACTLY the eligible set.
+ *
+ * This is the load-bearing proof for the whole purge branch: every later phase
+ * (nag, purge) reads this same predicate, so an over-inclusive predicate here
+ * would eventually erase someone it shouldn't.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { type PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { RetentionPurgeService } from './RetentionPurgeService.js';
+
+const OLD = new Date('2020-01-01T00:00:00Z'); // far past the 180-day window
+const RECENT = new Date(); // inside the window
+
+/** Users, one per predicate arm. */
+const ELIGIBLE_UNREACHABLE = 'c0407000-0000-4000-8000-000000000001';
+const ELIGIBLE_GONE = 'c0407000-0000-4000-8000-000000000002';
+const ACTIVE_RECENTLY = 'c0407000-0000-4000-8000-000000000003';
+const REACHABLE = 'c0407000-0000-4000-8000-000000000004';
+const SUPERUSER = 'c0407000-0000-4000-8000-000000000005';
+const EXEMPT = 'c0407000-0000-4000-8000-000000000006';
+const NEVER_STAMPED_YOUNG = 'c0407000-0000-4000-8000-000000000007';
+
+const PERSONALITY_SHARED = 'c0407000-0000-4000-8000-0000000000a1';
+const PERSONALITY_SOLO = 'c0407000-0000-4000-8000-0000000000a2';
+const OTHER_USER = 'c0407000-0000-4000-8000-0000000000b1';
+const OTHER_PERSONA = 'c0407000-0000-4000-8000-0000000000b2';
+
+let seq = 0;
+const nextId = (): string =>
+  `c0407000-0000-4000-8000-0000000001${(seq++).toString().padStart(2, '0')}`;
+
+describe('RetentionPurgeService (component, PGLite)', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+  let service: RetentionPurgeService;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+    service = new RetentionPurgeService(prisma);
+
+    const seed = async (userId: string, name: string): Promise<void> => {
+      await seedUserWithPersona(prisma, {
+        userId,
+        personaId: nextId(),
+        discordId: `9000000000000000${(seq + 10).toString().padStart(2, '0')}`,
+        username: name,
+        personaName: `${name} Persona`,
+        personaContent: 'x',
+      });
+    };
+
+    for (const [id, name] of [
+      [ELIGIBLE_UNREACHABLE, 'unreachable'],
+      [ELIGIBLE_GONE, 'goneaccount'],
+      [ACTIVE_RECENTLY, 'activerecent'],
+      [REACHABLE, 'reachable'],
+      [SUPERUSER, 'superowner'],
+      [EXEMPT, 'exemptuser'],
+      [NEVER_STAMPED_YOUNG, 'youngnostamp'],
+    ] as const) {
+      await seed(id, name);
+    }
+    await seedUserWithPersona(prisma, {
+      userId: OTHER_USER,
+      personaId: OTHER_PERSONA,
+      discordId: '900000000000000099',
+      username: 'otheractive',
+      personaName: 'Other Persona',
+      personaContent: 'x',
+    });
+
+    // Raw SQL for the retention columns: they're deliberately off the Prisma
+    // client path in production (sync-LWW), and created_at needs forcing too.
+    await prisma.$executeRaw`
+      UPDATE users SET dm_undeliverable_since = ${OLD}, last_active_at = ${OLD}
+      WHERE id = ${ELIGIBLE_UNREACHABLE}::uuid
+    `;
+    await prisma.$executeRaw`
+      UPDATE users SET discord_account_gone_at = ${OLD}, last_active_at = ${OLD}
+      WHERE id = ${ELIGIBLE_GONE}::uuid
+    `;
+    // Unreachable but ACTIVE recently → excluded (the flag alone isn't enough).
+    await prisma.$executeRaw`
+      UPDATE users SET dm_undeliverable_since = ${OLD}, last_active_at = ${RECENT}
+      WHERE id = ${ACTIVE_RECENTLY}::uuid
+    `;
+    // Inactive but REACHABLE → excluded (Phase 2 is the unreachable branch only).
+    await prisma.$executeRaw`
+      UPDATE users SET last_active_at = ${OLD} WHERE id = ${REACHABLE}::uuid
+    `;
+    // Unreachable + inactive, but exempted two different ways → excluded.
+    await prisma.$executeRaw`
+      UPDATE users SET dm_undeliverable_since = ${OLD}, last_active_at = ${OLD}, is_superuser = true
+      WHERE id = ${SUPERUSER}::uuid
+    `;
+    await prisma.$executeRaw`
+      UPDATE users SET dm_undeliverable_since = ${OLD}, last_active_at = ${OLD}, retention_exempt = true
+      WHERE id = ${EXEMPT}::uuid
+    `;
+    // Never stamped (NULL last_active_at) but created recently → the COALESCE
+    // fallback must read created_at and EXCLUDE them.
+    await prisma.$executeRaw`
+      UPDATE users SET dm_undeliverable_since = ${OLD}, last_active_at = NULL, created_at = ${RECENT}
+      WHERE id = ${NEVER_STAMPED_YOUNG}::uuid
+    `;
+
+    // Characters owned by the unreachable user: SHARED has another user's
+    // memory (→ re-home), SOLO has none (→ delete).
+    await prisma.$executeRaw`
+      INSERT INTO personalities (id, name, slug, character_info, personality_traits, owner_id, updated_at)
+      VALUES (${PERSONALITY_SHARED}::uuid, 'Shared', 'shared-cohort', 'c', 'Warm', ${ELIGIBLE_UNREACHABLE}::uuid, NOW()),
+             (${PERSONALITY_SOLO}::uuid, 'Solo', 'solo-cohort', 'c', 'Quiet', ${ELIGIBLE_UNREACHABLE}::uuid, NOW())
+    `;
+    await prisma.memory.create({
+      data: {
+        id: nextId(),
+        personaId: OTHER_PERSONA,
+        personalityId: PERSONALITY_SHARED,
+        content: 'other-user-with-shared',
+        senders: ['otheractive'],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  });
+
+  it('selects exactly the unreachable-and-inactive cohort', async () => {
+    const cohort = await service.selectPurgeCohort();
+
+    expect(cohort.map(row => row.userId).sort()).toEqual(
+      [ELIGIBLE_UNREACHABLE, ELIGIBLE_GONE].sort()
+    );
+    // Every exclusion is load-bearing — name them so a regression is legible.
+    const ids = cohort.map(row => row.userId);
+    expect(ids).not.toContain(ACTIVE_RECENTLY); // active again
+    expect(ids).not.toContain(REACHABLE); // still reachable
+    expect(ids).not.toContain(SUPERUSER); // bot owner
+    expect(ids).not.toContain(EXEMPT); // retention_exempt (also the orphan sentinel)
+    expect(ids).not.toContain(NEVER_STAMPED_YOUNG); // NULL last_active_at → created_at fallback
+  });
+
+  it('labels each eligible user with the signal that made them eligible', async () => {
+    const cohort = await service.selectPurgeCohort();
+    const byId = new Map(cohort.map(row => [row.userId, row.reason]));
+
+    expect(byId.get(ELIGIBLE_UNREACHABLE)).toBe('unreachable');
+    expect(byId.get(ELIGIBLE_GONE)).toBe('account_gone');
+  });
+
+  it('reports the character split and userbase share in the preview', async () => {
+    const preview = await service.buildPreview();
+
+    const unreachable = preview.users.find(user => user.reason === 'unreachable');
+    // SHARED has another user's memory → re-home; SOLO has none → delete.
+    expect(unreachable?.ownedCharacters).toEqual({ toDelete: 1, toReHome: 1 });
+    expect(preview.totals.charactersToDelete).toBe(1);
+    expect(preview.totals.charactersToReHome).toBe(1);
+
+    expect(preview.totals.eligibleCount).toBe(2);
+    expect(preview.totals.userbaseCount).toBe(8);
+    // 2/8 = 25% — over the 15% warn line, so the breaker annotation fires.
+    expect(preview.totals.percentOfUserbase).toBe(25);
+    expect(preview.totals.breakerWarning).toBe(true);
+  });
+});

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { RetentionPurgeService, RETENTION_WINDOW_DAYS } from './RetentionPurgeService.js';
+
+/** Join the template-strings array (call[0]) to assert on the SQL skeleton. */
+function joinSql(call: unknown[]): string {
+  return (call[0] as TemplateStringsArray).join(' ');
+}
+
+function makePrisma(overrides: Record<string, unknown> = {}) {
+  const queryRaw = vi.fn().mockResolvedValue([]);
+  const prisma = {
+    $queryRaw: queryRaw,
+    user: { count: vi.fn().mockResolvedValue(100) },
+    personality: { findMany: vi.fn().mockResolvedValue([]) },
+    ...overrides,
+  };
+  return { prisma: prisma as unknown as PrismaClient, queryRaw };
+}
+
+describe('RetentionPurgeService.selectPurgeCohort', () => {
+  it('gates on every predicate arm (D4) and nothing else', async () => {
+    const { prisma, queryRaw } = makePrisma();
+
+    await new RetentionPurgeService(prisma).selectPurgeCohort();
+
+    const sql = joinSql(queryRaw.mock.calls[0]);
+    // Unreachable OR gone — either signal qualifies.
+    expect(sql).toContain('u.dm_undeliverable_since IS NOT NULL');
+    expect(sql).toContain('u.discord_account_gone_at IS NOT NULL');
+    // Inactivity, with the NULL → created_at fallback (never "active now").
+    expect(sql).toContain('COALESCE(u.last_active_at, u.created_at)');
+    // The two exemptions that must never be purge-able.
+    expect(sql).toContain('u.is_superuser = false');
+    expect(sql).toContain('u.retention_exempt = false');
+    // The window is bound, not inlined — and it's the single named constant.
+    expect(queryRaw.mock.calls[0]).toEqual(expect.arrayContaining([RETENTION_WINDOW_DAYS]));
+
+    // NEGATIVE: the predicate must not silently widen to reachable users. A
+    // purge that ignores reachability would erase people who could be notified.
+    expect(sql).not.toContain('OR u.is_superuser');
+    expect(sql).not.toContain('notify_enabled');
+  });
+
+  it('labels a gone account as account_gone even when both signals are stamped', async () => {
+    const { prisma } = makePrisma({
+      $queryRaw: vi.fn().mockResolvedValue([
+        {
+          userId: 'u1',
+          discordId: '900000000000000001',
+          inactiveSince: new Date('2025-01-01'),
+          accountGone: true,
+        },
+        {
+          userId: 'u2',
+          discordId: '900000000000000002',
+          inactiveSince: new Date('2025-02-01'),
+          accountGone: false,
+        },
+      ]),
+    });
+
+    const cohort = await new RetentionPurgeService(prisma).selectPurgeCohort();
+
+    expect(cohort.map(row => row.reason)).toEqual(['account_gone', 'unreachable']);
+  });
+});
+
+describe('RetentionPurgeService.buildPreview', () => {
+  function makePreviewPrisma(opts: {
+    cohort: unknown[];
+    userbase: number;
+    owned?: { id: string }[];
+    reach?: { personalityId: string }[];
+  }) {
+    const queryRaw = vi
+      .fn()
+      // call 1 = the cohort; call 2+ = per-user reach
+      .mockResolvedValueOnce(opts.cohort)
+      .mockResolvedValue(opts.reach ?? []);
+    return {
+      $queryRaw: queryRaw,
+      user: { count: vi.fn().mockResolvedValue(opts.userbase) },
+      personality: { findMany: vi.fn().mockResolvedValue(opts.owned ?? []) },
+    } as unknown as PrismaClient;
+  }
+
+  const ONE_USER = [
+    {
+      userId: 'u1',
+      discordId: '900000000000000001',
+      inactiveSince: new Date('2025-01-01T00:00:00Z'),
+      accountGone: false,
+    },
+  ];
+
+  it('splits owned characters into delete vs re-home and totals them', async () => {
+    const prisma = makePreviewPrisma({
+      cohort: ONE_USER,
+      userbase: 100,
+      owned: [{ id: 'x1' }, { id: 'x2' }, { id: 'z1' }],
+      reach: [{ personalityId: 'x1' }, { personalityId: 'x2' }], // 2 re-homed, 1 deleted
+    });
+
+    const preview = await new RetentionPurgeService(prisma).buildPreview();
+
+    expect(preview.users[0]?.ownedCharacters).toEqual({ toDelete: 1, toReHome: 2 });
+    expect(preview.totals.charactersToDelete).toBe(1);
+    expect(preview.totals.charactersToReHome).toBe(2);
+    expect(preview.users[0]?.inactiveSince).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  it('computes the userbase percentage to one decimal place', async () => {
+    const prisma = makePreviewPrisma({ cohort: ONE_USER, userbase: 300 });
+
+    const { totals } = await new RetentionPurgeService(prisma).buildPreview();
+
+    expect(totals.eligibleCount).toBe(1);
+    expect(totals.userbaseCount).toBe(300);
+    expect(totals.percentOfUserbase).toBe(0.3);
+    expect(totals.breakerWarning).toBe(false);
+  });
+
+  it('raises the breaker warning when the cohort exceeds the warn fraction', async () => {
+    // 1 of 5 = 20% > 15% warn threshold.
+    const prisma = makePreviewPrisma({ cohort: ONE_USER, userbase: 5 });
+
+    const { totals } = await new RetentionPurgeService(prisma).buildPreview();
+
+    expect(totals.percentOfUserbase).toBe(20);
+    expect(totals.breakerWarning).toBe(true);
+  });
+
+  it('does NOT warn at exactly the warn fraction — the breaker fires on EXCEEDING it', async () => {
+    // 3 of 20 = exactly 15.0%. The threshold is a strict `>`, matching the
+    // "exceeds" wording; pinning the boundary so a future `>=` (or a nudged
+    // constant) can't silently start crying wolf on every ordinary run.
+    const cohort = ['u1', 'u2', 'u3'].map((userId, i) => ({
+      userId,
+      discordId: `90000000000000000${i}`,
+      inactiveSince: new Date('2025-01-01T00:00:00Z'),
+      accountGone: false,
+    }));
+    const prisma = makePreviewPrisma({ cohort, userbase: 20 });
+
+    const { totals } = await new RetentionPurgeService(prisma).buildPreview();
+
+    expect(totals.percentOfUserbase).toBe(15);
+    expect(totals.breakerWarning).toBe(false);
+  });
+
+  it('reports an empty cohort without dividing by zero on an empty userbase', async () => {
+    const prisma = makePreviewPrisma({ cohort: [], userbase: 0 });
+
+    const { users, totals } = await new RetentionPurgeService(prisma).buildPreview();
+
+    expect(users).toEqual([]);
+    expect(totals.percentOfUserbase).toBe(0);
+    expect(totals.breakerWarning).toBe(false);
+  });
+});

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.ts
@@ -1,0 +1,182 @@
+/**
+ * RetentionPurgeService — cohort selection + preview (Retention Phase 2, D2/D3/D4).
+ *
+ * Owns THE eligibility predicate. D3 requires exactly one, consumed by the
+ * preview (this PR), the daily nag, and the purge itself (both PR-D) — so the
+ * count the operator reviews can never drift from the set the purge acts on.
+ *
+ * This service is READ-ONLY. It selects and reports; it deletes nothing. The
+ * per-user purge (which re-evaluates this same predicate inside its transaction
+ * to close the preview→purge TOCTOU window) lands in PR-D.
+ */
+
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { findCrossUserReachIds } from './crossUserReach.js';
+
+/**
+ * The single retention window (epic decision: ONE 180-day window, not the
+ * rejected flat-90d). Inactivity is measured from last_active_at, falling back
+ * to created_at when the tracking clock never stamped (NULL = "no known
+ * activity", never "active now").
+ */
+export const RETENTION_WINDOW_DAYS = 180;
+
+/**
+ * Cohort share of the userbase that annotates the report with a warning (the
+ * Phase-2 circuit breaker is a WARNING, not a halt — the operator sees the
+ * batch and decides). The hard ceiling that even --force can't bypass is a
+ * purge-time gate and lands with the purge (PR-D).
+ */
+export const BREAKER_WARN_FRACTION = 0.15;
+
+/** Why a user is purge-eligible — the two unreachable signals (D13). */
+export type PurgeReason = 'unreachable' | 'account_gone';
+
+export interface PurgeCohortRow {
+  userId: string;
+  discordId: string;
+  /** Effective inactivity anchor: last_active_at ?? created_at. */
+  inactiveSince: Date;
+  reason: PurgeReason;
+}
+
+export interface RetentionPreviewUser {
+  discordId: string;
+  inactiveSince: string;
+  reason: PurgeReason;
+  ownedCharacters: {
+    /** Nobody else uses them — they die with the account. */
+    toDelete: number;
+    /** Other users have data on them — re-homed to the orphan sentinel (D11). */
+    toReHome: number;
+  };
+}
+
+export interface RetentionPreview {
+  users: RetentionPreviewUser[];
+  totals: {
+    eligibleCount: number;
+    userbaseCount: number;
+    percentOfUserbase: number;
+    charactersToDelete: number;
+    charactersToReHome: number;
+    /** Cohort exceeds BREAKER_WARN_FRACTION of the userbase — review closely. */
+    breakerWarning: boolean;
+  };
+}
+
+interface CohortSqlRow {
+  userId: string;
+  discordId: string;
+  inactiveSince: Date;
+  accountGone: boolean;
+}
+
+export class RetentionPurgeService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * THE eligibility predicate (D4). Unreachable-or-gone AND inactive past the
+   * window AND not the bot owner AND not exempted. `retention_exempt` also
+   * self-excludes the Orphaned-Characters sentinel, so re-homed characters are
+   * never purged out from under the users they were preserved for.
+   *
+   * Unbounded by design: the cohort IS the answer, and truncating it would
+   * under-report the very number the breaker exists to police. The breaker's
+   * percentage annotation is what flags an implausibly large result.
+   */
+  async selectPurgeCohort(): Promise<PurgeCohortRow[]> {
+    const rows = await this.prisma.$queryRaw<CohortSqlRow[]>`
+      SELECT u.id AS "userId",
+             u.discord_id AS "discordId",
+             COALESCE(u.last_active_at, u.created_at) AS "inactiveSince",
+             (u.discord_account_gone_at IS NOT NULL) AS "accountGone"
+      FROM users u
+      WHERE (u.dm_undeliverable_since IS NOT NULL OR u.discord_account_gone_at IS NOT NULL)
+        AND COALESCE(u.last_active_at, u.created_at)
+              < now() - make_interval(days => ${RETENTION_WINDOW_DAYS})
+        AND u.is_superuser = false
+        AND u.retention_exempt = false
+      ORDER BY COALESCE(u.last_active_at, u.created_at) ASC
+    `;
+    return rows.map(row => ({
+      userId: row.userId,
+      discordId: row.discordId,
+      inactiveSince: row.inactiveSince,
+      // A gone account is the stronger signal, so it wins the label when both
+      // are stamped (it also drives the faster purge policy in PR-D).
+      reason: row.accountGone ? 'account_gone' : 'unreachable',
+    }));
+  }
+
+  /**
+   * The operator-facing report: who is eligible and what would happen to their
+   * characters, with the breaker annotation.
+   *
+   * Walks the cohort per-user for the character split. That is N+1-shaped by
+   * construction, which is fine HERE and only here: the cohort is bounded in
+   * practice (tens of users — a cohort large enough for this to matter is
+   * itself the anomaly the breaker warning exists to surface), and the command
+   * is an interactive, operator-run read.
+   */
+  async buildPreview(): Promise<RetentionPreview> {
+    // Denominator is ALL users, deliberately — including the handful that can
+    // never be eligible (bot owner, retention_exempt, the orphan sentinel). The
+    // breaker asks "how much of the userbase would this run erase?", and a
+    // purgeable-population denominator would make the percentage drift every
+    // time an exemption is added rather than when real churn changes.
+    const [cohort, userbaseCount] = await Promise.all([
+      this.selectPurgeCohort(),
+      this.prisma.user.count(),
+    ]);
+
+    const users: RetentionPreviewUser[] = [];
+    for (const row of cohort) {
+      users.push({
+        discordId: row.discordId,
+        inactiveSince: row.inactiveSince.toISOString(),
+        reason: row.reason,
+        ownedCharacters: await this.splitOwnedCharacters(row.userId),
+      });
+    }
+
+    const charactersToDelete = users.reduce((sum, u) => sum + u.ownedCharacters.toDelete, 0);
+    const charactersToReHome = users.reduce((sum, u) => sum + u.ownedCharacters.toReHome, 0);
+    const percentOfUserbase =
+      userbaseCount === 0 ? 0 : Math.round((users.length / userbaseCount) * 1000) / 10;
+
+    return {
+      users,
+      totals: {
+        eligibleCount: users.length,
+        userbaseCount,
+        percentOfUserbase,
+        charactersToDelete,
+        charactersToReHome,
+        breakerWarning: userbaseCount > 0 && users.length / userbaseCount > BREAKER_WARN_FRACTION,
+      },
+    };
+  }
+
+  /** Owned characters split by the same reach signal the purge acts on (D11). */
+  private async splitOwnedCharacters(
+    userId: string
+  ): Promise<{ toDelete: number; toReHome: number }> {
+    // Intentionally unbounded (exception to the bounded-findMany rule, same as
+    // the eraser's owned-set query): a paginated page would under-report the
+    // character impact the operator is deciding on.
+    const owned = await this.prisma.personality.findMany({
+      where: { ownerId: userId },
+      select: { id: true },
+    });
+    if (owned.length === 0) {
+      return { toDelete: 0, toReHome: 0 };
+    }
+    const reHomeIds = await findCrossUserReachIds(
+      this.prisma,
+      userId,
+      owned.map(character => character.id)
+    );
+    return { toDelete: owned.length - reHomeIds.length, toReHome: reHomeIds.length };
+  }
+}

--- a/services/api-gateway/src/services/retention/crossUserReach.test.ts
+++ b/services/api-gateway/src/services/retention/crossUserReach.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Prisma } from '@tzurot/common-types/services/prisma';
+import { findCrossUserReachIds } from './crossUserReach.js';
+
+/** Join the template-strings array (call[0]) to assert on the SQL skeleton. */
+function joinSql(call: unknown[]): string {
+  return (call[0] as TemplateStringsArray).join(' ');
+}
+
+function makeDb(rows: { personalityId: string }[]) {
+  const queryRaw = vi.fn().mockResolvedValue(rows);
+  return { db: { $queryRaw: queryRaw } as unknown as Prisma.TransactionClient, queryRaw };
+}
+
+describe('findCrossUserReachIds', () => {
+  it('returns the ids other users have data on', async () => {
+    const { db } = makeDb([{ personalityId: 'x1' }, { personalityId: 'x2' }]);
+
+    expect(await findCrossUserReachIds(db, 'user-1', ['x1', 'x2', 'z1'])).toEqual(['x1', 'x2']);
+  });
+
+  it('short-circuits without querying when the user owns nothing', async () => {
+    const { db, queryRaw } = makeDb([]);
+
+    expect(await findCrossUserReachIds(db, 'user-1', [])).toEqual([]);
+    expect(queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('spans all three personality-scoped tables and excludes the owner themself', async () => {
+    const { db, queryRaw } = makeDb([]);
+
+    await findCrossUserReachIds(db, 'user-1', ['x1']);
+
+    const sql = joinSql(queryRaw.mock.calls[0]);
+    // Reach = memories ∪ conversation_history ∪ facts (D11's broadened signal).
+    // A narrowing regression here silently deletes characters other people use.
+    expect(sql).toContain('FROM memories m');
+    expect(sql).toContain('FROM conversation_history ch');
+    expect(sql).toContain('FROM memory_facts f');
+    // Reach is about ANOTHER user — the owner's own rows must not count.
+    expect(sql).toContain('p.owner_id != ');
+    // INNER JOINs drop null-persona (world) rows: un-owned content isn't reach.
+    expect(sql).toContain('JOIN personas p');
+    // The departed user's id and the owned ids cross the seam as bound values.
+    expect(queryRaw.mock.calls[0]).toEqual(expect.arrayContaining([['x1'], 'user-1']));
+  });
+});

--- a/services/api-gateway/src/services/retention/crossUserReach.ts
+++ b/services/api-gateway/src/services/retention/crossUserReach.ts
@@ -1,0 +1,57 @@
+/**
+ * Cross-user reach for retention (Phase 2, D11).
+ *
+ * A character has CROSS-USER reach when a user OTHER than its owner has a
+ * memory, conversation-history row, or fact scoped to it. That is the signal
+ * that decides a departed owner's character's fate under a retention purge:
+ *
+ *   - reach  → re-home to the Orphaned-Characters sentinel (other people are
+ *              still using it; deleting it would take their data with it)
+ *   - none   → delete with the account (nobody else uses it — minimize)
+ *
+ * Single-sourced here because BOTH the eraser (which acts on it) and the
+ * preview (which reports it) must agree — a drift between "what the report
+ * says will be re-homed" and "what the purge actually re-homes" is exactly the
+ * class of bug D3 exists to prevent.
+ */
+
+import { type Prisma } from '@tzurot/common-types/services/prisma';
+
+/**
+ * The ids among `ownedIds` that have cross-user reach — i.e. the characters a
+ * retention purge re-homes instead of deleting.
+ *
+ * Broadened from the memories-only `fetchOtherUserReach` to all three
+ * personality-scoped tables (council). The INNER JOINs drop world/orphan rows
+ * with a null `persona_id` — reach is about another USER, not un-owned content.
+ *
+ * Accepts a transaction client OR a plain `PrismaClient` (the latter is
+ * assignable to `Prisma.TransactionClient`), so the eraser can call it inside
+ * its deletion transaction and the preview can call it on the base client.
+ */
+export async function findCrossUserReachIds(
+  db: Prisma.TransactionClient,
+  userId: string,
+  ownedIds: string[]
+): Promise<string[]> {
+  if (ownedIds.length === 0) {
+    return [];
+  }
+  const rows = await db.$queryRaw<{ personalityId: string }[]>`
+    SELECT DISTINCT reach.personality_id AS "personalityId"
+    FROM (
+      SELECT m.personality_id FROM memories m
+        JOIN personas p ON m.persona_id = p.id
+        WHERE m.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
+      UNION ALL
+      SELECT ch.personality_id FROM conversation_history ch
+        JOIN personas p ON ch.persona_id = p.id
+        WHERE ch.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
+      UNION ALL
+      SELECT f.personality_id FROM memory_facts f
+        JOIN personas p ON f.persona_id = p.id
+        WHERE f.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
+    ) reach
+  `;
+  return rows.map(row => row.personalityId);
+}


### PR DESCRIPTION
## What

Retention Phase 2 **PR-C** (design D2/D3/D4). Selects and reports the purge-eligible cohort. **Deletes nothing** — the purge is PR-D. This is the first retention slice that's runnable against **prod at zero risk**.

### Changes
- **`RetentionPurgeService`** owns **THE** eligibility predicate (D3/D4): unreachable-or-account-gone **AND** inactive past the 180-day window (`last_active_at`, falling back to `created_at`) **AND** not the bot owner **AND** not `retention_exempt` — which also self-excludes the Orphaned Characters sentinel, so re-homed characters can never be purged out from under the users they were preserved for. One predicate, so the count an operator reviews can never drift from the set a purge acts on.
- **`buildPreview()`** adds per-user **character impact** (how many would be deleted vs. re-homed to the orphan bucket) and the **circuit-breaker** percentage annotation (warn above ~15% of the userbase — the Phase-2 breaker is a warning, not a halt).
- **`GET /api/internal/retention/preview`** — service-auth, `safeRead`, replies via `sendContractSuccess` so handler drift fails `tsc`.
- **`pnpm ops retention:preview --env dev|prod`** — read-only, **no confirmation prompt** (D5).
- **Extracted PR-B's private cross-user-reach query** into `retention/crossUserReach.ts`, so the eraser (which *acts* on reach) and the preview (which *reports* it) read the same definition and can't drift.

## The one notable decision: the CLI calls the gateway

This is the **first `packages/tooling` → api-gateway HTTP plumbing** (`getServiceClientForEnv` pulls `PUBLIC_GATEWAY_URL` + `INTERNAL_SERVICE_SECRET` from the api-gateway service's Railway variables). Every other ops command reads the DB directly.

Why build it here: **PR-D has no alternative** — its purge must go through the gateway because `AccountEraserService`'s off-DB cleanup (avatar unlink, Redis eviction, cache broadcast) can't run from tooling. The plumbing gets built either way, so debuting it on a **read-only** endpoint is strictly safer than debuting it on the destructive one. It also satisfies D3 literally (predicate lives in the service; the CLI never re-derives it).

## Scope boundaries (deliberate)

- **No purge, no mutating endpoint, no nag** — PR-D.
- **No TOCTOU re-check** — that belongs inside PR-D's per-user purge transaction.
- **The orphan-accessibility blocker stays open and still gates PR-D.** PR-C only *reports* the re-home split; it activates nothing.
- The reach split reflects today's S3 definition — if PR-D widens it (co-owner follow-up), preview numbers move automatically since both read the extracted module.

## Verification

- **PGLite component test** (`RetentionPurgeService.component.test.ts`) is the load-bearing proof: seeds a user for **every** predicate arm and asserts the cohort is exactly the eligible set — excluded-because-active-again, excluded-because-reachable, excluded-superuser, excluded-`retention_exempt`, and excluded-via-the-`COALESCE(last_active_at, created_at)`-fallback (NULL stamp + young account). Also asserts the character split and the breaker firing at 25%.
- **Conformance**: the new route replays over real HTTP + PGLite through the generated mounts (166 passed / 179 routes); `registry.test.ts` bijection satisfied.
- **Unit**: predicate SQL fragment assertions incl. **negative** ones (the predicate can't silently widen to reachable users); breaker math; both reason labels; handler payload validated against the manifest schema.
- **Tooling**: `gateway-client` asserts the exact Railway arg array (array args, no shell interpolation) and the actionable throw naming a missing variable; the CLI test pins that a gateway failure **exits non-zero** rather than rendering an empty cohort (a silent-empty would read as "nobody is eligible" — the most dangerous possible misreport for a purge preview).
- **Regression**: PR-B's `AccountDeletionService` unit + component tests pass **unchanged** after the reach extraction.
- Full local pre-push gate green (build/lint/test across 15 packages, typecheck:spec, cpd at baseline, guards, depcruise).

## After merge

`retention:preview --env dev` exercises the whole chain live (Railway credential read → service-auth call → predicate → report), and `--env prod` is equally safe — it produces the **first real cohort numbers**, i.e. the actual answer to "who would the purge take?" I'll propose both runs; the prod run is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)