### PR TITLE
feat(bot-client): retention PR-D2 — daily purge-eligibility nag

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -73,6 +73,10 @@ import {
   stopSecretRotationNagScheduler,
 } from './services/SecretRotationNagScheduler.js';
 import {
+  startRetentionNagScheduler,
+  stopRetentionNagScheduler,
+} from './services/RetentionNagScheduler.js';
+import {
   validateDiscordToken,
   validateRedisUrl,
   validateInternalServiceSecret,
@@ -553,6 +557,10 @@ client.once(Events.ClientReady, () => {
   // cooldown; see SecretRotationNagScheduler for the restart-cadence design).
   startSecretRotationNagScheduler(client, services.cacheRedis);
 
+  // Daily retention purge-eligibility check → owner-channel nag (same
+  // restart-friendly cadence; nothing purges automatically in Phase 2).
+  startRetentionNagScheduler(client, services.cacheRedis);
+
   // Restore saved bot presence from Redis
   void restoreBotPresence(client).catch(err => logger.warn({ err }, 'Failed to restore presence'));
 
@@ -625,6 +633,7 @@ async function disposeBotClient(): Promise<void> {
     stopNotificationCacheCleanup();
     stopVerificationCleanupScheduler();
     stopSecretRotationNagScheduler();
+    stopRetentionNagScheduler();
     // ioredis Redis#disconnect is synchronous (returns void) — kept outside
     // the awaited Promise.all because there's no Promise to await.
     services.cacheRedis.disconnect();

--- a/services/bot-client/src/services/RetentionNagScheduler.test.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the retention nag scheduler's check cycle and embed content.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Client } from 'discord.js';
+import type { Redis } from 'ioredis';
+import type { RetentionPreviewResponse } from '@tzurot/common-types/schemas/api/internal';
+
+const mockRetentionPreview = vi.fn();
+vi.mock('../utils/gatewayClients.js', () => ({
+  getServiceClient: () => ({ retentionPreview: mockRetentionPreview }),
+}));
+
+const mockPostOwnerChannelEmbed = vi.fn();
+vi.mock('../utils/ownerChannel.js', () => ({
+  postOwnerChannelEmbed: (...args: unknown[]) => mockPostOwnerChannelEmbed(...args),
+}));
+
+vi.mock('@tzurot/common-types/config/config', () => ({
+  getConfig: () => ({ NODE_ENV: 'production' }),
+}));
+
+import { runRetentionNagCheck, buildRetentionNagEmbed } from './RetentionNagScheduler.js';
+
+function makePreview(overrides: {
+  eligibleCount?: number;
+  breakerWarning?: boolean;
+  userCount?: number;
+}): RetentionPreviewResponse {
+  const eligibleCount = overrides.eligibleCount ?? 1;
+  const listedUsers = overrides.userCount ?? eligibleCount;
+  return {
+    users: Array.from({ length: listedUsers }, (_, i) => ({
+      discordId: `99000000000000${String(i).padStart(4, '0')}`,
+      inactiveSince: '2025-09-01T00:00:00.000Z',
+      reason: i === 0 ? ('unreachable' as const) : ('account_gone' as const),
+      ownedCharacters: { toDelete: 1, toReHome: 0 },
+    })),
+    totals: {
+      eligibleCount,
+      userbaseCount: 300,
+      percentOfUserbase: Math.round((eligibleCount / 300) * 1000) / 10,
+      charactersToDelete: listedUsers,
+      charactersToReHome: 0,
+      breakerWarning: overrides.breakerWarning ?? false,
+    },
+  } satisfies RetentionPreviewResponse;
+}
+
+function makeRedis(cooldownValue: string | null): Redis {
+  return {
+    get: vi.fn().mockResolvedValue(cooldownValue),
+    setex: vi.fn().mockResolvedValue('OK'),
+  } as unknown as Redis;
+}
+
+const client = {} as Client;
+
+describe('RetentionNagScheduler runRetentionNagCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPostOwnerChannelEmbed.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts the owner embed and arms the weekly cooldown when accounts are eligible', async () => {
+    mockRetentionPreview.mockResolvedValue({ ok: true, data: makePreview({ eligibleCount: 2 }) });
+    const redis = makeRedis(null);
+
+    await runRetentionNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    // Seam assertion: the cooldown key is what makes the nag at-most-weekly
+    // across restarts — its TTL is the contract.
+    expect(redis.setex).toHaveBeenCalledWith(
+      'retention-nag:cooldown',
+      7 * 24 * 60 * 60,
+      expect.any(String)
+    );
+  });
+
+  it('does NOT post while the cooldown key exists (at most one nag per week)', async () => {
+    mockRetentionPreview.mockResolvedValue({ ok: true, data: makePreview({}) });
+    const redis = makeRedis('2026-07-20T00:00:00.000Z');
+
+    await runRetentionNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+    expect(redis.setex).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when nobody is eligible (quiet week costs no Redis read)', async () => {
+    mockRetentionPreview.mockResolvedValue({
+      ok: true,
+      data: makePreview({ eligibleCount: 0, userCount: 0 }),
+    });
+    const redis = makeRedis(null);
+
+    await runRetentionNagCheck(client, redis);
+
+    expect(redis.get).not.toHaveBeenCalled();
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failed preview fetch (next daily tick retries)', async () => {
+    mockRetentionPreview.mockResolvedValue({ ok: false, error: 'gateway down' });
+    const redis = makeRedis(null);
+
+    await expect(runRetentionNagCheck(client, redis)).resolves.toBeUndefined();
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+  });
+
+  it('swallows a thrown error entirely (nag must never affect anything else)', async () => {
+    mockRetentionPreview.mockRejectedValue(new Error('network'));
+    const redis = makeRedis(null);
+
+    await expect(runRetentionNagCheck(client, redis)).resolves.toBeUndefined();
+  });
+});
+
+describe('buildRetentionNagEmbed', () => {
+  it('carries the counts, the reason labels, and the exact CLI commands with this env', () => {
+    const embed = buildRetentionNagEmbed(makePreview({ eligibleCount: 2 })).toJSON();
+
+    expect(embed.description).toContain('**2** of 300 users');
+    expect(embed.description).toContain('unreachable)');
+    expect(embed.description).toContain('account deleted)');
+    // The footer is the operator's handoff — both commands, env included
+    // (mocked config says production).
+    expect(embed.footer?.text).toContain('pnpm ops retention:preview --env prod');
+    expect(embed.footer?.text).toContain('pnpm ops retention:purge --env prod');
+  });
+
+  it('includes the breaker warning line only when the totals flag it', () => {
+    const calm = buildRetentionNagEmbed(makePreview({})).toJSON();
+    const warned = buildRetentionNagEmbed(makePreview({ breakerWarning: true })).toJSON();
+
+    expect(calm.description).not.toContain('breaker warning');
+    expect(warned.description).toContain('breaker warning');
+  });
+
+  it('caps the listed users and reports the overflow', () => {
+    const embed = buildRetentionNagEmbed(
+      makePreview({ eligibleCount: 14, userCount: 14 })
+    ).toJSON();
+
+    // 10 listed + the overflow line, never the full cohort.
+    expect(embed.description?.match(/inactive since/g)).toHaveLength(10);
+    expect(embed.description).toContain('and 4 more');
+  });
+});

--- a/services/bot-client/src/services/RetentionNagScheduler.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.ts
@@ -1,0 +1,126 @@
+/**
+ * Retention Nag Scheduler
+ *
+ * Daily check (plus one shortly after startup) of the gateway's retention
+ * preview; posts an owner-channel embed when any account is purge-eligible.
+ * Nothing purges automatically — the embed's whole job is to point the
+ * operator at the CLI commands that review and act.
+ *
+ * Cadence design mirrors SecretRotationNagScheduler: bot-client restarts on
+ * every deploy, so a weekly setInterval would effectively never fire. The
+ * CHECK runs daily/on-startup (restart-friendly — restarts make it fire more
+ * often, never less) and a Redis cooldown key caps the NAG at one post per
+ * week, surviving deploys precisely because in-process state does not.
+ */
+
+import { EmbedBuilder, type Client } from 'discord.js';
+import type { Redis } from 'ioredis';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import type { RetentionPreviewResponse } from '@tzurot/common-types/schemas/api/internal';
+import { getServiceClient } from '../utils/gatewayClients.js';
+import { createIntervalScheduler } from '../utils/intervalScheduler.js';
+import { postOwnerChannelEmbed } from '../utils/ownerChannel.js';
+
+const logger = createLogger('retention-nag');
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const STARTUP_DELAY_MS = 60_000;
+/** At most one nag per week, across restarts. */
+const NAG_COOLDOWN_SECONDS = 7 * 24 * 60 * 60;
+const COOLDOWN_KEY = 'retention-nag:cooldown';
+/** Embed line cap — the full cohort belongs to the preview CLI, not Discord. */
+const MAX_LISTED_USERS = 10;
+
+const scheduler = createIntervalScheduler<[Client, Redis]>({
+  intervalMs: CHECK_INTERVAL_MS,
+  startupDelayMs: STARTUP_DELAY_MS,
+  logger,
+  run: (client, redis) => runRetentionNagCheck(client, redis),
+});
+
+/** Start the daily purge-eligibility check (call once from the composition root). */
+export function startRetentionNagScheduler(client: Client, redis: Redis): void {
+  scheduler.start(client, redis);
+}
+
+/** Stop the scheduler (graceful shutdown). */
+export function stopRetentionNagScheduler(): void {
+  scheduler.stop();
+}
+
+/** The `--env` the embed's CLI commands should carry for THIS deployment. */
+function cliEnv(): 'prod' | 'dev' {
+  return getConfig().NODE_ENV === 'production' ? 'prod' : 'dev';
+}
+
+/** Build the owner-channel embed for a non-empty cohort. Exported for tests. */
+export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): EmbedBuilder {
+  const { users, totals } = preview;
+  const env = cliEnv();
+
+  const lines = users
+    .slice(0, MAX_LISTED_USERS)
+    .map(
+      user =>
+        `\`${user.discordId}\` — inactive since ${user.inactiveSince.slice(0, 10)} ` +
+        `(${user.reason === 'account_gone' ? 'account deleted' : 'unreachable'})`
+    );
+  if (users.length > MAX_LISTED_USERS) {
+    lines.push(`…and ${String(users.length - MAX_LISTED_USERS)} more (see the preview CLI)`);
+  }
+
+  const summary =
+    `**${String(totals.eligibleCount)}** of ${String(totals.userbaseCount)} users ` +
+    `(${String(totals.percentOfUserbase)}%) are unreachable and inactive. ` +
+    `Characters: ${String(totals.charactersToDelete)} would be deleted, ` +
+    `${String(totals.charactersToReHome)} re-homed to the Orphaned Characters bucket.`;
+
+  const breaker = totals.breakerWarning
+    ? '\n\n⚠️ **Cohort exceeds the breaker warning share of the userbase.** ' +
+      'Confirm this is real churn and not a tracking-signal glitch before purging.'
+    : '';
+
+  return new EmbedBuilder()
+    .setTitle('🗑️ Accounts eligible for retention purge')
+    .setDescription(`${summary}${breaker}\n\n${lines.join('\n')}`)
+    .setFooter({
+      text:
+        `Review: pnpm ops retention:preview --env ${env} · ` +
+        `Purge: pnpm ops retention:purge --env ${env}`,
+    })
+    .setTimestamp();
+}
+
+/** Exported for tests — one full check cycle. */
+export async function runRetentionNagCheck(client: Client, redis: Redis): Promise<void> {
+  try {
+    const result = await getServiceClient().retentionPreview();
+    if (!result.ok) {
+      logger.warn({ error: result.error }, 'Retention preview fetch failed; skipping check');
+      return;
+    }
+    const preview = result.data;
+    if (preview.totals.eligibleCount === 0) {
+      return;
+    }
+
+    // Cooldown AFTER the eligibility determination: a quiet week costs no
+    // Redis read, and the key only exists while a nag is being suppressed.
+    const cooling = await redis.get(COOLDOWN_KEY);
+    if (cooling !== null) {
+      logger.info(
+        { eligibleCount: preview.totals.eligibleCount },
+        'Purge-eligible accounts present but nag is in cooldown'
+      );
+      return;
+    }
+
+    await postOwnerChannelEmbed(client, buildRetentionNagEmbed(preview));
+    await redis.setex(COOLDOWN_KEY, NAG_COOLDOWN_SECONDS, new Date().toISOString());
+    logger.info({ eligibleCount: preview.totals.eligibleCount }, 'Posted retention nag');
+  } catch (error) {
+    // Nag failure must never affect anything else; next daily tick retries.
+    logger.warn({ err: error }, 'Retention nag check failed');
+  }
+}

--- a/services/bot-client/src/services/SecretRotationNagScheduler.test.ts
+++ b/services/bot-client/src/services/SecretRotationNagScheduler.test.ts
@@ -16,7 +16,7 @@ vi.mock('../utils/ownerChannel.js', () => ({
   postOwnerChannelEmbed: (...args: unknown[]) => mockPostOwnerChannelEmbed(...args),
 }));
 
-import { runCheck } from './SecretRotationNagScheduler.js';
+import { runSecretRotationNagCheck } from './SecretRotationNagScheduler.js';
 
 const OVERDUE_ENTRY = {
   name: 'byok-encryption-key',
@@ -34,7 +34,7 @@ function makeRedis(cooldownValue: string | null): Redis {
 
 const client = {} as Client;
 
-describe('SecretRotationNagScheduler runCheck', () => {
+describe('SecretRotationNagScheduler runSecretRotationNagCheck', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPostOwnerChannelEmbed.mockResolvedValue(undefined);
@@ -51,7 +51,7 @@ describe('SecretRotationNagScheduler runCheck', () => {
     });
     const redis = makeRedis(null);
 
-    await runCheck(client, redis);
+    await runSecretRotationNagCheck(client, redis);
 
     expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
     // Seam assertion: the cooldown key is what makes the nag at-most-weekly
@@ -70,7 +70,7 @@ describe('SecretRotationNagScheduler runCheck', () => {
     });
     const redis = makeRedis('2026-07-15T00:00:00.000Z');
 
-    await runCheck(client, redis);
+    await runSecretRotationNagCheck(client, redis);
 
     expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
     expect(redis.setex).not.toHaveBeenCalled();
@@ -86,7 +86,7 @@ describe('SecretRotationNagScheduler runCheck', () => {
     });
     const redis = makeRedis(null);
 
-    await runCheck(client, redis);
+    await runSecretRotationNagCheck(client, redis);
 
     expect(redis.get).not.toHaveBeenCalled();
     expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
@@ -96,7 +96,7 @@ describe('SecretRotationNagScheduler runCheck', () => {
     mockSecretRotationStatus.mockResolvedValue({ ok: false, error: 'gateway down' });
     const redis = makeRedis(null);
 
-    await expect(runCheck(client, redis)).resolves.toBeUndefined();
+    await expect(runSecretRotationNagCheck(client, redis)).resolves.toBeUndefined();
     expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
   });
 
@@ -104,6 +104,6 @@ describe('SecretRotationNagScheduler runCheck', () => {
     mockSecretRotationStatus.mockRejectedValue(new Error('network'));
     const redis = makeRedis(null);
 
-    await expect(runCheck(client, redis)).resolves.toBeUndefined();
+    await expect(runSecretRotationNagCheck(client, redis)).resolves.toBeUndefined();
   });
 });

--- a/services/bot-client/src/services/SecretRotationNagScheduler.ts
+++ b/services/bot-client/src/services/SecretRotationNagScheduler.ts
@@ -17,6 +17,7 @@ import { EmbedBuilder, type Client } from 'discord.js';
 import type { Redis } from 'ioredis';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { getServiceClient } from '../utils/gatewayClients.js';
+import { createIntervalScheduler } from '../utils/intervalScheduler.js';
 import { postOwnerChannelEmbed } from '../utils/ownerChannel.js';
 
 const logger = createLogger('secret-rotation-nag');
@@ -27,37 +28,25 @@ const STARTUP_DELAY_MS = 60_000;
 const NAG_COOLDOWN_SECONDS = 7 * 24 * 60 * 60;
 const COOLDOWN_KEY = 'secret-rotation-nag:cooldown';
 
-let checkInterval: ReturnType<typeof setInterval> | null = null;
+const scheduler = createIntervalScheduler<[Client, Redis]>({
+  intervalMs: CHECK_INTERVAL_MS,
+  startupDelayMs: STARTUP_DELAY_MS,
+  logger,
+  run: (client, redis) => runSecretRotationNagCheck(client, redis),
+});
 
 /** Start the daily overdue check (call once from the composition root). */
 export function startSecretRotationNagScheduler(client: Client, redis: Redis): void {
-  if (checkInterval !== null) {
-    logger.warn('Scheduler already running');
-    return;
-  }
-
-  checkInterval = setInterval(() => {
-    void runCheck(client, redis);
-  }, CHECK_INTERVAL_MS);
-
-  setTimeout(() => {
-    void runCheck(client, redis);
-  }, STARTUP_DELAY_MS);
-
-  logger.info({ intervalHours: CHECK_INTERVAL_MS / (60 * 60 * 1000) }, 'Started rotation nag');
+  scheduler.start(client, redis);
 }
 
 /** Stop the scheduler (graceful shutdown). */
 export function stopSecretRotationNagScheduler(): void {
-  if (checkInterval !== null) {
-    clearInterval(checkInterval);
-    checkInterval = null;
-    logger.info('Stopped rotation nag');
-  }
+  scheduler.stop();
 }
 
 /** Exported for tests — one full check cycle. */
-export async function runCheck(client: Client, redis: Redis): Promise<void> {
+export async function runSecretRotationNagCheck(client: Client, redis: Redis): Promise<void> {
   try {
     const result = await getServiceClient().secretRotationStatus();
     if (!result.ok) {

--- a/services/bot-client/src/services/VerificationCleanupScheduler.ts
+++ b/services/bot-client/src/services/VerificationCleanupScheduler.ts
@@ -7,6 +7,7 @@
  */
 
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { createIntervalScheduler } from '../utils/intervalScheduler.js';
 import { getVerificationCleanupService } from './VerificationCleanupService.js';
 
 const logger = createLogger('verification-cleanup-scheduler');
@@ -14,32 +15,22 @@ const logger = createLogger('verification-cleanup-scheduler');
 /** Run cleanup every 6 hours */
 const CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
-let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+/** Delay the startup run until the Discord client is fully ready. */
+const STARTUP_DELAY_MS = 30_000;
+
+const scheduler = createIntervalScheduler({
+  intervalMs: CLEANUP_INTERVAL_MS,
+  startupDelayMs: STARTUP_DELAY_MS,
+  logger,
+  run: () => runCleanup(),
+});
 
 /**
  * Start the scheduled cleanup
  * Called after Discord client and cleanup service are initialized
  */
 export function startVerificationCleanupScheduler(): void {
-  if (cleanupInterval !== null) {
-    logger.warn('Scheduler already running');
-    return;
-  }
-
-  // Run cleanup every 6 hours
-  cleanupInterval = setInterval(() => {
-    void runCleanup();
-  }, CLEANUP_INTERVAL_MS);
-
-  // Run once immediately on startup (after a short delay to ensure everything is ready)
-  setTimeout(() => {
-    void runCleanup();
-  }, 30000); // 30 second delay
-
-  logger.info(
-    { intervalHours: CLEANUP_INTERVAL_MS / (60 * 60 * 1000) },
-    'Started scheduled cleanup'
-  );
+  scheduler.start();
 }
 
 /**
@@ -47,11 +38,7 @@ export function startVerificationCleanupScheduler(): void {
  * Called during graceful shutdown
  */
 export function stopVerificationCleanupScheduler(): void {
-  if (cleanupInterval !== null) {
-    clearInterval(cleanupInterval);
-    cleanupInterval = null;
-    logger.info('Stopped scheduled cleanup');
-  }
+  scheduler.stop();
 }
 
 /**

--- a/services/bot-client/src/utils/intervalScheduler.test.ts
+++ b/services/bot-client/src/utils/intervalScheduler.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the interval-scheduler factory — the shared skeleton behind
+ * bot-client's periodic background checks.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createIntervalScheduler } from './intervalScheduler.js';
+
+function makeLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Parameters<typeof createIntervalScheduler>[0]['logger'];
+}
+
+const INTERVAL_MS = 60 * 60 * 1000;
+const STARTUP_DELAY_MS = 30_000;
+
+describe('createIntervalScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function make(run = vi.fn().mockResolvedValue(undefined)) {
+    const logger = makeLogger();
+    const scheduler = createIntervalScheduler({
+      intervalMs: INTERVAL_MS,
+      startupDelayMs: STARTUP_DELAY_MS,
+      logger,
+      run,
+    });
+    return { scheduler, run, logger };
+  }
+
+  it('runs once after the startup delay, then on every interval tick', async () => {
+    const { scheduler, run } = make();
+
+    scheduler.start();
+    expect(run).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(run).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  it('forwards start-time args to every run (the client/redis binding seam)', async () => {
+    const run = vi.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
+    const scheduler = createIntervalScheduler<[string, number]>({
+      intervalMs: INTERVAL_MS,
+      startupDelayMs: STARTUP_DELAY_MS,
+      logger,
+      run,
+    });
+
+    scheduler.start('ctx', 7);
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS + INTERVAL_MS);
+
+    expect(run).toHaveBeenNthCalledWith(1, 'ctx', 7);
+    expect(run).toHaveBeenNthCalledWith(2, 'ctx', 7);
+  });
+
+  it('refuses a second start while running', () => {
+    const { scheduler, logger } = make();
+
+    scheduler.start();
+    scheduler.start();
+
+    expect(logger.warn).toHaveBeenCalledWith('Scheduler already running');
+  });
+
+  it('stop clears the recurring interval', async () => {
+    const { scheduler, run } = make();
+
+    scheduler.start();
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS + INTERVAL_MS);
+    expect(run).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 3);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop inside the startup-delay window cancels the pending startup run', async () => {
+    // The stray-timer case the factory exists to close: a shutdown 10s after
+    // boot must not leave a one-shot check firing at the 60s mark.
+    const { scheduler, run } = make();
+
+    scheduler.start();
+    scheduler.stop();
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS * 2);
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('is safe to stop when never started, and can restart after stop', async () => {
+    const { scheduler, run } = make();
+
+    scheduler.stop();
+
+    scheduler.start();
+    scheduler.stop();
+    scheduler.start();
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/bot-client/src/utils/intervalScheduler.ts
+++ b/services/bot-client/src/utils/intervalScheduler.ts
@@ -1,0 +1,84 @@
+/**
+ * Interval-scheduler factory — the shared skeleton of bot-client's periodic
+ * background checks (verification cleanup, secret-rotation nag, retention nag).
+ *
+ * The shape every consumer shares: a guarded start (no double-scheduling), a
+ * recurring `setInterval` run, one startup run after a short delay (bot-client
+ * restarts on every deploy, so the startup run is what makes daily checks
+ * restart-friendly — restarts make them fire more often, never less), and a
+ * stop that clears BOTH timers. Clearing the startup timer matters: without it,
+ * a shutdown inside the startup-delay window leaves a stray one-shot check
+ * firing after the scheduler was told to stop.
+ *
+ * Deliberately `setInterval`-based: bot-client is single-instance, and these
+ * are idempotent checks. If bot-client ever scales past one replica, this
+ * factory is the single seam to swap for BullMQ repeatable jobs (see
+ * 04-discord.md § Timer Patterns).
+ */
+
+import type { createLogger } from '@tzurot/common-types/utils/logger';
+
+type Logger = ReturnType<typeof createLogger>;
+
+export interface IntervalSchedulerOptions<Args extends unknown[]> {
+  intervalMs: number;
+  /** Delay before the one startup run. */
+  startupDelayMs: number;
+  /**
+   * The consumer's own named logger — it carries the scheduler's identity in
+   * every start/stop/already-running line, so the factory needs no label.
+   */
+  logger: Logger;
+  /**
+   * One check cycle. Must swallow its own errors — the scheduler fires it
+   * unawaited, so a rejection here would surface as an unhandled rejection.
+   */
+  run: (...args: Args) => Promise<void>;
+}
+
+export interface IntervalScheduler<Args extends unknown[]> {
+  /** Idempotent while running: a second call warns and does nothing. */
+  start: (...args: Args) => void;
+  /** Safe to call when not running. Clears the recurring AND startup timers. */
+  stop: () => void;
+}
+
+export function createIntervalScheduler<Args extends unknown[]>(
+  options: IntervalSchedulerOptions<Args>
+): IntervalScheduler<Args> {
+  const { intervalMs, startupDelayMs, logger, run } = options;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let startupTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    start(...args: Args): void {
+      if (interval !== null) {
+        logger.warn('Scheduler already running');
+        return;
+      }
+
+      interval = setInterval(() => {
+        void run(...args);
+      }, intervalMs);
+
+      startupTimeout = setTimeout(() => {
+        startupTimeout = null;
+        void run(...args);
+      }, startupDelayMs);
+
+      logger.info({ intervalHours: intervalMs / (60 * 60 * 1000) }, 'Scheduler started');
+    },
+
+    stop(): void {
+      if (startupTimeout !== null) {
+        clearTimeout(startupTimeout);
+        startupTimeout = null;
+      }
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+        logger.info('Scheduler stopped');
+      }
+    },
+  };
+}


### PR DESCRIPTION
## What

Retention Phase 2, PR-D2 (the final slice): a daily owner-channel nag when any account is purge-eligible.

- **`RetentionNagScheduler`** — daily check + one ~60s after startup (restart-friendly: deploys make it fire more often, never less), weekly Redis cooldown (`retention-nag:cooldown`), **silent at 0 eligible**. The embed carries the cohort summary (count, % of userbase, character delete/re-home impact), up to 10 listed accounts, the breaker warning when the cohort exceeds the warn share, and the exact `retention:preview` / `retention:purge` CLI commands with this deployment's `--env`. Nothing purges automatically — Phase 2 keeps the human in the loop.
- **`createIntervalScheduler` factory** — the CPD ratchet flagged that this would be the *third* copy of the identical scheduler scaffolding (guarded start → `setInterval` → startup one-shot → stop). Extracted the skeleton (one `run` callback — well under the 2-callback ceiling) and migrated all three consumers (verification cleanup, secret-rotation nag, retention nag). Ride-along fix in all three: `stop()` now cancels a still-pending **startup** timer, so a shutdown inside the startup-delay window no longer leaves a stray one-shot check firing afterwards.
- Both nag `runCheck` exports renamed to distinct names (`runRetentionNagCheck` / `runSecretRotationNagCheck`) — `guard:duplicate-exports` caught the collision.

## Verified

- `pnpm --filter @tzurot/bot-client test` — 382 files / 5,850 tests green, including the pre-existing `VerificationCleanupScheduler` behavior tests running unchanged against the migrated implementation (the regression net for the factory swap).
- New tests: factory timer semantics under fake timers (startup-cancel case included), nag check cycle (post + cooldown arm, cooldown suppression, silent-at-zero, both failure swallows), embed content (counts, reason labels, per-env CLI commands, breaker line, 10-user cap + overflow).
- `pnpm quality` green — CPD back under the ceiling *without* a baseline bump (the extraction removed the clone).
- The preview endpoint this reads was runtime-verified this morning by the dev end-to-end purge smoke (CURRENT.md checklist item 10).

This closes retention Phase 2. Phases 3 (reachable branch) and 4 (autonomous) remain future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)