### PR TITLE
docs(skills): kimi k3 replaces k2.7-code in the council roster

### DIFF
--- a/.claude/skills/tzurot-council-mcp/SKILL.md
+++ b/.claude/skills/tzurot-council-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-council-mcp
 description: 'Multi-perspective AI consultation. Invoke with /tzurot-council-mcp for major refactors (>500 lines), structured debugging after failed attempts, or when a technical decision has multiple viable approaches.'
-lastUpdated: '2026-07-03'
+lastUpdated: '2026-07-25'
 ---
 
 # Council MCP Procedures
@@ -87,14 +87,18 @@ End the failed session, call `list_models` to find a replacement with similar ca
 
 ### Recommended models by task
 
-| Task Type        | Recommended Models                                                                                    | Notes                                                                                       |
-| ---------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Reasoning/Design | **GLM 5.2 · Kimi K2.7-code · Qwen 3.7 Max** (run all three in parallel) → Claude Sonnet/Opus fallback | **Avoid DeepSeek R1** — dated; design needs SOTA. Verify IDs via `list_models` (they drift) |
-| Coding/Review    | Claude Sonnet 4, Claude Opus 4                                                                        | Tool-use variants of Gemini also work for structured refactor tasks                         |
-| Vision/Images    | Gemini 2.5 Flash, Gemini 2.5 Pro                                                                      | (verify availability with `list_models`)                                                    |
-| Long Documents   | Gemini (1M token context)                                                                             | (verify availability with `list_models`)                                                    |
+| Task Type        | Recommended Models                                                                             | Notes                                                                                       |
+| ---------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Reasoning/Design | **GLM 5.2 · Kimi K3 · Qwen 3.7 Max** (run all three in parallel) → Claude Sonnet/Opus fallback | **Avoid DeepSeek R1** — dated; design needs SOTA. Verify IDs via `list_models` (they drift) |
+| Coding/Review    | Claude Sonnet 4, Claude Opus 4                                                                 | Tool-use variants of Gemini also work for structured refactor tasks                         |
+| Vision/Images    | Gemini 2.5 Flash, Gemini 2.5 Pro                                                               | (verify availability with `list_models`)                                                    |
+| Long Documents   | Gemini (1M token context)                                                                      | (verify availability with `list_models`)                                                    |
 
-**Why avoid DeepSeek R1 for reasoning/design**: explicit user feedback — R1 is dated; design questions need SOTA. For open design decisions, run the current preferred trio in parallel — **GLM 5.2 · Kimi K2.7-code · Qwen 3.7 Max** — and verify each ID via `list_models` first (the registry can lag a new release; fall back to the prior version of the same family). If those are unavailable, fall back to Claude Sonnet / Opus, **not** R1.
+**Why avoid DeepSeek R1 for reasoning/design**: explicit user feedback — R1 is dated; design questions need SOTA. For open design decisions, run the current preferred trio in parallel — **GLM 5.2 · Kimi K3 · Qwen 3.7 Max** — and verify each ID via `list_models` first (the registry can lag a new release; fall back to the prior version of the same family). If those are unavailable, fall back to Claude Sonnet / Opus, **not** R1.
+
+**Kimi specifically**: `moonshotai/kimi-k3` is the current SOTA pick (verify via `list_models` — this line will go stale exactly the way `kimi-k2.7-code` did); `kimi-k2.7-code` is superseded and should not be the default. K3 has **capacity pressure under demand** — expect occasional long waits (a council call has exceeded the 120s foreground window and backgrounded) — so falling back to the prior K2.x is a sanctioned practical compromise when K3 is unavailable, not a preference.
+
+**An empty response body is a distinct failure from a 404.** A superseded or overloaded model can return a well-formed response whose content is empty — observed on `kimi-k2.7-code`, and separately explainable by that family's reasoning-tag quirks. Treat an empty body as "this model did not answer": re-run once on the CURRENT model for that family before spending a tiebreaker slot, and never count it as a verdict. Two verdicts plus a silent third is a split, not a consensus.
 
 ### Per-call model specification
 


### PR DESCRIPTION
## What

Updates the council skill's reasoning/design roster: **Kimi K3** replaces the superseded **K2.7-code**, in both places the skill named it (the task table and the prose fallback guidance).

## Why

Owner correction raised mid-council: K2.7-code is no longer the SOTA Kimi model. The skill named it as the standing pick in two places, so any council pass *following the skill correctly* would keep reaching for a superseded model — the exact drift the skill's own "cached IDs are landmines" warning exists to prevent, except living in the skill itself.

## Two operational facts recorded in the same pass

Both were learned during the council run that surfaced this, and neither was covered:

**K3 capacity pressure.** A K3 call exceeded the 120s foreground window and backgrounded during this session. The skill now states that falling back to the prior K2.x when K3 is unavailable is a sanctioned practical compromise, not a preference — so a future session doesn't read the roster as absolute and stall.

**Empty response body ≠ 404.** The skill had a rule for 404s ("it's gone, not transient — do not retry") but nothing for a well-formed response whose content is empty, which is what `kimi-k2.7-code` actually returned here. That gap matters because of how it fails: without a rule, two verdicts plus a silent third reads as consensus. It is a split. The skill now says to re-run once on the family's current model before spending a tiebreaker slot, and never to count silence as a verdict.

## Verification

- Roster references swept — `kimi-k2.7-code` appears only in the new prose explaining that it is superseded, nowhere as a recommendation.
- Pre-push gate green (`lines:check`, `backlog:lint`, `guard:workflow-sync`).
- Skill file, so PR-gated per `00-critical.md` rather than taking the direct-doc-commit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)