### PR TITLE
feat: bystander split — deletion notice only for accounts that actually used the bot

### DIFF
--- a/docs/legal/PRIVACY_POLICY.md
+++ b/docs/legal/PRIVACY_POLICY.md
@@ -2,7 +2,7 @@
 
 **Status: In effect.**
 
-_Last updated: 2026-07-25_
+_Last updated: 2026-07-26_
 
 Tzurot is a Discord bot that lets you talk with AI characters. It is operated by an individual developer ("the operator", "we"). This policy explains what data the bot stores, why, where it goes, and what control you have over it. It is written to describe what the software actually does — nothing more.
 
@@ -56,10 +56,18 @@ still reach you:
   longer exists — your account may be erased without the notice, because there
   is no way to deliver one.
 
-Inactivity alone never erases anything silently while you are reachable: the
-notice and its grace period always come first. Any activity resets your
-inactivity clock; a notification that successfully reaches you resets the
-unreachability state.
+Inactivity alone never erases an account you actually used while you are
+reachable: the notice and its grace period always come first. Any activity
+resets your inactivity clock; a notification that successfully reaches you
+resets the unreachability state.
+
+One narrow exception to the notice: accounts with no sign of direct use. If
+your row shows no trace of actually using the bot — no conversations with its
+characters, no characters or personas you created, no keys or notification
+settings you configured — it holds nothing you made, and it is removed without notice once
+inactive. Such rows usually exist only because you spoke in a channel the bot
+could see. There is nothing to export, and a deletion notice from a bot you
+never really used would be noise, not information.
 
 Erasure is complete — everything `/settings data delete` removes, this removes.
 It differs from that self-serve deletion in exactly one way, and the difference

--- a/docs/proposals/backlog/inactivity-retention-purge-phase2.md
+++ b/docs/proposals/backlog/inactivity-retention-purge-phase2.md
@@ -168,6 +168,18 @@ The split isolates the enabling refactor (B) from the new capability (D) and kee
 
 **Three owner calls (2026-07-26):** 30-day grace window (`GRACE_PERIOD_DAYS`, published in the privacy policy — a policy number, not a tuning knob) · single notice per inactivity spell (reminder DM deferred; trigger = first grace cycle completes) · reclamation flow + orphan admin commands deferred (trigger = first purge actually re-homes a character). Both deferrals filed in `cold/follow-ups.md`.
 
+**The bystander split (owner call, 2026-07-26, pre-first-notify).** A prod
+classification of the first notify cohort found 32 of 53 were
+bystander-shaped: auto-provisioned rows (extended-context speakers) with no
+usage logs, no deliberate-use stamp, no created content. Cold-DMing them a
+deletion notice is the beta.174 spam class, and the notice protects content
+someone chose to create — which they have none of. Owner picked: notify only
+DELIBERATE users (usage logs / notify_opted_in_at / owned characters / BYOK
+keys / extra personas — the `DELIBERATE_USE` fragment in eligibility.ts);
+bystander-shaped accounts purge WITHOUT notice via a fourth eligibility arm
+(reason `bystander`), same 180-day bar, policy amended with the
+no-notice-for-never-users exception.
+
 **Split: PR-E1 + PR-E2.** E1 (read-only substrate): `users.retention_notified_at` + the grace-expired third arm on the purge predicate + the sibling notify predicates in `eligibility.ts` + preview/nag/CLI reachable-branch counts + activity-clears (grace aborts on use; deliberately NOT cleared by blast-send success — reach is not use). Inert until E2 writes the stamp. E2 (the notify capability): separate `retention-notify` BullMQ queue + bot-client worker mirroring the release-DM worker (1/sec pacing, per-recipient reporting, `classifyDmError` reuse — 20026 is a non-signal everywhere) + report routes stamping via a shared DM-failure helper extracted from `releaseBroadcast` + `retention:notify` CLI (manual-approval; breaker fractions reused) + notice copy with its own extended-context exclusion marker + the privacy-policy two-path rewrite (the current "Either condition alone is not enough" sentence is replaced; ships in the same release as the capability, ≥30 days before any grace-expired purge can exist).
 
 ---

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -705,6 +705,7 @@ describe('RetentionPreviewResponseSchema', () => {
       reachableToNotify: 0,
       inGrace: 0,
       graceExpired: 0,
+      bystander: 0,
     },
   };
 

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -308,10 +308,11 @@ export const RetentionPreviewUserSchema = z.object({
   inactiveSince: z.string().datetime(),
   /**
    * Label precedence mirrors signal strength: `account_gone` (Discord 10013)
-   * beats `unreachable`, which beats `grace_expired` (the Phase-3 reachable
-   * branch: warned, then silent through the whole grace window).
+   * beats `unreachable`, which beats the reachable reasons — `grace_expired`
+   * (warned, then silent through the whole grace window) and `bystander`
+   * (never deliberately used the bot; purged without notice by owner call).
    */
-  reason: z.enum(['unreachable', 'account_gone', 'grace_expired']),
+  reason: z.enum(['unreachable', 'account_gone', 'grace_expired', 'bystander']),
   ownedCharacters: z.object({
     /** Nobody else has data on them — deleted with the account. */
     toDelete: z.number().int().nonnegative(),
@@ -337,6 +338,8 @@ export const RetentionPreviewResponseSchema = z.object({
     inGrace: z.number().int().nonnegative(),
     /** Warned, window expired, still silent — the grace_expired purge subset. */
     graceExpired: z.number().int().nonnegative(),
+    /** Never deliberately used the bot — the silent-purge subset of the cohort. */
+    bystander: z.number().int().nonnegative(),
   }),
 });
 

--- a/packages/tooling/src/retention/preview.test.ts
+++ b/packages/tooling/src/retention/preview.test.ts
@@ -23,6 +23,7 @@ const EMPTY_TOTALS = {
   reachableToNotify: 0,
   inGrace: 0,
   graceExpired: 0,
+  bystander: 0,
 };
 
 const COHORT = {
@@ -50,6 +51,7 @@ const COHORT = {
     reachableToNotify: 0,
     inGrace: 0,
     graceExpired: 0,
+    bystander: 0,
   },
 };
 
@@ -145,6 +147,20 @@ describe('renderPreview', () => {
     expect(output).toContain('Discord account deleted');
     expect(output).toContain('2 would be re-homed');
     expect(output).toContain('Read-only');
+    logSpy.mockRestore();
+  });
+
+  it('appends the bystander note to the totals line only when the count is non-zero', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    renderPreview(COHORT);
+    expect(logSpy.mock.calls.flat().join('\n')).not.toContain('no notice owed');
+
+    logSpy.mockClear();
+    renderPreview({ ...COHORT, totals: { ...COHORT.totals, bystander: 3 } });
+    expect(logSpy.mock.calls.flat().join('\n')).toContain(
+      '3 never used the bot directly (no notice owed)'
+    );
     logSpy.mockRestore();
   });
 

--- a/packages/tooling/src/retention/preview.ts
+++ b/packages/tooling/src/retention/preview.ts
@@ -29,6 +29,7 @@ const REASON_LABEL: Record<RetentionPreviewResponse['users'][number]['reason'], 
   unreachable: 'DMs closed / left every shared server',
   account_gone: 'Discord account deleted',
   grace_expired: 'warned, grace window expired',
+  bystander: 'never used the bot directly (no notice sent)',
 };
 
 /** The reachable branch's pipeline states — printed on both cohort branches. */
@@ -77,7 +78,10 @@ export function renderPreview(preview: RetentionPreviewResponse): void {
   console.log(chalk.bold('\nTotals:'));
   console.log(
     `  eligible: ${totals.eligibleCount} of ${totals.userbaseCount} users ` +
-      `(${totals.percentOfUserbase}% of the userbase)`
+      `(${totals.percentOfUserbase}% of the userbase)` +
+      (totals.bystander > 0
+        ? ` — ${String(totals.bystander)} never used the bot directly (no notice owed)`
+        : '')
   );
   console.log(
     `  characters: ${totals.charactersToDelete} would be deleted, ` +

--- a/packages/tooling/src/retention/purge.test.ts
+++ b/packages/tooling/src/retention/purge.test.ts
@@ -35,6 +35,7 @@ function cohort(...discordIds: string[]) {
       reachableToNotify: 0,
       inGrace: 0,
       graceExpired: 0,
+      bystander: 0,
     },
   };
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,6 +178,9 @@ model RetentionPurgeLog {
 
 /// Tracks API usage per user for monitoring, billing, and abuse prevention.
 /// Even with BYOK, we track usage to prevent infrastructure abuse.
+/// Row EXISTENCE is deliberate-use evidence for retention (eligibility.ts
+/// DELIBERATE_USE): TTL-pruning this table independently would demote users
+/// to bystander — check that fragment's precedence argument before adding one.
 model UsageLog {
   id          String   @id @db.Uuid
   userId      String   @map("user_id") @db.Uuid

--- a/services/api-gateway/src/routes/internal/retentionPreview.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionPreview.test.ts
@@ -34,6 +34,7 @@ const PREVIEW = {
     reachableToNotify: 0,
     inGrace: 0,
     graceExpired: 0,
+    bystander: 0,
   },
 };
 
@@ -73,6 +74,7 @@ describe('GET /internal/retention/preview', () => {
         reachableToNotify: 0,
         inGrace: 0,
         graceExpired: 0,
+        bystander: 0,
       },
     });
     const { req, res } = createMockReqRes();

--- a/services/api-gateway/src/services/retention/RetentionNotifyService.component.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionNotifyService.component.test.ts
@@ -51,8 +51,11 @@ describe('RetentionNotifyService (component, PGLite)', () => {
         personaContent: 'x',
       });
     }
+    // Deliberate-use stamp: only accounts that actually used the bot get the
+    // warning DM (bystander-shaped rows purge without notice instead).
     await prisma.$executeRaw`
-      UPDATE users SET last_active_at = ${OLD} WHERE id = ${NOTIFY_TARGET}::uuid
+      UPDATE users SET last_active_at = ${OLD}, notify_opted_in_at = ${OLD}
+      WHERE id = ${NOTIFY_TARGET}::uuid
     `;
   });
 

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
@@ -34,6 +34,9 @@ const NEVER_STAMPED_YOUNG = 'c0407000-0000-4000-8000-000000000007';
 const GRACE_EXPIRED_USER = 'c0407000-0000-4000-8000-000000000008';
 const IN_GRACE_USER = 'c0407000-0000-4000-8000-000000000009';
 const MID_GRACE_BUT_BOUNCED = 'c0407000-0000-4000-8000-00000000000a';
+const BYSTANDER = 'c0407000-0000-4000-8000-00000000000b';
+const CO_OWNER = 'c0407000-0000-4000-8000-00000000000c';
+const NOTIFIED_EVIDENCE_LOST = 'c0407000-0000-4000-8000-00000000000d';
 
 const PERSONALITY_SHARED = 'c0407000-0000-4000-8000-0000000000a1';
 const PERSONALITY_SOLO = 'c0407000-0000-4000-8000-0000000000a2';
@@ -77,6 +80,9 @@ describe('RetentionPurgeService (component, PGLite)', () => {
       [GRACE_EXPIRED_USER, 'graceexpired'],
       [IN_GRACE_USER, 'ingrace'],
       [MID_GRACE_BUT_BOUNCED, 'gracebounced'],
+      [BYSTANDER, 'bystanderrow'],
+      [CO_OWNER, 'coownergrant'],
+      [NOTIFIED_EVIDENCE_LOST, 'gracefloor'],
     ] as const) {
       await seed(id, name);
     }
@@ -104,9 +110,29 @@ describe('RetentionPurgeService (component, PGLite)', () => {
       UPDATE users SET dm_undeliverable_since = ${OLD}, last_active_at = ${RECENT}
       WHERE id = ${ACTIVE_RECENTLY}::uuid
     `;
-    // Inactive but REACHABLE → excluded (Phase 2 is the unreachable branch only).
+    // Inactive but REACHABLE and DELIBERATE (opted-in stamp) → the notify
+    // cohort, never the silent-purge arm.
     await prisma.$executeRaw`
-      UPDATE users SET last_active_at = ${OLD} WHERE id = ${REACHABLE}::uuid
+      UPDATE users SET last_active_at = ${OLD}, notify_opted_in_at = ${OLD}
+      WHERE id = ${REACHABLE}::uuid
+    `;
+    // Inactive, reachable, and BYSTANDER-shaped (no usage, no stamp, no
+    // characters, only the auto-persona) → purges WITHOUT notice. This fixture
+    // also represents the command-only-history class: slash commands leave no
+    // durable per-user trace, so a browse-only user is indistinguishable from
+    // a pure bystander in the data — the owner ruled both purge silently, and
+    // the policy text describes the evidence bar, not command history.
+    await prisma.$executeRaw`
+      UPDATE users SET last_active_at = ${OLD} WHERE id = ${BYSTANDER}::uuid
+    `;
+    // Inactive, reachable, and holding a co-ownership GRANT on someone else's
+    // character as the ONLY deliberate-use evidence (the grant row is inserted
+    // below, after its personality exists). Inert in prod today (the sole
+    // writer self-duplicates ownerId), but a real grantee must classify
+    // deliberate — silent erasure would revoke live access to the granted
+    // character. Mirrors findCrossUserReachIds' fourth arm.
+    await prisma.$executeRaw`
+      UPDATE users SET last_active_at = ${OLD} WHERE id = ${CO_OWNER}::uuid
     `;
     // Unreachable + inactive, but exempted two different ways → excluded.
     await prisma.$executeRaw`
@@ -126,13 +152,15 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     // Phase 3 (reachable branch): warned 31 days ago, silent since → the
     // grace-expired arm makes them purge-eligible with NO unreachable flag.
     await prisma.$executeRaw`
-      UPDATE users SET retention_notified_at = ${GRACE_EXPIRED_STAMP}, last_active_at = ${OLD}
+      UPDATE users SET retention_notified_at = ${GRACE_EXPIRED_STAMP}, last_active_at = ${OLD},
+                       notify_opted_in_at = ${OLD}
       WHERE id = ${GRACE_EXPIRED_USER}::uuid
     `;
     // Warned 5 days ago → mid-grace: excluded from the purge cohort AND from
     // the notify cohort (one notice per spell), counted in inGrace.
     await prisma.$executeRaw`
-      UPDATE users SET retention_notified_at = ${IN_GRACE_STAMP}, last_active_at = ${OLD}
+      UPDATE users SET retention_notified_at = ${IN_GRACE_STAMP}, last_active_at = ${OLD},
+                       notify_opted_in_at = ${OLD}
       WHERE id = ${IN_GRACE_USER}::uuid
     `;
     // Mid-grace AND a later DM bounced: the unreachable arm makes them
@@ -140,8 +168,18 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     // never also in inGrace. The disjointness case from review round 1.
     await prisma.$executeRaw`
       UPDATE users SET retention_notified_at = ${IN_GRACE_STAMP}, dm_undeliverable_since = ${OLD},
-                       last_active_at = ${OLD}
+                       last_active_at = ${OLD}, notify_opted_in_at = ${OLD}
       WHERE id = ${MID_GRACE_BUT_BOUNCED}::uuid
+    `;
+    // Mid-grace with ZERO deliberate-use evidence (no opt-in stamp seeded).
+    // Unreachable via any app path today — the activity clear wipes the grace
+    // stamp on any evidence-losing action — but a non-user path (TTL prune,
+    // moderation removal) could produce it. The bystander arm's never-notified
+    // gate keeps the 30-day floor unconditional: excluded from the cohort
+    // until grace actually expires, still counted in inGrace.
+    await prisma.$executeRaw`
+      UPDATE users SET retention_notified_at = ${IN_GRACE_STAMP}, last_active_at = ${OLD}
+      WHERE id = ${NOTIFIED_EVIDENCE_LOST}::uuid
     `;
 
     // Characters owned by the unreachable user: SHARED has another user's
@@ -160,6 +198,12 @@ describe('RetentionPurgeService (component, PGLite)', () => {
         senders: ['otheractive'],
       },
     });
+    // CO_OWNER's grant (see the fixture comment above): a personality_owners
+    // row naming a user other than the personality's owner.
+    await prisma.$executeRaw`
+      INSERT INTO personality_owners (personality_id, user_id, role, created_at, updated_at)
+      VALUES (${PERSONALITY_SHARED}::uuid, ${CO_OWNER}::uuid, 'co-owner', NOW(), NOW())
+    `;
   });
 
   afterAll(async () => {
@@ -171,16 +215,26 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     const cohort = await service.selectPurgeCohort();
 
     expect(cohort.map(row => row.userId).sort()).toEqual(
-      [ELIGIBLE_UNREACHABLE, ELIGIBLE_GONE, GRACE_EXPIRED_USER, MID_GRACE_BUT_BOUNCED].sort()
+      [
+        ELIGIBLE_UNREACHABLE,
+        ELIGIBLE_GONE,
+        GRACE_EXPIRED_USER,
+        MID_GRACE_BUT_BOUNCED,
+        BYSTANDER,
+      ].sort()
     );
     // Every exclusion is load-bearing — name them so a regression is legible.
     const ids = cohort.map(row => row.userId);
     expect(ids).not.toContain(ACTIVE_RECENTLY); // active again
-    expect(ids).not.toContain(REACHABLE); // still reachable, never warned
+    expect(ids).not.toContain(REACHABLE); // reachable + DELIBERATE, never warned
     expect(ids).not.toContain(IN_GRACE_USER); // warned, grace window still running
     expect(ids).not.toContain(SUPERUSER); // bot owner
     expect(ids).not.toContain(EXEMPT); // retention_exempt (also the orphan sentinel)
     expect(ids).not.toContain(NEVER_STAMPED_YOUNG); // NULL last_active_at → created_at fallback
+    expect(ids).not.toContain(CO_OWNER); // a co-ownership grant is deliberate use, never bystander
+    // The grace floor is unconditional: a served notice blocks the bystander
+    // arm even when every deliberate-use signal is gone.
+    expect(ids).not.toContain(NOTIFIED_EVIDENCE_LOST);
   });
 
   it('labels each eligible user with the signal that made them eligible', async () => {
@@ -192,6 +246,8 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     expect(byId.get(GRACE_EXPIRED_USER)).toBe('grace_expired');
     // Precedence in real SQL: the unreachable stamp outranks the grace clock.
     expect(byId.get(MID_GRACE_BUT_BOUNCED)).toBe('unreachable');
+    // A never-used row qualifies by that fact alone — no notice, no stamps.
+    expect(byId.get(BYSTANDER)).toBe('bystander');
   });
 
   it('reports the character split and userbase share in the preview', async () => {
@@ -203,26 +259,31 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     expect(preview.totals.charactersToDelete).toBe(1);
     expect(preview.totals.charactersToReHome).toBe(1);
 
-    expect(preview.totals.eligibleCount).toBe(4);
-    expect(preview.totals.userbaseCount).toBe(11);
-    // 4/11 ≈ 36.4% — over the 15% warn line, so the breaker annotation fires.
-    expect(preview.totals.percentOfUserbase).toBe(36.4);
+    expect(preview.totals.eligibleCount).toBe(5);
+    expect(preview.totals.userbaseCount).toBe(14);
+    // 5/14 ≈ 35.7% — over the 15% warn line, so the breaker annotation fires.
+    expect(preview.totals.percentOfUserbase).toBe(35.7);
     expect(preview.totals.breakerWarning).toBe(true);
-    // Reachable-branch pipeline: REACHABLE awaits a warning, IN_GRACE_USER is
-    // mid-grace, and grace_expired is the labeled subset of the cohort above.
+    // Reachable-branch pipeline: REACHABLE and CO_OWNER await a warning;
+    // IN_GRACE_USER and NOTIFIED_EVIDENCE_LOST are mid-grace (the latter
+    // exactly once — the grace floor keeps it out of the cohort); and
+    // grace_expired is the labeled subset of the cohort above.
     // MID_GRACE_BUT_BOUNCED is in the cohort (unreachable) and must NOT also
     // count as in-grace — the counts partition, never double-report.
-    expect(preview.totals.reachableToNotify).toBe(1);
-    expect(preview.totals.inGrace).toBe(1);
+    expect(preview.totals.reachableToNotify).toBe(2);
+    expect(preview.totals.inGrace).toBe(2);
     expect(preview.totals.graceExpired).toBe(1);
+    expect(preview.totals.bystander).toBe(1);
   });
 
   it('selects the notify cohort disjoint from the purge cohort (real SQL)', async () => {
     const cohort = await selectNotifyCohort(prisma, null);
 
-    // Only REACHABLE: inactive ≥180d, no unreachable stamps, never warned.
-    // Everyone warned, flagged, exempt, young, or recently active is out.
-    expect(cohort.map(row => row.userId)).toEqual([REACHABLE]);
+    // REACHABLE (opt-in stamp) and CO_OWNER (grant arm): inactive ≥180d, no
+    // unreachable stamps, never warned, and DELIBERATE. Everyone warned,
+    // flagged, exempt, young, recently active, or bystander-shaped is out —
+    // bystanders purge without notice.
+    expect(cohort.map(row => row.userId).sort()).toEqual([REACHABLE, CO_OWNER].sort());
   });
 
   it('narrows the notify cohort by the outbound-DM allowlist in SQL', async () => {
@@ -237,11 +298,13 @@ describe('RetentionPurgeService (component, PGLite)', () => {
   it('filterStillNotifyEligible drops users who no longer qualify (real SQL)', async () => {
     const eligible = await filterStillNotifyEligible(prisma, [
       REACHABLE,
+      CO_OWNER, // deliberate via the grant arm — stays notify-eligible
       IN_GRACE_USER, // already warned
       ACTIVE_RECENTLY, // unreachable-stamped
+      BYSTANDER, // never deliberately used the bot — silent-purge arm, no DM
     ]);
 
-    expect(eligible).toEqual(new Set([REACHABLE]));
+    expect(eligible).toEqual(new Set([REACHABLE, CO_OWNER]));
   });
 });
 

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
@@ -45,6 +45,7 @@ describe('RetentionPurgeService.buildPreview', () => {
       inactiveSince: new Date('2025-01-01T00:00:00Z'),
       accountGone: false,
       unreachable: true,
+      wasNotified: false,
     },
   ];
 
@@ -95,6 +96,7 @@ describe('RetentionPurgeService.buildPreview', () => {
       inactiveSince: new Date('2025-01-01T00:00:00Z'),
       accountGone: false,
       unreachable: true,
+      wasNotified: false,
     }));
     const prisma = makePreviewPrisma({ cohort, userbase: 20 });
 
@@ -125,6 +127,7 @@ describe('RetentionPurgeService.buildPreview', () => {
         inactiveSince: new Date('2025-02-01T00:00:00Z'),
         accountGone: false,
         unreachable: false,
+        wasNotified: true,
       },
     ];
     const prisma = makePreviewPrisma({ cohort, userbase: 100, reachableToNotify: 51, inGrace: 4 });
@@ -135,6 +138,7 @@ describe('RetentionPurgeService.buildPreview', () => {
     expect(totals.reachableToNotify).toBe(51);
     expect(totals.inGrace).toBe(4);
     expect(totals.graceExpired).toBe(1);
+    expect(totals.bystander).toBe(0);
   });
 });
 

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.ts
@@ -74,6 +74,8 @@ export interface RetentionPreview {
     inGrace: number;
     /** Warned, window expired, still silent — the grace_expired purge subset. */
     graceExpired: number;
+    /** Never deliberately used the bot — the silent-purge subset of the cohort. */
+    bystander: number;
   };
 }
 
@@ -157,9 +159,11 @@ export class RetentionPurgeService {
         breakerWarning: userbaseCount > 0 && users.length / userbaseCount > BREAKER_WARN_FRACTION,
         reachableToNotify,
         inGrace,
-        // Grace-expired users are IN the purge cohort (the third predicate
-        // arm), so this is a labeled subset, not an addition to eligibleCount.
+        // Grace-expired and bystander users are IN the purge cohort (the
+        // third and fourth predicate arms) — labeled subsets, not additions
+        // to eligibleCount.
         graceExpired: users.filter(u => u.reason === 'grace_expired').length,
+        bystander: users.filter(u => u.reason === 'bystander').length,
       },
     };
   }

--- a/services/api-gateway/src/services/retention/eligibility.test.ts
+++ b/services/api-gateway/src/services/retention/eligibility.test.ts
@@ -61,10 +61,18 @@ describe('the eligibility predicate', () => {
     await selectEligibleUsers(db);
 
     const sql = flattenSql(queryRaw.mock.calls[0]);
-    // Unreachable OR gone OR grace-expired — any of the three qualifies.
+    // Unreachable OR gone OR grace-expired OR bystander — any of the four.
     expect(sql).toContain('u.dm_undeliverable_since IS NOT NULL');
     expect(sql).toContain('u.discord_account_gone_at IS NOT NULL');
     expect(sql).toContain('u.retention_notified_at <');
+    // The bystander arm is the NEGATION of deliberate use, gated on
+    // never-notified (a served notice makes the grace floor unconditional).
+    expect(sql).toContain('OR (NOT (');
+    expect(sql).toContain('AND u.retention_notified_at IS NULL)');
+    expect(sql).toContain('u.notify_opted_in_at IS NOT NULL');
+    expect(sql).toContain('FROM usage_logs');
+    // The co-ownership grant arm (inert today; see the fragment comment).
+    expect(sql).toContain('FROM personality_owners');
     // Inactivity, with the NULL → created_at fallback (never "active now").
     expect(sql).toContain('COALESCE(u.last_active_at, u.created_at)');
     // The two exemptions that must never be purge-able.
@@ -91,8 +99,10 @@ describe('the eligibility predicate', () => {
 
     const sql = flattenSql(queryRaw.mock.calls[0]).replace(/\s+/g, ' ');
     // Fragment-bound values flatten to `?` placeholders, hence the literal \?.
+    // The qualifying-signal OR-group (now four arms, ending in the negated
+    // deliberate-use fragment) must be ANDed with the inactivity window.
     expect(sql).toMatch(
-      /\(u\.dm_undeliverable_since IS NOT NULL OR u\.discord_account_gone_at IS NOT NULL OR u\.retention_notified_at < now\(\) - make_interval\(days => \?\)\) AND COALESCE/
+      /\(u\.dm_undeliverable_since IS NOT NULL OR u\.discord_account_gone_at IS NOT NULL OR u\.retention_notified_at < now\(\) - make_interval\(days => \?\) OR \(NOT \(.*\) AND u\.retention_notified_at IS NULL\) ?\) AND COALESCE/
     );
     expect(sql).not.toMatch(/OR u\.retention_notified_at[^)]*$/);
   });
@@ -105,6 +115,7 @@ describe('the eligibility predicate', () => {
         inactiveSince: new Date('2025-01-01'),
         accountGone: true,
         unreachable: true,
+        wasNotified: false,
       },
       {
         userId: 'u2',
@@ -112,6 +123,7 @@ describe('the eligibility predicate', () => {
         inactiveSince: new Date('2025-02-01'),
         accountGone: false,
         unreachable: true,
+        wasNotified: true,
       },
       {
         userId: 'u3',
@@ -119,12 +131,26 @@ describe('the eligibility predicate', () => {
         inactiveSince: new Date('2025-03-01'),
         accountGone: false,
         unreachable: false,
+        wasNotified: true,
+      },
+      {
+        userId: 'u4',
+        discordId: '900000000000000004',
+        inactiveSince: new Date('2025-04-01'),
+        accountGone: false,
+        unreachable: false,
+        wasNotified: false,
       },
     ]);
 
     const cohort = await selectEligibleUsers(db);
 
-    expect(cohort.map(row => row.reason)).toEqual(['account_gone', 'unreachable', 'grace_expired']);
+    expect(cohort.map(row => row.reason)).toEqual([
+      'account_gone',
+      'unreachable',
+      'grace_expired',
+      'bystander',
+    ]);
   });
 });
 
@@ -140,6 +166,11 @@ describe('the notify predicate (Phase 3)', () => {
     expect(sql).toContain('u.discord_account_gone_at IS NULL');
     // ...one notice per inactivity spell (also the cross-run idempotency guard)...
     expect(sql).toContain('u.retention_notified_at IS NULL');
+    // ...only DELIBERATE users get the notice (bystanders purge silently)...
+    expect(sql).toContain('u.notify_opted_in_at IS NOT NULL');
+    expect(sql).toContain('FROM usage_logs');
+    expect(sql).toContain('FROM personality_owners');
+    expect(sql).not.toContain('AND NOT (');
     // ...the same inactivity window and exemptions as the purge predicate.
     expect(sql).toContain('COALESCE(u.last_active_at, u.created_at)');
     expect(sql).toContain('u.is_superuser = false');

--- a/services/api-gateway/src/services/retention/eligibility.ts
+++ b/services/api-gateway/src/services/retention/eligibility.ts
@@ -30,10 +30,12 @@ import { RETENTION_POLICY } from '@tzurot/common-types/constants/retention';
 const { WINDOW_DAYS: RETENTION_WINDOW_DAYS, GRACE_PERIOD_DAYS } = RETENTION_POLICY;
 
 /**
- * Why a user is purge-eligible: the two unreachable signals (D13), or a
- * warning-notice grace window that expired with no activity (Phase 3).
+ * Why a user is purge-eligible: the two unreachable signals (D13), a
+ * warning-notice grace window that expired with no activity (Phase 3), or a
+ * bystander-shaped account that never deliberately used the bot (owner call:
+ * such rows purge WITHOUT notice — see DELIBERATE_USE).
  */
-export type PurgeReason = 'unreachable' | 'account_gone' | 'grace_expired';
+export type PurgeReason = 'unreachable' | 'account_gone' | 'grace_expired' | 'bystander';
 
 export interface PurgeCohortRow {
   userId: string;
@@ -49,7 +51,41 @@ interface CohortSqlRow {
   inactiveSince: Date;
   accountGone: boolean;
   unreachable: boolean;
+  wasNotified: boolean;
 }
+
+/**
+ * Evidence the account DELIBERATELY used the bot, as opposed to a bystander
+ * row auto-provisioned because someone spoke in a channel the bot could see.
+ * The distinction decides notice-vs-silent handling (owner call, prod-measured:
+ * 32 of the first notify cohort's 53 were bystander-shaped):
+ *
+ *   - DELIBERATE + inactive → warning DM + 30-day grace (the notice protects
+ *     content someone chose to create with us).
+ *   - BYSTANDER + inactive → purge without notice. Their rows are collected
+ *     context ABOUT them, there is nothing to export, and a deletion notice
+ *     from a bot they never talked to is spam-report surface, not information
+ *     (the beta.174 cold-DM class).
+ *
+ * Any arm's evidence appearing later (they run a command, generate, add a key)
+ * also bumps last_active_at, so a bystander who becomes a user exits the
+ * window entirely before this fragment ever reclassifies them.
+ *
+ * The personality_owners arm covers an EXPLICIT co-ownership grant, mirroring
+ * findCrossUserReachIds' fourth arm: inert today (the sole writer inserts
+ * userId === ownerId, a self-duplicate of the owner_id arm above), but the
+ * moment real grants exist, a co-owner who never chatted must not be
+ * classified bystander and silently erased — holding a granted character is
+ * direct use the activity arms cannot see.
+ */
+const DELIBERATE_USE = Prisma.sql`(
+      u.notify_opted_in_at IS NOT NULL
+      OR EXISTS (SELECT 1 FROM usage_logs ul WHERE ul.user_id = u.id)
+      OR EXISTS (SELECT 1 FROM personalities p WHERE p.owner_id = u.id)
+      OR EXISTS (SELECT 1 FROM personality_owners po WHERE po.user_id = u.id)
+      OR EXISTS (SELECT 1 FROM user_api_keys k WHERE k.user_id = u.id)
+      OR (SELECT count(*) FROM personas pe WHERE pe.owner_id = u.id) > 1
+)`;
 
 /**
  * The eligibility conditions, over an aliased `users u`.
@@ -61,11 +97,21 @@ interface CohortSqlRow {
  * exist when it was written, and 10013's false-positive rate has never been
  * measured. The clear ships alongside this (see the activity-stamp sites);
  * the fast-track stays unbuilt until the flag has run with a clearer.
+ *
+ * The bystander arm is gated on never-notified: a served notice makes the
+ * 30-day grace floor UNCONDITIONAL. Without the gate, deliberate-use evidence
+ * vanishing through a non-user path (a future usage_logs TTL prune, admin
+ * cleanup, moderation removal) would purge a mid-grace user early via the
+ * bystander arm — mislabeled grace_expired. The gate costs nothing for real
+ * bystanders (never deliberate → never notified, since NOTIFY_CONDITIONS
+ * requires deliberate use) and turns the cross-module activity-clear
+ * assumption into a SQL guarantee.
  */
 const ELIGIBILITY_CONDITIONS = Prisma.sql`
       (u.dm_undeliverable_since IS NOT NULL
        OR u.discord_account_gone_at IS NOT NULL
-       OR u.retention_notified_at < now() - make_interval(days => ${GRACE_PERIOD_DAYS}))
+       OR u.retention_notified_at < now() - make_interval(days => ${GRACE_PERIOD_DAYS})
+       OR (NOT ${DELIBERATE_USE} AND u.retention_notified_at IS NULL))
   AND COALESCE(u.last_active_at, u.created_at)
         < now() - make_interval(days => ${RETENTION_WINDOW_DAYS})
   AND u.is_superuser = false
@@ -84,6 +130,7 @@ const NOTIFY_CONDITIONS = Prisma.sql`
       u.dm_undeliverable_since IS NULL
   AND u.discord_account_gone_at IS NULL
   AND u.retention_notified_at IS NULL
+  AND ${DELIBERATE_USE}
   AND COALESCE(u.last_active_at, u.created_at)
         < now() - make_interval(days => ${RETENTION_WINDOW_DAYS})
   AND u.is_superuser = false
@@ -97,10 +144,25 @@ function toCohortRow(row: CohortSqlRow): PurgeCohortRow {
     discordId: row.discordId,
     inactiveSince: row.inactiveSince,
     // Label precedence mirrors signal strength: a gone account beats
-    // unreachable, and either unreachable stamp beats grace_expired (a user
-    // whose notice bounced later carries both a grace clock and the stamp the
-    // bounce wrote — the stamp is the operative reason).
-    reason: row.accountGone ? 'account_gone' : row.unreachable ? 'unreachable' : 'grace_expired',
+    // unreachable, either unreachable stamp beats the two reachable reasons (a
+    // user whose notice bounced carries both a grace clock and the stamp the
+    // bounce wrote — the stamp is the operative reason), and a served notice
+    // beats bystander (grace_expired implies the account was deliberate when
+    // warned). That last implication depends on the activity-clear in
+    // UserService.getOrCreateUser: any evidence-losing action (deleting a key,
+    // character, or persona) is itself authenticated activity, which resets
+    // last_active_at AND clears retention_notified_at — so a stale
+    // notified-but-no-longer-deliberate row cannot exist. That argument assumes
+    // evidence leaves only via the user's own authenticated actions; no code
+    // path removes another user's deliberate-use evidence involuntarily (purge
+    // re-homing only touches the purged owner's rows).
+    reason: row.accountGone
+      ? 'account_gone'
+      : row.unreachable
+        ? 'unreachable'
+        : row.wasNotified
+          ? 'grace_expired'
+          : 'bystander',
   };
 }
 
@@ -117,7 +179,8 @@ export async function selectEligibleUsers(db: Prisma.TransactionClient): Promise
            u.discord_id AS "discordId",
            COALESCE(u.last_active_at, u.created_at) AS "inactiveSince",
            (u.discord_account_gone_at IS NOT NULL) AS "accountGone",
-           (u.dm_undeliverable_since IS NOT NULL) AS "unreachable"
+           (u.dm_undeliverable_since IS NOT NULL) AS "unreachable",
+           (u.retention_notified_at IS NOT NULL) AS "wasNotified"
     FROM users u
     WHERE ${ELIGIBILITY_CONDITIONS}
     ORDER BY COALESCE(u.last_active_at, u.created_at) ASC

--- a/services/bot-client/src/services/RetentionNagScheduler.test.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.test.ts
@@ -30,6 +30,7 @@ function makePreview(overrides: {
   reachableToNotify?: number;
   inGrace?: number;
   graceExpired?: number;
+  bystander?: number;
 }): RetentionPreviewResponse {
   const eligibleCount = overrides.eligibleCount ?? 1;
   const listedUsers = overrides.userCount ?? eligibleCount;
@@ -50,6 +51,7 @@ function makePreview(overrides: {
       reachableToNotify: overrides.reachableToNotify ?? 0,
       inGrace: overrides.inGrace ?? 0,
       graceExpired: overrides.graceExpired ?? 0,
+      bystander: overrides.bystander ?? 0,
     },
   } satisfies RetentionPreviewResponse;
 }
@@ -154,6 +156,25 @@ describe('buildRetentionNagEmbed', () => {
     // (mocked config says production).
     expect(embed.footer?.text).toContain('pnpm ops retention:preview --env prod');
     expect(embed.footer?.text).toContain('pnpm ops retention:purge --env prod');
+  });
+
+  it('renders the bystander reason label (silent-purge rows need a legible tag)', () => {
+    const preview = makePreview({ eligibleCount: 1 });
+    preview.users[0] = { ...preview.users[0], reason: 'bystander' };
+
+    const embed = buildRetentionNagEmbed(preview).toJSON();
+
+    expect(embed.description).toContain('never used directly');
+  });
+
+  it('appends the bystander tally to the summary only when the count is non-zero', () => {
+    const silent = buildRetentionNagEmbed(makePreview({})).toJSON();
+    const split = buildRetentionNagEmbed(
+      makePreview({ eligibleCount: 33, bystander: 32 })
+    ).toJSON();
+
+    expect(silent.description).not.toContain('no notice owed');
+    expect(split.description).toContain('(32 never used the bot directly — no notice owed)');
   });
 
   it('includes the breaker warning line only when the totals flag it', () => {

--- a/services/bot-client/src/services/RetentionNagScheduler.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.ts
@@ -63,6 +63,7 @@ export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): Embed
     account_gone: 'account deleted',
     unreachable: 'unreachable',
     grace_expired: 'grace expired',
+    bystander: 'never used directly',
   } as const;
 
   const lines = users
@@ -76,9 +77,13 @@ export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): Embed
     lines.push(`…and ${String(users.length - MAX_LISTED_USERS)} more (see the preview CLI)`);
   }
 
+  const bystanderNote =
+    totals.bystander > 0
+      ? ` (${String(totals.bystander)} never used the bot directly — no notice owed)`
+      : '';
   const summary =
     `**${String(totals.eligibleCount)}** of ${String(totals.userbaseCount)} users ` +
-    `(${String(totals.percentOfUserbase)}%) are purge-eligible. ` +
+    `(${String(totals.percentOfUserbase)}%) are purge-eligible${bystanderNote}. ` +
     `Characters: ${String(totals.charactersToDelete)} would be deleted, ` +
     `${String(totals.charactersToReHome)} re-homed to the Orphaned Characters bucket.`;
 


### PR DESCRIPTION
## What

Pre-first-notify correction, from the owner's "are these users who actually used the bot?" check. A read-only prod classification of the 53-user notify cohort:

```
with_ai_usage:           20
deliberate_use_stamped:  21
owns_characters:          0
bystander_shaped:        32   ← no usage, no opt-in stamp, no characters, ≤1 persona
```

**60% of the cohort never deliberately used the bot** — they're extended-context speakers whose rows were auto-provisioned. Cold-DMing them "your account is scheduled for deletion" is the beta.174 spam class, describing an account they don't know they have.

## The split (owner call)

- **`DELIBERATE_USE` fragment** (eligibility.ts, the single-predicate module): opt-in stamp ∨ usage logs ∨ owned characters ∨ BYOK keys ∨ extra personas.
- **Notify narrows**: only deliberate users (~21) receive the warning DM + 30-day grace.
- **Purge widens**: a fourth eligibility arm — bystander-shaped + inactive ≥180d → purge-eligible **without notice**, reason `bystander`. Same TOCTOU re-check for free (shared fragment). A bystander who ever uses the bot bumps `last_active_at` by that same act and exits the window before reclassification could matter.
- **Labels**: `bystander` in the preview schema enum, the CLI reason map ("never used the bot directly (no notice sent)"), and the nag ("never used directly").
- **Policy** (📢 owner wording review): a narrow exception paragraph — rows that exist only because someone spoke near the bot hold no created content and are removed without notice; "there is nothing to export, and a deletion notice from a bot you never talked to would be noise, not information."
- Design doc records the measurement + call.

## Expected prod effect on merge+release

The nag flips from "0 purge-eligible / 53 awaiting DM" to **~32 purge-eligible (`bystander`) / ~21 awaiting DM**. 32/273 ≈ 11.7% — under the 15% warn line. Nothing acts on it until the operator runs the CLIs.

## Verified

- Component (PGLite, real SQL): a bystander-shaped row lands in the purge cohort labeled `bystander` and is excluded from both the notify cohort and the send-time filter; a deliberate inactive user stays notify-eligible; grace/unreachable label precedence unchanged. 15/15.
- Unit: predicate-shape assertions for the new arm (purge `OR NOT(deliberate)`, notify `AND deliberate`), label fallthrough, fixture sweep for the new `wasNotified` column.
- `pnpm test` (26 tasks) + `pnpm quality` green sequential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)