### PR TITLE
docs: enforce owner-assignee on every non-dependabot PR

### DIFF
--- a/.claude/hooks/pr-monitor-reminder.sh
+++ b/.claude/hooks/pr-monitor-reminder.sh
@@ -87,6 +87,34 @@ echo "$KEY" >>"$SEEN_FILE"
 # other accounts on a shared host to read one user's PR/SHA history.
 chmod 600 "$SEEN_FILE" 2>/dev/null || true
 
+# Owner policy: every non-dependabot PR carries the owner as assignee. The
+# skill's canonical `gh pr create --assignee lbds137` is the primary path;
+# this is the deterministic backfill when it was forgotten. REST endpoint
+# rather than `gh pr edit` (the latter is unreliable in this repo — see
+# 05-tooling.md "Use instead of broken gh pr edit"). Fail-open: an offline
+# `gh` must never block the reminder below.
+PR_META=$(gh pr view "$PR_NUM" --json author,assignees \
+    --jq '"\(.author.login) \(.assignees | length)"' 2>/dev/null || echo "")
+if [ -n "$PR_META" ]; then
+    AUTHOR=${PR_META% *}
+    ASSIGNEE_COUNT=${PR_META##* }
+    case "$AUTHOR" in
+    *dependabot*) : ;; # dependabot PRs stay unassigned by policy
+    *)
+        if [ "$ASSIGNEE_COUNT" = "0" ]; then
+            if gh api "repos/{owner}/{repo}/issues/${PR_NUM}/assignees" \
+                -f "assignees[]=lbds137" >/dev/null 2>&1; then
+                echo "pr-monitor-reminder: auto-assigned lbds137 to PR #$PR_NUM" >&2
+            else
+                # Fail-open by design, but say so — a silent permission error
+                # would otherwise read as "the backfill never runs".
+                echo "pr-monitor-reminder: assignee backfill failed for PR #$PR_NUM (proceeding)" >&2
+            fi
+        fi
+        ;;
+    esac
+fi
+
 cat <<EOF
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 PR MONITOR REMINDER — push detected on PR #$PR_NUM

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-07-26'
+lastUpdated: '2026-07-27'
 ---
 
 # Git Workflow Procedures
@@ -74,9 +74,10 @@ git checkout develop && git pull origin develop
 git checkout feat/your-feature
 git rebase develop
 
-# 2. Push and create PR
+# 2. Push and create PR (--assignee is owner policy: every non-dependabot PR
+#    carries the owner as assignee; pr-monitor-reminder.sh backfills if missed)
 git push -u origin feat/your-feature
-gh pr create --base develop --title "feat: description"
+gh pr create --base develop --title "feat: description" --assignee lbds137
 ```
 
 ### Arm CI monitor (required)
@@ -293,7 +294,7 @@ override, `pnpm install`, verify the lockfile resolves the patched version.
 high/critical.) The same list also appears in `pnpm ops health`.
 
 ```bash
-gh pr create --base main --head develop --title "Release v3.0.0-beta.XX: Description"
+gh pr create --base main --head develop --title "Release v3.0.0-beta.XX: Description" --assignee lbds137
 ```
 
 ### 4. Pre-Merge Migration (if release includes one)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ All rules load automatically from `.claude/rules/`:
 **REBASE-ONLY. NO SQUASH. NO MERGE COMMITS.**
 
 ```bash
-gh pr create --base develop --title "feat: description"
+gh pr create --base develop --title "feat: description" --assignee lbds137
 gh pr merge <number> --rebase --delete-branch  # Feature PRs only, when truly ready (00-critical § Merge Approval)
 gh pr merge <number> --rebase                  # Release PRs (develop → main) — NEVER delete develop
 ```


### PR DESCRIPTION
## What

Owner directive (2026-07-27): every PR we open gets the owner assigned; only dependabot PRs go unassigned.

- `tzurot-git-workflow` skill + root `CLAUDE.md`: the canonical `gh pr create` commands (feature + release) now carry `--assignee lbds137`.
- `.claude/hooks/pr-monitor-reminder.sh`: after resolving the PR number on any `git push`/`gh pr create`, it backfills the assignee when missing — via the REST `issues/N/assignees` endpoint (not `gh pr edit`, which is unreliable in this repo per `05-tooling.md`), skipping dependabot authors, fail-open so an offline `gh` never blocks the monitor reminder.

Two layers on purpose: the flag is the primary path; the hook makes it mechanical rather than memory-dependent (`00-critical.md` § Fix Recurring Failures Structurally).

## Verification

- `bash -n` clean on the hook.
- PR #1816 (created with the flag) and this PR itself exercise the create-time path; the hook's backfill path fires on the next push to any unassigned PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)