### PR TITLE
feat: retention Phase 3 notify pipeline — warning DMs + grace (PR-E2)

### DIFF
--- a/.github/baselines/cpd-baseline.json
+++ b/.github/baselines/cpd-baseline.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
-  "lastUpdated": "2026-07-23T01:50:56.833Z",
-  "filteredLines": 1762,
-  "filteredCount": 115,
-  "rawDedupedLines": 1689,
-  "rawCount": 119,
+  "lastUpdated": "2026-07-26T20:06:41.029Z",
+  "filteredLines": 1787,
+  "filteredCount": 117,
+  "rawDedupedLines": 1712,
+  "rawCount": 121,
   "threshold": 0.8,
   "graceMargin": 10,
   "notes": "Filtered = jscpd clones minus fragments where >=80% of classifiable lines are call-expression shape (i.e., helper-call-shape uniformity, not real duplication). See docs/reference/CPD_CAMPAIGN_AUDIT.md for the campaign close-out audit and the rationale for accepting structural-skeleton duplication as design intent. The ratchet enforces filteredLines + graceMargin; raw jscpd output stays informational. NOTE: filteredLines uses sum-of-per-clone-lines (counts overlap multiply); rawDedupedLines is jscpd's deduplicated count (each line counted once even if part of multiple clones). The two are not directly comparable — filtered may exceed rawDeduped on small clone sets due to the counting-method difference, not because the filter made things worse.",
   "meta": {
     "toolVersion": "cpd-check/1.0",
     "configHash": "a7f4e5150567",
-    "nodeVersion": "v25.4.0",
-    "generatedFromSha": "8e1c65380455586bd358f7c5ec7418407b3ae122",
-    "generatedAt": "2026-07-23T01:50:56.832Z"
+    "nodeVersion": "v24.11.1",
+    "generatedFromSha": "eadebce0034d0cc382abbe7b7d4867d8ad635e25",
+    "generatedAt": "2026-07-26T20:06:41.029Z"
   }
 }

--- a/docs/legal/PRIVACY_POLICY.md
+++ b/docs/legal/PRIVACY_POLICY.md
@@ -37,19 +37,29 @@ Tzurot is a Discord bot that lets you talk with AI characters. It is operated by
 | Release-DM delivery records   | Deleted once 90 days old and settled (the record of your latest notification is kept until it's replaced or you delete it) |
 | Account basics, usage records | Until you delete your account (see "Your controls"), or until the inactivity rule below applies                            |
 
-### Inactive, unreachable accounts
+### Inactive accounts
 
 We are not a commercial service that keeps your data forever on the chance you
-come back. If **both** of the following are true, your account and everything
-associated with it may be erased:
+come back. If **you have not used the bot for at least 180 days**, your account
+enters the retention process, and which path it takes depends on whether we can
+still reach you:
 
-- **You have not used the bot for at least 180 days**, and
-- **we can no longer reach you** — you have closed DMs and share no server with
+- **If we can reach you**, we first send you a DM naming a concrete deletion
+  date **at least 30 days away**. Using the bot once — any command or chat
+  message — resets your inactivity clock entirely and cancels the deletion.
+  The notice also points you at `/settings data export` (take a full copy of
+  your data) and `/settings data delete` (delete immediately instead of
+  waiting). Only if the 30 days pass with no activity may your account and
+  everything associated with it be erased.
+- **If we cannot reach you** — you have closed DMs and share no server with
   the bot, so a notification cannot be delivered; or your Discord account no
-  longer exists.
+  longer exists — your account may be erased without the notice, because there
+  is no way to deliver one.
 
-Either condition alone is not enough. Any activity — a message, a command, or a
-notification that successfully reaches you — resets both.
+Inactivity alone never erases anything silently while you are reachable: the
+notice and its grace period always come first. Any activity resets your
+inactivity clock; a notification that successfully reaches you resets the
+unreachability state.
 
 Erasure is complete — everything `/settings data delete` removes, this removes.
 It differs from that self-serve deletion in exactly one way, and the difference

--- a/packages/clients/src/clients/_generated/service-client.ts
+++ b/packages/clients/src/clients/_generated/service-client.ts
@@ -295,6 +295,42 @@ export class ServiceClient {
     });
   }
 
+  async retentionNotify(input: z.input<typeof ROUTE_MANIFEST.retentionNotify.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.retentionNotify.output>>> {
+    const fullPath = '/api/internal/retention/notify';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'POST',
+      path: fullPath,
+      body: input,
+      outputSchema: ROUTE_MANIFEST.retentionNotify.output,
+    });
+  }
+
+  async retentionNotifyFilter(input: z.input<typeof ROUTE_MANIFEST.retentionNotifyFilter.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.retentionNotifyFilter.output>>> {
+    const fullPath = '/api/internal/retention/notify/filter';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'POST',
+      path: fullPath,
+      body: input,
+      outputSchema: ROUTE_MANIFEST.retentionNotifyFilter.output,
+    });
+  }
+
+  async retentionNotifyReport(input: z.input<typeof ROUTE_MANIFEST.retentionNotifyReport.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.retentionNotifyReport.output>>> {
+    const fullPath = '/api/internal/retention/notify/report';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'POST',
+      path: fullPath,
+      body: input,
+      outputSchema: ROUTE_MANIFEST.retentionNotifyReport.output,
+    });
+  }
+
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -52,6 +52,12 @@ import {
   RetentionPurgeRequestSchema,
   RetentionPurgeResponseSchema,
   RetentionReconcileOffDbResponseSchema,
+  RetentionNotifyRequestSchema,
+  RetentionNotifyResponseSchema,
+  RetentionNotifyFilterRequestSchema,
+  RetentionNotifyFilterResponseSchema,
+  RetentionNotifyReportRequestSchema,
+  RetentionNotifyReportResponseSchema,
   RoutingContextRequestSchema,
   RoutingContextResponseSchema,
   SecretRotationStatusResponseSchema,
@@ -413,6 +419,52 @@ export const internalRoutes = {
     path: '/retention/reconcile-off-db',
     id: 'retentionReconcileOffDb',
     output: RetentionReconcileOffDbResponseSchema,
+    serviceOnly: true,
+  },
+
+  /**
+   * POST /api/internal/retention/notify
+   * Resolve the reachable-but-inactive cohort and enqueue warning-DM batches
+   * (Phase 3). Operator-driven via the retention:notify CLI only — autonomy
+   * is Phase 4. Cross-run idempotent via the predicate itself.
+   */
+  retentionNotify: {
+    audience: 'internal',
+    method: 'post',
+    path: '/retention/notify',
+    id: 'retentionNotify',
+    input: RetentionNotifyRequestSchema,
+    output: RetentionNotifyResponseSchema,
+    serviceOnly: true,
+  },
+
+  /**
+   * POST /api/internal/retention/notify/filter
+   * The worker's send-time still-eligible re-check: a user active since
+   * cohort resolution must not be DMed a deletion warning.
+   */
+  retentionNotifyFilter: {
+    audience: 'internal',
+    method: 'post',
+    path: '/retention/notify/filter',
+    id: 'retentionNotifyFilter',
+    input: RetentionNotifyFilterRequestSchema,
+    output: RetentionNotifyFilterResponseSchema,
+    serviceOnly: true,
+  },
+
+  /**
+   * POST /api/internal/retention/notify/report
+   * Per-recipient delivery outcomes: sent stamps the grace clock; a permanent
+   * bounce stamps the unreachable column (the re-route to the purge branch).
+   */
+  retentionNotifyReport: {
+    audience: 'internal',
+    method: 'post',
+    path: '/retention/notify/report',
+    id: 'retentionNotifyReport',
+    input: RetentionNotifyReportRequestSchema,
+    output: RetentionNotifyReportResponseSchema,
     serviceOnly: true,
   },
 

--- a/packages/common-types/src/constants/queue.ts
+++ b/packages/common-types/src/constants/queue.ts
@@ -47,6 +47,16 @@ export const FACT_EXTRACTION_QUEUE_NAME = 'fact-extraction';
 export const RELEASE_BROADCAST_QUEUE_NAME = 'release-broadcast';
 
 /**
+ * Queue for retention warning-DM delivery jobs (Phase 3's reachable branch).
+ * Produced by api-gateway (cohort resolution + grace bookkeeping live there);
+ * consumed by bot-client (the only service holding the Discord client).
+ * Deliberately NOT a job type on the release-broadcast queue: that queue's
+ * at-least-once delivery bound depends on it staying single-purpose,
+ * concurrency-1, FIFO (see docs/reference/features/release-notifications.md).
+ */
+export const RETENTION_NOTIFY_QUEUE_NAME = 'retention-notify';
+
+/**
  * Job ID prefixes for different job types
  */
 export const JOB_PREFIXES = {
@@ -241,4 +251,6 @@ export enum JobType {
   FactExtraction = 'fact-extraction',
   /** Release-notes / broadcast DM delivery batch (consumed by bot-client) */
   ReleaseBroadcastDm = 'release-broadcast-dm',
+  /** Retention warning-DM delivery batch (Phase 3; consumed by bot-client) */
+  RetentionNotifyDm = 'retention-notify-dm',
 }

--- a/packages/common-types/src/constants/retention.ts
+++ b/packages/common-types/src/constants/retention.ts
@@ -1,0 +1,24 @@
+/**
+ * Retention policy windows — the numbers the published privacy policy states.
+ *
+ * Shared here because two services must agree on them: api-gateway's
+ * eligibility predicates (services/api-gateway/src/services/retention/
+ * eligibility.ts is the single home of the SQL that consumes them) and
+ * bot-client's warning-notice copy (which tells the user these numbers).
+ * Changing either value is a POLICY change, not a tuning knob — the policy
+ * text at /privacy must move in the same release.
+ */
+export const RETENTION_POLICY = {
+  /**
+   * The single inactivity window (epic decision: ONE 180-day window, not the
+   * rejected flat-90d). Inactivity is measured from last_active_at, falling
+   * back to created_at when the tracking clock never stamped.
+   */
+  WINDOW_DAYS: 180,
+  /**
+   * The reachable branch's grace window (Phase 3, owner call): days between
+   * the warning DM landing and purge eligibility. Any bot use during grace
+   * clears retention_notified_at and exits the pipeline entirely.
+   */
+  GRACE_PERIOD_DAYS: 30,
+} as const;

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -25,8 +25,11 @@ import {
   RetentionReconcileOffDbResponseSchema,
   RetentionNotifyRequestSchema,
   RetentionNotifyResponseSchema,
+  RetentionNotifyCohortUserSchema,
   RetentionNotifyFilterRequestSchema,
+  RetentionNotifyFilterResponseSchema,
   RetentionNotifyReportRequestSchema,
+  RetentionNotifyReportResponseSchema,
 } from './internal.js';
 
 describe('DiscordSnowflakeSchema', () => {
@@ -888,5 +891,34 @@ describe('RetentionNotifyReportRequestSchema', () => {
         outcomes: [{ userId: 'a3bb189e-8bf9-3888-9912-ace4e6543002', status: 'skipped' }],
       }).success
     ).toBe(false);
+  });
+});
+
+describe('RetentionNotifyCohortUserSchema', () => {
+  it('accepts a cohort row and rejects a bare date (ISO datetime required)', () => {
+    const row = { discordId: '900000000000000001', inactiveSince: '2025-01-01T00:00:00.000Z' };
+    expect(RetentionNotifyCohortUserSchema.safeParse(row).success).toBe(true);
+    expect(
+      RetentionNotifyCohortUserSchema.safeParse({ ...row, inactiveSince: '2025-01-01' }).success
+    ).toBe(false);
+  });
+});
+
+describe('RetentionNotifyFilterResponseSchema', () => {
+  it('accepts an empty still-eligible set (everyone became active)', () => {
+    expect(
+      RetentionNotifyFilterResponseSchema.safeParse({ stillEligibleUserIds: [] }).success
+    ).toBe(true);
+  });
+
+  it('requires the field — a missing set must not read as empty', () => {
+    expect(RetentionNotifyFilterResponseSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('RetentionNotifyReportResponseSchema', () => {
+  it('accepts a processed count and rejects a negative one', () => {
+    expect(RetentionNotifyReportResponseSchema.safeParse({ processed: 1 }).success).toBe(true);
+    expect(RetentionNotifyReportResponseSchema.safeParse({ processed: -1 }).success).toBe(false);
   });
 });

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -23,6 +23,10 @@ import {
   RetentionPurgeRequestSchema,
   RetentionPurgeResponseSchema,
   RetentionReconcileOffDbResponseSchema,
+  RetentionNotifyRequestSchema,
+  RetentionNotifyResponseSchema,
+  RetentionNotifyFilterRequestSchema,
+  RetentionNotifyReportRequestSchema,
 } from './internal.js';
 
 describe('DiscordSnowflakeSchema', () => {
@@ -821,6 +825,68 @@ describe('RetentionReconcileOffDbResponseSchema', () => {
   it('rejects negative counters', () => {
     expect(
       RetentionReconcileOffDbResponseSchema.safeParse({ settled: 0, stillFailing: -1 }).success
+    ).toBe(false);
+  });
+});
+
+describe('RetentionNotifyRequestSchema', () => {
+  it('accepts a bare run — every field is optional', () => {
+    expect(RetentionNotifyRequestSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts the full operator payload', () => {
+    expect(
+      RetentionNotifyRequestSchema.safeParse({
+        dryRun: true,
+        breakerOverride: true,
+        runContext: 'first prod notify run',
+      }).success
+    ).toBe(true);
+  });
+});
+
+describe('RetentionNotifyResponseSchema', () => {
+  const response = {
+    status: 'enqueued',
+    cohortSize: 51,
+    userbaseCount: 273,
+    percentOfUserbase: 18.7,
+    breakerWarning: true,
+    batchesEnqueued: 2,
+    recipients: [{ discordId: '900000000000000001', inactiveSince: '2025-01-01T00:00:00.000Z' }],
+  };
+
+  it('accepts the first-real-run shape (warn-breaker true, still enqueued)', () => {
+    expect(RetentionNotifyResponseSchema.safeParse(response).success).toBe(true);
+  });
+
+  it('rejects an unknown status — the CLI branches on this enum', () => {
+    expect(
+      RetentionNotifyResponseSchema.safeParse({ ...response, status: 'partial' }).success
+    ).toBe(false);
+  });
+});
+
+describe('RetentionNotifyFilterRequestSchema', () => {
+  it('rejects an empty batch — the worker must not ask a vacuous question', () => {
+    expect(RetentionNotifyFilterRequestSchema.safeParse({ userIds: [] }).success).toBe(false);
+  });
+});
+
+describe('RetentionNotifyReportRequestSchema', () => {
+  it('accepts a single sent outcome (the per-recipient immediate report)', () => {
+    expect(
+      RetentionNotifyReportRequestSchema.safeParse({
+        outcomes: [{ userId: 'a3bb189e-8bf9-3888-9912-ace4e6543002', status: 'sent' }],
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects an outcome status outside the delivery vocabulary', () => {
+    expect(
+      RetentionNotifyReportRequestSchema.safeParse({
+        outcomes: [{ userId: 'a3bb189e-8bf9-3888-9912-ace4e6543002', status: 'skipped' }],
+      }).success
     ).toBe(false);
   });
 });

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -391,3 +391,97 @@ export const RetentionReconcileOffDbResponseSchema = z.object({
   settled: z.number().int().nonnegative(),
   stillFailing: z.number().int().nonnegative(),
 });
+
+// ============================================================================
+// POST /internal/retention/notify — enqueue warning-DM batches (Phase 3)
+// ============================================================================
+
+/**
+ * Operator-driven (manual-approval doctrine, like the purge): resolves the
+ * reachable-but-inactive cohort, enqueues warning-DM batches to the
+ * retention-notify queue. Cross-run idempotency is the predicate itself
+ * (retention_notified_at IS NULL) — re-running resumes where a run stopped.
+ */
+export const RetentionNotifyRequestSchema = z.object({
+  /** Resolve and report the cohort without enqueuing anything. */
+  dryRun: z.boolean().optional(),
+  /**
+   * Proceed past the hard-ceiling breaker share. Deliberately separate from
+   * the CLI's `--force` (which only skips the interactive prompt) — same
+   * two-flag discipline as the purge.
+   */
+  breakerOverride: z.boolean().optional(),
+  /** Operator/run label (log context + the deterministic-jobId seed). */
+  runContext: z.string().max(200).optional(),
+});
+
+export const RetentionNotifyCohortUserSchema = z.object({
+  discordId: DiscordSnowflakeSchema,
+  /** Inactivity anchor as ISO — last_active_at, or created_at when never stamped. */
+  inactiveSince: z.string().datetime(),
+});
+
+export const RetentionNotifyResponseSchema = z.object({
+  /** `refused_breaker` enqueues nothing; `empty` is the healthy steady state. */
+  status: z.enum(['enqueued', 'dry_run', 'empty', 'refused_breaker']),
+  cohortSize: z.number().int().nonnegative(),
+  userbaseCount: z.number().int().nonnegative(),
+  percentOfUserbase: z.number().nonnegative(),
+  /** Cohort exceeds the warn share — expected ~15-18% on the first real run (zombie cohort). */
+  breakerWarning: z.boolean(),
+  batchesEnqueued: z.number().int().nonnegative(),
+  /** Present when status is `refused_breaker`. */
+  breakerDetail: z.string().optional(),
+  /** The resolved cohort (who would be / was DMed) — the dry-run's whole point. */
+  recipients: z.array(RetentionNotifyCohortUserSchema),
+});
+
+export type RetentionNotifyResponse = z.infer<typeof RetentionNotifyResponseSchema>;
+
+// ============================================================================
+// POST /internal/retention/notify/filter — send-time still-eligible re-check
+// ============================================================================
+
+/**
+ * The notify analogue of the purge's TOCTOU re-check: of these users, which
+ * are STILL notify-eligible? A user active since cohort resolution must not
+ * be DMed a deletion warning. The worker calls this before every batch send
+ * (throw-before-spend: a filter failure aborts the batch, never skips it).
+ */
+export const RetentionNotifyFilterRequestSchema = z.object({
+  userIds: z.array(z.string().uuid()).min(1).max(50),
+});
+
+export const RetentionNotifyFilterResponseSchema = z.object({
+  stillEligibleUserIds: z.array(z.string().uuid()),
+});
+
+// ============================================================================
+// POST /internal/retention/notify/report — per-recipient delivery outcomes
+// ============================================================================
+
+/**
+ * The worker reports each outcome immediately after the send attempt (a
+ * mid-batch crash strands at most one row). `sent` stamps the grace clock;
+ * 50278/50007 stamp dm_undeliverable_since and 10013 stamps
+ * discord_account_gone_at (the re-route to the unreachable purge branch);
+ * bot-level (20026) and transient outcomes stamp NOTHING — a quarantined bot
+ * says nothing about the recipient.
+ */
+export const RetentionNotifyReportRequestSchema = z.object({
+  outcomes: z
+    .array(
+      z.object({
+        userId: z.string().uuid(),
+        status: z.enum(['sent', 'failed_permanent', 'failed_bot_level', 'failed_transient']),
+        /** Discord error code for failures (e.g. '50278', '10013'). */
+        errorCode: z.string().optional(),
+      })
+    )
+    .min(1)
+    .max(50),
+});
+
+export const RetentionNotifyReportResponseSchema = z.object({
+  processed: z.number().int().nonnegative(),
+});

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -483,5 +483,6 @@ export const RetentionNotifyReportRequestSchema = z.object({
 });
 
 export const RetentionNotifyReportResponseSchema = z.object({
+  /** Rows a stamp actually wrote — guarded no-ops (re-reports) contribute 0. */
   processed: z.number().int().nonnegative(),
 });

--- a/packages/common-types/src/types/jobs.test.ts
+++ b/packages/common-types/src/types/jobs.test.ts
@@ -26,6 +26,7 @@ import {
   factExtractionJobDataSchema,
   type FactExtractionJobData,
   releaseBroadcastDmJobDataSchema,
+  retentionNotifyDmJobDataSchema,
 } from './jobs.js';
 import {
   shapesImportJobDataSchema,
@@ -1141,6 +1142,45 @@ describe('BullMQ Job Contract Tests', () => {
     });
   });
 
+  describe('Retention Notify DM Job Contract', () => {
+    const validPayload = {
+      requestId: 'req-1',
+      jobType: JobType.RetentionNotifyDm,
+      responseDestination: { type: 'api' },
+      runId: 'notify-2026-07-26-prod',
+      recipients: [
+        {
+          userId: '323e4567-e89b-42d3-a456-426614174000',
+          discordUserId: '123456789012345678',
+        },
+      ],
+    };
+
+    it('should validate a well-formed batch', () => {
+      expect(retentionNotifyDmJobDataSchema.safeParse(validPayload).success).toBe(true);
+    });
+
+    it('should reject an empty recipients array', () => {
+      expect(
+        retentionNotifyDmJobDataSchema.safeParse({ ...validPayload, recipients: [] }).success
+      ).toBe(false);
+    });
+
+    it('should cap a batch at 50 recipients (the enqueue batch size)', () => {
+      const oversized = Array.from({ length: 51 }, (_, i) => ({
+        userId: `323e4567-e89b-42d3-a456-4266141740${String(i).padStart(2, '0')}`,
+        discordUserId: '123456789012345678',
+      }));
+      expect(
+        retentionNotifyDmJobDataSchema.safeParse({ ...validPayload, recipients: oversized }).success
+      ).toBe(false);
+    });
+
+    it('should participate in the discriminated union', () => {
+      expect(anyJobDataSchema.safeParse(validPayload).success).toBe(true);
+    });
+  });
+
   describe('Release Broadcast DM Job Contract', () => {
     const validPayload = {
       requestId: 'req-1',
@@ -1215,6 +1255,7 @@ describe('BullMQ Job Contract Tests', () => {
       [JobType.AccountExport]: accountExportJobDataSchema,
       [JobType.FactExtraction]: factExtractionJobDataSchema,
       [JobType.ReleaseBroadcastDm]: releaseBroadcastDmJobDataSchema,
+      [JobType.RetentionNotifyDm]: retentionNotifyDmJobDataSchema,
     };
 
     it('should have a Zod data schema for every JobType enum value', () => {

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -549,6 +549,34 @@ export const releaseBroadcastDmJobDataSchema = baseJobDataSchema.extend({
 export type ReleaseBroadcastDmJobData = z.infer<typeof releaseBroadcastDmJobDataSchema>;
 export type ReleaseBroadcastRecipient = z.infer<typeof releaseBroadcastRecipientSchema>;
 
+/** One warning-DM recipient inside a retention-notify batch. */
+const retentionNotifyRecipientSchema = z.object({
+  /** Internal users.id UUID — the grace stamp and re-check key on. */
+  userId: z.string().uuid(),
+  /** Discord snowflake the warning DM is sent to. */
+  discordUserId: z.string(),
+});
+
+/**
+ * Job data for one retention warning-DM batch (Phase 3's reachable branch).
+ *
+ * The worker re-filters recipients against the notify predicate before
+ * sending (a user active since cohort resolution must not receive a deletion
+ * warning), composes the notice body itself (Discord copy belongs to
+ * bot-client), and reports each outcome to the gateway — `sent` stamps the
+ * grace clock, a permanent bounce stamps the unreachable flag that re-routes
+ * the user to the existing purge branch.
+ */
+export const retentionNotifyDmJobDataSchema = baseJobDataSchema.extend({
+  jobType: z.literal(JobType.RetentionNotifyDm),
+  /** Operator run label (audit/log context; also the deterministic-jobId seed). */
+  runId: z.string().min(1),
+  recipients: z.array(retentionNotifyRecipientSchema).min(1).max(50),
+});
+
+export type RetentionNotifyDmJobData = z.infer<typeof retentionNotifyDmJobDataSchema>;
+export type RetentionNotifyRecipient = z.infer<typeof retentionNotifyRecipientSchema>;
+
 /**
  * Union schema for all job data types
  * Used for generic job validation
@@ -559,4 +587,5 @@ export const anyJobDataSchema = z.discriminatedUnion('jobType', [
   llmGenerationJobDataSchema,
   factExtractionJobDataSchema,
   releaseBroadcastDmJobDataSchema,
+  retentionNotifyDmJobDataSchema,
 ]);

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -33,6 +33,7 @@ import {
   type ConfigSourceId,
 } from './schemas/index.js';
 import { JobType, JobStatus } from '../constants/queue.js';
+import { DiscordSnowflakeSchema } from '../schemas/api/internal.js';
 import type { SttProvider } from './sttProvider.js';
 
 /**
@@ -513,7 +514,7 @@ const releaseBroadcastRecipientSchema = z.object({
   /** Internal users.id UUID (delivery reporting joins on this). */
   userId: z.string().uuid(),
   /** Discord snowflake the DM is sent to. */
-  discordUserId: z.string(),
+  discordUserId: DiscordSnowflakeSchema,
   /**
    * The user's most recent prior release DM still standing (ledger rows with
    * a sentMessageId and no messageDeletedAt). The worker deletes it before
@@ -554,7 +555,7 @@ const retentionNotifyRecipientSchema = z.object({
   /** Internal users.id UUID — the grace stamp and re-check key on. */
   userId: z.string().uuid(),
   /** Discord snowflake the warning DM is sent to. */
-  discordUserId: z.string(),
+  discordUserId: DiscordSnowflakeSchema,
 });
 
 /**

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -574,7 +574,6 @@ export const retentionNotifyDmJobDataSchema = baseJobDataSchema.extend({
   recipients: z.array(retentionNotifyRecipientSchema).min(1).max(50),
 });
 
-export type RetentionNotifyDmJobData = z.infer<typeof retentionNotifyDmJobDataSchema>;
 export type RetentionNotifyRecipient = z.infer<typeof retentionNotifyRecipientSchema>;
 
 /**

--- a/packages/test-utils/fixtures/contracts/retention-notify/batch.json
+++ b/packages/test-utils/fixtures/contracts/retention-notify/batch.json
@@ -1,0 +1,24 @@
+{
+  "name": "retention-notify-dm",
+  "data": {
+    "requestId": "2026-01-01T00:00:00.000Z-contract-fixture:0",
+    "jobType": "retention-notify-dm",
+    "responseDestination": {
+      "type": "api"
+    },
+    "runId": "2026-01-01T00:00:00.000Z-contract-fixture",
+    "recipients": [
+      {
+        "userId": "2f8c02d8-34a7-54e7-abaa-29c94ef8e464",
+        "discordUserId": "111111111111111111"
+      },
+      {
+        "userId": "82df0bc4-ee89-5f2c-9112-f74bf1cb1c07",
+        "discordUserId": "222222222222222222"
+      }
+    ]
+  },
+  "opts": {
+    "jobId": "retention-notify:2026-01-01T00:00:00.000Z-contract-fixture:0"
+  }
+}

--- a/packages/tooling/coverage-topology.json
+++ b/packages/tooling/coverage-topology.json
@@ -1906,6 +1906,48 @@
       ]
     },
     {
+      "id": "client:api-gateway:retentionNotify",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /retention/notify",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:retentionNotifyFilter",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /retention/notify/filter",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:retentionNotifyReport",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /retention/notify/report",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
       "id": "client:api-gateway:retentionPreview",
       "kind": "http-route",
       "producer": "client",

--- a/packages/tooling/coverage-topology.json
+++ b/packages/tooling/coverage-topology.json
@@ -58,6 +58,20 @@
       ]
     },
     {
+      "id": "api-gateway:bot-client:retention-notify-dm",
+      "kind": "bullmq-job",
+      "producer": "api-gateway",
+      "consumer": "bot-client",
+      "schemaRef": "retentionNotifyDmJobDataSchema",
+      "mechanism": "bullmq-contract",
+      "requiredTiers": [
+        "contract"
+      ],
+      "actualTiers": [
+        "contract"
+      ]
+    },
+    {
       "id": "bot-client:ai-worker:context-assembly",
       "kind": "context-envelope",
       "producer": "bot-client",

--- a/packages/tooling/src/codegen/handler-paths.ts
+++ b/packages/tooling/src/codegen/handler-paths.ts
@@ -54,6 +54,7 @@ const USER_PERSONA_CRUD = '../user/persona/crud.js';
 const USER_PERSONA_OVERRIDE = '../user/persona/override.js';
 const ADMIN_BROADCAST = '../admin/broadcast.js';
 const INTERNAL_RELEASE_BROADCAST = '../internal/releaseBroadcast.js';
+const INTERNAL_RETENTION_NOTIFY = '../internal/retentionNotify.js';
 const USER_NOTIFICATIONS = '../user/notifications.js';
 const USER_STT_OVERRIDE = '../user/stt-override.js';
 const USER_TIMEZONE = '../user/timezone.js';
@@ -142,6 +143,9 @@ const PATH_MAP: Readonly<Record<string, string>> = {
   retentionPreview: '../internal/retentionPreview.js',
   retentionPurge: '../internal/retentionPurge.js',
   retentionReconcileOffDb: '../internal/retentionReconcileOffDb.js',
+  retentionNotify: INTERNAL_RETENTION_NOTIFY,
+  retentionNotifyFilter: INTERNAL_RETENTION_NOTIFY,
+  retentionNotifyReport: INTERNAL_RETENTION_NOTIFY,
   getModels: '../internal/models.js',
   setDmSession: '../internal/dmSessionSet.js',
   lookupPersonalityFromMessage: '../user/conversationLookup.js',

--- a/packages/tooling/src/commands/retention.ts
+++ b/packages/tooling/src/commands/retention.ts
@@ -74,6 +74,34 @@ export function registerRetentionCommands(cli: CAC): void {
 
   cli
     .command(
+      'retention:notify',
+      'DM the deletion warning to reachable-but-inactive users (starts grace clocks)'
+    )
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
+    .option('--dry-run', 'Resolve and print the notify cohort without enqueuing anything')
+    .option('--force', FORCE_OPTION_DESC)
+    // Same two-flag discipline as the purge: --force asserts the operator is
+    // present; only --breaker-override vouches for an implausibly large cohort.
+    .option('--breaker-override', 'Proceed even though the cohort exceeds the safety ceiling')
+    .action(
+      async (options: {
+        env?: Environment;
+        dryRun?: boolean;
+        force?: boolean;
+        breakerOverride?: boolean;
+      }) => {
+        const { retentionNotify } = await import('../retention/notify.js');
+        await retentionNotify({
+          env: options.env ?? 'dev',
+          dryRun: options.dryRun,
+          force: options.force,
+          breakerOverride: options.breakerOverride,
+        });
+      }
+    );
+
+  cli
+    .command(
       'retention:reconcile-off-db',
       'Retry avatar cleanup a completed purge still owes (idempotent)'
     )

--- a/packages/tooling/src/retention/notify.test.ts
+++ b/packages/tooling/src/retention/notify.test.ts
@@ -89,17 +89,40 @@ describe('retentionNotify', () => {
     expect(retentionNotifyMock).toHaveBeenCalledTimes(1);
   });
 
-  it('a breaker refusal on the real run exits non-zero', async () => {
+  it('a refused preview stops BEFORE the confirmation — never confirm a refused action', async () => {
+    // The service runs the hard-ceiling breaker before its dry-run branch, so
+    // the PREVIEW call itself comes back refused for an over-ceiling cohort.
+    retentionNotifyMock.mockResolvedValue({
+      ok: true,
+      data: runResult({ status: 'refused_breaker', breakerDetail: 'too big' }),
+    });
+
+    await retentionNotify({ env: 'prod' });
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(retentionNotifyMock).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('--breaker-override proceeds past a refused preview to confirm + the real run', async () => {
     retentionNotifyMock
-      .mockResolvedValueOnce({ ok: true, data: runResult() })
       .mockResolvedValueOnce({
         ok: true,
         data: runResult({ status: 'refused_breaker', breakerDetail: 'too big' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: runResult({ status: 'enqueued', batchesEnqueued: 1 }),
       });
 
-    await retentionNotify({ env: 'dev' });
+    await retentionNotify({ env: 'prod', breakerOverride: true });
 
-    expect(process.exitCode).toBe(1);
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(retentionNotifyMock).toHaveBeenNthCalledWith(2, {
+      breakerOverride: true,
+      runContext: 'ops retention:notify (prod)',
+    });
+    expect(process.exitCode).toBeUndefined();
   });
 
   it('a gateway failure exits non-zero instead of reading as an empty cohort', async () => {

--- a/packages/tooling/src/retention/notify.test.ts
+++ b/packages/tooling/src/retention/notify.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { retentionNotifyMock, getClientMock, confirmMock } = vi.hoisted(() => ({
+  retentionNotifyMock: vi.fn(),
+  getClientMock: vi.fn(),
+  confirmMock: vi.fn(),
+}));
+
+vi.mock('../utils/env-runner.js', () => ({
+  validateEnvironment: vi.fn(),
+  showEnvironmentBanner: vi.fn(),
+  confirmProductionOperation: confirmMock,
+}));
+vi.mock('../utils/gateway-client.js', () => ({ resolveServiceClientOrExit: getClientMock }));
+
+import { retentionNotify, renderNotifyRun } from './notify.js';
+
+function runResult(overrides: Partial<Parameters<typeof renderNotifyRun>[0]> = {}) {
+  return {
+    status: 'dry_run' as const,
+    cohortSize: 2,
+    userbaseCount: 100,
+    percentOfUserbase: 2,
+    breakerWarning: false,
+    batchesEnqueued: 0,
+    recipients: [
+      { discordId: '900000000000000001', inactiveSince: '2025-01-01T00:00:00.000Z' },
+      { discordId: '900000000000000002', inactiveSince: '2025-02-01T00:00:00.000Z' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('retentionNotify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    getClientMock.mockReturnValue({ retentionNotify: retentionNotifyMock });
+    confirmMock.mockResolvedValue(true);
+  });
+
+  it('dry-run resolves the cohort and never enqueues', async () => {
+    retentionNotifyMock.mockResolvedValue({ ok: true, data: runResult() });
+
+    await retentionNotify({ env: 'prod', dryRun: true });
+
+    expect(retentionNotifyMock).toHaveBeenCalledTimes(1);
+    expect(retentionNotifyMock).toHaveBeenCalledWith({ dryRun: true });
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it('a real prod run previews first, confirms, then enqueues with runContext', async () => {
+    retentionNotifyMock
+      .mockResolvedValueOnce({ ok: true, data: runResult() })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: runResult({ status: 'enqueued', batchesEnqueued: 1 }),
+      });
+
+    await retentionNotify({ env: 'prod' });
+
+    // The confirmation names the action and the count — the operator vouches
+    // for exactly what the dry-run just showed them.
+    expect(confirmMock).toHaveBeenCalledWith(expect.stringContaining('2 inactive users'));
+    expect(retentionNotifyMock).toHaveBeenNthCalledWith(2, {
+      breakerOverride: false,
+      runContext: 'ops retention:notify (prod)',
+    });
+  });
+
+  it('a declined confirmation enqueues nothing', async () => {
+    retentionNotifyMock.mockResolvedValue({ ok: true, data: runResult() });
+    confirmMock.mockResolvedValue(false);
+
+    await retentionNotify({ env: 'prod' });
+
+    expect(retentionNotifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('an empty cohort stops before the confirmation', async () => {
+    retentionNotifyMock.mockResolvedValue({
+      ok: true,
+      data: runResult({ status: 'empty', cohortSize: 0, recipients: [] }),
+    });
+
+    await retentionNotify({ env: 'prod' });
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(retentionNotifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a breaker refusal on the real run exits non-zero', async () => {
+    retentionNotifyMock
+      .mockResolvedValueOnce({ ok: true, data: runResult() })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: runResult({ status: 'refused_breaker', breakerDetail: 'too big' }),
+      });
+
+    await retentionNotify({ env: 'dev' });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('a gateway failure exits non-zero instead of reading as an empty cohort', async () => {
+    retentionNotifyMock.mockResolvedValue({
+      ok: false,
+      kind: 'http',
+      error: 'Unauthorized',
+      status: 401,
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await retentionNotify({ env: 'dev' });
+
+    expect(process.exitCode).toBe(1);
+    errorSpy.mockRestore();
+  });
+});
+
+describe('renderNotifyRun', () => {
+  it('prints the warn annotation with first-run context when flagged', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    renderNotifyRun(runResult({ breakerWarning: true, percentOfUserbase: 18.7 }));
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Breaker warning');
+    expect(output).toContain('FIRST');
+    logSpy.mockRestore();
+  });
+});

--- a/packages/tooling/src/retention/notify.ts
+++ b/packages/tooling/src/retention/notify.ts
@@ -1,0 +1,144 @@
+/**
+ * `pnpm ops retention:notify` — send the retention warning DM to every
+ * reachable-but-inactive user (Retention Phase 3, the reachable branch).
+ *
+ * Non-destructive but outward-facing: each recipient gets a DM stating a
+ * concrete deletion date, and every send starts a 30-day grace clock. The
+ * safeguards, in the order a run hits them:
+ *
+ *   1. `--dry-run` resolves and prints the cohort without enqueuing.
+ *   2. On prod, `confirmProductionOperation` is the manual-approval gate —
+ *      `--force` skips the PROMPT only.
+ *   3. The gateway refuses the run when the cohort exceeds the hard-ceiling
+ *      share of the userbase; `--breaker-override` is the deliberate,
+ *      separate flag. The first real run is EXPECTED to trip the softer warn
+ *      annotation (~15-18%, the backfilled zombie cohort) — that prints, and
+ *      the run proceeds.
+ *
+ * **Resuming is re-running.** A sent notice stamps the user's grace clock,
+ * which removes them from the notify cohort — an interrupted or partially
+ * failed run picks up exactly the un-warned remainder next invocation.
+ *
+ * The command returns at ENQUEUE time; the DMs go out via bot-client's
+ * worker (1/sec pacing), which posts a per-batch tally to the owner channel.
+ */
+
+import chalk from 'chalk';
+import type { RetentionNotifyResponse } from '@tzurot/common-types/schemas/api/internal';
+import {
+  type Environment,
+  validateEnvironment,
+  showEnvironmentBanner,
+  confirmProductionOperation,
+} from '../utils/env-runner.js';
+import { resolveServiceClientOrExit } from '../utils/gateway-client.js';
+
+export interface RetentionNotifyOptions {
+  env: Environment;
+  /** Resolve and print the cohort without enqueuing anything. */
+  dryRun?: boolean;
+  /** Skip the production confirmation prompt. Does NOT bypass the breaker. */
+  force?: boolean;
+  /** Proceed despite the hard-ceiling breaker. Deliberately not `--force`. */
+  breakerOverride?: boolean;
+}
+
+/** Print a resolved run (dry or real). Exported for testing. */
+export function renderNotifyRun(result: RetentionNotifyResponse): void {
+  if (result.status === 'empty') {
+    console.log(chalk.green('\nNobody to warn — no reachable user is past the inactivity window.'));
+    console.log(chalk.dim(`  cohort: 0 of ${String(result.userbaseCount)} users`));
+    return;
+  }
+
+  console.log(chalk.bold('\nNotify cohort (reachable, inactive, not yet warned):'));
+  for (const user of result.recipients) {
+    console.log(`  ${user.discordId}  inactive since ${user.inactiveSince.slice(0, 10)}`);
+  }
+  console.log(
+    `\n  cohort: ${String(result.cohortSize)} of ${String(result.userbaseCount)} users ` +
+      `(${String(result.percentOfUserbase)}% of the userbase)`
+  );
+
+  if (result.breakerWarning) {
+    console.log(
+      chalk.yellow(
+        '\n⚠️  Breaker warning: the cohort exceeds the warn share of the userbase. On the FIRST ' +
+          'real run this is expected (the backfilled zombie cohort); on later runs, confirm real ' +
+          'churn before proceeding.'
+      )
+    );
+  }
+
+  if (result.status === 'refused_breaker') {
+    console.error(chalk.red(`\n${result.breakerDetail ?? 'Hard-ceiling breaker tripped.'}`));
+    return;
+  }
+  if (result.status === 'enqueued') {
+    console.log(
+      chalk.green(
+        `\nEnqueued ${String(result.batchesEnqueued)} batch(es). DMs go out at 1/sec via ` +
+          'bot-client; delivery tallies arrive in the owner channel as batches complete.'
+      )
+    );
+  }
+}
+
+/** Entry point for `pnpm ops retention:notify`. */
+export async function retentionNotify(options: RetentionNotifyOptions): Promise<void> {
+  const { env, dryRun = false, force = false, breakerOverride = false } = options;
+  validateEnvironment(env);
+  showEnvironmentBanner(env);
+
+  const client = resolveServiceClientOrExit(env);
+  if (client === null) {
+    return;
+  }
+
+  // Always resolve as a dry run first: the operator sees exactly who would be
+  // warned BEFORE the prod confirmation asks them to vouch for it.
+  const previewResult = await client.retentionNotify({ dryRun: true });
+  if (!previewResult.ok) {
+    console.error(
+      chalk.red(
+        `\nFailed to resolve the notify cohort (${previewResult.kind}): ${previewResult.error}`
+      )
+    );
+    process.exitCode = 1;
+    return;
+  }
+  renderNotifyRun(previewResult.data);
+
+  if (dryRun) {
+    console.log(chalk.yellow('\nDry run — nothing was enqueued.'));
+    return;
+  }
+  if (previewResult.data.status === 'empty') {
+    return;
+  }
+
+  if (env === 'prod' && !force) {
+    const confirmed = await confirmProductionOperation(
+      `DM a deletion warning to ${String(previewResult.data.cohortSize)} inactive users ` +
+        '(starts their 30-day grace clocks)'
+    );
+    if (!confirmed) {
+      console.log(chalk.yellow('\nOperation cancelled.'));
+      return;
+    }
+  }
+
+  const runResult = await client.retentionNotify({
+    breakerOverride,
+    runContext: `ops retention:notify (${env})`,
+  });
+  if (!runResult.ok) {
+    console.error(chalk.red(`\nNotify run failed (${runResult.kind}): ${runResult.error}`));
+    process.exitCode = 1;
+    return;
+  }
+  renderNotifyRun(runResult.data);
+  if (runResult.data.status === 'refused_breaker') {
+    process.exitCode = 1;
+  }
+}

--- a/packages/tooling/src/retention/notify.ts
+++ b/packages/tooling/src/retention/notify.ts
@@ -116,6 +116,16 @@ export async function retentionNotify(options: RetentionNotifyOptions): Promise<
   if (previewResult.data.status === 'empty') {
     return;
   }
+  // The preview call runs the same server-side breaker (it precedes the
+  // dry-run branch), so an over-ceiling cohort is refused HERE — asking the
+  // operator to confirm an action the server just refused would be noise.
+  if (previewResult.data.status === 'refused_breaker' && !breakerOverride) {
+    console.log(
+      chalk.yellow('\nRe-run with --breaker-override once you have confirmed the cohort is real.')
+    );
+    process.exitCode = 1;
+    return;
+  }
 
   if (env === 'prod' && !force) {
     const confirmed = await confirmProductionOperation(

--- a/packages/tooling/src/topology/coverageTopology.test.ts
+++ b/packages/tooling/src/topology/coverageTopology.test.ts
@@ -33,7 +33,7 @@ describe('generateCoverageTopology', () => {
     expect(routeSurfaces.every(s => s.consumer === 'api-gateway')).toBe(true);
   });
 
-  it('enumerates the four payload-bearing BullMQ jobs (bullmq-contract)', () => {
+  it('enumerates the five payload-bearing BullMQ jobs (bullmq-contract)', () => {
     const jobSurfaces = topology.surfaces.filter(s => s.kind === 'bullmq-job');
     // Build expected ids from the enum so a JobType value rename is caught.
     const expected = [
@@ -41,6 +41,7 @@ describe('generateCoverageTopology', () => {
       `api-gateway:ai-worker:${JobType.ImageDescription}`,
       `api-gateway:ai-worker:${JobType.LLMGeneration}`,
       `api-gateway:bot-client:${JobType.ReleaseBroadcastDm}`,
+      `api-gateway:bot-client:${JobType.RetentionNotifyDm}`,
     ].sort();
     expect(jobSurfaces.map(s => s.id).sort()).toEqual(expected);
     expect(jobSurfaces.every(s => s.mechanism === 'bullmq-contract')).toBe(true);
@@ -109,7 +110,8 @@ describe('generateCoverageTopology', () => {
         'audioTranscriptionJobDataSchema.safeParse(x);\n' +
           'imageDescriptionJobDataSchema.safeParse(x);\n' +
           'llmGenerationJobDataSchema.parse(x);\n' +
-          'releaseBroadcastDmJobDataSchema.safeParse(x);\n'
+          'releaseBroadcastDmJobDataSchema.safeParse(x);\n' +
+          'retentionNotifyDmJobDataSchema.safeParse(x);\n'
       );
       mkdirSync(dirname(producerPath), { recursive: true });
       // The broadcast surface keys off ITS OWN producer test — keep it REAL in
@@ -122,6 +124,17 @@ describe('generateCoverageTopology', () => {
       writeFileSync(
         broadcastProducerPath,
         "import { enqueueBroadcast } from './releaseBroadcast.js';\nenqueueBroadcast();\n"
+      );
+      // Likewise the retention-notify surface keys off ITS OWN producer test.
+      const retentionProducerPath = join(
+        tmpRoot,
+        'services/api-gateway/src/services/retention/RetentionNotifyContract.producer.test.ts'
+      );
+      mkdirSync(dirname(retentionProducerPath), { recursive: true });
+      writeFileSync(
+        retentionProducerPath,
+        "import { RetentionNotifyService } from './RetentionNotifyService.js';\n" +
+          'new RetentionNotifyService();\n'
       );
 
       // Circular: the producer hand-rolls a payload, importing the SCHEMA but never

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -100,6 +100,9 @@ const MECHANISM_TIER: Record<CoverageSurfaceMechanism, TestTier> = {
  * not compile until it is classified here, so a future payload-bearing job can't
  * be silently omitted from the topology.
  */
+// Repeated consumer/producer service name (sonarjs no-duplicate-string).
+const BOT_CLIENT = 'bot-client';
+
 const JOB_SCHEMA_BY_TYPE: Record<JobType, { schemaRef: string; consumer: string } | null> = {
   [JobType.AudioTranscription]: {
     schemaRef: 'audioTranscriptionJobDataSchema',
@@ -124,7 +127,13 @@ const JOB_SCHEMA_BY_TYPE: Record<JobType, { schemaRef: string; consumer: string 
   // worker consumes them — the payload schema IS the producer↔consumer contract.
   [JobType.ReleaseBroadcastDm]: {
     schemaRef: 'releaseBroadcastDmJobDataSchema',
-    consumer: 'bot-client',
+    consumer: BOT_CLIENT,
+  },
+  // Same cross-service shape as the broadcast: api-gateway produces retention
+  // warning-DM batches, bot-client's notify worker consumes them.
+  [JobType.RetentionNotifyDm]: {
+    schemaRef: 'retentionNotifyDmJobDataSchema',
+    consumer: BOT_CLIENT,
   },
 };
 
@@ -156,6 +165,8 @@ const BULLMQ_PRODUCER_TEST =
   'services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts';
 const BROADCAST_PRODUCER_TEST =
   'services/api-gateway/src/services/ReleaseBroadcastContract.producer.test.ts';
+const RETENTION_NOTIFY_PRODUCER_TEST =
+  'services/api-gateway/src/services/retention/RetentionNotifyContract.producer.test.ts';
 const BULLMQ_CONTRACT_DIR = 'tests/e2e/contracts';
 const VOICE_ENGINE_CONSUMER_TEST =
   'services/ai-worker/src/services/voice/VoiceEngineContract.consumer.contract.test.ts';
@@ -224,6 +235,12 @@ const REAL_IMPORTS = {
     symbol: 'enqueueBroadcast',
     from: '/releaseBroadcast.',
   },
+  /** Same shape as the broadcast: its own producer seam, its own fixture test. */
+  retentionNotifyProducer: {
+    file: RETENTION_NOTIFY_PRODUCER_TEST,
+    symbol: 'RetentionNotifyService',
+    from: '/RetentionNotifyService.',
+  },
   /**
    * The voice-engine JSON contract is cross-LANGUAGE: the PRODUCER is the Python
    * service, enforced by the `voice-engine-tests` CI job (a pytest asserts each real
@@ -247,6 +264,8 @@ interface MechanismPresence {
   bullmqProducerImportsReal: boolean;
   /** The broadcast producer test imports the real `enqueueBroadcast` (its own producer seam). */
   broadcastProducerImportsReal: boolean;
+  /** The retention-notify producer test imports the real `RetentionNotifyService`. */
+  retentionNotifyProducerImportsReal: boolean;
   /** The voice-engine consumer test imports the real response Zod schemas (TS half; Python half is CI-enforced). */
   voiceEngineImportsReal: boolean;
   /** Job schema names referenced by a `.safeParse(`/`.parse(` call in a BullMQ contract test. */
@@ -280,6 +299,7 @@ function buildMechanismPresence(projectRoot: string): MechanismPresence {
       imports(REAL_IMPORTS.envelopeProducer) && imports(REAL_IMPORTS.envelopeConsumer),
     bullmqProducerImportsReal: imports(REAL_IMPORTS.bullmqProducer),
     broadcastProducerImportsReal: imports(REAL_IMPORTS.broadcastProducer),
+    retentionNotifyProducerImportsReal: imports(REAL_IMPORTS.retentionNotifyProducer),
     voiceEngineImportsReal: imports(REAL_IMPORTS.voiceEngineConsumer),
     bullmqSchemas,
   };
@@ -303,7 +323,9 @@ const MECHANISM_PRESENT: Record<
     presence.bullmqSchemas.has(seed.schemaRef) &&
     (seed.schemaRef === 'releaseBroadcastDmJobDataSchema'
       ? presence.broadcastProducerImportsReal
-      : presence.bullmqProducerImportsReal),
+      : seed.schemaRef === 'retentionNotifyDmJobDataSchema'
+        ? presence.retentionNotifyProducerImportsReal
+        : presence.bullmqProducerImportsReal),
   'voice-engine-contract': (_seed, presence) => presence.voiceEngineImportsReal,
 };
 
@@ -371,7 +393,7 @@ export function generateCoverageTopology(projectRoot: string = defaultRootDir())
       {
         id: 'bot-client:ai-worker:context-assembly',
         kind: 'context-envelope',
-        producer: 'bot-client',
+        producer: BOT_CLIENT,
         consumer: 'ai-worker',
         schemaRef: 'rawAssemblyInputsSchema',
         mechanism: 'golden-fixture',

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -96,7 +96,13 @@ import {
 } from './bootstrap/index.js';
 
 // Queue
-import { aiQueue, releaseBroadcastQueue, queueEvents, closeQueue } from './queue.js';
+import {
+  aiQueue,
+  releaseBroadcastQueue,
+  retentionNotifyQueue,
+  queueEvents,
+  closeQueue,
+} from './queue.js';
 import { createShutdownHandler } from './shutdownHandler.js';
 import {
   initializeDeduplicationCache,
@@ -418,6 +424,7 @@ function registerRoutes(
     redis: cacheRedis,
     aiQueue,
     releaseBroadcastQueue,
+    retentionNotifyQueue,
     queueEvents,
   };
 

--- a/services/api-gateway/src/queue.ts
+++ b/services/api-gateway/src/queue.ts
@@ -6,7 +6,11 @@
 
 import { Queue, QueueEvents, FlowProducer } from 'bullmq';
 import { getConfig } from '@tzurot/common-types/config/config';
-import { QUEUE_CONFIG, RELEASE_BROADCAST_QUEUE_NAME } from '@tzurot/common-types/constants/queue';
+import {
+  QUEUE_CONFIG,
+  RELEASE_BROADCAST_QUEUE_NAME,
+  RETENTION_NOTIFY_QUEUE_NAME,
+} from '@tzurot/common-types/constants/queue';
 import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { parseRedisUrl, createBullMQRedisConfig } from '@tzurot/common-types/utils/redis';
@@ -75,6 +79,23 @@ export const releaseBroadcastQueue = new Queue(RELEASE_BROADCAST_QUEUE_NAME, {
   },
 });
 
+// Retention warning-DM queue (Phase 3) — produced here, consumed by
+// bot-client's notify worker. Deliberately its own queue: the release
+// queue's at-least-once bound depends on staying single-purpose.
+// eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: BullMQ Queue must be shared across route handlers; multiple instances against one queue name would fragment job bookkeeping.
+export const retentionNotifyQueue = new Queue(RETENTION_NOTIFY_QUEUE_NAME, {
+  connection: redisConfig,
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: {
+      type: 'exponential',
+      delay: TIMEOUTS.QUEUE_RETRY_DELAY,
+    },
+    removeOnComplete: { count: QUEUE_CONFIG.COMPLETED_HISTORY_LIMIT },
+    removeOnFail: { count: QUEUE_CONFIG.FAILED_HISTORY_LIMIT },
+  },
+});
+
 // Create flow producer for job dependencies
 // FlowProducer allows creating parent-child job relationships where parent waits for children
 // eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: FlowProducer must be shared to maintain job dependency relationships. Multiple instances would break parent-child job tracking.
@@ -107,6 +128,7 @@ export async function closeQueue(): Promise<void> {
   await queueEvents.close();
   await flowProducer.close();
   await releaseBroadcastQueue.close();
+  await retentionNotifyQueue.close();
   await aiQueue.close();
   logger.info('Queue connections closed');
 }

--- a/services/api-gateway/src/routes/_generated/mounts.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.ts
@@ -50,6 +50,7 @@ import { handleSecretRotationStatus } from '../internal/secretRotationStatus.js'
 import { handleRetentionPreview } from '../internal/retentionPreview.js';
 import { handleRetentionPurge } from '../internal/retentionPurge.js';
 import { handleRetentionReconcileOffDb } from '../internal/retentionReconcileOffDb.js';
+import { handleRetentionNotify, handleRetentionNotifyFilter, handleRetentionNotifyReport } from '../internal/retentionNotify.js';
 import { handleGetModels } from '../internal/models.js';
 import { handleGetDenylistCache, handleAddDenylistEntry, handleListDenylistEntries, handleRemoveDenylistEntry } from '../admin/denylist.js';
 import { handleUpdateDiagnosticResponseIds, handleGetRecentDiagnostics, handleGetDiagnosticByMessage, handleGetDiagnosticByResponse, handleGetDiagnosticByRequestId } from '../admin/diagnostic.js';
@@ -131,6 +132,9 @@ export function mountInternalRoutes(app: Express, deps: RouteDeps): void {
   app.get('/api/internal/retention/preview', handleRetentionPreview(deps));
   app.post('/api/internal/retention/purge', handleRetentionPurge(deps));
   app.post('/api/internal/retention/reconcile-off-db', handleRetentionReconcileOffDb(deps));
+  app.post('/api/internal/retention/notify', handleRetentionNotify(deps));
+  app.post('/api/internal/retention/notify/filter', handleRetentionNotifyFilter(deps));
+  app.post('/api/internal/retention/notify/report', handleRetentionNotifyReport(deps));
   app.get('/api/internal/models', handleGetModels(deps));
   app.get('/api/internal/denylist/cache', handleGetDenylistCache(deps));
   app.get('/api/internal/admin-settings', handleGetAdminSettings(deps));

--- a/services/api-gateway/src/routes/conformance/fixtures/internal.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/internal.ts
@@ -319,6 +319,27 @@ export const internalFixtures: Record<string, ConformanceEntry> = {
     body: { discordId: '829999999999999999', runContext: 'conformance' },
   },
 
+  retentionNotify: {
+    // Dry run against the empty steady state (the conformance actor is recent
+    // and reachable, so the notify cohort is empty): resolves, enqueues
+    // nothing, needs no queue and no seed.
+    body: { dryRun: true },
+  },
+
+  retentionNotifyFilter: {
+    // No user row carries this id, so the still-eligible subset is empty —
+    // the shape conformance checks, with zero seed and zero writes.
+    body: { userIds: ['829e4567-e89b-42d3-a456-426614174999'] },
+  },
+
+  retentionNotifyReport: {
+    // A transient outcome stamps NOTHING by design (the queue retries it), so
+    // this exercises the route's happy path without writing shared state.
+    body: {
+      outcomes: [{ userId: '829e4567-e89b-42d3-a456-426614174999', status: 'failed_transient' }],
+    },
+  },
+
   retentionReconcileOffDb: {
     // An empty audit ledger is the steady state: the sweep finds nothing owed
     // and returns { settled: 0, stillFailing: 0 } — zero seed needed.

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.ts
@@ -23,6 +23,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
 import { sendContractSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
+import { stampDmPermanentFailure } from '../../services/retention/dmFailureStamps.js';
 import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('internal-release-broadcast');
@@ -126,17 +127,10 @@ async function recordPermanentFailure(
     if (row === null) {
       return null;
     }
-    if (errorCode === '50278' || errorCode === '50007') {
-      await prisma.$executeRaw`
-        UPDATE users SET dm_undeliverable_since = NOW()
-        WHERE id = ${row.userId}::uuid AND dm_undeliverable_since IS NULL
-      `;
-    } else if (errorCode === '10013') {
-      await prisma.$executeRaw`
-        UPDATE users SET discord_account_gone_at = NOW()
-        WHERE id = ${row.userId}::uuid AND discord_account_gone_at IS NULL
-      `;
-    }
+    // The code→column mapping lives in the shared kernel — the retention
+    // notify report route stamps through the same one (drift here would
+    // desync the two delivery pipelines' unreachability semantics).
+    await stampDmPermanentFailure(prisma, row.userId, errorCode);
     return (await maybeAutoDisable(prisma, deliveryLogId, row.userId)) ? row.userId : null;
   } catch (err) {
     logger.warn(

--- a/services/api-gateway/src/routes/internal/retentionNotify.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionNotify.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import type { Queue } from 'bullmq';
+import {
+  handleRetentionNotify,
+  handleRetentionNotifyFilter,
+  handleRetentionNotifyReport,
+} from './retentionNotify.js';
+import type { RouteDeps } from '../routeDeps.js';
+
+const enqueueMock = vi.hoisted(() => vi.fn());
+const filterMock = vi.hoisted(() => vi.fn());
+const reportMock = vi.hoisted(() => vi.fn());
+vi.mock('../../services/retention/RetentionNotifyService.js', () => ({
+  RetentionNotifyService: class {
+    enqueueNotifyRun = enqueueMock;
+    filterEligible = filterMock;
+    reportOutcomes = reportMock;
+  },
+}));
+
+const EMPTY_RUN = {
+  status: 'empty',
+  cohortSize: 0,
+  userbaseCount: 100,
+  percentOfUserbase: 0,
+  breakerWarning: false,
+  batchesEnqueued: 0,
+  recipients: [],
+};
+
+function createMockReqRes(body: unknown) {
+  const req = { body } as Request;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return { req, res };
+}
+
+const deps = {
+  prisma: {},
+  retentionNotifyQueue: {} as Queue,
+} as RouteDeps;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('handleRetentionNotify', () => {
+  it('passes the operator flags through and returns the run result', async () => {
+    enqueueMock.mockResolvedValue(EMPTY_RUN);
+    const { req, res } = createMockReqRes({ dryRun: true, runContext: 'test-run' });
+
+    await handleRetentionNotify(deps)(req, res, vi.fn());
+
+    expect(enqueueMock).toHaveBeenCalledWith(deps.retentionNotifyQueue, {
+      dryRun: true,
+      runContext: 'test-run',
+    });
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.status).toBe('empty');
+  });
+
+  it('fails loudly when the queue is not configured — never a silent no-op', async () => {
+    const { req, res } = createMockReqRes({});
+
+    await handleRetentionNotify({ ...deps, retentionNotifyQueue: undefined } as RouteDeps)(
+      req,
+      res,
+      vi.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed body', async () => {
+    const { req, res } = createMockReqRes({ dryRun: 'yes' });
+
+    await handleRetentionNotify(deps)(req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('handleRetentionNotifyFilter', () => {
+  it('returns the still-eligible subset', async () => {
+    filterMock.mockResolvedValue(['a3bb189e-8bf9-3888-9912-ace4e6543002']);
+    const { req, res } = createMockReqRes({
+      userIds: ['a3bb189e-8bf9-3888-9912-ace4e6543002', 'b3bb189e-8bf9-3888-9912-ace4e6543002'],
+    });
+
+    await handleRetentionNotifyFilter(deps)(req, res, vi.fn());
+
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.stillEligibleUserIds).toEqual(['a3bb189e-8bf9-3888-9912-ace4e6543002']);
+  });
+
+  it('rejects an empty batch', async () => {
+    const { req, res } = createMockReqRes({ userIds: [] });
+
+    await handleRetentionNotifyFilter(deps)(req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(filterMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleRetentionNotifyReport', () => {
+  it('applies outcomes and reports the processed count', async () => {
+    reportMock.mockResolvedValue(1);
+    const outcomes = [{ userId: 'a3bb189e-8bf9-3888-9912-ace4e6543002', status: 'sent' }];
+    const { req, res } = createMockReqRes({ outcomes });
+
+    await handleRetentionNotifyReport(deps)(req, res, vi.fn());
+
+    expect(reportMock).toHaveBeenCalledWith(outcomes);
+    const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.processed).toBe(1);
+  });
+
+  it('rejects an outcome with an unknown status', async () => {
+    const { req, res } = createMockReqRes({
+      outcomes: [{ userId: 'a3bb189e-8bf9-3888-9912-ace4e6543002', status: 'maybe' }],
+    });
+
+    await handleRetentionNotifyReport(deps)(req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/services/api-gateway/src/routes/internal/retentionNotify.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionNotify.test.ts
@@ -62,7 +62,7 @@ describe('handleRetentionNotify', () => {
     expect(payload.status).toBe('empty');
   });
 
-  it('fails loudly when the queue is not configured — never a silent no-op', async () => {
+  it('fails loudly when a REAL run has no queue — never a silent no-op', async () => {
     const { req, res } = createMockReqRes({});
 
     await handleRetentionNotify({ ...deps, retentionNotifyQueue: undefined } as RouteDeps)(
@@ -73,6 +73,19 @@ describe('handleRetentionNotify', () => {
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it('lets a dry run proceed without a queue (it never enqueues)', async () => {
+    enqueueMock.mockResolvedValue(EMPTY_RUN);
+    const { req, res } = createMockReqRes({ dryRun: true });
+
+    await handleRetentionNotify({ ...deps, retentionNotifyQueue: undefined } as RouteDeps)(
+      req,
+      res,
+      vi.fn()
+    );
+
+    expect(enqueueMock).toHaveBeenCalledWith(null, { dryRun: true });
   });
 
   it('rejects a malformed body', async () => {

--- a/services/api-gateway/src/routes/internal/retentionNotify.ts
+++ b/services/api-gateway/src/routes/internal/retentionNotify.ts
@@ -1,0 +1,89 @@
+/**
+ * Retention Phase 3 — the notify pipeline's three internal routes.
+ *
+ *   POST /api/internal/retention/notify         — resolve cohort + enqueue batches
+ *   POST /api/internal/retention/notify/filter  — the worker's send-time re-check
+ *   POST /api/internal/retention/notify/report  — per-recipient delivery outcomes
+ *
+ * Operator-driven (manual-approval doctrine): only the retention:notify CLI
+ * calls the enqueue route; nothing runs it on a schedule (autonomy is
+ * Phase 4). The filter and report routes are the bot-client worker's two
+ * seams back into the grace bookkeeping.
+ *
+ * Service-auth protected upstream like every /internal/* route.
+ */
+
+import { type Request, type Response, type RequestHandler } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import {
+  RetentionNotifyFilterRequestSchema,
+  RetentionNotifyFilterResponseSchema,
+  RetentionNotifyReportRequestSchema,
+  RetentionNotifyReportResponseSchema,
+  RetentionNotifyRequestSchema,
+  RetentionNotifyResponseSchema,
+} from '@tzurot/common-types/schemas/api/internal';
+import { asyncHandler } from '../../utils/asyncHandler.js';
+import { sendContractSuccess, sendError } from '../../utils/responseHelpers.js';
+import { sendZodError } from '../../utils/zodHelpers.js';
+import { ErrorResponses } from '../../utils/errorResponses.js';
+import { RetentionNotifyService } from '../../services/retention/RetentionNotifyService.js';
+import type { RouteDeps } from '../routeDeps.js';
+
+/** POST /api/internal/retention/notify — resolve the cohort and enqueue warning DMs. */
+export const handleRetentionNotify = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = RetentionNotifyRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendZodError(res, parsed.error);
+      return;
+    }
+    if (deps.retentionNotifyQueue === undefined) {
+      sendError(res, ErrorResponses.internalError('Retention notify queue is not configured'));
+      return;
+    }
+
+    const result = await new RetentionNotifyService(deps.prisma).enqueueNotifyRun(
+      deps.retentionNotifyQueue,
+      parsed.data
+    );
+    sendContractSuccess(res, RetentionNotifyResponseSchema, result, StatusCodes.OK);
+  });
+
+/** POST /api/internal/retention/notify/filter — which of these users are still notify-eligible? */
+export const handleRetentionNotifyFilter = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = RetentionNotifyFilterRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendZodError(res, parsed.error);
+      return;
+    }
+
+    const stillEligibleUserIds = await new RetentionNotifyService(deps.prisma).filterEligible(
+      parsed.data.userIds
+    );
+    sendContractSuccess(
+      res,
+      RetentionNotifyFilterResponseSchema,
+      { stillEligibleUserIds },
+      StatusCodes.OK
+    );
+  });
+
+/** POST /api/internal/retention/notify/report — apply per-recipient outcomes. */
+export const handleRetentionNotifyReport = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = RetentionNotifyReportRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendZodError(res, parsed.error);
+      return;
+    }
+
+    // Stamp failures THROW (asyncHandler → 500): the worker's report retry is
+    // safe against the IS NULL-guarded stamps, and a swallowed failure here
+    // would strand a sent-but-unstamped user for the next run to double-DM.
+    const processed = await new RetentionNotifyService(deps.prisma).reportOutcomes(
+      parsed.data.outcomes
+    );
+    sendContractSuccess(res, RetentionNotifyReportResponseSchema, { processed }, StatusCodes.OK);
+  });

--- a/services/api-gateway/src/routes/internal/retentionNotify.ts
+++ b/services/api-gateway/src/routes/internal/retentionNotify.ts
@@ -38,13 +38,15 @@ export const handleRetentionNotify = (deps: RouteDeps): RequestHandler =>
       sendZodError(res, parsed.error);
       return;
     }
-    if (deps.retentionNotifyQueue === undefined) {
+    // Dry runs never enqueue, so they must not fail on a missing queue —
+    // the conformance harness and any read-only caller take this path.
+    if (parsed.data.dryRun !== true && deps.retentionNotifyQueue === undefined) {
       sendError(res, ErrorResponses.internalError('Retention notify queue is not configured'));
       return;
     }
 
     const result = await new RetentionNotifyService(deps.prisma).enqueueNotifyRun(
-      deps.retentionNotifyQueue,
+      deps.retentionNotifyQueue ?? null,
       parsed.data
     );
     sendContractSuccess(res, RetentionNotifyResponseSchema, result, StatusCodes.OK);

--- a/services/api-gateway/src/routes/routeDeps.ts
+++ b/services/api-gateway/src/routes/routeDeps.ts
@@ -113,6 +113,8 @@ export interface RouteDeps {
   readonly aiQueue?: Queue;
   /** BullMQ queue for release-broadcast DM batches (consumed by bot-client). */
   readonly releaseBroadcastQueue?: Queue;
+  /** BullMQ queue for retention warning-DM batches (consumed by bot-client). */
+  readonly retentionNotifyQueue?: Queue;
   /** BullMQ queue events for sync-completion waiting. */
   readonly queueEvents?: QueueEvents;
 }

--- a/services/api-gateway/src/services/releaseBroadcast.test.ts
+++ b/services/api-gateway/src/services/releaseBroadcast.test.ts
@@ -73,10 +73,10 @@ describe('resolveEligibleRecipients', () => {
   });
 
   it('narrows the WHERE clause to the allowlist when set (dev outbound gate)', async () => {
-    allowlistMock.value = new Set(['111']);
+    allowlistMock.value = new Set(['111111111111111111']);
     const prisma = makePrisma();
     prisma.user.findMany.mockResolvedValueOnce([
-      { id: USER_A, discordId: '111', username: 'owner' },
+      { id: USER_A, discordId: '111111111111111111', username: 'owner' },
     ]);
 
     await resolveEligibleRecipients(prisma as unknown as PrismaClient, 'major');
@@ -87,7 +87,7 @@ describe('resolveEligibleRecipients', () => {
           notifyEnabled: true,
           notifyOptedInAt: { not: null },
           notifyLevel: { in: ['major', 'minor', 'patch'] },
-          discordId: { in: ['111'] },
+          discordId: { in: ['111111111111111111'] },
         },
       })
     );
@@ -96,7 +96,7 @@ describe('resolveEligibleRecipients', () => {
   it('queries opted-in users at the level thresholds, gated on deliberate use', async () => {
     const prisma = makePrisma();
     prisma.user.findMany.mockResolvedValueOnce([
-      { id: USER_A, discordId: '111', username: 'alice' },
+      { id: USER_A, discordId: '111111111111111111', username: 'alice' },
     ]);
 
     const recipients = await resolveEligibleRecipients(prisma as unknown as PrismaClient, 'minor');
@@ -114,19 +114,21 @@ describe('resolveEligibleRecipients', () => {
         take: 500,
       })
     );
-    expect(recipients).toEqual([{ userId: USER_A, discordUserId: '111', username: 'alice' }]);
+    expect(recipients).toEqual([
+      { userId: USER_A, discordUserId: '111111111111111111', username: 'alice' },
+    ]);
   });
 
   it('paginates with a cursor until a short page arrives', async () => {
     const prisma = makePrisma();
     const fullPage = Array.from({ length: 500 }, (_unused, i) => ({
       id: `id-${String(i).padStart(3, '0')}`,
-      discordId: `d${i}`,
+      discordId: `9${String(i).padStart(17, '0')}`,
       username: `u${i}`,
     }));
     prisma.user.findMany
       .mockResolvedValueOnce(fullPage)
-      .mockResolvedValueOnce([{ id: 'id-tail', discordId: 'dt', username: 'ut' }]);
+      .mockResolvedValueOnce([{ id: 'id-tail', discordId: '911111111111111111', username: 'ut' }]);
 
     const recipients = await resolveEligibleRecipients(prisma as unknown as PrismaClient, 'major');
 
@@ -161,8 +163,8 @@ describe('enqueueBroadcast', () => {
   it('creates the announcement + pending logs and enqueues deterministic batches', async () => {
     const prisma = makePrisma();
     prisma.user.findMany.mockResolvedValueOnce([
-      { id: USER_A, discordId: '111', username: 'alice' },
-      { id: USER_B, discordId: '222', username: 'bob' },
+      { id: USER_A, discordId: '111111111111111111', username: 'alice' },
+      { id: USER_B, discordId: '222222222222222222', username: 'bob' },
     ]);
     const queue = makeQueue();
 
@@ -200,8 +202,8 @@ describe('enqueueBroadcast', () => {
   it("attaches each recipient's standing prior DM as previousDm", async () => {
     const prisma = makePrisma();
     prisma.user.findMany.mockResolvedValueOnce([
-      { id: USER_A, discordId: '111', username: 'alice' },
-      { id: USER_B, discordId: '222', username: 'bob' },
+      { id: USER_A, discordId: '111111111111111111', username: 'alice' },
+      { id: USER_B, discordId: '222222222222222222', username: 'bob' },
     ]);
     // Only alice has a standing prior release DM.
     prisma.releaseDeliveryLog.findMany.mockResolvedValueOnce([
@@ -247,7 +249,7 @@ describe('enqueueBroadcast', () => {
     prisma.user.findMany.mockResolvedValueOnce(
       Array.from({ length: BROADCAST_BATCH_SIZE + 1 }, (_unused, i) => ({
         id: `${String(i).padStart(8, '0')}-e89b-42d3-a456-426614174000`,
-        discordId: `d${i}`,
+        discordId: `9${String(i).padStart(17, '0')}`,
         username: `u${i}`,
       }))
     );
@@ -269,7 +271,7 @@ describe('enqueueBroadcast', () => {
   it('resolves a create-time unique violation (concurrent same-version race) to already-announced', async () => {
     const prisma = makePrisma();
     prisma.user.findMany.mockResolvedValueOnce([
-      { id: USER_A, discordId: '111', username: 'alice' },
+      { id: USER_A, discordId: '111111111111111111', username: 'alice' },
     ]);
     prisma.releaseAnnouncement.create.mockRejectedValueOnce({ code: 'P2002' });
     const queue = makeQueue();

--- a/services/api-gateway/src/services/retention/RetentionNotifyContract.producer.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionNotifyContract.producer.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Producer half of the api-gateway → bot-client retention-notify contract.
+ *
+ * Runs the REAL `RetentionNotifyService.enqueueNotifyRun()` and snapshots the
+ * captured `queue.add` payload (one warning-DM batch) to a committed JSON
+ * fixture under `@tzurot/test-utils` (`fixtures/contracts/retention-notify/`).
+ * `--update` regenerates; CI COMPARES (strict). Drift in the producer's batch
+ * shape → CI fails here.
+ *
+ * The consumer half (`tests/e2e/contracts/RetentionNotifyDm.contract.test.ts`)
+ * reads the SAME fixture and validates it against the notify worker's entry
+ * schema (`retentionNotifyDmJobDataSchema` — the worker's safeParse gate).
+ * The committed fixture IS the contract artifact — the two services share
+ * data, not code, and the payload is REAL producer output.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { contractFixtureFile, stableFixtureJson } from '@tzurot/test-utils';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { Queue } from 'bullmq';
+import { generateUserUuid } from '@tzurot/common-types/utils/deterministicUuid';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+vi.mock('@tzurot/common-types/utils/outboundDmAllowlist', () => ({
+  getOutboundDmAllowlist: () => null,
+}));
+
+import { RetentionNotifyService } from './RetentionNotifyService.js';
+
+// Deterministic cohort: internal ids derived from fixed snowflakes and a fixed
+// inactivity anchor, so the fixture is byte-stable across runs.
+const COHORT_ROWS = [{ discordId: '111111111111111111' }, { discordId: '222222222222222222' }].map(
+  user => ({
+    userId: generateUserUuid(user.discordId),
+    discordId: user.discordId,
+    inactiveSince: new Date('2025-01-01T00:00:00.000Z'),
+  })
+);
+
+describe('Contract producer: retention-notify DM batch (real enqueueNotifyRun output)', () => {
+  it('captures the enqueued batch payload as the committed contract fixture', async () => {
+    const prisma = {
+      $queryRaw: vi.fn().mockResolvedValue(COHORT_ROWS),
+      user: { count: vi.fn().mockResolvedValue(100) },
+    } as unknown as PrismaClient;
+    const added: unknown[] = [];
+    const queue = {
+      add: (name: string, data: unknown, opts?: unknown) => {
+        added.push({ name, data, opts });
+        return Promise.resolve({ id: 'contract-job' });
+      },
+    } as unknown as Queue;
+
+    const result = await new RetentionNotifyService(prisma).enqueueNotifyRun(queue, {
+      runContext: 'contract-fixture',
+      now: () => new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    expect(result.status).toBe('enqueued');
+    expect(added).toHaveLength(1);
+
+    await expect(stableFixtureJson(added[0])).toMatchFileSnapshot(
+      contractFixtureFile('retention-notify/batch.json')
+    );
+  });
+});

--- a/services/api-gateway/src/services/retention/RetentionNotifyService.component.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionNotifyService.component.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Component test: the notify pipeline's write seams over REAL PGLite — the
+ * grace-clock stamp (one notice per spell), the bounce re-route into the
+ * unreachable purge branch, and the enqueue path's cohort resolution with a
+ * schema-validated batch payload.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { type PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import type { Queue } from 'bullmq';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { RetentionNotifyService } from './RetentionNotifyService.js';
+import { selectEligibleUsers } from './eligibility.js';
+
+vi.mock('@tzurot/common-types/utils/outboundDmAllowlist', () => ({
+  getOutboundDmAllowlist: () => null,
+}));
+
+const OLD = new Date('2020-01-01T00:00:00Z');
+
+const NOTIFY_TARGET = 'c0408000-0000-4000-8000-000000000001';
+const ACTIVE_USER = 'c0408000-0000-4000-8000-000000000002';
+
+let seq = 0;
+const nextId = (): string =>
+  `c0408000-0000-4000-8000-0000000001${(seq++).toString().padStart(2, '0')}`;
+
+describe('RetentionNotifyService (component, PGLite)', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+  let service: RetentionNotifyService;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+    service = new RetentionNotifyService(prisma);
+
+    for (const [id, name] of [
+      [NOTIFY_TARGET, 'notifytarget'],
+      [ACTIVE_USER, 'activeuser'],
+    ] as const) {
+      await seedUserWithPersona(prisma, {
+        userId: id,
+        personaId: nextId(),
+        discordId: `9100000000000000${(seq + 10).toString().padStart(2, '0')}`,
+        username: name,
+        personaName: `${name} Persona`,
+        personaContent: 'x',
+      });
+    }
+    await prisma.$executeRaw`
+      UPDATE users SET last_active_at = ${OLD} WHERE id = ${NOTIFY_TARGET}::uuid
+    `;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  });
+
+  it('enqueues the reachable-inactive cohort as a schema-valid batch', async () => {
+    const add = vi.fn().mockResolvedValue(undefined);
+    const queue = { add: vi.fn().mockResolvedValue(undefined) } as unknown as Queue;
+    (queue as unknown as { add: typeof add }).add = add;
+
+    // 1 of 2 fixture users = 50% — over the hard ceiling by construction, so
+    // the override is required here; the ceiling's own behavior is unit-tested.
+    const result = await service.enqueueNotifyRun(queue, {
+      now: () => new Date(0),
+      breakerOverride: true,
+    });
+
+    expect(result.status).toBe('enqueued');
+    expect(result.cohortSize).toBe(1);
+    // addValidatedJob parsed the payload against the job schema before this
+    // reached the queue — a malformed batch would have thrown, not enqueued.
+    expect(add).toHaveBeenCalledTimes(1);
+    const [, payload, opts] = add.mock.calls[0] as [
+      string,
+      { recipients: unknown[] },
+      { jobId: string },
+    ];
+    expect(payload.recipients).toHaveLength(1);
+    expect(opts.jobId).toMatch(/^retention-notify:/);
+  });
+
+  it('stamps the grace clock exactly once on sent (one notice per spell)', async () => {
+    const processed = await service.reportOutcomes([{ userId: NOTIFY_TARGET, status: 'sent' }]);
+    expect(processed).toBe(1);
+
+    const first = await prisma.user.findUnique({ where: { id: NOTIFY_TARGET } });
+    expect(first?.retentionNotifiedAt).not.toBeNull();
+
+    // A worker-retry re-report must not advance the clock (IS NULL guard).
+    await service.reportOutcomes([{ userId: NOTIFY_TARGET, status: 'sent' }]);
+    const second = await prisma.user.findUnique({ where: { id: NOTIFY_TARGET } });
+    expect(second?.retentionNotifiedAt?.getTime()).toBe(first?.retentionNotifiedAt?.getTime());
+  });
+
+  it('drops a warned user from the notify cohort and the eligibility filter', async () => {
+    // NOTIFY_TARGET now carries a grace stamp (previous test): the one-notice
+    // guard excludes them from selection and from the send-time re-check.
+    const eligible = await service.filterEligible([NOTIFY_TARGET, ACTIVE_USER]);
+    expect(eligible).toEqual([]);
+
+    const queue = { add: vi.fn() } as unknown as Queue;
+    const rerun = await service.enqueueNotifyRun(queue, { now: () => new Date(0) });
+    expect(rerun.status).toBe('empty');
+  });
+
+  it('re-routes a bounced notice into the unreachable purge branch (real SQL)', async () => {
+    await service.reportOutcomes([
+      { userId: NOTIFY_TARGET, status: 'failed_permanent', errorCode: '50278' },
+    ]);
+
+    const row = await prisma.user.findUnique({ where: { id: NOTIFY_TARGET } });
+    expect(row?.dmUndeliverableSince).not.toBeNull();
+    // The whole point of cohort discovery: the bounced user is now in the
+    // PURGE cohort, labeled unreachable (stamp outranks the grace clock).
+    const cohort = await selectEligibleUsers(prisma);
+    expect(cohort.map(r => r.userId)).toContain(NOTIFY_TARGET);
+    expect(cohort.find(r => r.userId === NOTIFY_TARGET)?.reason).toBe('unreachable');
+  });
+});

--- a/services/api-gateway/src/services/retention/RetentionNotifyService.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionNotifyService.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Queue } from 'bullmq';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { RetentionNotifyService } from './RetentionNotifyService.js';
+
+const mockAllowlist = vi.hoisted(() => vi.fn());
+vi.mock('@tzurot/common-types/utils/outboundDmAllowlist', () => ({
+  getOutboundDmAllowlist: mockAllowlist,
+}));
+
+const mockAddValidatedJob = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/validatedQueue.js', () => ({ addValidatedJob: mockAddValidatedJob }));
+
+const NOW = (): Date => new Date('2026-07-26T12:00:00.000Z');
+
+function cohortRow(n: number) {
+  return {
+    userId: `c0407000-0000-4000-8000-1000000000${String(n).padStart(2, '0')}`,
+    discordId: `90000000000000${String(n).padStart(4, '0')}`,
+    inactiveSince: new Date('2025-01-01T00:00:00Z'),
+  };
+}
+
+function makePrisma(opts: { cohort: unknown[]; userbase: number }) {
+  return {
+    // call 1 = selectNotifyCohort; later calls = report stamps / filter
+    $queryRaw: vi.fn().mockResolvedValue(opts.cohort),
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    user: { count: vi.fn().mockResolvedValue(opts.userbase) },
+  } as unknown as PrismaClient;
+}
+
+const queue = {} as Queue;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAllowlist.mockReturnValue(null);
+  mockAddValidatedJob.mockResolvedValue(undefined);
+});
+
+describe('RetentionNotifyService.enqueueNotifyRun', () => {
+  it('reports empty as the healthy steady state without enqueuing', async () => {
+    const service = new RetentionNotifyService(makePrisma({ cohort: [], userbase: 100 }));
+
+    const result = await service.enqueueNotifyRun(queue, { now: NOW });
+
+    expect(result.status).toBe('empty');
+    expect(result.batchesEnqueued).toBe(0);
+    expect(mockAddValidatedJob).not.toHaveBeenCalled();
+  });
+
+  it('enqueues 50-recipient batches with per-invocation-unique jobIds', async () => {
+    const cohort = Array.from({ length: 51 }, (_, i) => cohortRow(i));
+    const service = new RetentionNotifyService(makePrisma({ cohort, userbase: 1000 }));
+
+    const result = await service.enqueueNotifyRun(queue, { now: NOW, runContext: 'first-run' });
+
+    expect(result.status).toBe('enqueued');
+    expect(result.batchesEnqueued).toBe(2);
+    expect(mockAddValidatedJob).toHaveBeenCalledTimes(2);
+    // The seam assertion: batch 0 carries 50 recipients, batch 1 the remainder,
+    // and the jobId embeds the timestamped runId (cross-run collisions would
+    // silently swallow a later run's batch behind BullMQ's dedup).
+    const [, , payload0, opts0] = mockAddValidatedJob.mock.calls[0];
+    const [, , payload1] = mockAddValidatedJob.mock.calls[1];
+    expect(payload0.recipients).toHaveLength(50);
+    expect(payload1.recipients).toHaveLength(1);
+    expect(payload0.recipients[0]).toEqual({
+      userId: cohort[0].userId,
+      discordUserId: cohort[0].discordId,
+    });
+    expect(opts0.jobId).toBe('retention-notify:2026-07-26T12:00:00.000Z-first-run:0');
+  });
+
+  it('warn-annotates without refusing between the warn and hard fractions', async () => {
+    // 51 of 273 ≈ 18.7% — the expected first-real-run shape (zombie cohort).
+    const cohort = Array.from({ length: 51 }, (_, i) => cohortRow(i));
+    const service = new RetentionNotifyService(makePrisma({ cohort, userbase: 273 }));
+
+    const result = await service.enqueueNotifyRun(queue, { now: NOW });
+
+    expect(result.status).toBe('enqueued');
+    expect(result.breakerWarning).toBe(true);
+    expect(result.percentOfUserbase).toBe(18.7);
+  });
+
+  it('refuses over the hard ceiling without breakerOverride — and enqueues nothing', async () => {
+    const cohort = Array.from({ length: 30 }, (_, i) => cohortRow(i));
+    const service = new RetentionNotifyService(makePrisma({ cohort, userbase: 100 }));
+
+    const result = await service.enqueueNotifyRun(queue, { now: NOW });
+
+    expect(result.status).toBe('refused_breaker');
+    expect(result.breakerDetail).toContain('hard ceiling');
+    expect(mockAddValidatedJob).not.toHaveBeenCalled();
+  });
+
+  it('proceeds past the ceiling with an explicit breakerOverride', async () => {
+    const cohort = Array.from({ length: 30 }, (_, i) => cohortRow(i));
+    const service = new RetentionNotifyService(makePrisma({ cohort, userbase: 100 }));
+
+    const result = await service.enqueueNotifyRun(queue, { now: NOW, breakerOverride: true });
+
+    expect(result.status).toBe('enqueued');
+  });
+
+  it('dry-run reports the full cohort and enqueues nothing', async () => {
+    const cohort = [cohortRow(1), cohortRow(2)];
+    const service = new RetentionNotifyService(makePrisma({ cohort, userbase: 100 }));
+
+    const result = await service.enqueueNotifyRun(queue, { now: NOW, dryRun: true });
+
+    expect(result.status).toBe('dry_run');
+    expect(result.recipients).toHaveLength(2);
+    expect(mockAddValidatedJob).not.toHaveBeenCalled();
+  });
+});
+
+describe('RetentionNotifyService.reportOutcomes', () => {
+  const USER = 'c0407000-0000-4000-8000-100000000001';
+
+  function makeReportPrisma() {
+    const executeRaw = vi.fn().mockResolvedValue(1);
+    return {
+      prisma: { $executeRaw: executeRaw } as unknown as PrismaClient,
+      executeRaw,
+    };
+  }
+
+  it('stamps the grace clock on sent, IS NULL-guarded', async () => {
+    const { prisma, executeRaw } = makeReportPrisma();
+
+    const processed = await new RetentionNotifyService(prisma).reportOutcomes([
+      { userId: USER, status: 'sent' },
+    ]);
+
+    expect(processed).toBe(1);
+    const [strings] = executeRaw.mock.calls[0] as [TemplateStringsArray];
+    const text = strings.join('');
+    expect(text).toContain('retention_notified_at = NOW()');
+    expect(text).toContain('retention_notified_at IS NULL');
+    expect(text).not.toContain('updated_at');
+  });
+
+  it('routes a 50278 bounce to the unreachable stamp (the re-route arm)', async () => {
+    const { prisma, executeRaw } = makeReportPrisma();
+
+    await new RetentionNotifyService(prisma).reportOutcomes([
+      { userId: USER, status: 'failed_permanent', errorCode: '50278' },
+    ]);
+
+    const [strings] = executeRaw.mock.calls[0] as [TemplateStringsArray];
+    expect(strings.join('')).toContain('dm_undeliverable_since = NOW()');
+  });
+
+  it('stamps nothing for bot-level and transient outcomes', async () => {
+    const { prisma, executeRaw } = makeReportPrisma();
+
+    const processed = await new RetentionNotifyService(prisma).reportOutcomes([
+      { userId: USER, status: 'failed_bot_level', errorCode: '20026' },
+      { userId: USER, status: 'failed_transient' },
+    ]);
+
+    expect(processed).toBe(0);
+    expect(executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('propagates stamp failures so the worker report retries', async () => {
+    const { prisma, executeRaw } = makeReportPrisma();
+    executeRaw.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(
+      new RetentionNotifyService(prisma).reportOutcomes([{ userId: USER, status: 'sent' }])
+    ).rejects.toThrow('db down');
+  });
+});

--- a/services/api-gateway/src/services/retention/RetentionNotifyService.ts
+++ b/services/api-gateway/src/services/retention/RetentionNotifyService.ts
@@ -62,7 +62,7 @@ export class RetentionNotifyService {
    * the action being guarded (both the mass-warning and the quarantine risk).
    */
   async enqueueNotifyRun(
-    queue: Queue,
+    queue: Queue | null,
     options: NotifyRunOptions
   ): Promise<RetentionNotifyResponse> {
     const { dryRun = false, breakerOverride = false, runContext } = options;
@@ -106,6 +106,12 @@ export class RetentionNotifyService {
 
     if (dryRun) {
       return { ...base, status: 'dry_run', batchesEnqueued: 0 };
+    }
+
+    if (queue === null) {
+      // Only a REAL run needs the queue; dry runs and the empty/refused
+      // branches never reach here. Loud beats a silent no-op enqueue.
+      throw new Error('Retention notify queue is not configured');
     }
 
     // Unique per invocation — deliberately NOT deterministic across runs. The

--- a/services/api-gateway/src/services/retention/RetentionNotifyService.ts
+++ b/services/api-gateway/src/services/retention/RetentionNotifyService.ts
@@ -1,0 +1,184 @@
+/**
+ * Retention Phase 3 — the reachable branch's notify orchestration.
+ *
+ * Resolves the reachable-but-inactive cohort (eligibility.ts owns the
+ * predicate), enforces the breaker, and enqueues warning-DM batches to the
+ * retention-notify queue for bot-client's worker. Also owns the two write
+ * seams the worker reports back through: the send-time still-eligible filter
+ * and the per-recipient outcome stamps.
+ *
+ * Operator-driven only (manual-approval doctrine, like the purge) — nothing
+ * calls enqueueNotifyRun on a schedule; autonomous execution is Phase 4.
+ *
+ * Idempotency layers:
+ *   - CROSS-RUN: the predicate itself (retention_notified_at IS NULL) — a
+ *     re-run's cohort excludes everyone already warned, so re-running resumes.
+ *   - WITHIN-RUN: BullMQ job retries re-run the same batch; the worker's
+ *     pre-send filter (filterStillNotifyEligible) drops anyone stamped by the
+ *     earlier attempt, and every report stamp is IS NULL-guarded.
+ */
+
+import { type Queue } from 'bullmq';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { JobType } from '@tzurot/common-types/constants/queue';
+import type {
+  RetentionNotifyResponse,
+  RetentionNotifyReportRequestSchema,
+} from '@tzurot/common-types/schemas/api/internal';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { getOutboundDmAllowlist } from '@tzurot/common-types/utils/outboundDmAllowlist';
+import type { z } from 'zod';
+import { addValidatedJob } from '../../utils/validatedQueue.js';
+import {
+  filterStillNotifyEligible,
+  selectNotifyCohort,
+  type NotifyCohortRow,
+} from './eligibility.js';
+import { BREAKER_HARD_FRACTION, BREAKER_WARN_FRACTION } from './RetentionPurgeService.js';
+import { stampDmPermanentFailure } from './dmFailureStamps.js';
+
+const logger = createLogger('RetentionNotifyService');
+
+/** Mirror of the blast's batch size (also the job schema's recipients cap). */
+const NOTIFY_BATCH_SIZE = 50;
+
+type NotifyOutcome = z.infer<typeof RetentionNotifyReportRequestSchema>['outcomes'][number];
+
+export interface NotifyRunOptions {
+  dryRun?: boolean;
+  breakerOverride?: boolean;
+  runContext?: string;
+  /** Injectable clock for tests (runId uniqueness). */
+  now?: () => Date;
+}
+
+export class RetentionNotifyService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Resolve the cohort and enqueue warning-DM batches (or report what would
+   * be sent, for dryRun). The breaker bounds the SEND SET — the
+   * allowlist-narrowed cohort this run would actually DM — because mass-DM is
+   * the action being guarded (both the mass-warning and the quarantine risk).
+   */
+  async enqueueNotifyRun(
+    queue: Queue,
+    options: NotifyRunOptions
+  ): Promise<RetentionNotifyResponse> {
+    const { dryRun = false, breakerOverride = false, runContext } = options;
+    const now = options.now ?? ((): Date => new Date());
+
+    const [cohort, userbaseCount] = await Promise.all([
+      selectNotifyCohort(this.prisma, getOutboundDmAllowlist()),
+      this.prisma.user.count(),
+    ]);
+
+    const percentOfUserbase =
+      userbaseCount === 0 ? 0 : Math.round((cohort.length / userbaseCount) * 1000) / 10;
+    const base = {
+      cohortSize: cohort.length,
+      userbaseCount,
+      percentOfUserbase,
+      breakerWarning: userbaseCount > 0 && cohort.length / userbaseCount > BREAKER_WARN_FRACTION,
+      recipients: cohort.map(row => ({
+        discordId: row.discordId,
+        inactiveSince: row.inactiveSince.toISOString(),
+      })),
+    };
+
+    if (cohort.length === 0) {
+      return { ...base, status: 'empty', batchesEnqueued: 0 };
+    }
+
+    if (
+      userbaseCount > 0 &&
+      cohort.length / userbaseCount > BREAKER_HARD_FRACTION &&
+      !breakerOverride
+    ) {
+      const breakerDetail =
+        `Notify cohort is ${String(cohort.length)} of ${String(userbaseCount)} users ` +
+        `(${String(percentOfUserbase)}%), over the ${String(BREAKER_HARD_FRACTION * 100)}% hard ceiling. ` +
+        'A cohort this large usually means a tracking-signal glitch, not real churn. ' +
+        'Re-run with the breaker override only after confirming the numbers.';
+      logger.warn({ cohortSize: cohort.length, userbaseCount }, 'Notify run refused by breaker');
+      return { ...base, status: 'refused_breaker', batchesEnqueued: 0, breakerDetail };
+    }
+
+    if (dryRun) {
+      return { ...base, status: 'dry_run', batchesEnqueued: 0 };
+    }
+
+    // Unique per invocation — deliberately NOT deterministic across runs. The
+    // blast's stable jobIds dedup a re-announce of the same release; here the
+    // predicate is the cross-run dedup, and a reused jobId would silently
+    // swallow a later run's batch behind a completed earlier one.
+    const runId = `${now().toISOString()}${runContext !== undefined ? `-${runContext}` : ''}`;
+
+    let batches = 0;
+    for (let start = 0; start < cohort.length; start += NOTIFY_BATCH_SIZE) {
+      const slice: NotifyCohortRow[] = cohort.slice(start, start + NOTIFY_BATCH_SIZE);
+      await addValidatedJob(
+        queue,
+        JobType.RetentionNotifyDm,
+        {
+          requestId: `${runId}:${String(batches)}`,
+          jobType: JobType.RetentionNotifyDm,
+          responseDestination: { type: 'api' },
+          runId,
+          recipients: slice.map(row => ({ userId: row.userId, discordUserId: row.discordId })),
+        },
+        { jobId: `retention-notify:${runId}:${String(batches)}` }
+      );
+      batches += 1;
+    }
+
+    logger.info(
+      { cohortSize: cohort.length, batches, runContext: runContext ?? null },
+      'Retention notify run enqueued'
+    );
+    return { ...base, status: 'enqueued', batchesEnqueued: batches };
+  }
+
+  /** The worker's pre-send re-check — see eligibility.filterStillNotifyEligible. */
+  async filterEligible(userIds: string[]): Promise<string[]> {
+    const eligible = await filterStillNotifyEligible(this.prisma, userIds);
+    return userIds.filter(id => eligible.has(id));
+  }
+
+  /**
+   * Apply per-recipient delivery outcomes. `sent` stamps the grace clock
+   * (IS NULL-guarded: one notice per inactivity spell, and a batch re-report
+   * after a worker retry is a no-op); a permanent bounce stamps the
+   * unreachable column via the shared kernel — the re-route that moves the
+   * user to the existing purge branch. Bot-level (20026) and transient
+   * outcomes stamp nothing.
+   *
+   * THROWS on database failure (unlike the blast's swallow): these stamps ARE
+   * the terminal transition, and the worker's report retry is safe against
+   * the idempotent guards — a 500 here must retry, not strand.
+   */
+  async reportOutcomes(outcomes: NotifyOutcome[]): Promise<number> {
+    let processed = 0;
+    for (const outcome of outcomes) {
+      if (outcome.status === 'sent') {
+        await this.prisma.$executeRaw`
+          UPDATE users SET retention_notified_at = NOW()
+          WHERE id = ${outcome.userId}::uuid AND retention_notified_at IS NULL
+        `;
+        processed += 1;
+      } else if (outcome.status === 'failed_permanent') {
+        await stampDmPermanentFailure(this.prisma, outcome.userId, outcome.errorCode);
+        processed += 1;
+      } else {
+        // failed_bot_level / failed_transient: recorded in logs only — a
+        // quarantined bot or a network blip says nothing about the user, and
+        // the un-stamped user simply rides the next notify run.
+        logger.info(
+          { userId: outcome.userId, status: outcome.status, errorCode: outcome.errorCode },
+          'Notify outcome recorded without a stamp'
+        );
+      }
+    }
+    return processed;
+  }
+}

--- a/services/api-gateway/src/services/retention/RetentionNotifyService.ts
+++ b/services/api-gateway/src/services/retention/RetentionNotifyService.ts
@@ -164,17 +164,18 @@ export class RetentionNotifyService {
    * the idempotent guards — a 500 here must retry, not strand.
    */
   async reportOutcomes(outcomes: NotifyOutcome[]): Promise<number> {
+    // `processed` counts rows a stamp actually WROTE — a guarded no-op (the
+    // re-report of an already-stamped user, an unknown error code) adds 0, so
+    // the number means the same thing in every branch.
     let processed = 0;
     for (const outcome of outcomes) {
       if (outcome.status === 'sent') {
-        await this.prisma.$executeRaw`
+        processed += await this.prisma.$executeRaw`
           UPDATE users SET retention_notified_at = NOW()
           WHERE id = ${outcome.userId}::uuid AND retention_notified_at IS NULL
         `;
-        processed += 1;
       } else if (outcome.status === 'failed_permanent') {
-        await stampDmPermanentFailure(this.prisma, outcome.userId, outcome.errorCode);
-        processed += 1;
+        processed += await stampDmPermanentFailure(this.prisma, outcome.userId, outcome.errorCode);
       } else {
         // failed_bot_level / failed_transient: recorded in logs only — a
         // quarantined bot or a network blip says nothing about the user, and

--- a/services/api-gateway/src/services/retention/dmFailureStamps.test.ts
+++ b/services/api-gateway/src/services/retention/dmFailureStamps.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { stampDmPermanentFailure } from './dmFailureStamps.js';
+
+function makePrisma() {
+  const executeRaw = vi.fn().mockResolvedValue(1);
+  return { prisma: { $executeRaw: executeRaw } as unknown as PrismaClient, executeRaw };
+}
+
+function sql(call: unknown[]): string {
+  const [strings] = call as [TemplateStringsArray, ...unknown[]];
+  return strings.join('');
+}
+
+describe('stampDmPermanentFailure', () => {
+  it.each(['50278', '50007'])('stamps dm_undeliverable_since for %s', async code => {
+    const { prisma, executeRaw } = makePrisma();
+
+    await stampDmPermanentFailure(prisma, 'user-1', code);
+
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    const text = sql(executeRaw.mock.calls[0]);
+    expect(text).toContain('dm_undeliverable_since = NOW()');
+    // First-failure only — a live streak must never advance the stamp.
+    expect(text).toContain('dm_undeliverable_since IS NULL');
+    expect(text).not.toContain('updated_at');
+  });
+
+  it('stamps discord_account_gone_at for 10013', async () => {
+    const { prisma, executeRaw } = makePrisma();
+
+    await stampDmPermanentFailure(prisma, 'user-1', '10013');
+
+    const text = sql(executeRaw.mock.calls[0]);
+    expect(text).toContain('discord_account_gone_at = NOW()');
+    expect(text).toContain('discord_account_gone_at IS NULL');
+  });
+
+  it('stamps NOTHING for 20026 — a quarantined bot says nothing about the user', async () => {
+    const { prisma, executeRaw } = makePrisma();
+
+    await stampDmPermanentFailure(prisma, 'user-1', '20026');
+
+    expect(executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('stamps nothing for an unknown or missing code', async () => {
+    const { prisma, executeRaw } = makePrisma();
+
+    await stampDmPermanentFailure(prisma, 'user-1', '99999');
+    await stampDmPermanentFailure(prisma, 'user-1', undefined);
+
+    expect(executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('propagates database failures — swallow-vs-throw is the caller choice', async () => {
+    const { prisma, executeRaw } = makePrisma();
+    executeRaw.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(stampDmPermanentFailure(prisma, 'user-1', '50278')).rejects.toThrow('db down');
+  });
+});

--- a/services/api-gateway/src/services/retention/dmFailureStamps.ts
+++ b/services/api-gateway/src/services/retention/dmFailureStamps.ts
@@ -23,22 +23,25 @@
 
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 
+/** Returns the number of rows actually stamped (0 = guarded no-op or unknown code). */
 export async function stampDmPermanentFailure(
   prisma: PrismaClient,
   userId: string,
   errorCode: string | undefined
-): Promise<void> {
+): Promise<number> {
   if (errorCode === '50278' || errorCode === '50007') {
-    await prisma.$executeRaw`
+    return prisma.$executeRaw`
       UPDATE users SET dm_undeliverable_since = NOW()
       WHERE id = ${userId}::uuid AND dm_undeliverable_since IS NULL
     `;
-  } else if (errorCode === '10013') {
-    await prisma.$executeRaw`
+  }
+  if (errorCode === '10013') {
+    return prisma.$executeRaw`
       UPDATE users SET discord_account_gone_at = NOW()
       WHERE id = ${userId}::uuid AND discord_account_gone_at IS NULL
     `;
   }
   // Any other code (or none) stamps nothing: transient failures retry, and
   // unknown permanent codes must not guess at a user-state column.
+  return 0;
 }

--- a/services/api-gateway/src/services/retention/dmFailureStamps.ts
+++ b/services/api-gateway/src/services/retention/dmFailureStamps.ts
@@ -1,0 +1,44 @@
+/**
+ * The single home of the DM-permanent-failure → retention-column mapping.
+ *
+ * Two delivery pipelines report permanent DM failures — the release blast and
+ * the retention warning notice — and both must stamp identically: 50278 (left
+ * every shared server) / 50007 (DMs closed or bot blocked) → dm_undeliverable_since;
+ * 10013 (Unknown User — the account is deleted) → discord_account_gone_at.
+ * A second copy of this mapping is exactly the drift the single-predicate
+ * rule (eligibility.ts) exists to prevent on the read side.
+ *
+ * NEVER 20026 (bot-wide quarantine): that code describes the BOT's state, not
+ * the recipient's — keying on it would false-flag every user in one event.
+ * The IS NULL guards record the FIRST failure only (a live streak never
+ * advances the stamp); raw SQL keeps the columns off updated_at, the
+ * dev<->prod sync LWW resolver.
+ *
+ * THROWS on database failure — swallow-vs-propagate is the caller's call:
+ * the blast route swallows (its ledger row is already terminal, a 500 would
+ * strand it), the notify report route propagates (its stamps ARE the terminal
+ * transition, and the worker's retry makes a re-report safe via these same
+ * idempotent guards).
+ */
+
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+
+export async function stampDmPermanentFailure(
+  prisma: PrismaClient,
+  userId: string,
+  errorCode: string | undefined
+): Promise<void> {
+  if (errorCode === '50278' || errorCode === '50007') {
+    await prisma.$executeRaw`
+      UPDATE users SET dm_undeliverable_since = NOW()
+      WHERE id = ${userId}::uuid AND dm_undeliverable_since IS NULL
+    `;
+  } else if (errorCode === '10013') {
+    await prisma.$executeRaw`
+      UPDATE users SET discord_account_gone_at = NOW()
+      WHERE id = ${userId}::uuid AND discord_account_gone_at IS NULL
+    `;
+  }
+  // Any other code (or none) stamps nothing: transient failures retry, and
+  // unknown permanent codes must not guess at a user-state column.
+}

--- a/services/api-gateway/src/services/retention/eligibility.test.ts
+++ b/services/api-gateway/src/services/retention/eligibility.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Prisma } from '@tzurot/common-types/services/prisma';
+import { RETENTION_POLICY } from '@tzurot/common-types/constants/retention';
 import {
-  GRACE_PERIOD_DAYS,
-  RETENTION_WINDOW_DAYS,
   countEligibleUsers,
   countInGrace,
   countNotifyCohort,
@@ -72,8 +71,8 @@ describe('the eligibility predicate', () => {
     expect(sql).toContain('u.is_superuser = false');
     expect(sql).toContain('u.retention_exempt = false');
     // The windows are bound, not inlined — and they're the single named constants.
-    expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_WINDOW_DAYS);
-    expect(flattenValues(queryRaw.mock.calls[0])).toContain(GRACE_PERIOD_DAYS);
+    expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_POLICY.WINDOW_DAYS);
+    expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_POLICY.GRACE_PERIOD_DAYS);
 
     // NEGATIVE: the predicate must not silently widen to reachable users. A
     // purge that ignores reachability would erase people who could be notified.
@@ -145,7 +144,7 @@ describe('the notify predicate (Phase 3)', () => {
     expect(sql).toContain('COALESCE(u.last_active_at, u.created_at)');
     expect(sql).toContain('u.is_superuser = false');
     expect(sql).toContain('u.retention_exempt = false');
-    expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_WINDOW_DAYS);
+    expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_POLICY.WINDOW_DAYS);
   });
 
   it('narrows by the outbound-DM allowlist at the SQL level when one is set', async () => {
@@ -206,7 +205,7 @@ describe('the reporting counts', () => {
     expect(sql).toContain('u.retention_notified_at >=');
     expect(sql).toContain('u.is_superuser = false');
     expect(sql).toContain('u.retention_exempt = false');
-    expect(flattenValues(queryRaw.mock.calls[0])).toContain(GRACE_PERIOD_DAYS);
+    expect(flattenValues(queryRaw.mock.calls[0])).toContain(RETENTION_POLICY.GRACE_PERIOD_DAYS);
   });
 
   it('countInGrace excludes users an unreachable stamp already made purge-eligible', async () => {

--- a/services/api-gateway/src/services/retention/eligibility.ts
+++ b/services/api-gateway/src/services/retention/eligibility.ts
@@ -22,23 +22,12 @@
  */
 
 import { Prisma } from '@tzurot/common-types/services/prisma';
+import { RETENTION_POLICY } from '@tzurot/common-types/constants/retention';
 
-/**
- * The single retention window (epic decision: ONE 180-day window, not the
- * rejected flat-90d). Inactivity is measured from last_active_at, falling back
- * to created_at when the tracking clock never stamped (NULL = "no known
- * activity", never "active now").
- */
-export const RETENTION_WINDOW_DAYS = 180;
-
-/**
- * The reachable branch's grace window (Phase 3, owner call): days between the
- * warning DM landing and purge eligibility. The privacy policy states this
- * number once the notify pipeline ships (its rewrite rides the same release
- * that first writes retention_notified_at) — changing it is a policy change,
- * not a tuning knob.
- */
-export const GRACE_PERIOD_DAYS = 30;
+// The policy windows live in common-types (bot-client's notice copy states
+// the same numbers); this module remains the single home of the SQL that
+// consumes them. Local names keep the fragments readable.
+const { WINDOW_DAYS: RETENTION_WINDOW_DAYS, GRACE_PERIOD_DAYS } = RETENTION_POLICY;
 
 /**
  * Why a user is purge-eligible: the two unreachable signals (D13), or a
@@ -172,6 +161,10 @@ export interface NotifyCohortRow {
 
 /**
  * The reachable-but-inactive cohort awaiting a warning DM, oldest first.
+ *
+ * Unbounded by design, like selectEligibleUsers: the cohort IS the answer,
+ * and truncating it would under-report the number the notify breaker
+ * polices. The enqueue path slices it into bounded batches downstream.
  *
  * `allowlist` is OUTBOUND_DM_ALLOWLIST narrowing at the SQL level (the
  * release-blast precedent): out-of-scope users never enter a run, so a dev

--- a/services/api-gateway/src/utils/validatedQueue.ts
+++ b/services/api-gateway/src/utils/validatedQueue.ts
@@ -23,6 +23,7 @@ import {
   llmGenerationJobDataSchema,
   factExtractionJobDataSchema,
   releaseBroadcastDmJobDataSchema,
+  retentionNotifyDmJobDataSchema,
 } from '@tzurot/common-types/types/jobs';
 import {
   shapesImportJobDataSchema,
@@ -47,6 +48,7 @@ const SCHEMA_MAP: Record<JobType, ZodSchema> = {
   [JobType.AccountExport]: accountExportJobDataSchema,
   [JobType.FactExtraction]: factExtractionJobDataSchema,
   [JobType.ReleaseBroadcastDm]: releaseBroadcastDmJobDataSchema,
+  [JobType.RetentionNotifyDm]: retentionNotifyDmJobDataSchema,
 };
 
 /**

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -37,6 +37,7 @@ import { ResultsListener } from './services/ResultsListener.js';
 import { JobTracker } from './services/JobTracker.js';
 import { JobFailureListener } from './services/JobFailureListener.js';
 import { setupReleaseDmWorker } from './services/releaseDm/setupReleaseDmWorker.js';
+import { setupRetentionNotifyWorker } from './services/retentionNotice/setupRetentionNotifyWorker.js';
 import { ResponseOrderingService } from './services/ResponseOrderingService.js';
 import { DiscordResponseSender } from './services/DiscordResponseSender.js';
 import { MessageContextBuilder } from './services/MessageContextBuilder.js';
@@ -171,6 +172,7 @@ interface Services {
    * in shutdown so no DM send straddles the process teardown.
    */
   releaseDmWorker: Worker;
+  retentionNotifyWorker: Worker;
 }
 
 /**
@@ -195,6 +197,28 @@ function buildCacheRedis(): Redis {
  * This is where all dependencies are instantiated and wired together.
  * Full dependency injection - no service creates its own dependencies.
  */
+/** Denylist cache + its pub/sub invalidation — built together, used together. */
+function createDenylistServices(cacheRedis: Redis): {
+  denylistCache: DenylistCache;
+  denylistCacheInvalidationService: DenylistCacheInvalidationService;
+} {
+  return {
+    denylistCache: new DenylistCache(),
+    denylistCacheInvalidationService: new DenylistCacheInvalidationService(cacheRedis),
+  };
+}
+
+/**
+ * The two gateway-fed DM workers (release broadcast + retention notice) —
+ * constructed eagerly, together, so shutdown ownership is explicit.
+ */
+function createDmWorkers(): { releaseDmWorker: Worker; retentionNotifyWorker: Worker } {
+  return {
+    releaseDmWorker: setupReleaseDmWorker({ client }),
+    retentionNotifyWorker: setupRetentionNotifyWorker({ client }),
+  };
+}
+
 function createServices(): Services {
   // Composition Root. bot-client never touches Prisma — all DB-backed work
   // goes through the gateway's internal endpoints (HTTP), so there is no
@@ -230,9 +254,7 @@ function createServices(): Services {
     cacheRedis
   );
 
-  // Denylist cache and invalidation service
-  const denylistCache = new DenylistCache();
-  const denylistCacheInvalidationService = new DenylistCacheInvalidationService(cacheRedis);
+  const { denylistCache, denylistCacheInvalidationService } = createDenylistServices(cacheRedis);
 
   // Maintenance-window gate (destructive-migration windows; `pnpm ops maintenance`).
   const maintenanceFlag = new MaintenanceFlag(cacheRedis);
@@ -274,9 +296,7 @@ function createServices(): Services {
     connection: createBullMQRedisConfig(parseRedisUrl(envConfig.REDIS_URL!)),
   });
 
-  // Release-broadcast DM worker: consumes gateway-produced batches and sends
-  // the DMs. Constructed here (not lazily) so shutdown ownership is explicit.
-  const releaseDmWorker = setupReleaseDmWorker({ client });
+  const { releaseDmWorker, retentionNotifyWorker } = createDmWorkers();
 
   // Multi-tag stack: coordinator + Redis persistence + recovery service.
   // Persistence is shared with DMSessionProcessor (backfill sentinel).
@@ -353,6 +373,7 @@ function createServices(): Services {
     multiTagRecovery,
     multiTagStateQueue,
     releaseDmWorker,
+    retentionNotifyWorker,
     dmCacheWarmer,
   };
 }
@@ -616,6 +637,7 @@ async function disposeBotClient(): Promise<void> {
   // block the buffered-result delivery below, so it's caught and logged.
   try {
     await services.releaseDmWorker.close();
+    await services.retentionNotifyWorker.close();
     await services.resultsListener.stop();
     await services.jobFailureListener.stop();
     await services.multiTagCoordinator.beginShutdown();

--- a/services/bot-client/src/services/RetentionNagScheduler.test.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.test.ts
@@ -112,6 +112,21 @@ describe('RetentionNagScheduler runRetentionNagCheck', () => {
     expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
   });
 
+  it('posts when reachable users await a warning even with zero purge-eligible', async () => {
+    // The notify CLI is the operator's action for this state — a gate on
+    // eligibleCount alone would hide the reachable branch until someone
+    // separately became unreachable.
+    const redis = makeRedis(null);
+    mockRetentionPreview.mockResolvedValue({
+      ok: true,
+      data: makePreview({ eligibleCount: 0, userCount: 0, reachableToNotify: 51 }),
+    });
+
+    await runRetentionNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+  });
+
   it('swallows a failed preview fetch (next daily tick retries)', async () => {
     mockRetentionPreview.mockResolvedValue({ ok: false, error: 'gateway down' });
     const redis = makeRedis(null);

--- a/services/bot-client/src/services/RetentionNagScheduler.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.ts
@@ -104,6 +104,7 @@ export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): Embed
     .setFooter({
       text:
         `Review: pnpm ops retention:preview --env ${env} · ` +
+        `Notify: pnpm ops retention:notify --env ${env} · ` +
         `Purge: pnpm ops retention:purge --env ${env}`,
     })
     .setTimestamp();
@@ -118,7 +119,11 @@ export async function runRetentionNagCheck(client: Client, redis: Redis): Promis
       return;
     }
     const preview = result.data;
-    if (preview.totals.eligibleCount === 0) {
+    // Nag when EITHER branch needs the operator: a purge-eligible cohort, or
+    // reachable-inactive users awaiting a warning DM (the notify CLI exists
+    // now, so that state is actionable). Mid-grace users need nobody's
+    // attention — the clock is doing the work.
+    if (preview.totals.eligibleCount === 0 && preview.totals.reachableToNotify === 0) {
       return;
     }
 

--- a/services/bot-client/src/services/channelFetcher/messageTypeFilters.ts
+++ b/services/bot-client/src/services/channelFetcher/messageTypeFilters.ts
@@ -7,6 +7,7 @@
 
 import type { Message } from 'discord.js';
 import { isReleaseNotesDm } from '../releaseDm/releaseDmContext.js';
+import { isRetentionNoticeDm } from '../retentionNotice/noticeContent.js';
 
 /**
  * Check if a message is a thinking block output
@@ -67,6 +68,7 @@ export function isContextExcludedBotMessage(msg: Message, botUserId: string): bo
   return (
     isBotTranscriptReply(msg, botUserId) ||
     isThinkingBlockMessage(msg) ||
-    isReleaseNotesDm(msg, botUserId)
+    isReleaseNotesDm(msg, botUserId) ||
+    isRetentionNoticeDm(msg, botUserId)
   );
 }

--- a/services/bot-client/src/services/retentionNotice/noticeContent.test.ts
+++ b/services/bot-client/src/services/retentionNotice/noticeContent.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import type { Message } from 'discord.js';
+import {
+  buildRetentionNotice,
+  isRetentionNoticeDm,
+  RETENTION_NOTICE_FOOTER,
+} from './noticeContent.js';
+
+const SENT_AT = new Date('2026-08-01T12:00:00.000Z');
+const BOT_ID = '999999999999999999';
+
+function makeMessage(authorId: string, content: string): Message {
+  return { author: { id: authorId }, content } as Message;
+}
+
+describe('buildRetentionNotice', () => {
+  it('stays inside the Discord budget with the footer attached', () => {
+    const full = buildRetentionNotice(SENT_AT) + RETENTION_NOTICE_FOOTER;
+
+    // Same 1800-char discipline as the release DM: comfortable headroom
+    // under Discord's 2000 cap.
+    expect(full.length).toBeLessThanOrEqual(1800);
+  });
+
+  it('renders the concrete deletion deadline as a localized Discord timestamp', () => {
+    const notice = buildRetentionNotice(SENT_AT);
+
+    // SENT_AT plus the 30-day grace window, as a unix epoch.
+    expect(notice).toContain('<t:1788177600:D>');
+    expect(notice).toContain('30 days from this notice');
+  });
+
+  it('offers the three affordances and never an expiring export link', () => {
+    const notice = buildRetentionNotice(SENT_AT);
+
+    expect(notice).toContain('use the bot once');
+    expect(notice).toContain('/settings data export');
+    expect(notice).toContain('/settings data delete');
+    expect(notice).not.toContain('/exports/');
+    expect(notice).toContain('180 days');
+  });
+
+  it('explains the shared-character re-home rather than promising total deletion', () => {
+    // The policy's one exception must be IN the notice — a user who reads
+    // "everything is erased" and later finds their shared character alive
+    // was misinformed by us.
+    expect(buildRetentionNotice(SENT_AT)).toContain('holding account');
+  });
+});
+
+describe('isRetentionNoticeDm', () => {
+  it('matches a bot-authored message carrying the footer', () => {
+    const msg = makeMessage(BOT_ID, `warning body${RETENTION_NOTICE_FOOTER}`);
+
+    expect(isRetentionNoticeDm(msg, BOT_ID)).toBe(true);
+  });
+
+  it('never matches a USER quoting the footer text (author check first)', () => {
+    const msg = makeMessage('111111111111111111', `look at this${RETENTION_NOTICE_FOOTER}`);
+
+    expect(isRetentionNoticeDm(msg, BOT_ID)).toBe(false);
+  });
+
+  it('ignores ordinary bot messages', () => {
+    expect(isRetentionNoticeDm(makeMessage(BOT_ID, 'hello there'), BOT_ID)).toBe(false);
+  });
+});

--- a/services/bot-client/src/services/retentionNotice/noticeContent.ts
+++ b/services/bot-client/src/services/retentionNotice/noticeContent.ts
@@ -1,0 +1,62 @@
+/**
+ * Retention warning-notice copy + extended-context exclusion (Phase 3).
+ *
+ * The footer doubles as the marker by which extended-context fetching
+ * recognizes a retention notice — same mechanism as the release DM's
+ * OPT_OUT_FOOTER: bot-authored notifications are not conversation, and
+ * without the exclusion a persona would ingest the deletion warning as
+ * something the user said.
+ *
+ * Deliberate policy properties of this copy (owner-reviewed wording):
+ *   - It states the CONCRETE deletion date (send time + grace), rendered as a
+ *     Discord timestamp so it localizes to the reader.
+ *   - It never carries an export LINK — export links expire in 24h and this
+ *     notice may sit unread for weeks; it points at the self-serve command.
+ *   - It is NOT gated on notification opt-in (a data-rights notice, not
+ *     marketing) and offers no opt-out — the "opt-out" is using the bot once,
+ *     or deleting the account now.
+ */
+
+import type { Message } from 'discord.js';
+import { RETENTION_POLICY } from '@tzurot/common-types/constants/retention';
+
+/**
+ * Distinctive, bot-controlled, present on every retention notice by
+ * construction — the exclusion marker (see isRetentionNoticeDm).
+ */
+export const RETENTION_NOTICE_FOOTER =
+  '\n\n-# This is an automated data-retention notice. Using the bot once keeps your account.';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Compose the warning DM. `sentAt` anchors the grace deadline (send time). */
+export function buildRetentionNotice(sentAt: Date): string {
+  const deadline = new Date(sentAt.getTime() + RETENTION_POLICY.GRACE_PERIOD_DAYS * DAY_MS);
+  const deadlineTag = `<t:${String(Math.floor(deadline.getTime() / 1000))}:D>`;
+
+  return (
+    '**Your data is scheduled for deletion.**\n\n' +
+    `This account has not used the bot in over ${String(RETENTION_POLICY.WINDOW_DAYS)} days. ` +
+    'Under the data-retention policy, inactive accounts are erased: conversations, memories, ' +
+    'characters, personas, and settings.\n\n' +
+    `**Deletion date: on or after ${deadlineTag}** ` +
+    `(${String(RETENTION_POLICY.GRACE_PERIOD_DAYS)} days from this notice).\n\n` +
+    '• **To keep everything** — use the bot once. Any command or chat message resets your ' +
+    'inactivity clock entirely.\n' +
+    '• **To take a copy first** — run `/settings data export` for a full export (download link ' +
+    'valid 24 hours).\n' +
+    '• **To delete now instead of waiting** — run `/settings data delete`.\n\n' +
+    'A character you created that other people have talked to is not deleted — it is moved to a ' +
+    'holding account so their conversations survive, and it can be returned to you if you come back.'
+  );
+}
+
+/**
+ * Author check first so a user quoting the footer text is never filtered —
+ * mirrors isReleaseNotesDm.
+ */
+const FOOTER_MARKER = RETENTION_NOTICE_FOOTER.trimStart();
+
+export function isRetentionNoticeDm(msg: Message, botUserId: string): boolean {
+  return msg.author.id === botUserId && msg.content.includes(FOOTER_MARKER);
+}

--- a/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.test.ts
+++ b/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the retention notify worker processor (the seams that matter:
+ * still-eligible filter → sequential sends with pacing → per-recipient
+ * outcome report that drives the grace clock and the unreachable re-route).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordAPIError, type Client } from 'discord.js';
+import { JobType } from '@tzurot/common-types/constants/queue';
+import type { Job } from 'bullmq';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const postOwnerChannelEmbedMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/ownerChannel.js', () => ({
+  postOwnerChannelEmbed: postOwnerChannelEmbedMock,
+}));
+
+const { createRetentionNotifyProcessor } = await import('./setupRetentionNotifyWorker.js');
+
+const USER_A = '423e4567-e89b-42d3-a456-426614174000';
+const USER_B = '523e4567-e89b-42d3-a456-426614174000';
+
+function makePayload() {
+  return {
+    requestId: 'run-1:0',
+    jobType: JobType.RetentionNotifyDm,
+    responseDestination: { type: 'api' },
+    runId: 'run-1',
+    recipients: [
+      { userId: USER_A, discordUserId: '111111111111111111' },
+      { userId: USER_B, discordUserId: '222222222222222222' },
+    ],
+  };
+}
+
+function makeDeps(sendImpl?: (discordId: string) => Promise<unknown>) {
+  const send = vi.fn().mockResolvedValue({ id: 'sent-msg-1' });
+  const fetch = vi.fn().mockImplementation((discordId: string) =>
+    Promise.resolve({
+      id: discordId,
+      send: sendImpl !== undefined ? () => sendImpl(discordId) : send,
+    })
+  );
+  const client = { users: { fetch } } as unknown as Client;
+  const sleep = vi.fn().mockResolvedValue(undefined);
+  const filterEligible = vi.fn().mockResolvedValue([USER_A, USER_B]);
+  const report = vi.fn().mockResolvedValue(true);
+  return { client, sleep, filterEligible, report, fetch, send };
+}
+
+function asJob(data: unknown): Job {
+  return { id: 'job-1', data } as unknown as Job;
+}
+
+describe('createRetentionNotifyProcessor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends to every still-eligible recipient with pacing, reporting each immediately', async () => {
+    const deps = makeDeps();
+    const processor = createRetentionNotifyProcessor(deps);
+
+    const result = await processor(asJob(makePayload()));
+
+    expect(deps.filterEligible).toHaveBeenCalledWith([USER_A, USER_B]);
+    expect(deps.send).toHaveBeenCalledTimes(2);
+    const sendArg = deps.send.mock.calls[0][0] as { content: string; allowedMentions: unknown };
+    // The notice carries the policy numbers, the self-serve affordances, and
+    // the exclusion footer — never an export link (they expire in 24h).
+    expect(sendArg.content).toContain('180 days');
+    expect(sendArg.content).toContain('/settings data export');
+    expect(sendArg.content).toContain('/settings data delete');
+    expect(sendArg.content).toContain('data-retention notice');
+    expect(sendArg.content).not.toContain('/exports/');
+    expect(sendArg.allowedMentions).toEqual({ parse: [] });
+    // One sleep between two sends, none after the last.
+    expect(deps.sleep).toHaveBeenCalledTimes(1);
+    // One report PER SEND (crash-window guard) — the seam that stamps grace.
+    expect(deps.report).toHaveBeenNthCalledWith(1, [{ userId: USER_A, status: 'sent' }]);
+    expect(deps.report).toHaveBeenNthCalledWith(2, [{ userId: USER_B, status: 'sent' }]);
+    expect(result).toEqual({ sent: 2, bounced: 0, skipped: 0 });
+  });
+
+  it('skips recipients no longer notify-eligible (activity since resolution / stall re-run)', async () => {
+    const deps = makeDeps();
+    deps.filterEligible.mockResolvedValue([USER_B]);
+    const processor = createRetentionNotifyProcessor(deps);
+
+    const result = await processor(asJob(makePayload()));
+
+    expect(deps.send).toHaveBeenCalledTimes(1);
+    expect(deps.report).toHaveBeenCalledWith([{ userId: USER_B, status: 'sent' }]);
+    expect(result).toEqual({ sent: 1, bounced: 0, skipped: 1 });
+  });
+
+  it('reports a 50278 bounce as failed_permanent — the cohort-discovery yield', async () => {
+    const gone = new DiscordAPIError(
+      { code: 50278, message: 'No mutual guilds' },
+      50278,
+      403,
+      'POST',
+      'url',
+      {}
+    );
+    const deps = makeDeps(discordId =>
+      discordId === '111111111111111111' ? Promise.reject(gone) : Promise.resolve({ id: 's' })
+    );
+    const processor = createRetentionNotifyProcessor(deps);
+
+    const result = await processor(asJob(makePayload()));
+
+    expect(deps.report).toHaveBeenNthCalledWith(1, [
+      { userId: USER_A, status: 'failed_permanent', errorCode: '50278' },
+    ]);
+    expect(result).toEqual({ sent: 1, bounced: 1, skipped: 0 });
+  });
+
+  it('reports a 20026 as failed_bot_level — never a user-state signal (dev quarantine)', async () => {
+    const quarantined = new DiscordAPIError(
+      { code: 20026, message: 'Bot cannot initiate DMs' },
+      20026,
+      403,
+      'POST',
+      'url',
+      {}
+    );
+    const deps = makeDeps(() => Promise.reject(quarantined));
+    const processor = createRetentionNotifyProcessor(deps);
+
+    const result = await processor(asJob(makePayload()));
+
+    expect(deps.report).toHaveBeenNthCalledWith(1, [
+      { userId: USER_A, status: 'failed_bot_level', errorCode: '20026' },
+    ]);
+    expect(result).toEqual({ sent: 0, bounced: 0, skipped: 0 });
+  });
+
+  it('posts the owner-channel batch tally (delivery results outlive the CLI call)', async () => {
+    const deps = makeDeps();
+    const processor = createRetentionNotifyProcessor(deps);
+
+    await processor(asJob(makePayload()));
+
+    expect(postOwnerChannelEmbedMock).toHaveBeenCalledTimes(1);
+    const embed = postOwnerChannelEmbedMock.mock.calls[0][1] as {
+      toJSON: () => { description?: string };
+    };
+    expect(embed.toJSON().description).toContain('2 warned');
+  });
+
+  it('fail-skips an invalid payload without touching Discord or the gateway', async () => {
+    const deps = makeDeps();
+    const processor = createRetentionNotifyProcessor(deps);
+
+    const result = await processor(asJob({ nope: true }));
+
+    expect(deps.filterEligible).not.toHaveBeenCalled();
+    expect(deps.send).not.toHaveBeenCalled();
+    expect(result).toEqual({ sent: 0, bounced: 0, skipped: 0 });
+  });
+
+  it('propagates a filter failure so BullMQ retries the batch (nothing sent)', async () => {
+    const deps = makeDeps();
+    deps.filterEligible.mockRejectedValue(new Error('gateway down'));
+    const processor = createRetentionNotifyProcessor(deps);
+
+    await expect(processor(asJob(makePayload()))).rejects.toThrow('gateway down');
+    expect(deps.send).not.toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.ts
+++ b/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.ts
@@ -66,12 +66,13 @@ const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTi
 /** Send one warning DM; returns the report outcome. */
 async function sendOne(
   client: Client,
-  recipient: RetentionNotifyRecipient
+  recipient: RetentionNotifyRecipient,
+  sentAt: Date
 ): Promise<Omit<NotifyOutcomeReport, 'userId'>> {
   try {
     const user = await client.users.fetch(recipient.discordUserId);
     await user.send({
-      content: buildRetentionNotice(new Date()) + RETENTION_NOTICE_FOOTER,
+      content: buildRetentionNotice(sentAt) + RETENTION_NOTICE_FOOTER,
       allowedMentions: { parse: [] },
     });
     return { status: 'sent' };
@@ -110,9 +111,12 @@ export function createRetentionNotifyProcessor(deps: RetentionNotifyWorkerDeps) 
 
     let sent = 0;
     let bounced = 0;
+    // One anchor per batch: with 1/sec pacing a batch straddling midnight
+    // would otherwise show different deletion DATES within the same run.
+    const sentAt = new Date();
     for (let i = 0; i < toSend.length; i++) {
       const recipient = toSend[i];
-      const outcome = await sendOne(deps.client, recipient);
+      const outcome = await sendOne(deps.client, recipient, sentAt);
       // Report EACH outcome immediately: a mid-batch crash then leaves at most
       // one sent-but-unstamped user for the pre-send filter to re-drop.
       await report([{ userId: recipient.userId, ...outcome }]);

--- a/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.ts
+++ b/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.ts
@@ -1,0 +1,186 @@
+/**
+ * Retention warning-DM worker — bot-client's BullMQ consumer for the
+ * retention-notify queue (api-gateway produces the batches; Phase 3).
+ *
+ * Delivery discipline mirrors the release-DM worker:
+ *   - Re-filters the batch against the notify predicate before sending
+ *     (a user active since cohort resolution must not get a deletion
+ *     warning; a stalled-and-rerun batch never double-DMs).
+ *   - Sends sequentially, 1/sec pacing — background sends must not
+ *     head-of-line block the shared discord.js REST queue.
+ *   - Classifies failures (dmErrorClassifier) and reports EACH outcome
+ *     immediately: sent → the grace clock; a permanent bounce → the
+ *     unreachable stamp that re-routes the user to the purge branch;
+ *     bot-level (20026, dev quarantine) and transient → no stamp.
+ *   - Posts a per-batch owner-channel tally — the operator's CLI returns at
+ *     enqueue time, so this embed is where delivery results surface.
+ */
+
+import { Worker, type Job } from 'bullmq';
+import { EmbedBuilder, type Client } from 'discord.js';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { RETENTION_NOTIFY_QUEUE_NAME } from '@tzurot/common-types/constants/queue';
+import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
+import {
+  retentionNotifyDmJobDataSchema,
+  type RetentionNotifyRecipient,
+} from '@tzurot/common-types/types/jobs';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { parseRedisUrl, createBullMQRedisConfig } from '@tzurot/common-types/utils/redis';
+import { classifyDmError, dmErrorCode } from '../../utils/dmErrorClassifier.js';
+import {
+  filterNotifyEligible,
+  reportNotifyOutcomes,
+  type NotifyOutcomeReport,
+} from '../../utils/gatewayServiceCalls.js';
+import { postOwnerChannelEmbed } from '../../utils/ownerChannel.js';
+import { buildRetentionNotice, RETENTION_NOTICE_FOOTER } from './noticeContent.js';
+
+const logger = createLogger('RetentionNotifyWorker');
+
+/** Inter-DM delay — the same REST-queue-friendly pacing as the release worker. */
+const DM_SEND_DELAY_MS = 1000;
+
+/** Classified failure kind → report status (bot_level is its own terminal outcome). */
+const OUTCOME_STATUS_BY_KIND = {
+  permanent: 'failed_permanent',
+  bot_level: 'failed_bot_level',
+  transient: 'failed_transient',
+} as const satisfies Record<
+  ReturnType<typeof classifyDmError>['kind'],
+  NotifyOutcomeReport['status']
+>;
+
+export interface RetentionNotifyWorkerDeps {
+  client: Client;
+  /** Injectable for fake-timer tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable gateway seams for tests (default: real calls). */
+  filterEligible?: typeof filterNotifyEligible;
+  report?: typeof reportNotifyOutcomes;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/** Send one warning DM; returns the report outcome. */
+async function sendOne(
+  client: Client,
+  recipient: RetentionNotifyRecipient
+): Promise<Omit<NotifyOutcomeReport, 'userId'>> {
+  try {
+    const user = await client.users.fetch(recipient.discordUserId);
+    await user.send({
+      content: buildRetentionNotice(new Date()) + RETENTION_NOTICE_FOOTER,
+      allowedMentions: { parse: [] },
+    });
+    return { status: 'sent' };
+  } catch (error) {
+    const classified = classifyDmError(error);
+    logger.warn(
+      { userId: recipient.userId, kind: classified.kind, code: dmErrorCode(classified) },
+      'Retention notice DM failed'
+    );
+    return { status: OUTCOME_STATUS_BY_KIND[classified.kind], errorCode: dmErrorCode(classified) };
+  }
+}
+
+/** The processor body — exported for direct seam-testing without a real queue. */
+export function createRetentionNotifyProcessor(deps: RetentionNotifyWorkerDeps) {
+  const sleep = deps.sleep ?? defaultSleep;
+  const filterEligible = deps.filterEligible ?? filterNotifyEligible;
+  const report = deps.report ?? reportNotifyOutcomes;
+
+  return async (job: Job): Promise<{ sent: number; bounced: number; skipped: number }> => {
+    const parsed = retentionNotifyDmJobDataSchema.safeParse(job.data);
+    if (!parsed.success) {
+      // Fail-to-skip: a malformed payload can never succeed on retry.
+      logger.error({ jobId: job.id, issues: parsed.error.issues }, 'Invalid notify payload');
+      return { sent: 0, bounced: 0, skipped: 0 };
+    }
+    const data = parsed.data;
+
+    // Throws on gateway failure — BEFORE any spend, so BullMQ's retry re-runs
+    // the whole batch rather than completing it silently undelivered.
+    const eligibleIds = new Set(
+      await filterEligible(data.recipients.map(recipient => recipient.userId))
+    );
+    const toSend = data.recipients.filter(recipient => eligibleIds.has(recipient.userId));
+    const skipped = data.recipients.length - toSend.length;
+
+    let sent = 0;
+    let bounced = 0;
+    for (let i = 0; i < toSend.length; i++) {
+      const recipient = toSend[i];
+      const outcome = await sendOne(deps.client, recipient);
+      // Report EACH outcome immediately: a mid-batch crash then leaves at most
+      // one sent-but-unstamped user for the pre-send filter to re-drop.
+      await report([{ userId: recipient.userId, ...outcome }]);
+      if (outcome.status === 'sent') {
+        sent += 1;
+      } else if (outcome.status === 'failed_permanent') {
+        bounced += 1;
+      }
+      if (i < toSend.length - 1) {
+        await sleep(DM_SEND_DELAY_MS);
+      }
+    }
+
+    logger.info({ runId: data.runId, sent, bounced, skipped }, 'Retention notify batch processed');
+    await postBatchReport(deps.client, { sent, bounced, skipped, total: toSend.length });
+    return { sent, bounced, skipped };
+  };
+}
+
+/**
+ * Per-batch owner-channel tally (best-effort — the helper swallows failures).
+ * Bounced users are the cohort-discovery yield: they just became purge-eligible.
+ */
+async function postBatchReport(
+  client: Client,
+  tally: { sent: number; bounced: number; skipped: number; total: number }
+): Promise<void> {
+  const failedOtherwise = tally.total - tally.sent - tally.bounced;
+  const embed = new EmbedBuilder()
+    .setColor(DISCORD_COLORS.BLURPLE)
+    .setTitle('📪 Retention notice batch delivered')
+    .setDescription(
+      `${String(tally.sent)} warned (grace clock started), ` +
+        `${String(tally.bounced)} bounced (now purge-eligible as unreachable), ` +
+        `${String(failedOtherwise)} failed without a stamp, ` +
+        `${String(tally.skipped)} skipped (active again or already warned)`
+    )
+    .setTimestamp();
+  await postOwnerChannelEmbed(client, embed);
+}
+
+/** Construct (but don't start-gate) the worker; caller owns close(). */
+export function setupRetentionNotifyWorker(deps: RetentionNotifyWorkerDeps): Worker {
+  const config = getConfig();
+  if (config.REDIS_URL === undefined || config.REDIS_URL.length === 0) {
+    throw new Error('REDIS_URL environment variable is required');
+  }
+  const connection = createBullMQRedisConfig(parseRedisUrl(config.REDIS_URL));
+
+  const worker = new Worker(RETENTION_NOTIFY_QUEUE_NAME, createRetentionNotifyProcessor(deps), {
+    connection,
+    // Sequential batches: notices are background work; the per-DM sleep paces.
+    concurrency: 1,
+    lockDuration: TIMEOUTS.WORKER_LOCK_DURATION,
+    // One stall-recovery re-run for deploy-killed batches; the pre-send
+    // filter makes the re-run spend-safe (no double-DMs).
+    maxStalledCount: 1,
+  });
+
+  worker.on('failed', (job, err) => {
+    logger.warn({ jobId: job?.id, err }, 'Notify batch failed (BullMQ will retry)');
+  });
+  worker.on('stalled', (jobId: string) => {
+    logger.warn({ jobId }, 'Notify batch stalled (owning process died) — re-queued');
+  });
+  worker.on('error', err => {
+    logger.error({ err }, 'Retention notify worker error');
+  });
+
+  return worker;
+}

--- a/services/bot-client/src/utils/gatewayServiceCalls.test.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.test.ts
@@ -21,6 +21,8 @@ const mockServiceClient = {
   aiConfirmDelivery: vi.fn(),
   releaseBroadcastPending: vi.fn(),
   releaseBroadcastDeliveries: vi.fn(),
+  retentionNotifyFilter: vi.fn(),
+  retentionNotifyReport: vi.fn(),
 };
 
 vi.mock('./gatewayClients.js', () => ({
@@ -42,6 +44,8 @@ import {
   confirmDelivery,
   filterPendingDeliveries,
   reportDeliveries,
+  filterNotifyEligible,
+  reportNotifyOutcomes,
   transcribe,
   healthCheck,
   invalidateChannelSettingsCache,
@@ -184,6 +188,56 @@ describe('fire-and-forget helpers', () => {
     expect(mockServiceClient.stampUserActivity).toHaveBeenCalledWith({
       discordId: '123456789012345678',
     });
+  });
+
+  it('filterNotifyEligible THROWS on gateway failure (pre-send: BullMQ must retry)', async () => {
+    mockServiceClient.retentionNotifyFilter.mockResolvedValue(err(503));
+    await expect(filterNotifyEligible(['u-1'])).rejects.toThrow('Notify-eligibility filter failed');
+  });
+
+  it('filterNotifyEligible forwards { userIds } and returns the eligible subset', async () => {
+    mockServiceClient.retentionNotifyFilter.mockResolvedValue(
+      ok({ stillEligibleUserIds: ['u-1'] })
+    );
+    await expect(filterNotifyEligible(['u-1', 'u-2'])).resolves.toEqual(['u-1']);
+    expect(mockServiceClient.retentionNotifyFilter).toHaveBeenCalledWith({
+      userIds: ['u-1', 'u-2'],
+    });
+  });
+
+  it('reportNotifyOutcomes retries a transient failure, then succeeds', async () => {
+    vi.useFakeTimers();
+    try {
+      mockServiceClient.retentionNotifyReport
+        .mockResolvedValueOnce({ ok: false, kind: 'network', error: 'x', status: 0 })
+        .mockResolvedValueOnce(ok({ processed: 1 }));
+
+      const promise = reportNotifyOutcomes([{ userId: 'u-1', status: 'sent' }]);
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBe(true);
+
+      expect(mockServiceClient.retentionNotifyReport).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reportNotifyOutcomes NEVER throws after retries exhaust (post-send contract)', async () => {
+    vi.useFakeTimers();
+    try {
+      mockServiceClient.retentionNotifyReport.mockResolvedValue({
+        ok: false,
+        kind: 'network',
+        error: 'x',
+        status: 0,
+      });
+
+      const promise = reportNotifyOutcomes([{ userId: 'u-1', status: 'sent' }]);
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('filterPendingDeliveries THROWS on gateway failure (pre-send: BullMQ must retry)', async () => {

--- a/services/bot-client/src/utils/gatewayServiceCalls.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.ts
@@ -374,6 +374,60 @@ export async function reportDeliveries(
   return undefined;
 }
 
+/**
+ * Retention notify: the worker's send-time still-eligible re-check. THROWS on
+ * gateway failure — this runs BEFORE any DM is sent (same before-spend
+ * contract as filterPendingDeliveries), so failing the job lets BullMQ's
+ * retry re-run the batch instead of silently skipping it.
+ */
+export async function filterNotifyEligible(userIds: string[]): Promise<string[]> {
+  const result = await getServiceClient().retentionNotifyFilter({ userIds });
+  if (!result.ok) {
+    logger.error({ status: result.status }, 'Failed to filter notify-eligible users');
+    throw new Error(`Notify-eligibility filter failed: ${result.status} ${result.error}`);
+  }
+  return result.data.stillEligibleUserIds;
+}
+
+/** One reported notify outcome (mirrors the internal-route contract). */
+export interface NotifyOutcomeReport {
+  userId: string;
+  status: 'sent' | 'failed_permanent' | 'failed_bot_level' | 'failed_transient';
+  errorCode?: string;
+}
+
+/**
+ * Report retention-notice outcomes. AFTER-spend contract (mirrors
+ * reportDeliveries): retries transient gateway failures, then returns false
+ * and never throws — the DM has already happened, and the stamps'
+ * IS NULL guards make the pre-send filter absorb an eventual re-run.
+ */
+export async function reportNotifyOutcomes(outcomes: NotifyOutcomeReport[]): Promise<boolean> {
+  if (outcomes.length === 0) {
+    return true;
+  }
+  for (let attempt = 1; attempt <= REPORT_MAX_ATTEMPTS; attempt++) {
+    const result = await getServiceClient().retentionNotifyReport({ outcomes });
+    if (result.ok) {
+      return true;
+    }
+    if (!isRetryableGatewayFailure(result) || attempt === REPORT_MAX_ATTEMPTS) {
+      logger.error(
+        { status: result.status, attempt },
+        'Failed to report notify outcomes — un-stamped users ride the next run'
+      );
+      return false;
+    }
+    const delayMs = REPORT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    logger.warn(
+      { status: result.status, attempt, nextDelayMs: delayMs },
+      'Transient failure reporting notify outcomes; retrying'
+    );
+    await new Promise(resolve => setTimeout(resolve, delayMs));
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Raw-fetch helpers (the two sanctioned exceptions to typed-client usage).
 //

--- a/tests/e2e/contracts/RetentionNotifyDm.contract.test.ts
+++ b/tests/e2e/contracts/RetentionNotifyDm.contract.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Contract test: retention-notify DM batch (api-gateway producer → bot-client consumer).
+ *
+ * Reads the COMMITTED fixture written by the producer half
+ * (`services/api-gateway/src/services/retention/RetentionNotifyContract.producer.test.ts`,
+ * which runs the REAL `enqueueNotifyRun`) and validates the captured batch
+ * against the notify worker's entry schema — the same `safeParse` gate
+ * `createRetentionNotifyProcessor` applies before sending anything.
+ *
+ * Non-circular by construction: the payload is REAL producer output, so a
+ * drift in `enqueueNotifyRun` that breaks the consumer schema (renamed field,
+ * missing key, oversized batch) fails HERE.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { loadContractFixture } from '@tzurot/test-utils';
+import { JobType } from '@tzurot/common-types/constants/queue';
+import { retentionNotifyDmJobDataSchema } from '@tzurot/common-types/types/jobs';
+
+interface CapturedBatch {
+  name: string;
+  data: unknown;
+  opts?: { jobId?: string };
+}
+
+describe('Contract: retention-notify DM batch (real producer fixture → consumer schema)', () => {
+  let batch: CapturedBatch;
+
+  beforeAll(() => {
+    batch = loadContractFixture<CapturedBatch>('retention-notify/batch.json');
+  });
+
+  it('is enqueued under the RetentionNotifyDm job type with a runId-scoped jobId', () => {
+    expect(batch.name).toBe(JobType.RetentionNotifyDm);
+    expect(batch.opts?.jobId).toMatch(/^retention-notify:.+:0$/);
+  });
+
+  it("validates against the notify worker's entry schema (its safeParse gate)", () => {
+    const parsed = retentionNotifyDmJobDataSchema.safeParse(batch.data);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('carries the fields the worker reads: internal ids and snowflakes', () => {
+    const data = retentionNotifyDmJobDataSchema.parse(batch.data);
+    expect(data.runId.length).toBeGreaterThan(0);
+    expect(data.recipients.length).toBeGreaterThan(0);
+    for (const recipient of data.recipients) {
+      expect(recipient.userId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(recipient.discordUserId).toMatch(/^\d{17,19}$/);
+    }
+  });
+});


### PR DESCRIPTION
## What

The reachable branch's capability half — **PR-E2 of two** (E1 #1800 shipped the substrate). Design authority: the accepted epic + Phase-3 build notes; owner calls: 30-day grace · single notice · reclamation deferred.

- **Pipeline**: new `retention-notify` BullMQ queue (its own queue — the release queue's at-least-once bound depends on staying single-purpose) → gateway `RetentionNotifyService` (allowlist-narrowed SQL cohort, warn/hard breaker reusing the purge fractions, per-invocation-unique jobIds — a reused jobId would let BullMQ dedup swallow a later run's batch) → bot-client worker mirroring the release-DM worker (pre-send still-eligible filter throws before spend; 1/sec sequential sends; per-recipient immediate reporting; per-batch owner-channel tally, since the CLI returns at enqueue time).
- **Stamps**: `sent` → grace clock (`IS NULL`-guarded, one notice per spell); 50278/50007/10013 → the unreachable columns via a **shared kernel extracted from the release report route** (`dmFailureStamps.ts` — one code→column mapping for both delivery pipelines); 20026/transient → nothing. Report-route stamp failures THROW (worker retry is idempotent-safe) — deliberately unlike the blast's swallow, whose ledger row is already terminal.
- **Contract discipline**: the new cross-service seam gets the broadcast treatment — a producer test runs the REAL `enqueueNotifyRun` and commits the fixture; `tests/e2e/contracts/RetentionNotifyDm.contract.test.ts` validates it against the worker's safeParse gate; the coverage topology carries the surface with its own producer probe.
- **Riders**: `retention:notify` CLI (dry-run-first flow, prod-confirm names the count, two-flag breaker discipline) · nag gate widens to the reachable branch + notify footer command (both round-3 review items from E1) · policy windows moved to `common-types/constants/retention.ts` (the notice copy and the SQL predicates must state the same numbers) · conformance fixtures for the three routes (dry runs no longer require the queue — they never enqueue).

## 📢 Owner review requested: two public-facing texts

**1. The warning DM copy** (`noticeContent.ts`) — what an inactive user receives:

> **Your data is scheduled for deletion.**
>
> This account has not used the bot in over 180 days. Under the data-retention policy, inactive accounts are erased: conversations, memories, characters, personas, and settings.
>
> **Deletion date: on or after <localized date>** (30 days from this notice).
>
> • **To keep everything** — use the bot once. Any command or chat message resets your inactivity clock entirely.
> • **To take a copy first** — run `/settings data export` for a full export (download link valid 24 hours).
> • **To delete now instead of waiting** — run `/settings data delete`.
>
> A character you created that other people have talked to is not deleted — it is moved to a holding account so their conversations survive, and it can be returned to you if you come back.
>
> -# This is an automated data-retention notice. Using the bot once keeps your account.

No export links (they die in 24h; the notice may sit unread for weeks). The footer doubles as the extended-context exclusion marker (personas never ingest the notice as user speech). Deliberately NOT gated on notification opt-in — data-rights notice, not marketing.

**2. The privacy-policy rewrite** (live at /privacy on release) — § "Inactive, unreachable accounts" becomes § "Inactive accounts" with the two-path form; the old "Either condition alone is not enough" promise is replaced by "Inactivity alone never erases anything silently while you are reachable: the notice and its grace period always come first."

## Verified

- `pnpm test` (26 tasks) + `pnpm quality` green sequential; pre-push full gate green twice.
- Component (PGLite, real SQL): grace stamp lands exactly once (worker-retry re-report is a no-op); a warned user leaves the notify cohort AND the send-time filter; a 50278 bounce lands the user in the PURGE cohort labeled `unreachable` — the cohort-discovery loop proven end to end.
- Worker unit suite mirrors the release worker's: classification per code (20026 = non-signal), per-recipient report seam assertions, pacing under fake timers, filter-failure → batch retry.
- Producer→consumer contract fixture is real `enqueueNotifyRun` output, byte-compared in CI.

## Behavior notes for the first prod run

`pnpm ops retention:notify --env prod` will show the ~15-18% **warn** annotation (backfilled zombie cohort — expected, the CLI says so) and requires typed prod confirmation naming the recipient count. Nothing sends on a schedule; autonomy is Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CPD baseline note (reviewer-requested)

The +25-line ratchet move is NOT the worker skeleton (that mirror never tripped the post-filter). It is the `retention:notify` CLI's entry preamble cloning `retention:purge`'s (validate → banner → resolve client → preview-fetch error handling) — a **new member of the already-filed env-scoped-op preamble extraction pass** in `cold/follow-ups.md`. Deliberate: the batch owns the extraction; a third instance strengthens its case rather than justifying a one-off helper here.
