### PR TITLE
fix(ci): promise-ledger hook — drop the escape hatch, catch the queue-list shape

### DIFF
--- a/.claude/hooks/promise-ledger-check.probe.sh
+++ b/.claude/hooks/promise-ledger-check.probe.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # Fixture check for promise-ledger-check.sh — run after ANY edit to the hook.
-# Asserts the exit-code table over synthetic transcripts: a deferred-work
-# promise with no same-turn backlog write (and no backlog-file mention) blocks;
-# a same-turn write, a backlog-file mention, a process-action promise, and a
-# no-promise close all pass. The stop_hook_active re-stop always passes.
+# Asserts the exit-code table over synthetic transcripts. A deferred-work
+# promise blocks unless a same-turn backlog write happened — and a bare mention
+# of a backlog FILENAME no longer clears it (fixture `f`), because naming a file
+# is topic correlation rather than evidence this commitment is tracked. Passing
+# cases: a same-turn write, a process-action promise, a no-promise close, and
+# the stop_hook_active re-stop.
 #
 # Colocated with the hook — the transcript-parsing python is the fragile part;
 # this harness pins its behavior on hook edits.
@@ -48,8 +50,216 @@ check 0 "no promise" "$TMP/d.jsonl"
 mktx "$TMP/e.jsonl" "Good idea — let's not forget the ratchet trend work."
 check 2 "let's-not-forget, no write" "$TMP/e.jsonl"
 
+# SPEC CHANGE (deliberate, not a weakened assertion): the filename escape hatch
+# is gone. Naming a backlog file no longer clears the turn — it is topic
+# correlation, not proof this commitment is tracked, and it passed every promise
+# made on a day whose work WAS the backlog. Expectation flips 0 → 2.
 mktx "$TMP/f.jsonl" "I'll circle back to the browse retrofit after this PR. Tracked in follow-ups.md already."
-check 0 "promise but names a backlog file" "$TMP/f.jsonl"
+check 2 "naming a backlog file no longer clears a promise (hatch removed)" "$TMP/f.jsonl"
+
+# The queue-list shape — verbatim forms that slipped past the prose matcher.
+# Each was a real untracked commitment: an enumeration under a label carries no
+# future-tense verb and no deferral marker, so PROMISE cannot see it.
+mktx "$TMP/q1.jsonl" "Done and merged.
+
+**Still queued**: the two \`commands:audit\` findings, the orphan doc, and the monitor caveat."
+check 2 "queue-list: bolded 'Still queued:' lead-in" "$TMP/q1.jsonl"
+
+mktx "$TMP/q2.jsonl" "That's landed.
+
+## Queue
+
+- the commands:audit pair
+- the 05-tooling caveat"
+check 2 "queue-list: markdown heading" "$TMP/q2.jsonl"
+
+mktx "$TMP/q3.jsonl" "All green. Remaining: the singleton sweep and the parity guard."
+check 2 "queue-list: 'Remaining:' lead-in" "$TMP/q3.jsonl"
+
+# False-positive guards — the queue words in ordinary prose, no label anchor.
+mktx "$TMP/q4.jsonl" "The remaining budget is about 50k tokens, so we have room."
+check 0 "FP guard: 'remaining' in prose, no colon anchor" "$TMP/q4.jsonl"
+
+mktx "$TMP/q5.jsonl" "Two runs are still queued on GitHub's side; nothing for us to do."
+check 0 "FP guard: 'still queued' describing CI, no label anchor" "$TMP/q5.jsonl"
+
+# A queue-list WITH a same-turn backlog write still passes — filing is the fix.
+mktx "$TMP/q6.jsonl" "**Still queued**: the audit pair and the caveat." "$CLAUDE_PROJECT_DIR/backlog/now.md"
+check 0 "queue-list + same-turn backlog write" "$TMP/q6.jsonl"
+
+# Anchor coverage. The plain ASCII hyphen is the one that matters most: voice
+# transcription renders a spoken pause as "-", never as an em dash, so an anchor
+# class without it misses the likeliest real form.
+mktx "$TMP/q7.jsonl" "All green. Remaining - the singleton sweep and the parity guard."
+check 2 "queue-list: plain ASCII hyphen lead-in (voice-dictated form)" "$TMP/q7.jsonl"
+
+mktx "$TMP/q8.jsonl" "All green. Remaining – the singleton sweep."
+check 2 "queue-list: en-dash lead-in" "$TMP/q8.jsonl"
+
+# Heading vocabulary parity — these matched NEITHER pattern when the list and
+# heading matchers kept separate word lists.
+mktx "$TMP/q9.jsonl" "Merged.
+
+## Still Open
+
+- the parity guard"
+check 2 "queue-heading: 'Still Open' (list-only vocabulary before the merge)" "$TMP/q9.jsonl"
+
+mktx "$TMP/q10.jsonl" "Merged.
+
+### Left To Do
+
+- the singleton sweep"
+check 2 "queue-heading: 'Left To Do' (list-only vocabulary before the merge)" "$TMP/q10.jsonl"
+
+# A bare "queue" is heading-only. In a BullMQ/Redis codebase these are ordinary
+# sentences, and a shared-vocabulary union would fire on both.
+mktx "$TMP/q11.jsonl" "Traced it: the BullMQ queue: jobs are processed in order, so ordering is fine."
+check 0 "FP guard: bare 'queue' + colon in prose (BullMQ discussion)" "$TMP/q11.jsonl"
+
+mktx "$TMP/q12.jsonl" "Redis queue - the worker drains it every 30s, so the backlog clears itself."
+check 0 "FP guard: bare 'queue' + hyphen in prose (Redis discussion)" "$TMP/q12.jsonl"
+
+mktx "$TMP/q13.jsonl" "Done.
+
+## Queue
+
+- the audit pair"
+check 2 "queue-heading: bare 'queue' IS allowed in heading position" "$TMP/q13.jsonl"
+
+# ── Vocabulary coverage: every QUEUE_WORDS alternative, positive AND negative.
+# Half the vocabulary previously had zero fixtures, so "all fixtures pass" said
+# nothing about most of the words it claimed to verify.
+mktx "$TMP/v1.jsonl"  "Outstanding: the parity guard and the sweep."
+check 2 "vocab+: 'outstanding' as a line-leading label" "$TMP/v1.jsonl"
+mktx "$TMP/v2.jsonl"  "Next up - the commands:audit pair."
+check 2 "vocab+: 'next up' as a line-leading label" "$TMP/v2.jsonl"
+mktx "$TMP/v3.jsonl"  "Queued up: the drain batches."
+check 2 "vocab+: 'queued up' as a line-leading label" "$TMP/v3.jsonl"
+mktx "$TMP/v4.jsonl"  "Queues behind it — the singleton sweep."
+check 2 "vocab+: 'queues behind' as a line-leading label" "$TMP/v4.jsonl"
+mktx "$TMP/v5.jsonl"  "Still to do: the receipt ritual."
+check 2 "vocab+: 'still to do' as a line-leading label" "$TMP/v5.jsonl"
+mktx "$TMP/v6.jsonl"  "Still to come — the question-receipt hook."
+check 2 "vocab+: 'still to come' as a line-leading label" "$TMP/v6.jsonl"
+
+# ── FP guards in an EM-DASH-HEAVY prose style. The earlier guards used a
+# semicolon, a form the owner does not write, so they passed while the same
+# sentences with an em dash fired. Mid-sentence position must not match.
+mktx "$TMP/v7.jsonl"  "Two runs are still queued on GitHub's side — nothing for us to do."
+check 0 "FP guard: 'still queued' mid-sentence + em dash" "$TMP/v7.jsonl"
+mktx "$TMP/v8.jsonl"  "The work here is outstanding — nice catch on the anchor class."
+check 0 "FP guard: 'outstanding' mid-sentence + em dash" "$TMP/v8.jsonl"
+mktx "$TMP/v9.jsonl"  "This PR is still open for review — nothing blocking."
+check 0 "FP guard: 'still open' mid-sentence + em dash" "$TMP/v9.jsonl"
+mktx "$TMP/v10.jsonl" "The remaining budget is about 50k — plenty of room."
+check 0 "FP guard: 'remaining' mid-sentence + em dash" "$TMP/v10.jsonl"
+mktx "$TMP/v11.jsonl" "That's outstanding work on the parity guard - thanks."
+check 0 "FP guard: 'outstanding' mid-sentence + ASCII hyphen" "$TMP/v11.jsonl"
+
+# Code regions are stripped before matching. A pasted type declaration is the
+# strongest false trigger available: a line-leading queue word with a colon at
+# distance zero is precisely the label shape the rules above are tuned for, and
+# in a TypeScript repo those field names are ordinary.
+TICK=$(printf '\140')
+FENCE="$TICK$TICK$TICK"
+
+mktx "$TMP/c1.jsonl" "Here is the shape:
+
+${FENCE}ts
+interface RateLimitState {
+  remaining: number;
+  outstanding: string[];
+}
+${FENCE}
+
+Nothing deferred."
+check 0 "FP guard: 'remaining:' / 'outstanding:' inside a fenced TS block" "$TMP/c1.jsonl"
+
+mktx "$TMP/c2.jsonl" "Done.
+
+**Still queued**: the ${TICK}commands:audit${TICK} pair and the caveat."
+check 2 "real label still fires when it contains an inline code span" "$TMP/c2.jsonl"
+
+mktx "$TMP/c3.jsonl" "Quoting the old wording: ${TICK}Remaining: the sweep${TICK} and nothing more."
+check 0 "FP guard: a label QUOTED inside an inline span does not fire" "$TMP/c3.jsonl"
+
+# ACCEPTED false negative, pinned so it is a decision rather than a surprise: a
+# trigger word wrapped in its own span does not fire. The backtick SPLITS the
+# phrase, so keeping trigger-bearing spans would not fix it either — only
+# deleting backtick characters would, and that makes "`remaining: number` is the
+# field" a line-leading label. Rare miss traded for a likelier misfire.
+mktx "$TMP/c4.jsonl" "Done.
+
+**Still ${TICK}queued${TICK}**: the sweep and the guard."
+check 0 "ACCEPTED FN: trigger word split by its own inline span" "$TMP/c4.jsonl"
+
+# Bare "queue" is heading-only AND must be the whole heading. A heading ABOUT
+# the job system is not a list of deferred work; the multi-word phrases keep
+# the looser rule because "## Remaining Tasks" is a deferred-work list whatever
+# follows the trigger.
+mktx "$TMP/h1.jsonl" "Traced it.
+
+## Queue Configuration
+
+The prefetch is set to 4."
+check 0 "FP guard: '## Queue Configuration' is a job-system heading" "$TMP/h1.jsonl"
+
+mktx "$TMP/h2.jsonl" "Traced it.
+
+## Queue Health
+
+Depth is nominal."
+check 0 "FP guard: '## Queue Health' is a job-system heading" "$TMP/h2.jsonl"
+
+mktx "$TMP/h3.jsonl" "Merged.
+
+## Remaining Tasks
+
+- the singleton sweep"
+check 2 "phrase headings keep the looser rule ('## Remaining Tasks')" "$TMP/h3.jsonl"
+
+# Hyphenated compound words must not supply the anchor. The <=30-char window
+# otherwise reaches the "-" inside an ordinary compound, and this codebase's
+# prose is dense with them (user-facing, fail-closed, read-only, cross-user).
+# Dash anchors therefore require leading whitespace; colons do not.
+mktx "$TMP/w1.jsonl" "Remaining work is user-facing polish."
+check 0 "FP guard: compound word supplies no anchor ('user-facing')" "$TMP/w1.jsonl"
+mktx "$TMP/w2.jsonl" "Outstanding items are fail-closed by design."
+check 0 "FP guard: compound word supplies no anchor ('fail-closed')" "$TMP/w2.jsonl"
+mktx "$TMP/w3.jsonl" "Next up we need cross-user checks before the sweep."
+check 0 "FP guard: compound word supplies no anchor ('cross-user')" "$TMP/w3.jsonl"
+mktx "$TMP/w4.jsonl" "Remaining - the singleton sweep and the parity guard."
+check 2 "spaced hyphen IS still a valid anchor" "$TMP/w4.jsonl"
+
+# The anchor WINDOW stops a colon reaching across a clause. Real labels have a
+# tail of 0-6 chars between trigger and colon; ordinary prose runs 8-9. Window
+# of 6 is measured, not guessed.
+mktx "$TMP/x1.jsonl" "Remaining question: should we ship now or wait?"
+check 0 "FP guard: colon across a clause ('Remaining question:')" "$TMP/x1.jsonl"
+mktx "$TMP/x2.jsonl" "Outstanding balance: 50 dollars due."
+check 0 "FP guard: colon across a clause ('Outstanding balance:')" "$TMP/x2.jsonl"
+mktx "$TMP/x3.jsonl" "Next up question: do we ship today?"
+check 0 "FP guard: colon across a clause ('Next up question:')" "$TMP/x3.jsonl"
+mktx "$TMP/x4.jsonl" "Remaining Tasks: the singleton sweep."
+check 2 "label with a short tail still fires ('Remaining Tasks:')" "$TMP/x4.jsonl"
+
+# Subagent-delegated filing: the write lands in a DIFFERENT transcript, so this
+# hook cannot see it and blocks once. Naming the file no longer clears it (the
+# hatch is gone), so the only recovery is the ordinary stop-and-re-ack. Pinned
+# because the hook comment now makes that claim explicitly.
+mktx "$TMP/s1.jsonl" "Filed via a subagent. Tracked in backlog/cold/follow-ups.md now.
+
+**Still queued**: the audit pair."
+check 2 "subagent-delegated write blocks once (no cross-transcript visibility)" "$TMP/s1.jsonl"
+check 0 "…and the re-stop clears it" "$TMP/s1.jsonl" true
+
+# Code stripping is SHARED with PROMISE/ALT, not queue-list-scoped. Pinned so the
+# consequence is a recorded decision rather than a surprise to a future editor.
+mktx "$TMP/s2.jsonl" "I'll ${TICK}refactor${TICK} this later once the schema settles."
+check 0 "ACCEPTED: prose promise whose VERB sits in a stripped span" "$TMP/s2.jsonl"
+mktx "$TMP/s3.jsonl" "I'll refactor the ${TICK}QueueService${TICK} later once the schema settles."
+check 2 "prose promise still fires when only an incidental span is stripped" "$TMP/s3.jsonl"
 
 mktx "$TMP/h.jsonl" "I will add the sync gate later once the schema settles."
 check 2 "full-form 'I will' promise (not just the contraction), no write" "$TMP/h.jsonl"

--- a/.claude/hooks/promise-ledger-check.sh
+++ b/.claude/hooks/promise-ledger-check.sh
@@ -75,8 +75,13 @@ BACKLOG_RE = re.compile(r"(^|/)(backlog/|CURRENT\.md|BACKLOG\.md)")
 
 # (a) same-turn backlog writes. LIMITATION: only direct Edit/Write/MultiEdit in
 # THIS transcript count — a backlog file written by a delegated subagent (Agent
-# tool) lands in a different transcript and won't be seen here; the closing
-# message must then name the backlog file to take the escape hatch below.
+# tool) lands in a different transcript and won't be seen here. There is no
+# longer any way for the closing message to assert the write happened: naming
+# the file used to satisfy an escape hatch, and that hatch is deliberately gone
+# (see below). So a subagent-delegated filing WILL block once, and the only
+# recovery is the ordinary one — say where it was filed and stop again, which
+# `stop_hook_active` lets through. That is the accepted one-acked-turn cost,
+# not a defect.
 wrote_backlog = any(
     block.get("type") == "tool_use"
     and block.get("name") in ("Edit", "Write", "MultiEdit")
@@ -99,17 +104,55 @@ for entry in records:
 if wrote_backlog or not final_text.strip():
     print("ok"); sys.exit()
 
-# Escape hatch: the message names an actual backlog FILE where it's tracked.
-# Deliberately filename-based, not a bare "filed/tracked" word — the word form
-# false-negatived "Filed the export nit. I'll add the gate later" (the "filed"
-# was about a different thing; the promise was still unfiled). False positives
-# here cost one acknowledged turn; false negatives defeat the hook — bias to fire.
-TEXT_TRACK_RE = re.compile(
-    r"(backlog/|follow-ups\.md|ideas\.md|now\.md|active-epic\.md|epic-log\.md|queue\.md|CURRENT\.md|BACKLOG\.md)",
-    re.I,
-)
-if TEXT_TRACK_RE.search(final_text):
+# Strip fenced code blocks and inline spans BEFORE any matching. A pasted type
+# declaration is the strongest false trigger there is — `remaining: number;` is a
+# line-leading queue word with a colon at distance zero, exactly the label shape
+# every position and anchor rule below is tuned to catch. In a TypeScript repo,
+# messages carrying an interface are routine and `remaining` / `outstanding` /
+# `queued` are ordinary field names.
+#
+# Lexical, not semantic: this removes markdown code regions by their delimiters,
+# the same class of operation as reading a tool name out of the transcript. It
+# does not interpret what the code says. A real label survives an inline span
+# inside it, because only the span itself is removed.
+#
+# SHARED, not queue-list-scoped: this rewrites `final_text` for every matcher
+# below, PROMISE and ALT included. The motivating case was a pasted type
+# declaration, but the consequence reaches further — "I'll `refactor` this
+# later" no longer fires, because the verb is inside the stripped span. Accepted
+# under the same cost model, and stated here so a future editor does not assume
+# the prose matchers see the raw message.
+#
+# Known uncovered shapes, all judged acceptable against the one-acked-turn cost:
+# an UNTERMINATED fence (a truncated paste) is not stripped, but that fails
+# toward firing, which is the safe direction; 4-space INDENTED code blocks are
+# not stripped at all; and a status heading like "## Remaining Tasks" fires,
+# which is arguably correct rather than a false positive — such a heading is a
+# list of deferred work.
+#
+# One known FALSE NEGATIVE, the expensive direction, kept deliberately: a
+# trigger word wrapped in its own span ("**Still `queued`**: …") does not fire.
+# Note this is NOT merely because the span is removed — a backtick SPLITS the
+# phrase, so "still queued" fails to match whether the span survives or not.
+# Keeping trigger-bearing spans therefore does not fix it; only deleting the
+# backtick characters would, and that turns "`remaining: number` is the field"
+# into a line-leading label, trading this rare miss for a likelier misfire.
+# Widen this only on an observed misfire, not on speculation: every previous
+# attempt to pre-empt a shape here made the matcher worse.
+final_text = re.sub(r"```.*?```", "", final_text, flags=re.S)
+final_text = re.sub(r"`[^`\n]*`", "", final_text)
+if not final_text.strip():
     print("ok"); sys.exit()
+
+# NO filename escape hatch. A previous version passed the turn whenever the
+# closing message mentioned any backlog filename, on the theory that naming the
+# file meant the promise was tracked there. That inference is topic-correlated,
+# not commitment-specific, and it collapses on exactly the days it matters: when
+# the backlog IS the work, those filenames appear constantly for unrelated
+# reasons, and every promise made that day sails through. Removed deliberately —
+# a false positive costs one acknowledged turn (this hook blocks at most once),
+# while a false negative costs an untracked commitment. The costs are asymmetric
+# by orders of magnitude, so this fails toward firing.
 
 # Deferred-WORK promise: a work verb + a deferral marker, reasonably close.
 # Narrow on purpose — "I'll merge once CI passes" (process, not backlogged
@@ -124,7 +167,93 @@ ALT = re.compile(
     r"\b(let['’]?s\s+not\s+forget|as\s+a\s+follow[-\s]?up|in\s+a\s+follow[-\s]?up\s+PR)\b",
     re.I,
 )
-if PROMISE.search(final_text) or ALT.search(final_text):
+
+# The QUEUE-LIST shape. PROMISE above only matches first-person prose ("I'll fix
+# that later") — but deferred work is far more often written as an enumeration
+# under a label: "**Still queued**: the two audit findings, the orphan doc, …".
+# That form carries no future-tense verb and no deferral marker, so it slipped
+# past the prose matcher on every occurrence of a full session.
+#
+# POSITION is the discriminator, not proximity. A label LEADS A LINE; a prose
+# mention sits mid-sentence. An earlier version only required the anchor
+# punctuation within ~60 chars of the queue word, which fires on ordinary writing
+# in an em-dash-heavy style: "two runs are still queued on GitHub's side — nothing
+# for us to do" matched, and so did "the work here is outstanding — nice catch".
+# A hook firing on normal sentences at every turn-end trains reflexive
+# acknowledgement, which destroys the signal more thoroughly than missing would.
+#
+# So the queue word must start a line (after an optional list marker and optional
+# bold/italic markup), with the anchor following inside a SHORT same-line window.
+QUEUE_WORDS = (
+    r"still\s+queued|queued(?:\s+up)?|remaining|outstanding|next\s+up|"
+    r"left\s+to\s+do|still\s+open|queue[sd]?\s+behind|still\s+to\s+(?:do|come)"
+)
+
+# Headings get one extra word — a bare "queue" — under a STRICTER rule than the
+# phrases get. The vocabularies are deliberately not identical: "## Queue" is
+# unambiguously a deferred-work list, while "the BullMQ queue: jobs run in order"
+# is ordinary prose, and in THIS codebase (BullMQ, Redis, job queues) that
+# sentence is likely rather than hypothetical. Heading position is strong
+# evidence, so it can afford a weaker word; the list matcher cannot.
+#
+# But heading position alone is not enough for a word this weak: "## Queue
+# Configuration" and "## Queue Health" are headings ABOUT the job system, not
+# lists of deferred work. So bare "queue" must be the WHOLE heading, while the
+# multi-word phrases may appear anywhere in one ("## Remaining Tasks" is a
+# deferred-work list no matter what follows the trigger).
+
+# Lead-in punctuation. ASCII hyphen included deliberately: the owner dictates by
+# voice, and transcribers render a spoken pause as a plain "-", never an em dash.
+# An anchor class omitting it would miss the most likely real form while
+# accepting the typographically-correct one nobody types.
+#
+# Dash-family anchors REQUIRE leading whitespace; colons do not. Without that,
+# the window reaches the hyphen inside an ordinary compound word: "Remaining
+# work is user-facing polish." matched, because the lazy scan walked 13 chars
+# and found the "-" in "user-facing". This codebase's prose is dense with such
+# compounds (fail-closed, read-only, cross-user, long-lived), so that is a
+# routine sentence, not a contrived one. Colons need no whitespace guard — they
+# never occur inside a word.
+#
+# The WINDOW is what stops a colon reaching across a clause, and 6 is measured
+# rather than guessed. Tail length between the trigger word and the anchor:
+#   real labels  → 0, 0, 0, 2, 6   ("Remaining:", "**Still queued**:", "Remaining Tasks:")
+#   ordinary prose → 8, 9, 9       ("Remaining question:", "Outstanding balance:")
+# A window of 6 keeps every label form actually written here and rejects all
+# three prose forms. It gives up one uncommon true positive — "Still queued
+# behind them:" at 12 — which is the deliberate trade: a false positive at every
+# turn-end trains reflexive acknowledgement, and that destroys the signal more
+# thoroughly than an occasional miss.
+QUEUE_ANCHOR = r"(?:\s[-–—]|[:：])"
+
+# Where a label may begin: line start, OR immediately after a sentence boundary
+# on the same line ("All green. Remaining: the sweep."). Sentence-start is
+# included because a label routinely follows a closing sentence, and requiring
+# line-start alone rejected that real form. It does NOT reintroduce the
+# mid-sentence false positives — those have the queue word inside a clause, not
+# opening one. Then optional furniture: indent, list bullet or ordinal, bold.
+QUEUE_LEAD = (
+    r"(?:^|\n|(?<=[.!?])[ \t])[ \t]{0,3}"
+    r"(?:[-*+]\s+|\d+[.)]\s+)?(?:\*\*|__|\*)?[ \t]*"
+)
+
+QUEUE_LIST = re.compile(
+    rf"{QUEUE_LEAD}({QUEUE_WORDS})\b[^\n]{{0,6}}?{QUEUE_ANCHOR}", re.I
+)
+QUEUE_HEADING = re.compile(
+    rf"(?:^|\n)\s{{0,3}}#{{1,6}}\s*(?:"
+    rf"[^\n]{{0,40}}?\b({QUEUE_WORDS})\b"  # phrases: anywhere in the heading
+    rf"|queue\s*:?\s*(?=\n|$)"             # bare "queue": must BE the heading
+    rf")",
+    re.I,
+)
+
+if (
+    PROMISE.search(final_text)
+    or ALT.search(final_text)
+    or QUEUE_LIST.search(final_text)
+    or QUEUE_HEADING.search(final_text)
+):
     print("promise")
 else:
     print("ok")
@@ -137,9 +266,14 @@ cat >&2 << 'MSG'
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 PROMISE LEDGER — deferred-work promise without a same-turn backlog write
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Your closing message defers work ("I'll … later" / "follow-up …") but
-no backlog/**/*.md or CURRENT.md write happened this turn. Per
-06-backlog.md § promise ledger, a promise that lives only in chat
+Your closing message defers work but no backlog/**/*.md or CURRENT.md
+write happened this turn. It matched one of:
+  - a prose promise      — "I'll add that later" / "as a follow-up"
+  - an enumerated queue  — "**Still queued**: a, b, c" / "## Remaining"
+The second form is the one that reads as innocuous: a list under a
+label carries no future-tense verb and no deferral marker, which is
+exactly why it went unnoticed long enough to lose real commitments.
+Per 06-backlog.md § promise ledger, a promise that lives only in chat
 dies at the next compaction.
 
 Do ONE of:


### PR DESCRIPTION
## The failure

The `Stop` hook that exists to stop deferred work from living in chat **missed ~8 times in one session**. Three items ended up tracked nowhere. One was worse than untracked — it lived as a sentence inside a backlog entry that was later legitimately removed, taking the nested commitment with it. The owner asked twice, hours apart, whether the queue was tracked; the second ask is what surfaced it.

## Why — and why it isn't a tuning problem

Session mining plus a council pass (**GLM 5.2 / Kimi K2.7-code / Qwen 3.7-max — unanimous, no split**) found the failure is structural.

The hook made **three separate semantic inferences from prose**: did a promise occur, is it tracked, is the tracking still relevant. Each has its own failure surface, which is why one day produced three *independent* misses:

| # | Inference | How it broke |
|---|---|---|
| 1 | "message names a backlog file → tracked there" | The day's *work* was the backlog, so those filenames appeared constantly for unrelated reasons |
| 2 | "a backlog write this turn → promises covered" | Filing item A cleared a promise about item B |
| 3 | "promises look like `I'll <verb> … later`" | Real form is `**Still queued**: a, b, c` — no future verb, no deferral marker |

> "Hooks work when they check canonical representations. They fail when they infer semantics from unstructured text." — GLM 5.2

Qwen added a base-rate argument: this hook fires on **every** turn, so even a small false-positive rate compounds into multiple daily misfires. That cuts both ways, and shaped the design below.

## What this PR changes

**Removed — the filename escape hatch.** Topic correlation is not commitment-specific evidence. The asymmetry: a false positive costs **one acknowledged turn** (the hook blocks at most once per turn-end); a false negative costs a **lost commitment**.

**Added — queue-list detection, discriminated by POSITION rather than proximity.** A label leads a line or follows a sentence boundary; a prose mention sits inside a clause. An earlier revision only required the anchor punctuation *within 60 chars*, which fired on ordinary em-dash writing:

```
FIRES | Two runs are still queued on GitHub's side — nothing for us to do.
FIRES | The work here is outstanding — nice catch.
```

A hook firing on normal sentences at every turn end trains reflexive acknowledgement, which destroys the signal more thoroughly than the original gap did.

**Added — code regions stripped before matching.** A pasted type declaration is the strongest false trigger available: `remaining: number;` is a line-leading queue word with a colon at distance zero. In a TypeScript repo those field names are ordinary. The strip is lexical (markdown delimiters), not semantic — a real label still fires when it *contains* an inline span.

**Anchor includes the ASCII hyphen** deliberately: the owner dictates by voice, and transcribers render a spoken pause as `-`, never an em dash. An anchor class omitting it would miss the likeliest real form.

**Heading vocabulary is a deliberate strict superset** — bare `queue` is allowed only in heading position, because `## Queue` is unambiguous while `the BullMQ queue: jobs run in order` is prose, and in this codebase that sentence is likely rather than hypothetical.

## What this PR deliberately does NOT fix

**A same-turn backlog write still clears every promise in the turn.** Filing A licenses promising B. Fixing that by matching write-to-promise would reintroduce the exact semantic inference this change removes. The council's answer is a structured turn-receipt validated for **format** — filed on the board (`cold/ideas.md` § Closure-audit enforcement) with the design and a recorded dissent on the always-on form.

## Spec change, called out

Probe fixture `f` (`"promise but names a backlog file"`) flips **expect-0 → expect-2**. That is the hatch removal, not a weakened assertion — flagged explicitly per `00-critical`'s never-modify-tests-to-pass rule.

## Verification

**52 probe fixtures, all passing.** Every `QUEUE_WORDS` alternative is now exercised — 5 of 10 previously had zero coverage, so "all fixtures pass" verified half of what it appeared to.

Coverage added across rounds:
- Every vocabulary alternative, positively (`v1`–`v6`)
- Em-dash-prose FP guards for the four highest-risk words (`v7`–`v11`) — the earlier guards used a **semicolon**, a form the owner doesn't write, so they passed while the same sentences with an em dash fired
- Fenced-TS-block and inline-span guards (`c1`–`c3`)
- Hyphen and en-dash lead-ins (`q7`, `q8`); heading-vocabulary parity (`q9`, `q10`); heading-only bare `queue` (`q11`–`q13`)

Also run against a real closing message from the session transcript: **exit 2**, where it previously passed silently.

**Accepted cost, stated rather than buried**: the detector cannot distinguish *use* from *mention*, so a message describing the queue-list pattern fires. One acknowledged turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)