### PR TITLE
fix(ci): weekly audit measures develop and names the ref it measured

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -38,7 +38,28 @@ jobs:
     # visibly rather than inherit GitHub's 360-minute default.
     timeout-minutes: 30
     steps:
+      # Measure `develop`, NOT the trigger ref. A scheduled workflow can only
+      # be fired from the default branch, but its checkout ref is independent
+      # of that — and the ratchet margins answer "will the next PR breach a
+      # ceiling?", which is a question about the branch PRs land on. Measuring
+      # main reports the last RELEASED state, so every margin lags by a full
+      # release: a main-measured `lines current: 96/97` read as one line from
+      # the ceiling while develop had 24 lines of room. The report header names
+      # the resolved ref, so a future change here — or a failure to check out
+      # what was intended — self-reports either way.
+      #
+      # Shallow (the default) on purpose: no tool in HEALTH_TOOLS diffs against
+      # another ref, and the header's ref resolution degrades to a bare SHA
+      # rather than lying if remote-tracking refs are ever absent. Add
+      # fetch-depth: 0 when a roster tool actually needs history, not before.
+      #
+      # A manual run keeps the ref selected in the UI, because the only reason
+      # to dispatch this by hand is to preview one branch's margins before
+      # merging it — pinning `develop` here would silently hand back develop's
+      # numbers instead, with nothing but the header to reveal the swap.
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || 'develop' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/packages/tooling/src/audits/health.test.ts
+++ b/packages/tooling/src/audits/health.test.ts
@@ -156,6 +156,31 @@ describe('runHealth', () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it('prints the measured-ref annotation directly under the header', () => {
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      const argv = args as string[];
+      if (cmd === 'git') {
+        return argv[0] === 'rev-parse' ? 'deadbee\n' : 'origin/develop\n';
+      }
+      return summaryLine(argv[1], 'ok');
+    });
+
+    runHealth({ noFail: true });
+
+    // The composed call site is the one seam the unit tests can't see:
+    // measured-ref.test.ts proves the resolution, formatHealthReport's own
+    // tests prove the rendering, but neither proves the two are wired.
+    const headerBlock = vi
+      .mocked(console.log)
+      .mock.calls.map(call => String(call[0]))
+      .find(text => text.startsWith('## Audit health:'));
+    expect(headerBlock).toBeDefined();
+    // Adjacency is load-bearing, not cosmetic: the Discord step slices from
+    // the header and truncates the TAIL, so a line that drifts down the
+    // report can be cut from the posted message.
+    expect(headerBlock?.split('\n')[1]).toBe('_Measured: origin/develop @ deadbee_');
+  });
+
   it('treats a non-zero exit WITH a fail summary as a finding, not a broken tool', () => {
     vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
       const tool = (args as string[])[1];

--- a/packages/tooling/src/audits/health.ts
+++ b/packages/tooling/src/audits/health.ts
@@ -28,6 +28,7 @@ import chalk from 'chalk';
 import { parseSummary, type AuditSummary } from './summary.js';
 import { collectHealthExtras, formatHealthExtras, type SecurityCount } from './health-extras.js';
 import { collectOpenAdvisories, formatAdvisoriesReport } from './advisories.js';
+import { describeMeasuredRef, formatMeasuredRef } from './measured-ref.js';
 
 /**
  * The static tool roster. Add a tool when it gains `--summary` support AND
@@ -165,9 +166,16 @@ const STATUS_ICON = { ok: '✅', warn: '⚠️', fail: '❌' } as const;
  * Render the consolidated report. Markdown-flavored plain text — readable in
  * a terminal AND postable to Discord verbatim by the weekly workflow.
  */
-export function formatHealthReport(report: HealthReport): string {
+export function formatHealthReport(report: HealthReport, measuredRef?: string): string {
   const lines: string[] = [];
   lines.push(`## Audit health: ${STATUS_ICON[report.overall]} ${report.overall.toUpperCase()}`);
+  // Directly under the header, so it survives both the Discord step's
+  // `sed`-from-the-header slice and its `head -c` tail truncation. Every
+  // number below is measured against THIS tree; the scheduled run's trigger
+  // ref (always the default branch) says nothing about which tree that is.
+  if (measuredRef !== undefined) {
+    lines.push(measuredRef);
+  }
   lines.push('');
   for (const { tool, summary, brokenReason } of report.results) {
     if (summary === null) {
@@ -191,15 +199,16 @@ export function runHealth(options: { noFail?: boolean; rootDir?: string } = {}):
     results.push(runTool(tool));
   }
 
+  const rootDir = options.rootDir ?? process.cwd();
+
   const report = aggregateHealth(results);
   console.log('');
-  console.log(formatHealthReport(report));
+  console.log(formatHealthReport(report, formatMeasuredRef(describeMeasuredRef(rootDir))));
 
   // Report-only context sections (security surface, ratchet margins, docs
   // orphans) — printed after the tool bullets, NEVER part of the verdict or
   // the exit code. Every collector degrades in place rather than throwing.
   console.log('');
-  const rootDir = options.rootDir ?? process.cwd();
 
   // Fetch the full advisory list ONCE and derive the alerts-count bullet from
   // it, rather than paying a second live call to the same endpoint.

--- a/packages/tooling/src/audits/measured-ref.test.ts
+++ b/packages/tooling/src/audits/measured-ref.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const execFileSync = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ execFileSync }));
+
+const { describeMeasuredRef, formatMeasuredRef } = await import('./measured-ref.js');
+
+/** Route each git invocation by its subcommand so tests read declaratively. */
+function stubGit(responses: { sha?: string | Error; refs?: string | Error }): void {
+  execFileSync.mockImplementation((_cmd: string, args: string[]) => {
+    const answer = args[0] === 'rev-parse' ? responses.sha : responses.refs;
+    if (answer === undefined) {
+      throw new Error('git failed');
+    }
+    if (answer instanceof Error) {
+      throw answer;
+    }
+    return answer;
+  });
+}
+
+describe('describeMeasuredRef', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves the short sha and the remote branch pointing at HEAD', () => {
+    stubGit({ sha: '96d0384a2\n', refs: 'origin/develop\n' });
+
+    expect(describeMeasuredRef('/repo')).toEqual({
+      sha: '96d0384a2',
+      remoteRefs: ['origin/develop'],
+    });
+  });
+
+  it('passes argument arrays to git, never an interpolated string', () => {
+    stubGit({ sha: 'abc1234', refs: 'origin/main' });
+
+    describeMeasuredRef('/repo');
+
+    for (const call of execFileSync.mock.calls) {
+      expect(call[0]).toBe('git');
+      expect(Array.isArray(call[1])).toBe(true);
+      expect(call[2]).toMatchObject({ cwd: '/repo' });
+    }
+  });
+
+  it('drops origin/HEAD, which mirrors the default branch and labels nothing', () => {
+    stubGit({ sha: 'abc1234', refs: 'origin/HEAD\norigin/main\n' });
+
+    expect(describeMeasuredRef('/repo').remoteRefs).toEqual(['origin/main']);
+  });
+
+  it('reports no remote branch when the commit is unpushed', () => {
+    stubGit({ sha: 'abc1234', refs: '' });
+
+    expect(describeMeasuredRef('/repo').remoteRefs).toEqual([]);
+  });
+
+  it('treats empty git output as no answer, so the annotation never renders a hole', () => {
+    // A git call that succeeds with empty stdout would otherwise yield '',
+    // which passes a `!== null` check and reaches the formatter as a gap:
+    // `_Measured:  (no matching remote branch)_`.
+    stubGit({ sha: '', refs: '' });
+
+    const ref = describeMeasuredRef('/repo');
+
+    expect(ref.sha).toBeNull();
+    expect(formatMeasuredRef(ref)).toBe('_Measured: ref unavailable (git not readable)_');
+  });
+
+  it('keeps every remote branch when several point at the same commit', () => {
+    // Happens in a full clone after a develop→main fast-forward. NOT reachable
+    // in the weekly workflow, whose checkout fetches only the one requested
+    // ref — this pins the pure function's behaviour, not a pipeline scenario.
+    stubGit({ sha: 'abc1234', refs: 'origin/develop\norigin/main\n' });
+
+    expect(describeMeasuredRef('/repo').remoteRefs).toEqual(['origin/develop', 'origin/main']);
+  });
+
+  it('returns a null sha rather than throwing when git is unreadable', () => {
+    stubGit({ sha: new Error('not a git repository'), refs: new Error('nope') });
+
+    expect(describeMeasuredRef('/repo')).toEqual({ sha: null, remoteRefs: [] });
+  });
+});
+
+describe('formatMeasuredRef', () => {
+  it('names the branch and sha when both resolve', () => {
+    expect(formatMeasuredRef({ sha: '96d0384a2', remoteRefs: ['origin/develop'] })).toBe(
+      '_Measured: origin/develop @ 96d0384a2_'
+    );
+  });
+
+  it('states the sha and says so when no remote branch matches', () => {
+    expect(formatMeasuredRef({ sha: 'abc1234', remoteRefs: [] })).toBe(
+      '_Measured: abc1234 (no matching remote branch)_'
+    );
+  });
+
+  it('degrades to an explicit unavailable rather than implying a branch', () => {
+    const text = formatMeasuredRef({ sha: null, remoteRefs: [] });
+
+    expect(text).toBe('_Measured: ref unavailable (git not readable)_');
+    // The failure mode this guards: silently reading as the reader's own branch.
+    expect(text).not.toContain('origin/');
+  });
+});

--- a/packages/tooling/src/audits/measured-ref.ts
+++ b/packages/tooling/src/audits/measured-ref.ts
@@ -1,0 +1,84 @@
+/**
+ * Measured-ref annotation for the audit-health report.
+ *
+ * The weekly audit is launched by `schedule:`, which GitHub only fires from
+ * the default branch — but a workflow's CHECKOUT ref is independent of its
+ * TRIGGER ref, so the tree the report measures need not be the tree that
+ * launched it. A report that names no ref invites the reader to assume it
+ * measured the branch they are working on, and the ratchet-margin bullets are
+ * where that assumption does damage: `lines current: 96/97 (1 headroom, live
+ * measure)` reads as one line from the ceiling, while the branch the next PR
+ * lands on had 24 lines of room. "live measure" attests that the number was
+ * measured, not which tree it was measured against.
+ *
+ * The annotation is DERIVED from the checkout (git rev-parse / for-each-ref)
+ * rather than passed in by the caller, so it cannot drift from what was
+ * actually measured — a workflow that changes its checkout ref, or forgets
+ * to, self-reports either way.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** Remote symbolic ref that mirrors the default branch — never a useful label. */
+const ORIGIN_HEAD = 'origin/HEAD';
+
+export interface MeasuredRef {
+  /** Short commit SHA of the measured tree; null when git is unreadable. */
+  sha: string | null;
+  /** Remote branches pointing at that commit, e.g. `['origin/develop']`. */
+  remoteRefs: string[];
+}
+
+/**
+ * Run git, returning null for BOTH failure and empty output. Collapsing the
+ * two keeps `null` meaning exactly "no answer" — an empty string would satisfy
+ * a `!== null` check and reach the formatter as a hole in the annotation.
+ */
+function git(args: string[], cwd: string): string | null {
+  try {
+    const output = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return output === '' ? null : output;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve what the current checkout actually is. Remote branches are used
+ * rather than `rev-parse --abbrev-ref HEAD` because `actions/checkout` with an
+ * explicit `ref:` leaves a detached HEAD, for which that command answers the
+ * useless literal `HEAD`.
+ */
+export function describeMeasuredRef(rootDir: string): MeasuredRef {
+  const sha = git(['rev-parse', '--short', 'HEAD'], rootDir);
+  const raw = git(
+    ['for-each-ref', '--format=%(refname:short)', '--points-at', 'HEAD', 'refs/remotes/origin'],
+    rootDir
+  );
+  const remoteRefs =
+    raw === null
+      ? []
+      : raw
+          .split('\n')
+          .map(line => line.trim())
+          .filter(line => line.length > 0 && line !== ORIGIN_HEAD);
+  return { sha, remoteRefs };
+}
+
+/**
+ * One-line annotation for the report header. Degrades rather than lying: an
+ * unresolvable ref says so instead of implying a branch.
+ */
+export function formatMeasuredRef(ref: MeasuredRef): string {
+  if (ref.sha === null) {
+    return '_Measured: ref unavailable (git not readable)_';
+  }
+  if (ref.remoteRefs.length === 0) {
+    return `_Measured: ${ref.sha} (no matching remote branch)_`;
+  }
+  return `_Measured: ${ref.remoteRefs.join(', ')} @ ${ref.sha}_`;
+}


### PR DESCRIPTION
## The bug

This week's audit reported:

```
- lines rules:   2229/2270 (41 headroom, live measure)
- lines current: 96/97     (1 headroom,  live measure)
```

One line of headroom on `CURRENT.md` reads as urgent. It wasn't — those are `main`'s numbers:

| Ref | CURRENT.md | rules |
|---|---:|---:|
| `main` | 96 / 97 | 2229 / 2270 |
| `origin/develop` | **73** | **1891** |

So every ratchet margin lagged by a full release, understating rules headroom by **338 lines**. The margins answer "will the next PR breach a ceiling?" — a question about the branch PRs land on, not the last released state.

## Why it happened

`schedule:` can only *fire* from the default branch. That part is a GitHub constraint. But a workflow's **checkout** ref is independent of its **trigger** ref, and the checkout was bare:

```yaml
- uses: actions/checkout@v7          # → main
```

## The deeper defect

The report named **no ref at all**. `live measure` attests that a number was measured, not which tree it was measured against — so a reader assumes their own branch. Proving otherwise took a manual line-count across three refs.

The header now carries the resolved ref:

```
## Audit health: ⚠️ WARN
_Measured: origin/develop @ 96d0384a2_
```

It is **derived** from the checkout, not passed in by the workflow, so it cannot drift from what was measured — a future change to the checkout ref, or a failure to check out what was intended, self-reports either way. That is the durable half of this fix; `ref: develop` alone would leave the next divergence just as invisible.

## Implementation notes

- Remote branches (`for-each-ref --points-at HEAD`) rather than `rev-parse --abbrev-ref HEAD`, because `actions/checkout` with an explicit `ref:` leaves a **detached HEAD**, for which that command answers the useless literal `HEAD`.
- `origin/HEAD` is filtered — it only mirrors the default branch and labels nothing.
- An unresolvable ref renders `_Measured: ref unavailable (git not readable)_` rather than implying a branch. A test asserts the degraded string contains no `origin/`.
- The line sits **directly under the header** so it survives both the Discord step's `sed`-from-header slice and its `head -c 1800` tail truncation. A test pins that adjacency, since it's load-bearing rather than cosmetic.
- **Checkout stays shallow.** An earlier revision added `fetch-depth: 0` justified as keeping `origin/main` reachable for `guard:workflow-sync`. That justification was false and the review caught it: `guard:workflow-sync` is not in `HEALTH_TOOLS`, and nothing in the audit path diffs against another ref (`grep 'origin/main|workflow-sync' packages/tooling/src/audits/` → nothing). The flag is gone; the comment now says to add it when a roster tool actually needs history. If the ref resolution ever degrades to a bare SHA on a shallow checkout, that's a one-line fix backed by evidence instead of speculation.

## Verification

- **10 new unit tests** — 9 in `measured-ref.test.ts` (git seam mocked; one asserts args cross the seam as an **array**, never an interpolated string, per `00-critical` shell-safety), plus a `runHealth` seam assertion that the composed call site actually reaches the printed output. That last one was verified to be a real regression test by un-wiring the call site and confirming it fails.
- **Full tooling suite green**; `pnpm quality` green, 27/27 gate parity
- YAML parses (`yaml.safe_load`)
- **End-to-end smoke** against a live checkout, since the unit tests mock the git seam:
  ```
  resolved: {"sha":"96d0384a2","remoteRefs":["origin/chore/backlog-admission-bar"]}
  ## Audit health: ⚠️ WARN
  _Measured: origin/chore/backlog-admission-bar @ 96d0384a2_
  ```
- Blast radius confined to `packages/tooling` — `grep -rn "audits/"` outside that package returns nothing

## Related

A GitHub Actions major outage during this PR's first push surfaced a separate gap: a workflow that never starts registers **no check-runs**, so `gh pr view` reports `mergeStateStatus: CLEAN` — and `develop` has `required_status_checks: null`, so nothing mechanically blocks a merge with unrun checks. Filed as a Quick Win in `backlog/now.md` (`bcdbea074`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)