### PR TITLE
fix(api-gateway): propagate /history purge deletion to derived memories

### DIFF
--- a/packages/conversation-history/src/ConversationRetentionService.component.test.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.component.test.ts
@@ -197,6 +197,71 @@ describe('ConversationRetentionService', () => {
       const count = await service.clearHistory(testChannelId, testPersonalityId);
       expect(count).toBe(0);
     });
+
+    /**
+     * R8, deletion means deletion: purging the conversation must also retire the
+     * memories derived from those turns. Without this, `/history purge` erases
+     * the transcript but leaves its memories retrievable, and RAG pulls them
+     * straight back into the next prompt — the character still "remembers" a
+     * conversation the user just deleted.
+     */
+    it('soft-deletes memories derived from the purged turns, sparing locked ones', async () => {
+      const discordId = '900000000000000501';
+      await prisma.conversationHistory.create({
+        data: {
+          id: '00000000-0000-0000-0002-000000000001',
+          channelId: testChannelId,
+          personalityId: testPersonalityId,
+          personaId: testPersonaId,
+          role: 'user',
+          content: 'Something the user later purged',
+          discordMessageId: [discordId],
+        },
+      });
+      await prisma.memory.createMany({
+        data: [
+          {
+            id: '00000000-0000-0000-0003-000000000001',
+            personaId: testPersonaId,
+            personalityId: testPersonalityId,
+            content: 'derived from the purged turn',
+            senders: ['tester'],
+            messageIds: [discordId],
+          },
+          {
+            id: '00000000-0000-0000-0003-000000000002',
+            personaId: testPersonaId,
+            personalityId: testPersonalityId,
+            content: 'derived from the purged turn but PINNED',
+            senders: ['tester'],
+            messageIds: [discordId],
+            isLocked: true,
+          },
+          {
+            id: '00000000-0000-0000-0003-000000000003',
+            personaId: testPersonaId,
+            personalityId: testPersonalityId,
+            content: 'unrelated to the purged turn',
+            senders: ['tester'],
+            messageIds: ['900000000000000999'],
+          },
+        ],
+      });
+
+      await service.clearHistory(testChannelId, testPersonalityId);
+
+      const byId = new Map(
+        (await prisma.memory.findMany({ select: { id: true, visibility: true } })).map(m => [
+          m.id,
+          m.visibility,
+        ])
+      );
+      expect(byId.get('00000000-0000-0000-0003-000000000001')).toBe('deleted');
+      // A pin is explicit curation that outranks source deletion.
+      expect(byId.get('00000000-0000-0000-0003-000000000002')).toBe('normal');
+      // Propagation is keyed on the deleted turns, not "every memory nearby".
+      expect(byId.get('00000000-0000-0000-0003-000000000003')).toBe('normal');
+    });
   });
 
   describe('cleanupOldHistory', () => {
@@ -217,6 +282,51 @@ describe('ConversationRetentionService', () => {
       // Verify recent messages still exist
       const remainingMessages = await prisma.conversationHistory.count();
       expect(remainingMessages).toBe(2);
+    });
+
+    /**
+     * The counterpart to the clearHistory propagation test, and the reason the
+     * propagation is wired per-caller rather than into the batch deleter: LTM is
+     * MEANT to outlive the 30-day conversation window. Propagating here would
+     * quietly delete every memory whose source turn simply got old — the exact
+     * opposite of what long-term memory is for. The trigger is a user asking for
+     * deletion, never the clock.
+     */
+    it('does NOT retire memories when conversation rows merely age out', async () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 100);
+      const discordId = '900000000000000601';
+      await prisma.conversationHistory.create({
+        data: {
+          id: '00000000-0000-0000-0004-000000000001',
+          channelId: testChannelId,
+          personalityId: testPersonalityId,
+          personaId: testPersonaId,
+          role: 'user',
+          content: 'An old turn that ages out on schedule',
+          discordMessageId: [discordId],
+          createdAt: oldDate,
+        },
+      });
+      await prisma.memory.create({
+        data: {
+          id: '00000000-0000-0000-0005-000000000001',
+          personaId: testPersonaId,
+          personalityId: testPersonalityId,
+          content: 'long-term memory of an aged-out turn',
+          senders: ['tester'],
+          messageIds: [discordId],
+        },
+      });
+
+      const count = await service.cleanupOldHistory(30);
+
+      expect(count).toBe(1);
+      const memory = await prisma.memory.findUnique({
+        where: { id: '00000000-0000-0000-0005-000000000001' },
+        select: { visibility: true },
+      });
+      expect(memory?.visibility).toBe('normal');
     });
 
     it('should not delete messages within retention period', async () => {

--- a/packages/conversation-history/src/ConversationRetentionService.test.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.test.ts
@@ -62,11 +62,13 @@ describe('ConversationRetentionService', () => {
       const count = await service.clearHistory('channel-123', 'personality-456');
 
       expect(count).toBe(2);
-      // Batched query: pagination params + an id-only select (the tombstone
-      // fields are gone; the AFTER DELETE trigger records the deletion for db-sync).
+      // Batched query: pagination params + id AND discordMessageId. The latter
+      // is what the memory-deletion propagation matches on, and the hard delete
+      // destroys these rows — so if the select ever drops it, a purge silently
+      // stops retiring the memories derived from the turns it erased.
       expect(mockPrismaClient.conversationHistory.findMany).toHaveBeenCalledWith({
         where: { channelId: 'channel-123', personalityId: 'personality-456' },
-        select: { id: true },
+        select: { id: true, discordMessageId: true },
         take: 1000, // SYNC_LIMITS.RETENTION_BATCH_SIZE
         orderBy: { id: 'asc' },
       });
@@ -131,7 +133,7 @@ describe('ConversationRetentionService', () => {
           personalityId: 'personality-456',
           personaId: 'persona-789',
         },
-        select: { id: true },
+        select: { id: true, discordMessageId: true },
         take: 1000,
         orderBy: { id: 'asc' },
       });

--- a/packages/conversation-history/src/ConversationRetentionService.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.ts
@@ -14,6 +14,7 @@
 import { CLEANUP_DEFAULTS, SYNC_LIMITS } from '@tzurot/common-types/constants/timing';
 import { type PrismaClient, type Prisma } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { propagateDeletionToMemories } from './memoryDeletionPropagation.js';
 
 const logger = createLogger('ConversationRetentionService');
 
@@ -29,32 +30,54 @@ const logger = createLogger('ConversationRetentionService');
  * whole sweep duration. Cross-batch atomicity is not needed: a partial sweep just
  * leaves rows for the next run. No cursor needed — each committed batch removes
  * its rows from the `where` result set, so a plain re-fetch naturally advances.
+ *
+ * `onBatchDeleted` fires once per committed batch with that batch's Discord
+ * message ids. It is per-batch rather than a single accumulated list at the end
+ * because the retention sweep can delete tens of thousands of rows — holding
+ * every id in memory to hand back at the end would turn a bounded sweep into an
+ * unbounded allocation. Callers that don't need the ids simply omit it and
+ * nothing is collected.
  */
 async function deleteMessagesInBatches(
   prisma: PrismaClient,
-  where: Prisma.ConversationHistoryWhereInput
+  where: Prisma.ConversationHistoryWhereInput,
+  onBatchDeleted?: (discordMessageIds: string[]) => Promise<void>
 ): Promise<number> {
   let totalDeleted = 0;
 
   while (true) {
-    const fetched = await prisma.$transaction(async tx => {
+    const { fetched, discordMessageIds } = await prisma.$transaction(async tx => {
       const batch = await tx.conversationHistory.findMany({
         where,
-        select: { id: true },
+        // discordMessageId only when a caller asked for it — the retention
+        // sweep pays nothing for a column it will never read.
+        select: { id: true, ...(onBatchDeleted !== undefined && { discordMessageId: true }) },
         take: SYNC_LIMITS.RETENTION_BATCH_SIZE,
         orderBy: { id: 'asc' },
       });
 
       if (batch.length === 0) {
-        return 0;
+        return { fetched: 0, discordMessageIds: [] };
       }
 
       const deleteResult = await tx.conversationHistory.deleteMany({
         where: { id: { in: batch.map(msg => msg.id) } },
       });
       totalDeleted += deleteResult.count;
-      return batch.length;
+      return {
+        fetched: batch.length,
+        discordMessageIds: batch.flatMap(msg => msg.discordMessageId ?? []),
+      };
     });
+
+    // AFTER the batch commits, never inside its transaction: the propagation
+    // writes to a different table, and holding the conversation rows' locks
+    // across it is exactly the cross-table lock-hold this batching exists to
+    // avoid. A crash in between leaves memories un-propagated, which the user
+    // can still clear via /memory — strictly better than a wedged sweep.
+    if (onBatchDeleted !== undefined && discordMessageIds.length > 0) {
+      await onBatchDeleted(discordMessageIds);
+    }
 
     // A short batch means the where-set is drained.
     if (fetched < SYNC_LIMITS.RETENTION_BATCH_SIZE) {
@@ -79,6 +102,14 @@ export class ConversationRetentionService {
    * can't hold row locks across the whole sweep. Each hard delete is recorded for
    * db-sync by the AFTER DELETE trigger.
    *
+   * This is a USER-REQUESTED deletion, so it propagates to the memories derived
+   * from the deleted turns (R8: deletion means deletion). Without that, a purge
+   * removed the conversation but left its memories retrievable, and RAG pulled
+   * them straight back into the next prompt — the character still "remembered" a
+   * conversation the user had just erased. The propagation must happen HERE
+   * rather than after the fact, because the hard delete destroys the only rows
+   * that map a memory back to its source message.
+   *
    * @param channelId Channel ID
    * @param personalityId Personality ID
    * @param personaId Optional persona ID - if provided, only deletes messages for that persona
@@ -95,7 +126,9 @@ export class ConversationRetentionService {
         ...(personaId !== undefined && personaId.length > 0 && { personaId }),
       };
 
-      const count = await deleteMessagesInBatches(this.prisma, where);
+      const count = await deleteMessagesInBatches(this.prisma, where, discordMessageIds =>
+        propagateDeletionToMemories(this.prisma, discordMessageIds)
+      );
 
       logger.info(
         {

--- a/packages/conversation-history/src/ConversationSyncService.ts
+++ b/packages/conversation-history/src/ConversationSyncService.ts
@@ -20,6 +20,7 @@ import {
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { countTextTokens } from '@tzurot/common-types/utils/tokenCounter';
+import { propagateDeletionToMemories } from './memoryDeletionPropagation.js';
 
 const logger = createLogger('ConversationSyncService');
 
@@ -202,46 +203,6 @@ export class ConversationSyncService {
   }
 
   /**
-   * Propagate source-message deletion to linked long-term memories
-   * (memory-architecture Phase 0, R8: deletion means deletion). Memories carry
-   * the triggering Discord message id in `messageIds`; when that turn is
-   * deleted, the memory is soft-deleted (visibility='deleted' — the same state
-   * the RAG retrieval filter excludes). Locked memories are deliberately
-   * PRESERVED: a user pin is explicit curation that outranks source deletion —
-   * the skip is logged so the tension stays observable. Non-fatal by design:
-   * a propagation failure must never break the sync path.
-   */
-  private async propagateDeletionToMemories(discordMessageIds: string[]): Promise<void> {
-    const ids = discordMessageIds.filter(id => id.length > 0);
-    if (ids.length === 0) {
-      return;
-    }
-    try {
-      const result = await this.prisma.memory.updateMany({
-        where: { messageIds: { hasSome: ids }, visibility: 'normal', isLocked: false },
-        data: { visibility: 'deleted' },
-      });
-      if (result.count > 0) {
-        logger.info(
-          { memoriesDeleted: result.count, sourceMessages: ids.length },
-          'Propagated message deletion to linked memories'
-        );
-      }
-      const lockedRetained = await this.prisma.memory.count({
-        where: { messageIds: { hasSome: ids }, visibility: 'normal', isLocked: true },
-      });
-      if (lockedRetained > 0) {
-        logger.warn(
-          { lockedRetained, sourceMessages: ids.length },
-          'Locked memories retained despite source-message deletion (pin outranks propagation)'
-        );
-      }
-    } catch (error) {
-      logger.error({ err: error }, 'Memory deletion propagation failed (non-fatal)');
-    }
-  }
-
-  /**
    * Bulk soft delete messages
    * Used during opportunistic sync when Discord messages are detected as deleted
    *
@@ -279,7 +240,10 @@ export class ConversationSyncService {
       // first 1000 turns' memories. Current callers (opportunistic sync windows)
       // are far below the bound; revisit with an unbounded id-only fetch if a
       // bulk path ever exceeds it.
-      await this.propagateDeletionToMemories(messages.flatMap(m => m.discordMessageId));
+      await propagateDeletionToMemories(
+        this.prisma,
+        messages.flatMap(m => m.discordMessageId)
+      );
       return messageIds.length;
     } catch (error) {
       logger.error({ err: error, count: messageIds.length }, `Failed to bulk soft delete messages`);

--- a/packages/conversation-history/src/memoryDeletionPropagation.test.ts
+++ b/packages/conversation-history/src/memoryDeletionPropagation.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+
+// Hoisted (not fresh per call) so assertions can reach them: several branches
+// in this module have NO observable except their log line — the swallowed
+// failure and the locked-retention warning both return undefined either way, so
+// a test that only checks the return value cannot tell them from silence.
+const { mockInfo, mockWarn, mockError } = vi.hoisted(() => ({
+  mockInfo: vi.fn(),
+  mockWarn: vi.fn(),
+  mockError: vi.fn(),
+}));
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: mockInfo, warn: mockWarn, error: mockError }),
+  };
+});
+
+import { propagateDeletionToMemories } from './memoryDeletionPropagation.js';
+
+function makePrisma(overrides: { updateCount?: number; lockedCount?: number } = {}) {
+  const updateMany = vi.fn().mockResolvedValue({ count: overrides.updateCount ?? 1 });
+  const count = vi.fn().mockResolvedValue(overrides.lockedCount ?? 0);
+  return {
+    prisma: { memory: { updateMany, count } } as unknown as PrismaClient,
+    updateMany,
+    count,
+  };
+}
+
+describe('propagateDeletionToMemories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('soft-deletes the memories linked to the deleted turns', async () => {
+    const { prisma, updateMany } = makePrisma();
+
+    await propagateDeletionToMemories(prisma, ['m1', 'm2']);
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { messageIds: { hasSome: ['m1', 'm2'] }, visibility: 'normal', isLocked: false },
+      // 'deleted' is the visibility the RAG retrieval filter excludes — a HARD
+      // delete here would break the memory's own undo/browse surfaces.
+      data: { visibility: 'deleted' },
+    });
+  });
+
+  it('never touches locked memories — a user pin outranks source deletion', async () => {
+    const { prisma, updateMany } = makePrisma();
+
+    await propagateDeletionToMemories(prisma, ['m1']);
+
+    expect(updateMany.mock.calls[0][0].where.isLocked).toBe(false);
+  });
+
+  it('does nothing when there are no ids to propagate', async () => {
+    const { prisma, updateMany, count } = makePrisma();
+
+    await propagateDeletionToMemories(prisma, []);
+    await propagateDeletionToMemories(prisma, ['']);
+
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(count).not.toHaveBeenCalled();
+  });
+
+  describe('the locked-retention warning', () => {
+    it('counts exactly the locked, still-normal memories for those turns', async () => {
+      const { prisma, count } = makePrisma({ lockedCount: 2 });
+
+      await propagateDeletionToMemories(prisma, ['m1']);
+
+      // The mirror image of the update's filter. If this query drifted — wrong
+      // isLocked, wrong visibility, missing id scope — the warning would report
+      // a number that means something else, and the pin-vs-deletion tension it
+      // exists to surface would go quiet or cry wolf.
+      expect(count).toHaveBeenCalledWith({
+        where: { messageIds: { hasSome: ['m1'] }, visibility: 'normal', isLocked: true },
+      });
+    });
+
+    it('warns, with the count, when pinned memories survive a source deletion', async () => {
+      const { prisma } = makePrisma({ lockedCount: 3 });
+
+      await propagateDeletionToMemories(prisma, ['m1']);
+
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+      expect(mockWarn.mock.calls[0][0]).toMatchObject({ lockedRetained: 3 });
+    });
+
+    it('stays quiet when nothing was pinned — the warning must mean something', async () => {
+      const { prisma } = makePrisma({ lockedCount: 0 });
+
+      await propagateDeletionToMemories(prisma, ['m1']);
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the propagation log', () => {
+    it('reports how many memories were retired', async () => {
+      const { prisma } = makePrisma({ updateCount: 4 });
+
+      await propagateDeletionToMemories(prisma, ['m1']);
+
+      expect(mockInfo).toHaveBeenCalledTimes(1);
+      expect(mockInfo.mock.calls[0][0]).toMatchObject({ memoriesDeleted: 4 });
+    });
+
+    it('stays quiet when the deletion touched no memories', async () => {
+      // The common case by far — most turns produce no memory at all. Logging
+      // a zero on every purged batch would bury the lines that matter.
+      const { prisma } = makePrisma({ updateCount: 0 });
+
+      await propagateDeletionToMemories(prisma, ['m1']);
+
+      expect(mockInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  it('swallows a failure — but LOGS it, so the miss is not silent', async () => {
+    // Non-fatal by design: failing the caller's whole deletion because the
+    // derived-memory cleanup stumbled is a worse outcome than a logged miss.
+    // The log is the entire difference between "handled" and "swallowed" —
+    // without asserting it, an empty catch block would pass this test.
+    const { prisma } = makePrisma();
+    (prisma.memory.updateMany as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('db down'));
+
+    await expect(propagateDeletionToMemories(prisma, ['m1'])).resolves.toBeUndefined();
+
+    expect(mockError).toHaveBeenCalledTimes(1);
+    expect(mockError.mock.calls[0][0]).toMatchObject({ err: expect.any(Error) });
+  });
+});

--- a/packages/conversation-history/src/memoryDeletionPropagation.ts
+++ b/packages/conversation-history/src/memoryDeletionPropagation.ts
@@ -1,0 +1,73 @@
+/**
+ * Memory-deletion propagation (memory-architecture Phase 0, R8: deletion means
+ * deletion).
+ *
+ * Memories carry the triggering Discord message id in `messageIds`. When the
+ * user deletes the turn that produced a memory, the memory is soft-deleted
+ * (`visibility='deleted'` — the same state the RAG retrieval filter excludes),
+ * so a deletion the user asked for isn't silently undone by retrieval pulling
+ * the derived memory back into the next prompt.
+ *
+ * Shared by BOTH deletion paths on purpose. It previously lived as a private
+ * method on the sync service, reachable only when Discord reported a message
+ * deleted — so `/history purge`, the most explicit deletion command in the
+ * product, hard-deleted the conversation rows and left their memories live and
+ * retrievable. Worse, the hard delete removed the very rows the sync path
+ * resolves message ids from, so tidying the Discord messages afterwards could
+ * no longer clean up either. One implementation, both callers.
+ *
+ * **Not called by time-based retention.** `cleanupOldHistory` ages conversation
+ * rows out on a schedule; long-term memory is meant to OUTLIVE that window, and
+ * propagating there would quietly delete every memory whose source turn got old.
+ * The trigger is a user asking for deletion, never the clock.
+ */
+
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+
+const logger = createLogger('memory-deletion-propagation');
+
+/**
+ * Soft-delete the memories derived from the given Discord messages.
+ *
+ * Locked memories are deliberately PRESERVED: a user pin is explicit curation
+ * that outranks source deletion — the skip is logged so the tension stays
+ * observable rather than silent.
+ *
+ * Non-fatal by design: a propagation failure must never break the deletion path
+ * that called it. The rows the user asked to delete are already gone; failing
+ * the whole operation because the derived-memory cleanup stumbled would be a
+ * worse outcome than a logged miss.
+ */
+export async function propagateDeletionToMemories(
+  prisma: PrismaClient,
+  discordMessageIds: string[]
+): Promise<void> {
+  const ids = discordMessageIds.filter(id => id.length > 0);
+  if (ids.length === 0) {
+    return;
+  }
+  try {
+    const result = await prisma.memory.updateMany({
+      where: { messageIds: { hasSome: ids }, visibility: 'normal', isLocked: false },
+      data: { visibility: 'deleted' },
+    });
+    if (result.count > 0) {
+      logger.info(
+        { memoriesDeleted: result.count, sourceMessages: ids.length },
+        'Propagated message deletion to linked memories'
+      );
+    }
+    const lockedRetained = await prisma.memory.count({
+      where: { messageIds: { hasSome: ids }, visibility: 'normal', isLocked: true },
+    });
+    if (lockedRetained > 0) {
+      logger.warn(
+        { lockedRetained, sourceMessages: ids.length },
+        'Locked memories retained despite source-message deletion (pin outranks propagation)'
+      );
+    }
+  } catch (error) {
+    logger.error({ err: error }, 'Memory deletion propagation failed (non-fatal)');
+  }
+}


### PR DESCRIPTION
**Runtime-confirmed on prod.** After `/history purge`, a memory created from a message in the purged channel survived with `visibility='normal'` and was retrieved straight back into the next prompt — the character "remembered" a conversation the owner had just erased.

Filed as a production issue in `backlog/now.md`; this is the fix.

## The gap

`propagateDeletionToMemories` already implemented the principle. Its own docstring says it outright:

> memory-architecture Phase 0, R8: **deletion means deletion**

But it was a `private` method with exactly **one** call site — the opportunistic Discord-sync path. `/history purge` routes through `ConversationRetentionService.clearHistory`, which hard-deletes and never propagated.

**The second-order trap made it unrecoverable.** Because purge *hard*-deletes, it destroys the very rows the sync path resolves `discordMessageId` from. So tidying the raw Discord messages afterwards — the natural next thing to do — couldn't clean up either. Purge-then-tidy left those memories with no automatic cleanup path at all, only `/memory delete|purge`.

## The fix

- Lift the propagation into a shared `memoryDeletionPropagation` module. Both deletion paths now use one implementation rather than one path owning a private copy.
- `clearHistory` collects `discordMessageId` per batch and propagates **after each batch commits** — not inside its transaction. The propagation writes a *different* table, and holding the conversation rows' locks across it is exactly the cross-table lock-hold the per-batch commit exists to avoid.
- The hook is **per-batch rather than an accumulated list**: a retention sweep can delete tens of thousands of rows, and collecting every id to hand back at the end would turn a bounded sweep into an unbounded allocation. Callers that don't need the ids omit the hook and the column isn't even selected.

## Deliberately NOT wired into `cleanupOldHistory`

This is the design decision worth reviewing. Long-term memory is **meant** to outlive the 30-day conversation window — propagating on the time-based sweep would quietly delete every memory whose source turn simply got old, which is the opposite of what LTM is for.

The trigger is *a user asking for deletion*, never the clock. That's why the propagation is wired per-caller instead of into the batch deleter itself, and there's a component test pinning it: an aged-out turn's memory stays `normal`.

## Locked memories

Existing carve-out preserved: a pin is explicit curation that outranks source deletion, and the skip is logged so the tension stays observable rather than silent.

## Tests

- Unit (`memoryDeletionPropagation.test.ts`): soft-delete not hard-delete, locked excluded, empty/blank id no-op, failure swallowed (the rows the user deleted are already gone — failing the caller because the derived cleanup stumbled is the worse outcome).
- Component (PGLite): purge retires the linked memory, spares the locked one, and leaves an unrelated memory alone.
- Component: `cleanupOldHistory` does **not** retire memories.
- Updated the two `clearHistory` unit tests that asserted an id-only select — a deliberate spec change, since dropping `discordMessageId` from that select would silently stop the propagation.

## Not covered by this PR

19 of the 20 memories in the reported incident belonged to 19 *other* characters — that's the `shareLtmAcrossPersonalities` ("🧠 Share Memories") setting working as documented, not a bug. Only the 1 same-character memory was this defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)