### PR TITLE
docs: assign the PR creator, not a hardcoded owner login

### DIFF
--- a/.claude/hooks/pr-monitor-reminder.sh
+++ b/.claude/hooks/pr-monitor-reminder.sh
@@ -87,10 +87,11 @@ echo "$KEY" >>"$SEEN_FILE"
 # other accounts on a shared host to read one user's PR/SHA history.
 chmod 600 "$SEEN_FILE" 2>/dev/null || true
 
-# Owner policy: every non-dependabot PR carries the owner as assignee. The
-# skill's canonical `gh pr create --assignee lbds137` is the primary path;
-# this is the deterministic backfill when it was forgotten. REST endpoint
-# rather than `gh pr edit` (the latter is unreliable in this repo — see
+# Owner policy: every human-authored PR carries its CREATOR as assignee; bot
+# PRs (dependabot etc.) stay unassigned. The skill's canonical
+# `gh pr create --assignee @me` is the primary path; this is the
+# deterministic backfill when the flag was forgotten. REST endpoint rather
+# than `gh pr edit` (the latter is unreliable in this repo — see
 # 05-tooling.md "Use instead of broken gh pr edit"). Fail-open: an offline
 # `gh` must never block the reminder below.
 PR_META=$(gh pr view "$PR_NUM" --json author,assignees \
@@ -98,13 +99,16 @@ PR_META=$(gh pr view "$PR_NUM" --json author,assignees \
 if [ -n "$PR_META" ]; then
     AUTHOR=${PR_META% *}
     ASSIGNEE_COUNT=${PR_META##* }
+    # One pattern covers bots AND input hygiene: real GitHub logins are
+    # [A-Za-z0-9-] only, so "app/dependabot", "foo[bot]", or anything mangled
+    # falls through to skip rather than reach the API call.
     case "$AUTHOR" in
-    *dependabot*) : ;; # dependabot PRs stay unassigned by policy
+    '' | *dependabot* | *[!A-Za-z0-9-]*) : ;;
     *)
         if [ "$ASSIGNEE_COUNT" = "0" ]; then
             if gh api "repos/{owner}/{repo}/issues/${PR_NUM}/assignees" \
-                -f "assignees[]=lbds137" >/dev/null 2>&1; then
-                echo "pr-monitor-reminder: auto-assigned lbds137 to PR #$PR_NUM" >&2
+                -f "assignees[]=${AUTHOR}" >/dev/null 2>&1; then
+                echo "pr-monitor-reminder: auto-assigned ${AUTHOR} to PR #$PR_NUM" >&2
             else
                 # Fail-open by design, but say so — a silent permission error
                 # would otherwise read as "the backfill never runs".

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -74,10 +74,11 @@ git checkout develop && git pull origin develop
 git checkout feat/your-feature
 git rebase develop
 
-# 2. Push and create PR (--assignee is owner policy: every non-dependabot PR
-#    carries the owner as assignee; pr-monitor-reminder.sh backfills if missed)
+# 2. Push and create PR (--assignee @me is owner policy: every human-authored
+#    PR carries its creator as assignee, bots stay unassigned;
+#    pr-monitor-reminder.sh backfills the PR author if missed)
 git push -u origin feat/your-feature
-gh pr create --base develop --title "feat: description" --assignee lbds137
+gh pr create --base develop --title "feat: description" --assignee @me
 ```
 
 ### Arm CI monitor (required)
@@ -294,7 +295,7 @@ override, `pnpm install`, verify the lockfile resolves the patched version.
 high/critical.) The same list also appears in `pnpm ops health`.
 
 ```bash
-gh pr create --base main --head develop --title "Release v3.0.0-beta.XX: Description" --assignee lbds137
+gh pr create --base main --head develop --title "Release v3.0.0-beta.XX: Description" --assignee @me
 ```
 
 ### 4. Pre-Merge Migration (if release includes one)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ All rules load automatically from `.claude/rules/`:
 **REBASE-ONLY. NO SQUASH. NO MERGE COMMITS.**
 
 ```bash
-gh pr create --base develop --title "feat: description" --assignee lbds137
+gh pr create --base develop --title "feat: description" --assignee @me
 gh pr merge <number> --rebase --delete-branch  # Feature PRs only, when truly ready (00-critical § Merge Approval)
 gh pr merge <number> --rebase                  # Release PRs (develop → main) — NEVER delete develop
 ```

--- a/docs/reference/GITHUB_CLI_REFERENCE.md
+++ b/docs/reference/GITHUB_CLI_REFERENCE.md
@@ -79,9 +79,10 @@ gh pr view 123 --json number,title,body,state,comments
 
 ### Create PR
 
-> **Owner policy**: every non-dependabot PR carries the owner as assignee — add
-> `--assignee lbds137` at create time (the `pr-monitor-reminder.sh` hook
-> backfills it on the next push if forgotten).
+> **Owner policy**: every human-authored PR carries its creator as assignee
+> (bot PRs stay unassigned) — add `--assignee @me` at create time (the
+> `pr-monitor-reminder.sh` hook backfills the PR author on the next push if
+> forgotten).
 
 ```bash
 # Basic PR creation (opens editor for title/body)
@@ -91,10 +92,10 @@ gh pr create
 gh pr create --title "feat: add new feature" --body "Description here"
 
 # Specify base branch (IMPORTANT for Tzurot - always use develop!)
-gh pr create --base develop --title "feat: add new feature" --assignee lbds137
+gh pr create --base develop --title "feat: add new feature" --assignee @me
 
 # Using HEREDOC for multiline body (recommended for Claude Code)
-gh pr create --base develop --title "feat: your feature" --assignee lbds137 --body "$(cat <<'EOF'
+gh pr create --base develop --title "feat: your feature" --assignee @me --body "$(cat <<'EOF'
 ## Summary
 - Change 1
 - Change 2
@@ -358,7 +359,7 @@ gh issue close 123
 ### Creating a PR to develop
 
 ```bash
-gh pr create --base develop --title "feat: description" --assignee lbds137 --body "$(cat <<'EOF'
+gh pr create --base develop --title "feat: description" --assignee @me --body "$(cat <<'EOF'
 ## Summary
 - Brief description of changes
 
@@ -522,7 +523,7 @@ gh auth refresh -s repo
 | Task                 | Command                                                       |
 | -------------------- | ------------------------------------------------------------- |
 | View PR              | `gh pr view 123`                                              |
-| Create PR to develop | `gh pr create --base develop --assignee lbds137`              |
+| Create PR to develop | `gh pr create --base develop --assignee @me`                  |
 | Edit PR body ⚠️      | `gh api -X PATCH repos/{owner}/{repo}/pulls/123 -f body="…"`  |
 | Edit PR title ⚠️     | `gh api -X PATCH repos/{owner}/{repo}/pulls/123 -f title="…"` |
 | Comment on PR        | `gh pr comment 123 --body "text"`                             |


### PR DESCRIPTION
## What

Owner refinement of the assignee policy: assign the **PR creator**, not a hardcoded login — bots stay unassigned.

- Canonical `gh pr create` commands (skill, CLAUDE.md, GITHUB_CLI_REFERENCE.md — all 8 sites) now use `--assignee @me`, which gh resolves to the authenticated creator.
- `pr-monitor-reminder.sh` backfill now assigns the PR's actual `author.login`; the bot-skip is a strict login-shape check (`[A-Za-z0-9-]` only) that rejects `app/dependabot`, `foo[bot]`, and any mangled value in one pattern — doubling as input hygiene before the value reaches the API call.

## Verification

- `bash -n` clean; this PR itself created with `--assignee @me`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)