### PR TITLE
fix(common-types): retention report surfaces fail open on malformed stored ids

### DIFF
--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -679,10 +679,20 @@ describe('RetentionPreviewUserSchema', () => {
     );
   });
 
-  it('rejects a non-snowflake discordId and negative character counts', () => {
-    expect(RetentionPreviewUserSchema.safeParse({ ...user, discordId: 'nope' }).success).toBe(
-      false
+  it('ACCEPTS a malformed stored discordId — the report must display the anomaly', () => {
+    // A legacy prod row holds the literal 'unknown'; snowflake validation
+    // here crashed the preview CLI and silenced the daily nag the moment the
+    // bystander arm made the cohort non-empty. Display surfaces fail open.
+    expect(RetentionPreviewUserSchema.safeParse({ ...user, discordId: 'unknown' }).success).toBe(
+      true
     );
+  });
+
+  it('still rejects empty/oversized ids and negative character counts', () => {
+    expect(RetentionPreviewUserSchema.safeParse({ ...user, discordId: '' }).success).toBe(false);
+    expect(
+      RetentionPreviewUserSchema.safeParse({ ...user, discordId: 'x'.repeat(33) }).success
+    ).toBe(false);
     expect(
       RetentionPreviewUserSchema.safeParse({
         ...user,
@@ -748,8 +758,13 @@ describe('RetentionPurgeRequestSchema', () => {
     expect(RetentionPurgeRequestSchema.safeParse({}).success).toBe(false);
   });
 
-  it('rejects a malformed Discord id', () => {
-    expect(RetentionPurgeRequestSchema.safeParse({ discordId: 'not-a-snowflake' }).success).toBe(
+  it('ACCEPTS a malformed stored id — the operator must be able to purge the junk the preview surfaced', () => {
+    // The id is a lookup key, not a trust boundary (parameterized SQL + the
+    // in-tx eligibility re-check own safety); a nonexistent id skips as
+    // already_gone. Empty and oversized ids stay rejected.
+    expect(RetentionPurgeRequestSchema.safeParse({ discordId: 'unknown' }).success).toBe(true);
+    expect(RetentionPurgeRequestSchema.safeParse({ discordId: '' }).success).toBe(false);
+    expect(RetentionPurgeRequestSchema.safeParse({ discordId: 'x'.repeat(33) }).success).toBe(
       false
     );
   });

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -303,7 +303,15 @@ export const SecretRotationStatusResponseSchema = z.object({
  * Read-only reporting: the preview mutates nothing.
  */
 export const RetentionPreviewUserSchema = z.object({
-  discordId: DiscordSnowflakeSchema,
+  /**
+   * Deliberately NOT snowflake-validated: the preview is a display-only
+   * report, and a malformed stored id (a legacy row holds the literal
+   * 'unknown') is a finding the report must SURFACE — snowflake validation
+   * here crashed the CLI and silenced the daily nag on exactly that anomaly
+   * the moment the bystander arm made the cohort non-empty. The notify
+   * pipeline's recipient schemas stay strict; such rows never qualify there.
+   */
+  discordId: z.string().min(1).max(32),
   /** Inactivity anchor as ISO — last_active_at, or created_at when never stamped. */
   inactiveSince: z.string().datetime(),
   /**
@@ -355,7 +363,13 @@ export type RetentionPreviewResponse = z.infer<typeof RetentionPreviewResponseSc
  * unrecorded purge; the CLI loops instead, and re-running it resumes.
  */
 export const RetentionPurgeRequestSchema = z.object({
-  discordId: DiscordSnowflakeSchema,
+  /**
+   * Same relaxation as the preview user schema: the id is a lookup key, not
+   * a trust boundary (parameterized SQL + the in-tx eligibility re-check own
+   * safety), and the operator must be able to purge a malformed-id row the
+   * preview surfaced — that junk is precisely what the bystander arm sweeps.
+   */
+  discordId: z.string().min(1).max(32),
   /** Operator/run label recorded in the audit ledger. */
   runContext: z.string().max(200).optional(),
   /**
@@ -368,7 +382,9 @@ export const RetentionPurgeRequestSchema = z.object({
 });
 
 export const RetentionPurgeResponseSchema = z.object({
-  discordId: DiscordSnowflakeSchema,
+  // Echoes the request's id — same relaxation, or purging a malformed-id row
+  // would succeed server-side and then fail the client's response parse.
+  discordId: z.string().min(1).max(32),
   /** `skipped` covers every normal no-op; only a thrown error is a failure. */
   status: z.enum(['purged', 'skipped']),
   /** Present when status is `skipped`. */

--- a/services/api-gateway/src/routes/internal/retentionPurge.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionPurge.test.ts
@@ -109,8 +109,26 @@ describe('POST /internal/retention/purge', () => {
     expect(RetentionPurgeResponseSchema.safeParse(payload).success).toBe(true);
   });
 
-  it('rejects a malformed Discord id without touching the service', async () => {
-    const { req, res } = createMockReqRes({ discordId: 'not-a-snowflake' });
+  it('accepts a malformed stored id — the id is a lookup key, not a trust boundary', async () => {
+    // A legacy prod row holds the literal 'unknown'; the preview surfaces it
+    // and the operator must be able to purge it. Safety lives in the
+    // parameterized SQL + the in-tx eligibility re-check; a nonexistent id
+    // just skips as already_gone.
+    purgeUserMock.mockResolvedValue({
+      status: 'skipped',
+      discordId: 'unknown',
+      reason: 'already_gone',
+    });
+    const { req, res } = createMockReqRes({ discordId: 'unknown' });
+
+    await handleRetentionPurge({} as RouteDeps)(req, res, vi.fn());
+
+    expect(purgeUserMock).toHaveBeenCalledWith(expect.objectContaining({ discordId: 'unknown' }));
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('still rejects an empty-string id without touching the service', async () => {
+    const { req, res } = createMockReqRes({ discordId: '' });
 
     await handleRetentionPurge({} as RouteDeps)(req, res, vi.fn());
 


### PR DESCRIPTION
## What

**Prod finding from the beta.179 deploy verification** (runtime-observed, not code-read): the first live `retention:preview --env prod` failed client-side schema validation on `users[15].discordId`. A read-only probe found the cause — a legacy prod row (created 2025-12-21) holds the literal `discord_id = 'unknown'`. The snowflake pattern on the preview user schema never fired before because the cohort array was empty until the bystander arm populated it; the report crashed on exactly the anomaly it exists to surface. The prod daily nag consumes the same schema and would silently swallow.

(The other non-snowflake row is the Orphaned-Characters sentinel — `retention_exempt`, correctly excluded from the cohort.)

## Fix

Report/lookup surfaces fail open; the DM pipeline stays strict:

- `RetentionPreviewUserSchema.discordId` → bounded plain string (display-only report; malformed stored ids are findings to show, not protocol violations to reject)
- `RetentionPurgeRequestSchema.discordId` + response echo → bounded plain string (a lookup key, not a trust boundary — safety lives in parameterized SQL + the in-tx eligibility re-check; the operator must be able to purge the junk row the preview surfaces, which is precisely what the bystander arm exists for)
- `RetentionNotifyCohortUserSchema` and every other `DiscordSnowflakeSchema` use **unchanged** — the junk row has no deliberate-use evidence, so it never qualifies for a DM

## Verified

- Regression pinned at both tiers: schema unit tests accept `'unknown'` (reject empty/oversized), and the gateway route test asserts a malformed id now crosses the seam to the service while an empty id still 400s.
- Full suites green: common-types 2620, api-gateway 2647, bot-client 5875, tooling 1706.
- Needs a fast-follow release (beta.180) to restore the prod nag; the local preview/purge CLIs are fixed the moment this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)