### PR TITLE
feat: retention Phase 3 substrate — grace clock + notify predicates (PR-E1)

### DIFF
--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -695,6 +695,9 @@ describe('RetentionPreviewResponseSchema', () => {
       charactersToDelete: 0,
       charactersToReHome: 0,
       breakerWarning: false,
+      reachableToNotify: 0,
+      inGrace: 0,
+      graceExpired: 0,
     },
   };
 

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -306,8 +306,12 @@ export const RetentionPreviewUserSchema = z.object({
   discordId: DiscordSnowflakeSchema,
   /** Inactivity anchor as ISO — last_active_at, or created_at when never stamped. */
   inactiveSince: z.string().datetime(),
-  /** `account_gone` (Discord 10013) is the stronger signal and wins when both are set. */
-  reason: z.enum(['unreachable', 'account_gone']),
+  /**
+   * Label precedence mirrors signal strength: `account_gone` (Discord 10013)
+   * beats `unreachable`, which beats `grace_expired` (the Phase-3 reachable
+   * branch: warned, then silent through the whole grace window).
+   */
+  reason: z.enum(['unreachable', 'account_gone', 'grace_expired']),
   ownedCharacters: z.object({
     /** Nobody else has data on them — deleted with the account. */
     toDelete: z.number().int().nonnegative(),
@@ -327,6 +331,12 @@ export const RetentionPreviewResponseSchema = z.object({
     charactersToReHome: z.number().int().nonnegative(),
     /** Cohort exceeds the breaker's warning share — review before purging. */
     breakerWarning: z.boolean(),
+    /** Reachable + inactive ≥180d, not yet warned — the notify cohort (Phase 3). */
+    reachableToNotify: z.number().int().nonnegative(),
+    /** Warned, grace window still running (any activity aborts the clock). */
+    inGrace: z.number().int().nonnegative(),
+    /** Warned, window expired, still silent — the grace_expired purge subset. */
+    graceExpired: z.number().int().nonnegative(),
   }),
 });
 

--- a/packages/identity/src/UserService.test.ts
+++ b/packages/identity/src/UserService.test.ts
@@ -213,6 +213,9 @@ describe('UserService', () => {
       expect(template.join('')).toContain('last_active_at');
       expect(template.join('')).toContain('dm_undeliverable_since = NULL');
       expect(template.join('')).toContain('discord_account_gone_at = NULL');
+      // Grace aborts on use: the same seam clears the reachable-branch grace
+      // clock, or a warned user who came back would still be purge-eligible.
+      expect(template.join('')).toContain('retention_notified_at = NULL');
       expect(template.join('')).not.toContain('updated_at');
       expect(userId).toBe('active-user-id');
     });

--- a/packages/identity/src/UserService.ts
+++ b/packages/identity/src/UserService.ts
@@ -189,19 +189,23 @@ export class UserService {
       // `updated_at` untouched. A raw UPDATE on a mid-flight-deleted row matches
       // 0 rows without throwing, matching the TOCTOU cache guard below.
       //
-      // The same stamp also CLEARS both unreachability flags: activity is proof
-      // of reach, so an active user is never left flagged unreachable. All three
-      // are retention signals maintained together on this one activity seam —
-      // the release-blast path sets the flags, any provisioning clears them (a
-      // later failure re-stamps fresh, since the clear resets the first-failure
-      // guard). discord_account_gone_at needs this MORE than its sibling, not
-      // less: a Discord 10013 is meant to mean "this account no longer exists",
-      // so a live user who is here provisioning is the direct disproof, and
-      // without the clear a single mis-stamp would flag them permanently.
+      // The same stamp also CLEARS both unreachability flags AND the retention
+      // grace clock: activity is proof of reach, so an active user is never
+      // left flagged unreachable, and using the bot mid-grace aborts the
+      // reachable-branch purge pipeline entirely (one notice per inactivity
+      // spell — a fresh spell starts a fresh notice). All four are retention
+      // signals maintained together on this one activity seam — the DM-failure
+      // paths set the flags, any provisioning clears them (a later failure
+      // re-stamps fresh, since the clear resets the first-failure guard).
+      // discord_account_gone_at needs this MORE than its sibling, not less: a
+      // Discord 10013 is meant to mean "this account no longer exists", so a
+      // live user who is here provisioning is the direct disproof, and without
+      // the clear a single mis-stamp would flag them permanently.
       try {
         await this.prisma.$executeRaw`
           UPDATE users
-          SET last_active_at = NOW(), dm_undeliverable_since = NULL, discord_account_gone_at = NULL
+          SET last_active_at = NOW(), dm_undeliverable_since = NULL,
+              discord_account_gone_at = NULL, retention_notified_at = NULL
           WHERE id = ${user.id}::uuid
         `;
       } catch (stampError) {

--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE "users" (
     "last_active_at" TIMESTAMP(3),
     "dm_undeliverable_since" TIMESTAMP(3),
     "discord_account_gone_at" TIMESTAMP(3),
+    "retention_notified_at" TIMESTAMP(3),
     "retention_exempt" BOOLEAN NOT NULL DEFAULT false,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,

--- a/packages/tooling/src/retention/backfill-last-active.ts
+++ b/packages/tooling/src/retention/backfill-last-active.ts
@@ -23,6 +23,15 @@
  *    attribution (the user's own conversational identity) counts; memories with a
  *    NULL persona_id are skipped (those users are covered by usage_logs anyway).
  *
+ * Grace-clock caveat: this tool advances last_active_at WITHOUT clearing
+ * retention_notified_at, unlike the live activity-stamp sites (which clear it
+ * because activity aborts the reachable-branch grace window). Safe for its
+ * one-time Phase-1 purpose — no grace clocks existed then — but a re-run
+ * against a database with live grace clocks could leave a user looking
+ * "mid-grace" whose backfilled activity actually disqualifies them from the
+ * inactivity window. If re-running ever becomes a real need, clear
+ * retention_notified_at on the same rows.
+ *
  * Guardrails, mirroring repair-fact-timestamps:
  *  - FORWARD-ONLY into a fresh column, but idempotent: a row is only touched when
  *    the computed activity is newer than the stored value (or the stored value is

--- a/packages/tooling/src/retention/preview.test.ts
+++ b/packages/tooling/src/retention/preview.test.ts
@@ -20,6 +20,9 @@ const EMPTY_TOTALS = {
   charactersToDelete: 0,
   charactersToReHome: 0,
   breakerWarning: false,
+  reachableToNotify: 0,
+  inGrace: 0,
+  graceExpired: 0,
 };
 
 const COHORT = {
@@ -44,6 +47,9 @@ const COHORT = {
     charactersToDelete: 1,
     charactersToReHome: 2,
     breakerWarning: false,
+    reachableToNotify: 0,
+    inGrace: 0,
+    graceExpired: 0,
   },
 };
 
@@ -103,7 +109,28 @@ describe('renderPreview', () => {
 
     renderPreview({ users: [], totals: EMPTY_TOTALS });
 
-    expect(logSpy.mock.calls.flat().join('\n')).toContain('No users are purge-eligible');
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('No users are purge-eligible');
+    // All pipeline counts zero → no reachable-branch line to render.
+    expect(output).not.toContain('reachable branch');
+    logSpy.mockRestore();
+  });
+
+  it('prints the reachable-branch line whenever ANY pipeline count is non-zero', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    // graceExpired-only is a real steady state: those users have left the
+    // other two counts (window passed, already warned) — a guard on only the
+    // two upstream counts would drop the line exactly when it matters.
+    renderPreview({
+      ...COHORT,
+      totals: { ...COHORT.totals, graceExpired: 2 },
+    });
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain(
+      'reachable branch: 0 awaiting a warning DM, 0 in grace, 2 grace-expired'
+    );
     logSpy.mockRestore();
   });
 

--- a/packages/tooling/src/retention/preview.ts
+++ b/packages/tooling/src/retention/preview.ts
@@ -28,7 +28,22 @@ export interface RetentionPreviewOptions {
 const REASON_LABEL: Record<RetentionPreviewResponse['users'][number]['reason'], string> = {
   unreachable: 'DMs closed / left every shared server',
   account_gone: 'Discord account deleted',
+  grace_expired: 'warned, grace window expired',
 };
+
+/** The reachable branch's pipeline states — printed on both cohort branches. */
+function renderReachableBranch(totals: RetentionPreviewResponse['totals']): void {
+  // All THREE counts gate the line: grace-expired users left the other two
+  // counts (window passed, already warned), so a graceExpired-only steady
+  // state is real and must still render.
+  if (totals.reachableToNotify === 0 && totals.inGrace === 0 && totals.graceExpired === 0) {
+    return;
+  }
+  console.log(
+    `  reachable branch: ${String(totals.reachableToNotify)} awaiting a warning DM, ` +
+      `${String(totals.inGrace)} in grace, ${String(totals.graceExpired)} grace-expired`
+  );
+}
 
 /** Print the cohort report. Exported for testing without the transport. */
 export function renderPreview(preview: RetentionPreviewResponse): void {
@@ -39,9 +54,10 @@ export function renderPreview(preview: RetentionPreviewResponse): void {
     // indistinguishable from a query that silently returned nothing, which
     // undercuts the one job a read-only report has.
     console.log(
-      chalk.green('\nNo users are purge-eligible — nobody is both unreachable and inactive.')
+      chalk.green('\nNo users are purge-eligible — no inactive user is unreachable or past grace.')
     );
     console.log(chalk.dim(`  eligible: 0 of ${String(totals.userbaseCount)} users`));
+    renderReachableBranch(totals);
     return;
   }
 
@@ -67,6 +83,7 @@ export function renderPreview(preview: RetentionPreviewResponse): void {
     `  characters: ${totals.charactersToDelete} would be deleted, ` +
       `${totals.charactersToReHome} would be re-homed to the Orphaned Characters bucket`
   );
+  renderReachableBranch(totals);
 
   if (totals.breakerWarning) {
     console.log(

--- a/packages/tooling/src/retention/purge.test.ts
+++ b/packages/tooling/src/retention/purge.test.ts
@@ -32,6 +32,9 @@ function cohort(...discordIds: string[]) {
       charactersToDelete: discordIds.length,
       charactersToReHome: 0,
       breakerWarning: false,
+      reachableToNotify: 0,
+      inGrace: 0,
+      graceExpired: 0,
     },
   };
 }

--- a/prisma/migrations/20260726181830_add_retention_notified_at/migration.sql
+++ b/prisma/migrations/20260726181830_add_retention_notified_at/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memory_facts_embedding";
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "retention_notified_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,16 @@ model User {
   /// and the audit ledger, not because they differ in timing. Reads guard with
   /// != null.
   discordAccountGoneAt  DateTime?                  @map("discord_account_gone_at")
+  /// State machine (the reachable branch's grace clock): NULL until a retention
+  /// warning DM is confirmed SENT to this reachable-but-inactive user; set to
+  /// the send-confirmation time, never advancing while non-null (one notice per
+  /// inactivity spell). Cleared back to NULL by any activity — the same stamp
+  /// sites that maintain lastActiveAt — so using the bot mid-grace aborts the
+  /// pipeline entirely; deliberately NOT cleared by a release DM landing (reach
+  /// is not use). While non-null and older than the grace window, the user is
+  /// purge-eligible with reason grace_expired (retention/eligibility.ts is the
+  /// single source). Reads guard with != null.
+  retentionNotifiedAt   DateTime?                  @map("retention_notified_at")
   /// Operator-set exemption: when true, the retention purge job never selects
   /// this user (test/burner/VIP/pending-dispute accounts). Distinct from
   /// isSuperuser (which grants admin powers — the wrong lever for an exemption).

--- a/services/api-gateway/src/routes/internal/retentionPreview.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionPreview.test.ts
@@ -31,6 +31,9 @@ const PREVIEW = {
     charactersToDelete: 1,
     charactersToReHome: 2,
     breakerWarning: false,
+    reachableToNotify: 0,
+    inGrace: 0,
+    graceExpired: 0,
   },
 };
 
@@ -67,6 +70,9 @@ describe('GET /internal/retention/preview', () => {
         charactersToDelete: 0,
         charactersToReHome: 0,
         breakerWarning: false,
+        reachableToNotify: 0,
+        inGrace: 0,
+        graceExpired: 0,
       },
     });
     const { req, res } = createMockReqRes();

--- a/services/api-gateway/src/routes/internal/usersActivity.test.ts
+++ b/services/api-gateway/src/routes/internal/usersActivity.test.ts
@@ -63,6 +63,9 @@ describe('POST /internal/users/activity', () => {
     // Nothing else clears the gone-flag, so a live user who was mis-stamped
     // with Discord 10013 relies on exactly this write to become un-purgeable.
     expect(sql).toContain('discord_account_gone_at = NULL');
+    // Grace aborts on use: activity mid-grace must exit the reachable-branch
+    // purge pipeline, or a warned user who came back gets purged anyway.
+    expect(sql).toContain('retention_notified_at = NULL');
     expect(sql).toContain('discord_id');
     expect(sql).not.toContain('updated_at');
     expect(discordId).toBe(VALID_DISCORD_ID);

--- a/services/api-gateway/src/routes/internal/usersActivity.ts
+++ b/services/api-gateway/src/routes/internal/usersActivity.ts
@@ -40,15 +40,17 @@ export const handleStampUserActivity = (deps: RouteDeps): RequestHandler => {
     }
     const { discordId } = parseResult.data;
 
-    // Raw UPDATE (not the Prisma client): last_active_at and both
-    // unreachability flags are retention signals that must NOT bump updated_at
-    // (the dev<->prod sync LWW resolver) — see UserService.getOrCreateUser for
-    // the full rationale, including why activity clears the flags. `$executeRaw`
+    // Raw UPDATE (not the Prisma client): last_active_at, both unreachability
+    // flags, and the retention grace clock are retention signals that must NOT
+    // bump updated_at (the dev<->prod sync LWW resolver) — see
+    // UserService.getOrCreateUser for the full rationale, including why
+    // activity clears all three flags (grace aborts on use). `$executeRaw`
     // returns the affected-row count, which is 0 when the user isn't provisioned
     // yet (a legitimate no-op, not an error).
     const affected = await prisma.$executeRaw`
       UPDATE users
-      SET last_active_at = NOW(), dm_undeliverable_since = NULL, discord_account_gone_at = NULL
+      SET last_active_at = NOW(), dm_undeliverable_since = NULL,
+          discord_account_gone_at = NULL, retention_notified_at = NULL
       WHERE discord_id = ${discordId}
     `;
 

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
@@ -16,9 +16,12 @@ import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot
 import { generateUserUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { ORPHAN_SENTINEL_DISCORD_ID } from '@tzurot/common-types/constants/persona';
 import { RetentionPurgeService } from './RetentionPurgeService.js';
+import { filterStillNotifyEligible, selectNotifyCohort } from './eligibility.js';
 
 const OLD = new Date('2020-01-01T00:00:00Z'); // far past the 180-day window
 const RECENT = new Date(); // inside the window
+const GRACE_EXPIRED_STAMP = new Date(Date.now() - 31 * 24 * 3600 * 1000); // past the 30-day grace
+const IN_GRACE_STAMP = new Date(Date.now() - 5 * 24 * 3600 * 1000); // inside the grace window
 
 /** Users, one per predicate arm. */
 const ELIGIBLE_UNREACHABLE = 'c0407000-0000-4000-8000-000000000001';
@@ -28,6 +31,9 @@ const REACHABLE = 'c0407000-0000-4000-8000-000000000004';
 const SUPERUSER = 'c0407000-0000-4000-8000-000000000005';
 const EXEMPT = 'c0407000-0000-4000-8000-000000000006';
 const NEVER_STAMPED_YOUNG = 'c0407000-0000-4000-8000-000000000007';
+const GRACE_EXPIRED_USER = 'c0407000-0000-4000-8000-000000000008';
+const IN_GRACE_USER = 'c0407000-0000-4000-8000-000000000009';
+const MID_GRACE_BUT_BOUNCED = 'c0407000-0000-4000-8000-00000000000a';
 
 const PERSONALITY_SHARED = 'c0407000-0000-4000-8000-0000000000a1';
 const PERSONALITY_SOLO = 'c0407000-0000-4000-8000-0000000000a2';
@@ -68,6 +74,9 @@ describe('RetentionPurgeService (component, PGLite)', () => {
       [SUPERUSER, 'superowner'],
       [EXEMPT, 'exemptuser'],
       [NEVER_STAMPED_YOUNG, 'youngnostamp'],
+      [GRACE_EXPIRED_USER, 'graceexpired'],
+      [IN_GRACE_USER, 'ingrace'],
+      [MID_GRACE_BUT_BOUNCED, 'gracebounced'],
     ] as const) {
       await seed(id, name);
     }
@@ -114,6 +123,26 @@ describe('RetentionPurgeService (component, PGLite)', () => {
       UPDATE users SET dm_undeliverable_since = ${OLD}, last_active_at = NULL, created_at = ${RECENT}
       WHERE id = ${NEVER_STAMPED_YOUNG}::uuid
     `;
+    // Phase 3 (reachable branch): warned 31 days ago, silent since → the
+    // grace-expired arm makes them purge-eligible with NO unreachable flag.
+    await prisma.$executeRaw`
+      UPDATE users SET retention_notified_at = ${GRACE_EXPIRED_STAMP}, last_active_at = ${OLD}
+      WHERE id = ${GRACE_EXPIRED_USER}::uuid
+    `;
+    // Warned 5 days ago → mid-grace: excluded from the purge cohort AND from
+    // the notify cohort (one notice per spell), counted in inGrace.
+    await prisma.$executeRaw`
+      UPDATE users SET retention_notified_at = ${IN_GRACE_STAMP}, last_active_at = ${OLD}
+      WHERE id = ${IN_GRACE_USER}::uuid
+    `;
+    // Mid-grace AND a later DM bounced: the unreachable arm makes them
+    // purge-eligible NOW — they must count once (cohort, as unreachable),
+    // never also in inGrace. The disjointness case from review round 1.
+    await prisma.$executeRaw`
+      UPDATE users SET retention_notified_at = ${IN_GRACE_STAMP}, dm_undeliverable_since = ${OLD},
+                       last_active_at = ${OLD}
+      WHERE id = ${MID_GRACE_BUT_BOUNCED}::uuid
+    `;
 
     // Characters owned by the unreachable user: SHARED has another user's
     // memory (→ re-home), SOLO has none (→ delete).
@@ -138,16 +167,17 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     await pglite.close();
   });
 
-  it('selects exactly the unreachable-and-inactive cohort', async () => {
+  it('selects exactly the unreachable, gone, and grace-expired cohort', async () => {
     const cohort = await service.selectPurgeCohort();
 
     expect(cohort.map(row => row.userId).sort()).toEqual(
-      [ELIGIBLE_UNREACHABLE, ELIGIBLE_GONE].sort()
+      [ELIGIBLE_UNREACHABLE, ELIGIBLE_GONE, GRACE_EXPIRED_USER, MID_GRACE_BUT_BOUNCED].sort()
     );
     // Every exclusion is load-bearing — name them so a regression is legible.
     const ids = cohort.map(row => row.userId);
     expect(ids).not.toContain(ACTIVE_RECENTLY); // active again
-    expect(ids).not.toContain(REACHABLE); // still reachable
+    expect(ids).not.toContain(REACHABLE); // still reachable, never warned
+    expect(ids).not.toContain(IN_GRACE_USER); // warned, grace window still running
     expect(ids).not.toContain(SUPERUSER); // bot owner
     expect(ids).not.toContain(EXEMPT); // retention_exempt (also the orphan sentinel)
     expect(ids).not.toContain(NEVER_STAMPED_YOUNG); // NULL last_active_at → created_at fallback
@@ -159,6 +189,9 @@ describe('RetentionPurgeService (component, PGLite)', () => {
 
     expect(byId.get(ELIGIBLE_UNREACHABLE)).toBe('unreachable');
     expect(byId.get(ELIGIBLE_GONE)).toBe('account_gone');
+    expect(byId.get(GRACE_EXPIRED_USER)).toBe('grace_expired');
+    // Precedence in real SQL: the unreachable stamp outranks the grace clock.
+    expect(byId.get(MID_GRACE_BUT_BOUNCED)).toBe('unreachable');
   });
 
   it('reports the character split and userbase share in the preview', async () => {
@@ -170,11 +203,45 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     expect(preview.totals.charactersToDelete).toBe(1);
     expect(preview.totals.charactersToReHome).toBe(1);
 
-    expect(preview.totals.eligibleCount).toBe(2);
-    expect(preview.totals.userbaseCount).toBe(8);
-    // 2/8 = 25% — over the 15% warn line, so the breaker annotation fires.
-    expect(preview.totals.percentOfUserbase).toBe(25);
+    expect(preview.totals.eligibleCount).toBe(4);
+    expect(preview.totals.userbaseCount).toBe(11);
+    // 4/11 ≈ 36.4% — over the 15% warn line, so the breaker annotation fires.
+    expect(preview.totals.percentOfUserbase).toBe(36.4);
     expect(preview.totals.breakerWarning).toBe(true);
+    // Reachable-branch pipeline: REACHABLE awaits a warning, IN_GRACE_USER is
+    // mid-grace, and grace_expired is the labeled subset of the cohort above.
+    // MID_GRACE_BUT_BOUNCED is in the cohort (unreachable) and must NOT also
+    // count as in-grace — the counts partition, never double-report.
+    expect(preview.totals.reachableToNotify).toBe(1);
+    expect(preview.totals.inGrace).toBe(1);
+    expect(preview.totals.graceExpired).toBe(1);
+  });
+
+  it('selects the notify cohort disjoint from the purge cohort (real SQL)', async () => {
+    const cohort = await selectNotifyCohort(prisma, null);
+
+    // Only REACHABLE: inactive ≥180d, no unreachable stamps, never warned.
+    // Everyone warned, flagged, exempt, young, or recently active is out.
+    expect(cohort.map(row => row.userId)).toEqual([REACHABLE]);
+  });
+
+  it('narrows the notify cohort by the outbound-DM allowlist in SQL', async () => {
+    const reachableRow = await prisma.user.findUnique({ where: { id: REACHABLE } });
+    const someoneElse = new Set(['100000000000000001']);
+
+    expect(await selectNotifyCohort(prisma, someoneElse)).toEqual([]);
+    const narrowed = await selectNotifyCohort(prisma, new Set([reachableRow!.discordId]));
+    expect(narrowed.map(row => row.userId)).toEqual([REACHABLE]);
+  });
+
+  it('filterStillNotifyEligible drops users who no longer qualify (real SQL)', async () => {
+    const eligible = await filterStillNotifyEligible(prisma, [
+      REACHABLE,
+      IN_GRACE_USER, // already warned
+      ACTIVE_RECENTLY, // unreachable-stamped
+    ]);
+
+    expect(eligible).toEqual(new Set([REACHABLE]));
   });
 });
 

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
@@ -21,11 +21,15 @@ describe('RetentionPurgeService.buildPreview', () => {
     userbase: number;
     owned?: { id: string }[];
     reach?: { personalityId: string }[];
+    reachableToNotify?: number;
+    inGrace?: number;
   }) {
     const queryRaw = vi
       .fn()
-      // call 1 = the cohort; call 2+ = per-user reach
+      // call 1 = the cohort; calls 2-3 = notify/in-grace counts; call 4+ = per-user reach
       .mockResolvedValueOnce(opts.cohort)
+      .mockResolvedValueOnce([{ n: BigInt(opts.reachableToNotify ?? 0) }])
+      .mockResolvedValueOnce([{ n: BigInt(opts.inGrace ?? 0) }])
       .mockResolvedValue(opts.reach ?? []);
     return {
       $queryRaw: queryRaw,
@@ -40,6 +44,7 @@ describe('RetentionPurgeService.buildPreview', () => {
       discordId: '900000000000000001',
       inactiveSince: new Date('2025-01-01T00:00:00Z'),
       accountGone: false,
+      unreachable: true,
     },
   ];
 
@@ -89,6 +94,7 @@ describe('RetentionPurgeService.buildPreview', () => {
       discordId: `90000000000000000${i}`,
       inactiveSince: new Date('2025-01-01T00:00:00Z'),
       accountGone: false,
+      unreachable: true,
     }));
     const prisma = makePreviewPrisma({ cohort, userbase: 20 });
 
@@ -106,6 +112,29 @@ describe('RetentionPurgeService.buildPreview', () => {
     expect(users).toEqual([]);
     expect(totals.percentOfUserbase).toBe(0);
     expect(totals.breakerWarning).toBe(false);
+  });
+
+  it('surfaces the reachable-branch pipeline counts (Phase 3)', async () => {
+    // graceExpired is a labeled SUBSET of the cohort, not an addition to it —
+    // the count must come from the reasons, not a fourth query.
+    const cohort = [
+      { ...ONE_USER[0] },
+      {
+        userId: 'u2',
+        discordId: '900000000000000002',
+        inactiveSince: new Date('2025-02-01T00:00:00Z'),
+        accountGone: false,
+        unreachable: false,
+      },
+    ];
+    const prisma = makePreviewPrisma({ cohort, userbase: 100, reachableToNotify: 51, inGrace: 4 });
+
+    const { totals } = await new RetentionPurgeService({ prisma }).buildPreview();
+
+    expect(totals.eligibleCount).toBe(2);
+    expect(totals.reachableToNotify).toBe(51);
+    expect(totals.inGrace).toBe(4);
+    expect(totals.graceExpired).toBe(1);
   });
 });
 

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.ts
@@ -19,6 +19,8 @@ import type { AccountDeletionSummary } from '../AccountDeletionService.js';
 import { findCrossUserReachIds } from './crossUserReach.js';
 import {
   countEligibleUsers,
+  countInGrace,
+  countNotifyCohort,
   selectEligibleUsers,
   type PurgeCohortRow,
   type PurgeReason,
@@ -66,6 +68,12 @@ export interface RetentionPreview {
     charactersToReHome: number;
     /** Cohort exceeds BREAKER_WARN_FRACTION of the userbase — review closely. */
     breakerWarning: boolean;
+    /** Reachable + inactive ≥180d, not yet warned — the notify cohort (Phase 3). */
+    reachableToNotify: number;
+    /** Warned, grace window still running (any activity aborts the clock). */
+    inGrace: number;
+    /** Warned, window expired, still silent — the grace_expired purge subset. */
+    graceExpired: number;
   };
 }
 
@@ -115,9 +123,11 @@ export class RetentionPurgeService {
     // breaker asks "how much of the userbase would this run erase?", and a
     // purgeable-population denominator would make the percentage drift every
     // time an exemption is added rather than when real churn changes.
-    const [cohort, userbaseCount] = await Promise.all([
+    const [cohort, userbaseCount, reachableToNotify, inGrace] = await Promise.all([
       this.selectPurgeCohort(),
       this.prisma.user.count(),
+      countNotifyCohort(this.prisma),
+      countInGrace(this.prisma),
     ]);
 
     // Concurrent, not sequential: the daily nag calls this on a schedule, so a
@@ -145,6 +155,11 @@ export class RetentionPurgeService {
         charactersToDelete,
         charactersToReHome,
         breakerWarning: userbaseCount > 0 && users.length / userbaseCount > BREAKER_WARN_FRACTION,
+        reachableToNotify,
+        inGrace,
+        // Grace-expired users are IN the purge cohort (the third predicate
+        // arm), so this is a labeled subset, not an addition to eligibleCount.
+        graceExpired: users.filter(u => u.reason === 'grace_expired').length,
       },
     };
   }

--- a/services/api-gateway/src/services/retention/eligibility.test.ts
+++ b/services/api-gateway/src/services/retention/eligibility.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Prisma } from '@tzurot/common-types/services/prisma';
 import {
+  GRACE_PERIOD_DAYS,
   RETENTION_WINDOW_DAYS,
   countEligibleUsers,
+  countInGrace,
+  countNotifyCohort,
+  filterStillNotifyEligible,
   isStillEligibleForPurge,
   selectEligibleUsers,
+  selectNotifyCohort,
 } from './eligibility.js';
 
 /**
@@ -57,16 +62,18 @@ describe('the eligibility predicate', () => {
     await selectEligibleUsers(db);
 
     const sql = flattenSql(queryRaw.mock.calls[0]);
-    // Unreachable OR gone — either signal qualifies.
+    // Unreachable OR gone OR grace-expired — any of the three qualifies.
     expect(sql).toContain('u.dm_undeliverable_since IS NOT NULL');
     expect(sql).toContain('u.discord_account_gone_at IS NOT NULL');
+    expect(sql).toContain('u.retention_notified_at <');
     // Inactivity, with the NULL → created_at fallback (never "active now").
     expect(sql).toContain('COALESCE(u.last_active_at, u.created_at)');
     // The two exemptions that must never be purge-able.
     expect(sql).toContain('u.is_superuser = false');
     expect(sql).toContain('u.retention_exempt = false');
-    // The window is bound, not inlined — and it's the single named constant.
+    // The windows are bound, not inlined — and they're the single named constants.
     expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_WINDOW_DAYS);
+    expect(flattenValues(queryRaw.mock.calls[0])).toContain(GRACE_PERIOD_DAYS);
 
     // NEGATIVE: the predicate must not silently widen to reachable users. A
     // purge that ignores reachability would erase people who could be notified.
@@ -74,41 +81,145 @@ describe('the eligibility predicate', () => {
     expect(sql).not.toContain('notify_enabled');
   });
 
-  it('makes a gone account clear the 180-day bar too — it is NOT a fast-track', async () => {
+  it('makes every signal clear the 180-day bar too — none is a fast-track', async () => {
     // Owner call: D13 sketched purging a Discord-10013 account without waiting
-    // out the inactivity window. That stays unbuilt, so the inactivity
-    // condition must apply to BOTH signals — i.e. the OR covers only the two
-    // unreachability flags and is ANDed with the window, never ORed around it.
+    // out the inactivity window. That stays unbuilt, and the Phase-3 grace arm
+    // inherits the same rule: the OR covers only the three qualifying signals
+    // and is ANDed with the inactivity window, never ORed around it.
     const { db, queryRaw } = makeDb();
 
     await selectEligibleUsers(db);
 
     const sql = flattenSql(queryRaw.mock.calls[0]).replace(/\s+/g, ' ');
+    // Fragment-bound values flatten to `?` placeholders, hence the literal \?.
     expect(sql).toMatch(
-      /\(u\.dm_undeliverable_since IS NOT NULL OR u\.discord_account_gone_at IS NOT NULL\) AND COALESCE/
+      /\(u\.dm_undeliverable_since IS NOT NULL OR u\.discord_account_gone_at IS NOT NULL OR u\.retention_notified_at < now\(\) - make_interval\(days => \?\)\) AND COALESCE/
     );
-    expect(sql).not.toMatch(/OR u\.discord_account_gone_at IS NOT NULL\s*\)?\s*$/);
+    expect(sql).not.toMatch(/OR u\.retention_notified_at[^)]*$/);
   });
 
-  it('labels a gone account as account_gone even when both signals are stamped', async () => {
+  it('labels by signal strength: account_gone > unreachable > grace_expired', async () => {
     const { db } = makeDb([
       {
         userId: 'u1',
         discordId: '900000000000000001',
         inactiveSince: new Date('2025-01-01'),
         accountGone: true,
+        unreachable: true,
       },
       {
         userId: 'u2',
         discordId: '900000000000000002',
         inactiveSince: new Date('2025-02-01'),
         accountGone: false,
+        unreachable: true,
+      },
+      {
+        userId: 'u3',
+        discordId: '900000000000000003',
+        inactiveSince: new Date('2025-03-01'),
+        accountGone: false,
+        unreachable: false,
       },
     ]);
 
     const cohort = await selectEligibleUsers(db);
 
-    expect(cohort.map(row => row.reason)).toEqual(['account_gone', 'unreachable']);
+    expect(cohort.map(row => row.reason)).toEqual(['account_gone', 'unreachable', 'grace_expired']);
+  });
+});
+
+describe('the notify predicate (Phase 3)', () => {
+  it('selects only reachable, un-warned, inactive, non-exempt users', async () => {
+    const { db, queryRaw } = makeDb();
+
+    await selectNotifyCohort(db, null);
+
+    const sql = flattenSql(queryRaw.mock.calls[0]);
+    // Reachable: BOTH unreachable stamps must be null...
+    expect(sql).toContain('u.dm_undeliverable_since IS NULL');
+    expect(sql).toContain('u.discord_account_gone_at IS NULL');
+    // ...one notice per inactivity spell (also the cross-run idempotency guard)...
+    expect(sql).toContain('u.retention_notified_at IS NULL');
+    // ...the same inactivity window and exemptions as the purge predicate.
+    expect(sql).toContain('COALESCE(u.last_active_at, u.created_at)');
+    expect(sql).toContain('u.is_superuser = false');
+    expect(sql).toContain('u.retention_exempt = false');
+    expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_WINDOW_DAYS);
+  });
+
+  it('narrows by the outbound-DM allowlist at the SQL level when one is set', async () => {
+    const { db, queryRaw } = makeDb();
+
+    await selectNotifyCohort(db, new Set(['111111111111111111']));
+
+    const sql = flattenSql(queryRaw.mock.calls[0]);
+    expect(sql).toContain('u.discord_id = ANY(');
+    expect(flattenValues(queryRaw.mock.calls[0])).toContainEqual(['111111111111111111']);
+  });
+
+  it('adds no allowlist clause when unrestricted (prod)', async () => {
+    const { db, queryRaw } = makeDb();
+
+    await selectNotifyCohort(db, null);
+
+    expect(flattenSql(queryRaw.mock.calls[0])).not.toContain('ANY(');
+  });
+});
+
+describe('filterStillNotifyEligible (the send-time re-check)', () => {
+  it('returns the still-eligible subset', async () => {
+    const { db, queryRaw } = makeDb([{ userId: 'keep-1' }, { userId: 'keep-2' }]);
+
+    const eligible = await filterStillNotifyEligible(db, ['keep-1', 'gone-active', 'keep-2']);
+
+    expect(eligible).toEqual(new Set(['keep-1', 'keep-2']));
+    const sql = flattenSql(queryRaw.mock.calls[0]);
+    // Scoped to the batch AND evaluating the full notify predicate — dropping
+    // any arm would DM a deletion warning to a user who just came back.
+    expect(sql).toContain('u.id = ANY(');
+    expect(sql).toContain('u.retention_notified_at IS NULL');
+  });
+
+  it('short-circuits on an empty batch without touching the db', async () => {
+    const { db, queryRaw } = makeDb();
+
+    expect(await filterStillNotifyEligible(db, [])).toEqual(new Set());
+    expect(queryRaw).not.toHaveBeenCalled();
+  });
+});
+
+describe('the reporting counts', () => {
+  it('countNotifyCohort returns a number', async () => {
+    const { db } = makeDb([{ n: 51n }]);
+
+    expect(await countNotifyCohort(db)).toBe(51);
+  });
+
+  it('countInGrace bounds by the grace window and keeps the exemption guards', async () => {
+    const { db, queryRaw } = makeDb([{ n: 3n }]);
+
+    const count = await countInGrace(db);
+
+    expect(count).toBe(3);
+    const sql = flattenSql(queryRaw.mock.calls[0]);
+    expect(sql).toContain('u.retention_notified_at >=');
+    expect(sql).toContain('u.is_superuser = false');
+    expect(sql).toContain('u.retention_exempt = false');
+    expect(flattenValues(queryRaw.mock.calls[0])).toContain(GRACE_PERIOD_DAYS);
+  });
+
+  it('countInGrace excludes users an unreachable stamp already made purge-eligible', async () => {
+    // Disjointness: a mid-grace user whose LATER release DM bounced is in the
+    // purge cohort via the unreachable arm — counting them as "in grace" too
+    // would report the same user as both purgeable-now and still-waiting.
+    const { db, queryRaw } = makeDb([{ n: 0n }]);
+
+    await countInGrace(db);
+
+    const sql = flattenSql(queryRaw.mock.calls[0]);
+    expect(sql).toContain('u.dm_undeliverable_since IS NULL');
+    expect(sql).toContain('u.discord_account_gone_at IS NULL');
   });
 });
 

--- a/services/api-gateway/src/services/retention/eligibility.ts
+++ b/services/api-gateway/src/services/retention/eligibility.ts
@@ -14,6 +14,11 @@
  *
  * Both forms evaluate the same fragment, so the re-check cannot disagree with
  * the selection that produced the cohort.
+ *
+ * Phase 3 adds the sibling NOTIFY predicate (reachable + inactive + not yet
+ * warned) in this same module for the same reason: the warning cohort, the
+ * in-grace count, and the send-time re-check must share one definition. The
+ * two predicates are disjoint by construction — see NOTIFY_CONDITIONS.
  */
 
 import { Prisma } from '@tzurot/common-types/services/prisma';
@@ -26,8 +31,20 @@ import { Prisma } from '@tzurot/common-types/services/prisma';
  */
 export const RETENTION_WINDOW_DAYS = 180;
 
-/** Why a user is purge-eligible — the two unreachable signals (D13). */
-export type PurgeReason = 'unreachable' | 'account_gone';
+/**
+ * The reachable branch's grace window (Phase 3, owner call): days between the
+ * warning DM landing and purge eligibility. The privacy policy states this
+ * number once the notify pipeline ships (its rewrite rides the same release
+ * that first writes retention_notified_at) — changing it is a policy change,
+ * not a tuning knob.
+ */
+export const GRACE_PERIOD_DAYS = 30;
+
+/**
+ * Why a user is purge-eligible: the two unreachable signals (D13), or a
+ * warning-notice grace window that expired with no activity (Phase 3).
+ */
+export type PurgeReason = 'unreachable' | 'account_gone' | 'grace_expired';
 
 export interface PurgeCohortRow {
   userId: string;
@@ -42,6 +59,7 @@ interface CohortSqlRow {
   discordId: string;
   inactiveSince: Date;
   accountGone: boolean;
+  unreachable: boolean;
 }
 
 /**
@@ -56,7 +74,27 @@ interface CohortSqlRow {
  * the fast-track stays unbuilt until the flag has run with a clearer.
  */
 const ELIGIBILITY_CONDITIONS = Prisma.sql`
-      (u.dm_undeliverable_since IS NOT NULL OR u.discord_account_gone_at IS NOT NULL)
+      (u.dm_undeliverable_since IS NOT NULL
+       OR u.discord_account_gone_at IS NOT NULL
+       OR u.retention_notified_at < now() - make_interval(days => ${GRACE_PERIOD_DAYS}))
+  AND COALESCE(u.last_active_at, u.created_at)
+        < now() - make_interval(days => ${RETENTION_WINDOW_DAYS})
+  AND u.is_superuser = false
+  AND u.retention_exempt = false
+`;
+
+/**
+ * The reachable branch's notify predicate (Phase 3): who should receive a
+ * retention warning DM. Disjoint from the purge cohort by construction — a
+ * user with either unreachable stamp can't be DMed, and a non-null
+ * retention_notified_at means the one notice was already sent (the IS NULL
+ * clause is also the cross-run idempotency guard: re-running a notify run
+ * resumes exactly where it stopped).
+ */
+const NOTIFY_CONDITIONS = Prisma.sql`
+      u.dm_undeliverable_since IS NULL
+  AND u.discord_account_gone_at IS NULL
+  AND u.retention_notified_at IS NULL
   AND COALESCE(u.last_active_at, u.created_at)
         < now() - make_interval(days => ${RETENTION_WINDOW_DAYS})
   AND u.is_superuser = false
@@ -69,9 +107,11 @@ function toCohortRow(row: CohortSqlRow): PurgeCohortRow {
     userId: row.userId,
     discordId: row.discordId,
     inactiveSince: row.inactiveSince,
-    // A gone account is the stronger signal, so it wins the label when both
-    // are stamped.
-    reason: row.accountGone ? 'account_gone' : 'unreachable',
+    // Label precedence mirrors signal strength: a gone account beats
+    // unreachable, and either unreachable stamp beats grace_expired (a user
+    // whose notice bounced later carries both a grace clock and the stamp the
+    // bounce wrote — the stamp is the operative reason).
+    reason: row.accountGone ? 'account_gone' : row.unreachable ? 'unreachable' : 'grace_expired',
   };
 }
 
@@ -87,7 +127,8 @@ export async function selectEligibleUsers(db: Prisma.TransactionClient): Promise
     SELECT u.id AS "userId",
            u.discord_id AS "discordId",
            COALESCE(u.last_active_at, u.created_at) AS "inactiveSince",
-           (u.discord_account_gone_at IS NOT NULL) AS "accountGone"
+           (u.discord_account_gone_at IS NOT NULL) AS "accountGone",
+           (u.dm_undeliverable_since IS NOT NULL) AS "unreachable"
     FROM users u
     WHERE ${ELIGIBILITY_CONDITIONS}
     ORDER BY COALESCE(u.last_active_at, u.created_at) ASC
@@ -121,4 +162,88 @@ export async function isStillEligibleForPurge(
     WHERE u.id = ${userId}::uuid AND ${ELIGIBILITY_CONDITIONS}
   `;
   return rows.length > 0;
+}
+
+export interface NotifyCohortRow {
+  userId: string;
+  discordId: string;
+  inactiveSince: Date;
+}
+
+/**
+ * The reachable-but-inactive cohort awaiting a warning DM, oldest first.
+ *
+ * `allowlist` is OUTBOUND_DM_ALLOWLIST narrowing at the SQL level (the
+ * release-blast precedent): out-of-scope users never enter a run, so a dev
+ * dry-run can never fabricate grace state about prod-shaped users. `null`
+ * means unrestricted (prod).
+ */
+export async function selectNotifyCohort(
+  db: Prisma.TransactionClient,
+  allowlist: ReadonlySet<string> | null
+): Promise<NotifyCohortRow[]> {
+  const allowlistClause =
+    allowlist === null
+      ? Prisma.empty
+      : Prisma.sql`AND u.discord_id = ANY(${[...allowlist]}::text[])`;
+  return db.$queryRaw<NotifyCohortRow[]>`
+    SELECT u.id AS "userId",
+           u.discord_id AS "discordId",
+           COALESCE(u.last_active_at, u.created_at) AS "inactiveSince"
+    FROM users u
+    WHERE ${NOTIFY_CONDITIONS} ${allowlistClause}
+    ORDER BY COALESCE(u.last_active_at, u.created_at) ASC
+  `;
+}
+
+/** How many users the notify predicate selects (un-narrowed — reporting). */
+export async function countNotifyCohort(db: Prisma.TransactionClient): Promise<number> {
+  const rows = await db.$queryRaw<{ n: bigint }[]>`
+    SELECT count(*) AS n FROM users u WHERE ${NOTIFY_CONDITIONS}
+  `;
+  return Number(rows[0]?.n ?? 0);
+}
+
+/**
+ * How many users are mid-grace: notified, window not yet expired, and STILL
+ * reachable. The reachability guards keep this disjoint from the purge cohort:
+ * a mid-grace user whose LATER release DM bounces acquires an unreachable
+ * stamp (nothing clears retention_notified_at except activity) and becomes
+ * purge-eligible via that arm immediately — counting them here too would
+ * report the same user as both purgeable-now and still-waiting. Any activity
+ * clears retention_notified_at entirely, so every stamp this selects is a
+ * live grace clock — no inactivity re-check needed. Superuser/exempt guards
+ * kept for consistency with the sibling counts.
+ */
+export async function countInGrace(db: Prisma.TransactionClient): Promise<number> {
+  const rows = await db.$queryRaw<{ n: bigint }[]>`
+    SELECT count(*) AS n FROM users u
+    WHERE u.retention_notified_at >= now() - make_interval(days => ${GRACE_PERIOD_DAYS})
+      AND u.dm_undeliverable_since IS NULL
+      AND u.discord_account_gone_at IS NULL
+      AND u.is_superuser = false
+      AND u.retention_exempt = false
+  `;
+  return Number(rows[0]?.n ?? 0);
+}
+
+/**
+ * The send-time re-check (the notify analogue of D4's TOCTOU close): of these
+ * users, which are STILL notify-eligible? A user who became active between
+ * cohort resolution and the worker picking up the batch must not be DMed a
+ * deletion warning. Returns the still-eligible subset of `userIds`.
+ */
+export async function filterStillNotifyEligible(
+  db: Prisma.TransactionClient,
+  userIds: string[]
+): Promise<Set<string>> {
+  if (userIds.length === 0) {
+    return new Set();
+  }
+  const rows = await db.$queryRaw<{ userId: string }[]>`
+    SELECT u.id AS "userId"
+    FROM users u
+    WHERE u.id = ANY(${userIds}::uuid[]) AND ${NOTIFY_CONDITIONS}
+  `;
+  return new Set(rows.map(r => r.userId));
 }

--- a/services/bot-client/src/services/RetentionNagScheduler.test.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.test.ts
@@ -27,6 +27,9 @@ function makePreview(overrides: {
   eligibleCount?: number;
   breakerWarning?: boolean;
   userCount?: number;
+  reachableToNotify?: number;
+  inGrace?: number;
+  graceExpired?: number;
 }): RetentionPreviewResponse {
   const eligibleCount = overrides.eligibleCount ?? 1;
   const listedUsers = overrides.userCount ?? eligibleCount;
@@ -44,6 +47,9 @@ function makePreview(overrides: {
       charactersToDelete: listedUsers,
       charactersToReHome: 0,
       breakerWarning: overrides.breakerWarning ?? false,
+      reachableToNotify: overrides.reachableToNotify ?? 0,
+      inGrace: overrides.inGrace ?? 0,
+      graceExpired: overrides.graceExpired ?? 0,
     },
   } satisfies RetentionPreviewResponse;
 }
@@ -141,6 +147,29 @@ describe('buildRetentionNagEmbed', () => {
 
     expect(calm.description).not.toContain('breaker warning');
     expect(warned.description).toContain('breaker warning');
+  });
+
+  it('shows the reachable-branch pipeline line only when that pipeline has anyone in it', () => {
+    const quiet = buildRetentionNagEmbed(makePreview({})).toJSON();
+    const active = buildRetentionNagEmbed(
+      makePreview({ reachableToNotify: 51, inGrace: 4, graceExpired: 1 })
+    ).toJSON();
+
+    expect(quiet.description).not.toContain('Reachable branch');
+    expect(active.description).toContain('**51** awaiting a warning DM');
+    expect(active.description).toContain('**4** in grace');
+    expect(active.description).toContain('**1** grace-expired');
+  });
+
+  it('still shows the pipeline line in the graceExpired-only steady state', () => {
+    // Grace-expired users have LEFT the other two counts (window passed,
+    // already warned), so everyone-warned-and-expired is a real steady state —
+    // a guard that checks only the two upstream counts silently drops the
+    // aggregate line exactly when the operator needs it.
+    const expiredOnly = buildRetentionNagEmbed(makePreview({ graceExpired: 2 })).toJSON();
+
+    expect(expiredOnly.description).toContain('Reachable branch');
+    expect(expiredOnly.description).toContain('**2** grace-expired');
   });
 
   it('caps the listed users and reports the overflow', () => {

--- a/services/bot-client/src/services/RetentionNagScheduler.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.ts
@@ -59,12 +59,18 @@ export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): Embed
   const { users, totals } = preview;
   const env = cliEnv();
 
+  const reasonLabel = {
+    account_gone: 'account deleted',
+    unreachable: 'unreachable',
+    grace_expired: 'grace expired',
+  } as const;
+
   const lines = users
     .slice(0, MAX_LISTED_USERS)
     .map(
       user =>
         `\`${user.discordId}\` — inactive since ${user.inactiveSince.slice(0, 10)} ` +
-        `(${user.reason === 'account_gone' ? 'account deleted' : 'unreachable'})`
+        `(${reasonLabel[user.reason]})`
     );
   if (users.length > MAX_LISTED_USERS) {
     lines.push(`…and ${String(users.length - MAX_LISTED_USERS)} more (see the preview CLI)`);
@@ -72,9 +78,20 @@ export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): Embed
 
   const summary =
     `**${String(totals.eligibleCount)}** of ${String(totals.userbaseCount)} users ` +
-    `(${String(totals.percentOfUserbase)}%) are unreachable and inactive. ` +
+    `(${String(totals.percentOfUserbase)}%) are purge-eligible. ` +
     `Characters: ${String(totals.charactersToDelete)} would be deleted, ` +
     `${String(totals.charactersToReHome)} re-homed to the Orphaned Characters bucket.`;
+
+  // The reachable branch's pipeline states (Phase 3). Grace-expired users are
+  // already IN the cohort above; the other two are upstream of it. All THREE
+  // counts gate the line — grace-expired users have left the other two counts
+  // (window passed, already warned), so a graceExpired-only state is real.
+  const reachable =
+    totals.reachableToNotify > 0 || totals.inGrace > 0 || totals.graceExpired > 0
+      ? `\n\nReachable branch: **${String(totals.reachableToNotify)}** awaiting a warning DM · ` +
+        `**${String(totals.inGrace)}** in grace · ` +
+        `**${String(totals.graceExpired)}** grace-expired (counted in the cohort above).`
+      : '';
 
   const breaker = totals.breakerWarning
     ? '\n\n⚠️ **Cohort exceeds the breaker warning share of the userbase.** ' +
@@ -83,7 +100,7 @@ export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): Embed
 
   return new EmbedBuilder()
     .setTitle('🗑️ Accounts eligible for retention purge')
-    .setDescription(`${summary}${breaker}\n\n${lines.join('\n')}`)
+    .setDescription(`${summary}${reachable}${breaker}\n\n${lines.join('\n')}`)
     .setFooter({
       text:
         `Review: pnpm ops retention:preview --env ${env} · ` +


### PR DESCRIPTION
## What

The reachable branch's read-only foundation — **PR-E1 of two** (E2 ships the notify pipeline: queue, worker, routes, CLI, notice copy, privacy-policy amendment). Design authority: `inactivity-retention-purge.md` (ACCEPTED) + the three owner calls taken 2026-07-26 (**30-day grace · single notice · reclamation deferred**).

- **Schema**: `users.retention_notified_at` (the grace clock; additive migration; null-semantics doc per 03-database). PGLite schema regenerated.
- **Eligibility** (`eligibility.ts`, the single-predicate module): a third OR-arm — `retention_notified_at < now() - 30d` — inside the qualifying-signal group, still ANDed with the 180-day inactivity window (no fast-track, same rule as D13). `PurgeReason` gains `grace_expired`; label precedence `account_gone > unreachable > grace_expired`. New sibling **notify predicates**: `selectNotifyCohort` (SQL-level OUTBOUND_DM_ALLOWLIST narrowing — out-of-scope users never enter a run), `countNotifyCohort`, `countInGrace`, `filterStillNotifyEligible` (the send-time re-check, mirroring `filterPendingDeliveries`).
- **Reporting**: preview totals gain `reachableToNotify` / `inGrace` / `graceExpired` (schema-pinned in common-types so Zod strip-mode can't drop them); nag embed + `retention:preview` CLI print the reachable-branch pipeline line. The `retention:notify` footer mention deliberately waits for E2 — advertising a CLI that doesn't exist yet would lie for the E1→E2 window.
- **Activity clears**: both stamp sites (`UserService.getOrCreateUser`, `POST /internal/users/activity`) now also clear `retention_notified_at` — grace aborts on use. Deliberately NOT cleared by blast-send success (`clearUndeliverableForSent`): receiving a release DM proves *reach*, not *use*.

**Everything is inert in production**: nothing writes `retention_notified_at` until E2, so the grace-expired arm selects nobody.

## Verified

- `pnpm test` (26 tasks) + `pnpm quality` green, sequential; pre-push full gate green.
- Component (PGLite, real SQL): grace-expired user IS in the cohort with the right reason; in-grace and never-warned users are NOT; notify cohort disjoint from purge cohort; allowlist narrowing in SQL; send-time re-check drops warned/flagged users. 11/11.
- Seam assertions added where the new clear crosses the raw-SQL seam (both stamp sites), and `updated_at` asserted untouched (sync LWW).
- Fixture sweep for the new required totals fields done by FIELD name (`breakerWarning` grep across the repo), per the untyped-fixture rule: 7 fixture sites updated across 5 packages.

## Deliberately not here (PR-E2)

Notify queue + bot-client worker + report routes + `retention:notify` CLI + notice copy + the privacy-policy two-path rewrite. Also deferred with triggers (filed on merge): reclamation flow/orphan admin commands (first re-home), reminder DM (first grace cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)