### PR TITLE
docs: state the notify worker's real crash-window semantics

### DIFF
--- a/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.ts
+++ b/services/bot-client/src/services/retentionNotice/setupRetentionNotifyWorker.ts
@@ -117,8 +117,13 @@ export function createRetentionNotifyProcessor(deps: RetentionNotifyWorkerDeps) 
     for (let i = 0; i < toSend.length; i++) {
       const recipient = toSend[i];
       const outcome = await sendOne(deps.client, recipient, sentAt);
-      // Report EACH outcome immediately: a mid-batch crash then leaves at most
-      // one sent-but-unstamped user for the pre-send filter to re-drop.
+      // Report EACH outcome immediately. Nothing after the send can THROW
+      // (sendOne catches, report retries-then-swallows), so the only mid-batch
+      // interruption is process death: a stall re-run then re-sends at most
+      // ONE sent-but-unstamped recipient (at-least-once, the accepted model).
+      // Everyone reported with a TERMINAL outcome (sent / permanent bounce) is
+      // dropped by the pre-send filter; bot-level and transient failures are
+      // un-stamped by design and correctly ride the re-run — no DM reached them.
       await report([{ userId: recipient.userId, ...outcome }]);
       if (outcome.status === 'sent') {
         sent += 1;


### PR DESCRIPTION
Follow-up to the beta.178 release review's second observation: the worker's crash-window comment described a scenario the code's no-throw contracts make impossible, while omitting the real residual (process-death → one duplicate notice on the stall re-run, at-least-once by design). Comment-only change; the reviewer's trace was verified against sendOne's catch-all and reportNotifyOutcomes' retry-then-swallow contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)