### PR TITLE
fix(rules): sweep the dead getPrismaClient example out of every doc

### DIFF
--- a/.claude/rules/03-database.md
+++ b/.claude/rules/03-database.md
@@ -3,12 +3,16 @@
 ## Connection Management
 
 ```typescript
-// ✅ GOOD - Reuse singleton from common-types
-import { getPrismaClient } from '@tzurot/common-types';
+// ✅ GOOD - the shared factory owns the pg.Pool + driver adapter
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 
-// ❌ BAD - Creates new connection every time
-const prisma = new PrismaClient(); // Don't do this!
+const { prisma, dispose } = createPrismaClient();
+
+// ❌ BAD - bypasses the adapter entirely; under Prisma 7 it THROWS at construction
+const prisma = new PrismaClient();
 ```
+
+Call `dispose()` when a one-shot process finishes — it stops the pool-stats gauge and closes the pool. One-shot scripts and migrations should also pass the transient pool size rather than the long-running app default: `createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX })`, with `DB_POOL_DEFAULTS` from `@tzurot/common-types/services/poolConfig`.
 
 **Pool configuration:** The Prisma 7 driver adapter (`@prisma/adapter-pg`) runs over an explicit node-postgres `pg.Pool` configured in `packages/common-types/src/services/poolConfig.ts` — **default `max = 20` per service process**, env-tunable via `DATABASE_POOL_MAX`, with a finite `DATABASE_POOL_CONN_TIMEOUT_MS` (default 10s) acquisition timeout. **Gotcha:** the driver adapter **ignores the `?connection_limit=` URL param** — pool size MUST be set in `poolConfig.ts`/env, never on `DATABASE_URL`. The pool previously fell back to pg's defaults (`max = 10`, wait-forever acquisition), which starved under load. Set `DATABASE_POOL_STATS_INTERVAL_MS` to enable the saturation gauge (warns when connections queue). Keep total connections (Σ `max` across all service processes/replicas) under the Postgres `max_connections` (~100 on Railway).
 

--- a/backlog/cold/themes/self-hosted-tts-byok-re-evaluation.md
+++ b/backlog/cold/themes/self-hosted-tts-byok-re-evaluation.md
@@ -130,9 +130,10 @@ Probed two complementary post-processing approaches; both ruled out. Documenting
 ```ts
 // pnpm ops run --env prod npx tsx scripts/src/db/fetch-voice-ref.ts <slug> <out>
 import { writeFileSync } from 'node:fs';
-import { getPrismaClient } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
 const [, , slug, out] = process.argv;
-const prisma = getPrismaClient();
+const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
 const p = await prisma.personality.findFirst({
   where: { slug },
   select: { voiceReferenceData: true, displayName: true },
@@ -140,7 +141,7 @@ const p = await prisma.personality.findFirst({
 if (!p?.voiceReferenceData) throw new Error(`no ref for ${slug}`);
 writeFileSync(out, p.voiceReferenceData);
 console.log(`wrote ${p.voiceReferenceData.length} bytes (${p.displayName})`);
-await prisma.$disconnect();
+await dispose();
 ```
 
 If we end up needing this 2+ more times, promote to `pnpm ops voice-refs:export <slug> <out>` rather than recreating the scratch.

--- a/codecov.yml
+++ b/codecov.yml
@@ -71,7 +71,7 @@ ignore:
   - 'services/ai-worker/src/index.ts'
   - 'services/bot-client/src/index.ts'
   - 'services/api-gateway/src/queue.ts'
-  # DB composition root: getPrismaClient() wires pg.Pool + the driver adapter +
+  # DB composition root: createPrismaClient() wires pg.Pool + the driver adapter +
   # PrismaClient. Same class as the entry points above — unit-testing it means
   # mocking pg/adapter/client (testing the mocks). The real logic (pool sizing,
   # the saturation gauge) lives in the fully-tested poolConfig.ts. Already

--- a/docs/reference/standards/HANDLER_FACTORY_PATTERN.md
+++ b/docs/reference/standards/HANDLER_FACTORY_PATTERN.md
@@ -201,9 +201,9 @@ function createHandler(
   cacheService?: CacheInvalidationService
 ) { ... }
 
-// Bad - importing singletons inside handler
+// Bad - constructing the client inside the handler
 function createHandler() {
-  const prisma = getPrismaClient();  // Hidden dependency
+  const { prisma } = createPrismaClient();  // Hidden dependency, and its own pool
 }
 ```
 

--- a/packages/tooling/src/dev/check-boundaries.WHY.md
+++ b/packages/tooling/src/dev/check-boundaries.WHY.md
@@ -5,7 +5,8 @@
 Scans every source file across services and packages for forbidden imports defined in `BOUNDARY_RULES`. The current rules enforce:
 
 - `bot-client` never imports from `@prisma/client` directly (must go through `api-gateway` HTTP endpoints)
-- `bot-client` never imports Prisma-backed code (`getPrismaClient`, `PrismaClient`, `PersonaResolver`, `PersonalityService`, `ConversationHistoryService`, `PersonaCacheInvalidationService`, …) re-exported from the `@tzurot/common-types` barrel
+- `bot-client` never imports the Prisma **client** symbols still re-exported from the `@tzurot/common-types` barrel — `createPrismaClient`, `PrismaClient`, `Prisma`. The authoritative set is `BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS` in `check-boundaries.ts`, and a colocated drift test asserts every entry is a real common-types export, so a renamed or deleted symbol fails CI rather than silently no-op-matching
+  - **Not this rule**: the former Prisma-backed _services_ (`PersonaResolver`, `PersonalityService`, `ConversationHistoryService`, the cache invalidators) moved to dedicated packages and are banned by their own per-package **depcruise** rules. They are a different enforcement mechanism with a different failure message — look there, not here, when one of them trips
 - No cross-service imports (services may only import from `@tzurot/common-types`)
 - `ai-worker` internals are not exposed outside the service
 

--- a/packages/tooling/src/test/audit-unified.WHY.md
+++ b/packages/tooling/src/test/audit-unified.WHY.md
@@ -41,7 +41,7 @@ The baseline is in `.github/baselines/test-coverage-baseline.json` and tracks kn
 
 `--strict` flips the default to "every file must have a test," used for occasional cleanup passes that close pre-baseline gaps.
 
-The Prisma auto-detection is heuristic: `hasPrismaUsage()` greps for `getPrismaClient()` and similar import patterns. False positives are possible but rare; false negatives (Prisma access that the heuristic misses) are mitigated by the contract-category check covering the same files from a different angle.
+The Prisma auto-detection is heuristic: `hasPrismaUsage()` greps for `createPrismaClient()`, `new PrismaClient()`, `@prisma/client` imports, and `prisma.<model>.<op>` call shapes (`PRISMA_PATTERNS` in `audit-utils.ts`). False positives are possible but rare; false negatives (Prisma access that the heuristic misses) are mitigated by the contract-category check covering the same files from a different angle.
 
 ## Decay check
 


### PR DESCRIPTION
## The defect

`.claude/rules/03-database.md` § Connection Management opens with the example every contributor is meant to copy:

```typescript
// ✅ GOOD - Reuse singleton from common-types
import { getPrismaClient } from '@tzurot/common-types';
```

**There is no such export.** Nothing in `packages/common-types/src` defines it, and no service imports it. The real factory is `createPrismaClient()` in `services/prisma.ts`, returning `{ prisma, dispose }`.

## Why it matters more than a typo

The block's "BAD" example is `new PrismaClient()`, captioned *"Creates new connection every time."* Under Prisma 7 that's no longer the failure mode — the driver adapter is mandatory, so it **throws at construction**.

So the rule pointed at a non-existent good path, and understated the bad one. Anyone following it hits a module-resolution error, reaches for the documented alternative, and hits a runtime throw.

## How it surfaced

Following the rule literally while writing a one-off read-only prod probe during the beta.176 release. Both failures happened in sequence, which is what made the drift visible — a rule this wrong is invisible until someone actually uses it, and its two examples fail in different layers.

## The fix

- `createPrismaClient()` with the `{ prisma, dispose }` destructure.
- `DB_POOL_DEFAULTS.TRANSIENT_MAX` noted for one-shot scripts and migrations, which shouldn't take the long-running app pool size.
- `dispose()` documented as the pool close.
- The "BAD" caption corrected to say it throws.

## Verification

- The corrected form is the one that actually ran against prod during the release (the probe worked once switched to it).
- `pnpm ops lines:check` — within budget (+7 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)