### PR TITLE
fix(bot-client): clear both commands:audit warnings

### DIFF
--- a/packages/common-types/src/constants/uxVocabulary.ts
+++ b/packages/common-types/src/constants/uxVocabulary.ts
@@ -82,7 +82,10 @@ export const SELECTOR_DESCRIPTION = {
   preset: 'Which preset',
   globalPreset: 'Which global preset',
   persona: 'Which persona',
-  voice: 'Which voice',
+  // "Which voice" reads as contentless under `/voice voices delete` (the noun
+  // is already the command and the group); "cloned" is what actually
+  // distinguishes these from a TTS config's provider voice.
+  voice: 'Which cloned voice',
   ttsConfig: 'Which TTS config',
 } as const;
 

--- a/packages/common-types/src/generated/commandOptions.ts
+++ b/packages/common-types/src/generated/commandOptions.ts
@@ -64,10 +64,10 @@ export const adminBroadcastOptions = defineTypedOptions({
 });
 
 /**
- * /admin cleanup <timeframe>
+ * /admin cleanup <days>
  */
 export const adminCleanupOptions = defineTypedOptions({
-  timeframe: { type: 'integer', required: false },
+  days: { type: 'integer', required: false },
 });
 
 /**

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -175,8 +175,8 @@
                 "max_value": 365,
                 "min_value": 1,
                 "type": 4,
-                "name": "timeframe",
-                "description": "Time window in days — keep history newer than this (default: 30)",
+                "name": "days",
+                "description": "Keep history newer than this many days (default: 30)",
                 "required": false
               }
             ]
@@ -2565,7 +2565,7 @@
                     "autocomplete": true,
                     "type": 3,
                     "name": "voice",
-                    "description": "Which voice",
+                    "description": "Which cloned voice",
                     "required": true
                   }
                 ]

--- a/services/bot-client/src/commands/admin/cleanup.test.ts
+++ b/services/bot-client/src/commands/admin/cleanup.test.ts
@@ -88,7 +88,7 @@ describe('handleCleanup', () => {
           getString: vi.fn(() => null),
           getBoolean: vi.fn(() => null),
           getInteger: vi.fn((name: string) => {
-            if (name === 'timeframe') return days;
+            if (name === 'days') return days;
             return null;
           }),
         },
@@ -102,7 +102,7 @@ describe('handleCleanup', () => {
       commandName: 'admin',
       isEphemeral: true,
       getOption: vi.fn((name: string) => {
-        if (name === 'timeframe') return days;
+        if (name === 'days') return days;
         return null;
       }),
       getRequiredOption: vi.fn(),

--- a/services/bot-client/src/commands/admin/cleanup.ts
+++ b/services/bot-client/src/commands/admin/cleanup.ts
@@ -19,7 +19,7 @@ const logger = createLogger('admin-cleanup');
 
 export async function handleCleanup(context: DeferredCommandContext): Promise<void> {
   const options = adminCleanupOptions(context.interaction);
-  const daysToKeep = options.timeframe() ?? CLEANUP_DEFAULTS.DAYS_TO_KEEP_HISTORY;
+  const daysToKeep = options.days() ?? CLEANUP_DEFAULTS.DAYS_TO_KEEP_HISTORY;
 
   try {
     const { ownerClient } = clientsFor(context.interaction);

--- a/services/bot-client/src/commands/admin/index.ts
+++ b/services/bot-client/src/commands/admin/index.ts
@@ -338,12 +338,16 @@ export default defineCommand({
         .setName('cleanup')
         .setDescription('Clean up old conversation history')
         .addIntegerOption(option =>
-          // Unlike the enum-window `timeframe`s (usage, incognito, memory
-          // delete), cleanup's is a RAW DAY COUNT — arbitrary N-days is real
-          // admin utility a fixed choice set would destroy (§4.2/D10 call).
+          // A RAW DAY COUNT, not one of the enum windows `timeframe` names
+          // elsewhere (usage, incognito, memory delete) — arbitrary N-days is
+          // real admin utility a fixed choice set would destroy (§4.2/D10
+          // call). It carries its own name for that reason: a shared option
+          // name whose type differs per subcommand is what makes copying one
+          // handler's `options.x()` into another silently return the wrong
+          // shape.
           option
-            .setName('timeframe')
-            .setDescription('Time window in days — keep history newer than this (default: 30)')
+            .setName('days')
+            .setDescription('Keep history newer than this many days (default: 30)')
             .setRequired(false)
             .setMinValue(1)
             .setMaxValue(365)

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
@@ -187,11 +187,11 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
       {
         "autocomplete": undefined,
         "choices": undefined,
-        "description": "Time window in days — keep history newer than this (default: 30)",
+        "description": "Keep history newer than this many days (default: 30)",
         "description_localizations": undefined,
         "max_value": 365,
         "min_value": 1,
-        "name": "timeframe",
+        "name": "days",
         "name_localizations": undefined,
         "required": false,
         "type": 4,
@@ -3183,7 +3183,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "Which voice",
+            "description": "Which cloned voice",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,


### PR DESCRIPTION
Both warnings printed on every `pnpm quality` run. `pnpm ops commands:audit` now reports zero findings.

## `option-name-drift` — the one that could actually bite

`/admin cleanup <timeframe>` is an **integer raw day count**; `/admin usage` and `/memory` use `timeframe` as a **string enum window**. The audit has an `ACCEPTED_OPTION_TYPE_DRIFT` allowlist whose own bar is "intentional AND documented," and this drift *was* documented in-code — but that comment is the argument for renaming rather than allowlisting:

> Unlike the enum-window `timeframe`s (usage, incognito, memory delete), cleanup's is a RAW DAY COUNT

If the semantics deliberately differ, the name should differ. The hazard is sharper than the existing `type` precedent too: `type` drifts across *different commands*, whereas `timeframe` drifted between two subcommands of `/admin`, where `options.timeframe()` returns a string in one and a number in the other.

Renamed to `days` (verified free — no other command in the manifest uses it) and reworded the description to match: `Keep history newer than this many days (default: 30)`.

## `description-presence` — a length false-positive on a deliberate phrase

`SELECTOR_DESCRIPTION.voice` was `"Which voice"` — 11 chars against the heuristic's 12-char floor. It's the only §4.2 selector phrase short enough to trip it (`Which character` 15, `Which preset` 12, `Which persona` 13, `Which TTS config` 16), purely because "voice" is a short word.

The phrasing is deliberate and pinned by `commandManifest.test.ts` ("every entity-selector option uses the §4.2 SELECTOR_DESCRIPTION phrasing"), so the fix is a better phrase, not a weaker heuristic. `"Which cloned voice"` names what distinguishes these from a TTS config's provider voice — and under `/voice voices delete`, where the noun is already the command *and* the group, the old text was near-contentless.

## What the owner sees differently

- `/admin cleanup` — the option is now `days` instead of `timeframe`. Owner-only command; the picker text and description both change.
- `/voice voices delete` — the `voice` option's description reads "Which cloned voice".

No behavior change beyond the option name; `cleanup.ts` reads `options.days()` and passes the same `daysToKeep` value through.

## Verification

- `pnpm ops commands:audit` — 0 errors, 0 warnings (was 0 / 2)
- `pnpm test` — 5836 passed
- `pnpm test:component` — 565 passed; `CommandHandler.component.test.ts` snapshots regenerated (2 entries, both shown in the diff)
- `pnpm quality` — green end to end, including `codegen:command-types --check`

Regenerated artifacts: `commandOptions.ts`, `command-manifest.json`, the component snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)