### PR TITLE
feat(backlog): import follow-ups into the Backlog.md tracker store

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,11 @@ _generated/
 # widths drift naturally and have zero review value, so exclude them.
 backlog/
 
+# The Backlog.md tracker store: the CLI owns these files' shape (frontmatter +
+# section markers, rewritten on every task edit) — prettier fighting it adds
+# noise to unrelated diffs and risks a shape the two tools don't agree on.
+tracker/
+
 # Auto-generated command manifest. Its drift guard compares the committed file
 # byte-for-byte against `JSON.stringify(…, 2)` output; prettier collapses arrays
 # onto single lines, which would permanently break that comparison. Exclude so

--- a/backlog.config.yml
+++ b/backlog.config.yml
@@ -1,0 +1,17 @@
+project_name: 'tzurot'
+default_status: 'To Do'
+statuses: ['To Do', 'In Progress', 'Done']
+labels: []
+date_format: yyyy-mm-dd
+max_column_width: 20
+default_editor: 'vim'
+auto_open_browser: false
+default_port: 6420
+remote_operations: false
+auto_commit: false
+filesystem_only: true
+bypass_git_hooks: false
+check_active_branches: false
+active_branch_days: 30
+task_prefix: 'task'
+backlog_directory: 'tracker'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "eval:fold-score": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/foldAwareScoring.eval.test.ts",
     "eval:extraction": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts",
     "eval:fact-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/factPooling.eval.test.ts",
-    "eval:fact-score": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/factScoring.eval.test.ts"
+    "eval:fact-score": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/factScoring.eval.test.ts",
+    "tracker": "backlog"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
@@ -77,6 +78,7 @@
     "@typescript-eslint/parser": "^8.65.0",
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/eslint-plugin": "^1.6.24",
+    "backlog.md": "1.48.0",
     "dependency-cruiser": "^18.1.0",
     "dotenv": "^17.4.2",
     "eslint": "^10.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@vitest/eslint-plugin':
         specifier: ^1.6.24
         version: 1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.10)
+      backlog.md:
+        specifier: 1.48.0
+        version: 1.48.0
       dependency-cruiser:
         specifier: ^18.1.0
         version: 18.1.0
@@ -3564,6 +3567,40 @@ packages:
   babel-walk@3.0.0-canary-5:
     resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
     engines: {node: '>= 10.0.0'}
+
+  backlog.md-darwin-arm64@1.48.0:
+    resolution: {integrity: sha512-g/CfNQfjKpm24O6Mc9nZ30zJJR3ZQFTLISz7OIVwdg0Sf0UfmCE00+jzYZnUVmWWAfV2MTZNm6Dqh1xw/Urd+w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  backlog.md-darwin-x64@1.48.0:
+    resolution: {integrity: sha512-/lRs0XgP0bGiuJXmSiZInpnUWJOc/yQAaP8q2KBlQaWdhKYtht2noY62dLixFpwmooryNdx0k18DBiVM5FZuCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  backlog.md-linux-arm64@1.48.0:
+    resolution: {integrity: sha512-Pw4bdZlkxzwe/NM/wy3W0Gy76TU0kiRmpfq1ryBjttmnUOJI5H92JxORXGt8ME+ExdAMygvyN24Qj7TsmmYs9A==}
+    cpu: [arm64]
+    os: [linux]
+
+  backlog.md-linux-x64@1.48.0:
+    resolution: {integrity: sha512-dJ9YuiJdErOVkKFUryXILw/mAkCEeOcS6m0Vi9AaT0gMJ9smf0kSyTKFt3QClpR9VJjPY0XG1UhChlWrT8A4WQ==}
+    cpu: [x64]
+    os: [linux]
+
+  backlog.md-windows-arm64@1.48.0:
+    resolution: {integrity: sha512-Q025PS2Qs4F9bZcY6u9ihNIU3eEQ/SKyXyop6FgBeC+OiCuEFEaVma6tqKYg+DuLSr3PrINOhpcxdcfaubf3zw==}
+    cpu: [arm64]
+    os: [win32]
+
+  backlog.md-windows-x64@1.48.0:
+    resolution: {integrity: sha512-5THHykPK135+jpMCpf1dcFyDxQ6jB/zkcXUUhLZWkLLqm9kjdfFJhsP7Y2wycdTAXPjqoyk9eZGwgsY+QmiM0g==}
+    cpu: [x64]
+    os: [win32]
+
+  backlog.md@1.48.0:
+    resolution: {integrity: sha512-9IMWw9ojgsLvYHbZtsZ/m2XeoX3LBmdfdx1mUS/ymsU8NPDlE8DtsS+a8LOT5RiAoerYJwZvpoVUnm2LRxW8nw==}
+    hasBin: true
 
   badgen@3.3.2:
     resolution: {integrity: sha512-fbQwK9norfdzbdsoPwbLIAmgBXDGEme3jeIyqPAH7o6vp9lmuLHS7uXULvOiQ6XnMLkYNG4gDjILf74hgtTAug==}
@@ -10051,6 +10088,33 @@ snapshots:
   babel-walk@3.0.0-canary-5:
     dependencies:
       '@babel/types': 7.29.7
+
+  backlog.md-darwin-arm64@1.48.0:
+    optional: true
+
+  backlog.md-darwin-x64@1.48.0:
+    optional: true
+
+  backlog.md-linux-arm64@1.48.0:
+    optional: true
+
+  backlog.md-linux-x64@1.48.0:
+    optional: true
+
+  backlog.md-windows-arm64@1.48.0:
+    optional: true
+
+  backlog.md-windows-x64@1.48.0:
+    optional: true
+
+  backlog.md@1.48.0:
+    optionalDependencies:
+      backlog.md-darwin-arm64: 1.48.0
+      backlog.md-darwin-x64: 1.48.0
+      backlog.md-linux-arm64: 1.48.0
+      backlog.md-linux-x64: 1.48.0
+      backlog.md-windows-arm64: 1.48.0
+      backlog.md-windows-x64: 1.48.0
 
   badgen@3.3.2: {}
 

--- a/tracker/tasks/task-10 - visionTierParamsSchema-bounds-validation-convention-alignment-The-schema-crosses.md
+++ b/tracker/tasks/task-10 - visionTierParamsSchema-bounds-validation-convention-alignment-The-schema-crosses.md
@@ -1,0 +1,20 @@
+---
+id: TASK-10
+title: 'visionTierParamsSchema bounds validation (convention alignment) — The schema crosses a…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 10000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — `visionTierParamsSchema` bounds validation (convention alignment) — The schema crosses a BullMQ job-payload boundary (`loadedPersonalitySchema` embeds it) but validates only types, not ranges — unlike its sibling `llmAdvancedParams.ts` (`temperature: min(0).max(2)` etc.). Values originate from DB-side-validated `advancedParameters` JSONB, so no live gap; defense-in-depth per the Zod-at-boundaries rule if a future write path skips the DB validation. **Fix shape**: mirror the sibling's bounds onto the nine numeric fields. **Promote when**: next touch of `visionTierParamsSchema`, or a new write path for vision configs. Surfaced by #1602 round-2 review (deferred at the iteration cap).
+
+**Why:** Boundary-validation convention; not a live gap.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-100 - DiscordChannelFetcherconvertMessage-cognitive-complexity-follow-up-extraction.md
+++ b/tracker/tasks/task-100 - DiscordChannelFetcherconvertMessage-cognitive-complexity-follow-up-extraction.md
@@ -1,0 +1,19 @@
+---
+id: TASK-100
+title: 'DiscordChannelFetcher.convertMessage cognitive-complexity follow-up extraction'
+status: To Do
+assignee: []
+created_date: '2026-05-16 00:00'
+labels: []
+dependencies: []
+ordinal: 100000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`DiscordChannelFetcher.convertMessage` cognitive-complexity follow-up extraction
+
+**Why:** The bot-footer strip added in PR #1035 pushed `convertMessage` over `sonarjs/cognitive-complexity` (suppressed alongside the existing `complexity` suppression — two suppressors on one function is a yellow flag the reviewer surfaced in rounds 4–5). The function does legitimate message-type-conversion branching (role detection, content building, attachment handling, reference resolution, forwarded-message extraction, footer stripping), so the suppression is justified, but extracting one of the sub-concerns into a helper would let the rule re-engage. **Fix shape**: candidate extractions — pull the attachment-handling block, the forwarded-message metadata builder, OR the reference-resolution path into a private method. ~30 LOC + light test rework. **Promote when**: next non-trivial `DiscordChannelFetcher` touch (opportunistic) — the reviewer explicitly framed this as "follow-up extraction in a future `DiscordChannelFetcher` touch." Surfaced 2026-05-16 PR #1035.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-101 - Reply-resolution-tier-2-latency-monitoring-post-deploy.md
+++ b/tracker/tasks/task-101 - Reply-resolution-tier-2-latency-monitoring-post-deploy.md
@@ -1,0 +1,21 @@
+---
+id: TASK-101
+title: 'Reply-resolution tier-2 latency monitoring post-deploy'
+status: To Do
+assignee: []
+created_date: '2026-05-16 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:redis'
+dependencies: []
+ordinal: 101000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Reply-resolution tier-2 latency monitoring post-deploy
+
+**Why:** PR #1035 dropped the `isDM` gate on `ReplyResolutionService.lookupPersonalityIdentifier`'s tier-2 DB lookup, so every Redis miss in guild channels now triggers an api-gateway round trip. Reply Redis keys have a 7-day TTL; under normal traffic the hit rate should keep this cheap, but bursty patterns (Redis restart, high-traffic channel after a long quiet period, batch reply scenarios) could surface p99 spikes on the reply-resolution path that the pre-PR code masked by returning null. **Fix shape options**: (a) restore a narrower gate keyed on "is the bot a member of the channel for >7d" (not really a thing) — likely impractical; (b) add a short in-memory negative cache for failed tier-2 lookups so a chain of replies to an unmatched personality doesn't hammer the gateway; (c) accept and monitor. **Promote when**: production logs show p99 latency spikes on the reply-resolution path correlated with the post-PR-#1035 window, OR a recurring "tier-2 hit rate" metric crosses some threshold worth dashboarding. Surfaced 2026-05-16 PR #1035 round 4.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-102 - MessageContextBuildercachedBotSuffix-promote-pre-login-note-to-hard-invariant.md
+++ b/tracker/tasks/task-102 - MessageContextBuildercachedBotSuffix-promote-pre-login-note-to-hard-invariant.md
@@ -1,0 +1,20 @@
+---
+id: TASK-102
+title: 'MessageContextBuilder.cachedBotSuffix promote pre-login note to hard invariant'
+status: To Do
+assignee: []
+created_date: '2026-05-16 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 102000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`MessageContextBuilder.cachedBotSuffix` promote pre-login note to hard invariant
+
+**Why:** The `cachedBotSuffix` field documents that it freezes at `''` if `fetchExtendedContext` runs before the Discord client logs in. Today this can't happen — extended context is driven by message events that only fire post-`ready` — but the safety is implicit. **Fix shape**: when an explicit `Client.isReady()` (or equivalent gateway-ready) assertion lands at the entry point of the bot-client message pipeline, this method becomes a candidate to remove the `cachedBotSuffix === null` guard and reach for `client.user.tag` directly with a non-null assertion, turning the post-login assumption into an enforced invariant. ~5 LOC. **Promote when**: an explicit gateway-ready assertion is added to the bot-client startup or message-handler entry point. Surfaced 2026-05-16 PR #1035 round 5.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-103 - Pocket-TTS-quantizeTrue-for-memory-savings.md
+++ b/tracker/tasks/task-103 - Pocket-TTS-quantizeTrue-for-memory-savings.md
@@ -1,0 +1,21 @@
+---
+id: TASK-103
+title: 'Pocket TTS quantize=True for memory savings'
+status: To Do
+assignee: []
+created_date: '2026-05-14 00:00'
+labels:
+  - 'area:voice'
+  - 'area:embeddings'
+dependencies: []
+ordinal: 103000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Pocket TTS `quantize=True` for memory savings
+
+**Why:** pocket-tts 2.1+ exposes a `quantize: bool` arg in `TTSModel.load_model()` (requires `pocket-tts[quantize]` extra → torchao). Docstring claims ~48% memory reduction + ~27% speed improvement on x86 (FBGEMM). **Probed 2026-05-14 on Sapphire Rapids 8581C with separate-process measurement (kernel-tracked peak RSS to avoid Python allocator confounds): peak RSS 1259MB → 1247MB = ~1% reduction; generation RTF 0.575 → 0.658 = +14% slower.** Net-negative for Railway billing (vCPU-time goes up more than memory-time goes down). Likely cause: docstring's "48%" measures transformer-layer weights (attention + FFN — what int8 quantization targets) which are a small fraction of total process RSS (Mimi codec, text tokenizer, voice embeddings, PyTorch runtime dominate); plus torchao 0.17.0 emits deprecation warnings suggesting it may not be hitting FBGEMM on this hardware. Quality preserved per user A/B (Emily + ha-shem refs). **Promote when**: actual Railway memory pressure surfaces (OOM kills, needing tier upgrade), OR a future pocket-tts release ships a quantize implementation that delivers process-level memory savings on commodity x86 (changelog mentioning Sapphire Rapids / AVX-512 specifically would be a re-probe trigger). Surfaced 2026-05-14 PR #1029 follow-up. Deferred 2026-05-14.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-104 - Trim-7-over-cap-voice-references.md
+++ b/tracker/tasks/task-104 - Trim-7-over-cap-voice-references.md
@@ -1,0 +1,20 @@
+---
+id: TASK-104
+title: 'Trim 7 over-cap voice references'
+status: To Do
+assignee: []
+created_date: '2026-05-13 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 104000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Trim 7 over-cap voice references
+
+**Why:** Blocked on owner re-uploading trimmed clips for 8 personalities (refs >30s silently fall through Mistral cloning to self-hosted): `rich-fairbank-meshavesh-astrategi` (235.63s outlier), `verosika-hi-sukubusit` (43.15s), `baphomet-ani-miqdash-tame` (39.94s), `machbiel-ani-mistori` (33.62s), `shekhinah-hi-akhat-kan` (33.38s), `ha-shem-keev-ima` (31.78s), `sir-pentious-malakh-nachash` (30.35s), plus `lilith-tzel-shani` (29.99s — at the cap). No code work — audit tool shipped 2026-05-13. **Re-run** `pnpm ops voice-refs:audit --env prod` after each trim batch. Deferred 2026-05-19 (inbox sweep).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-105 - Audit-api-gateway-key-validators-for-5xx-as-transient-classification.md
+++ b/tracker/tasks/task-105 - Audit-api-gateway-key-validators-for-5xx-as-transient-classification.md
@@ -1,0 +1,21 @@
+---
+id: TASK-105
+title: 'Audit api-gateway key validators for 5xx-as-transient classification'
+status: To Do
+assignee: []
+created_date: '2026-05-17 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 105000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Audit api-gateway key validators for 5xx-as-transient classification
+
+**Why:** The deleted ai-worker `KeyValidationService` had `ProviderUnavailableError` to distinguish 5xx from 401; current gateway validators (4 providers — elevenlabs/mistral/openrouter/zaiCoding) may not all share this. No current bug — validators run on user-submit and a transient 5xx producing "key invalid" is recoverable. **Promote when**: runtime key-health reporting gets wired up (then mis-classification corrupts the health signal). **Start**: `services/api-gateway/src/utils/apiKeyValidation/types.ts` + each provider file. Surfaced 2026-05-17 by PR #1044 review. Deferred 2026-05-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-106 - Normalize-non-standard-IP-formats-in-publicRouteKeyGenerator.md
+++ b/tracker/tasks/task-106 - Normalize-non-standard-IP-formats-in-publicRouteKeyGenerator.md
@@ -1,0 +1,21 @@
+---
+id: TASK-106
+title: 'Normalize non-standard IP formats in publicRouteKeyGenerator'
+status: To Do
+assignee: []
+created_date: '2026-05-17 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:redis'
+dependencies: []
+ordinal: 106000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Normalize non-standard IP formats in `publicRouteKeyGenerator`
+
+**Why:** Two edge cases land the same client in different Redis buckets: bracket+port IPv6 (`[2001:db8::1]:8080`, RFC 7239 §6.3) and IPv4-mapped IPv6 (`::ffff:127.0.0.1` from Node's `socket.remoteAddress`). Won't surface in current Railway deployment. **Promote when**: Railway logs show non-standard XFF formats, or when adopting non-Railway hosting. **Start**: `services/api-gateway/src/utils/RedisRateLimiter.ts` `publicRouteKeyGenerator`. Surfaced 2026-05-17 by PR #1046 review. Deferred 2026-05-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-107 - Tighten-AttachmentMetadataoriginalUrl-schema.md
+++ b/tracker/tasks/task-107 - Tighten-AttachmentMetadataoriginalUrl-schema.md
@@ -1,0 +1,20 @@
+---
+id: TASK-107
+title: 'Tighten AttachmentMetadata.originalUrl schema'
+status: To Do
+assignee: []
+created_date: '2026-05-18 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 107000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Tighten `AttachmentMetadata.originalUrl` schema
+
+**Why:** After PR #1050, `extractAttachments` always sets `originalUrl: attachment.url`, but the schema keeps it `z.string().optional()` because other paths (`services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts:420,442`) construct attachments without it. The reader's defensive `if (originalUrl === undefined) return null` guard in `AudioProcessor.lookupCachedTranscript` is load-bearing because of this. **Fix shape**: either (a) require `originalUrl` at the schema level + update the few callers to default to `attachment.url`, or (b) split into `BotClientAttachment` (requires originalUrl) vs `WorkerInternalAttachment` types. Option (a) is simpler. **Promote when**: doing a multimodal attachment-handling refactor or when the defensive guard becomes load-bearing in a new code path. Surfaced 2026-05-18 by PR #1050 reviewer. Deferred 2026-05-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-108 - ErrorCodeUNAUTHORIZED-HTTP-403-mapping-probably-should-be-401-split-from….md
+++ b/tracker/tasks/task-108 - ErrorCodeUNAUTHORIZED-HTTP-403-mapping-probably-should-be-401-split-from….md
@@ -1,0 +1,20 @@
+---
+id: TASK-108
+title: 'ErrorCode.UNAUTHORIZED → HTTP 403 mapping (probably should be 401) + split from…'
+status: To Do
+assignee: []
+created_date: '2026-05-18 00:00'
+labels:
+  - 'area:api-gateway'
+dependencies: []
+ordinal: 108000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`ErrorCode.UNAUTHORIZED` → HTTP 403 mapping (probably should be 401) + split from `forbidden()`
+
+**Why:** `services/api-gateway/src/utils/errorResponses.ts:20` maps `UNAUTHORIZED` → 403; per RFC 7235 it should be 401. `ErrorResponses.unauthorized` and `.forbidden` both wrap `UNAUTHORIZED`, so a naive flip breaks `forbidden()`. Paired fix: add `ErrorCode.FORBIDDEN` (→ 403), point `forbidden()` at it, flip `UNAUTHORIZED` → 401. ~15-20 LOC + test updates. No current user-visible bug (clients don't distinguish 401/403 in our context). **Promote when**: any API consumer reports auth-required vs auth-insufficient confusion, OR when next touching errorResponses.ts. Surfaced 2026-05-18 by PR #1051. Deferred 2026-05-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-109 - Re-process-bot-tags-on-message-edits-typo-recovery.md
+++ b/tracker/tasks/task-109 - Re-process-bot-tags-on-message-edits-typo-recovery.md
@@ -1,0 +1,20 @@
+---
+id: TASK-109
+title: 'Re-process bot tags on message edits (typo recovery)'
+status: To Do
+assignee: []
+created_date: '2026-05-17 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 109000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Re-process bot tags on message edits (typo recovery)
+
+**Why:** If a user mistypes a bot's name in @-tagging and then edits to fix it, the bot doesn't notice — Discord.js `messageUpdate` events are ignored today. Subscribe in bot-client; if the edit changed which bot tags resolve, trigger the original processing path. **Edge cases**: idempotency on unchanged tag-set; no duplicate responses; sensible edit-window limit (Discord allows editing indefinitely but processing a 6-hour-old edit is weird). **Promote when**: any user complains about typo'd bot tags being lost (low frequency expected), OR when next touching the message-handling routing layer. **Start**: `services/bot-client/src/handlers/MessageHandler.ts` (routing) + add `messageUpdate` listener in `services/bot-client/src/index.ts`. Surfaced 2026-05-17 in personal notes. Deferred 2026-05-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-11 - pre-commit-temporal-marker-regex-misses-hyphenated-round-refs-two-shipped-archae.md
+++ b/tracker/tasks/task-11 - pre-commit-temporal-marker-regex-misses-hyphenated-round-refs-two-shipped-archae.md
@@ -1,0 +1,19 @@
+---
+id: TASK-11
+title: 'pre-commit temporal-marker regex misses hyphenated round refs + two shipped archaeology…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels: []
+dependencies: []
+ordinal: 11000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — pre-commit temporal-marker regex misses hyphenated round refs + two shipped archaeology comments — The `.husky/pre-commit` scanner's round-marker pattern expects a space (`round [0-9]+`) so `round-1 review` slips through — #1602 shipped two test comments carrying exactly that archaeology (`VisionConfigResolver.test.ts` ~line 107, `stampResolvedConfig.test.ts` ~line 25), reviewer-caught post-hoc. **Fix shape**: tighten the hook regex to `round[- ][0-9]+` AND strip the two comments to invariant-only phrasing in the same pass. **Promote when**: next touch of either file or the pre-commit hook.
+
+**Why:** Structural-guard gap + the two comments it let through; one PR fixes both.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-110 - Channel-topic-awareness-layered-user-controllable-system-prompting.md
+++ b/tracker/tasks/task-110 - Channel-topic-awareness-layered-user-controllable-system-prompting.md
@@ -1,0 +1,22 @@
+---
+id: TASK-110
+title: 'Channel-topic awareness + layered user-controllable system prompting'
+status: To Do
+assignee: []
+created_date: '2026-05-18 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:docs'
+  - 'area:backlog'
+dependencies: []
+ordinal: 110000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Channel-topic awareness + layered user-controllable system prompting
+
+**Why:** Two-part deferred feature: (a) bots should be aware of the Discord channel topic so they can recognize on-topic vs off-topic content; (b) this requires updating the default system prompt in the system-prompts table, which in turn benefits from layered user-controllable prompting first (system → channel → persona → user layers with explicit precedence). Part (b) is the structural enabler; part (a) is the user-facing payoff. **Promote when**: ready to tackle the system-prompts-table architecture work — layered composition design comes first, then schema change, then channel-topic plumbing. **Start**: review `services/ai-worker/src/services/prompt/` for current single-layer assembly; design layered composition before changing schema. Surfaced 2026-05-18 in personal notes. Deferred 2026-05-19. **DESIGN LANDED 2026-07-05**: the layered-composition seam (platform → channel → personality → user-overrides) is §2.1 of `docs/proposals/backlog/prompt-assembly-architecture.md` — typed layers ship in its Phase 1; the channel layer + schema stay trigger-gated as before. Entry retained until the channel layer ships.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-111 - JobTracker-orphan-state-after-JobFailureListener-cancels-a-job.md
+++ b/tracker/tasks/task-111 - JobTracker-orphan-state-after-JobFailureListener-cancels-a-job.md
@@ -1,0 +1,21 @@
+---
+id: TASK-111
+title: 'JobTracker orphan state after JobFailureListener cancels a job'
+status: To Do
+assignee: []
+created_date: '2026-05-19 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:jobs'
+dependencies: []
+ordinal: 111000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`JobTracker` orphan state after `JobFailureListener` cancels a job
+
+**Why:** `JobFailureListener.handleTerminalEvent` deliberately doesn't call `jobTracker.completeJob()` (would silently delete the "taking longer" Discord message), so the JobTracker slot + its typing indicator and notification sit until the orphan sweep at `TYPING_INDICATOR_TIMEOUT_MS + ORPHAN_SWEEP_GRACE_MS`. Symptom: a user could see a stale "taking longer" notification for up to 40 min after a job failure, even after the ordering queue is unblocked. **Fix shape**: surface the failure to the user (delete the "taking longer" message + send a brief "your request couldn't complete" notice) BEFORE calling `completeJob`. **Promote when**: any user reports a stale "taking longer" notification, OR when adding user-facing failure messaging to the AI pipeline. **Start**: `services/bot-client/src/services/JobFailureListener.ts` `handleTerminalEvent`. Surfaced 2026-05-19 by release PR #1060 review. Deferred 2026-05-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-112 - Migrate-tts-configtestts-extractHandler-to-shared-getRouteHandler.md
+++ b/tracker/tasks/task-112 - Migrate-tts-configtestts-extractHandler-to-shared-getRouteHandler.md
@@ -1,0 +1,22 @@
+---
+id: TASK-112
+title: 'Migrate tts-config.test.ts extractHandler to shared getRouteHandler'
+status: To Do
+assignee: []
+created_date: '2026-05-21 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:voice'
+  - 'area:db'
+dependencies: []
+ordinal: 112000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Migrate `tts-config.test.ts` `extractHandler` to shared `getRouteHandler`
+
+**Why:** `services/api-gateway/src/routes/admin/tts-config.test.ts:106-115`. PR #1075 extracted `getAllRoutes()` to `expressRouterUtils.ts` but left the pre-existing `extractHandler` helper (25 call sites) unmigrated. The local `RouterLayer` interface stays alive solely to support `extractHandler`. **Fix shape**: replace `extractHandler(router, method, path)` calls with `getRouteHandler(router, method, path)` from `expressRouterUtils.js`; the return type widens from `(req: Request, res: Response) => Promise<void>` to `(...args: unknown[]) => unknown`, so each call site needs an `as` cast OR a thin local wrapper. Delete the local `RouterLayer` interface after migration. ~25-line mechanical touch. **Promote when**: next touching `tts-config.test.ts` for any reason, OR opportunistically during a wider test-utility cleanup pass. Surfaced 2026-05-21 by PR #1075 round-2 claude-bot review. Deferred 2026-05-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-113 - Tighten-usersdefaultllmconfigid-and-defaultttsconfigid-to-NOT-NULL-post-Phase-5b.md
+++ b/tracker/tasks/task-113 - Tighten-usersdefaultllmconfigid-and-defaultttsconfigid-to-NOT-NULL-post-Phase-5b.md
@@ -1,0 +1,20 @@
+---
+id: TASK-113
+title: 'Tighten users.default_llm_config_id and default_tts_config_id to NOT NULL post-Phase-5b'
+status: To Do
+assignee: []
+created_date: '2026-05-21 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 113000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Tighten `users.default_llm_config_id` and `default_tts_config_id` to NOT NULL post-Phase-5b
+
+**Why:** `prisma/schema.prisma:26-27`. Both columns are `String?` (nullable). They predate Phase 5b's atomic user-creation work (which made `default_persona_id` NOT NULL). With users now created via a deterministic CTE that has access to system free-defaults, these two columns could be backfilled and tightened too — eliminating defensive `?? fallback` in `LlmConfigResolver` / `TtsConfigResolver`. **Fix shape**: (a) migration to backfill any existing NULL rows with the system free-default config id; (b) `ALTER COLUMN ... SET NOT NULL`; (c) update `schema.prisma` to drop the `?`; (d) audit resolver code to remove no-longer-reachable null branches. ~50-80 LOC + migration. **Why deferred**: no bug today — the resolvers handle null correctly, and the cascade design tolerates user-tier null gracefully. Tightening is for invariant clarity + dead-code removal, not bug fix. **Promote when**: next user-identity audit, OR alongside the syncTables comment fix above (same scope), OR if a new config-cascade bug traces to ambiguous null semantics. Surfaced 2026-05-21 by Schema Audit. Deferred 2026-05-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-114 - Share-a-single-ts-morph-Project-across-globSourceFiles-classifyReads-analyzeWrit.md
+++ b/tracker/tasks/task-114 - Share-a-single-ts-morph-Project-across-globSourceFiles-classifyReads-analyzeWrit.md
@@ -1,0 +1,20 @@
+---
+id: TASK-114
+title: 'Share a single ts-morph Project across globSourceFiles / classifyReads / analyzeWrites'
+status: To Do
+assignee: []
+created_date: '2026-05-21 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 114000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Share a single `ts-morph` `Project` across `globSourceFiles` / `classifyReads` / `analyzeWrites`
+
+**Why:** `packages/tooling/src/dev/schema-audit.ts` `globSourceFiles()` creates a `new Project(...)` to expand globs into paths; `classifyReads()` and `analyzeWrites()` each construct another `Project` from those same paths. Each pass triggers full ts-morph parsing — three parse passes over the source tree per audit run. **Fix shape**: change `globSourceFiles` to return `{ paths, project }` and thread the project into the two analyzers. ~30 LOC delta. **Why deferred**: tool is documented as one-shot / quarterly; ~3x parse cost is tolerable. Promote if/when runtime becomes a complaint, or if any caller wires the audit into a recurring CI step. Surfaced 2026-05-21 by PR #1076 round-3 claude-bot review. Deferred 2026-05-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-115 - Harden-globSourceFiles-test-exclusion-against-custom-non-ts-globs.md
+++ b/tracker/tasks/task-115 - Harden-globSourceFiles-test-exclusion-against-custom-non-ts-globs.md
@@ -1,0 +1,20 @@
+---
+id: TASK-115
+title: 'Harden globSourceFiles test-exclusion against custom non-*.ts globs'
+status: To Do
+assignee: []
+created_date: '2026-05-21 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 115000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Harden `globSourceFiles` test-exclusion against custom non-`*.ts` globs
+
+**Why:** `packages/tooling/src/dev/schema-audit.ts` `globSourceFiles()` builds the test exclusion via `glob.replace(/\*\.ts$/, '*.test.ts')`. If a caller passes a custom `sourceGlobs` ending in `*.tsx` or `*.ts?(x)`, the replace silently no-ops and the "exclusion" pattern becomes the original glob — excluding ALL files in the custom path rather than just test variants. The default `['services/**/*.ts', 'packages/**/*.ts']` is fine; the edge case only surfaces when callers override. **Fix shape**: guard the exclusion generation behind `glob.endsWith('*.ts')`, OR generalize the test exclusion to a separate explicit pattern that doesn't depend on the input glob's suffix. ~5 LOC. **Why deferred**: no caller currently overrides `sourceGlobs`; tests use defaults. Promote when adding TSX support or the first custom-glob caller. Surfaced 2026-05-21 by PR #1076 round-3 claude-bot review. Deferred 2026-05-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-116 - Index-classifyReads-field-lookup-by-name-eliminate-inner-scan.md
+++ b/tracker/tasks/task-116 - Index-classifyReads-field-lookup-by-name-eliminate-inner-scan.md
@@ -1,0 +1,21 @@
+---
+id: TASK-116
+title: 'Index classifyReads field lookup by name (eliminate inner-scan)'
+status: To Do
+assignee: []
+created_date: '2026-05-21 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:db'
+dependencies: []
+ordinal: 116000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Index `classifyReads` field lookup by name (eliminate inner-scan)
+
+**Why:** `packages/tooling/src/dev/schema-audit-reads.ts` `classifyReads()` walks every `PropertyAccessExpression` node in the source tree and runs a linear scan over `optionalFields` per access. The companion `analyzeWrites` already pre-groups fields by accessor name — `classifyReads` can mirror that. **Fix shape**: build a `Map<fieldName, PrismaField[]>` outside the file loop, then `fieldsByName.get(fieldName) ?? []` instead of the inner `for (const field of optionalFields)`. ~10 LOC delta. **Why deferred**: tool is one-shot / quarterly; complexity is `O(propAccesses × optionalFields)` ≈ 50k × 500 = 25M comparisons on the current codebase — measurable but tolerable. Promote when audit runtime becomes a complaint, OR when wiring into a recurring step that runs more than monthly. Surfaced 2026-05-21 by PR #1076 round-5 claude-bot review. Deferred 2026-05-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-117 - Index-printFindingBlock-readswrites-lookup-eliminate-linear-find.md
+++ b/tracker/tasks/task-117 - Index-printFindingBlock-readswrites-lookup-eliminate-linear-find.md
@@ -1,0 +1,20 @@
+---
+id: TASK-117
+title: 'Index printFindingBlock reads/writes lookup (eliminate linear .find())'
+status: To Do
+assignee: []
+created_date: '2026-05-21 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 117000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Index `printFindingBlock` reads/writes lookup (eliminate linear `.find()`)
+
+**Why:** `packages/tooling/src/dev/schema-audit-report.ts` `printFindingBlock` does `reads.find(c => c.model === f.model && c.field === f.field)` and the same for writes — O(N) per finding, called once per finding render. `generateFindings` already builds `Map`s keyed by `${model}.${field}`; could pass them down or build them once at the top of `printMarkdownReport`. **Fix shape**: thread the `Map<string, ReadModeClassification>` and `Map<string, WriteSiteClassification>` from `generateFindings` into `printMarkdownReport`, replace `.find()` with `.get(key)`. ~15 LOC delta. **Why deferred**: with 4 findings × <100 optional fields, the cost is invisible. Co-fix candidate with the `ts-morph` Project-sharing entry above. **Promote when**: bundled with the Project-sharing fix, OR if findings volume reaches the hundreds (unlikely). Surfaced 2026-05-21 by PR #1076 round-6 claude-bot review. Deferred 2026-05-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-118 - Validate-auditconfig-reviewedAt-as-ISO-date.md
+++ b/tracker/tasks/task-118 - Validate-auditconfig-reviewedAt-as-ISO-date.md
@@ -1,0 +1,20 @@
+---
+id: TASK-118
+title: 'Validate audit.config reviewedAt as ISO date'
+status: To Do
+assignee: []
+created_date: '2026-05-21 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 118000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Validate `audit.config` `reviewedAt` as ISO date
+
+**Why:** `packages/tooling/src/dev/schema-audit-suppression.ts` `assertConfigShape` accepts any string for the optional `reviewedAt` field. The intent is a human-accountability / staleness audit timestamp, so values like `"last tuesday"` or typos pass silently. **Fix shape**: when `e.reviewedAt` is present, check `/^\d{4}-\d{2}-\d{2}/.test(e.reviewedAt)` (or `Date.parse` not NaN) and throw on failure. ~3 LOC. **Why deferred**: tool is one-shot / quarterly; bad timestamps are aesthetic, not load-bearing. Promote when adding a staleness-check pass that compares `reviewedAt` ages against a freshness budget (would require parseable dates). Surfaced 2026-05-21 by PR #1076 round-6 claude-bot review. Deferred 2026-05-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-119 - Drop-qs-pnpm-override-when-expresssupertest-ship-versions-that-bump-qs-upstream.md
+++ b/tracker/tasks/task-119 - Drop-qs-pnpm-override-when-expresssupertest-ship-versions-that-bump-qs-upstream.md
@@ -1,0 +1,20 @@
+---
+id: TASK-119
+title: 'Drop qs pnpm override when express/supertest ship versions that bump qs upstream'
+status: To Do
+assignee: []
+created_date: '2026-05-23 00:00'
+labels:
+  - 'area:ci'
+dependencies: []
+ordinal: 119000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Drop `qs` pnpm override when express/supertest ship versions that bump qs upstream
+
+**Why:** PR #1088 added `qs@>=6.11.1 <6.15.2: >=6.15.2 <7.0.0` to root `package.json` pnpm overrides to clear `GHSA-q8mj-m7cp-5q26`. Override is transient — once `express@5.2.x` and `supertest@7.x` ship versions that depend on `qs@>=6.15.2` directly, the override becomes a no-op and can be deleted to keep `package.json` lean. **Fix shape**: `pnpm why qs` shows current consumers; when both report `qs@>=6.15.2` as their direct dep (not via the override), delete the override line and re-run `pnpm install`. **Promote when**: dependabot opens a follow-up to bump express or supertest (it usually does for transitive vulns once the upstream catches up), OR opportunistically during the next dep-audit pass. Surfaced 2026-05-23 by PR #1088 claude-review. Deferred 2026-05-23.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-12 - three-copies-of-the-apply-LLMCONFIGOVERRIDEKEYS-pattern-….md
+++ b/tracker/tasks/task-12 - three-copies-of-the-apply-LLMCONFIGOVERRIDEKEYS-pattern-….md
@@ -1,0 +1,23 @@
+---
+id: TASK-12
+title: 'three copies of the apply-LLM_CONFIG_OVERRIDE_KEYS pattern —…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:ai-worker'
+  - 'area:common-types'
+  - 'area:config-resolver'
+dependencies: []
+ordinal: 12000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — three copies of the apply-`LLM_CONFIG_OVERRIDE_KEYS` pattern — `LlmConfigResolver.mergeWithPersonality`/`extractFromPersonality` (config-resolver), `stampResolvedConfig.applyResolvedConfig` (api-gateway), and `quotaFallback.applyConfigToPersonality` (ai-worker) are structurally identical key-copy loops (reviewer-verified on #1600). Three copies of the same decision can drift — a fourth key-semantics change (e.g. a nested-merge field) would need three edits. **Fix shape**: one shared helper in common-types (likely next to `LLM_CONFIG_OVERRIDE_KEYS` itself in `llmAdvancedParams.ts`), three call sites converted. **Promote when**: next touch of any of the three, or when a new override key with non-trivial merge semantics lands.
+
+**Why:** Reuse-scout consolidation; the copies must not disagree about the same question.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-120 - Extract-buildQueryString-from-generated-client-files-route-codegen.md
+++ b/tracker/tasks/task-120 - Extract-buildQueryString-from-generated-client-files-route-codegen.md
@@ -1,0 +1,23 @@
+---
+id: TASK-120
+title: 'Extract buildQueryString from generated client files (route-codegen)'
+status: To Do
+assignee: []
+created_date: '2026-05-24 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:common-types'
+  - 'area:tooling'
+  - 'area:ci'
+dependencies: []
+ordinal: 120000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Extract `buildQueryString` from generated client files (route-codegen)
+
+**Why:** All three generated client classes inline the same 6-line `buildQueryString` helper. Council finding from PR #1090 (claude-bot review 2, 2026-05-24): valid concern that the duplication is invisible to readers because generated files are never hand-edited, but the helper could be exported from `clients/transport.ts` and imported via `'../../index.js'` (already present in every generated file's import block) to eliminate the repetition. **Why deferred**: trade-off is marginal — the codegen output is excluded from CPD, knip, and codecov, and keeping generated files self-contained-ish has some readability value. **Fix shape**: move the function body to `packages/common-types/src/clients/transport.ts`, export it, then drop `buildQueryHelper()` from `packages/tooling/src/codegen/client-builder.ts` and add `buildQueryString` to the import-symbols list emitted by `buildImports`. Regenerate. **Promote when**: a 4th generated client (e.g. PR-1.5's `mounts.ts` server-side or a future ai-worker client) makes the inlining feel embarrassing, OR opportunistically when next touching `client-builder.ts`. Surfaced 2026-05-24 by PR #1090 round 1 claude-bot review. Deferred 2026-05-24.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-121 - Migrate-the-3-remaining-local-err-arrow-builders-to-makeErr.md
+++ b/tracker/tasks/task-121 - Migrate-the-3-remaining-local-err-arrow-builders-to-makeErr.md
@@ -1,0 +1,19 @@
+---
+id: TASK-121
+title: 'Migrate the 3 remaining local err() arrow-builders to makeErr'
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels: []
+dependencies: []
+ordinal: 121000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Migrate the 3 remaining local `err()` arrow-builders to `makeErr`
+
+**Why:** The 7 command-test `function err(status, message)` builders were swept to the shared `makeErr` (identical semantics). Three files remain with a DIFFERENT shape (`error: 'boom'`, status-only params, one without `kind`): `services/HttpPersonalityLoader.test.ts`, `utils/gatewayWriteHelpers.test.ts`, `utils/gatewayServiceCalls.test.ts` — call sites must become `makeErr(status, 'boom')` and assertions re-checked. **Promote when**: next touching any of those three test files. Surfaced 2026-06-xx; re-scoped 2026-07-02 (sweep).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-122 - Narrow-pre-commit-codegen-routes-trigger-to-skip-testts.md
+++ b/tracker/tasks/task-122 - Narrow-pre-commit-codegen-routes-trigger-to-skip-testts.md
@@ -1,0 +1,22 @@
+---
+id: TASK-122
+title: 'Narrow pre-commit codegen-routes trigger to skip *.test.ts'
+status: To Do
+assignee: []
+created_date: '2026-05-24 00:00'
+labels:
+  - 'area:common-types'
+  - 'area:tooling'
+  - 'area:clients'
+dependencies: []
+ordinal: 122000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Narrow pre-commit codegen-routes trigger to skip `*.test.ts`
+
+**Why:** `.husky/pre-commit` regenerates and stages the `_generated/` client files whenever any file under `packages/common-types/src/routes/` is staged — including test files. Test edits trigger a no-op regen and re-stage of unchanged files, adding minor noise to the diff. **Fix shape**: tighten the grep to `'^packages/common-types/src/routes/.*\.ts$' | grep -v '\.test\.ts$'`. **Why deferred**: noise is mild (the regen is fast and the file content doesn't change so `git add` is a no-op on unchanged content), and the simpler trigger is easier to reason about. **Promote when**: a contributor complains about regen noise on test-only edits, OR when the codegen tool gains side effects that make running it on every routes/ edit costly. Surfaced 2026-05-24 by PR #1090 round 1 claude-bot review. **UPGRADED 2026-06-24 — confirmed stale-path bug (bigger than the test-skip):** the trigger greps `^packages/common-types/src/routes/`, a directory that no longer exists — the routes-package refactor moved `ROUTE_MANIFEST` to `packages/clients/src/routes/manifest.ts`, so the grep NEVER matches and the pre-commit codegen auto-regen is silently DEAD (editing the manifest no longer regenerates/stages `_generated/`; CI's `codegen-drift` gate is the only remaining backstop — friction, not data loss). The `git add` stage path (`packages/common-types/src/clients/_generated/`) and the `packages/tooling/src/codegen/routes.ts:4` docstring ("Reads ROUTE_MANIFEST from @tzurot/common-types") are stale the same way. **Revised fix shape**: (1) repoint the trigger grep + the `git add` stage path to `packages/clients/...` (verify the real `_generated/` dir); (2) fix the codegen docstring; (3) THEN add the `'^packages/clients/src/routes/.*\.ts$' | grep -v '\.test\.ts$'` skip; (4) verify by staging a manifest edit and confirming the regen fires. Not "cheap" — a real (CI-backstopped) latent bug; deferred from beta.137 PR4 for this reason. Deferred 2026-05-24.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-123 - Required-query-params-lose-required-ness-AND-numeric-narrowing-in-generated-clie.md
+++ b/tracker/tasks/task-123 - Required-query-params-lose-required-ness-AND-numeric-narrowing-in-generated-clie.md
@@ -1,0 +1,19 @@
+---
+id: TASK-123
+title: 'Required-query-params lose required-ness AND numeric narrowing in generated client…'
+status: To Do
+assignee: []
+created_date: '2026-05-24 00:00'
+labels: []
+dependencies: []
+ordinal: 123000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Required-query-params lose required-ness AND numeric narrowing in generated client signatures
+
+**Why:** `RouteDef.query` accepts a record of Zod schemas; `buildOptionsType` in `method-builder.ts` widens every key to `{ [key]?: string }` because all HTTP query values are strings on the wire. Two ergonomic gaps for PR-2 callers: (1) **required-ness loss** — for routes where a query param is genuinely required server-side (rejected with 400 if absent), the client signature gives callers no compile-time signal; (2) **numeric narrowing loss** — `z.coerce.number().int().positive().optional()` on the server (e.g., `recentUsers.sinceDays`) narrows to `number` after coercion, but the client signature stays `string?`, so a caller passing `7` gets a TS error and must wrap with `String(7)`. Reviewer's suggested fix shape: add a `requiredQuery` field to `RouteDef` (or a `.required()` marker) that the codegen renders as required positional parameters; optionally inspect schema kind for `z.coerce.number()` to widen the client type to `number | string`. **Why deferred**: closely related to the timeout-escape-hatch backlog item — same `method-builder.ts` / `buildOptionsType` territory, same client-signature-narrowing problem class. Co-fix candidate. No production evidence yet. **Promote when**: PR-2 surfaces a real call site where required-but-optional causes a 400 OR numeric-coerce causes call-site friction, OR opportunistically alongside the timeout-escape-hatch refactor. Surfaced 2026-05-24 by PR #1090 rounds 7+10 claude-bot reviews. Deferred 2026-05-24.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-124 - Capture-non-JSON-error-body-text-in-parseErrorResponse-for-operator-logs.md
+++ b/tracker/tasks/task-124 - Capture-non-JSON-error-body-text-in-parseErrorResponse-for-operator-logs.md
@@ -1,0 +1,20 @@
+---
+id: TASK-124
+title: 'Capture non-JSON error body text in parseErrorResponse for operator logs'
+status: To Do
+assignee: []
+created_date: '2026-05-24 00:00'
+labels:
+  - 'area:common-types'
+dependencies: []
+ordinal: 124000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Capture non-JSON error body text in `parseErrorResponse` for operator logs
+
+**Why:** `packages/common-types/src/clients/errors.ts` `parseErrorResponse` catches non-JSON bodies (nginx 502, CDN HTML pages) and falls back to `{ message: 'HTTP <status>' }`, discarding the response body entirely. Operators debugging "why did the gateway 502?" see only the status code — no nginx error page text, no CDN diagnostic. **Fix shape**: have `parseErrorResponse` populate an optional `rawText?: string` field from `response.text()` on the catch path; `callGateway` forwards it through `onWarn`'s second argument so log infrastructure (pino, structured loggers) can surface the body. User-facing message stays `HTTP <status>`; operators get full context. **Promote when**: a production gateway 502/503 surfaces with no debug info, OR opportunistically alongside the next `errors.ts` change. Surfaced 2026-05-24 by PR #1090 rounds 11 + post-autosquash claude-bot reviews. Deferred 2026-05-24.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-125 - asActor-asSubject-accept-empty-strings-defense-in-depth-guard.md
+++ b/tracker/tasks/task-125 - asActor-asSubject-accept-empty-strings-defense-in-depth-guard.md
@@ -1,0 +1,20 @@
+---
+id: TASK-125
+title: 'asActor / asSubject accept empty strings (defense-in-depth guard)'
+status: To Do
+assignee: []
+created_date: '2026-05-24 00:00'
+labels:
+  - 'area:common-types'
+dependencies: []
+ordinal: 125000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`asActor` / `asSubject` accept empty strings (defense-in-depth guard)
+
+**Why:** `packages/common-types/src/routes/types.ts` smart constructors `asActor(id)` and `asSubject(id)` cast any string to the branded type, including `""`. Today the brands are only minted at the Discord interaction boundary (`interaction.user.id` is always a non-empty snowflake), so the risk is low. A one-line guard adds defense in depth against a future call site that forgets to validate before minting. **Fix shape**: `if (id.length === 0) throw new TypeError('asActor: id must be non-empty')` inside both smart constructors. ~4 LOC across both. **Promote when**: a new caller mints brands outside the Discord interaction boundary (e.g., from CLI args, request bodies), OR opportunistically alongside the next `types.ts` change. Surfaced 2026-05-24 by PR #1090 post-autosquash claude-bot review. Deferred 2026-05-24.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-126 - Wire-clearChannelConfigOverrides-close-settingstestts-coverage-gaps.md
+++ b/tracker/tasks/task-126 - Wire-clearChannelConfigOverrides-close-settingstestts-coverage-gaps.md
@@ -1,0 +1,20 @@
+---
+id: TASK-126
+title: 'Wire clearChannelConfigOverrides + close settings.test.ts coverage gaps'
+status: To Do
+assignee: []
+created_date: '2026-05-28 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 126000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Wire `clearChannelConfigOverrides` + close `settings.test.ts` coverage gaps
+
+**Why:** PR-2g registered `clearChannelConfigOverrides` in the manifest (DELETE `/user/channel/:channelId/config-overrides`) and generated the corresponding `userClient` method, but `services/bot-client/src/commands/channel/settings.ts` doesn't yet call it — the dashboard has no "Reset to defaults" UX path. Stub deliberately omits the method to keep the test contract honest. Three related coverage gaps in `settings.test.ts` were flagged by claude-bot across multiple review rounds and all naturally land alongside the DELETE wiring: (1) `handleChannelSettingsButton` describe block only covers failure path (~lines 406–441) — happy-path test confirming `createUpdateHandler`'s channelId binding end-to-end is missing; (2) `updateChannelConfigOverrides` failure branch at `settings.ts:231-234` is not exercised — the user-visible error message goes untested; (3) the "should display settings dashboard embed with permission" test (~line 200) doesn't assert `stub.resolveCascade.toHaveBeenCalledWith('personality-123', { channelId: 'channel-123' })` — the channel-scoping contract is the load-bearing argument and goes unverified. **Fix shape**: add a "Reset to defaults" button to the channel settings dashboard wired to `userClient.clearChannelConfigOverrides(channelId)`; extend `UserClientStub` with the method; add the three test fixtures while the file is open. **Promote when**: dashboard UX work adds a "Reset to defaults" surface for channel config overrides, OR a user requests one-click clearing. Surfaced 2026-05-28 by PR #1110 post-autosquash + post-merge claude-bot reviews. Deferred 2026-05-28.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-127 - 3-second-ack-rule-violation-in-memory-handleEditButton.md
+++ b/tracker/tasks/task-127 - 3-second-ack-rule-violation-in-memory-handleEditButton.md
@@ -1,0 +1,21 @@
+---
+id: TASK-127
+title: '3-second ack-rule violation in memory handleEditButton'
+status: To Do
+assignee: []
+created_date: '2026-05-28 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:db'
+dependencies: []
+ordinal: 127000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+3-second ack-rule violation in memory `handleEditButton`
+
+**Why:** `services/bot-client/src/commands/memory/detailModals.ts` `handleEditButton` calls `fetchMemory` (one gateway round-trip) BEFORE any `interaction.reply` / `showModal` ack. Per `04-discord.md` "the first await in a component handler must be on `interaction.deferUpdate()`" — async work must follow an ack, not precede it. The handler currently absorbs the entire 3-second interaction budget on the API call; users on a slow gateway will see "Interaction failed." Pre-existing behavior (preserved through the PR-2h typed-client migration; same race existed under the old `callGatewayApi` shape). **Fix shape**: cannot use `deferUpdate` directly because the success path is `showModal`, which is forbidden after defer. Two options: (a) skip the pre-fetch — pre-fill the modal with a placeholder and load the content asynchronously via `interaction.message.edit` after the modal is shown; (b) refactor to surface a "loading" embed first, then defer + showModal once the fetch is done (UX change). The sibling `handleEditTruncatedButton` and `handleEditModalSubmit` paths have the same shape and should be fixed alongside. **Promote when**: a user reports the "Interaction failed" UX OR opportunistically on next memory-detail refactor pass. Surfaced 2026-05-28 by PR #1111 round-4 claude-bot review (flagged as pre-existing). Deferred 2026-05-28.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-128 - Zod-safeParse-on-SyntheticTimeoutContext-read-back-in-getSyntheticTimeout.md
+++ b/tracker/tasks/task-128 - Zod-safeParse-on-SyntheticTimeoutContext-read-back-in-getSyntheticTimeout.md
@@ -1,0 +1,20 @@
+---
+id: TASK-128
+title: 'Zod safeParse on SyntheticTimeoutContext read-back in getSyntheticTimeout'
+status: To Do
+assignee: []
+created_date: '2026-05-29 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 128000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Zod `safeParse` on `SyntheticTimeoutContext` read-back in `getSyntheticTimeout`
+
+**Why:** `services/bot-client/src/services/MultiTagPersistence.ts` `getSyntheticTimeout` casts the parsed JSON marker straight to `SyntheticTimeoutContext` (`JSON.parse(raw) as SyntheticTimeoutContext`) with no runtime schema check. Today this is safe: we write the marker ourselves and the 30-min TTL keeps any cross-deploy shape drift transient. The latent risk is schema evolution — if a future PR adds a **required** field to `SyntheticTimeoutContext`, markers written by old code parse successfully (the cast doesn't validate at runtime) and the consumer sees `undefined` for the missing field, potentially producing a surprising `sendResponse` call or a Discord API error rather than a clean null-and-skip. **Fix shape**: a one-time `z.object({...}).safeParse(raw)` returning `null` on failure inside `getSyntheticTimeout` eliminates the class entirely (the existing catch already handles malformed JSON; this extends it to structurally-valid-but-wrong-shape). ~10 LOC + schema. **Promote when**: `SyntheticTimeoutContext` next gains a required field, OR opportunistically alongside the next `MultiTagPersistence` change. Surfaced 2026-05-29 by PR #1117 round-3 claude-bot review (advisory, non-blocking). Deferred 2026-05-29.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-129 - Manifest-per-route-mount-auth-override-authShape.md
+++ b/tracker/tasks/task-129 - Manifest-per-route-mount-auth-override-authShape.md
@@ -1,0 +1,20 @@
+---
+id: TASK-129
+title: 'Manifest per-route mount-auth override (authShape)'
+status: To Do
+assignee: []
+created_date: '2026-05-29 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 129000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Manifest per-route mount-auth override (`authShape`)
+
+**Why:** The route-manifest codegen (`packages/tooling/src/codegen/mounts-builder.ts`) hard-codes one uniform middleware chain per audience (`internal` → none, `admin` → `requireUserAuth`+`requireOwnerAuth`, `user` → `requireUserAuth`). There is no per-route way to express a non-standard chain like "service-OR-owner" at the mount. The GatewayClient-dissolution PR needed exactly that for admin-settings service reads and solved it with an **internal-audience alias** (`getAdminSettingsInternal` reusing `handleGetAdminSettings`) — clean, zero generator changes. A general `authShape` field on `RouteDef` (+ builder support + invariant tests) would only pay off if a SECOND route needs a bespoke mount-auth shape that the alias trick can't express. **Fix shape**: add an optional `authShape` (or `mountMiddleware`) field to `RouteDef`; teach `buildMountCall`/`buildMountFunction` to emit it; add manifest-invariant tests; document when to use it vs. the alias pattern. **Why deferred**: explicitly rejected for the dissolution PR — the alias pattern covered the need with far less surface, and YAGNI applies until a second case appears. **Promote when**: a second route genuinely needs mount-level service-or-owner (or other non-standard) auth that an internal-alias can't model. Surfaced 2026-05-29 during the GatewayClient-dissolution design. Deferred 2026-05-29.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-13 - estimator-disambiguation-drift-self-variant-comment-direction-1599-round-4-nits-.md
+++ b/tracker/tasks/task-13 - estimator-disambiguation-drift-self-variant-comment-direction-1599-round-4-nits-.md
@@ -1,0 +1,19 @@
+---
+id: TASK-13
+title: 'estimator disambiguation drift + self-variant comment direction (#1599 round-4 nits) —…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels: []
+dependencies: []
+ordinal: 13000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — estimator disambiguation drift + self-variant comment direction (#1599 round-4 nits) — (a) `getFormattedMessageCharLength` has no `allPersonalityNames` parameter, so the user-branch disambiguation suffix (`" (@username)"`) is unaccounted when the collision is against a SIBLING personality name (pre-existing, few chars per collision) — and `resolveSpeakerForEstimation`'s "can't drift" docstring overclaims accordingly; (b) the accepted-edge comments on `participantUtils.isSelf` / `referenceRole.isSelfVariant` describe one direction of a symmetric bidirectional-prefix check — the reverse edge (responder "Alex", unrelated sibling "Alexandra" reads as self) applies equally and should be written down. **Fix shape**: thread the set (or note the bound) + two comment edits. **Promote when**: next touch of either file.
+
+**Why:** Doc honesty + a few-token estimate gap; both reviewer-flagged non-blocking.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-130 - Make-admin-db-sync-an-async-job-instead-of-a-synchronous-HTTP-request.md
+++ b/tracker/tasks/task-130 - Make-admin-db-sync-an-async-job-instead-of-a-synchronous-HTTP-request.md
@@ -1,0 +1,20 @@
+---
+id: TASK-130
+title: 'Make /admin db-sync an async job instead of a synchronous HTTP request'
+status: To Do
+assignee: []
+created_date: '2026-05-30 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 130000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Make `/admin db-sync` an async job instead of a synchronous HTTP request
+
+**Why:** `db-sync` scans every table and flushes cross-environment writes, so its duration scales with data (observed ~11s on dev). It's a synchronous `ownerClient.dbSync` call the bot waits on, bounded by the route's `timeoutMs`. The dissolution-era smoke bumped that 10s→30s (`GATEWAY_TIMEOUTS.BULK_OPERATION`) to stop the false-timeout, but a fixed synchronous HTTP timeout is fundamentally a band-aid for a long-running operation — same anti-pattern as the `transcribe` long-poll. The manifest caps `timeoutMs` at 60s, so there's no room to keep raising it. **Correct fix**: model db-sync like AI generation — submit a BullMQ job, return a job ID immediately, deliver the result (stats summary) via the existing result-stream / a follow-up edit, so the operation's duration is decoupled from any HTTP timeout. Owner-only tool, rarely run, so this is YAGNI until it actually needs it. **Promote when**: db-sync approaches/exceeds the 30s budget again (a real timeout recurrence), OR the sync set grows enough that the operation is routinely >15s. Surfaced 2026-05-30 during beta.126 dev smoke (db-sync reported "Request timeout (HTTP 0)" at 10s while the gateway completed the sync ~0.8s later). Deferred 2026-05-30.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-131 - Monitor-default-timeout-2500ms-routes-that-arent-obviously-fast.md
+++ b/tracker/tasks/task-131 - Monitor-default-timeout-2500ms-routes-that-arent-obviously-fast.md
@@ -1,0 +1,21 @@
+---
+id: TASK-131
+title: "Monitor default-timeout (2500ms) routes that aren't obviously fast"
+status: To Do
+assignee: []
+created_date: '2026-05-30 00:00'
+labels:
+  - 'area:embeddings'
+  - 'area:db'
+dependencies: []
+ordinal: 131000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Monitor default-timeout (2500ms) routes that aren't obviously fast
+
+**Why:** The timeout-regression fix (PR #1119) restored explicit `timeoutMs` on every route beta.125 had bumped and registered the rest in `DEFAULT_TIMEOUT_OK` (manifest.test.ts) as "fast, 2500ms is fine." A few in that allowlist are not _obviously_ fast and were never bumped in beta.125 (so not regressions, left as default): **`search`** (`POST /memory/search` — pgvector similarity: query embedding + vector scan, the slowest "fast" route), **`batchDelete`** / **`purge`** (`/memory/*` token-gated bulk destructive; the heavy counting is in `batchDeletePreview`, so the execute leg is likely bounded but unverified), **`clearHistory`** (`/history/clear` scoped delete-many). **Promote when**: any of these surfaces a real `HTTP 0` false-timeout, OR a handler read confirms the op can exceed 2500ms — then move it out of `DEFAULT_TIMEOUT_OK` and give it an explicit `timeoutMs` (DEFERRED). The allowlist registration already makes that a conscious change. Surfaced 2026-05-30 during the PR #1119 timeout audit. Deferred 2026-05-30.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-132 - Per-call-timeoutMs-override-for-dual-context-autocomplete-browse-list-routes.md
+++ b/tracker/tasks/task-132 - Per-call-timeoutMs-override-for-dual-context-autocomplete-browse-list-routes.md
@@ -1,0 +1,19 @@
+---
+id: TASK-132
+title: 'Per-call timeoutMs override for dual-context (autocomplete + browse) list routes'
+status: To Do
+assignee: []
+created_date: '2026-05-30 00:00'
+labels: []
+dependencies: []
+ordinal: 132000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Per-call `timeoutMs` override for dual-context (autocomplete + browse) list routes
+
+**Why:** `listPersonalities`/`listPersonas`/`listShapes` are served at `DEFERRED` (10s) because their post-defer browse callers need it, but their autocomplete callers (`autocompleteCache.ts`) share the route — so on a slow gateway the autocomplete request stays open up to 10s even though Discord expires the interaction at 3s (bot gets an unusable response; Discord.js logs "Unknown interaction" on `respond()`). Wasteful, not a correctness bug. **Fix shape**: a per-call `timeoutMs` override (call-site `AbortSignal`) so autocomplete handlers pass a short budget while browse callers use the route default — needs the typed-client method to accept an optional per-call timeout (related to the `method-builder.ts` timeout-escape-hatch item). **Promote when**: "Unknown interaction" autocomplete noise becomes observable, OR alongside the timeout-escape-hatch refactor. Surfaced 2026-05-30 by PR #1119 round-2 review. Deferred 2026-05-30.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-133 - Re-verify-shapes-import-shapes-export-end-to-end-after-beta126.md
+++ b/tracker/tasks/task-133 - Re-verify-shapes-import-shapes-export-end-to-end-after-beta126.md
@@ -1,0 +1,19 @@
+---
+id: TASK-133
+title: 'Re-verify /shapes import + /shapes export end-to-end after beta.126'
+status: To Do
+assignee: []
+created_date: '2026-05-30 00:00'
+labels: []
+dependencies: []
+ordinal: 133000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Re-verify `/shapes import` + `/shapes export` end-to-end after beta.126
+
+**Why:** The beta.126 dev smoke confirmed the whole core transport surface (chat, voice in/out, multi-tag, DMs, db-sync, persona/character/voice-models) but **shapes import/export was not hand-verified** — it needs a desktop Chrome session to grab the shapes.inc auth cookie, and the smoke was done from a phone. The timeout-regression fix restored these routes to `DEFERRED` (PR #1119), identical to beta.125 and the same mechanism as the verified db-sync, so confidence is high — but the external shapes.inc round-trip itself wasn't exercised. Low-usage feature; even a breakage is low-impact. **Promote when**: next time at a desktop with shapes.inc auth — run an import + export against the dev (or prod) bot and confirm no `HTTP 0`/timeout. Surfaced 2026-05-30 during beta.126 release smoke. Deferred 2026-05-30.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-134 - Forensic-audit-trail-for-non-owner-diagnostic-log-404-lookups.md
+++ b/tracker/tasks/task-134 - Forensic-audit-trail-for-non-owner-diagnostic-log-404-lookups.md
@@ -1,0 +1,19 @@
+---
+id: TASK-134
+title: 'Forensic audit trail for non-owner diagnostic-log 404 lookups'
+status: To Do
+assignee: []
+created_date: '2026-05-23 00:00'
+labels: []
+dependencies: []
+ordinal: 134000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Forensic audit trail for non-owner diagnostic-log 404 lookups
+
+**Why:** The server-side 404-not-403 design for `GET /api/internal/diagnostic/:requestId` correctly hides existence from non-owners, but loses the only signal for detecting enumeration probing (a user iterating `requestId`s). `handleGetByRequestId`'s extended-WHERE `findUnique` returns null for both "doesn't exist" and "exists but not yours," so the handler cannot distinguish at all. The reviewer's suggested mitigation (a debug log on every non-owner 404) is a noisy false-positive tradeoff vs. zero signal. **Fix shape**: a sampled count-only secondary query for non-owner 404s, or a separate structured audit-log table — needs a proper threat-model design pass. **Promote when**: enumeration probing is observed in production, OR a feature requires forensic visibility into denied diagnostic accesses. Surfaced 2026-05-23 PR #1087 round 6; carried over from current-focus when the typed-client epic closed 2026-05-30.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-135 - Structural-test-coverage-gap-as-the-test-infra-packages-tzurottest-factories….md
+++ b/tracker/tasks/task-135 - Structural-test-coverage-gap-as-the-test-infra-packages-tzurottest-factories….md
@@ -1,0 +1,21 @@
+---
+id: TASK-135
+title: 'Structural-test coverage gap as the test-infra packages (@tzurot/test-factories,…'
+status: To Do
+assignee: []
+created_date: '2026-06-03 00:00'
+labels:
+  - 'area:common-types'
+  - 'area:testing'
+dependencies: []
+ordinal: 135000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Structural-test coverage gap as the test-infra packages (`@tzurot/test-factories`, `@tzurot/test-utils`) grow
+
+**Why:** `EXCLUDE_PATTERNS` in `packages/common-types/src/structure.test.ts` blanket-exempts the entire `@tzurot/test-factories/src/` AND `@tzurot/test-utils/src/` directories from the "every source file has a colocated test" rule, mirroring the legacy in-package `factories/` exclusion. Correct today: test-factories' builders are collectively covered by `factories.test.ts` + `factoryUtils.test.ts`, and test-utils is pure infra (mocks, PGLite setup, `seed.ts` exercised by `seed.component.test.ts`). The tradeoff (same for both): a future contributor could add a `new-logic.ts` file with NO test and the structure audit won't catch it — the blanket exclusion is a bigger gap surface now that each is a dedicated package than it was for a handful of files inside common-types. **Fix shape**: when either package grows logic files, replace the blanket `/\/test-(factories|utils)\/src\//` exclusion with a narrower one (exclude only the known infra files, or require each `*.ts` to be referenced by an import in the package's collective test). **Promote when**: either package gains a third+ logic file, OR a coverage gap is observed. Surfaced 2026-06-03 by PR #1142 (test-factories) + PR #1143 (test-utils) claude-reviews (non-blocking observations). Deferred 2026-06-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-136 - Turbo-cache-staleness-window-for-tzurottest-utils-typecheckspec.md
+++ b/tracker/tasks/task-136 - Turbo-cache-staleness-window-for-tzurottest-utils-typecheckspec.md
@@ -1,0 +1,21 @@
+---
+id: TASK-136
+title: 'Turbo cache-staleness window for @tzurot/test-utils typecheck:spec'
+status: To Do
+assignee: []
+created_date: '2026-06-03 00:00'
+labels:
+  - 'area:common-types'
+  - 'area:testing'
+dependencies: []
+ordinal: 136000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Turbo cache-staleness window for `@tzurot/test-utils` `typecheck:spec`
+
+**Why:** `packages/test-utils/tsconfig.spec.json` resolves `@tzurot/common-types` via a tsconfig `paths` alias (mirroring the `vitest.component.config.ts` runtime alias) rather than a package dependency — deliberately, to avoid recreating the `common-types ↔ test-utils` Turbo build cycle. Consequence: the `typecheck:spec` turbo task's inputs (`src/**` + the two tsconfigs + `^build`) don't include `common-types` source, and there's no package-graph edge, so if common-types' types change while test-utils' own source is unchanged, Turbo could replay a stale `typecheck:spec` pass. This is the SAME accepted trade-off that already exists for the `seed.component.test.ts` runtime alias (`test:component`), not new debt. **Fix shape**: add a test-utils-specific `typecheck:spec` input override in `turbo.json` — `"../../packages/common-types/src/**"` — scoped to `@tzurot/test-utils#typecheck:spec` (NOT the global task, which would over-invalidate every package's spec typecheck on any common-types change; packages with a real edge already get invalidation via `^build`). Same fix would apply to `@tzurot/test-factories` if its spec typecheck ever gains a common-types `paths` alias. **Promote when**: a spurious `typecheck:spec` CI pass is observed (a real type error in `seed.component.test.ts` slips through because common-types changed but test-utils didn't), OR opportunistically alongside the next `turbo.json` input change. Surfaced 2026-06-03 by PR #1143 claude-review (non-blocking, explicitly framed as a known trade-off). Deferred 2026-06-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-137 - no-prod-import-test-factories-depcruise-rule-lacks-a-packagestest-utils-exemptio.md
+++ b/tracker/tasks/task-137 - no-prod-import-test-factories-depcruise-rule-lacks-a-packagestest-utils-exemptio.md
@@ -1,0 +1,20 @@
+---
+id: TASK-137
+title: 'no-prod-import-test-factories depcruise rule lacks a packages/test-utils/ exemption'
+status: To Do
+assignee: []
+created_date: '2026-06-03 00:00'
+labels:
+  - 'area:testing'
+dependencies: []
+ordinal: 137000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`no-prod-import-test-factories` depcruise rule lacks a `packages/test-utils/` exemption
+
+**Why:** test-utils may someday legitimately re-export test-factories mock utilities; the rule's `pathNot` would need `^packages/test-utils/` added. **Promote when**: test-utils gains a test-factories import and the rule fires. Surfaced by PR #1147 claude-review. Deferred 2026-06-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-138 - handleExpandField-tests-stub-config-as.md
+++ b/tracker/tasks/task-138 - handleExpandField-tests-stub-config-as.md
@@ -1,0 +1,19 @@
+---
+id: TASK-138
+title: 'handleExpandField tests stub config as {}'
+status: To Do
+assignee: []
+created_date: '2026-06-03 00:00'
+labels: []
+dependencies: []
+ordinal: 138000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`handleExpandField` tests stub `config` as `{}`
+
+**Why:** Fine today — the handler ignores its `_config` param. **Promote when**: `handleExpandField` starts reading config properties; the stubbed `{}` would silently skip coverage of those paths. Surfaced by PR #1149 claude-review. Deferred 2026-06-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-139 - checkDockerfileDist-orchestration-tests-use-a-single-service-mock-workspace.md
+++ b/tracker/tasks/task-139 - checkDockerfileDist-orchestration-tests-use-a-single-service-mock-workspace.md
@@ -1,0 +1,19 @@
+---
+id: TASK-139
+title: 'checkDockerfileDist orchestration tests use a single-service mock workspace'
+status: To Do
+assignee: []
+created_date: '2026-06-03 00:00'
+labels: []
+dependencies: []
+ordinal: 139000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`checkDockerfileDist` orchestration tests use a single-service mock workspace
+
+**Why:** `checkService` unit coverage is thorough; the untested property is multi-service aggregation (findings from several services combined, exit code set on any). **Promote when**: a coverage audit flags the orchestration path, or the guard gains per-service behavior that diverges by service count. Surfaced by PR #1148 claude-review. Deferred 2026-06-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-14 - langchainConverterconvertConversationHistory-attributes-EVERY-stored-assistant-r.md
+++ b/tracker/tasks/task-14 - langchainConverterconvertConversationHistory-attributes-EVERY-stored-assistant-r.md
@@ -1,0 +1,19 @@
+---
+id: TASK-14
+title: 'langchainConverter.convertConversationHistory attributes EVERY stored assistant row to…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels: []
+dependencies: []
+ordinal: 14000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — `langchainConverter.convertConversationHistory` attributes EVERY stored assistant row to the CURRENT personality (`formatAssistantMessageContent(msg.content, personalityName, …)` — it ignores the row's own `personalityName`) and maps them all to `AIMessage`. Today its output (`PreparedContext.conversationHistory`) is only COUNTED (MemoryRetriever log fields) — no model ever sees it, so no live bug — but any future consumer inherits sibling-lines-credited-to-self, the exact class the role="character" fix killed in the chat log. **Fix shape**: either delete the near-dead conversion path (knip can't flag it — it IS referenced) or fix attribution (use `msg.personalityName`, skip/mark sibling rows). **Promote when**: anything starts consuming `PreparedContext.conversationHistory` beyond counting, or next ContextStep rework. Surfaced during the sibling-persona role fix.
+
+**Why:** A booby-trapped API: correct-looking history that silently mis-attributes sibling personas the moment someone uses it.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-140 - extractRunnerDistCopies-anchors-to-the-LAST-FROM-stage-not-AS-runner-by-name.md
+++ b/tracker/tasks/task-140 - extractRunnerDistCopies-anchors-to-the-LAST-FROM-stage-not-AS-runner-by-name.md
@@ -1,0 +1,19 @@
+---
+id: TASK-140
+title: 'extractRunnerDistCopies anchors to the LAST FROM stage, not AS runner by name'
+status: To Do
+assignee: []
+created_date: '2026-06-03 00:00'
+labels: []
+dependencies: []
+ordinal: 140000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`extractRunnerDistCopies` anchors to the LAST `FROM` stage, not `AS runner` by name
+
+**Why:** Correct for all current Dockerfiles (runner is always last). If a stage is ever added AFTER runner (debug stage, `FROM scratch AS export`), the guard would silently scan the wrong stage → false negatives. **Fix sketch** (from review): `RUNNER_STAGE_PATTERN = /^\s*FROM\s+\S+\s+AS\s+runner\b/i`, `findIndex` for it, fall back to last-FROM when absent (single-stage case). **Promote when**: any service Dockerfile gains a stage after runner, or the guard false-negatives on a real miss. Surfaced by PR #1148 post-autosquash claude-review. Deferred 2026-06-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-141 - PATHTOKENPATTERN-in-packagestoolingsrcdevcheck-deferred-refsts-can-over-match….md
+++ b/tracker/tasks/task-141 - PATHTOKENPATTERN-in-packagestoolingsrcdevcheck-deferred-refsts-can-over-match….md
@@ -1,0 +1,20 @@
+---
+id: TASK-141
+title: 'PATH_TOKEN_PATTERN in packages/tooling/src/dev/check-deferred-refs.ts can over-match…'
+status: To Do
+assignee: []
+created_date: '2026-06-03 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 141000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`PATH_TOKEN_PATTERN` in `packages/tooling/src/dev/check-deferred-refs.ts` can over-match inside URLs
+
+**Why:** A GitHub deep link containing `/packages/...` or `/services/...` path segments in a deferred entry would be extracted as if it were a repo path, producing false-positive reminders. No current entry contains such links (entries reference paths bare). **Fix sketch**: exclude matches preceded by `://`-bearing prefixes (lookbehind or pre-strip URLs from the row before tokenizing). **Promote when**: deferred.md gains GitHub deep links to monorepo files, or a false-positive reminder is observed. Surfaced by PR #1151 claude-review. Deferred 2026-06-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-142 - Migrate-CPD-tooling-to-jscpd-5-Rust-rewrite.md
+++ b/tracker/tasks/task-142 - Migrate-CPD-tooling-to-jscpd-5-Rust-rewrite.md
@@ -1,0 +1,22 @@
+---
+id: TASK-142
+title: 'Migrate CPD tooling to jscpd 5 (Rust rewrite)'
+status: To Do
+assignee: []
+created_date: '2026-06-08 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:db'
+  - 'area:ci'
+dependencies: []
+ordinal: 142000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Migrate CPD tooling to jscpd 5 (Rust rewrite)
+
+**Why:** jscpd 5.0.4 is a fresh Rust rewrite (shipped 2026-06-08; v4.2.5 shipped 2026-06-07, so v4 is still maintained in parallel). The dev-deps dependabot bump to 5.x was reverted to 4.2.5 and pinned via `.github/dependabot.yml` major-version ignore (see PR #1180). **Three concrete things break/shift under 5.x, all investigated 2026-06-08:** (1) **Config `ignore` key is silently dropped** — the Rust binary only honors ignore via the CLI `--ignore-pattern`/`-i` flag, NOT the `.jscpd.json` `ignore` array. Verified: with `-i "<patterns>"`, clones drop 2288→166 (0 in ignored files); without, 93% of clones (2123/2288) are in test/generated files we exclude, ballooning the filtered count 1718→30255 and tripping the ratchet. All OTHER config keys (`minTokens`, `minLines`, `format`, `threshold`) ARE honored (tested: minTokens 50→166 clones, 200→2). (2) **Genuine detection drift** — at identical minTokens=50/minLines=10, the Rust engine reports MORE duplication than the JS engine: filtered 2786 (Rust) vs 1718 baseline (JS), once ignores are restored. Needs a re-baseline. (3) **Post-filter heuristic suspect** — `packages/tooling/src/cpd/postFilter.ts` excluded only 4 clones as call-dominant on the Rust output (vs hundreds on JS output); the Rust fragment shape may not match the call-dominance parser, possibly inflating (2). **Migration steps**: (a) move ignore patterns from `.jscpd.json` `ignore` → the `cpd`/`cpd:report` scripts' `-i` flag (comma-separated) — or file an upstream bug for config `ignore` and wait; (b) re-validate/adjust the call-dominance heuristic in `postFilter.ts` against jscpd-5 fragments; (c) spot-check the residual is skeleton-noise not real debt, then `pnpm ops cpd:update-baseline` to the jscpd-5 number. **No upstream issue exists yet for the config-`ignore` regression** (v5 is days old) — we'd own the workaround. **Promote when**: a jscpd 5.x feature becomes compelling (current draw is only speed, which we don't need — our CPD run is sub-second), or v4 maintenance stops. Surfaced by dependabot PR #1180 (jscpd 4.2.4→5.0.4). Deferred 2026-06-08.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-143 - Time-based-audit-for-stale-debug-commits-left-on-develop.md
+++ b/tracker/tasks/task-143 - Time-based-audit-for-stale-debug-commits-left-on-develop.md
@@ -1,0 +1,20 @@
+---
+id: TASK-143
+title: 'Time-based audit for stale debug commits left on develop'
+status: To Do
+assignee: []
+created_date: '2026-06-08 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 143000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Time-based audit for stale `debug` commits left on develop
+
+**Why:** The `debug` commit type (PR #1179) relies on a manual `git log --grep '^debug[:(]'` to catch instrumentation added but never removed — advisory, not enforced. A merge-time gate (claude-review's Medium-2 suggestion, mirroring `fixup-check`) is the WRONG remedy: `debug` commits are _supposed_ to merge temporarily, so a gate can't distinguish intentional-temporary from forgotten — both look identical at merge. **Fix shape**: a periodic audit-class tool (fits the `pnpm ops` audit framework — measurement + threshold + periodic) that flags `debug` commits on develop older than N releases/days; that's the "you forgot to remove this" signal a merge gate structurally cannot give. **Promote when**: `debug` commits start accumulating on develop (the convention sees real use and a stale one is observed or missed). Surfaced by PR #1179 claude-review Medium-2; reframed from the rejected merge-gate remedy. Deferred 2026-06-08.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-144 - Type-VisionConfigapiKeymodel-as-non-empty-drop-the-legacy-empty-string-sentinel.md
+++ b/tracker/tasks/task-144 - Type-VisionConfigapiKeymodel-as-non-empty-drop-the-legacy-empty-string-sentinel.md
@@ -1,0 +1,19 @@
+---
+id: TASK-144
+title: 'Type VisionConfig.apiKey/model as non-empty (drop the legacy empty-string sentinel)'
+status: To Do
+assignee: []
+created_date: '2026-06-14 00:00'
+labels: []
+dependencies: []
+ordinal: 144000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Type `VisionConfig.apiKey`/`model` as non-empty (drop the legacy empty-string sentinel)
+
+**Why:** The no-`apiKeyResolver` legacy path in `ImageDescriptionJob` synthesizes `{ apiKey: '', model: '', ... }` and the call site normalizes the empties back to `undefined`. Works + documented, but `VisionConfig` permits `apiKey: ''` only in that one branch; typing `apiKey`/`model` as `string | undefined` (non-empty contract enforced at construction) would delete the normalization and stop a caller silently passing `''` to `createChatModel`. **Promote when**: `resolveVisionConfig`/`VisionConfig` gets a 3rd caller, OR the no-resolver legacy path is removed. Surfaced 2026-06-14 across #1204/#1208 reviews (test-fixture-only path; non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-145 - Re-add-an-admin-model-cache-refresh-endpoint.md
+++ b/tracker/tasks/task-145 - Re-add-an-admin-model-cache-refresh-endpoint.md
@@ -1,0 +1,19 @@
+---
+id: TASK-145
+title: 'Re-add an admin model-cache-refresh endpoint'
+status: To Do
+assignee: []
+created_date: '2026-06-15 00:00'
+labels: []
+dependencies: []
+ordinal: 145000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Re-add an admin model-cache-refresh endpoint
+
+**Why:** The `POST /models/refresh` (owner-only force-refresh of `OpenRouterModelCache`) was dropped with the root `/models` router in #1213 — it had no source caller. The cache self-refreshes on a 24h TTL, so there's currently no manual escape valve if the prod model list goes stale mid-day (e.g. a new model launches and isn't pickable until the TTL rolls). **Fix shape**: add `POST /api/admin/models/refresh` as an admin manifest route (audience `admin`, `requireOwnerAuth`) calling `modelCache.refreshCache()`. **Promote when**: a stale-model-list incident is observed in prod, or the 24h TTL becomes operationally painful. Surfaced 2026-06-15 by PR #1213 (review flagged the capability drop; backlog tracks re-add). Deferred 2026-06-15.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-146 - Harden-fetchCatalogModelById-against-catalog-growth-past-the-limit-1000-window.md
+++ b/tracker/tasks/task-146 - Harden-fetchCatalogModelById-against-catalog-growth-past-the-limit-1000-window.md
@@ -1,0 +1,20 @@
+---
+id: TASK-146
+title: 'Harden fetchCatalogModelById against catalog growth past the limit: 1000 window'
+status: To Do
+assignee: []
+created_date: '2026-06-15 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 146000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Harden `fetchCatalogModelById` against catalog growth past the `limit: 1000` window
+
+**Why:** `fetchCatalogModelById` (`services/bot-client/src/utils/modelCatalog.ts`) resolves an exact slug by fetching up to 1000 catalog candidates (substring match on the gateway) and pinning the exact id. With ~340 OpenRouter models today the ceiling is comfortable, but if the catalog grows well past 1000 with many short common slugs, the exact match could be silently truncated out of the candidate window. **Fix shape**: NOT a dedicated `GET /models/:id` gateway route — that was evaluated and rejected because `fetchCatalogModelById` relies on `fetchModelCatalog`'s OpenRouter+z.ai _merge_ (it must find z.ai-only models like `glm-5.2` and attach z.ai docs to `both`-source cards); an OpenRouter-only by-id route would fragment that. Instead raise the limit, or add a merge-aware bounded exact-match. **Promote when**: the OpenRouter catalog approaches ~1000 models, or a by-id lookup miss is observed in prod. Surfaced 2026-06-15 by PR #1217 round 3; fix-shape corrected 2026-06-15 (PR #1221 evaluation).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-147 - purge-confirmation-footer-prefix-renamed-Personality-Character-cross-deploy….md
+++ b/tracker/tasks/task-147 - purge-confirmation-footer-prefix-renamed-Personality-Character-cross-deploy….md
@@ -1,0 +1,20 @@
+---
+id: TASK-147
+title: 'purge confirmation footer prefix renamed Personality: →Character:  (cross-deploy…'
+status: To Do
+assignee: []
+created_date: '2026-06-16 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 147000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`purge` confirmation footer prefix renamed `Personality: `→`Character: ` (cross-deploy display-name blank)
+
+**Why:** `memory/purge.ts` `FOOTER_PREFIX` encodes the character display name in the confirmation embed footer and `readPersonalityNameFromMessage` reads it back via `startsWith(FOOTER_PREFIX)`. A purge confirmation shown _before_ the beta.133 deploy whose button/modal is clicked _after_ the bot-client restart will fail the new `startsWith('Character: ')` check → `readPersonalityNameFromMessage` returns `null` → display name renders blank. **Not a functional regression**: the personalityId lives in the customId, so the purge still targets the right character; only the footer-derived display text is affected, and it self-heals on the next purge. A dual-prefix fallback was explicitly rejected as the backward-compat the project's "No Backward Compatibility" rule forbids. **Promote when**: blank-purge-footer reports actually surface in monitoring (otherwise this one-time deploy-window glitch needs no action). Surfaced 2026-06-16 across all three PR #1232 claude-review rounds (non-blocking; flagged for awareness). Deferred 2026-06-16.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-148 - Relay-echo-personaId-clusters-under-the-bots-Discord-ID.md
+++ b/tracker/tasks/task-148 - Relay-echo-personaId-clusters-under-the-bots-Discord-ID.md
@@ -1,0 +1,19 @@
+---
+id: TASK-148
+title: "Relay-echo personaId clusters under the bot's Discord ID"
+status: To Do
+assignee: []
+created_date: '2026-06-16 00:00'
+labels: []
+dependencies: []
+ordinal: 148000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Relay-echo `personaId` clusters under the bot's Discord ID
+
+**Why:** In `DiscordChannelFetcher.convertMessage`, a chime-in/slash relay echo is now correctly `role=user` (PR #1236 Bug B), but `personaId` is `INTERNAL_DISCORD_ID_PREFIX + msg.author.id` where `msg.author.id` is the **bot's** id (it authored the echo), not the real user's. So all relay echoes in a window share one `personaId`. **Not harmful today**: `personaName` carries the correct user name from the `**Name:** ` prefix (attribution is visible), and `isRealUser` (`msg.author.bot !== true`) already excludes echoes from participant/persona collection, so it doesn't pollute participants or compound. The real user's Discord id is genuinely unrecoverable from a bot-authored message. **Fix shape**: thread the original user's id onto the relay echo at send time (e.g. persist it, or store it in the webhook/relay registry) so `convertMessage` can attribute `personaId` precisely. **Promote when**: a `personaId`-keyed feature needs relay echoes attributed to the real user — e.g. `/inspect` wanting to show the echo as the original user, or per-user dedup/analytics over relay echoes. Surfaced 2026-06-16 by PR #1236 claude-review (observation 2, non-blocking). Deferred 2026-06-16.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-149 - ResolvedLlmConfig-carries-no-provider.md
+++ b/tracker/tasks/task-149 - ResolvedLlmConfig-carries-no-provider.md
@@ -1,0 +1,20 @@
+---
+id: TASK-149
+title: 'ResolvedLlmConfig carries no provider'
+status: To Do
+assignee: []
+created_date: '2026-06-17 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 149000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`ResolvedLlmConfig` carries no `provider` — cross-provider model overrides could mis-route
+
+**Why:** The LLM cascade (`LlmConfigResolver.resolveConfig`) returns `model`/`visionModel` but no `provider`, so the gateway's job-chain stamp (#1239) and ai-worker's `AuthStep` keep the personality SEED provider. Harmless today: every `LlmConfig` is `provider='openrouter'` and `ProviderRouter` auto-promotes by model-name prefix (`z-ai/`), so routing keys off the model name, not this field. **Fix shape**: add `provider` to `LlmConfigMapper`/`ResolvedLlmConfig` and stamp the configured (pre-promotion) provider so AuthStep auto-promote still fires. **Promote when**: a user LLM config selects a model whose provider differs from the seed AND isn't derivable from the model-name prefix (a real cross-provider override exists in prod). Surfaced 2026-06-17 by PR #1239 (Bug X consolidation). Deferred 2026-06-17.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-15 - releasefinalize-prerelease-sweep-follow-ups-from-1598-review-a-doc-sync-….md
+++ b/tracker/tasks/task-15 - releasefinalize-prerelease-sweep-follow-ups-from-1598-review-a-doc-sync-….md
@@ -1,0 +1,20 @@
+---
+id: TASK-15
+title: 'release:finalize prerelease-sweep follow-ups from #1598 review: (a) doc sync —…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 15000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — `release:finalize` prerelease-sweep follow-ups from #1598 review: (a) doc sync — finalize.ts module JSDoc, `/tzurot-git-workflow` SKILL.md step-6 description, and OPS_CLI_REFERENCE.md one-liner all still describe only the rebase sequence, none mention the sweep (SKILL.md is review-gated → needs a small PR); (b) per-tag failure attribution — a mid-loop `gh release edit` failure warns generically without naming which tag failed / how many succeeded (+ test). **Promote when**: next tooling/docs PR, or next release cut (whichever first).
+
+**Why:** Skill/docs understating an automated step invites redundant manual work; attribution nit is diagnosability-only (self-heals next run).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-150 - bot-client-gateway-double-LLM-cascade-resolve-per-request.md
+++ b/tracker/tasks/task-150 - bot-client-gateway-double-LLM-cascade-resolve-per-request.md
@@ -1,0 +1,20 @@
+---
+id: TASK-150
+title: 'bot-client ↔ gateway double LLM-cascade resolve per request'
+status: To Do
+assignee: []
+created_date: '2026-06-17 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 150000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+bot-client ↔ gateway double LLM-cascade resolve per request
+
+**Why:** bot-client's `PersonalityChatManager.resolveConfig` resolves the LLM cascade (for context-size settings) AND the gateway's `createJobChain` now resolves it again (for model stamping, #1239) — the same cascade walked twice per request. Both are consistent (same logic), just redundant. **Fix shape**: single-resolution path — e.g. the gateway returns the resolved model+context in one response bot-client passes through, or bot-client forwards what it already resolved. Requires a bot-client↔gateway request-contract change. **Promote when**: the duplicate cascade shows up as measurable latency/DB load, or the contract is being reworked anyway. Surfaced 2026-06-17 by PR #1239. Deferred 2026-06-17.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-151 - tryResolveUserKey-has-no-no-user-key-cache-sentinel.md
+++ b/tracker/tasks/task-151 - tryResolveUserKey-has-no-no-user-key-cache-sentinel.md
@@ -1,0 +1,20 @@
+---
+id: TASK-151
+title: 'tryResolveUserKey has no "no-user-key" cache sentinel'
+status: To Do
+assignee: []
+created_date: '2026-06-17 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 151000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`tryResolveUserKey` has no "no-user-key" cache sentinel
+
+**Why:** `ApiKeyResolver.tryResolveUserKey` (ai-worker) caches a hit but NOT a miss, so a user lacking a key for the vision provider re-reads the DB on every cross-provider vision request (cold-cache path). PR #1240 routes more RAG vision traffic through per-provider resolution, hitting this more. The code comment already flags it. **Fix shape**: a distinct "no-user-key" cache state (without muddying the system-source cache semantics `resolveApiKey` depends on). **Promote when**: per-request DB reads for missing vision keys become a measured hotspot. Surfaced 2026-06-17 by PR #1240 (Bug Y). Deferred 2026-06-17.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-152 - Standardize-replyError-test-mocks-to-state-flipping-deferReply.md
+++ b/tracker/tasks/task-152 - Standardize-replyError-test-mocks-to-state-flipping-deferReply.md
@@ -1,0 +1,19 @@
+---
+id: TASK-152
+title: 'Standardize replyError test mocks to state-flipping deferReply'
+status: To Do
+assignee: []
+created_date: '2026-06-19 00:00'
+labels: []
+dependencies: []
+ordinal: 152000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Standardize `replyError` test mocks to state-flipping `deferReply`
+
+**Why:** Four handler test factories (`character/view`, `persona/view`, `preset/create`, `memory/detail`) statically pre-set `deferred: true`, while `inspect/index` and `apikey/modal` flip `deferred` inside a `deferReply` `mockImplementation`. Both are correct today because every error path in those four handlers runs AFTER `deferReply` (no pre-defer/fresh path), so static-deferred accurately reflects the runtime ack state. **Latent trap**: if a future contributor adds a pre-defer (fresh) error path to one of those handlers, the static mock would silently exercise the deferred (`editReply`) branch while the real path is fresh (`reply`) — a green test for the wrong branch. **Fix shape**: convert the four factories to the state-flipping pattern (`deferReply = vi.fn().mockImplementation(() => { interaction.deferred = true; return Promise.resolve(); })`); ~4 factory edits, no behavior change. **Promote when**: next touching any of those four test files, OR adding a fresh (pre-defer) error path to any of those handlers. Surfaced 2026-06-19 by PR #1266 claude-review round 3 (nit, non-blocking). Deferred 2026-06-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-153 - ConversationPersistence-flatten-to-module-functions-post-CONTEXTMODE-cleanup.md
+++ b/tracker/tasks/task-153 - ConversationPersistence-flatten-to-module-functions-post-CONTEXTMODE-cleanup.md
@@ -1,0 +1,19 @@
+---
+id: TASK-153
+title: 'ConversationPersistence flatten to module functions (post-CONTEXT_MODE cleanup)'
+status: To Do
+assignee: []
+created_date: '2026-06-19 00:00'
+labels: []
+dependencies: []
+ordinal: 153000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`ConversationPersistence` flatten to module functions (post-CONTEXT_MODE cleanup)
+
+**Why:** The `contextWritePath`→`gatewayWriteHelpers` rename half of this item shipped in #1311. Remaining half: `ConversationPersistence` is a stateless class (no fields/constructor, 4 save methods) instantiated once in `index.ts` and injected into MessageHandler/SlotDelivery/PersonalityChatManager/SyncExecutor — it could be standalone module exports. **Deliberately parked, not a clear defect**: it's an injected service consistent with the project's constructor-injection DI approach, so flattening is a lateral style change that would churn consumer signatures rather than fix a defect. **Promote when**: next substantively touching `ConversationPersistence`, OR the injection wiring is reworked anyway. Surfaced 2026-06-19 by PR #1268; rename shipped #1311 2026-06-23.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-154 - Extract-the-ContextStep-pass-through-test-stub-to-test-utils.md
+++ b/tracker/tasks/task-154 - Extract-the-ContextStep-pass-through-test-stub-to-test-utils.md
@@ -1,0 +1,21 @@
+---
+id: TASK-154
+title: 'Extract the ContextStep pass-through test stub to test-utils'
+status: To Do
+assignee: []
+created_date: '2026-06-19 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:testing'
+dependencies: []
+ordinal: 154000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Extract the `ContextStep` pass-through test stub to test-utils
+
+**Why:** The class-form `ContextStep` stub (pass-through returning an empty `preparedContext`) is duplicated verbatim in `AIJobProcessor.component.test.ts` and `LLMGenerationHandler.test.ts` — both stub it so legacy-shaped fixtures don't trip the `kind:'envelope'` contract. CPD doesn't fire (class-body, not call-expression) and `pnpm quality` is green, so it's not a gate concern. **Fix shape**: a shared `makeContextStepStub()` in `@tzurot/test-utils` (or an ai-worker test helper) imported by both files. **Promote when**: a THIRD consumer needs the same stub. Surfaced 2026-06-19 by PR #1269 claude-review (non-blocking cold follow-up). Deferred 2026-06-19.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-155 - Harden-downloadImageToDataUrl-for-SVG-animated-images.md
+++ b/tracker/tasks/task-155 - Harden-downloadImageToDataUrl-for-SVG-animated-images.md
@@ -1,0 +1,20 @@
+---
+id: TASK-155
+title: 'Harden downloadImageToDataUrl for SVG + animated images'
+status: To Do
+assignee: []
+created_date: '2026-06-20 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 155000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Harden `downloadImageToDataUrl` for SVG + animated images
+
+**Why:** The shared image→vision download helper (`imageToDataUrl.ts`) routes everything through `resizeImageIfNeeded`, which assumes raster input. An SVG (`image/svg+xml`) could mis-decode (1×1 raster) or OOM on recursive `<use>`/embedded data; an animated GIF/APNG/WebP silently loses all but the first frame on the JPEG re-encode. Per-attachment size/timeout caps already exist in `fetchAttachmentBytes`, so this is purely format handling. **Fix shape**: reject SVG by content-type/magic-bytes (or rasterize with a bounded viewport, e.g. sharp `density`+max-dims) before resize; add a `supportsAnimation` provider flag and skip JPEG re-encode (preserve GIF/WebP/APNG) when the target vision model supports it. **Promote when**: a user reports an SVG/animated embed mis-described, OR onboarding a video/animation-capable vision model. Surfaced 2026-06-20 (council review of the image→vision consolidation; deferred as independent hardening). Deferred 2026-06-20.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-156 - VoiceTranscriptionServicehasVoiceAttachment-keeps-a-parallel-forwarded-snapshot….md
+++ b/tracker/tasks/task-156 - VoiceTranscriptionServicehasVoiceAttachment-keeps-a-parallel-forwarded-snapshot….md
@@ -1,0 +1,19 @@
+---
+id: TASK-156
+title: 'VoiceTranscriptionService.hasVoiceAttachment keeps a parallel forwarded-snapshot…'
+status: To Do
+assignee: []
+created_date: '2026-06-23 00:00'
+labels: []
+dependencies: []
+ordinal: 156000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`VoiceTranscriptionService.hasVoiceAttachment` keeps a parallel forwarded-snapshot detection path
+
+**Why:** After PR #1309's `isVoiceAttachment` consolidation, `hasVoiceAttachment` still detects forwarded-snapshot voice via its own `snapshotHasAudio` (calls `isVoiceAttachment` on raw snapshot attachments) rather than delegating to `forwardedMessageUtils.hasForwardedVoiceAttachment` (which reads the precomputed `isVoiceMessage` flag). Both call `isVoiceAttachment` today so they agree, but it's a parallel implementation — exactly the drift shape #1309 just eliminated elsewhere. **Fix shape**: have `hasVoiceAttachment`'s forwarded branch delegate to `hasForwardedVoiceAttachment(message)` (note the two paths use different mechanisms — raw `some(isVoiceAttachment)` vs the `isVoiceMessage` flag — so reconcile carefully; they currently agree on the omitted-content-type case but verify). **Promote when**: next touching `VoiceTranscriptionService.hasVoiceAttachment`, OR either snapshot-detection path changes. Surfaced 2026-06-23 by PR #1309 final claude-review (Finding 2, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-157 - AttachmentMetadataisVoiceMessage-is-zbooleanoptional.md
+++ b/tracker/tasks/task-157 - AttachmentMetadataisVoiceMessage-is-zbooleanoptional.md
@@ -1,0 +1,20 @@
+---
+id: TASK-157
+title: 'AttachmentMetadata.isVoiceMessage is z.boolean().optional()'
+status: To Do
+assignee: []
+created_date: '2026-06-23 00:00'
+labels:
+  - 'area:common-types'
+dependencies: []
+ordinal: 157000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`AttachmentMetadata.isVoiceMessage` is `z.boolean().optional()` — latent silent false-negative
+
+**Why:** PR #1309 made `forwardedMessageUtils.hasForwardedVoiceAttachment` read `a.isVoiceMessage === true` instead of re-deriving from content-type+duration. Correct **as long as** every `AttachmentMetadata` was built by `extractAttachments` (the only constructor today, always reached via `extractAllForwardedContent`). But the Zod schema (`packages/common-types/src/types/schemas/discord.ts:~58`) marks the field `optional()`, so a future construction path that omits it yields `isVoiceMessage: undefined` → `hasForwardedVoiceAttachment` silently returns `false` for a real voice message. The forwardedMessageUtils docstring documents the trust chain; the schema doesn't. **Fix shape**: make `isVoiceMessage` required in the schema (audit all `AttachmentMetadata` constructors first — it's a cross-service shape), or add a constructor-guard. **Promote when**: a second `AttachmentMetadata` construction path is added, OR the field's required-ness is being reconsidered. Surfaced 2026-06-23 by PR #1309 final claude-review (Finding 3, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-158 - Add-an-explicit-disableCache-boolean-to-BaseConfigResolverOptions.md
+++ b/tracker/tasks/task-158 - Add-an-explicit-disableCache-boolean-to-BaseConfigResolverOptions.md
@@ -1,0 +1,20 @@
+---
+id: TASK-158
+title: 'Add an explicit disableCache?: boolean to BaseConfigResolverOptions'
+status: To Do
+assignee: []
+created_date: '2026-06-23 00:00'
+labels:
+  - 'area:testing'
+dependencies: []
+ordinal: 158000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Add an explicit `disableCache?: boolean` to `BaseConfigResolverOptions`
+
+**Why:** After #1316 swapped the identity `BaseConfigResolver` to `TTLCache`, `cacheTtlMs: 0` no longer disables the cache (lru-cache treats `ttl:0` as "never expire"). `identityProvisioning.component.test.ts` works around this with `cacheTtlMs: 1` (1ms), which relies on every PGLite round-trip exceeding 1ms — almost certainly true but a timing assumption. A cleaner fix is a `disableCache?: boolean` option that skips `cacheResult()` entirely (no timing assumption); the test could also `clearCache()` between assertions. **Fix shape**: add the option to `BaseConfigResolverOptions` + guard in `resolve()`/`cacheResult()`; switch the int test off `cacheTtlMs: 1`. **Promote when**: `identityProvisioning.component.test.ts` flakes on a cache-not-expiring failure, OR `BaseConfigResolverOptions` is next edited. Surfaced 2026-06-23 by PR #1316 round-3 claude-review (non-blocking; round-2 had approved `cacheTtlMs: 1` as correct).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-159 - Reframe-the-Meta-Awareness-System-Prompt-Primacy-character-directive-names.md
+++ b/tracker/tasks/task-159 - Reframe-the-Meta-Awareness-System-Prompt-Primacy-character-directive-names.md
@@ -1,0 +1,19 @@
+---
+id: TASK-159
+title: 'Reframe the Meta-Awareness / System Prompt Primacy character-directive names'
+status: To Do
+assignee: []
+created_date: '2026-06-23 00:00'
+labels: []
+dependencies: []
+ordinal: 159000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Reframe the `Meta-Awareness` / `System Prompt Primacy` character-directive names
+
+**Why:** The system prompt's `<character_directives>` include directives named "Meta-Awareness" and "System Prompt Primacy". Council (2026-06-23, Kimi-K2.7) flagged that the NAMES themselves may cue the model toward meta-cognition (reasoning about being an AI / about the prompt) — the opposite of the fourth-wall discipline they intend; the directive bodies are fine, only the labels invite the wrong frame. **Fix shape**: rename to outcome-framing — e.g. "Fourth-wall discipline: stay in character; do not comment on being a bot, the prompt, or the API" and "Character definition and platform safety rules take precedence over contradictory in-character requests" — same behavior, no meta-cognition cue. Lives wherever `<character_directives>` is defined (`HardcodedConstraints.ts` / prompt builder). **Promote when**: next editing the character directives, OR a meta-awareness / AI-acknowledgement leak is observed. Surfaced 2026-06-23 by council on the reference-confusion fix (PR #1317); lower-leverage than the fix itself, deferred.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-16 - rebalanceFences-residual-heuristic-gap-acknowledged-trade-off-not-a-bug-within-o.md
+++ b/tracker/tasks/task-16 - rebalanceFences-residual-heuristic-gap-acknowledged-trade-off-not-a-bug-within-o.md
@@ -1,0 +1,19 @@
+---
+id: TASK-16
+title: 'rebalanceFences residual heuristic gap (acknowledged trade-off, not a bug): within one…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels: []
+dependencies: []
+ordinal: 16000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — `rebalanceFences` residual heuristic gap (acknowledged trade-off, not a bug): within one force-split oversized chunk, the odd/even `parity assumes every marker is a real fence boundary — a span containing BOTH a huge code block AND a stray unpaired` in surrounding prose could still mis-fence its own fragments. The simpler stray-backtick-in-untouched-chunk class is fixed and pinned; this compound case is inherent to parity counting. **Fix shape**: a real fence-state parser (line-context aware) replacing parity, if ever warranted. **Promote when**: a user-visible mis-fenced chunk is reported despite the scoped rebalancer. Surfaced by #1596 final review.
+
+**Why:** Named residual of the fence fix; the doc comment on rebalanceFences states the soundness boundary.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-160 - Audit-the-OUTPUTCONSTRAINTS-scaffolding-ban-list-for-completeness.md
+++ b/tracker/tasks/task-160 - Audit-the-OUTPUTCONSTRAINTS-scaffolding-ban-list-for-completeness.md
@@ -1,0 +1,19 @@
+---
+id: TASK-160
+title: 'Audit the OUTPUT_CONSTRAINTS scaffolding-ban list for completeness'
+status: To Do
+assignee: []
+created_date: '2026-06-23 00:00'
+labels: []
+dependencies: []
+ordinal: 160000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Audit the `OUTPUT_CONSTRAINTS` scaffolding-ban list for completeness
+
+**Why:** The output-constraint ban (`HardcodedConstraints.ts`) names observed-leak tags (`<from_id>/<user>/<message>` — the GLM-4.5-Air fake-user-echo quirk) plus the structural tags PR #1317 touched (`<quote>/<contextual_references>`). `claude-review` on #1317 noted `<instruction>` is also a tag the model sees (in `<participants>`/`<memory_archive>`/`<contextual_references>`) yet isn't banned — but adding it piecemeal is arbitrary (why not `<time>`/`<content>`?). Do one deliberate pass: enumerate every structural tag the assembled prompt exposes, decide which are leak-prone wrappers that belong in the ban vs. which are harmless content tags. Lower urgency now that GLM-4.5-Air is no longer free on OpenRouter (less scaffolding-leak pressure). **Promote when**: next editing `OUTPUT_CONSTRAINTS`, or a new tag-leak quirk is observed. Surfaced 2026-06-23 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-161 - Dedup-time-fallback-can-mislabel-a-proximity-matched-message-as-the-reply-target.md
+++ b/tracker/tasks/task-161 - Dedup-time-fallback-can-mislabel-a-proximity-matched-message-as-the-reply-target.md
@@ -1,0 +1,19 @@
+---
+id: TASK-161
+title: 'Dedup time-fallback can mislabel a proximity-matched message as the reply-target'
+status: To Do
+assignee: []
+created_date: '2026-06-23 00:00'
+labels: []
+dependencies: []
+ordinal: 161000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Dedup time-fallback can mislabel a proximity-matched message as the reply-target
+
+**Why:** `isDuplicateReference`'s time-based fallback (`referenceEnrichment.ts`) marks a reference `isDeduplicated` when a recent webhook/bot message falls within `MESSAGE_TIMESTAMP_TOLERANCE` — by timestamp proximity, not exact id. If the proximity-matched history row isn't the exact message being replied to, the deduped stub's marker (`[Referenced message — full text in <chat_log>]`) points at text that isn't actually in `<chat_log>`. Pre-existing — PR #1317 didn't change the fallback; low probability (tight tolerance). **Fix shape**: prefer exact-id match and only fall back to proximity when no id match exists, or drop the "full text in chat_log" marker when the match was proximity-based. **Promote when**: a mismatched-reference incident is observed, or when reworking the dedup fallback. Surfaced 2026-06-23 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-162 - quotedmessages-deduped-stubs-miss-the-roleassistant-signal.md
+++ b/tracker/tasks/task-162 - quotedmessages-deduped-stubs-miss-the-roleassistant-signal.md
@@ -1,0 +1,19 @@
+---
+id: TASK-162
+title: '<quoted_messages> deduped stubs miss the role="assistant" signal'
+status: To Do
+assignee: []
+created_date: '2026-06-23 00:00'
+labels: []
+dependencies: []
+ordinal: 162000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`<quoted_messages>` deduped stubs miss the `role="assistant"` signal
+
+**Why:** In `xmlMetadataFormatters.ts`, `formatStoredReferencedMessage` (the non-deduped path) computes `role` via `isAuthorAssistant(...)`, but the deduped path (`dedupedRefs.map` → `formatDedupedQuote`) omits it — so a deduped quote of a bot's own prior message in `<quoted_messages>` renders `<quote from="Lilith">` without `role="assistant"`. Same self-reply-confusion bug-class PR #1317 fixed on the live `<contextual_references>` path, but on the historical/stored path (lower stakes — it's prior-turn context, and the global anti-continuation `OUTPUT_CONSTRAINTS` partially covers it). Pre-existing on develop; #1317 only touched this file's test. **Fix shape**: in the `dedupedRefs.map` callback, derive `role` via the already-in-scope `isAuthorAssistant(authorName, personalityName, allPersonalityNames)` and pass it to `formatDedupedQuote`; consider also emptying bot-authored stub content for parity with the live path (secondary — stored text is already in history). Add a colocated test + refresh snapshots. **Promote when**: next touching `xmlMetadataFormatters.ts`, or a stored-path self-reply spiral is observed. Surfaced 2026-06-23 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-163 - Confirm-TupperBoxs-applicationId-appears-on-a-real-proxied-message.md
+++ b/tracker/tasks/task-163 - Confirm-TupperBoxs-applicationId-appears-on-a-real-proxied-message.md
@@ -1,0 +1,20 @@
+---
+id: TASK-163
+title: "Confirm TupperBox's applicationId appears on a real proxied message"
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:common-types'
+dependencies: []
+ordinal: 163000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Confirm TupperBox's applicationId appears on a real proxied message
+
+**Why:** `KNOWN_PROXY_APP_IDS` (`packages/common-types/src/constants/proxyBots.ts`) includes TupperBox (`431544605209788416`) on an operator-confirmed public-app-id basis, but it's not yet observed in our message data. Safe failure mode: a wrong/typo'd id degrades a TupperBox-proxied human to `role="bot"` (reads as automation, not the person addressed) — NOT self-reply confusion (that needs `assistant`). **Confirm shape**: capture a real TupperBox-proxied reference's `applicationId` (log/probe) and verify it equals the constant. **Promote when**: a TupperBox user is available to test, or a TupperBox-proxied message appears in logs. Surfaced 2026-06-24 by PR #1321 round-3 claude-review.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-164 - deriveRefRole-name-match-fallback-can-promote-a-name-colliding-human-to-assistan.md
+++ b/tracker/tasks/task-164 - deriveRefRole-name-match-fallback-can-promote-a-name-colliding-human-to-assistan.md
@@ -1,0 +1,20 @@
+---
+id: TASK-164
+title: 'deriveRefRole name-match fallback can promote a name-colliding human to assistant in the…'
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 164000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`deriveRefRole` name-match fallback can promote a name-colliding human to `assistant` in the fallback window
+
+**Why:** `deriveRefRole` (`services/ai-worker/src/services/prompt/referenceRole.ts`) name-matches without a bot-authorship guard (dropped for symmetry with the stored path), so within the bounded fallback window a human whose display name prefixes a personality's would read as `role="assistant"`. Bounded: needs a name collision AND the reference lacking `authorRole` (pre-classifier stored history ~30d, or a rolling-deploy window). The module doc documents the tradeoff. **NOT fully bounded — forwarded refs are permanent**: the release-PR review (#1324) sharpened this — forwarded references (`SnapshotFormatter`, see the row below) NEVER carry `authorRole` because Discord strips `applicationId` from message snapshots, so a forwarded message whose author's display-name prefix-matches a personality reads as `role="assistant"` _indefinitely_, not just during the 30-day aging window. The aging closes only the stored-history path; the forwarded path stays open until the bot-authorship guard is threaded. **Fix shape (if needed)**: thread a bot-authorship signal into the fallback so only machine-authored refs name-match. **Promote when**: ~30 days after beta.136 ships (≈2026-07-24, when pre-classifier stored history has aged out and only the live deploy-window + permanent forwarded-ref paths remain) — re-evaluate whether the guard is worth adding, OR if a name-collision mislabel is observed. Surfaced 2026-06-24 by PR #1321 round-3 claude-review; forwarded-ref permanence sharpened by PR #1324 release review.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-165 - SnapshotFormatter-forwarded-references-always-read-as-roleuser.md
+++ b/tracker/tasks/task-165 - SnapshotFormatter-forwarded-references-always-read-as-roleuser.md
@@ -1,0 +1,19 @@
+---
+id: TASK-165
+title: 'SnapshotFormatter forwarded references always read as role="user"'
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels: []
+dependencies: []
+ordinal: 165000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`SnapshotFormatter` forwarded references always read as `role="user"`
+
+**Why:** Discord message snapshots strip author identity (no `applicationId` or bot flags), so `SnapshotFormatter.formatSnapshot` can't stamp `authorRole` — a forwarded persona voice/text message reads as `role="user"`, not `assistant`, in the worker's fallback. Known Discord-API limitation (a code comment documents it at the construction site). **Fix shape**: none possible until Discord surfaces author identity on snapshots; if/when it does, classify forwarded refs the same as live refs. **Promote when**: Discord exposes `applicationId`/author-bot flags on message snapshots, OR a forwarded-persona-message self-reply spiral is observed. Surfaced 2026-06-24 by PR #1321 round-3 claude-review.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-166 - Live-path-deriveRefRole-fallback-thread-allPersonalityNames-document-the-botuser.md
+++ b/tracker/tasks/task-166 - Live-path-deriveRefRole-fallback-thread-allPersonalityNames-document-the-botuser.md
@@ -1,0 +1,20 @@
+---
+id: TASK-166
+title: 'Live-path deriveRefRole fallback: thread allPersonalityNames + document the bot→user…'
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 166000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Live-path `deriveRefRole` fallback: thread `allPersonalityNames` + document the bot→user transition gap
+
+**Why:** Two transition-window gaps in the live `ReferencedMessageFormatter` fallback (fires only when `authorRole` is absent — pre-classifier stored history, or an old bot-client mid-rolling-deploy): (1) it passes only `personality.displayName` to `deriveRefRole`, not `allPersonalityNames`, so a SIBLING persona's reference renders `role="user"` on the live path but `role="assistant"` on the stored path (which threads the set) — an asymmetry during the deploy window in multi-persona conversations; (2) the fallback is a binary assistant/user ternary, so a third-party bot (MEE6, non-proxy webhook) with no `authorRole` reads as `role="user"` during the ~30-day aging window — which the instruction defines as "a person." **Fix shape**: add `allPersonalityNames?: Set<string>` to `formatReferencedMessages` and thread it to both `deriveRefRole` call sites (requires sourcing the participant set in `ConversationInputProcessor`); add a test asserting `deriveRefRole(undefined, 'MEE6', 'Lilith')` → `'user'` with a comment that this is accepted transition-window degradation, not a missed case. **Promote when**: ~30 days post-beta.136 (pre-classifier history aged out, only the deploy-window path remains), OR a sibling-persona/third-party-bot mislabel is observed. Surfaced 2026-06-24 by PR #1321 post-amend claude-review (round 5; bounded transition-window, merged-and-backlogged).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-167 - deleteVoiceclearVoices-chain-sequential-external-calls.md
+++ b/tracker/tasks/task-167 - deleteVoiceclearVoices-chain-sequential-external-calls.md
@@ -1,0 +1,20 @@
+---
+id: TASK-167
+title: 'deleteVoice/clearVoices chain sequential external calls'
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 167000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`deleteVoice`/`clearVoices` chain sequential external calls — can exceed the sync timeout cap
+
+**Why:** The external-call-timeout contract (#1323) covers SINGLE-call routes (`setWalletKey`, `testWalletKey`, `listVoices`, `listShapes`). But `voices.ts` `deleteVoiceImpl` does fetch-then-delete (2 sequential provider calls × `EXTERNAL_AUDIO_API_CALL` 30s = up to 60s) and `clearVoicesImpl` loops N sequential `deleteVoiceAtProvider` calls (N × 30s) — both can exceed even `EXTERNAL_PROVIDER` (40s) / the manifest's 60s `timeoutMs` cap. They're a genuinely different shape than the single-call class: the type-doc says >60s sync work should be a BullMQ job with push-based delivery. **Fix shape**: parallelize delete's fetch+delete where safe, and/or move `clearVoices` to a BullMQ job. **Promote when**: a delete/clear-voices timeout is observed, or the voices-management UX is next touched. Surfaced 2026-06-24 by PR #1323 (external-call-timeout contract; deliberately scoped to single-call routes).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-168 - Fetch-detecting-guard-so-an-external-call-route-cant-omit-externalCallBudgetMs.md
+++ b/tracker/tasks/task-168 - Fetch-detecting-guard-so-an-external-call-route-cant-omit-externalCallBudgetMs.md
@@ -1,0 +1,21 @@
+---
+id: TASK-168
+title: "Fetch-detecting guard so an external-call route can't omit externalCallBudgetMs"
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:tooling'
+dependencies: []
+ordinal: 168000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Fetch-detecting guard so an external-call route can't omit `externalCallBudgetMs`
+
+**Why:** #1323's manifest invariant test (`timeoutMs >= externalCallBudgetMs + overhead`) only fires for routes that DECLARE `externalCallBudgetMs`. A future route whose handler does external I/O but forgets to declare a budget slips through silently — the second layer the declared-field approach doesn't cover. **Fix shape**: a lint/guard (`pnpm ops guard:...`) that flags an api-gateway route handler containing `fetch(`/external-client calls whose manifest route lacks `externalCallBudgetMs`. Hard to make precise (handler→route linkage), so a heuristic with an allowlist may be the pragmatic shape. **Promote when**: a new external-call route ships without a budget (the failure this prevents), or during a CI-guard hardening pass. Surfaced 2026-06-24 by PR #1323 (declared-field invariant is the first layer; this is the second).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-169 - Gateway-completes-the-DB-write-after-the-client-aborts-walletset.md
+++ b/tracker/tasks/task-169 - Gateway-completes-the-DB-write-after-the-client-aborts-walletset.md
@@ -1,0 +1,20 @@
+---
+id: TASK-169
+title: 'Gateway completes the DB write after the client aborts (wallet/set)'
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 169000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Gateway completes the DB write after the client aborts (wallet/set)
+
+**Why:** In `handleSetWalletKey`, when the bot-client aborts the request (transport timeout), the Express handler keeps running and still upserts the key — which is WHY the z.ai user's key saved despite the "failed" message. Benign/helpful today (storing a validated key is the desired outcome), and #1323's timeout fix removes the happy-path abort so it's no longer user-facing. But completing a mutation after the client gave up is a latent correctness smell (no `req.aborted` guard before the write). **Fix shape**: optionally check `req.aborted`/an AbortSignal before the upsert, OR accept it as harmless-by-design and document why. **Promote when**: a post-abort write causes an observable inconsistency, or the wallet-write path is next reworked. Surfaced 2026-06-24 by PR #1323 (Bug B, latent; not user-facing after the timeout fix).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-17 - DebugViewResult-allows-chunkedText-to-coexist-with-contentembedsfiles-at-the-typ.md
+++ b/tracker/tasks/task-17 - DebugViewResult-allows-chunkedText-to-coexist-with-contentembedsfiles-at-the-typ.md
@@ -1,0 +1,19 @@
+---
+id: TASK-17
+title: 'DebugViewResult allows chunkedText to coexist with content/embeds/files at the type level…'
+status: To Do
+assignee: []
+created_date: '2026-07-11 00:00'
+labels: []
+dependencies: []
+ordinal: 17000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-11 — `DebugViewResult` allows `chunkedText` to coexist with `content`/`embeds`/`files` at the type level while `renderViewResult` silently prefers `chunkedText` — a discriminated union would make the exclusivity compiler-enforced. (The sibling `embeds: []` nit shipped with the rendering-hardening PR.) Converting ripples through every view builder + test, so it waits for a natural rewrite. **Promote when**: adding an /inspect view or reworking DebugViewResult. Surfaced by #1588 round-6 review.
+
+**Why:** Latent trap for the NEXT contributor; harmless in current call graphs.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-170 - classifyReferenceAuthorRole-mislabels-own-persona-as-bot-when-clientUserId-is-un.md
+++ b/tracker/tasks/task-170 - classifyReferenceAuthorRole-mislabels-own-persona-as-bot-when-clientUserId-is-un.md
@@ -1,0 +1,21 @@
+---
+id: TASK-170
+title: "classifyReferenceAuthorRole mislabels own persona as 'bot' when clientUserId is undefined…"
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:conversation-history'
+dependencies: []
+ordinal: 170000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`classifyReferenceAuthorRole` mislabels own persona as `'bot'` when `clientUserId` is undefined (startup/reconnect)
+
+**Why:** `classifyReferenceAuthorRole` (`services/bot-client/src/handlers/references/authorRole.ts`) gates the `'assistant'` check on `signals.clientUserId !== undefined`. `clientUserId` is `message.client.user?.id`, which is `undefined` before `ClientReady` fires and during gateway reconnects — so in that window a reference to our own persona's webhook reply falls through to `return 'bot'`. Because `authorRole` is persisted into stored conversation-history snapshots, the mislabel is durable: later turns read `role='bot'` and attribute the persona's own prior line to a third-party bot. The window is narrow (startup + reconnects) but the stored row is permanently wrong. `authorRole.test.ts` currently asserts this degraded path returns `'bot'` and calls it "does not misclassify" — that assertion is itself wrong for our own persona. **Fix shape**: when `applicationId` is present but `clientUserId` is undefined, omit `authorRole` (let the worker's name-match fallback run) rather than hard-coding `'bot'`; update the test expectation + comment. **Promote when**: next touching `authorRole.ts`, OR a startup/reconnect-window self-attribution spiral is observed. Surfaced 2026-06-24 by PR #1324 release review.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-171 - readValidatedBody-treats-a-204-No-Content-as-a-kind-schema-failure.md
+++ b/tracker/tasks/task-171 - readValidatedBody-treats-a-204-No-Content-as-a-kind-schema-failure.md
@@ -1,0 +1,20 @@
+---
+id: TASK-171
+title: "readValidatedBody treats a 204 No Content as a kind: 'schema' failure"
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:clients'
+dependencies: []
+ordinal: 171000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`readValidatedBody` treats a 204 No Content as a `kind: 'schema'` failure
+
+**Why:** `readValidatedBody` (`packages/clients/src/clients/transport.ts`) calls `response.json()` unconditionally on any 2xx, so a 204 (empty body) throws and surfaces as `kind: 'schema'` / `status: 0` — indistinguishable from a malformed body — even though the mutation succeeded. **Latent today**: no gateway route returns 204, so it's unreachable until one does, but the silent-failure shape is more consequential now that callers branch on the `kind` discriminant. **Fix shape**: guard `if (response.status === 204) return { ok: true, data: null };` before the `response.json()` call; add a transport test for the 204 path. **Promote when**: a gateway route is added that returns 204 (or any empty-body 2xx), OR next touching `readValidatedBody`. Surfaced 2026-06-24 by PR #1324 release review (round 2).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-172 - VoiceTranscriptCache-swallows-all-Redis-errors-as-cache-misses-no-operational-si.md
+++ b/tracker/tasks/task-172 - VoiceTranscriptCache-swallows-all-Redis-errors-as-cache-misses-no-operational-si.md
@@ -1,0 +1,21 @@
+---
+id: TASK-172
+title: 'VoiceTranscriptCache swallows all Redis errors as cache misses (no operational signal)'
+status: To Do
+assignee: []
+created_date: '2026-06-24 00:00'
+labels:
+  - 'area:common-types'
+  - 'area:redis'
+dependencies: []
+ordinal: 172000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`VoiceTranscriptCache` swallows all Redis errors as cache misses (no operational signal)
+
+**Why:** `VoiceTranscriptCache.store`/`get` (`packages/common-types/src/services/VoiceTranscriptCache.ts`) catch every Redis error and return `undefined`/`null`, which callers treat identically to a miss — so a Redis outage is invisible until users notice stale behaviour. The graceful-degradation shape is correct; the observability is the gap (there's `error`-level logging but nothing that alerts). Reviewer flagged as "no action required, just noting." **Fix shape (if promoted)**: emit a distinct counter/metric on the catch path (cache-error vs. cache-miss) so an outage is dashboard-visible, OR raise to a rate-limited alertable log. **Promote when**: alerting/metrics infra lands for cache layers, OR a Redis outage goes undiagnosed because it read as cold cache. Surfaced 2026-06-24 by PR #1324 release review (round 2).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-173 - Lenient-loadPersonality-collapses-GatewayClientError-non-404-4xx-to-null-for-rou.md
+++ b/tracker/tasks/task-173 - Lenient-loadPersonality-collapses-GatewayClientError-non-404-4xx-to-null-for-rou.md
@@ -1,0 +1,19 @@
+---
+id: TASK-173
+title: 'Lenient loadPersonality collapses GatewayClientError (non-404 4xx) to null for routing'
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels: []
+dependencies: []
+ordinal: 173000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Lenient `loadPersonality` collapses `GatewayClientError` (non-404 4xx) to null for routing
+
+**Why:** `HttpPersonalityLoader.loadPersonality` (the routing/mention-parsing wrapper) catches BOTH `InfraError` and `GatewayClientError` and returns `null` ("treat unknown as no-match"). A 403 Forbidden means "the character exists but access is denied" — collapsing it to "no match" is correct for routing today (you can't use a character you can't access), but the wrapper has discarded the exists-but-forbidden vs. doesn't-exist distinction. Not a bug; a lost signal. **Fix shape (only if needed)**: have the wrapper re-raise or tag `GatewayClientError` so a routing caller that needs to differentiate can. **Promote when**: a routing/mention path needs to separate "forbidden" from "absent". Surfaced 2026-06-25 by the beta.137 release review (#1338).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-174 - Simplify-the-conversation-persist-handlers-stale-dual-write-fallback-doc.md
+++ b/tracker/tasks/task-174 - Simplify-the-conversation-persist-handlers-stale-dual-write-fallback-doc.md
@@ -1,0 +1,21 @@
+---
+id: TASK-174
+title: "Simplify the conversation persist handlers' stale dual-write fallback + doc"
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:db'
+dependencies: []
+ordinal: 174000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Simplify the conversation persist handlers' stale dual-write fallback + doc
+
+**Why:** `conversationUserMessage.ts` + `conversationAssistantMessage.ts` carry a "dual-write window" JSDoc + a `compareExisting`-first + `P2002`-race fallback that assume a concurrent **legacy direct writer**. That writer is gone — the 2.5d epic closed dual-write and bot-client's `saveUserMessage` now routes through the gateway (no direct Prisma), so the gateway endpoint is the sole writer. The doc is misleading and the P2002-race branch is likely dead. **Fix shape**: grep-confirm no second `conversationHistory` writer remains, then drop/simplify the compare-first + P2002 fallback and rewrite the JSDoc to describe the single-writer reality. Behavioral change to the write path → its own PR, separate from the beta.138 timeout fix. **Promote when**: next touching the persist handlers, or a dual-write-doc-confusion report. Surfaced 2026-06-25 during the fast-pool-timeout investigation.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-175 - Document-the-pooler-strips-options-gateway-boot-fails-caveat-for-the-fast-pool.md
+++ b/tracker/tasks/task-175 - Document-the-pooler-strips-options-gateway-boot-fails-caveat-for-the-fast-pool.md
@@ -1,0 +1,21 @@
+---
+id: TASK-175
+title: 'Document the "pooler strips options → gateway boot fails" caveat for the fast pool'
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels:
+  - 'area:db'
+  - 'area:docs'
+dependencies: []
+ordinal: 175000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Document the "pooler strips `options` → gateway boot fails" caveat for the fast pool
+
+**Why:** The fast-pool timeouts (#1343) set `statement_timeout`/`lock_timeout` via the Postgres `options` startup string, and `verifyPoolTimeouts` deliberately FAILS gateway boot if they didn't apply. Intentional (loud failure beats silently reverting to the silent-hang bug), but a future deployer who fronts the gateway's DB with a pooler that strips startup params (PgBouncer txn-mode, Prisma Accelerate, pgpool) would hit a mysterious boot crash. **Fix shape**: note the caveat in `FAST_POOL_DEFAULTS`/`fastPoolConnectionOptions` JSDoc (`poolConfig.ts`) + the deployment runbook (`docs/reference/deployment/`). **Promote when**: a connection pooler is added to the gateway's DB path, OR a deployment-runbook pass. Surfaced 2026-06-25 by PR #1343 round-2 claude-review.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-176 - Fast-pool-timeout-PR-1343-code-polish-nits-3-all-genuinely-minor.md
+++ b/tracker/tasks/task-176 - Fast-pool-timeout-PR-1343-code-polish-nits-3-all-genuinely-minor.md
@@ -1,0 +1,20 @@
+---
+id: TASK-176
+title: 'Fast-pool timeout PR #1343 code-polish nits (3, all genuinely minor)'
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 176000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Fast-pool timeout PR #1343 code-polish nits (3, all genuinely minor)
+
+**Why:** From #1343 round-2 claude-review, all explicitly "minor": (1) `verifyPoolTimeouts` (`prisma.ts`) asserts only `statement_timeout`+`lock_timeout`, not `idle_in_transaction_session_timeout` — extend the `pg_settings` `WHERE IN` + expected for completeness (low value: idleInTx is hardcoded, a full `options` strip is already caught); (2) the `query-timeout-or-dead-conn` case has no HANDLER-level test (only exhaustive coverage in `dbTimeout.test.ts`) — add an `it` block or a comment noting the intentional asymmetry; (3) the fast-pool-timeout `catch` comment in both persist handlers documents WHAT ("asyncHandler turns it into the gateway's 5xx") not WHY — reword per 02-code-standards to "classify before rethrowing so the 5xx carries the diagnostic label in logs." **Promote when**: next touching the fast-pool code, or a polish pass. Surfaced 2026-06-25 by PR #1343 round-2 claude-review.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-177 - testaudit-misses-Loaderts-Prisma-services-naming-convention-gap.md
+++ b/tracker/tasks/task-177 - testaudit-misses-Loaderts-Prisma-services-naming-convention-gap.md
@@ -1,0 +1,22 @@
+---
+id: TASK-177
+title: 'test:audit misses *Loader.ts Prisma services (naming-convention gap)'
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:identity'
+  - 'area:db'
+dependencies: []
+ordinal: 177000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`test:audit` misses `*Loader.ts` Prisma services (naming-convention gap)
+
+**Why:** `findServiceFiles` (`packages/tooling/src/test/audit-unified.ts`) matches `/Service\.ts$/`, so a Prisma-using class named `*Loader.ts` escapes the component-test ratchet. Concrete case: `PersonalityLoader.ts` (`packages/identity`) holds the actual `this.prisma.*` calls (PersonalityService delegates to it + only imports `PrismaClient` as a type, so PersonalityService correctly isn't flagged). NO coverage gap today — `PersonalityService.component.test.ts` exercises the full Service→Loader stack — but if that test were deleted, the ratchet wouldn't catch it. **Fix shape**: widen the pattern to `/Service\.ts$|Loader\.ts$/` (bump TEST_AUDIT_IMPL_VERSION + refresh baseline; verify no new gaps), OR a broader rename convention. **Promote when**: next touching `audit-unified.ts`, or a `*Loader.ts` Prisma class loses its coverage. Surfaced 2026-06-25 by PR #1344 round-3 claude-review.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-178 - testaudit-serviceDirs-is-a-hardcoded-list.md
+++ b/tracker/tasks/task-178 - testaudit-serviceDirs-is-a-hardcoded-list.md
@@ -1,0 +1,23 @@
+---
+id: TASK-178
+title: 'test:audit serviceDirs is a hardcoded list'
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:conversation-history'
+  - 'area:db'
+  - 'area:testing'
+dependencies: []
+ordinal: 178000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`test:audit` `serviceDirs` is a hardcoded list — auto-discover `packages/*/src`
+
+**Why:** `findServiceFiles` enumerates scan dirs by hand (4 service/package dirs + now identity + conversation-history via #1344). Every package the next extraction creates silently escapes the ratchet until someone remembers to add it here — the exact hole #1344 just closed, which will recur. `hasPrismaUsage()` already filters at the file level, so the blast radius of scanning all packages is low. **Fix shape**: replace the hardcoded list with a glob over `packages/*/src` + `services/*/src` (readdirSync), keeping the Prisma-usage filter; exclude non-service packages (tooling, test-utils, test-factories) if they produce noise. Bump TEST_AUDIT_IMPL_VERSION + refresh baseline. **Promote when**: the next package extraction, or another "package escaped the ratchet" omission. Surfaced 2026-06-25 by PR #1344 round-2/3 claude-review (explicitly "no change needed in this PR; backlog candidate").
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-179 - Pre-assert-the-cross-channel-group-before-checking-its-env-name-test-diagnostic-.md
+++ b/tracker/tasks/task-179 - Pre-assert-the-cross-channel-group-before-checking-its-env-name-test-diagnostic-.md
@@ -1,0 +1,19 @@
+---
+id: TASK-179
+title: 'Pre-assert the cross-channel group before checking its env name (test diagnostic clarity)'
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels: []
+dependencies: []
+ordinal: 179000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Pre-assert the cross-channel group before checking its env name (test diagnostic clarity)
+
+**Why:** In `ContextAssembler.component.test.ts` the cross-channel decoration test does `expect(byChannel(CHANNEL_ID_C)?.channel.name).toBe('unknown-channel')`. If the group were absent entirely (e.g. a DB query silently filtering it), the failure reads `expected undefined to equal 'unknown-channel'` — ambiguous between "wrong name" and "group not found." **Fix shape**: pre-assert `expect(envC).toBeDefined()` before the name check (same for B). Pure diagnostic-clarity; the current form still catches real regressions. **Promote when**: next touching that test file. Surfaced 2026-06-25 by PR #1345 round-3 claude-review (non-blocking, optional).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-18 - tombstone-LWW-uses-wall-clock-TIMESTAMP3-only-a-same-ms-create-then-delete-tie-f.md
+++ b/tracker/tasks/task-18 - tombstone-LWW-uses-wall-clock-TIMESTAMP3-only-a-same-ms-create-then-delete-tie-f.md
@@ -1,0 +1,20 @@
+---
+id: TASK-18
+title: 'tombstone LWW uses wall-clock TIMESTAMP(3) only; a same-ms create-then-delete tie fails…'
+status: To Do
+assignee: []
+created_date: '2026-07-11 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 18000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-11 — tombstone LWW uses wall-clock TIMESTAMP(3) only; a same-ms create-then-delete tie fails toward preservation (deliberate), but a genuinely fast create→delete could resurrect a row across sync. **Fix shape**: sequence number (or logical clock) alongside the timestamp closes the class. **Promote when**: any prod resurrection is observed, or next sync-schema migration. Surfaced by #1589 release review (non-blocking).
+
+**Why:** Wall-clock ties are the one hole in LWW deletion semantics.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-180 - Keep-the-prod-voice-engine-warm-so-the-STT-budget-is-inference-not-cold-start.md
+++ b/tracker/tasks/task-180 - Keep-the-prod-voice-engine-warm-so-the-STT-budget-is-inference-not-cold-start.md
@@ -1,0 +1,21 @@
+---
+id: TASK-180
+title: 'Keep the prod voice-engine warm so the STT budget is inference, not cold-start'
+status: To Do
+assignee: []
+created_date: '2026-06-27 00:00'
+labels:
+  - 'area:voice'
+  - 'area:jobs'
+dependencies: []
+ordinal: 180000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Keep the prod voice-engine warm so the STT budget is inference, not cold-start
+
+**Why:** The prod voice-engine runs Railway-serverless (sleeps on idle); the first voice message after idle pays a ~23–135s cold-start that stacks on top of the transcription and eats into `STT_GATEWAY` (especially for a long first message). beta.139's chunking + bigger timeouts handle the common case, but cold-start variance remains. **Fix shape**: a keep-warm ping (a BullMQ repeatable job hitting `/health`, or disable the serverless idle policy on the prod voice-engine service) so the engine is hot when a voice message arrives. **Promote when**: post-fix prod logs still show cold-start eating the STT budget (a large gap before `inference_sec` begins), OR a long first-message-after-idle still times out. Surfaced 2026-06-27 by the long-audio STT chunking work (beta.139).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-181 - Evaluate-batched-asrmodeltranscribewindows-vs-the-sequential-per-window-loop.md
+++ b/tracker/tasks/task-181 - Evaluate-batched-asrmodeltranscribewindows-vs-the-sequential-per-window-loop.md
@@ -1,0 +1,20 @@
+---
+id: TASK-181
+title: 'Evaluate batched asr_model.transcribe([...windows]) vs the sequential per-window loop'
+status: To Do
+assignee: []
+created_date: '2026-06-27 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 181000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Evaluate batched `asr_model.transcribe([...windows])` vs the sequential per-window loop
+
+**Why:** The voice-engine chunked path (`_transcribe_chunks`, `services/voice-engine/server.py`) transcribes windows ONE AT A TIME under `_asr_inference_lock` — deterministic memory, version-independent. NeMo _may_ accept a batch of windows in one `.transcribe()` call (potentially faster), but batch memory/parallelism is version-specific and could OOM the 4GB box. **Fix shape**: benchmark batched vs sequential per-window inference time + peak RSS on Railway CPU; switch only if the speedup is real and memory stays bounded. **Promote when**: prod `per_chunk_sec` logs show the sequential loop is the latency bottleneck for long audio, OR a measurement pass is run. Surfaced 2026-06-27 by the long-audio STT chunking work (beta.139).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-182 - Add-a-runtime-narrowing-guard-before-the-as-ConfigKind-cast-if-kind-is-ever-read.md
+++ b/tracker/tasks/task-182 - Add-a-runtime-narrowing-guard-before-the-as-ConfigKind-cast-if-kind-is-ever-read.md
@@ -1,0 +1,19 @@
+---
+id: TASK-182
+title: 'Add a runtime narrowing guard before the as ConfigKind cast if kind is ever read outside…'
+status: To Do
+assignee: []
+created_date: '2026-06-28 00:00'
+labels: []
+dependencies: []
+ordinal: 182000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Add a runtime narrowing guard before the `as ConfigKind` cast if `kind` is ever read outside autocomplete
+
+**Why:** `preset/autocomplete.ts` + `settings/preset/autocomplete.ts` do `const kind = (interaction.options.getString('kind', false) ?? 'text') as ConfigKind`. Safe TODAY: Discord restricts the value to the choice set (`CONFIG_KINDS`) and the autocomplete error handler returns `[]` on anything unexpected — no security hole. Adding a guard now would be premature defensiveness for an input that can't occur. **Fix shape**: `const raw = …getString('kind', false) ?? 'text'; const kind: ConfigKind = CONFIG_KINDS.includes(raw as ConfigKind) ? (raw as ConfigKind) : 'text';`. **Promote when**: `kind` is read in a NON-autocomplete context (e.g. a deferred handler) where Discord's choice-set guarantee doesn't hold. Surfaced 2026-06-28 by PR #1380 (S2c) claude-review (non-blocking, reviewer self-qualified as "if/when used in a non-autocomplete context").
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-183 - Retire-the-manual-AUTODEPLOYCOMMANDS-boolean.md
+++ b/tracker/tasks/task-183 - Retire-the-manual-AUTODEPLOYCOMMANDS-boolean.md
@@ -1,0 +1,19 @@
+---
+id: TASK-183
+title: 'Retire the manual AUTO_DEPLOY_COMMANDS boolean'
+status: To Do
+assignee: []
+created_date: '2026-06-28 00:00'
+labels: []
+dependencies: []
+ordinal: 183000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Retire the manual `AUTO_DEPLOY_COMMANDS` boolean — derive command-registration from the environment (+ optional change-detection)
+
+**Why:** Slash-command registration on bot boot (`index.ts:722`) is gated on the hand-set `AUTO_DEPLOY_COMMANDS` env var (schema: optional, default-falsy; `.env.example`=false; dev+prod="true"). Its ONE legitimate job is the **local-dev opt-out** (a local `pnpm dev` skips registration so it can't clobber/churn the shared app's GLOBAL commands). But it's a **footgun**: a hand-set per-env flag that MUST be `true` on dev/prod — if it ever silently went missing there, the bot boots fine while commands quietly stop updating (the exact "new option didn't appear in Discord" confusion). It also re-runs a global bulk `rest.put` on EVERY boot/redeploy even when the command set is unchanged, churning Discord's ~1h global propagation + burning the command-update rate budget on crash-loops. **Fix shape**: (a) derive enablement from the environment (auto-on when running on Railway / `ENVIRONMENT ∈ {dev,prod}`, off locally) instead of a hand-set boolean — kills the footgun while keeping local protection; (b) optionally add change-detection — hash `command-manifest.json` (already generated), store/compare the last-registered hash, skip the PUT when unchanged. **Open question** (determines whether the local opt-out is even needed): does local `pnpm dev` point at the SHARED dev Discord app or a separate throwaway app? If always separate → the clobber concern evaporates and the var is near-dead config (simpler: just always-register on Railway). If shared → the env-derived guard is required. **Promote when**: a config/`.claude` tidy pass, or if a crash-loop hits Discord command rate limits. Surfaced 2026-06-28 (user, during S2c/S2d dev-validation setup).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-184 - take-100-silently-truncates-the-all-kinds-list-for-power-users.md
+++ b/tracker/tasks/task-184 - take-100-silently-truncates-the-all-kinds-list-for-power-users.md
@@ -1,0 +1,19 @@
+---
+id: TASK-184
+title: 'take: 100 silently truncates the all-kinds list for power users'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels: []
+dependencies: []
+ordinal: 184000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`take: 100` silently truncates the all-kinds list for power users
+
+**Why:** `handleListModelOverrides` (`model-override.ts`) and `LlmConfigService.list('all')` cap each query at `take: 100`. With `kind=all` a personality with both FKs expands to two summary rows (≤200), and USER-scope list runs two parallel capped queries (≤200) — neither returns a `hasMore` signal, so a user with 100+ override'd personalities (or 100+ configs) gets a silently-incomplete list with no way to tell "got everything" from "got the first 100". Power-user-only today; browse paginates so the in-view set is fine. **Fix shape**: cursor/offset pagination on the endpoint, or at minimum a `hasMore: boolean` in the response. **Promote when**: a user's personality/config count approaches ~100, or the list endpoints are reworked. Surfaced 2026-06-29 by PR #1383 (S2f) claude-review (non-blocking, documented in-code).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-185 - Verify-no-warm-Redis-cache-validation-break-from-the-kind-required-LlmConfigSumm.md
+++ b/tracker/tasks/task-185 - Verify-no-warm-Redis-cache-validation-break-from-the-kind-required-LlmConfigSumm.md
@@ -1,0 +1,20 @@
+---
+id: TASK-185
+title: 'Verify no warm Redis-cache validation break from the kind-required LlmConfigSummary bump'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'area:redis'
+dependencies: []
+ordinal: 185000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Verify no warm Redis-cache validation break from the `kind`-required `LlmConfigSummary` bump
+
+**Why:** S2f made `LlmConfigSummary.kind` REQUIRED (was detail-only). If any Redis-cached LLM-config LIST response (serialized pre-`kind`) is deserialized + re-validated against the new schema post-deploy, it would fail `LlmConfigSummarySchema`. **Likely a non-issue**: the gateway always projects `kind` fresh (it's in `LLM_CONFIG_LIST_SELECT`), and the cache audit (`03-database.md`) lists no Redis-backed config-LIST cache (the autocomplete cache is in-memory + 30s TTL, resets on deploy). **Action**: confirm there's no long-TTL Redis cache of the list response before the prod release; if one exists, do a one-time cache invalidation at deploy. **Promote when**: cutting the prod release for the Model-Config epic, or if a post-deploy `LlmConfigSummarySchema` validation error appears. Surfaced 2026-06-29 by PR #1383 (S2f) claude-review (deploy-time, low-risk).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-186 - Revisit-AdminSettings-default-pointer-storage-FK-columns-normalized-junction-tab.md
+++ b/tracker/tasks/task-186 - Revisit-AdminSettings-default-pointer-storage-FK-columns-normalized-junction-tab.md
@@ -1,0 +1,20 @@
+---
+id: TASK-186
+title: 'Revisit AdminSettings default-pointer storage: FK columns → normalized junction table'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'area:embeddings'
+dependencies: []
+ordinal: 186000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Revisit `AdminSettings` default-pointer storage: FK columns → normalized junction table
+
+**Why:** P3-S3 stores the global/free default config pointers as **4 nullable FK columns** on the `AdminSettings` singleton (`{global,free}Default{Llm,Vision}ConfigId`) — councilled (GLM-5.2 / Kimi-K2.7 / Qwen-3.7-max) and chosen on **YAGNI** grounds: it matches the existing per-slot-FK pattern (`User.defaultVisionConfigId`, `UserPersonalityConfig`) and 2 tiers × 2 slots is too few to justify a table. Qwen's dissent favored a normalized `DefaultLlmConfig(tier, slot) → configId` junction table (enums `GLOBAL/FREE` × `CHAT/VISION`) for extensibility — the right call IF the slot/tier count grows (new modalities/tiers don't sprawl columns on the singleton + don't diverge from a clean lookup). **Fix shape**: migrate the N FK columns on `AdminSettings` → a `DefaultLlmConfig` junction table with `@@id([tier, slot])` + `onDelete:SetNull`; resolver does one `findMany` → `Record<Tier, Record<Slot, Config>>`. **Promote when**: the default slot or tier count grows beyond 2×2 (e.g. an audio/embeddings slot, or a premium/beta tier). Surfaced 2026-06-29 (P3-S3 schema council; owner swayed by YAGNI for now, flagged for revisit).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-187 - Decide-the-kind-echo-on-the-PUT-default-set-response-UserDefaultConfig.md
+++ b/tracker/tasks/task-187 - Decide-the-kind-echo-on-the-PUT-default-set-response-UserDefaultConfig.md
@@ -1,0 +1,21 @@
+---
+id: TASK-187
+title: 'Decide the kind-echo on the PUT /default set response (UserDefaultConfig)'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:common-types'
+dependencies: []
+ordinal: 187000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Decide the `kind`-echo on the `PUT /default` set response (`UserDefaultConfig`)
+
+**Why:** `handleSetModelOverride` returns `{ override: { …, kind } }` but `handleSetDefaultModelConfig` returns `{ default: { configId, configName } }` — no `kind`. The caller always knows what slot it sent, so it's not a bug, but the asymmetry is more visible now both SET handlers accept `?kind=` (P3-S2). **Fix shape**: if bot-client (P3-S4) needs to confirm the written slot without threading it through call state, add `kind` to `UserDefaultConfig` (common-types) + populate it in the handler. **Promote when**: implementing P3-S4 — decide there based on whether the command flow needs the echo. Surfaced 2026-06-29 by PR #1385 (P3-S2) claude-review (non-blocking; tracked on task #60).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-188 - Wire-the-two-write-only-default-pointers-into-the-resolver-cascade.md
+++ b/tracker/tasks/task-188 - Wire-the-two-write-only-default-pointers-into-the-resolver-cascade.md
@@ -1,0 +1,19 @@
+---
+id: TASK-188
+title: 'Wire the two write-only default pointers into the resolver cascade'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels: []
+dependencies: []
+ordinal: 188000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Wire the two write-only default pointers into the resolver cascade
+
+**Why:** After P3-S3 the resolver reads only `freeDefaultLlmConfig` (`LlmConfigResolver`) and `globalDefaultVisionConfig` (`VisionConfigResolver`). The other two pointers — `globalDefaultLlmConfigId` (paid chat-global) and `freeDefaultVisionConfigId` (free vision) — are admin-settable and the delete guard honours them, but **no resolver tier consults them**, so setting either has no resolution effect today. This matches the pre-cutover flags (the LLM cascade never had a paid-chat-global tier; the vision-free read was already deferred — see `VisionConfigResolver` comment). **Side effect to fix when wiring**: an admin who sets one of these gets `{success:true}` with no live change AND is then blocked from deleting that config by the pointer-aware delete guard — invisible friction until the reader tiers ship; consider surfacing the occupied slot in the delete-guard 400 body at that point. **Fix shape**: add a `globalDefaultLlmConfig` read tier in `LlmConfigResolver` + a `freeDefaultVisionConfig` read tier in `VisionConfigResolver`. **Promote when**: Slice 4, or whenever the cascade gains a paid-chat-global / free-vision tier. Surfaced 2026-06-29 by PR #1388 (P3-S3) claude-review (referenced by the `setAsDefault` JSDoc).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-189 - Delete-guard-read-then-act-transaction-hardening.md
+++ b/tracker/tasks/task-189 - Delete-guard-read-then-act-transaction-hardening.md
@@ -1,0 +1,20 @@
+---
+id: TASK-189
+title: 'Delete-guard read-then-act transaction hardening'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 189000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Delete-guard read-then-act transaction hardening
+
+**Why:** The admin config delete guard reads `adminSettings.findUnique` then deletes as two steps — a concurrent `set-default` between them could let a just-promoted default be deleted (FK `onDelete:SetNull` bounds the blast radius; admin-only endpoint). Same read-then-act class: `setAsDefault`/`setAsFreeDefault` no longer pre-validate the config exists (the route layer does via `findGlobalConfigOrSendError`), so a config vanishing in the race window surfaces as a Prisma FK-500 rather than a clean 404 — a deliberate, JSDoc'd error-quality regression for the narrow race. **Fix shape**: wrap the guard + delete in a transaction if admin-endpoint concurrency ever matters. (The null-singleton-row branch is now unit-tested — only the transaction hardening remains.) **Promote when**: admin concurrency becomes a concern, or opportunistically when next touching the delete handler. Surfaced 2026-06-29 by PR #1388 (P3-S3) claude-review (non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-19 - generate-schemats-harvester-comment-stripping-is-a-blind-whole-file-regex-fine-f.md
+++ b/tracker/tasks/task-19 - generate-schemats-harvester-comment-stripping-is-a-blind-whole-file-regex-fine-f.md
@@ -1,0 +1,20 @@
+---
+id: TASK-19
+title: 'generate-schema.ts harvester comment-stripping is a blind whole-file regex; fine for…'
+status: To Do
+assignee: []
+created_date: '2026-07-10 00:00'
+labels:
+  - 'area:testing'
+dependencies: []
+ordinal: 19000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-10 — `generate-schema.ts` harvester comment-stripping is a blind whole-file regex; fine for short DDL, but the new plpgsql-function harvester processes full bodies — a future function whose string literal contains `--` or `/*` (a URL, example text) would be silently corrupted/dropped from the PGLite schema. **Fix shape**: dollar-quote-aware stripping (skip $$…$$ spans) or a harvest-count parity assertion vs live migrations. **Promote when**: next time a plpgsql function is added/edited, or the next generate-schema touch.
+
+**Why:** Silent trigger loss in PGLite = component tests quietly stop exercising prod behavior (reviewer flag on #1579).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-190 - preset-browse-transfers-the-full-config-set-on-every-paginationfilter-interactio.md
+++ b/tracker/tasks/task-190 - preset-browse-transfers-the-full-config-set-on-every-paginationfilter-interactio.md
@@ -1,0 +1,19 @@
+---
+id: TASK-190
+title: '/preset browse transfers the full config set on every pagination/filter interaction'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels: []
+dependencies: []
+ordinal: 190000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`/preset browse` transfers the full config set on every pagination/filter interaction
+
+**Why:** S4b-1 (#1395) moved the second filter axis (text/vision) from a server-scoped fetch to **always-fetch-all-then-filter client-side** (`fetchPresets` hardcodes `kind: 'all'`; `filterPresets` applies scope+capability in-memory). Necessary — capability (`supportsVision`) is model-derived, not a server-filterable column — but it means every page-turn / filter-change re-transfers the user's entire config set. Fine for typical config counts; a user with a large config set may feel filter changes get slightly slower. **Fix shape**: if it becomes observable, cache the fetched config list per browse session (keyed on the browse message id, like the existing dashboard session pattern) so pagination/filter reuses it instead of re-fetching, OR add server-side capability filtering once `supportsVision` is a persisted/queryable column. **Promote when**: a user reports sluggish `/preset browse` filter/pagination, or config counts grow large enough to matter. Surfaced 2026-06-29 by PR #1395 (S4b-1) claude-review (non-blocking, acceptable trade-off).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-191 - Decouple-voice-engine-cold-start-from-the-TTS-synthesis-timeout.md
+++ b/tracker/tasks/task-191 - Decouple-voice-engine-cold-start-from-the-TTS-synthesis-timeout.md
@@ -1,0 +1,20 @@
+---
+id: TASK-191
+title: 'Decouple voice-engine cold-start from the TTS synthesis timeout'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 191000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Decouple voice-engine cold-start from the TTS synthesis timeout
+
+**Why:** `TTSStep.runWithTimeout` wraps the WHOLE self-hosted dispatch — including the serverless cold-start warmup (up to the 120s `voiceEngineWarmup` budget) — in one `TTS_MAX_TOTAL_MS` race, so a cold-start eats into the synthesis budget. The flat bump to 300s (this fix) covers a typical cold-start (~52s) + a long synthesis (~190s), but a pathological full-120s cold-start + very-long synthesis can still exceed it. **Proper fix**: start the synthesis timeout at warmup-completion (the warmup already has its own 120s budget) so the two are budgeted independently — a genuine synthesis hang still fails fast from synthesis-start, and a cold-start never starves the synthesis. Needs the dispatcher/`SelfHostedTtsProvider` to signal "warmup done, synthesizing" so `runWithTimeout` can (re)start the synthesis clock. Related robustness win: deliver the late-completed audio as a follow-up instead of discarding it (`TTSStep` currently throws away audio that finishes after the timeout). **Why the cold path is hit routinely (not rarely)**: moderation-blocked (edgy) content fails the Mistral BYOK guardrail (403 `guardrail_violation`) and ALWAYS falls back to the serverless self-hosted engine, which cold-starts — so for such content the ~52s warmup is the norm, which is exactly what stacks onto a long synthesis to blow the budget. **Promote when**: the 300s budget is exceeded again in prod (full cold-start + long text), or opportunistically when next touching the TTS pipeline. Surfaced 2026-06-29 (prod voice-output-dropped diagnosis; observed trace: ~52s cold-start + 190s self-hosted synthesis > the 240s pre-fix budget, late audio discarded).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-192 - Zero-staleness-invalidation-for-the-owner-global-config-autocomplete-cache.md
+++ b/tracker/tasks/task-192 - Zero-staleness-invalidation-for-the-owner-global-config-autocomplete-cache.md
@@ -1,0 +1,20 @@
+---
+id: TASK-192
+title: 'Zero-staleness invalidation for the owner global-config autocomplete cache'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 192000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Zero-staleness invalidation for the owner global-config autocomplete cache
+
+**Why:** beta.142 shipped the INTERIM fix: `handleGlobalConfigAutocomplete`'s `globalConfigCache` got its own dedicated 30s TTL (`GLOBAL_CONFIG_CACHE_TTL_MS`) instead of the shared `TIMEOUTS.CACHE_TTL` — which a stale comment claimed was 60s but is actually **5 minutes**, so a new global preset was invisible in the `/preset global default|free-default` picker for up to 5 min (runtime-observed 2026-06-29 owner dev smoke: imported "qwen 3.7", "took a while" to appear). 30s bounds it; the cache is NOT yet event-invalidated, so up-to-30s staleness remains. (The picker is now capability-agnostic — one `global-configs:all` cache key, not per-kind — so the invalidation target is a single key.) **Proper fix (this follow-up)**: pub/sub-invalidate on global-config mutation for zero staleness. **Open question that gates it**: which mutation makes a config GLOBAL (no obvious `/preset global create`; import/create make USER configs) — that's the invalidation point. **Fix shape**: subscribe bot-client to `LlmConfigCacheInvalidationService` global-scope events (bot-client doesn't subscribe to LLM-config events today — only personality/channel/denylist) + reset the cache on receipt; the gateway must broadcast on the global-config mutation. **Promote when**: the 30s window still bites the owner, or the next preset-autocomplete touch. Surfaced 2026-06-29 (owner dev smoke for beta.142); interim TTL fix in the beta.142 release.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-193 - refreshCache-can-join-the-in-flight-guard-instead-of-forcing-a-fresh-load.md
+++ b/tracker/tasks/task-193 - refreshCache-can-join-the-in-flight-guard-instead-of-forcing-a-fresh-load.md
@@ -1,0 +1,20 @@
+---
+id: TASK-193
+title: 'refreshCache() can join the in-flight guard instead of forcing a fresh load'
+status: To Do
+assignee: []
+created_date: '2026-06-30 00:00'
+labels:
+  - 'area:redis'
+dependencies: []
+ordinal: 193000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`refreshCache()` can join the in-flight guard instead of forcing a fresh load
+
+**Why:** PR #1406 added a `getModels()` in-flight guard (concurrent cold callers share one fetch). `OpenRouterModelCache.refreshCache()` clears both cache tiers + calls `getModels()` to force a fresh load — but with the guard, if a cold `getModels()` is already in flight, `refreshCache`'s call JOINS it and returns possibly-pre-`del()` data (admin-only path, narrow race). An inline fix was attempted + reverted because it's subtle: naively nulling `this.inFlight` BEFORE `await redis.del()` opens a worse window — a concurrent caller arriving during the `del` await reads the not-yet-deleted stale Redis key and warms `memoryCache` with stale data for the full 5-min TTL. **Fix shape**: null `this.inFlight` AFTER `await redis.del()` (so `refreshCache`'s own `getModels()` loads against an emptied Redis), plus a test that seeds a stale Redis key and asserts the refresh returns fresh data — NOT a `redis.get→null` mock (that can't catch the stale-key poisoning). **Promote when**: `refreshCache` becomes a user-visible/automated trigger, or admin cache-refresh races are observed. Surfaced 2026-06-30 by PR #1406 review (non-blocking; reviewer's original guidance was "backlog this").
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-194 - modelSupportsVisionopenrouterfree-can-misreport-non-vision-on-a-catalog-cache-mi.md
+++ b/tracker/tasks/task-194 - modelSupportsVisionopenrouterfree-can-misreport-non-vision-on-a-catalog-cache-mi.md
@@ -1,0 +1,20 @@
+---
+id: TASK-194
+title: "modelSupportsVision('openrouter/free') can misreport non-vision on a catalog cache-miss"
+status: To Do
+assignee: []
+created_date: '2026-06-30 00:00'
+labels:
+  - 'area:redis'
+dependencies: []
+ordinal: 194000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`modelSupportsVision('openrouter/free')` can misreport non-vision on a catalog cache-miss
+
+**Why:** `MODEL_DEFAULTS.VISION_FALLBACK_FREE` is now `openrouter/free`. `ModelCapabilityChecker` resolves vision capability from the Redis-cached OpenRouter catalog, falling back to substring `VISION_MODEL_PATTERNS` (`ModelCapabilityChecker.ts:214-238`) on a cache miss — and `openrouter/free` matches no pattern (no `gemini`/`gemma`/`qwen` substring). So if the router lacks its own catalog row AND the cache misses, `modelSupportsVision` returns `false`. **Not a bug today**: `selectVisionModel` (`VisionProcessor.ts:526-533`) assigns the free vision fallback DIRECTLY, without gating on capability. **Fix shape**: special-case `openrouter/free` as vision-capable in `ModelCapabilityChecker` (or add a router entry to `VISION_MODEL_PATTERNS`) so a direct query can't misreport it. **Promote when**: any code path starts gating the free vision fallback on `modelSupportsVision`/`hasVisionSupport`, or a guest image request fails a capability check. Surfaced 2026-06-30 by PR #1412 review (non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-195 - Branch-aware-component-handler-ack-first-source-order-per-branch.md
+++ b/tracker/tasks/task-195 - Branch-aware-component-handler-ack-first-source-order-per-branch.md
@@ -1,0 +1,19 @@
+---
+id: TASK-195
+title: 'Branch-aware component-handler-ack-first (source-order → per-branch)'
+status: To Do
+assignee: []
+created_date: '2026-06-30 00:00'
+labels: []
+dependencies: []
+ordinal: 195000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Branch-aware `component-handler-ack-first` (source-order → per-branch)
+
+**Why:** The rule tracks `sawRealAsync` function-scoped + source-order, not per-branch. So a dispatch function where an EARLIER branch does real-async-before-its-own-ack forces a fresh `eslint-disable` on every LATER branch's ack (`dashboardActions.ts` `handleAction`: 3/4 branches suppressed; `purge.ts` `handlePurgeModal`: 2). As more `actionId` branches get added to these dispatchers, the suppression count grows rather than the rule catching new violations "for free." **Fix shape**: make the rule reset/scope `sawRealAsync` at branch boundaries (if/switch-case), so a sibling branch's async doesn't leak — likely needs ESLint's code-path analysis (`onCodePathStart`/`onCodePathSegmentStart`) rather than the current single-pass walk. **Promote when**: the suppression count in these dispatchers grows, or a new dispatch handler hits the same pattern. Surfaced 2026-06-30 by PR #1409 review (design observation, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-196 - Harvester-dedup-keys-on-bare-constraintindex-name-not-table-name.md
+++ b/tracker/tasks/task-196 - Harvester-dedup-keys-on-bare-constraintindex-name-not-table-name.md
@@ -1,0 +1,22 @@
+---
+id: TASK-196
+title: 'Harvester dedup keys on bare constraint/index name, not (table, name)'
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels:
+  - 'area:db'
+  - 'area:testing'
+  - 'origin:review'
+dependencies: []
+ordinal: 196000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Harvester dedup keys on bare constraint/index name, not (table, name)
+
+**Why:** `harvestLastWins` in `generate-schema.ts` dedups by the quoted name alone, across all three harvesters (CHECK, partial-unique, DEFERRABLE). Prisma's `<table>_<column>_fkey`/`_key` naming makes cross-table collisions effectively impossible today, but a hand-written migration using a bare name (e.g. `"valid_range"` on two tables) would last-wins-collapse to ONE statement and silently drop the other from `pglite-schema.sql`. **Fix shape**: key the dedup map on `table + name` (the regexes already match the quoted table — promote it to a capture group). **Promote when**: a hand-written migration introduces a constraint/index name that isn't table-prefixed, or next touching the harvest kernel. Surfaced 2026-07-02 (PR #1458 review — latent, pre-existing across all three harvesters).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-197 - Extractor-loses-providerError-detail-when-an-error-finish-choice-has-no-message-.md
+++ b/tracker/tasks/task-197 - Extractor-loses-providerError-detail-when-an-error-finish-choice-has-no-message-.md
@@ -1,0 +1,20 @@
+---
+id: TASK-197
+title: 'Extractor loses providerError detail when an error-finish choice has no message stub'
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 197000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Extractor loses providerError detail when an error-finish choice has no `message` stub
+
+**Why:** `validateAndExtractRawMessage` (extractOpenRouterReasoning.ts) returns null when `choices[0].message` is absent, so `buildOpenrouterMetadata` never runs and `response_metadata.openrouter.providerError` is not captured for that shape. The invoker's error-finish throw/retry is unaffected (it reads `finish_reason` from native metadata) — only the diagnostic detail in the warn log + /inspect is lost. The confirmed prod incident carried a message stub, so this is a hypothetical variant. **Fix shape**: capture the error object before the message-stub gate (or relax the gate to proceed with metadata-only extraction when an error object exists). **Promote when**: a prod error-finish warn log appears WITHOUT providerErrorDetail, or next touching the extractor. Surfaced 2026-07-02 (PR #1462 review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-198 - Decide-whether-CI-jobs-beyond-unit-testslint-become-required-status-checks.md
+++ b/tracker/tasks/task-198 - Decide-whether-CI-jobs-beyond-unit-testslint-become-required-status-checks.md
@@ -1,0 +1,22 @@
+---
+id: TASK-198
+title: 'Decide whether CI jobs beyond unit-tests+lint become required status checks'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels:
+  - 'area:voice'
+  - 'area:ci'
+  - 'origin:review'
+dependencies: []
+ordinal: 198000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Decide whether CI jobs beyond unit-tests+lint become required status checks
+
+**Why:** `.github/rulesets/branch-protection.json` requires only `test` and `lint`; `mutation-tests`, `component-integration-tests`, `voice-engine-tests`, and `build` rely on the merge-discipline gate (`00-critical.md` all-green-complete-read + the pr-merge-review-check hook) rather than GitHub-level enforcement. Consistent with current practice, but a plain-UI merge would not be blocked by those jobs failing. **Fix shape**: policy decision — either add the full job set to `required_status_checks` (belt-and-suspenders; costs nothing given all-green is already the standard) or explicitly document the two-tier intent in the ruleset file. **Promote when**: next touching branch protection, or if a red non-required check ever slips through a merge. Surfaced 2026-07-03 (PR #1463 review, informational).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-199 - Tune-lintcomplexity-report-bare-run-mode-for-the-opshealth-roster.md
+++ b/tracker/tasks/task-199 - Tune-lintcomplexity-report-bare-run-mode-for-the-opshealth-roster.md
@@ -1,0 +1,19 @@
+---
+id: TASK-199
+title: 'Tune lint:complexity-report bare-run mode for the ops:health roster'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels: []
+dependencies: []
+ordinal: 199000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Tune `lint:complexity-report` bare-run mode for the ops:health roster
+
+**Why:** A repo-wide run includes the deliberately-broken audit-canary fixture (complexity 25), so `--summary` structurally reports fail every time — 1507 findings on the maiden ops:health run. **Fix shape**: exclude `test-fixtures/audit-canaries/` from the default scan (the canary test passes targetDirs explicitly, so canary coverage is unaffected) and consider a baseline so status reflects regressions, not absolute counts. Then add it back to `HEALTH_TOOLS` in `audits/health.ts`. **Promote when**: next touching complexity-report, or when the weekly report needs more coverage. Surfaced 2026-07-03 (ops:health maiden run).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-2 - createIntervalScheduler-bot-client-has-no-in-flight-overlap-guard-a-run-cycle….md
+++ b/tracker/tasks/task-2 - createIntervalScheduler-bot-client-has-no-in-flight-overlap-guard-a-run-cycle….md
@@ -1,0 +1,21 @@
+---
+id: TASK-2
+title: 'createIntervalScheduler (bot-client) has no in-flight overlap guard: a run cycle…'
+status: To Do
+assignee: []
+created_date: '2026-07-26 00:00'
+labels:
+  - 'area:bot-client'
+  - 'origin:review'
+dependencies: []
+ordinal: 2000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-26 (#1797 review observation) — `createIntervalScheduler` (bot-client) has no in-flight overlap guard: a `run` cycle outlasting `intervalMs` would overlap the next tick. Unreachable at current cadences (6h/24h intervals vs. seconds-long checks), which is why it shipped without one. The co-named seam: `RetentionPurgeService.buildPreview` does a per-user reach lookup (`Promise.all`, one query pair per cohort member) that the daily nag now puts on a timer — fine at today's cohort size, the pair to revisit together. **Fix shape**: an in-flight flag in the factory (skip-and-log the overlapping tick) + collapse the per-user reach split into one grouped query. **Promote when**: a fast-cadence consumer adopts the factory (interval within ~10× of run duration), or the eligible cohort grows large enough that preview latency is noticeable in the nag/CLI.
+
+**Why:** Overlap is structurally possible but unreachable at every current call site; the trigger is a new consumer shape, not time.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-20 - memory-facts-has-no-cross-personality-VIEW-retrieval-now-honors….md
+++ b/tracker/tasks/task-20 - memory-facts-has-no-cross-personality-VIEW-retrieval-now-honors….md
@@ -1,0 +1,19 @@
+---
+id: TASK-20
+title: '/memory facts has no cross-personality VIEW: retrieval now honors…'
+status: To Do
+assignee: []
+created_date: '2026-07-10 00:00'
+labels: []
+dependencies: []
+ordinal: 20000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-10 — `/memory facts` has no cross-personality VIEW: retrieval now honors `shareLtmAcrossPersonalities` (facts+episodes parity, owner call) but browse still requires one personality. **Fix shape**: optional personality on GET /user/fact/list (persona-scoped is safe — you only ever see facts about you) + a browse "all characters" mode with per-character attribution on each row. **Promote when**: next `/memory` UI pass, or when the owner asks to see the whole fact picture.
+
+**Why:** Sharing users can't audit what the flag actually exposes across characters.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-200 - Add-a-recentunapplied-range-mode-to-dbcheck-safety-for-the-opshealth-roster.md
+++ b/tracker/tasks/task-200 - Add-a-recentunapplied-range-mode-to-dbcheck-safety-for-the-opshealth-roster.md
@@ -1,0 +1,19 @@
+---
+id: TASK-200
+title: 'Add a recent/unapplied-range mode to db:check-safety for the ops:health roster'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels: []
+dependencies: []
+ordinal: 200000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Add a recent/unapplied-range mode to `db:check-safety` for the ops:health roster
+
+**Why:** A bare run scans ALL historical migrations and re-flags applied, reviewed ones forever (26 findings, e.g. Feb 2026 drops) — perma-red in aggregate mode. **Fix shape**: a `--range`/`--recent` mode scoped to migrations newer than the last applied (or last N), keeping the full-history scan for explicit invocations. Then add it back to `HEALTH_TOOLS`. **Promote when**: next touching check-safety, or when the weekly report needs more coverage. Surfaced 2026-07-03 (ops:health maiden run).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-201 - Month-3-eval-of-the-weekly-audit-45-day-age-gate-decision.md
+++ b/tracker/tasks/task-201 - Month-3-eval-of-the-weekly-audit-45-day-age-gate-decision.md
@@ -1,0 +1,19 @@
+---
+id: TASK-201
+title: 'Month-3 eval of the weekly audit + 45-day age-gate decision'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels: []
+dependencies: []
+ordinal: 201000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Month-3 eval of the weekly audit + 45-day age-gate decision
+
+**Why:** The periodic-audit proposal's final steps: after ~3 months of weekly `ops health` runs (from ~2026-07), evaluate whether the reports are being read, prune always-green roster tools, and decide on the 45-day CI age-gate (age from GitHub Actions run history, not a file). Also revisit `TOOL_TIMEOUT_MS` (5min) × roster size vs the job's `timeout-minutes: 30` when growing the roster (PR #1466 round-5 review note). **Promote when**: ~2026-10, or when the roster next grows. Surfaced 2026-07-03.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-202 - Narrow-personalitiesslug-DB-column-VarChar25550.md
+++ b/tracker/tasks/task-202 - Narrow-personalitiesslug-DB-column-VarChar25550.md
@@ -1,0 +1,22 @@
+---
+id: TASK-202
+title: 'Narrow personalities.slug DB column VarChar(255)→(50)'
+status: To Do
+assignee: []
+created_date: '2026-07-24 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:db'
+  - 'area:docs'
+dependencies: []
+ordinal: 202000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Narrow `personalities.slug` DB column VarChar(255)→(50) — Code now guarantees ≤50 at every write path (`normalizeSlugForUser` cap, #1484), but the column stays VarChar(255) and pre-cap rows may exceed 50 (shapes imports never enforced length at persist). **Fix shape**: data migration first (re-normalize any >50 rows via the truncate+hash path, updating references), then the column narrowing, then `pnpm ops test:generate-schema`. **Promote when**: the next PR that PRODUCES A MIGRATION touching `personalities` — owner-designated trigger: ride along rather than running a standalone migration. (Sharpened 2026-07-24: the original wording said "touches `prisma/schema.prisma`", which a comment-only edit satisfies while offering no migration to ride along with — the letter fired without the intent.) Filed 2026-07-04 (owner deferral, post-beta.147). ~~**Rider**: stale doc-comment citing the deleted `docs/planning/SLASH_COMMAND_ARCHITECTURE.md`~~ ✅ DONE — rewritten to state the invariant (per-persona cutoffs) instead of pointing at a dead path.
+
+**Why:** Schema permits what code forbids; drift is invisible until an out-of-band write bypasses the app layer.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-203 - Sweep-remaining-high-cardinality-vision-INFO-logs-if-noise-resurfaces.md
+++ b/tracker/tasks/task-203 - Sweep-remaining-high-cardinality-vision-INFO-logs-if-noise-resurfaces.md
@@ -1,0 +1,19 @@
+---
+id: TASK-203
+title: 'Sweep remaining high-cardinality vision INFO logs if noise resurfaces'
+status: To Do
+assignee: []
+created_date: '2026-07-04 00:00'
+labels: []
+dependencies: []
+ordinal: 203000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Sweep remaining high-cardinality vision INFO logs if noise resurfaces
+
+**Why:** #1487 demoted 11 per-image/per-turn vision INFO sites; the reviewer flagged that other pipeline files (e.g. `ragVisionAuth.ts`, job-chain `DependencyStep`) may carry similar per-image INFO traces not in that sweep. **Fix shape**: grep `logger.info` across the vision/job-chain path, classify per-image vs per-request, demote the plumbing. **Promote when**: vision log volume is a problem again during an investigation. Filed 2026-07-04 (#1487 review nit). Also sweep the 3 stale `[Image unavailable: …]` doc-comment mentions in `VisionProcessor.ts` (lines ~39/135/494 — comment-only, describe the retired format).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-204 - Close-the-vision-cache-store-race-with-a-LuaCAS-script.md
+++ b/tracker/tasks/task-204 - Close-the-vision-cache-store-race-with-a-LuaCAS-script.md
@@ -1,0 +1,20 @@
+---
+id: TASK-204
+title: 'Close the vision-cache store race with a Lua/CAS script'
+status: To Do
+assignee: []
+created_date: '2026-07-04 00:00'
+labels:
+  - 'area:redis'
+dependencies: []
+ordinal: 204000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Close the vision-cache store race with a Lua/CAS script
+
+**Why:** `VisionDescriptionCache.store()`'s read→decide→setex is non-atomic; two concurrent stores for the same image race to last-writer-wins (documented in the file; bounded to one 1h TTL cycle, rare under the per-request describe flow). Deferred from #1485 because no Lua-capable Redis test infra exists. **Fix shape**: CAS-style Lua promotion script + a Lua-capable test harness (or integration-tier coverage). **Promote when**: vision-description quality becomes a support complaint (beta.147 release-review trigger). Surfaced 2026-07-04 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-205 - Empty-response-as-censorship-retry.md
+++ b/tracker/tasks/task-205 - Empty-response-as-censorship-retry.md
@@ -1,0 +1,19 @@
+---
+id: TASK-205
+title: 'Empty-response-as-censorship retry'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels: []
+dependencies: []
+ordinal: 205000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Empty-response-as-censorship retry — **VERIFIED 2026-07-05, partial**: empty completions ARE detected (LLMInvoker EMPTY_RESPONSE, retryable) and retried same-model with escalating params (temperature/frequency/history-reduction), final failure shows an honest user error. Missing: DIFFERENT-model fallback — no text-generation equivalent of the vision fallback chain exists. **Home: the profiles design** (paid+free fallback container, model-configuration-overhaul theme) — a targeted retry-with-free-default could ship earlier if the pain is real.
+
+**Why:** The remaining gap is a product design call, not a bug.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-206 - Channel-wide-bot-history-delete.md
+++ b/tracker/tasks/task-206 - Channel-wide-bot-history-delete.md
@@ -1,0 +1,20 @@
+---
+id: TASK-206
+title: 'Channel-wide bot-history delete'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 206000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Channel-wide bot-history delete — **BUILD-READY (owner decision 2026-07-05)**
+
+**Why:** Permission: **Manage Messages in that channel, or bot owner**. Surface: `scope` option on `/history purge` (`own` = default/current behavior; `everyone` = permission-gated channel-wide). Mechanics already exist: `ConversationRetentionService.clearHistory(channelId, personalityId)` with personaId omitted does the channel-wide delete — the route needs a scope param + permission check, the command needs the option + a destructive confirm whose copy states the FULL scope ("ALL users' conversation history with X in this channel"). Bot-side history only; memories untouched (same as personal delete). **Promote when**: next /history touch, or Opus build-queue pull.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-207 - Preset-model-field-autocomplete-from-OpenRouterModelCache-instead-of-freeform-te.md
+++ b/tracker/tasks/task-207 - Preset-model-field-autocomplete-from-OpenRouterModelCache-instead-of-freeform-te.md
@@ -1,0 +1,19 @@
+---
+id: TASK-207
+title: 'Preset model field: autocomplete from OpenRouterModelCache instead of freeform text'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels: []
+dependencies: []
+ordinal: 207000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Preset model field: autocomplete from OpenRouterModelCache instead of freeform text
+
+**Why:** Server-side validation + context-window caps shipped (config-cascade-design Phase 1b); the UX half of the old note remains — preset create/edit model input is freeform; autocomplete from the model cache (like /models browse) would kill typos at the source. Ingested 2026-07-05.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-208 - Shapes-import-verify-multi-user-shared-memory-splitting-is-handled-by-the-pipeli.md
+++ b/tracker/tasks/task-208 - Shapes-import-verify-multi-user-shared-memory-splitting-is-handled-by-the-pipeli.md
@@ -1,0 +1,19 @@
+---
+id: TASK-208
+title: 'Shapes import: verify multi-user shared-memory splitting is handled by the pipeline'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels: []
+dependencies: []
+ordinal: 208000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Shapes import: verify multi-user shared-memory splitting is handled by the pipeline
+
+**Why:** Pre-pipeline manual scripts split shared memories into per-user copies and mapped shapes UUIDs. ShapesPersonaMapping + import pipeline have since shipped — VERIFY the multi-user-memory split case is covered (grep ShapesImportMemories for multi-user handling); file a real gap if not. Ingested 2026-07-05.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-209 - Tighten-the-reuse-scout-skill-eval-trigger-if-it-proves-noisy.md
+++ b/tracker/tasks/task-209 - Tighten-the-reuse-scout-skill-eval-trigger-if-it-proves-noisy.md
@@ -1,0 +1,19 @@
+---
+id: TASK-209
+title: 'Tighten the reuse-scout skill-eval trigger if it proves noisy'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels: []
+dependencies: []
+ordinal: 209000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Tighten the reuse-scout skill-eval trigger if it proves noisy
+
+**Why:** `do we (already )?have (a|an|any)` matches common phrasings well beyond the "existing utility?" case; cost is only a suggestion banner. **Promote when**: the banner observably fires on unrelated prompts often enough to annoy. Surfaced by #1496 review. Surfaced 2026-07-05 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-21 - confirmProductionOperation-tooling-env-runner-returns-a-boolean-that-callers-can.md
+++ b/tracker/tasks/task-21 - confirmProductionOperation-tooling-env-runner-returns-a-boolean-that-callers-can.md
@@ -1,0 +1,20 @@
+---
+id: TASK-21
+title: 'confirmProductionOperation (tooling env-runner) returns a boolean that callers can…'
+status: To Do
+assignee: []
+created_date: '2026-07-10 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 21000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-10 — `confirmProductionOperation` (tooling env-runner) returns a boolean that callers can silently discard, making the prod gate decorative (bit once: backfill-facts shipped the prompt without checking the result; caught in review). **Fix shape**: change the API to throw/exit on decline (or add `requireProductionConfirmation` and migrate the ~4 call sites), so the class of discarded-boolean gates becomes unrepresentable. **Promote when**: next tooling PR.
+
+**Why:** A safety prompt that can be held wrong isn't a gate; API-level fix kills the class per the structural directive.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-210 - Bulk-deletememory-propagation-shares-the-MAXMESSAGEBATCH-bound.md
+++ b/tracker/tasks/task-210 - Bulk-deletememory-propagation-shares-the-MAXMESSAGEBATCH-bound.md
@@ -1,0 +1,19 @@
+---
+id: TASK-210
+title: 'Bulk delete→memory propagation shares the MAX_MESSAGE_BATCH bound'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels: []
+dependencies: []
+ordinal: 210000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Bulk delete→memory propagation shares the MAX_MESSAGE_BATCH bound
+
+**Why:** `softDeleteMessages` soft-deletes ALL ids but the tombstone fetch (and therefore memory propagation) is bounded at 1000 — a >1000-id bulk delete would leave the tail's linked memories live. Current callers (opportunistic sync windows) are far below the bound; the code comment at the propagation call names the fix shape (unbounded id-only fetch). **Promote when**: any bulk-delete path can exceed ~1000 ids. Surfaced by #1497 review. Surfaced 2026-07-05 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-211 - Capture-race-window-a-memory-captured-mid-flight-after-a-delete-sync-sweep-escap.md
+++ b/tracker/tasks/task-211 - Capture-race-window-a-memory-captured-mid-flight-after-a-delete-sync-sweep-escap.md
@@ -1,0 +1,20 @@
+---
+id: TASK-211
+title: 'Capture-race window: a memory captured mid-flight after a delete-sync sweep escapes…'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels:
+  - 'area:conversation-history'
+dependencies: []
+ordinal: 211000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Capture-race window: a memory captured mid-flight after a delete-sync sweep escapes propagation
+
+**Why:** Propagation fires once at soft-delete time; a memory whose generation completes AFTER that sweep carries the deleted trigger id but is never retroactively caught (RAG filter checks only memories.visibility, no join to conversation_history.deletedAt). Low probability (slow generation × sync pass in the window), non-catastrophic (one stale memory surfaces, no data loss). **Fix shape**: either a capture-time check (trigger row already deleted → capture as visibility='deleted') or a periodic reconciliation sweep. **Promote when**: memory Phase 2 extraction lands (same pipeline), or a stale-memory report. Surfaced by #1497 final review. Surfaced 2026-07-05 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-212 - ops-queue-tooling-hardcodes-ai-requests-ignoring-the-QUEUENAME-env-seam.md
+++ b/tracker/tasks/task-212 - ops-queue-tooling-hardcodes-ai-requests-ignoring-the-QUEUENAME-env-seam.md
@@ -1,0 +1,23 @@
+---
+id: TASK-212
+title: 'ops queue tooling hardcodes ai-requests, ignoring the QUEUE_NAME env seam'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:tooling'
+  - 'area:db'
+  - 'area:jobs'
+dependencies: []
+ordinal: 212000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`ops` queue tooling hardcodes `ai-requests`, ignoring the `QUEUE_NAME` env seam
+
+**Why:** `bullmqConnection.ts`'s `DEFAULT_QUEUE_NAME` is a literal while ai-worker's actual queue name is env-configurable (`QUEUE_NAME`, defaults to the same value). If the env var ever diverged, `pnpm ops maintenance on` would pause/drain the WRONG queue during a destructive-migration window (silent, high-stakes miss); `inspect:queue`/`inspect:dlq` share the seam (lower stakes). **Fix shape**: have the tooling fetch `QUEUE_NAME` from the target env's Railway vars (like it already fetches `REDIS_URL`) with the literal as fallback. **Promote when**: `QUEUE_NAME` is ever overridden in any environment, or when next touching bullmqConnection. Surfaced by #1502 round-4 review. Surfaced 2026-07-06 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-213 - claude-review-runs-but-never-posts-on-large-release-PRs-turn-cap-suspect.md
+++ b/tracker/tasks/task-213 - claude-review-runs-but-never-posts-on-large-release-PRs-turn-cap-suspect.md
@@ -1,0 +1,20 @@
+---
+id: TASK-213
+title: 'claude-review runs-but-never-posts on large release PRs (turn-cap suspect)'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 213000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+claude-review runs-but-never-posts on large release PRs (turn-cap suspect)
+
+**Why:** The beta.149 release PR's review executed fully TWICE (56-turn runs, `success`, 17 permission denials; no billing impact — the Action rides the Max plan) yet posted no comment — a NEW variant of the known completed-without-posting failure (previously: placeholder posts). RECURRED 2026-07-06 on feature PR #1506 (23 turns, 48 permission denials, no post; rerun posted fine at 8m) — the high denial count points at the action's TOOL PERMISSIONS as the likelier root cause than the turn cap: the agent burns turns attempting denied actions (possibly its own posting step) and completes without posting. **Fix shape**: raise/verify the action's max-turns for release-sized diffs, or make the workflow post a failure marker when the result contains no posted comment — workflow change ⇒ main-cut PR per the claude-workflow rule. **Promote when**: the next release PR review goes silent, or opportunistically with any claude-workflow maintenance. Surfaced 2026-07-06 (beta.149 release; owner manually re-triggered to get a posted review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-214 - Maintenance-mode-runbook-Redis-down-during-window-fail-open-gap.md
+++ b/tracker/tasks/task-214 - Maintenance-mode-runbook-Redis-down-during-window-fail-open-gap.md
@@ -1,0 +1,21 @@
+---
+id: TASK-214
+title: 'Maintenance-mode runbook: Redis-down-during-window fail-open gap'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'area:db'
+  - 'area:redis'
+dependencies: []
+ordinal: 214000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Maintenance-mode runbook: Redis-down-during-window fail-open gap
+
+**Why:** `MaintenanceFlag` fails OPEN on Redis errors (correct for normal operation), which means if Redis is down during the exact destructive-migration window, traffic is NOT quiesced precisely when quiescing matters most. Reviewer-flagged (beta.149 release review), accepted as a narrow known edge. **Fix shape**: one runbook line in `/tzurot-deployment` ("verify `maintenance status` shows ON before premigrate; if Redis is down, do not proceed") — optionally a `maintenance verify` hard-check subcommand later. **Promote when**: next touching the deployment skill or before the next destructive release. Surfaced 2026-07-06.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-215 - shortModelName-merges-different-models-sharing-a-trailing-path-segment.md
+++ b/tracker/tasks/task-215 - shortModelName-merges-different-models-sharing-a-trailing-path-segment.md
@@ -1,0 +1,20 @@
+---
+id: TASK-215
+title: 'shortModelName merges different models sharing a trailing path segment'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 215000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`shortModelName` merges different models sharing a trailing path segment
+
+**Why:** `/usage` byModel now keys on the last `/` segment, so hypothetical `providerA/turbo` + `providerB/turbo` would merge into one row — the guarantee is "same trailing segment," not "same model." Accepted tradeoff for the real z-ai/openrouter duplication; no known colliding pair today. **Fix shape** (if ever needed): key on `(shortName)` but display provider list per row, or maintain a curated alias map. **Promote when**: a real cross-provider name collision shows up in /usage. Surfaced 2026-07-06 (beta.149 release review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-216 - First-post-release-db-sync-exceeds-the-30s-client-budget-async-rework-is-the-fix.md
+++ b/tracker/tasks/task-216 - First-post-release-db-sync-exceeds-the-30s-client-budget-async-rework-is-the-fix.md
@@ -1,0 +1,19 @@
+---
+id: TASK-216
+title: 'First-post-release db-sync exceeds the 30s client budget (async rework is the fix)'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels: []
+dependencies: []
+ordinal: 216000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+First-post-release db-sync exceeds the 30s client budget (async rework is the fix)
+
+**Why:** Measured on beta.149 day-one syncs: two server-side completions aborted client-side at exactly the `BULK_OPERATION` budget (29997ms/29995ms), third attempt converged at 7410ms — the gateway always finishes, upserts are idempotent, retries converge, so nothing is lost. Cause stack: first-run-after-a-gap carries the accumulated delta + #1497 restored full-width memories rows (the rotted SELECT had been syncing narrow) + two new memories indexes tax every upsert. Owner declined a 120s stopgap ("not worth the churn") — the durable fix is the async-job-with-progress db-sync rework already designed in the accepted UX spec (the route's own comment names it). **Promote when**: the UX boulder's db-sync phase builds, OR immediately if a sync ever fails to CONVERGE on retry (converge-on-retry is the accepted degraded mode). Surfaced 2026-07-06 (beta.149 smoke; prod logs).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-217 - Retire-the-memoryScoreThreshold-knob-and-audit-memoryLimit.md
+++ b/tracker/tasks/task-217 - Retire-the-memoryScoreThreshold-knob-and-audit-memoryLimit.md
@@ -1,0 +1,19 @@
+---
+id: TASK-217
+title: 'Retire the memoryScoreThreshold knob (and audit memoryLimit)'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels: []
+dependencies: []
+ordinal: 217000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Retire the `memoryScoreThreshold` knob (and audit `memoryLimit`)
+
+**Why:** Data-verified 2026-07-06: every llm_config on BOTH dev and prod sits at the 0.50 default — the knob has never been adjusted by anyone; it is shapes.inc-parity inheritance (owner: parity is no longer a goal). Retiring it removes a schema column, a dashboard field, Zod bounds in 3 schemas, and the cascade-override plumbing — the same retirement muscle as the legacy-column theme. Interacts with the parked hybrid-retrieval branch (threshold gates only the dense arm there) and Phase 1b composite scoring (which may replace it wholesale) — retire alongside one of those rather than standalone. **Promote when**: Phase 1b composite scoring is designed, or the parked hybrid branch resumes.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-218 - Doom-cache-bucket-scoping-guests-bucket-per-user-and-a-forced-system-key-retry-w.md
+++ b/tracker/tasks/task-218 - Doom-cache-bucket-scoping-guests-bucket-per-user-and-a-forced-system-key-retry-w.md
@@ -1,0 +1,20 @@
+---
+id: TASK-218
+title: 'Doom-cache bucket scoping: guests bucket per-user, and a forced-system-key retry writes…'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 218000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Doom-cache bucket scoping: guests bucket per-user, and a forced-system-key retry writes the USER's bucket
+
+**Why:** Two related quirks of `deriveCacheKeyId(userApiKey, userId)` branching on key-definedness rather than billing entity (pre-existing, surfaced by the quota-fallback review). (a) Guests carry the resolved SYSTEM key, so `deriveCacheKeyId` returns `user:<id>` — each guest independently discovers a system-key outage instead of sharing the documented `system` bucket (efficiency loss, not correctness). (b) The quota fallback's forced-system-key retry (credit-exhausted BYOK) bills the system account but any CREDIT_EXHAUSTION it hits writes to the user's `user:<id>` bucket via LLMInvoker's failure caching — a coincident system-wide outage can prolong a block on a user whose own account already recovered (bounded by the wallet-update clear + 1h TTL). **Fix shape**: derive the bucket from the billing entity (e.g. source-aware `deriveCacheKeyId(source, userId)`), which fixes both at once; interacts with the key-rotation row above. **Promote when**: profiles Phase 1, or a user reports a stale block after a system outage. Surfaced 2026-07-06 (PR #1506 review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-219 - Retire-the-BullMQ-context-schemas-legacy-tolerance-once-safe.md
+++ b/tracker/tasks/task-219 - Retire-the-BullMQ-context-schemas-legacy-tolerance-once-safe.md
@@ -1,0 +1,24 @@
+---
+id: TASK-219
+title: "Retire the BullMQ context schema's legacy tolerance once safe"
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:common-types'
+  - 'area:testing'
+  - 'area:jobs'
+  - 'area:redis'
+dependencies: []
+ordinal: 219000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Retire the BullMQ context schema's legacy tolerance once safe
+
+**Why:** `jobContextBaseSchema` keeps `kind: z.enum(['legacy','envelope']).default('legacy')` so pre-cutover jobs already queued in Redis still parse — but bot-client has shipped envelope-only since the cutover, and the worker's ContextStep hard-rejects legacy anyway, so the tolerance now only delays the failure from ValidationStep to ContextStep. The contract suite (2026-07-06) PINS the current tolerated-but-rejected behavior explicitly (legacy fixtures asserted schema-pass + ContextStep-reject). Tightening = require `kind:'envelope'` at the schema, drop the default, delete the legacy fixtures' reject-pin. **Promote when**: any maintenance window that drains the queues (no pre-cutover job can survive one), or the next jobs.ts schema touch. Ride-alongs for the same touch (review nits, PR #1509 round 5): a one-line comment in `test-utils/jobContextArbitraries.ts` noting the `'image/'`/`'audio/'` literals mirror `CONTENT_TYPES.IMAGE_PREFIX`/`AUDIO_PREFIX` (deliberate no-common-types posture, greppability aid); drop the redundant `as LLMGenerationJobData` cast in the pipeline consumer test; consider wiring `legacyContextArb` into a property when the retirement lands (it currently only self-tests). Surfaced 2026-07-06 (contract-suite exploration: the three-tier width mismatch).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-22 - tooling-CLI-commands-coerce-numeric-flags-with-bare-Numberoptionsx-deployts-and….md
+++ b/tracker/tasks/task-22 - tooling-CLI-commands-coerce-numeric-flags-with-bare-Numberoptionsx-deployts-and….md
@@ -1,0 +1,20 @@
+---
+id: TASK-22
+title: 'tooling CLI commands coerce numeric flags with bare Number(options.x) (deploy.ts and…'
+status: To Do
+assignee: []
+created_date: '2026-07-10 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 22000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-10 — tooling CLI commands coerce numeric flags with bare `Number(options.x)` (deploy.ts and siblings; reviewer-noted while fixing backfill-facts, which now validates): NaN flows into comparisons that silently no-op. **Fix shape**: sweep `packages/tooling/src/commands/*.ts` for `Number(` coercions and add `Number.isInteger`/bounds validation (or a shared parseIntFlag helper). **Promote when**: next tooling-commands hygiene pass.
+
+**Why:** NaN comparisons are always-false — flags silently ignore themselves; backfill-facts showed the worst case (an uncapped canary).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-220 - Resolve-cascade-route-lacks-the-UUID-gate-its-sibling-mutators-have.md
+++ b/tracker/tasks/task-220 - Resolve-cascade-route-lacks-the-UUID-gate-its-sibling-mutators-have.md
@@ -1,0 +1,21 @@
+---
+id: TASK-220
+title: 'Resolve-cascade route lacks the UUID gate its sibling mutators have'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 220000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Resolve-cascade route lacks the UUID gate its sibling mutators have
+
+**Why:** `config-overrides.ts` `handleResolveCascade` reads `:personalityId` via bare `getRequiredParam` while the PATCH/DELETE handlers 400 on malformed ids via `getValidatedPersonalityId`; a malformed id on the GET path likely surfaces as a Prisma uuid-cast error (500-shaped) instead of a 400. One-line fix (call the shared helper) but it changes the route's error contract, so it wants its own tiny PR + a test rather than riding a behavior-preservation refactor. Surfaced 2026-07-06 (PR #1518 review adjacency flag).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-221 - Episode-type-value-rename-memoryepisode-zod-vocabulary.md
+++ b/tracker/tasks/task-221 - Episode-type-value-rename-memoryepisode-zod-vocabulary.md
@@ -1,0 +1,20 @@
+---
+id: TASK-221
+title: "Episode type value rename 'memory'→'episode' + zod vocabulary"
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 221000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Episode `type` value rename 'memory'→'episode' + zod vocabulary — `memories.type` still uses legacy values ('memory'/'knowledge') vs the artifact's typed model (episode/fact/reflection/canon); facts live in their own table so the rename is cosmetic. **Promote when**: any migration touches the memories table anyway. Filed 2026-07-06 (Phase 2 plan).
+
+**Why:** Avoids a solo migration for naming.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-222 - Join-memoryfacts-to-db-sync-SYNCCONFIG.md
+++ b/tracker/tasks/task-222 - Join-memoryfacts-to-db-sync-SYNCCONFIG.md
@@ -1,0 +1,20 @@
+---
+id: TASK-222
+title: 'Join memory_facts to db-sync SYNC_CONFIG'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'area:embeddings'
+dependencies: []
+ordinal: 222000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Join `memory_facts` to db-sync SYNC_CONFIG — The table sits in EXCLUDED_TABLES while shadow-mode (empty, nothing reads it). Facts are non-regenerable user data like memories (no bulk re-extraction), so once real data flows they should sync like memories does — needs column list, FK map (incl. the supersededById self-FK ordering), and embedding handling in SyncUpsertBuilder. **Promote when**: memory Phase 2 slice 4 (retrieval integration) ships. Filed 2026-07-06 (slice 1 review cycle).
+
+**Why:** Sync parity for the fact corpus.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-223 - Guard-test-three-protected-index-registries-must-agree.md
+++ b/tracker/tasks/task-223 - Guard-test-three-protected-index-registries-must-agree.md
@@ -1,0 +1,21 @@
+---
+id: TASK-223
+title: 'Guard test: three protected-index registries must agree'
+status: To Do
+assignee: []
+created_date: '2026-07-06 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:db'
+dependencies: []
+ordinal: 223000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Guard test: three protected-index registries must agree — `prisma/drift-ignore.json` protectedIndexes, `check-migration-safety.ts` PROTECTED_INDEXES, and `inspect-database.ts` PROTECTED_INDEXES are three hand-synced lists (memory_facts was the second table to need all three; the review caught two missing). A small tooling test asserting name-set agreement kills the drift class. **Promote when**: next tooling-touching session, or the third table joins the lists. Filed 2026-07-06 (PR #1527 review).
+
+**Why:** ~30min; kills a recurring sync-miss class.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-224 - buildFullSystemPrompt-runs-3-per-generation-for-token-counting.md
+++ b/tracker/tasks/task-224 - buildFullSystemPrompt-runs-3-per-generation-for-token-counting.md
@@ -1,0 +1,20 @@
+---
+id: TASK-224
+title: 'buildFullSystemPrompt runs 3× per generation for token counting'
+status: To Do
+assignee: []
+created_date: '2026-07-07 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 224000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`buildFullSystemPrompt` runs 3× per generation for token counting — Perf-only observation from external review: the prompt is assembled three times per generation just to count tokens. Act only if ai-worker CPU becomes a bottleneck — natural rider on the memory epic's budget refactor. (The two memory-visibility riders that shared this row shipped: incognito forget-count filter, and shapes-import dedup deliberately kept visibility-unfiltered so purged content is never resurrected — documented + pinned by test.) **Promote when**: ai-worker CPU profiling shows prompt assembly hot.
+
+**Why:** Pure perf; no user-visible behavior at stake today. Surfaced 2026-07-07 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-225 - Extract-AtomicDailyCounter-from-ExtractionBudget-VisionFallbackQuota.md
+++ b/tracker/tasks/task-225 - Extract-AtomicDailyCounter-from-ExtractionBudget-VisionFallbackQuota.md
@@ -1,0 +1,21 @@
+---
+id: TASK-225
+title: 'Extract AtomicDailyCounter from ExtractionBudget + VisionFallbackQuota'
+status: To Do
+assignee: []
+created_date: '2026-07-07 00:00'
+labels:
+  - 'area:redis'
+  - 'origin:review'
+dependencies: []
+ordinal: 225000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Extract `AtomicDailyCounter` from ExtractionBudget + VisionFallbackQuota — Identical public shape (constructor(redis, dailyLimit), tryConsume, UTC-day key, 25h TTL, fail-open) with only DATA varying — passes the 2-callback ceiling with zero callbacks. Bonus: backports ExtractionBudget's atomic Lua INCR+EXPIRE to VisionFallbackQuota, closing its real crash-between-incr-and-expire gap. **Promote when**: a third daily-counter clone appears, or next touching either file. Surfaced 2026-07-07 (PR #1528 post-rebase review).
+
+**Why:** Two clones today; the extraction is also a correctness backport.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-226 - calculateHistoryBudget-doesnt-reserve-the-response-safety-margin.md
+++ b/tracker/tasks/task-226 - calculateHistoryBudget-doesnt-reserve-the-response-safety-margin.md
@@ -1,0 +1,20 @@
+---
+id: TASK-226
+title: "calculateHistoryBudget doesn't reserve the response safety margin"
+status: To Do
+assignee: []
+created_date: '2026-07-07 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 226000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`calculateHistoryBudget` doesn't reserve the response safety margin — `ContextWindowManager.calculateHistoryBudget` (~:254) omits the RESPONSE_SAFETY_MARGIN_RATIO subtraction that `calculateMemoryBudget` applies — in the contention case the worst-case sum of prompt+message+memories+history can exceed the window by up to the margin. Bounded upstream by computeContextCap's 50% effective-window cap, so not manifesting; unify the margin accounting when the memory epic's budget refactor touches this (same family as the pre/post-truncation lens). **Promote when**: memory epic Phase 1b budget refactor, or any calculateHistoryBudget touch. Surfaced 2026-07-07 (PR #1530 review).
+
+**Why:** Tightens the same shared-space accounting item 7 fixed.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-227 - NullVectorReembedder-per-row-attempt-cap-Phase-5-memory-consolidation-scope.md
+++ b/tracker/tasks/task-227 - NullVectorReembedder-per-row-attempt-cap-Phase-5-memory-consolidation-scope.md
@@ -1,0 +1,19 @@
+---
+id: TASK-227
+title: 'NullVectorReembedder per-row attempt cap (Phase-5 memory consolidation scope)'
+status: To Do
+assignee: []
+created_date: '2026-07-07 00:00'
+labels: []
+dependencies: []
+ordinal: 227000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+NullVectorReembedder per-row attempt cap (Phase-5 memory consolidation scope) — A row whose re-embed persistently fails re-enters every hourly batch forever, occupying one of 50 slots. Failed counts ARE logged every run (visible signal), so severity is low; the sweep is deliberately minimal pending Phase-5 memory consolidation, which should absorb dead-letter semantics (attempt cap + sentinel) like PendingMemoryProcessor's. From the #1536 review. **Promote when**: Phase-5 scoping starts, or a persistent-failure row is observed in the sweep logs.
+
+**Why:** Prevents a poisoned row from permanently occupying batch slots. Surfaced 2026-07-07 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-228 - guardprompt-tags-STRINGLITERALS-regex-mis-bounds-nested-template-literals.md
+++ b/tracker/tasks/task-228 - guardprompt-tags-STRINGLITERALS-regex-mis-bounds-nested-template-literals.md
@@ -1,0 +1,20 @@
+---
+id: TASK-228
+title: 'guard:prompt-tags STRING_LITERALS regex mis-bounds nested template literals'
+status: To Do
+assignee: []
+created_date: '2026-07-07 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 228000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+guard:prompt-tags STRING_LITERALS regex mis-bounds nested template literals — A template literal containing a nested backtick template inside `${...}` terminates the outer match at the first inner backtick — could misparse rather than fail loudly if a formatter is refactored to nested templates (none exist today; TAG_PROPERTY/HELPER_TAG_ARG would likely still catch the tag). **Fix shape**: brace-aware template scan, or accept the redundancy. **Promote when**: a formatter introduces nested templates. Surfaced 2026-07-07 (#1538 post-autosquash review).
+
+**Why:** Guard parses every emission shape robustly.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-229 - character-command-option-access-idiom-drift-avatarts-raw-vs-importts-typed-acces.md
+++ b/tracker/tasks/task-229 - character-command-option-access-idiom-drift-avatarts-raw-vs-importts-typed-acces.md
@@ -1,0 +1,20 @@
+---
+id: TASK-229
+title: '/character command option-access idiom drift (avatar.ts raw vs import.ts typed accessor)'
+status: To Do
+assignee: []
+created_date: '2026-07-07 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 229000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+/character command option-access idiom drift (avatar.ts raw vs import.ts typed accessor) — avatar.ts/voice.ts read options via raw `interaction.options.getString/getAttachment`; import.ts uses the generated typed `characterImportOptions` accessor. Leaves `characterAvatarOptions`/`characterAvatarClearOptions` generated-but-unused (knip ignores generated/). Cosmetic consistency. **Fix shape**: pick one idiom across the command group. **Promote when**: the beta.154 view/browse unification consistency pass touches these files. Surfaced 2026-07-07 (#1541 review).
+
+**Why:** One option-access idiom across the /character handlers.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-23 - docsreferenceREASONINGMODELFORMATSmd-is-stale-on-extraction-mechanics-describes-.md
+++ b/tracker/tasks/task-23 - docsreferenceREASONINGMODELFORMATSmd-is-stale-on-extraction-mechanics-describes-.md
@@ -1,0 +1,20 @@
+---
+id: TASK-23
+title: 'docs/reference/REASONING_MODEL_FORMATS.md is stale on extraction mechanics: describes the…'
+status: To Do
+assignee: []
+created_date: '2026-07-05 00:00'
+labels:
+  - 'area:docs'
+dependencies: []
+ordinal: 23000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-05 — `docs/reference/REASONING_MODEL_FORMATS.md` is stale on extraction mechanics: describes the removed transport-layer body mutation (`interceptReasoningResponse` in ModelFactory); actual mechanism is `__includeRawResponse` + `extractOpenRouterReasoning.ts` post-parse. Also its o-series section describes deprecated models (the system→user transform is deleted per the prompt-assembly design). **Fix shape**: rewrite the mechanics section against current code; doc-only, direct develop commit fine. **Promote when**: next touching reasoning-extraction code, or a docs pass.
+
+**Why:** A reference doc that misdescribes the live mechanism actively misleads debugging.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-230 - Voice-reference-export-round-trip-symmetry-with-voice-at-import.md
+++ b/tracker/tasks/task-230 - Voice-reference-export-round-trip-symmetry-with-voice-at-import.md
@@ -1,0 +1,20 @@
+---
+id: TASK-230
+title: 'Voice reference export (round-trip symmetry with voice-at-import)'
+status: To Do
+assignee: []
+created_date: '2026-07-07 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 230000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Voice reference export (round-trip symmetry with voice-at-import) — Export emits no voice file; import accepts one. Design GROUNDED during the definition-privacy epic: the existing `/voice-references/:slug` route is deliberately service-auth-gated (anti-enumeration) and bot-client's serviceFetch contract forbids non-infrastructure use — so the correct shape is a NEW owner-gated user route (`GET /user/personality/:slug/voice-reference`, requireUserAuth + canEdit) returning `{ voiceReferenceData: dataUri, voiceReferenceType }` via the typed client (mirrors how import uploads it), then export decodes to a file attachment like the avatar. Needs: route + manifest entry + client regen + export wiring + tests. **Promote when**: next character-command session, or user asks for voice round-trip. Filed 2026-07-07 (epic PR3 scope split, pre-authorized by the plan).
+
+**Why:** Voice survives export → re-import like avatar does.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-231 - Classifier-plain-Error-wrapper-throws-lose-the-transport-kind.md
+++ b/tracker/tasks/task-231 - Classifier-plain-Error-wrapper-throws-lose-the-transport-kind.md
@@ -1,0 +1,20 @@
+---
+id: TASK-231
+title: 'Classifier: plain-Error wrapper throws lose the transport kind'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 231000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Classifier: plain-Error wrapper throws lose the transport kind — `classifyGatewayFailure`'s plain-`Error` branch extracts the wrapper-format message and always renders `gatewayRejection` — it never reaches `specForKind`, so a read TIMEOUT thrown as `new Error('...: 500 - ...')` (e.g. `checkExistingCharacter` in character/import.ts) renders a flat message instead of the read-timeout shape. Not unsafe (never renders write-uncertain copy) but inconsistent with the typed carriers. **Fix shape**: either convert the remaining plain-Error wrapper throws to `GatewayApiError` (kind preserved — same move as character/api.ts in PR-C), or teach the plain-Error branch `opts.operation` awareness before defaulting to gatewayRejection. Same family (string-collapse RESULT wrappers, kind destroyed upstream): `persona/api.ts` `deletePersona` (`{success, error?}`) and `characterCache.ts` `getCachedPersonalities` (`{kind:'error', error: string}`) — widen to carry the fail-arm so their callers can classify (persona delete + randomPick render generic today). **Promote when**: PR-D3 (natural rider — both named in the D3 task). Surfaced 2026-07-08 (PR #1554 + #1555 reviews).
+
+**Why:** Consistency of the classifier's carrier matrix.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-232 - Readwrite-phase-split-helper-if-a-third-command-needs-it.md
+++ b/tracker/tasks/task-232 - Readwrite-phase-split-helper-if-a-third-command-needs-it.md
@@ -1,0 +1,20 @@
+---
+id: TASK-232
+title: 'Read/write-phase split helper if a third command needs it'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 232000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Read/write-phase split helper if a third command needs it — avatar.ts + voice.ts now carry the identical fetchEditableCharacter read-phase-catch → write-phase-catch shape (deliberate same-family duplication; reviewer + 2-callback ceiling agree not to extract at two copies). **Promote when**: a third command adopts the same split — prototype the kernel then. Surfaced 2026-07-08 (PR #1554 round-4 review).
+
+**Why:** Threshold-gated extraction.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-233 - Watch-retry-volumelatency-after-maxRetries-0-ships.md
+++ b/tracker/tasks/task-233 - Watch-retry-volumelatency-after-maxRetries-0-ships.md
@@ -1,0 +1,20 @@
+---
+id: TASK-233
+title: 'Watch retry volume/latency after maxRetries: 0 ships'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 233000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Watch retry volume/latency after `maxRetries: 0` ships — The 429-storm fix (#1556) set `maxRetries: 0` on both ChatOpenAI builds, moving ALL retry responsibility onto LLMInvoker's outer ladder. Net effect for transient 5xx blips: the SDK's in-attempt retries (which could absorb a brief blip inside one 3-min window) are gone, so a 5xx now consumes a full outer-ladder attempt instead. Intended for 429s (kills the ~9-min burn) but changes retry timing/volume against upstream for the 5xx class too. **Promote when**: post-#1556 prod metrics show attempt-count or latency regression on transient-5xx bursts (or a user reports slower recovery from a provider blip). Surfaced 2026-07-08 (PR #1556 round-2 review).
+
+**Why:** Confirm the blast radius is benign, not just intended.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-234 - batchDelete-inner-catch-mislabels-a-thrown-delete-as-a-timeout.md
+++ b/tracker/tasks/task-234 - batchDelete-inner-catch-mislabels-a-thrown-delete-as-a-timeout.md
@@ -1,0 +1,20 @@
+---
+id: TASK-234
+title: 'batchDelete inner catch mislabels a thrown delete as a timeout'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 234000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+batchDelete inner catch mislabels a thrown delete as a timeout — `memory/batchDelete.ts`'s inner try around `userClient.batchDelete()` unconditionally renders 'Deletion cancelled - confirmation timed out.' on ANY thrown exception — a real (possibly-applied) write failure reads as a benign timeout, hiding the duplicate-write-risk the campaign exists to surface. Pre-existing (not the D3a sweep). **Fix shape**: distinguish the awaitMessageComponent timeout from a thrown batchDelete() failure — classify the latter via classifyGatewayFailure. ALSO in this family: `purge.ts`'s `executePurgeHandshake`/`handlePurgeModal` have no try/catch, so a THROWN (not `!ok`) `issuePurgeToken`/`purge` propagates uncaught past the classify logic to CommandHandler's generic catch-all (pre-existing, not a regression). Same fix shape — wrap the write and classify. **Promote when**: next touch of batchDelete or the purge handshake, or a user reports a confusing 'timed out' on a partially-applied delete. Surfaced 2026-07-08 (PR #1557 rounds 2+5 review).
+
+**Why:** Outcome-honesty on the one memory write the sweep couldn't reach.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-235 - System-voice-straggler-wording-uxcatalog.md
+++ b/tracker/tasks/task-235 - System-voice-straggler-wording-uxcatalog.md
@@ -1,0 +1,20 @@
+---
+id: TASK-235
+title: 'System-voice straggler wording → ux/catalog'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 235000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+System-voice straggler wording → ux/catalog — Non-command error surfaces still using raw literals (no behavior change, pure wording): STT ×3 (`VoiceTranscriptionService.ts:350-354`, 'Sorry, transcription…'), `MessageHandler.ts:129-130` top-level catch ('Sorry, I encountered an error…'), truncation notices (`multiTagDeliveryFlow.ts` tag-count `_(Only the first N…)_`, `DiscordResponseSender.ts:382-387` TTS over-size). None have a personality in scope (system-register only). Route through `CATALOG.*`/`renderSpec` for one emoji map + wording discipline. **Why deferred**: owner split PR-E (#1561) to keep the feature review focused on the multi-tag behavior change. **Promote when**: a wording-polish pass, or the catalog gains a system-register straggler intent. Surfaced 2026-07-08 (PR-E scoping).
+
+**Why:** Consistency of the non-command error surfaces with the swept command surfaces.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-236 - Submit-failure-errored-slots-dropped-in-a-PARTIAL-success-multi-tag-batch.md
+++ b/tracker/tasks/task-236 - Submit-failure-errored-slots-dropped-in-a-PARTIAL-success-multi-tag-batch.md
@@ -1,0 +1,20 @@
+---
+id: TASK-236
+title: 'Submit-failure errored slots dropped in a PARTIAL-success multi-tag batch'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 236000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Submit-failure errored slots dropped in a PARTIAL-success multi-tag batch — PR-E delivers per-persona in-character errors only when EVERY slot failed (`runtimeSlots.length === 0`). If a batch mixes submitted + submit-errored slots (e.g. 2 succeed, 1's `submitChatJob` throws), the errored persona's outcome is collected but never delivered — silently dropped (pre-existing; the old `anyInfraError` boolean had the same restriction). NOTE: post-submission job failures (RuntimeSlot.status==='errored') ARE delivered via deliverGroup — this gap is ONLY submit-throws in a partial batch (rare: a gateway write-timeout on one slot while others submit fine). **Fix shape**: deliver `erroredOutcomes` alongside the group even when runtimeSlots>0 (route through deliverErrorNoPersist in the ordered burst). **Promote when**: product confirms 'every errored character always speaks', or a user reports a silently-missing character in a partial-failure multi-tag. Surfaced 2026-07-08 (PR #1561 round-3 review).
+
+**Why:** Completeness of the in-character error guarantee across partial vs total failure.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-237 - pnpm-quality-pre-commit-on-un-prettified-source-can-disagree-with-the-lint-stage.md
+++ b/tracker/tasks/task-237 - pnpm-quality-pre-commit-on-un-prettified-source-can-disagree-with-the-lint-stage.md
@@ -1,0 +1,19 @@
+---
+id: TASK-237
+title: 'pnpm quality (pre-commit, on un-prettified source) can disagree with the lint-staged hook…'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels: []
+dependencies: []
+ordinal: 237000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`pnpm quality` (pre-commit, on un-prettified source) can disagree with the lint-staged hook on formatting-sensitive rules — CORRECTED 2026-07-08 after empirical investigation — the original "cwd config divergence / CI is the lenient side" framing was WRONG (disproven: `eslint --print-config` is identical from both cwds; a long-function probe is flagged identically from repo root AND the package dir; `pnpm quality`/turbo catches it too). **Real mechanism**: lint-staged runs `prettier --write` BEFORE `eslint`, so it lints the prettier-EXPANDED code; a manual `pnpm quality` run before committing lints the compact as-written source, so a function near a size limit (e.g. `max-lines-per-function` 100) can pass quality yet fail the hook once prettier wraps it (proven: a 94-line fn → 103 lines post-prettier → warns). **Severity: benign** — NOT a gate hole. Once the prettier-expanded code is committed, CI lints the same expanded form and catches it; the pre-commit hook catches it before commit. The only surprise is a manual pre-commit `pnpm quality` on unformatted source. **Options**: (a) do nothing (expected — run `pnpm quality` after staging/format, or trust the hook); (b) doc note that the hook is authoritative on formatting-sensitive rules. **Promote when**: this actually causes friction. Surfaced 2026-07-08 (release:publish build); mis-diagnosed then corrected same day.
+
+**Why:** It's an ordering artifact, not a CI leniency bug.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-238 - release-CLI-wiring-layer-is-untested.md
+++ b/tracker/tasks/task-238 - release-CLI-wiring-layer-is-untested.md
@@ -1,0 +1,21 @@
+---
+id: TASK-238
+title: 'release:* CLI-wiring layer is untested'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'area:tooling'
+  - 'origin:review'
+dependencies: []
+ordinal: 238000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+release:* CLI-wiring layer is untested — `commands.test.ts` covers no `release:*` subcommand — including release:publish's new `--notes-file` required-guard (`commands/release.ts`). Core `publish.ts` logic is thoroughly unit-tested; the gap is the cac registration + dispatch + required-flag guard. Not island-testing just publish (the other release subcommands are equally untested) — establish the release-command wiring test pattern once, covering all of them. **Promote when**: a release-command wiring bug bites, or during a tooling-test pass. Surfaced 2026-07-08 (PR #1563 review).
+
+**Why:** Coverage of the one new-logic bit (the guard) + the pre-existing release-wiring gap.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-239 - Usage-history-weighting-for-the-free-tier-quota-v2.md
+++ b/tracker/tasks/task-239 - Usage-history-weighting-for-the-free-tier-quota-v2.md
@@ -1,0 +1,19 @@
+---
+id: TASK-239
+title: 'Usage-history weighting for the free-tier quota (v2)'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels: []
+dependencies: []
+ordinal: 239000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Usage-history weighting for the free-tier quota (v2) — `FreeTierRequestQuota` v1 divides the window budget equally among concurrent users (clamped). Owner floated ("maybe") weighting by usage history so habitual light users get more headroom and heavy users throttle first. Council: defer — minimal form is a per-user EWMA multiplier on the window cap, needs an extra keyspace + a population-mean approximation. **Promote when**: the flat rolling cap proves too blunt in practice. Surfaced 2026-07-08 (free-tier-quota build).
+
+**Why:** Fairness refinement; not needed to fix the starvation the v1 addresses.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-24 - Extend-pnpm-ops-backlog-lint-check-outbound-themedocs-relative-links-resolve-5….md
+++ b/tracker/tasks/task-24 - Extend-pnpm-ops-backlog-lint-check-outbound-themedocs-relative-links-resolve-5….md
@@ -1,0 +1,20 @@
+---
+id: TASK-24
+title: 'Extend pnpm ops backlog lint: check outbound theme→docs relative links resolve (5…'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 24000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-03 — Extend `pnpm ops backlog` lint: check outbound theme→docs relative links resolve (5 wrong-depth dead links found in the 2026-07-03 sweep; the lint only checks cold/themes/ inbound links today).
+
+**Why:** Dead links in HOT/theme files silently rot navigation.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-240 - Sybil-alt-account-dilution-guard-for-the-free-tier-quota-v2.md
+++ b/tracker/tasks/task-240 - Sybil-alt-account-dilution-guard-for-the-free-tier-quota-v2.md
@@ -1,0 +1,19 @@
+---
+id: TASK-240
+title: 'Sybil / alt-account dilution guard for the free-tier quota (v2)'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels: []
+dependencies: []
+ordinal: 240000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Sybil / alt-account dilution guard for the free-tier quota (v2) — `N` (rolling active-user count) is inflatable by alt accounts — cheap on Discord — shrinking every legit user's share and draining the shared key across sock-puppets. v1 has no cost-of-entry bound. **Fix shape**: a per-guild distinct-free-user cap, or tie eligibility to account age/membership. **Promote when**: alt-account budget-draining is observed. Surfaced 2026-07-08 (Kimi council, free-tier-quota build).
+
+**Why:** Abuse-resistance; the primary single-heavy-user vector IS bounded by v1.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-241 - zai-key-half-of-the-fair-share-owner-first-headroom.md
+++ b/tracker/tasks/task-241 - zai-key-half-of-the-fair-share-owner-first-headroom.md
@@ -1,0 +1,22 @@
+---
+id: TASK-241
+title: 'z.ai key half of the fair-share + owner-first headroom'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'area:docs'
+  - 'area:jobs'
+  - 'area:backlog'
+dependencies: []
+ordinal: 241000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+z.ai key half of the fair-share + owner-first headroom — This PR did the OpenRouter shared-key half only. The provider-agnostic mechanism in `docs/proposals/backlog/free-tier-zai-piggyback.md` § Quota fairness (owner-first headroom so free users never queue behind the owner's paid plan; free-tier hard-caps at N%/day of the z.ai window) remains for when the z.ai key lands. **Promote when**: the z.ai piggyback is picked up. Surfaced 2026-07-08 (free-tier-quota build).
+
+**Why:** Scoped-out half of the two-key mechanism.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-242 - FreeTierRequestQuotatryConsume-pipelining-perf.md
+++ b/tracker/tasks/task-242 - FreeTierRequestQuotatryConsume-pipelining-perf.md
@@ -1,0 +1,20 @@
+---
+id: TASK-242
+title: 'FreeTierRequestQuota.tryConsume pipelining (perf)'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'area:redis'
+dependencies: []
+ordinal: 242000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+FreeTierRequestQuota.tryConsume pipelining (perf) — `tryConsume` does up to 10 sequential Redis round-trips (2×zremrangebyscore, 2×zcard, get, then on allow 2×zadd, incr, 3×expire) on every guest/BYOK-fallback message. An ioredis `.pipeline()` (non-transactional — preserves the check-then-increment ordering) cuts it to ~2 round-trips without touching the atomicity tradeoff. Deferred from PR #1564 review (non-blocking) because it also needs the unit-test mock reworked from per-method spies to a pipeline stub. **Promote when**: the free-key path shows latency, or during a quota perf pass.
+
+**Why:** Hot-path latency; behavior-neutral. Surfaced 2026-07-08 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-243 - FreeTierRequestQuota-computeWindowCap-has-no-minmax-guard.md
+++ b/tracker/tasks/task-243 - FreeTierRequestQuota-computeWindowCap-has-no-minmax-guard.md
@@ -1,0 +1,19 @@
+---
+id: TASK-243
+title: 'FreeTierRequestQuota computeWindowCap has no min<=max guard'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels: []
+dependencies: []
+ordinal: 243000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+FreeTierRequestQuota computeWindowCap has no min<=max guard — If `FREE_TIER_MIN_PER_WINDOW > FREE_TIER_MAX_PER_WINDOW` were ever misconfigured, `clamp` silently collapses to a fixed `min` regardless of contention (the dynamic behavior disappears). The promote-when trigger FIRED (knobs became admin-tunable, admin-runtime PR 1): the system-settings WRITE surface now enforces min<=max on the merged bag (#1605 `validateWindowPair`). Residual: the env path stays unguarded until env deletion (admin-runtime consumer-swap slice), and `computeWindowCap` itself still has no runtime assert. **Fix shape**: a one-line swap-if-inverted (or assert) in `computeWindowCap` as defense-in-depth. **Promote when**: the consumer-swap slice touches the quota provider fns anyway.
+
+**Why:** Config-sanity guard; write-surface half shipped. Surfaced 2026-07-08 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-244 - FreeTierRequestQuota-polish.md
+++ b/tracker/tasks/task-244 - FreeTierRequestQuota-polish.md
@@ -1,0 +1,20 @@
+---
+id: TASK-244
+title: 'FreeTierRequestQuota polish'
+status: To Do
+assignee: []
+created_date: '2026-07-08 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 244000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+FreeTierRequestQuota polish — N-comment accuracy + redundant resolveSystemKey (batch w/ pipelining) — Two PR #1564 round-4 non-blocking nits, same files as the pipelining follow-up (fold together): (a) `computeWindowCap`'s "N excludes the current user" comment is only true on a user's FIRST in-window request — a repeat requester's own userId stays in the ACTIVE ZSET, so N self-includes thereafter (no correctness bug; the cap just runs slightly tighter/conservative — reword the comment or note self-inclusion is intentional); (b) `resolveTargetAndCredentials` can call `deps.resolveSystemKey()` twice on the degraded failure path (harmless, one-line short-circuit). **Promote when**: the pipelining follow-up is picked up. Surfaced 2026-07-08 (PR #1564 review).
+
+**Why:** Doc accuracy + micro-cleanup.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-245 - scoreExtraction-double-embeds-the-extracted-statements.md
+++ b/tracker/tasks/task-245 - scoreExtraction-double-embeds-the-extracted-statements.md
@@ -1,0 +1,22 @@
+---
+id: TASK-245
+title: 'scoreExtraction double-embeds the extracted statements'
+status: To Do
+assignee: []
+created_date: '2026-07-09 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:embeddings'
+  - 'origin:review'
+dependencies: []
+ordinal: 245000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`scoreExtraction` double-embeds the extracted statements — `services/ai-worker/src/services/eval/factEquivalence.ts` — `scoreExtraction` calls `matchFacts(extracted, expectFacts)` then `matchFacts(extracted, [...expectFacts, ...allowedExtras])`, embedding the same `extracted` statements twice. Eval-only, manual, 50 goldens → not a concern now (reviewer agreed). **Fix shape**: memoize `embeddings.getEmbedding` per unique statement (roughly halves real-model latency/cost). **Promote when**: the extraction golden corpus grows toward the 100-sample re-open trigger. Surfaced 2026-07-09 (PR #1566 review).
+
+**Why:** Eval cost/latency at larger corpus size.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-246 - Propagating-memory-forget-episode-community-pool.md
+++ b/tracker/tasks/task-246 - Propagating-memory-forget-episode-community-pool.md
@@ -1,0 +1,19 @@
+---
+id: TASK-246
+title: 'Propagating /memory forget (episode + community-pool)'
+status: To Do
+assignee: []
+created_date: '2026-07-09 00:00'
+labels: []
+dependencies: []
+ordinal: 246000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Propagating `/memory forget` (episode + community-pool) — The correction slice shipped `/memory forget` as **per-fact terminal** (owner decision). The architecture doc §3.6a defines the fuller semantics: forgetting a fact ALSO soft-deletes the source episode(s) it derived from and removes its community-pool contributions. **Fix shape**: extend the forget handler to walk `sourceMemoryIds` and (with confirmation) soft-delete those episodes + strip pool contributions. **Promote when**: Phase-3 community-pool machinery lands (pool contributions don't exist yet). Surfaced 2026-07-09 (correction slice, owner-scoped to per-fact for now).
+
+**Why:** The doc's full forget semantics; deferred to when pools exist.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-247 - Browsedetail-router-pattern-two-inherited-UX-edges-episodes-AND-facts.md
+++ b/tracker/tasks/task-247 - Browsedetail-router-pattern-two-inherited-UX-edges-episodes-AND-facts.md
@@ -1,0 +1,20 @@
+---
+id: TASK-247
+title: 'Browse/detail router pattern: two inherited UX edges (episodes AND facts)'
+status: To Do
+assignee: []
+created_date: '2026-07-09 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 247000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Browse/detail router pattern: two inherited UX edges (episodes AND facts) — Both surfaces share the shapes byte-for-byte (facts copied them forward from `browse.ts` deliberately): (a) **stale-pagination render** — pagination fetches the REQUESTED page, then computes `safePage` from the fresh total but renders the already-fetched (possibly empty) items instead of re-fetching at `safePage`; concurrent deletions can briefly show an empty state; (b) **silent no-op on expired session** in `refreshBrowseList`/`refreshSearchList`/`refreshFactsList` (back/confirm-delete/confirm-forget paths) — no "expired" followUp, unlike the pagination handlers. **Fix shape**: re-fetch at `safePage` when it differs from the requested page; add the expired followUp to the refresh helpers; also remove (or comment) the dead `xHelpers.isBrowseSelect` OR-branches in `handleSelectMenu` — both episode and fact select menus actually route via the detail `::select` id, so the browse-select checks never match (PR #1568 round-2 observation). Fix all copies together (reuse-scout consolidation rule). **Promote when**: next touching the browse/detail router pattern, or a user reports the phantom-empty-page. Surfaced 2026-07-09 (PR #1568 review, inherited from episode browse).
+
+**Why:** Shared-pattern UX consistency; three copies must not drift.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-248 - Forced-system-key-rate-limit-pre-check-reads-the-wrong-cache-identity.md
+++ b/tracker/tasks/task-248 - Forced-system-key-rate-limit-pre-check-reads-the-wrong-cache-identity.md
@@ -1,0 +1,22 @@
+---
+id: TASK-248
+title: 'Forced-system-key rate-limit pre-check reads the wrong cache identity'
+status: To Do
+assignee: []
+created_date: '2026-07-10 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:redis'
+  - 'origin:review'
+dependencies: []
+ordinal: 248000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Forced-system-key rate-limit pre-check reads the wrong cache identity — Same provenance-vs-presence class as the #1570 incident fix, one level upstream: `selectQuotaFallbackTarget`'s `forceSystemKey` branch (`services/ai-worker/src/services/quotaFallback.ts:146-149`) checks `caches.rateLimit.isRateLimited` under the CALLER's pre-retarget `cacheKeyId` (`user:<id>`), but post-#1570 a forced-system-key invocation's own 429 is written under `system` — the pre-check reads a different Redis key than gets written, so the known-doomed fail-fast never fires for this path (one wasted doomed round trip against the shared free model; fail-safe, no wrong answer). Three funnel points share it: `quotaFallback.ts:146`, `retargetRoute.ts downgradeToFreeDefault`, `quotaFallbackRunner.ts resolveTargetAndCredentials` guestTarget — all through `selectQuotaFallbackTarget`. **Fix shape (reviewer-sketched)**: have `selectQuotaFallbackTarget` derive/accept the TARGET's identity ('system' when forceSystemKey) for the viability check instead of reusing the caller's. **Fourth instance (PR #1584 round-4 review)**: `AuthStep.resolveLlmAuthWithQuotaCheck` derives `deriveCacheKeyId(resolvedApiKey, userId)` WITHOUT `isSystemKeyRoute: true` on guest/system-key routes, so a zai-admitted guest's viability check reads `user:<id>` doom marks from their OpenRouter history — post-hoc vetoing an already-consumed zai fair-share slot (conservative over-count, but the same wrong-identity class; fix likely shared). **Fifth instance (PR #1618 review)**: the D12 floor hop's `checkModelViability` reuses the pre-downgrade `cacheKeyId` even when hop-1 forced a credential swap — same wrong-identity class, fail-safe only. **Ride-along at fix time**: reword `checkModelViability`'s JSDoc — the fail-open lives INSIDE `RateLimitCache.isRateLimited`/`CreditExhaustionCache.isCreditExhausted`'s own try/catch, not at the callers' seams; the runner's unwrapped `await selectQuotaFallbackTarget` would propagate if the caches ever stopped fail-opening internally (#1618 round-3 nit). **Promote when**: next quota-fallback touch, or if free-tier 429 storms show wasted doomed round trips. Surfaced 2026-07-10 (PR #1570 post-autosquash review).
+
+**Why:** Fail-fast optimization gap in the exact class #1570 fixed at the invoke site.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-249 - Weekly-audit-Dependabot-ALERTS-call-may-still-403-under-GITHUBTOKEN.md
+++ b/tracker/tasks/task-249 - Weekly-audit-Dependabot-ALERTS-call-may-still-403-under-GITHUBTOKEN.md
@@ -1,0 +1,21 @@
+---
+id: TASK-249
+title: 'Weekly-audit Dependabot ALERTS call may still 403 under GITHUB_TOKEN'
+status: To Do
+assignee: []
+created_date: '2026-07-11 00:00'
+labels:
+  - 'area:ci'
+  - 'origin:review'
+dependencies: []
+ordinal: 249000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Weekly-audit Dependabot ALERTS call may still 403 under GITHUB_TOKEN — PR #1583 gave the audit's security surface a GH_TOKEN + `security-events: read`; `gh pr list` is definitely covered, but the Dependabot alerts REST endpoint's permission model differs and GITHUB_TOKEN coverage is unverified. The stderr fix means a failure now degrades with a clear HTTP error naming the endpoint. **Fix shape**: fine-grained PAT (Dependabot alerts: read) stored as a secret, used only for the alerts call. **Promote when**: the next weekly-audit run (Saturday) still shows `security: unavailable` — with a 403 reason. Surfaced 2026-07-11 (PR #1583 review).
+
+**Why:** Watch-item with a dated trigger; PR-body notes don't count as tracking.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-25 - Distill-closed-probe-archaeology-out-of-self-hosted-tts-byok-re-evaluationmd-int.md
+++ b/tracker/tasks/task-25 - Distill-closed-probe-archaeology-out-of-self-hosted-tts-byok-re-evaluationmd-int.md
@@ -1,0 +1,21 @@
+---
+id: TASK-25
+title: 'Distill closed-probe archaeology out of self-hosted-tts-byok-re-evaluation.md into…'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels:
+  - 'area:voice'
+  - 'area:docs'
+dependencies: []
+ordinal: 25000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-03 — Distill closed-probe archaeology out of `self-hosted-tts-byok-re-evaluation.md` into docs/research per the completed-writeups policy; themes keep only open work. (The `voice-engine.md` half resolved itself: theme closed + deleted 2026-07-13, TEN note relocated to `docs/research/ten-turn-detection.md`.)
+
+**Why:** Theme files are working surfaces, not archives.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-250 - Retire-the-free-tier-zai-piggyback-proposal-into-reference-docs.md
+++ b/tracker/tasks/task-250 - Retire-the-free-tier-zai-piggyback-proposal-into-reference-docs.md
@@ -1,0 +1,21 @@
+---
+id: TASK-250
+title: 'Retire the free-tier-zai-piggyback proposal into reference docs'
+status: To Do
+assignee: []
+created_date: '2026-07-11 00:00'
+labels:
+  - 'area:docs'
+  - 'origin:review'
+dependencies: []
+ordinal: 250000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Retire the free-tier-zai-piggyback proposal into reference docs — The proposal shipped (slice 2) but holds the only record of the probe-verified z.ai quota-endpoint response shape and the 429 business-code table — reviewer flagged it now sits as a completed proposal instead of reference material. **Fix shape**: move the endpoint shape + code table into `docs/reference/` (likely alongside REASONING_MODEL_FORMATS-style provider references), then delete the proposal per the doc lifecycle rule. **Promote when**: after the dev-enable observation window confirms the endpoint shape is stable (one poll cycle of real use). Surfaced 2026-07-11 (PR #1584 round-2 review).
+
+**Why:** Doc-lifecycle hygiene without losing the only shape record.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-251 - db-synccleanup-as-async-BullMQ-jobs-outgrow-the-LONGSYNC-timeout-ladder.md
+++ b/tracker/tasks/task-251 - db-synccleanup-as-async-BullMQ-jobs-outgrow-the-LONGSYNC-timeout-ladder.md
@@ -1,0 +1,21 @@
+---
+id: TASK-251
+title: 'db-sync/cleanup as async BullMQ jobs (outgrow the LONG_SYNC timeout ladder)'
+status: To Do
+assignee: []
+created_date: '2026-07-11 00:00'
+labels:
+  - 'area:embeddings'
+  - 'area:jobs'
+dependencies: []
+ordinal: 251000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+db-sync/cleanup as async BullMQ jobs (outgrow the LONG_SYNC timeout ladder) — Both routes' duration scales with table size; a fact-carrying db-sync outgrew the 30s tier (succeeded server-side AFTER the client aborted — false-failure UX) and was raised to LONG_SYNC (300s) as the owner-chosen stopgap. **Fix shape**: gateway enqueues a sync/cleanup job + returns a job id; bot polls or receives the result via followUp (export_jobs is the in-house precedent); route timeout drops back to WRITE tier. **Data point (2026-07-13)**: owner observed dev db-sync 'very slow' during the fact-backfill's heavy write phase (extraction + embedding writes contending; memory_facts at ~20k rows with 3 protected indexes); it recovered — the caught-up run completed in 32s. Transient load-coupled, not promoted yet. **Promote when**: `Sync complete` log timestamps show any run past ~2 min under NORMAL load, OR a third route wants the LONG_SYNC exemption (the manifest test's comment marks that as the trigger). Surfaced 2026-07-11 (owner-hit false failure; prior intent recorded in the route comment).
+
+**Why:** The structural fix the timeout ladder defers to.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-252 - Re-check-main-pool-idle-in-tx-GUC-if-interactive-transactions-arrive.md
+++ b/tracker/tasks/task-252 - Re-check-main-pool-idle-in-tx-GUC-if-interactive-transactions-arrive.md
@@ -1,0 +1,21 @@
+---
+id: TASK-252
+title: 'Re-check main-pool idle-in-tx GUC if interactive transactions arrive'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 252000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Re-check main-pool idle-in-tx GUC if interactive transactions arrive — The 60s `idle_in_transaction_session_timeout` (#1606) is safe today because nothing holds a Postgres transaction across external I/O — reviewer verified zero `$transaction`/manual-BEGIN usage in the codebase. A future interactive-transaction pattern (e.g. a `$transaction` block awaiting an LLM/API call between statements) could idle past 60s and get reaped mid-work. **Promote when**: any PR introduces `$transaction`/interactive-transaction usage (grep is the check). Surfaced 2026-07-12 (#1606 review).
+
+**Why:** Guard-vs-future-pattern interaction; invisible until someone writes the first interactive transaction.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-253 - Goldens-miner-Hamilton-apportionment-malformed-JSON-friendly-error-replacements….md
+++ b/tracker/tasks/task-253 - Goldens-miner-Hamilton-apportionment-malformed-JSON-friendly-error-replacements….md
@@ -1,0 +1,20 @@
+---
+id: TASK-253
+title: 'Goldens miner: Hamilton apportionment + malformed-JSON friendly error + replacements…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 253000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Goldens miner: Hamilton apportionment + malformed-JSON friendly error + `replacements` naming — Three #1608 final-round non-blocking items, one surface: (a) `stratifySample`'s global `slice(0, sampleSize)` trims from the LAST-processed personality — for an extreme imbalance (reviewer's valid 899:2 hand-trace) the small personality's intended 1-row quota is silently zeroed. UNREACHABLE with the current corpus (Lila 6,210:3,543 mined exactly 510+290=800, zero truncation — verified). Fix shape: largest-remainder (Hamilton) apportionment so quotas sum to sampleSize with no truncation step. (b) a hand-edited `swap-map.json` with broken JSON throws a raw SyntaxError — give it the same friendly-error treatment as the missing-file cases. (c) `replacements` counts rows-affected-per-entity, not occurrences — rename for clarity. **Promote when**: any re-mine targets a different persona/personality set (the imbalance becomes possible), or the next miner touch. Surfaced 2026-07-12 (#1608 final review).
+
+**Why:** Corpus-integrity guard for future mines; current corpus verified unaffected.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-254 - contextFoldTurns-as-a-ConfigOverrides-cascade-field.md
+++ b/tracker/tasks/task-254 - contextFoldTurns-as-a-ConfigOverrides-cascade-field.md
@@ -1,0 +1,19 @@
+---
+id: TASK-254
+title: 'contextFoldTurns as a ConfigOverrides cascade field'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels: []
+dependencies: []
+ordinal: 254000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`contextFoldTurns` as a `ConfigOverrides` cascade field — The fold turn-count is a hardcoded constant (`AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS = 3`, read in `extractRecentHistoryWindow`). 1c PR-1 makes it a defaulted param for the eval sweep; making it user/admin-TUNABLE at runtime needs the full field-#12 cascade ceremony (schema field + `NULL_TERMINAL_FIELDS`/`CONFIG_OVERRIDES_KEYS`/`HARDCODED_CONFIG_DEFAULTS` + colocated drift test + dashboard family + source label). **Promote when**: the 1c turn-sweep (3/5/8) shows N materially moves recall — build the knob only if the measurement justifies it. Surfaced 2026-07-12 (1c re-baseline plan).
+
+**Why:** Measure-first: don't build the cascade field before the sweep proves N matters.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-255 - Share-arm-name-constants-if-a-third-fold-eval-glue-script-appears.md
+++ b/tracker/tasks/task-255 - Share-arm-name-constants-if-a-third-fold-eval-glue-script-appears.md
@@ -1,0 +1,20 @@
+---
+id: TASK-255
+title: 'Share arm-name constants if a third fold-eval glue script appears'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 255000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Share arm-name constants if a third fold-eval glue script appears — `ARMS`/`DENSE_SWEEP` arm-name string literals (`bare-dense`, `fold3-dense`, …) are duplicated between `foldAwarePooling.eval.test.ts` (producer) and `foldAwareScoring.eval.test.ts` (consumer) — two independently-run local scripts with intentionally no runtime dependency, so reviewer ruled it below the wrong-abstraction ceiling today. **Fix shape**: lift the arm names into `qrelsReconciliation.ts` (already the shared-types home) as an exported const. **Promote when**: a third eval glue script joins the fold-pool family. Surfaced 2026-07-12 (#1613 final review).
+
+**Why:** Two copies is fine; three is a registry.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-256 - Settings-dashboard-page-jump-select-7-pages-via-prevnext-is-walkable-but-clicky.md
+++ b/tracker/tasks/task-256 - Settings-dashboard-page-jump-select-7-pages-via-prevnext-is-walkable-but-clicky.md
@@ -1,0 +1,19 @@
+---
+id: TASK-256
+title: 'Settings dashboard page-jump select (7 pages via prev/next is walkable but clicky)'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels: []
+dependencies: []
+ordinal: 256000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Settings dashboard page-jump select (7 pages via prev/next is walkable but clicky) — The paged settings dashboards (admin: 7 pages, defaults: 3) navigate only by ◀/▶ one page at a time. A page-jump select menu row (one option per page label) would cut worst-case clicks from 6 to 1 on the admin dashboard. Deliberately deferred from admin-runtime PR 2 — prev/next is fully functional and the extra select row costs a component slot on every overview render. **Fix shape**: optional second select row (or replace the indicator button) listing page labels, routed via a `page::…::jump` customId. **Promote when**: owner friction report, or an 8th page joins the dashboard. Surfaced 2026-07-13 (admin-runtime PR 2 plan).
+
+**Why:** UX polish gated on real friction; mechanism supports it cheaply.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-257 - Retire-the-admin-runtime-settings-artifact-into-reference-docs.md
+++ b/tracker/tasks/task-257 - Retire-the-admin-runtime-settings-artifact-into-reference-docs.md
@@ -1,0 +1,20 @@
+---
+id: TASK-257
+title: 'Retire the admin-runtime-settings artifact into reference docs'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'area:docs'
+dependencies: []
+ordinal: 257000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Retire the admin-runtime-settings artifact into reference docs — All four phasing rows shipped (#1605/#1616/#1617/#1618). Per the doc lifecycle rule, a completed proposal is verified-then-deleted — but this artifact holds the registry criteria, D4 SWR contract, D12 category semantics, and the council record. **Fix shape**: distill the durable pieces (settings registry how-to, floor semantics, descent category table) into `docs/reference/` (likely `features/` or `architecture/`), then delete the proposal; keep the config-cascade cross-links intact (`guard:proposal-links` must stay green). **Promote when**: after the operational tail closes (Railway cleanup done + dev walk passed) — the artifact is still the live runbook until then. Surfaced 2026-07-13 (epic completion).
+
+**Why:** Doc-lifecycle hygiene; artifact is the only home of several contracts.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-258 - Take-the-TypeScript-7-major-deliberately-remove-the-dependabot-ignore.md
+++ b/tracker/tasks/task-258 - Take-the-TypeScript-7-major-deliberately-remove-the-dependabot-ignore.md
@@ -1,0 +1,20 @@
+---
+id: TASK-258
+title: 'Take the TypeScript 7 major deliberately + remove the dependabot ignore'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'area:ci'
+dependencies: []
+ordinal: 258000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Take the TypeScript 7 major deliberately + remove the dependabot ignore — Dependabot's dev-deps group bundled TypeScript 6.0.3→7.0.2, and `@typescript-eslint/typescript-estree` (8.63.0) crashes at parse time under TS 7 (`Cannot read properties of undefined (reading 'Cjs')`) — every group PR carrying the major goes permanently red (#1622). #1625 parks TS majors in `dependabot.yml` `ignore` (same shape as the jscpd-major entry). **Fix shape**: when typescript-eslint ships TS 7 support, bump `typescript` deliberately across the workspace, verify `pnpm quality` (parser + rules), and delete the ignore entry. **Promote when**: typescript-eslint's supported-range includes TS 7 (check their releases page). Surfaced 2026-07-13 (#1622 diagnosis).
+
+**Why:** Majors get taken on purpose, not by a weekly group PR.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-259 - Shapesinc-resume-from-page-for-mid-job-cookie-expiry.md
+++ b/tracker/tasks/task-259 - Shapesinc-resume-from-page-for-mid-job-cookie-expiry.md
@@ -1,0 +1,19 @@
+---
+id: TASK-259
+title: 'Shapes.inc resume-from-page for mid-job cookie expiry'
+status: To Do
+assignee: []
+created_date: '2026-04-22 00:00'
+labels: []
+dependencies: []
+ordinal: 259000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Shapes.inc resume-from-page for mid-job cookie expiry — The one residual of the fetcher-hardening theme (closed 2026-07-13, #1630/#1631 + docs): a session cookie expiring mid-export currently fails the job and a re-run restarts from page 1. True resume needs partial-progress persistence, a resume-point in job data, and re-submit UX — a real feature, deliberately not built as hardening. The diagnostic half shipped: mid-job 401s report the exact page (`[memories traversal stopped at page N]`), which doubles as the tripwire. **Fix shape**: persist fetched pages (or page cursor) on the export row, accept a resume-from field, re-enter the traversal loop at that page. **Promote when**: a mid-job 401 with a page stamp is actually observed in prod logs (Better Auth sessions last ~7 days vs minutes-long jobs, so this should be rare). Surfaced 2026-04-22 (hardening proposal item 6b); filed at theme close-out 2026-07-13.
+
+**Why:** The page-stamped error message is the evidence-gate for building this.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-26 - Fair-share-quota-allocation-for-the-SHARED-system-OpenRouter-free-tier-key-desig.md
+++ b/tracker/tasks/task-26 - Fair-share-quota-allocation-for-the-SHARED-system-OpenRouter-free-tier-key-desig.md
@@ -1,0 +1,21 @@
+---
+id: TASK-26
+title: 'Fair-share quota allocation for the SHARED system OpenRouter free-tier key (design in…'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels:
+  - 'area:docs'
+  - 'area:backlog'
+dependencies: []
+ordinal: 26000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-03 — Fair-share quota allocation for the SHARED system OpenRouter free-tier key (design in `docs/proposals/backlog/free-tier-zai-piggyback.md` § Quota fairness — the mechanism is provider-agnostic; the OpenRouter half is live exposure TODAY, not gated on the z.ai piggyback shipping).
+
+**Why:** One heavy free user can currently exhaust the shared free-tier quota and starve everyone else; owner flagged it as "address sooner rather than later."
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-260 - Release-the-shapes-fetch-gate-slot-after-the-last-shapesinc-call-not-at-job-end.md
+++ b/tracker/tasks/task-260 - Release-the-shapes-fetch-gate-slot-after-the-last-shapesinc-call-not-at-job-end.md
@@ -1,0 +1,21 @@
+---
+id: TASK-260
+title: 'Release the shapes fetch-gate slot after the last shapes.inc call, not at job end'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 260000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Release the shapes fetch-gate slot after the last shapes.inc call, not at job end — #1631 review observation: the import job holds one of 2 global slots through the pgvector memory-import phase, which touches no shapes.inc traffic — for a maximal import that's most of an hour of slot pressure with zero etiquette benefit. **Fix shape**: release after `downloadAndStoreAvatar` (the last shapes.inc/CDN call) instead of the outer `finally`; keep the finally as a held-slot backstop. **Promote when**: shapes import volume or duration grows enough that gate contention is observed (busy errors in logs from real overlap). Surfaced 2026-07-13 (#1631 review).
+
+**Why:** Tightens the etiquette window without weakening it; irrelevant at current traffic.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-261 - Root-dockerignore-for-the-node-service-build-contexts.md
+++ b/tracker/tasks/task-261 - Root-dockerignore-for-the-node-service-build-contexts.md
@@ -1,0 +1,22 @@
+---
+id: TASK-261
+title: 'Root .dockerignore for the node-service build contexts'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'area:embeddings'
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 261000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Root `.dockerignore` for the node-service build contexts — The three node images build from the repo root and `COPY . .` in the pruner stage — the full tree incl. `.git/`, `reports/`, `coverage/` ships as build context on every Railway deploy AND every `docker-build-smoke` firing (#1640 review). **Fix shape**: root `.dockerignore` excluding `.git`, `reports/`, `coverage/`, `node_modules/` — verify against each Dockerfile's COPY needs (prisma/, tsconfig.json, packages/embeddings/models/ must stay) and prove with the smoke job (a `.dockerignore` addition should fire all three node legs via a lockfile-less trigger... it won't match the filters — pair it with a Dockerfile comment touch). **Promote when**: next Dockerfile/CI-build touch, or smoke-job build times get annoying. Surfaced 2026-07-13 (#1640 review).
+
+**Why:** Build-context waste on every deploy; cheap one-file fix with a verification path.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-262 - Add-docker-build-smoke-ok-to-the-develop-rulesets-required-contexts.md
+++ b/tracker/tasks/task-262 - Add-docker-build-smoke-ok-to-the-develop-rulesets-required-contexts.md
@@ -1,0 +1,20 @@
+---
+id: TASK-262
+title: "Add docker-build-smoke-ok to the develop ruleset's required contexts"
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 262000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Add `docker-build-smoke-ok` to the develop ruleset's required contexts — The join job exists precisely to be ONE stable required-check name over the four matrix legs; until it's in the ruleset, a red smoke build blocks only by house rule (attention), not structurally. **Fix shape**: owner dashboard action — Settings → Rules → develop ruleset → add `docker-build-smoke-ok`. **Promote when**: next ruleset touch (or immediately — 30 seconds). Surfaced 2026-07-13 (#1640 review).
+
+**Why:** Structural teeth for the new gate; one dashboard click.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-263 - Extract-shared-oldestHistoryMspriorHistory-eval-helper.md
+++ b/tracker/tasks/task-263 - Extract-shared-oldestHistoryMspriorHistory-eval-helper.md
@@ -1,0 +1,20 @@
+---
+id: TASK-263
+title: 'Extract shared oldestHistoryMs(priorHistory) eval helper'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 263000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Extract shared `oldestHistoryMs(priorHistory)` eval helper — The "empty history → `Number.MAX_SAFE_INTEGER`, else `Math.min(createdAt…)`" block (incl. the Infinity-serializes-to-null rationale) is duplicated verbatim in `factPooling.eval.test.ts` and `foldAwarePooling.eval.test.ts` — real logic, not call-shape, so it's a clean extraction into a small shared eval module. **Promote when**: next touch of either eval runner. Surfaced 2026-07-13 (#1637 round-2 review).
+
+**Why:** Two copies of real logic in sibling runners; third copy would force it anyway.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-264 - Deployment-skill-railway-redeploy-acts-on-the-LINKED-environment.md
+++ b/tracker/tasks/task-264 - Deployment-skill-railway-redeploy-acts-on-the-LINKED-environment.md
@@ -1,0 +1,20 @@
+---
+id: TASK-264
+title: 'Deployment skill: railway redeploy acts on the LINKED environment'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 264000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Deployment skill: `railway redeploy` acts on the LINKED environment — `railway redeploy` has no `--environment` flag — it targets whatever env the CLI is linked to (`railway status` shows it). A blind `redeploy -s voice-engine -y` nearly bounced PROD when the link happened to be production; the safe sequence is status-check → `railway environment <env>` → redeploy → restore link. **Fix shape**: one gotcha line + the safe sequence in `/tzurot-deployment` § Service Restart (skills are review-gated → ride the next skills PR). **Promote when**: next skills-touching PR. Surfaced 2026-07-13 (voice-engine boot probe).
+
+**Why:** The near-miss class: env-implicit CLI commands against shared infra.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-265 - BYOK-TTS-providers-receive-but-dont-consult-the-abort-signal.md
+++ b/tracker/tasks/task-265 - BYOK-TTS-providers-receive-but-dont-consult-the-abort-signal.md
@@ -1,0 +1,21 @@
+---
+id: TASK-265
+title: "BYOK TTS providers receive but don't consult the abort signal"
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'area:voice'
+  - 'origin:review'
+dependencies: []
+ordinal: 265000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+BYOK TTS providers receive but don't consult the abort signal — `TtsContext.signal` (#1636) is checked by the self-hosted chunker and the dispatcher's fallback walk; `MistralTtsProvider`/`ElevenLabsTtsProvider` single-shot `synthesize()` calls receive the field and ignore it — correct today (no chunking, no shared semaphore, own per-request HTTP timeouts). **Fix shape**: add `signal?.throwIfAborted()` between requests if either provider grows a multi-request synthesis path. **Promote when**: a BYOK TTS provider grows chunked/long-running multi-request synthesis. Surfaced 2026-07-13 (#1636 round-2 review).
+
+**Why:** The signal contract exists; new multi-request paths must opt in.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-266 - withPolicyArms-0-fallback-poisons-partially-ranking-arms.md
+++ b/tracker/tasks/task-266 - withPolicyArms-0-fallback-poisons-partially-ranking-arms.md
@@ -1,0 +1,19 @@
+---
+id: TASK-266
+title: "withPolicyArm's ?? 0 fallback poisons partially-ranking arms"
+status: To Do
+assignee: []
+created_date: '2026-07-14 00:00'
+labels: []
+dependencies: []
+ordinal: 266000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`withPolicyArm`'s `?? 0` fallback poisons partially-ranking arms — `factPoolScoring.withPolicyArm` assigns rank 0 when `policyRanks` misses a candidate — never triggers today (policyRanks ranks everything; the #1643 review called it harmless), but `poolScoring.rankedIds` treats 0 as a REAL rank that sorts FIRST, so any future arm that ranks a subset (e.g. a collapse/filter arm) silently puts its DROPPED candidates at the top of the ordering (bit a collapse-gate sim: recall@5 read 0.013 until diagnosed). **Fix shape**: fallback to `null` (the documented "not surfaced" value) + loosen `FactPooledCandidate.ranks` to `number | null`; or make `rankedIds` skip non-positive ranks. **Promote when**: next eval-scoring touch. Surfaced 2026-07-14 (slice-B offline gate).
+
+**Why:** A defensive default that actively lies is worse than a throw.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-267 - Shapesinc-voice-import.md
+++ b/tracker/tasks/task-267 - Shapesinc-voice-import.md
@@ -1,0 +1,20 @@
+---
+id: TASK-267
+title: 'Shapes.inc voice import'
+status: To Do
+assignee: []
+created_date: '2026-07-13 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 267000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Shapes.inc voice import — locate the voice data, then build step 7.5 — shapes.inc has a user-visible voice feature (owner-confirmed 2026-07-13, overriding the 2026-07-09 competitive research which under-reported it), but our fetcher's four endpoints expose no known voice fields — so imported characters currently lose their voice. **Fix shape**: first identify where the voice data lives (grep a fresh raw JSON export for voice/audio/tts keys — post-#1630 exports pass all fields through verbatim; if absent, probe for an unfetched voice endpoint), then build the pre-designed import step 7.5: clone `downloadAndStoreAvatar` (`ShapesImportHelpers.ts`) into `downloadAndStoreVoiceReference` writing `Personality.voiceReferenceData`/`voiceReferenceType` + `voiceEnabled: true`; lazy register/clone fires automatically via `VoiceRegistrationService.ensureVoiceRegistered` — no provider wiring needed. **Promote when**: a voice field/endpoint is identified in live shapes.inc data. Surfaced at voice-engine theme close-out 2026-07-13 (owner decision).
+
+**Why:** Building against guessed field shapes is the class of work this project refuses; the data shape is the gate.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-268 - Preprocessing-jobs-STTvisionshapes-wrappers-lack-a-spend-idempotency-guard-on….md
+++ b/tracker/tasks/task-268 - Preprocessing-jobs-STTvisionshapes-wrappers-lack-a-spend-idempotency-guard-on….md
@@ -1,0 +1,21 @@
+---
+id: TASK-268
+title: 'Preprocessing jobs (STT/vision/shapes wrappers) lack a spend-idempotency guard on…'
+status: To Do
+assignee: []
+created_date: '2026-07-14 00:00'
+labels:
+  - 'area:voice'
+  - 'area:redis'
+dependencies: []
+ordinal: 268000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Preprocessing jobs (STT/vision/shapes wrappers) lack a spend-idempotency guard on stall-requeue — `processLLMGenerationJob` holds a Redis idempotency lock (`markMessageProcessing` on triggerMessageId+personalityId) before the paid call; `processAudioTranscriptionJobWrapper`/`processImageDescriptionJobWrapper` (and the shapes import/export wrappers) call the paid STT/vision API with no check-and-set — a FALSE stall (≥5 min continuous event-loop block or Redis outage, post-#1647) re-queues the job while the original is mid-flight and double-bills the provider (BYOK included). Real stalls (dead process) don't double-bill. Surfaced by #1647 review round 2, which also narrowed the false-stall margin 20min→5min. **Fix shape**: job.id-keyed Redis check-and-set in the preprocessing wrappers (mirror `markMessageProcessing`; these aren't per-personality fan-outs, so job.id suffices). NOTE: the LLM path re-entered this exposure class when its lock became ownership-aware (a false-stall re-run now recognizes its own lock and proceeds — duplicate reply + spend on a false stall, accepted deliberately vs. the swallowed-reply-on-real-stall bug it fixed; real-stall re-runs now deliver). Same tripwire; a fencing token is the complete fix if the trigger fires. Full scope for that fix (review #1799): atomic compare-and-set / compare-and-delete (Lua) closing the GET→SET TOCTOU (a third genuinely-different run can slip past the at-most-2 bound) and the TTL-boundary false-deny (GET null after a lost SET NX); ownership-aware `releaseMessageLock`; plus the two deferred test cases (GET-null-after-NX-miss, concurrent re-acquire ordering). **Promote when**: prod `Job stalled` warns (new #1647 logging — the purpose-built tripwire) show a stall for an STT/vision job whose original was still alive, or any repeat-spend signal on those providers.
+
+**Why:** The tripwire ships before the guard: stalled-event logs make the gap observable, and false stalls need minutes of continuous stall to occur at all. Surfaced 2026-07-14 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-269 - BYOK-extraction-billing.md
+++ b/tracker/tasks/task-269 - BYOK-extraction-billing.md
@@ -1,0 +1,19 @@
+---
+id: TASK-269
+title: 'BYOK extraction billing'
+status: To Do
+assignee: []
+created_date: '2026-07-14 00:00'
+labels: []
+dependencies: []
+ordinal: 269000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+BYOK extraction billing — quota-burn trigger — Fact extraction bills the SYSTEM key only (z.ai coding plan when extractionProvider='zai-coding'; OpenRouter fallback) — verified in resolveExtractionProvider; no per-user key lookup exists. Owner call: fine unless organic extraction meaningfully burns the coding-plan quota (this week's 62% was backfill-dominated — an anomaly). **Fix shape**: per-user key attribution needs a design pass (batches span multiple users per personality-channel) + the consent disclosure the onboarding-DM theme already notes (billing a user's key for background work they didn't invoke must not be silent). **Promote when**: a normal (non-backfill) week shows extraction consuming a significant share of the weekly coding-plan quota. Surfaced 2026-07-14 (z.ai usage-uptick investigation).
+
+**Why:** The dashboard IS the tripwire — owner checks it anyway; next normal week is the baseline read.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-27 - Guard-outbound-doc-references-from-source-comments.md
+++ b/tracker/tasks/task-27 - Guard-outbound-doc-references-from-source-comments.md
@@ -1,0 +1,20 @@
+---
+id: TASK-27
+title: 'Guard: outbound doc references from source comments'
+status: To Do
+assignee: []
+created_date: '2026-07-03 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 27000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-03 — Guard: outbound doc references from source comments. `guard:claude-content-refs` covers `.claude/` → `pnpm ops` refs and `guard:proposal-links` covers inbound proposal links, but nothing catches a source-code comment/error-string pointing at a deleted doc (PR #1469 review found 8 such refs to purged files). Candidate: extend claude-content-refs or the weekly orphan scan to verify doc paths cited in `packages/*/src` + `services/*/src` comments resolve.
+
+**Why:** A deleted/moved doc silently 404s every code comment citing it; one was a runtime error-message string.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-270 - Derive-SYNCCONFIG-mechanics-from-the-Prisma-schema.md
+++ b/tracker/tasks/task-270 - Derive-SYNCCONFIG-mechanics-from-the-Prisma-schema.md
@@ -1,0 +1,20 @@
+---
+id: TASK-270
+title: 'Derive SYNC_CONFIG mechanics from the Prisma schema'
+status: To Do
+assignee: []
+created_date: '2026-07-14 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 270000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Derive SYNC_CONFIG mechanics from the Prisma schema — Every new-tables PR trips prod db-sync "not in SYNC_CONFIG" warnings during the schema-ahead-of-code window, and the config hand-codes per-table PKs/timestamps/uuidColumns with only a component test as backstop (the test DID gate #1648 — the forgotten-config class is dead; this is about shrinking the hand-coded surface). Owner 2026-07-14: "manual hard coding of columns isn't working." **Fix shape**: derive pk/timestamps/uuidColumns from the Prisma DMMF at build or runtime; SYNC_CONFIG shrinks to the irreducibly-human per-table verdict (sync vs exclude + reason). The schema-ahead warnings themselves are timing-inherent (old prod code, new schema) and vanish per release — a derivation makes them accurate but can't remove them. **Promote when**: next PR that touches syncTables.ts, or the next time a sync-config field-level bug (not just a warning) surfaces. Surfaced 2026-07-14 (post-#1648 prod sync report).
+
+**Why:** Same philosophy as the queued "derive serialize field sets from Zod" theme — decisions stay manual, mechanics derive.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-271 - Broadcast-dry-run-should-count-not-sweep.md
+++ b/tracker/tasks/task-271 - Broadcast-dry-run-should-count-not-sweep.md
@@ -1,0 +1,20 @@
+---
+id: TASK-271
+title: 'Broadcast dry-run should count, not sweep'
+status: To Do
+assignee: []
+created_date: '2026-07-14 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 271000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Broadcast dry-run should count, not sweep — `handleBroadcast`'s dry-run calls the full cursor-paginated `resolveEligibleRecipients` sweep just to show a count + 10-name sample — N/500 round-trips for data a `user.count` + `findMany({take:10})` provides (review #1649 r1 obs 3). Admin-only and trivial at current scale. **Fix shape**: dedicated `countEligibleRecipients` + capped sample query in `releaseBroadcast.ts`; keep the real-send path on the full sweep. Ride-alongs for the same touch (#1649 r4): swap the sequential per-batch enqueue loop for the existing `addValidatedJobs` helper, add seconds to `defaultLabel` (same-minute ad-hoc broadcasts currently collide into a safe-but-surprising rejection), and hoist the `[...allowlist]` spread out of the pagination loop in `resolveEligibleRecipients` (#1650 r3 nit — rebuilt per page today, harmless under one page). **Promote when**: the opted-in audience grows past a few hundred users, or the next `releaseBroadcast.ts` touch. Surfaced 2026-07-14 (#1649 review; allowlist nit #1650 review).
+
+**Why:** Correct-but-lazy beats clever-but-divergent while the audience fits in one page.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-272 - Allowlist-path-perf-polish-1650-r3-nit-item-2-of-2.md
+++ b/tracker/tasks/task-272 - Allowlist-path-perf-polish-1650-r3-nit-item-2-of-2.md
@@ -1,0 +1,20 @@
+---
+id: TASK-272
+title: 'Allowlist-path perf polish (#1650 r3 nit, item 2 of 2)'
+status: To Do
+assignee: []
+created_date: '2026-07-14 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 272000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Allowlist-path perf polish (#1650 r3 nit, item 2 of 2) — ~~(1) `atLimit` computed post-filter~~ SHIPPED #1662. Remaining: (2) `getOutboundDmAllowlist()` re-parses the env string per call — fine at once-per-request/broadcast cadence; add a module-level cache with a `resetConfig()`-style reset (the `getConfig()` pattern) if it ever moves into a hotter path. **Promote when**: the allowlist gate lands in a per-message path, or next `outboundDmAllowlist.ts` touch. Surfaced 2026-07-14 (#1650 review).
+
+**Why:** Not-yet-hot path — polish, not a defect.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-273 - Shapes-export-retrofit-the-ZIPmulti-file-shape-from-export-v2.md
+++ b/tracker/tasks/task-273 - Shapes-export-retrofit-the-ZIPmulti-file-shape-from-export-v2.md
@@ -1,0 +1,19 @@
+---
+id: TASK-273
+title: 'Shapes export: retrofit the ZIP/multi-file shape from export v2'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels: []
+dependencies: []
+ordinal: 273000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Shapes export: retrofit the ZIP/multi-file shape from export v2 — Owner 2026-07-15: shapes export is "a bit better [than the giant account JSON] but might need work too." Once export v2 proves the ZIP-with-per-section-files + both-formats shape, consider retrofitting shapes export to match (drop its format toggle, reuse the zip assembly + markdown formatters). **Promote when**: export v2 ships and the owner confirms the shape works in practice. Surfaced 2026-07-15 (account-export smoke debrief).
+
+**Why:** One export UX across the bot beats two divergent ones.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-274 - AIJobProcessor-name-routed-dispatch-branches-lack-routing-tests.md
+++ b/tracker/tasks/task-274 - AIJobProcessor-name-routed-dispatch-branches-lack-routing-tests.md
@@ -1,0 +1,20 @@
+---
+id: TASK-274
+title: 'AIJobProcessor name-routed dispatch branches lack routing tests'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 274000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+AIJobProcessor name-routed dispatch branches lack routing tests — The `job.name ===` dispatch for ShapesImport/ShapesExport/AccountExport has no test asserting a job with each name reaches its processor (flagged #1653 r2; pre-existing class for the shapes branches — merits: a mis-route fails silent-weird, and the seam rule wants the routing asserted). **Fix shape**: table-driven unit test in AIJobProcessor.test.ts with the three processors mocked, asserting each name dispatches to the right wrapper. **Promote when**: next AIJobProcessor touch. Surfaced 2026-07-15 (#1653 r2).
+
+**Why:** Three-line dispatch, three-line test each — cheap insurance on a growing switch.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-275 - zai-free-tier-integration-legibility-dig.md
+++ b/tracker/tasks/task-275 - zai-free-tier-integration-legibility-dig.md
@@ -1,0 +1,19 @@
+---
+id: TASK-275
+title: 'z.ai free-tier integration legibility dig'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels: []
+dependencies: []
+ordinal: 275000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+z.ai free-tier integration legibility dig — Owner-flagged 2026-07-15 after an adversarial code-reading agent concluded the z.ai free tier doesn't exist: `ApiKeyResolver.getSystemApiKey(ZaiCoding)` returns null with "No system fallback for z.ai — every user must bring their own coding-plan key," while `ZaiFreeTierAdmission` (a parallel gate upstream, wired via `guestModeOverrides`) routes admitted guests onto the system `ZAI_CODING_API_KEY` anyway. Runtime behavior is believed correct (admission → GLM-4.5-Air, denial → silent OpenRouter degrade), but the two mechanisms don't reference each other and the resolver's comment reads as authoritative denial. **Dig shape**: trace the guest-request key-resolution end-to-end; either unify the free-tier path into the resolver's model or cross-document the seam (resolver comment names the admission gate; admission gate names why it bypasses the resolver); check for real seam bugs while there (e.g. does any path consult the resolver first and wrongly conclude guest-z.ai is impossible?). **Promote when**: next free-tier/provider-routing touch, or the BYOK-first extraction billing boulder (same subsystem). Surfaced 2026-07-15 (legal-doc verification pass).
+
+**Why:** A feature a careful reader can't find is a feature the next refactor breaks.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-276 - User-message-envelope-assembly-is-convoluted-owner-flagged.md
+++ b/tracker/tasks/task-276 - User-message-envelope-assembly-is-convoluted-owner-flagged.md
@@ -1,0 +1,20 @@
+---
+id: TASK-276
+title: 'User-message envelope assembly is convoluted (owner-flagged)'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 276000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+User-message envelope assembly is convoluted (owner-flagged) — Owner reviewed a debug export 2026-07-15: a 3-char user message ships with (a) the `<contextual_references>` block DUPLICATED verbatim in system prompt AND user message (~200 wasted tokens per reply-shaped message), (b) a quote stub whose only payload is "go find it in the chat log" — indirection the chat log already provides, (c) two speaker-encoding idioms in one prompt (`<message from=…>` in history vs bare `<from>` tag + loose text for the current message — the inconsistency the output-constraints scaffolding-ban then pays for). Same class as the vision-injection row above. **Fix shape**: belongs to the prompt-assembly-architecture implementation (accepted boulder artifact) — dedupe the instruction block to system-prompt-only, drop or enrich the stub, unify the speaker encoding; regression-check against REASONING_MODEL_FORMATS quirks (GLM/Kimi scaffolding-echo class). **Promote when**: prompt-assembly implementation phase starts, or the next assembler touch. Surfaced 2026-07-15 (owner prompt-export review).
+
+**Why:** Models cope with messy envelopes; tokens, retrieval, and maintenance surface pay the real bill.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-277 - Reconcile-fetcher-single-page-assumption-perpage30.md
+++ b/tracker/tasks/task-277 - Reconcile-fetcher-single-page-assumption-perpage30.md
@@ -1,0 +1,20 @@
+---
+id: TASK-277
+title: 'Reconcile fetcher single-page assumption (per_page=30)'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 277000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Reconcile fetcher single-page assumption (per_page=30) — `createGitHubReleasesFetcher` pulls one newest-first page of 30 and assumes that covers any allowed lookback window (≤168h) — true at current cadence, but a hotfix burst pushing an unannounced release past position 30 would silently drop it from the sweep (quiet failure mode; #1651 review obs 2). **Fix shape**: follow the `Link: rel="next"` header while the page's oldest release is still inside the window, or simply log a warn when item 30 is younger than the cutoff (cheap tripwire). **Promote when**: release cadence ever exceeds ~30 releases/week, or the next `releaseReconcile.ts` touch. Surfaced 2026-07-15 (#1651 review).
+
+**Why:** The cheap tripwire beats speculative pagination while cadence is ~3/week.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-278 - Attribute-vision-descriptions-in-the-prompt.md
+++ b/tracker/tasks/task-278 - Attribute-vision-descriptions-in-the-prompt.md
@@ -1,0 +1,20 @@
+---
+id: TASK-278
+title: 'Attribute vision descriptions in the prompt'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 278000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Attribute vision descriptions in the prompt — personas think the USER wrote them — Prod-observed (owner, 2026-07-15, Azura image-pick session): the vision pipeline injects image descriptions bare into the user-message content (`[Image: <filename>]` + "This image depicts…" with no authorship marker), so the persona credited the description prose to the user ("You described the posture… with a precision the others did not receive") — flattering but wrong, and it misattributes an AI artifact as user intent. Confirmed against an /inspect prompt export: the Visual Interpretation directive says "when image descriptions are provided, engage fully" but never says WHO wrote them. Owner reviewed the raw format 2026-07-15 and widened scope: the whole injection block is confusing, not just unattributed — the `[Image: …]` marker carries Discord CDN query junk (`?ex=…&is=…&hm=<64-char hash>&` — token waste, unreadable), and there's no end boundary between a description and the user's resuming text (3-image messages blur entirely). **Fix shape** (ai-worker): (1) restructure the injection into a delimited block consistent with the prompt's XML idiom — e.g. `<attached_image name="<filename sans query params>">` + an explicit "auto-generated description (vision model — not written by the user)" lead-in + closing tag (new tag must be classified for the `check-prompt-tags` gate); (2) strip CDN query params from the displayed filename; (3) one sentence in the Visual Interpretation directive: descriptions come from an automated vision model. Character-prompt change only (no extraction eval); verify with one dev multi-image round. **Promote when**: next ai-worker prompt/vision touch, or the misattribution recurs in prod (owner formatting concern already raised twice — this is drifting toward a Quick Win).
+
+**Why:** The description reads as user prose because structurally it IS user-message content — boundaries and attribution must both be explicit.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-279 - Rename-MemoryActionTokenService-ActionTokenService.md
+++ b/tracker/tasks/task-279 - Rename-MemoryActionTokenService-ActionTokenService.md
@@ -1,0 +1,19 @@
+---
+id: TASK-279
+title: 'Rename MemoryActionTokenService → ActionTokenService'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels: []
+dependencies: []
+ordinal: 279000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Rename `MemoryActionTokenService` → `ActionTokenService` — The service now mints memory-preview, memory-purge, AND account-deletion tokens — the `Memory` prefix undersells its scope and misleads greps. Pure rename (class, file, imports, tests). **Promote when**: next touch of that file. Surfaced 2026-07-15 (PR-B build).
+
+**Why:** Names should match scope; three token families outgrew the original one.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-28 - LlmConfigServicets-sits-at-the-max-lines-ceiling.md
+++ b/tracker/tasks/task-28 - LlmConfigServicets-sits-at-the-max-lines-ceiling.md
@@ -1,0 +1,20 @@
+---
+id: TASK-28
+title: 'LlmConfigService.ts sits at the max-lines ceiling'
+status: To Do
+assignee: []
+created_date: '2026-07-04 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 28000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`LlmConfigService.ts` sits at the max-lines ceiling — The file is at the eslint `max-lines: 400` limit (counted, after skipBlankLines/skipComments; ~722 raw), so any new logic forces an extraction — as #1483 did for the reasoning check. **Fix shape**: split a cohesive chunk into its own module — the read/format helpers (`formatConfigSummary`/`formatConfigDetail`/`enrichWithModelContext`) or the name-collision/clone logic are natural seams. **Promote when**: the next feature touching LlmConfigService needs to add lines, or a max-lines lint failure recurs. Surfaced 2026-07-04 (#1483 review, non-blocking).
+
+**Why:** Every future change to this service pays an extraction tax; a proactive split removes the friction.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-280 - Expression-index-for-the-case-insensitive-entitytags-sweep.md
+++ b/tracker/tasks/task-280 - Expression-index-for-the-case-insensitive-entitytags-sweep.md
@@ -1,0 +1,19 @@
+---
+id: TASK-280
+title: 'Expression index for the case-insensitive entity_tags sweep'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels: []
+dependencies: []
+ordinal: 280000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Expression index for the case-insensitive entity_tags sweep — Account deletion's fact sweep (`DELETE FROM memory_facts f WHERE EXISTS (SELECT 1 FROM unnest(f.entity_tags) t(tag) WHERE lower(t.tag) = ANY($1::text[]))`) seq-scans memory_facts — fine at current scale, owner-accepted. **Fix shape**: GIN expression index over lowered tags (e.g. index on `(SELECT array_agg(lower(t)) FROM unnest(entity_tags) t)` via an immutable helper, or normalize tags to lowercase at write time and use a plain GIN + `@>`). Index must land with the query per 03-database. **Promote when**: memory_facts >~100k rows or observed sweep slowness in the deletion-duration logs. Surfaced 2026-07-15 (PR-B design D3).
+
+**Why:** Deletion is rare; a write-path tax on every fact insert needs scale evidence first.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-281 - Async-account-deletion-promotion-trigger.md
+++ b/tracker/tasks/task-281 - Async-account-deletion-promotion-trigger.md
@@ -1,0 +1,19 @@
+---
+id: TASK-281
+title: 'Async account-deletion promotion trigger'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels: []
+dependencies: []
+ordinal: 281000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Async account-deletion promotion trigger — Deletion runs synchronously in one 60s-timeout transaction (owner-decided: atomicity beats a job that could leave a half-deleted account); the route logs completion via the ACCOUNT DELETED warn line. **Fix shape**: promote to a queued job with progress reporting ONLY if real deletions approach the interaction window. **Promote when**: logged deletion duration p95 >10s. Surfaced 2026-07-15 (PR-B design D1).
+
+**Why:** The transaction is the correctness win; async is a latency optimization with a measurable trigger.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-282 - Export-v2-leftovers-raw-usage-logs-avatar-binaries-on-request.md
+++ b/tracker/tasks/task-282 - Export-v2-leftovers-raw-usage-logs-avatar-binaries-on-request.md
@@ -1,0 +1,19 @@
+---
+id: TASK-282
+title: 'Export v2 leftovers: raw usage logs + avatar binaries on request'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels: []
+dependencies: []
+ordinal: 282000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Export v2 leftovers: raw usage logs + avatar binaries on request — The account export ships an aggregate usage summary and excludes avatar/voice binaries (disclosed in the README). If a user asks for raw per-request usage rows or their uploaded binaries, extend the assembler — the ZIP shape now makes both cheap to add as extra files. **Promote when**: a user asks. Surfaced 2026-07-15 (export v2 scope cut).
+
+**Why:** Disclosed exclusions with zero demand yet; the ZIP layout keeps the door open.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-283 - Entity-tag-erasure-sweep-is-exact-match.md
+++ b/tracker/tasks/task-283 - Entity-tag-erasure-sweep-is-exact-match.md
@@ -1,0 +1,20 @@
+---
+id: TASK-283
+title: 'Entity-tag erasure sweep is exact-match'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 283000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Entity-tag erasure sweep is exact-match — disclose or widen — Account deletion's facts-about-you sweep matches `user:` tags against username + persona names + preferred names (lowercased, exact). Free-text model tags using a nickname/variant ("Ali" for "Alice") under OTHER users' scopes survive "delete everything about me" (#1655 r2 obs 1 — inherent to free-text tagging, not a coding bug). **Fix shape**: (a) one disclosure line in the privacy policy's erasure section + the delete warning embed ("references to you under nicknames other users' characters coined may persist"), and/or (b) widen the sweep (fuzzy/trigram match or an alias table) — needs design; owner already accepted exact-name collateral, fuzzy raises the false-positive stakes. **Promote when**: the legal docs' finalization pass (contact-method/effective-date fill-in) — the disclosure belongs in that edit; or a real erasure request arrives. Surfaced 2026-07-15 (#1655 r2).
+
+**Why:** The erasure right must not overclaim; a one-line disclosure is the honest floor.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-284 - Feedback-gate-values-are-code-constants.md
+++ b/tracker/tasks/task-284 - Feedback-gate-values-are-code-constants.md
@@ -1,0 +1,22 @@
+---
+id: TASK-284
+title: 'Feedback gate values are code constants'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels:
+  - 'area:common-types'
+  - 'area:docs'
+  - 'area:backlog'
+dependencies: []
+ordinal: 284000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Feedback gate values are code constants — runtime-config them on second retune — `FEEDBACK_LIMITS` (300s cooldown / 5 daily / 7d dedupe window) ships as deliberate constants in common-types. If the owner retunes them more than once, fold them into the admin-settings runtime config (the accepted [`admin-runtime-settings`](../../docs/proposals/backlog/admin-runtime-settings.md) proposal's disposition table is the home). **Promote when**: the second retune request. Surfaced 2026-07-15 (PR-4 build).
+
+**Why:** One retune is a constant edit; two is a knob wanting a dashboard.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-285 - Feedback-dedupe-check-then-insert-can-race-under-concurrency.md
+++ b/tracker/tasks/task-285 - Feedback-dedupe-check-then-insert-can-race-under-concurrency.md
@@ -1,0 +1,21 @@
+---
+id: TASK-285
+title: 'Feedback dedupe check-then-insert can race under concurrency'
+status: To Do
+assignee: []
+created_date: '2026-07-15 00:00'
+labels:
+  - 'area:redis'
+  - 'origin:review'
+dependencies: []
+ordinal: 285000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Feedback dedupe check-then-insert can race under concurrency — The intake's near-dup gate is `findFirst` → `create` with no transaction or unique constraint (the `[userId, contentHash]` index is non-unique because legitimate resubmission after the 7-day window must insert the same hash) — two CONCURRENT identical submissions can both pass the read and double-insert (#1656 review; same accepted TOCTOU shape as FreeTierRequestQuota). Bounded by the 5/day attempt cap; sequential retries are absorbed correctly. **Fix shape** if it ever matters: short-lived Redis lock on the discordId held across the gate sequence, or a time-bucketed unique key. **Promote when**: duplicate rows actually observed in user_feedback. Surfaced 2026-07-15 (#1656 review).
+
+**Why:** Abuse-gate surface, not billing/integrity — the cap bounds the damage to noise.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-286 - Notification-eligibility-refinements-beyond-the-deliberate-use-gate-a-activity-r.md
+++ b/tracker/tasks/task-286 - Notification-eligibility-refinements-beyond-the-deliberate-use-gate-a-activity-r.md
@@ -1,0 +1,19 @@
+---
+id: TASK-286
+title: 'Notification-eligibility refinements beyond the deliberate-use gate: (a) activity recency…'
+status: To Do
+assignee: []
+created_date: '2026-07-17 00:00'
+labels: []
+dependencies: []
+ordinal: 286000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-17 (community feedback, Mythica in Elephant in the Room; owner: "future refinement" / "under consideration") — Notification-eligibility refinements beyond the deliberate-use gate: (a) **activity recency** — limit release DMs to accounts with ≥X uses in the last Y days (UsageLog already carries the timestamps; dormant one-time users arguably shouldn't get DMs forever); (b) **interaction-surface relevance** — server-only users "might not care if you updated it, long as it works"; consider whether DM-usage should weight the default, or whether this is over-segmentation. Both are product-taste calls on top of the shipped gate, not correctness gaps — the current gate already fails toward the defensible audience. **Promote when**: post-beta.167 blast feedback suggests the ~117 audience is still too broad, or next notifications-eligibility touch.
+
+**Why:** The incident fix drew the line at "real user"; these refine WHERE among real users the line sits — owner explicitly parked both for later.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-287 - eslint-on-editsh-runs-a-synchronous-pnpm-exec-eslint-binary-resolution-flat-conf.md
+++ b/tracker/tasks/task-287 - eslint-on-editsh-runs-a-synchronous-pnpm-exec-eslint-binary-resolution-flat-conf.md
@@ -1,0 +1,20 @@
+---
+id: TASK-287
+title: 'eslint-on-edit.sh runs a synchronous pnpm exec eslint (binary resolution + flat-config…'
+status: To Do
+assignee: []
+created_date: '2026-07-17 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 287000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-17 (#1687 r2 observation) — `eslint-on-edit.sh` runs a synchronous `pnpm exec eslint` (binary resolution + flat-config load) on every TS Edit/Write; no debounce or skip-if-recently-linted. Advisory, fail-open, output-bounded — acceptable today. **Fix shape**: debounce by file+mtime. **`--cache` is RULED OUT — measured 2026-07-24 and disproved**: ESLint's cache is keyed on the linted TARGET, and this hook only ever lints the file that was just edited, so the entry is always stale and can never hit (4839/4787/4707ms without vs 4778/4899/4795ms with, target touched each run; the cache is worth ~2.5x only on an UNCHANGED target, which this shape never produces). It was added on that basis and reverted in #1783; `eslint-on-edit.sh` now carries a comment so it isn't re-added. **Promote when**: edit latency becomes noticeable in practice on the Deck.
+
+**Why:** The in-session feedback is worth some latency; a cache/debounce is cheap if the tax ever shows.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-288 - failedtransient-release-DMs-have-no-retry-path-the-incomplete-broadcast-resweep-.md
+++ b/tracker/tasks/task-288 - failedtransient-release-DMs-have-no-retry-path-the-incomplete-broadcast-resweep-.md
@@ -1,0 +1,20 @@
+---
+id: TASK-288
+title: 'failed_transient release DMs have no retry path: the incomplete-broadcast resweep only…'
+status: To Do
+assignee: []
+created_date: '2026-07-16 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 288000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-16 (#1683 r3 observation) — `failed_transient` release DMs have no retry path: the incomplete-broadcast resweep only re-enqueues `pending` rows, so a transient Discord/network blip during a blast means that one user silently never gets the release note (the dmErrorClassifier doc's promised "future retry sweep" was never built; retention then purges the row at 90d as settled). **Fix shape**: extend the resweep to also re-enqueue `failed_transient` rows (needs a per-row attempt bound so a permanent-ish transient doesn't retry forever — e.g. flip to failed_permanent after N resweep retries), or fold into a dedicated retry pass. **Trigger technically fired 2026-07-17** (first blast: failedTransient=26) — but ALL 26 were discord-50278 (no mutual guilds — durable, not retryable; misclassification fixed via the now.md Quick Win). Zero genuinely-transient failures observed yet, so the retry pass stays parked. **Promote when**: a tally shows nonzero failedTransient that is NOT a misclassified durable code.
+
+**Why:** Transient = retryable by definition; today it's terminal in practice, just invisibly.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-289 - the-release-broadcast-eligibility-scan-resolveEligibleRecipients-notifyEnabled-….md
+++ b/tracker/tasks/task-289 - the-release-broadcast-eligibility-scan-resolveEligibleRecipients-notifyEnabled-….md
@@ -1,0 +1,20 @@
+---
+id: TASK-289
+title: 'the release-broadcast eligibility scan (resolveEligibleRecipients: notifyEnabled +…'
+status: To Do
+assignee: []
+created_date: '2026-07-16 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 289000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-16 (#1679 r2 observation) — the release-broadcast eligibility scan (`resolveEligibleRecipients`: `notifyEnabled` + `notifyOptedInAt` + `notifyLevel`) has no backing index on `users` — full-table scan, once per release. Correct-as-is at current scale (~hundreds of rows; an index would tax every user-row write for a query that runs a few times a month). **Fix shape**: partial index (e.g. on `notify_level` WHERE `notify_enabled AND notify_opted_in_at IS NOT NULL`), landing WITH the query per 03-database. Same disposition for the retention job's daily `release_delivery_log` sweep (#1683 r1 obs: filters `createdAt`+`status`, only `[releaseId,userId]`/`[userId]` indexes exist — full-table scan, fine at ~hundreds of rows/release). **Promote when**: users table >~50k rows, delivery-log >~100k rows, or broadcast-enqueue latency becomes visible in logs.
+
+**Why:** Index-ships-with-its-query cuts both ways: no scale evidence yet, write-path tax is real, trigger is measurable. Same scale trigger for the resweep wedge heuristic itself (#1683 r5): a genuinely slow >30min blast (thousands of recipients) would be re-enqueued hourly until drained — harmless (pre-filter) but wasteful; revisit the threshold or add an in-flight check alongside the index work.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-29 - Comment-withParallelRetry-is-a-no-op-on-the-vision-fallback-path.md
+++ b/tracker/tasks/task-29 - Comment-withParallelRetry-is-a-no-op-on-the-vision-fallback-path.md
@@ -1,0 +1,20 @@
+---
+id: TASK-29
+title: 'Comment: withParallelRetry is a no-op on the vision-fallback path'
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 29000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Comment: `withParallelRetry` is a no-op on the vision-fallback path
+
+**Why:** `MultimodalProcessor.processAttachments` still wraps `processSingleAttachment` in `withParallelRetry`, but on the Phase-4 path `describeImageWithFallback` never throws by contract — the outer retry can never fire. Harmless, but a future reader will misattribute where retries happen. **Fix shape**: one comment at the wrap site noting the fallback-loop path retries internally (tier loop) and the outer wrapper only covers non-vision attachment types. **Promote when**: next touching MultimodalProcessor. Surfaced 2026-07-02 (release #1439 holistic review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-290 - hard-delete-customId-overflow-for-3050-char-slugs….md
+++ b/tracker/tasks/task-290 - hard-delete-customId-overflow-for-3050-char-slugs….md
@@ -1,0 +1,20 @@
+---
+id: TASK-290
+title: 'hard-delete customId overflow for 30–50-char slugs:…'
+status: To Do
+assignee: []
+created_date: '2026-07-17 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 290000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-17 (#1697 r1, pre-existing class) — hard-delete customId overflow for 30–50-char slugs: `history::destructive::…::{slug}|{channelId}` fits ≤29-char slugs in Discord's 100-char customId limit, but `SLUG_MAX_LENGTH` is 50 — a long-slugged character makes `buildDestructiveWarning` throw at `setCustomId`. Pre-dates #1697 (the invoker-segment design that worsened it was reverted same-PR). **Fix shape**: move entityId to server-side state keyed by a short token (the memory/purge `issuePurgeToken` handshake is the in-repo precedent). **Promote when**: a long-slug hard-delete report, or PR-1b/PR-3's server-side-state work touches the flow.
+
+**Why:** The failure is a synchronous throw, not a degraded reply — invisible until someone hits it.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-291 - bot-client-has-ZERO-Discord-shard-lifecycle-observability-no….md
+++ b/tracker/tasks/task-291 - bot-client-has-ZERO-Discord-shard-lifecycle-observability-no….md
@@ -1,0 +1,20 @@
+---
+id: TASK-291
+title: 'bot-client has ZERO Discord shard-lifecycle observability: no…'
+status: To Do
+assignee: []
+created_date: '2026-07-18 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 291000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-18 (dev autocomplete outage, ~02:33–04:25Z) — bot-client has ZERO Discord shard-lifecycle observability: no `shardDisconnect`/`shardResume`/`shardError`/`invalidated` listeners exist (grep-verified), so a silently dead/zombied gateway websocket is invisible — the process looks healthy, logs go quiet, and every interaction (incl. autocomplete) vanishes without a trace. Runtime evidence: bot booted clean 02:33Z, emitted nothing for ~2h while the owner actively retried autocomplete (gateway alive with zero requests → handler never ran); redeploy forced a fresh connection and **CURED it (owner-confirmed 2026-07-18, ~04:30Z)** — the restart-cures signature. Mechanism = suspected zombied ws (evidence-consistent incl. the cure, not directly observed — the missing listeners are exactly why it can't be observed). **Fix shape**: register shard-lifecycle listeners with structured logs (disconnect code, resume/reconnect events, `invalidated` fatal); consider a liveness watchdog (no gateway event in N min while guilds > 0 → log loud / self-heal). May also illuminate the "post-reconnect DM subscription loss" asymmetry from the DM-troubleshooting reference. **Promote when**: next bot-client boot-path touch, or a second silent-outage occurrence.
+
+**Why:** A wedge class that presents as "user error" until someone pulls three services' logs; one listener block makes it diagnosable in one glance.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-292 - my-aliases-shadow-probe-is-APPROXIMATE-at-extreme-scale-the-batched-personalityf.md
+++ b/tracker/tasks/task-292 - my-aliases-shadow-probe-is-APPROXIMATE-at-extreme-scale-the-batched-personalityf.md
@@ -1,0 +1,20 @@
+---
+id: TASK-292
+title: 'my-aliases shadow probe is APPROXIMATE at extreme scale: the batched personality.findMany…'
+status: To Do
+assignee: []
+created_date: '2026-07-18 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 292000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-18 (#1702 r1 observation) — my-aliases shadow probe is APPROXIMATE at extreme scale: the batched `personality.findMany` match query is bounded at `take: MAX_LIST_ROWS` (100), but one alias text can match multiple rows (name AND slug, or several same-named characters), so a caller with >100 visible name/slug collisions could get a false `shadowed: false` on later aliases. Documented in-code at the query; needs ~100+ colliding characters visible to ONE caller — far beyond current scale. **Fix shape**: bump the bound (2× alias count) or aggregate per-alias existence instead of row-capping. **Promote when**: the PR-4 browse ⚠️ badge under-reports in practice, or any caller's visible character fleet approaches triple digits.
+
+**Why:** Only affects the caller's own badge accuracy — never privacy; the in-code comment marks the spot.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-293 - reverse-shadow-warning-omits-the-callers-OWN-personal-aliases-renaming-your-char.md
+++ b/tracker/tasks/task-293 - reverse-shadow-warning-omits-the-callers-OWN-personal-aliases-renaming-your-char.md
@@ -1,0 +1,20 @@
+---
+id: TASK-293
+title: "reverse-shadow warning omits the caller's OWN personal aliases: renaming your character…"
+status: To Do
+assignee: []
+created_date: '2026-07-18 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 293000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-18 (#1702 r2 observation) — reverse-shadow warning omits the caller's OWN personal aliases: renaming your character to match your own personal alias silently kills that alias with no proactive nudge (the my-aliases browse shows `shadowed: true` after the fact, so it's discoverable, just not at rename time). Global rows warn; personal rows were excluded for privacy — but the CALLER's own rows have no privacy concern. **Fix shape**: extend the create/rename shadow probe with a second query over the caller's own personal rows (`userId = caller`), merged into `shadowedAliases`. **Promote when**: next reverse-shadow/alias-warning touch, or an owner report of a silently-dead personal alias.
+
+**Why:** Caller's own data — the privacy rationale doesn't apply to it; two-line query addition.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-294 - footer-on-empty-suppression-code-point-safe-metadata-truncation-models-badge-leg.md
+++ b/tracker/tasks/task-294 - footer-on-empty-suppression-code-point-safe-metadata-truncation-models-badge-leg.md
@@ -1,0 +1,20 @@
+---
+id: TASK-294
+title: 'footer-on-empty suppression, code-point-safe metadata truncation, models badge-legend…'
+status: To Do
+assignee: []
+created_date: '2026-07-18 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 294000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-18 (#1709 r3/r4 observations; items a–c SHIPPED in PR-4b-2b — footer-on-empty suppression, code-point-safe metadata truncation, models badge-legend completion) — remaining item: **browse pagination failure is silent** — deferUpdate then keep-current-view on fetch failure is the deliberate cross-surface pattern (character-browse-documented), but an ephemeral error followUp is the D-family answer; decide ONCE at the builder/catalog level, not per surface. **Promote when**: the epic's error-state/catalog pass, or the next browse-pagination touch.
+
+**Why:** The pattern is consistent today, just silently so — the decision deserves one deliberate call, not six drifting ones.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-295 - releasepublish-immediately-after-the-release-merge-races-the-prod-deploy-window-.md
+++ b/tracker/tasks/task-295 - releasepublish-immediately-after-the-release-merge-races-the-prod-deploy-window-.md
@@ -1,0 +1,20 @@
+---
+id: TASK-295
+title: 'release:publish immediately after the release merge races the prod deploy window: all…'
+status: To Do
+assignee: []
+created_date: '2026-07-18 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 295000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-18 (beta.169 publish) — `release:publish` immediately after the release merge races the prod deploy window: all three beta.169 release webhooks (published/created/released) got **502 at Railway's edge** during the container handoff (GitHub's delivery log confirms; GitHub never retries), and the DM blast arrived via the :41 hourly reconcile sweep instead (10-min lag; recipients=1, worked exactly as designed). **Decide + document**: either (a) note in the git-workflow skill's publish step that the immediate-publish race is known-benign and the DM may lag ≤1h via reconcile, or (b) have `release:publish` (or the skill) wait for the prod gateway deploy to settle before creating the release for an immediate DM. (a) is zero-code; (b) is nicer UX for the announce. Skill edits are review-gated — batch with the next skill/tooling touch. **Promote when**: next release-flow touch, or if a future release's DM lag causes real confusion.
+
+**Why:** The reconcile absorbed it perfectly — this is documentation of a benign race, not a bug fix.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-296 - the-three-direct-pagination-handlers-memorybrowsets-handleBrowsePagination….md
+++ b/tracker/tasks/task-296 - the-three-direct-pagination-handlers-memorybrowsets-handleBrowsePagination….md
@@ -1,0 +1,20 @@
+---
+id: TASK-296
+title: 'the three direct pagination handlers (memory/browse.ts handleBrowsePagination,…'
+status: To Do
+assignee: []
+created_date: '2026-07-18 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 296000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-18 (#1710 r1, the stale-page race) — the three direct pagination handlers (`memory/browse.ts` `handleBrowsePagination`, `factsBrowse.ts` `handleFactsPagination`, `search.ts` `handleSearchPagination`) fetch the requested offset raw; only the refresh-after-delete paths route through `fetchPageWithEmptyFallback`'s step-back. The builder now degrades a stale empty page to the empty state (shipped same PR), but the SOURCE fix is routing those three through the same fallback so a stale click lands on the last real page instead of an empty-state screen. **Promote when**: next memory-browse handler touch, or a user report of the empty-state-on-stale-click annoyance.
+
+**Why:** The builder fix makes the race benign; the fallback routing would make it invisible.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-297 - narrowed-extractSubmission-catch-shared-truncateByCodePoints-across-all-four-pre.md
+++ b/tracker/tasks/task-297 - narrowed-extractSubmission-catch-shared-truncateByCodePoints-across-all-four-pre.md
@@ -1,0 +1,20 @@
+---
+id: TASK-297
+title: 'narrowed extractSubmission catch, shared truncateByCodePoints across all four prefill…'
+status: To Do
+assignee: []
+created_date: '2026-07-19 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 297000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-19 (#1711 r2 + #1713/#1714 reviews; items a–c SHIPPED in #1714 — narrowed extractSubmission catch, shared `truncateByCodePoints` across all four prefill sites, toolkit type split) — remaining modal-toolkit item, one trigger: (d) **non-text validation + submission-path convergence** — `validateSubmission` covers text only, AND the live submission path still reads through `extractModalValues`' blanket `catch {}` (the narrowed catch protects a path with zero production callers; safe today because every live field is text-kind, whose only throwable is the skippable field-not-found). When the first non-text field consumer lands: extend per-kind validation AND converge submission-reading onto `extractSubmission` (retiring `extractModalValues`' catch-all) in the same slice. **Promote when**: first non-text modal field consumer.
+
+**Why:** Two implementations of one operation with different hardening levels is a temporary state — the first real non-text consumer is the forcing function.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-298 - buildEntityDetailCards-notice-vs-cap-invariant-is-documented-but-unenforced-a….md
+++ b/tracker/tasks/task-298 - buildEntityDetailCards-notice-vs-cap-invariant-is-documented-but-unenforced-a….md
@@ -1,0 +1,20 @@
+---
+id: TASK-298
+title: "buildEntityDetailCard's notice-vs-cap invariant is documented but unenforced: a…"
+status: To Do
+assignee: []
+created_date: '2026-07-19 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 298000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-19 (#1719 r2+r3 observations) — `buildEntityDetailCard`'s notice-vs-cap invariant is documented but unenforced: a `truncationNotice` longer than `descriptionCap` floors the cut at 0 and returns just the notice, which can itself exceed the cap — contradicting the "provably ≤ cap" contract. Safe today (only caller: ~90-char notice vs 3800 cap; the pairing itself is type-forced). **Fix shape**: a dev-time throw (or clamp) in `resolveDescription` when `[...notice].length >= descriptionCap`, + one test. **Promote when**: any new `descriptionCap` caller lands, especially with a small cap.
+
+**Why:** The type union forces the pair; this closes the remaining size relation the types can't express.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-299 - characterexportts79-builds-the-public-avatar-URL-GATEWAYURLavatarsslugpng….md
+++ b/tracker/tasks/task-299 - characterexportts79-builds-the-public-avatar-URL-GATEWAYURLavatarsslugpng….md
@@ -1,0 +1,22 @@
+---
+id: TASK-299
+title: 'character/export.ts:79 builds the public avatar URL (${GATEWAY_URL}/avatars/${slug}.png)…'
+status: To Do
+assignee: []
+created_date: '2026-07-19 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:common-types'
+  - 'origin:review'
+dependencies: []
+ordinal: 299000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-19 (#1726 review nit) — `character/export.ts:79` builds the public avatar URL (`${GATEWAY_URL}/avatars/${slug}.png`) WITHOUT `encodeURIComponent` on the slug, unlike the V2 pilot's `viewV2.viewAvatarUrl` which encodes. Not exploitable (`SLUG_PATTERN` constrains slugs server-side) but inconsistent defense-in-depth, and 00-critical's SSRF rule says encode ALL dynamic path segments regardless of source trust. ~~**Fix shape**: wrap the slug in `encodeURIComponent`~~ ✅ DONE (both live sites: `character/export.ts` + identity's `deriveAvatarUrl`). REMAINING: extract a shared avatar-URL helper so the sites can't drift — deferred because the two shapes differ (internal URL + no cache-buster vs public URL + timestamp) AND live in different packages (bot-client vs identity), so sharing means a common-types move, not a local extraction. Note the row's "third site" is stale: `viewV2.viewAvatarUrl` no longer builds a URL, it returns `character.avatarUrl`. THIRD site (beta.172 release review): identity's `deriveAvatarUrl` itself concatenates the slug unencoded — the canonical deriver has the same gap, mitigated only by creation-time slug validation. The shared-helper fix covers all three. **Promote when**: next avatar-URL touch, or if slug validation ever loosens.
+
+**Why:** One-line alignment; the shared-helper variant kills the drift class.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-3 - add-a-short-rule-to-03-databasemd-a-high-frequency-or-non-semantic-write-to-a….md
+++ b/tracker/tasks/task-3 - add-a-short-rule-to-03-databasemd-a-high-frequency-or-non-semantic-write-to-a….md
@@ -1,0 +1,22 @@
+---
+id: TASK-3
+title: 'add a short rule to 03-database.md: a high-frequency or non-semantic write to a…'
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:00'
+labels:
+  - 'area:db'
+  - 'area:process'
+  - 'origin:review'
+dependencies: []
+ordinal: 3000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-22 (retention 1b, #1765 review) — add a short rule to `03-database.md`: a **high-frequency or non-semantic write to a sync-tracked table** (`syncTables.ts`) via the Prisma client auto-bumps `updated_at` (via `@updatedAt`), which `DatabaseSyncService` uses as the dev↔prod **last-write-wins conflict resolver** — so the write silently makes that env's rows "win" and can clobber the other env's edits on the next sync. The retention `lastActiveAt` stamp hit exactly this (hourly per active user) and was fixed by writing via `$executeRaw` (bypasses `@updatedAt`, leaves `updated_at` untouched). **Fix shape**: one paragraph near `03-database.md`'s sync/`updated_at` material — "for a high-frequency or non-semantic column on a sync-tracked table, write it via raw SQL so it doesn't bump `updated_at`." **Promote when**: next `.claude/rules` PR, or the next stamp/counter/last-seen field added to a sync-tracked table.
+
+**Why:** Subtle cross-system side-effect = silent sync data loss; the code comment documents it at the one site, a rule catches the class.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-30 - Bootstrap-reseed-can-override-an-admin-nulled-TTS-default-pointer-extreme-sequen.md
+++ b/tracker/tasks/task-30 - Bootstrap-reseed-can-override-an-admin-nulled-TTS-default-pointer-extreme-sequen.md
@@ -1,0 +1,21 @@
+---
+id: TASK-30
+title: 'Bootstrap reseed can override an admin-nulled TTS default pointer (extreme sequence)'
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels:
+  - 'area:voice'
+  - 'origin:review'
+dependencies: []
+ordinal: 30000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Bootstrap reseed can override an admin-nulled TTS default pointer (extreme sequence)
+
+**Why:** If an admin explicitly NULLs a TTS default pointer AND all global TTS configs are later deleted (only possible once the pointer is null — the delete guard no longer blocks), the next `list(GLOBAL)` re-triggers `bootstrapTtsSystemGlobalsIfNeeded`, which reseeds BOTH pointers to kyutai — silently overriding the earlier explicit-null choice. Accepted tradeoff for now (a wiped-globals fresh state SHOULD converge to working defaults; the sequence is extreme), but undocumented. **Fix shape**: one comment at `seedDefaultPointersIfUnset` noting the tradeoff, or a sentinel distinguishing admin-nulled from never-set. **Promote when**: explicit-null pointer semantics become a real admin workflow. Surfaced 2026-07-02 (#1446 round-2 review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-300 - mutation-tests-matrix-split-parked-fan-out-one-CI-leg-per-tracked-package….md
+++ b/tracker/tasks/task-300 - mutation-tests-matrix-split-parked-fan-out-one-CI-leg-per-tracked-package….md
@@ -1,0 +1,20 @@
+---
+id: TASK-300
+title: 'mutation-tests matrix split parked: fan out one CI leg per tracked package…'
+status: To Do
+assignee: []
+created_date: '2026-07-19 00:00'
+labels:
+  - 'area:common-types'
+dependencies: []
+ordinal: 300000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-19 (CI-bottleneck assessment, owner-approved option 1 = the changed-aware gate) — mutation-tests matrix split parked: fan out one CI leg per tracked package (`mutation:check` fans in on report artifacts), capping worst-case wall-clock at setup + slowest package (~3min vs ~7min sequential) at the cost of 5× setup overhead per run. Not worth the plumbing at 5 tracked packages now that the gate skips untouched-surface PRs entirely. **Promote when**: a 6th package joins `MUTATED_PACKAGES` (sequential wall-clock grows linearly; common-types would blow past 10min), or gate-passing PRs become the common case.
+
+**Why:** The gate fixes the common case (untouched surface); the matrix caps the worst case — only needed when the worst case grows.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-301 - PersonalitySummarySchema-listbrowse-responses-carries-hasAvatar-but-not-avatarUr.md
+++ b/tracker/tasks/task-301 - PersonalitySummarySchema-listbrowse-responses-carries-hasAvatar-but-not-avatarUr.md
@@ -1,0 +1,21 @@
+---
+id: TASK-301
+title: 'PersonalitySummarySchema (list/browse responses) carries hasAvatar but not avatarUrl;…'
+status: To Do
+assignee: []
+created_date: '2026-07-19 00:00'
+labels:
+  - 'area:bot-client'
+  - 'origin:review'
+dependencies: []
+ordinal: 301000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-19 (#1730 review observation) — `PersonalitySummarySchema` (list/browse responses) carries `hasAvatar` but not `avatarUrl`; fine today (no browse surface renders thumbnails), but a future browse-thumbnail feature reaching for `hasAvatar` and hand-building a URL from bot-client's internal gateway base would recreate the exact broken-image bug class #1730 fixed (Discord's media proxy can't reach the internal hostname). **Fix shape**: extend `PersonalitySummarySchema` + the list formatter with the same gateway-derived `avatarUrl` field; never hand-build client-side. **Promote when**: any browse/list surface wants avatar thumbnails.
+
+**Why:** The bug class has bitten twice; the schema field is the structural fix — this row makes the third occurrence impossible to write innocently.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-302 - the-claudehooksprobesh-exit-code-harnesses-cwd-drift-promise-ledger….md
+++ b/tracker/tasks/task-302 - the-claudehooksprobesh-exit-code-harnesses-cwd-drift-promise-ledger….md
@@ -1,0 +1,22 @@
+---
+id: TASK-302
+title: 'the .claude/hooks/*.probe.sh exit-code harnesses (cwd-drift, promise-ledger,…'
+status: To Do
+assignee: []
+created_date: '2026-07-20 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:process'
+  - 'origin:review'
+dependencies: []
+ordinal: 302000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-20 (#1732 review observation) — the `.claude/hooks/*.probe.sh` exit-code harnesses (cwd-drift, promise-ledger, develop-code-commit-guard) are "run manually after editing the hook," not wired into `pnpm quality`/CI — a future hook edit could silently regress the guard with no safety net. Applies to the pre-existing develop-code-commit-guard.probe.sh too (not new to #1732). **Fix shape**: a lightweight gate that runs every `*.probe.sh` when any `.claude/hooks/*.sh` changed (a `guard:hook-probes` ops command in the lint job, or a pre-commit keyed on the hooks-dir diff). **Promote when**: next hook-script touch, or a probe-detectable regression slips through.
+
+**Why:** 05-tooling prefers structural enforcement over remembered manual steps; the probes exist but their execution is memory-dependent.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-303 - two-fake-optional-columns-the-audit-flags-as-always-passed-no-default….md
+++ b/tracker/tasks/task-303 - two-fake-optional-columns-the-audit-flags-as-always-passed-no-default….md
@@ -1,0 +1,20 @@
+---
+id: TASK-303
+title: 'two fake-optional columns the audit flags as always-passed-no-default:…'
+status: To Do
+assignee: []
+created_date: '2026-07-23 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 303000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-23 (retention 1c, `dev:schema-audit` run) — two fake-optional columns the audit flags as always-passed-no-default: `LlmDiagnosticLog.userId` (3/3 write sites pass a value) and `ExportJob.downloadToken` (4/4). The `?` is unused — every writer supplies a value and no `@default` justifies skipping it. **Fix shape**: verify each call site, then `ALTER COLUMN … SET NOT NULL` + drop the `?` in `schema.prisma` (one migration per column, or both together). Pre-existing; unrelated to retention, deferred because it needs a migration + call-site sweep (risky breadth for a 1c rider). **Promote when**: next migration on either table, or a schema-hardening pass.
+
+**Why:** Fake-optional columns are the exact bug-class `schema-audit` exists to catch; tracking them durably beats an ad-hoc tool run nobody re-runs.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-304 - the-sync-config-completeness-tests-schema-parser-schemaTableNames-in….md
+++ b/tracker/tasks/task-304 - the-sync-config-completeness-tests-schema-parser-schemaTableNames-in….md
@@ -1,0 +1,21 @@
+---
+id: TASK-304
+title: "the sync-config completeness test's schema parser (schemaTableNames in…"
+status: To Do
+assignee: []
+created_date: '2026-07-20 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 304000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-20 (#1733 review observation) — the sync-config completeness test's schema parser (`schemaTableNames` in `syncTables.test.ts`) assumes every model's closing brace is unindented on its own line (documented in-code). A `prisma format` or schema-wide style reformat could change that and make the parser silently UNDER-count tables — the test would stop guarding (fail-safe-ish: no runtime bug, but a false sense of completeness). **Fix shape**: parse via Prisma DMMF, or add a sanity assert that the parsed table count equals the `model` keyword count. **Promote when**: a schema reformat lands, or the completeness test ever needs to survive a brace-style change.
+
+**Why:** Documented assumption; the fix trades the fast pure-regex test for DMMF robustness — only worth it if the assumption actually breaks.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-305 - every-routesinternal-handler-sends-via-sendCustomSuccess-instead-of-the-preferre.md
+++ b/tracker/tasks/task-305 - every-routesinternal-handler-sends-via-sendCustomSuccess-instead-of-the-preferre.md
@@ -1,0 +1,20 @@
+---
+id: TASK-305
+title: 'every routes/internal/* handler sends via sendCustomSuccess instead of the preferred…'
+status: To Do
+assignee: []
+created_date: '2026-07-23 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 305000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-23 (retention 1d, #1767 review) — every `routes/internal/*` handler sends via `sendCustomSuccess` instead of the preferred `sendContractSuccess`, which pins the response to the manifest's declared `output` schema at compile time (`responseHelpers.ts` documents the preference for routes with a manifest entry). Class-wide: `dmSessionSet`, `usersRecent`, `usersActivity`, `secretRotationStatus`, and the rest. **Fix shape**: sweep the internal handlers to `sendContractSuccess(res, <Schema>, data)` — a mechanical swap that adds compile-time output-schema pinning. **Promote when**: next internal-routes touch, or a response-shape drift bug.
+
+**Why:** Reviewer flagged it as a class-wide follow-up sweep, not a one-off; fixing only the new route would deviate from the family.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-306 - all-acknowledged-trade-offs-of-the-fail-open-design-none-a-false-block-a-the….md
+++ b/tracker/tasks/task-306 - all-acknowledged-trade-offs-of-the-fail-open-design-none-a-false-block-a-the….md
@@ -1,0 +1,20 @@
+---
+id: TASK-306
+title: 'all acknowledged trade-offs of the fail-open design, none a false-block: (a) the…'
+status: To Do
+assignee: []
+created_date: '2026-07-20 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 306000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-20 (#1732 review, three in-spec fail-safe gaps in `cwd-drift-guard.sh` + `promise-ledger-check.sh`) — all acknowledged trade-offs of the fail-open design, none a false-block: (a) the quote-strip that prevents false-blocking commit messages ALSO blinds the guard to a genuinely-quoted drifted pathspec (`git add "packages/x/y.ts"` from a subdir → stripped → allowed); (b) the `git -C` short-circuit substring-matches anywhere, so `git -C /other status && git add packages/x` from a drift waves the whole compound command through; (c) `promise-ledger-check.sh` re-reads+re-parses the full transcript JSONL every Stop event — O(transcript) per turn-end, grows with long/compacted sessions. **Fix shapes**: (a) scan the git subcommand's arg tokens instead of quote-stripping wholesale, or accept+comment; (b) evaluate `-C` per pipeline segment; (c) walk backward for the last user-turn boundary + last text block instead of a full forward pass. **Promote when**: a real drift mistake slips one of a/b, or turn-end latency from (c) becomes noticeable.
+
+**Why:** All fail-OPEN (miss a block), never false-block — in-spec for a narrow guard; refine only if a real miss or latency shows up.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-307 - the-bug-remediation-skill-eval-trigger-was-broadened-to-fire-at-the-FIRST-fix-of.md
+++ b/tracker/tasks/task-307 - the-bug-remediation-skill-eval-trigger-was-broadened-to-fire-at-the-FIRST-fix-of.md
@@ -1,0 +1,20 @@
+---
+id: TASK-307
+title: 'the bug-remediation skill-eval trigger was broadened to fire at the FIRST fix of a…'
+status: To Do
+assignee: []
+created_date: '2026-07-20 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 307000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-20 (#1731 r4 observation) — the bug-remediation skill-eval trigger was broadened to fire at the FIRST fix of a path-specific UI/flow bug (`delete/edit/create/browse/view button|flow|screen`, `doesn't show/appear`, `only shows after`). Intentionally broad so it fires on first-fix, not just recurrence — but if it fires on ordinary one-off UI bug reports often enough, the SKILL CHECK banner becomes noise the owner skims past, blunting the check-every-time effect. **Fix shape**: tighten the alternation (e.g. require a sibling-flow contrast like "after creation…after edit", or a component-family + malfunction pair) if it proves chatty. **Promote when**: the banner visibly over-fires on non-remediation prompts.
+
+**Why:** A too-eager nudge trains skim-past, which defeats the nudge — watch real firing frequency before tightening.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-308 - utilsoverrideBrowsets-is-unpaginated-it-pre-slices-to-the-25-option-select-cap-a.md
+++ b/tracker/tasks/task-308 - utilsoverrideBrowsets-is-unpaginated-it-pre-slices-to-the-25-option-select-cap-a.md
@@ -1,0 +1,20 @@
+---
+id: TASK-308
+title: 'utils/overrideBrowse.ts is unpaginated: it pre-slices to the 25-option select cap and…'
+status: To Do
+assignee: []
+created_date: '2026-07-20 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 308000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-20 (Phase 3 planning census) — `utils/overrideBrowse.ts` is unpaginated: it pre-slices to the 25-option select cap and footers "first 25 shown; use `/…clear` for the rest". Fine at current per-user override counts. **Fix shape**: adopt the browse builder's server-page mode (both consumers — settings-preset-override + voice-tts-override — share the one helper). **Promote when**: any user's override list exceeds 25, or the next overrideBrowse touch.
+
+**Why:** A disclosed cap with zero real-world hits; pagination is mechanical when the trigger fires.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-309 - models-browses-sort-toggle-button-uses-SORTDISPLAYdefault-while-the-ROUTER-badge.md
+++ b/tracker/tasks/task-309 - models-browses-sort-toggle-button-uses-SORTDISPLAYdefault-while-the-ROUTER-badge.md
@@ -1,0 +1,20 @@
+---
+id: TASK-309
+title: "/models browse's sort-toggle button uses 🔀 (SORT_DISPLAY.default) while the ROUTER badge…"
+status: To Do
+assignee: []
+created_date: '2026-07-20 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 309000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-20 (#1744 PR body + r2 review observation) — `/models browse`'s sort-toggle button uses 🔀 (`SORT_DISPLAY.default`) while the ROUTER badge is now registry-official 🔀 on the same screen: a control-register glyph and a badge-register glyph co-occur on one surface (same carve-out class as ⚠️, but those never share a screen). **Fix shape**: swap the sort button's glyph (↕️ or 🎯 — it means "usable first", not shuffle) — one character in `SORT_DISPLAY`. **Promote when**: PR-3/enforcement wave's vocabulary re-audit, or the next models-browse touch.
+
+**Why:** Button emoji are outside §2.2's letter; the confusion is real but redesigning controls mid-sweep was wrong scope — one-line fix at the next touch.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-31 - Vision-error-pattern-recall-watch-for-unanchored-provider-phrasings.md
+++ b/tracker/tasks/task-31 - Vision-error-pattern-recall-watch-for-unanchored-provider-phrasings.md
@@ -1,0 +1,19 @@
+---
+id: TASK-31
+title: 'Vision error-pattern recall: watch for unanchored provider phrasings'
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels: []
+dependencies: []
+ordinal: 31000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Vision error-pattern recall: watch for unanchored provider phrasings
+
+**Why:** The ERROR_DESCRIPTION_PATTERNS tightening traded recall for precision — an error phrased outside the anchors (e.g. "I don't have access to any image URL") now positively caches as a "valid" description for the 1h VISION_DESCRIPTION_TTL, blocking retries for that window. Acceptable (fixes a real currently-firing false positive; blast radius is one TTL). **Promote when**: a prod log shows an error-shaped description that `isLikelyErrorDescription` missed — add its phrasing to the anchored list in `visionDescriptionValidity.ts`. Surfaced 2026-07-02 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-310 - button-order-danger-lasts-chain-walker-when-the-LAST-executed-setStyle-uses-a….md
+++ b/tracker/tasks/task-310 - button-order-danger-lasts-chain-walker-when-the-LAST-executed-setStyle-uses-a….md
@@ -1,0 +1,20 @@
+---
+id: TASK-310
+title: "button-order-danger-last's chain walker: when the LAST-executed .setStyle(...) uses a…"
+status: To Do
+assignee: []
+created_date: '2026-07-20 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 310000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-20 (#1740 r2 observation) — `button-order-danger-last`'s chain walker: when the LAST-executed `.setStyle(...)` uses a non-literal argument (ternary/variable) while an EARLIER call in the same chain used a literal `ButtonStyle.Danger`, the walk skips the unresolvable outer call and classifies from the stale overridden literal — the runtime style is actually unknown. Not live anywhere today (the one dynamic-style site calls setStyle once). **Fix shape**: on the first-visited (last-executed) setStyle hit, if the argument is non-literal, mark the whole chain unresolvable (return null) instead of falling through; + a pin test. **Promote when**: the double-setStyle-with-dynamic-last shape appears in the codebase, or the rule produces a confusing false positive.
+
+**Why:** Guard precision on a shape that doesn't exist yet; the fix is 3 lines when the trigger fires.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-311 - helps-execute-routes-getting-started-explicitly-and-falls-through-to-the-command.md
+++ b/tracker/tasks/task-311 - helps-execute-routes-getting-started-explicitly-and-falls-through-to-the-command.md
@@ -1,0 +1,21 @@
+---
+id: TASK-311
+title: "/help's execute routes 'getting-started' explicitly and falls through to the commands…"
+status: To Do
+assignee: []
+created_date: '2026-07-21 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 311000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-21 (#1750 claude-review) — `/help`'s execute routes `'getting-started'` explicitly and falls through to the commands browser otherwise. Safe with exactly two subcommands (Discord guarantees one fires), but a third section (`faq`, `migration`) added without updating the branch silently lands in the commands browser instead of erroring. **Fix shape**: explicit `switch` over subcommand names with an unrouted-error default, in the same PR that adds the third section. **Promote when**: a third `/help` subcommand lands.
+
+**Why:** Preemptive exhaustiveness over two values is ceremony; the fix is 5 lines exactly when the trigger fires — reviewer and agent agreed "not worth doing now".
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-312 - history-has-no-browseview-users-run-correctivedestructive-commands-undo-clear….md
+++ b/tracker/tasks/task-312 - history-has-no-browseview-users-run-correctivedestructive-commands-undo-clear….md
@@ -1,0 +1,19 @@
+---
+id: TASK-312
+title: '/history has no browse/view: users run corrective/destructive commands (undo, clear,…'
+status: To Do
+assignee: []
+created_date: '2026-07-21 00:00'
+labels: []
+dependencies: []
+ordinal: 312000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-21 (walkthrough, Qwen 3.7 Max power-user finding) — `/history` has no `browse`/`view`: users run corrective/destructive commands (`undo`, `clear`, `purge`) without a way to inspect the stored rows first. **Fix shape**: `/history browse <character>` over the stored conversation rows (server-page mode of the shared browse builder). **Promote when**: a user reports deleting the wrong thing, or the next history-family feature touch.
+
+**Why:** Additive feature, not a rename — nothing forces it into the breaking window.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-313 - user-facing-bot-client-copy-hardcodes-the-Tzurot-brand-at-15-sites-voice-purgebr.md
+++ b/tracker/tasks/task-313 - user-facing-bot-client-copy-hardcodes-the-Tzurot-brand-at-15-sites-voice-purgebr.md
@@ -1,0 +1,20 @@
+---
+id: TASK-313
+title: 'user-facing bot-client copy hardcodes the "Tzurot" brand at ~15 sites (voice purge/browse…'
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 313000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-22 (owner, `/help getting-started` on dev) — user-facing bot-client copy hardcodes the "Tzurot" brand at ~15 sites (voice purge/browse copy, shapes import description, maintenance message, webhook name "Tzurot Personalities", `/help` command descriptions) — the dev app is Rotzot, so dev copy misbrands. The getting-started EMBED now brands from the runtime bot identity + `PUBLIC_SITE_URL`; the rest remain static. Constraint: registered command metadata is deploy-time static — env-driven descriptions would fork the manifest + component snapshots per environment. **Fix shape**: brand-neutral wording ("the bot", "cloned voices") where natural; runtime `client.user.username` where the surface is dynamic. **Promote when**: the next copy sweep touches these families, or a dev user reports confusion.
+
+**Why:** Dev-only cosmetic misbranding; prod copy is correct — not worth forking snapshots now.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-314 - the-website-services-Railway-watch-patterns-must-cover-every-Dockerfile-COPYd-co.md
+++ b/tracker/tasks/task-314 - the-website-services-Railway-watch-patterns-must-cover-every-Dockerfile-COPYd-co.md
@@ -1,0 +1,21 @@
+---
+id: TASK-314
+title: "the website service's Railway watch patterns must cover every Dockerfile-COPY'd content…"
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:00'
+labels:
+  - 'area:website'
+  - 'area:docs'
+dependencies: []
+ordinal: 314000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-22 (owner smoke: dev site served pre-rename docs) — the website service's Railway watch patterns must cover every Dockerfile-COPY'd content path; `docs/guides/**` + `docs/commands.md` were missing, so every docs push since the beta.173 version bump was SKIPPED (deploy-side staleness; the repo content was correct). Immediate fix = dashboard watch-pattern edit (both envs) + redeploy — Dockerfile now carries the invariant as a comment. **Fix shape (structural)**: Railway config-as-code (`services/website/railway.json` with `watchPatterns`) so the list is repo-reviewed and drift-proof; needs a one-time dashboard action to point the service at the config file. **Promote when**: the watch list drifts again, or the next website-service touch.
+
+**Why:** Dashboard edit fixes it today; config-as-code is the durable version but needs owner dashboard setup either way.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-315 - the-IsAdmin-brand-common-typesownerMiddleware-is-applied-to-ONE-function-today….md
+++ b/tracker/tasks/task-315 - the-IsAdmin-brand-common-typesownerMiddleware-is-applied-to-ONE-function-today….md
@@ -1,0 +1,21 @@
+---
+id: TASK-315
+title: 'the IsAdmin brand (common-types/ownerMiddleware) is applied to ONE function today:…'
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:00'
+labels:
+  - 'area:common-types'
+  - 'origin:review'
+dependencies: []
+ordinal: 315000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-22 (#1757 review) — the `IsAdmin` brand (common-types/ownerMiddleware) is applied to ONE function today: `getCharacterDashboardConfig`'s admin gate. `DashboardContext.isAdmin` and `isBotOwner`'s return stay plain `boolean` (deliberate — branding isBotOwner would churn ~40 mocks). Two thin spots: (a) a future admin-gated config for another entity (persona/preset/…) could reinvent a plain-`boolean` isAdmin param and re-open the canEdit-vs-isAdmin leak class — the next author should reuse `IsAdmin`, not a fresh boolean; (b) the `asIsAdmin` escape hatch can't stop `asIsAdmin(character.canEdit)` (JSDoc warns, but it's social). **Fix shape**: when the 2nd admin-gated entity config lands, type its gate `IsAdmin` and (if `asIsAdmin(` call sites multiply) consider an ESLint rule flagging `asIsAdmin(<expr containing canEdit>)`. **Promote when**: a second admin-gated dashboard/config function is added, or `asIsAdmin` grows past ~2 call sites.
+
+**Why:** One branded param today is enough; generalize when a second consumer proves the pattern.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-316 - createFreshRoutes-memory-fresh-routing-is-marked-Legacy…-preserved-for-existing….md
+++ b/tracker/tasks/task-316 - createFreshRoutes-memory-fresh-routing-is-marked-Legacy…-preserved-for-existing….md
@@ -1,0 +1,20 @@
+---
+id: TASK-316
+title: 'createFreshRoutes (memory fresh routing) is marked "Legacy… preserved for existing…'
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 316000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-22 (#1761 release-review) — `createFreshRoutes` (memory `fresh` routing) is marked "Legacy… preserved for existing wiring" but its JSDoc is ambiguous about which path prod actually mounts: the generated `mounts.ts` path vs. this factory. Risk: two routing paths silently drift, or one is unnoticed dead code. **Fix shape**: confirm which path is mounted in prod; delete the dead one (or clarify the JSDoc if both are intentionally live). **Promote when**: the next memory-routing touch, or a fresh/incognito route bug that could stem from path divergence.
+
+**Why:** Cheap to verify; ambiguous dual-path wiring is a latent maintenance trap, not a live bug.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-317 - bounding-the-pnpmoverrides-1773-closed-the-overshoot-into-vulnerable-major-direc.md
+++ b/tracker/tasks/task-317 - bounding-the-pnpmoverrides-1773-closed-the-overshoot-into-vulnerable-major-direc.md
@@ -1,0 +1,21 @@
+---
+id: TASK-317
+title: 'bounding the pnpm.overrides (#1773) closed the overshoot-into-vulnerable-major direction…'
+status: To Do
+assignee: []
+created_date: '2026-07-23 00:00'
+labels:
+  - 'area:tooling'
+  - 'origin:review'
+dependencies: []
+ordinal: 317000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-23 (#1773 review, non-blocking) — bounding the pnpm.overrides (#1773) closed the overshoot-into-vulnerable-major direction but opened the INVERSE silent-drift: a future advisory whose fix only lands in the next major (crossing one of the new `<X.0.0` ceilings) is silently blocked — `pnpm install` keeps resolving the old, now-known-vulnerable major until someone manually raises the cap. **Fix shape**: teach `pnpm ops security:advisories` to flag "advisory fix crosses an override ceiling" as a distinct actionable case (separate from the existing "transitive-only, needs manual override bump"), and/or note it in `05-tooling.md`. **Promote when**: an advisory's fix version exceeds one of the override ceilings, or the next `security:advisories` enhancement.
+
+**Why:** The bounding sweep trades one silent-drift failure for another; detection closes the new gap the same way #1768 closed the old one.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-318 - the-seededTimestampi-test-helper-is-now-defined-identically-in….md
+++ b/tracker/tasks/task-318 - the-seededTimestampi-test-helper-is-now-defined-identically-in….md
@@ -1,0 +1,22 @@
+---
+id: TASK-318
+title: 'the seededTimestamp(i) test helper is now defined identically in…'
+status: To Do
+assignee: []
+created_date: '2026-07-23 00:00'
+labels:
+  - 'area:conversation-history'
+  - 'area:testing'
+  - 'origin:review'
+dependencies: []
+ordinal: 318000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-23 (#1772 review, non-blocking) — the `seededTimestamp(i)` test helper is now defined identically in `ConversationSyncService.component.test.ts` and `ConversationHistoryService.component.test.ts`, and a third component test (`DuplicateDetectionFlow`) uses a separate auto-increment `seedMessage` wrapper for the same purpose — two conventions for one need. Also `futureTime = seededTimestamp(100)` is a bare magic number ("far enough future" for a `>=` window check). **Fix shape**: if/when a third conversation-history-style component test needs seeded timestamps, promote a shared test-util (single helper + a named `FAR_FUTURE_OFFSET_SECONDS`-style constant) rather than copy the 2-liner again. **Promote when**: a third file needs the seeded-timestamp helper, or a shared test-utils consolidation pass touches these files.
+
+**Why:** Duplicated 2-line helper across 2 files is below the CPD ratchet and reasonable now; consolidation only pays off at a third consumer.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-319 - the-release-DM-send-loop-createReleaseDmProcessor-setupReleaseDmWorkerts-has-no….md
+++ b/tracker/tasks/task-319 - the-release-DM-send-loop-createReleaseDmProcessor-setupReleaseDmWorkerts-has-no….md
@@ -1,0 +1,20 @@
+---
+id: TASK-319
+title: 'the release-DM send loop (createReleaseDmProcessor, setupReleaseDmWorker.ts) has no…'
+status: To Do
+assignee: []
+created_date: '2026-07-23 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 319000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-23 (#1774 review, non-blocking) — the release-DM send loop (`createReleaseDmProcessor`, `setupReleaseDmWorker.ts`) has no fast-path for a `bot_level` (Discord 20026) failure: since 20026 means the BOT is quarantined bot-wide, once one send returns `bot_level` every remaining recipient in the batch — and every later batch of the same blast — fails identically, yet the loop still burns the full `DM_SEND_DELAY_MS` (1s) per recipient and reports each individually. A large blast during a quarantine becomes a multi-minute-to-hour no-op instead of failing fast. **Fix shape**: short-circuit the batch/blast on the first `bot_level` outcome (mark remaining recipients `failed_bot_level` without sleeping, or abort the blast). **Promote when**: a real prod quarantine event happens (the first time this actually wastes wall-clock at scale).
+
+**Why:** Real but rare efficiency issue — the waste is time, not correctness, on an infrequent event; out of #1774's classification/accounting scope.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-32 - Guard-new-packages-must-use-clean-first-build-scripts.md
+++ b/tracker/tasks/task-32 - Guard-new-packages-must-use-clean-first-build-scripts.md
@@ -1,0 +1,19 @@
+---
+id: TASK-32
+title: 'Guard: new packages must use clean-first build scripts'
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels: []
+dependencies: []
+ordinal: 32000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Guard: new packages must use clean-first build scripts
+
+**Why:** The turbo cache-poisoning fix depends on every package's build script being `rm -rf dist tsconfig.tsbuildinfo && tsc`; a new package added with bare `"build": "tsc"` silently reintroduces the class. **Fix shape**: a structural check (shape like `guard:duplicate-exports` — binary sync-check, not audit-class) failing CI when any `packages/*|services/*` package.json has a `build` script invoking tsc without the clean-first prefix. **Promote when**: the next new workspace package is added, or alongside R166's guard work. Surfaced 2026-07-02 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-320 - a-retention-orphaned-character-shows-its-creator-as-Unknown-in-character-browse-.md
+++ b/tracker/tasks/task-320 - a-retention-orphaned-character-shows-its-creator-as-Unknown-in-character-browse-.md
@@ -1,0 +1,19 @@
+---
+id: TASK-320
+title: 'a retention-orphaned character shows its creator as "Unknown" in /character browse (the…'
+status: To Do
+assignee: []
+created_date: '2026-07-24 00:00'
+labels: []
+dependencies: []
+ordinal: 320000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-24 (retention PR-B #1780, D11) — a retention-orphaned character shows its creator as **"Unknown"** in `/character browse` (the sentinel owner's reserved non-numeric discordId fails Discord `users.fetch` → the `'Unknown'` fallback in `commands/character/api.ts`). Functionally fine (orphans stay usable), but a departed-owner character reads as creatorless rather than "Orphaned Characters". **Fix shape**: special-case the sentinel discordId in the browse creator-name resolution (surface `ORPHAN_SENTINEL_USERNAME`), landing with the Phase-3 reclamation/management commands that already touch this surface. **Promote when**: Phase 3 (sentinel admin/reclamation) lands, or a browse-creator-display change touches `character/api.ts`.
+
+**Why:** Cosmetic display gap, deferred with the rest of sentinel management per D11's Phase-3 scoping.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-321 - two-cross-user-reach-definitions-now-coexist-AccountDeletionServicefetchOtherUse.md
+++ b/tracker/tasks/task-321 - two-cross-user-reach-definitions-now-coexist-AccountDeletionServicefetchOtherUse.md
@@ -1,0 +1,21 @@
+---
+id: TASK-321
+title: 'two cross-user-reach definitions now coexist: AccountDeletionService.fetchOtherUserReach…'
+status: To Do
+assignee: []
+created_date: '2026-07-24 00:00'
+labels:
+  - 'area:conversation-history'
+  - 'origin:review'
+dependencies: []
+ordinal: 321000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-24 (retention PR-C #1781 review, non-blocking) — **two cross-user-reach definitions now coexist**: `AccountDeletionService.fetchOtherUserReach` (self-serve delete preview — `memories` only, returns per-character COUNTS) vs `findCrossUserReachIds` (retention — `memories` ∪ `conversation_history` ∪ `memory_facts`, returns IDS). Deliberate and correctly scoped (S3 broadened only the retention signal), but the consequence is user-visible: the self-serve delete warning can tell someone "0 other users have memories with this character" while the retention path would treat that same character as shared and re-home it. **Fix shape**: back `fetchOtherUserReach`'s count with the same three-table union (it already returns a distinct-owner count, so it's a query swap, not a semantic change to self-serve deletion). **Promote when**: the next touch to the self-serve delete preview, or a user reports the warning under-counting.
+
+**Why:** Not a PR-C regression — a pre-existing asymmetry PR-C made legible. The self-serve warning gates a destructive user action, so under-counting there is worth closing eventually.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-322 - a-purge-preserves-a-character-with-cross-user-reach-and-findCrossUserReachIds-ne.md
+++ b/tracker/tasks/task-322 - a-purge-preserves-a-character-with-cross-user-reach-and-findCrossUserReachIds-ne.md
@@ -1,0 +1,19 @@
+---
+id: TASK-322
+title: 'a purge preserves a character with cross-user reach, and findCrossUserReachIds never…'
+status: To Do
+assignee: []
+created_date: '2026-07-25 00:00'
+labels: []
+dependencies: []
+ordinal: 322000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-25, **DISPOSITIONED 2026-07-25 (owner)** — a purge preserves a character with cross-user reach, and `findCrossUserReachIds` never checks `isPublic`, so a character that was public, accumulated another user's history, then went private is **kept** (re-homed to the sentinel, where only the bot owner can reach it). **Owner accepted the over-retention**: the alternative — treating a currently-private character as unreached and deleting it — also deletes the OTHER users' memory/history/fact rows scoped to it, for people who never asked for a deletion and can no longer reach the character to notice. Retaining a dead character beats deleting someone else's data. Recorded in `AccountDeletionService`/`reHome.ts` so the next reader doesn't 'fix' it. **Promote when**: a measured count shows the retained set is material, or reclamation (Phase 3) gives these characters a way back to a real owner.
+
+**Why:** Live, deliberate behaviour of the shipped purge — kept on the board as a disposition, not a defect.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-323 - linescheck-measures-LINES-which-is-a-poor-proxy-for-context-cost-and….md
+++ b/tracker/tasks/task-323 - linescheck-measures-LINES-which-is-a-poor-proxy-for-context-cost-and….md
@@ -1,0 +1,21 @@
+---
+id: TASK-323
+title: 'lines:check measures LINES, which is a poor proxy for context cost, and…'
+status: To Do
+assignee: []
+created_date: '2026-07-24 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:ci'
+dependencies: []
+ordinal: 323000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-24 (context-trim rounds 1–2) — **`lines:check` measures LINES, which is a poor proxy for context cost, and `lines:update-baseline` has no per-surface flag**. Measured: rules average ~72 chars/line; CURRENT.md averaged ~400. The guard therefore rated CURRENT.md "comfortable" at 95/97 while it was the single heaviest always-loaded file in the repo (~9.5k est. tokens — 28% of the whole rules surface). Round 1 cut 122 lines for ~857 est. tokens; round 2 cut 217 lines for ~5,426. Separately, the all-or-nothing baseline refresh means a post-trim `--update` would ratchet `rules` DOWN (2120→1891) but loosen `current` UP (37→73, limit 97→133) in the same write — so the refresh was deliberately NOT run after the trim. **Fix shape**: add a bytes (or est.-token) dimension alongside `lines` in `lines-baseline.json` + the check output, and a `--surface <name>` flag on `lines:update-baseline` so one metric can be ratcheted without loosening another. **Promote when**: the next always-loaded-context trim, or the next time a baseline refresh is wanted for one surface only. **Start**: `packages/tooling/src/…` `lines:check` / `lines:update-baseline`, `.github/baselines/lines-baseline.json`.
+
+**Why:** Not deferred on origin: the guard works as written, but it optimizes the wrong quantity, so it will keep mis-ranking trim targets. Deferred only because the trim it would have guided is already done by hand.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-324 - skill-evalshs-new-review-response-branch-addressreviewfinding-is-unanchored-so-a.md
+++ b/tracker/tasks/task-324 - skill-evalshs-new-review-response-branch-addressreviewfinding-is-unanchored-so-a.md
@@ -1,0 +1,20 @@
+---
+id: TASK-324
+title: "skill-eval.sh's new review-response branch address.*(review|finding) is unanchored, so a…"
+status: To Do
+assignee: []
+created_date: '2026-07-24 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 324000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-24 (#1783 review r4, non-blocking) — `skill-eval.sh`'s new review-response branch `address.*(review|finding)` is unanchored, so a multi-clause prompt containing "address" and "review"/"finding" far apart false-matches (verified: `"update the address field and review the schema"` fires). Nudge-only, so the cost is one advisory line, not a behavior change. (The reviewer's OTHER claimed false positive — `claude.?review` matching `"hey claude, review the auth flow"` — was **disproved**: `.?` allows one char and `", "` is two, so it does not match.) **Fix shape**: bound the gap (`address[^.]{0,20}(review|finding)`) or anchor to adjacency (`address (the |these )?(review|finding)`), then re-probe the positive set. **Promote when**: the nudge proves noisy in practice (the reviewer's own trigger), or the next edit to `skill-eval.sh`.
+
+**Why:** Correct-as-is for now on merits, not origin: a false nudge costs one line of hook output and cannot change behavior, so tuning it did not justify another CI round on an LGTM PR.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-325 - retentions-unreachability-signal-only-refreshes-on-a-MAJOR-release-blast….md
+++ b/tracker/tasks/task-325 - retentions-unreachability-signal-only-refreshes-on-a-MAJOR-release-blast….md
@@ -1,0 +1,19 @@
+---
+id: TASK-325
+title: "retention's unreachability signal only refreshes on a MAJOR-release blast…"
+status: To Do
+assignee: []
+created_date: '2026-07-25 00:00'
+labels: []
+dependencies: []
+ordinal: 325000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-25, **DISPOSITIONED 2026-07-25 (owner)** — retention's unreachability signal only refreshes on a MAJOR-release blast (`releaseBroadcast.ts` is the sole writer of `dm_undeliverable_since`), so the Phase-2 cohort is structurally near-empty between majors. Measured on prod: 0 stamped, 51 inactive ≥180d, ~27 would become both after the next major. **Owner accepted the coupling**: Phase 2 _is_ the unreachable branch, and blast-proven unreachability is exactly its input — the 51 inactive-but-reachable users are **Phase 3's** cohort (notify + export offer + grace), not this one. So the coupling bounds Phase 2's reach rather than breaking it, and the first real purge waits on the next major cut. Documented in the privacy policy's inactivity section. **Promote when**: Phase 3 is scoped (it inherits the reachable population), or a reachability source independent of blasts becomes worth building.
+
+**Why:** Not a defect — a deliberate scope boundary between Phase 2 and Phase 3, recorded so the empty cohort doesn't read as a broken query.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-326 - the-retention-breakers-hard-ceiling-check-RetentionPurgeServicecheckHardCeiling-.md
+++ b/tracker/tasks/task-326 - the-retention-breakers-hard-ceiling-check-RetentionPurgeServicecheckHardCeiling-.md
@@ -1,0 +1,21 @@
+---
+id: TASK-326
+title: "the retention breaker's hard-ceiling check (RetentionPurgeService.checkHardCeiling) and…"
+status: To Do
+assignee: []
+created_date: '2026-07-25 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 326000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-25 (PR-D1 #1795 claude-review, non-blocking) — the retention breaker's hard-ceiling check (`RetentionPurgeService.checkHardCeiling`) and the per-user eligibility lookup are separate round-trips from the erasure transaction, so the ceiling is evaluated on stale-by-a-query data. **Provably a non-issue today**: the only caller is `retention:purge`'s explicitly sequential loop, and the real correctness gate (the D4 TOCTOU re-check) is inside the transaction. But "there are no concurrent callers" is an assumption nothing enforces. **Fix shape**: when a second caller exists, either serialize purge runs with a Postgres advisory lock or move the ceiling evaluation into the transaction — note the latter alone does NOT fix it (two transactions can each pass a count taken before the other commits), which is why the lock is the real answer. **Promote when**: Phase 4 (autonomous execution) is scoped — it IS the second automated caller — or any scheduled job starts calling the purge endpoint.
+
+**Why:** Reviewer flagged it as an implicit, unenforced assumption rather than a defect; the trigger is a concrete future phase, not a vague someday. **Second member of the same assumption (PR-D1 review r5)**: `purgeUser` resolves the user row BEFORE opening the erasure transaction, so a concurrent purge (or a self-serve delete) removing that row in between makes `deleteAccount`'s `findUniqueOrThrow` raise a plain Prisma not-found rather than `RetentionIneligibleError` — which `eraseAndAudit` then records as a `failed` ledger row and the CLI reports as `FAILED` instead of the accurate `already_gone`. Cosmetic today (no corruption, the loop continues), and it shares this row's trigger exactly: it only becomes reachable when a second caller exists. Harden alongside the lock — catching Prisma P2025 in `eraseAndAudit` and mapping it to the already-gone skip is the narrow fix.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-327 - RetentionPurgeServicereconcileOffDb-and-its-internalretentionreconcile-off-db-ro.md
+++ b/tracker/tasks/task-327 - RetentionPurgeServicereconcileOffDb-and-its-internalretentionreconcile-off-db-ro.md
@@ -1,0 +1,21 @@
+---
+id: TASK-327
+title: 'RetentionPurgeService.reconcileOffDb and its /internal/retention/reconcile-off-db route…'
+status: To Do
+assignee: []
+created_date: '2026-07-25 00:00'
+labels:
+  - 'area:jobs'
+  - 'origin:review'
+dependencies: []
+ordinal: 327000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-25 (PR-D1 #1795 claude-review r3, non-blocking) — `RetentionPurgeService.reconcileOffDb` and its `/internal/retention/reconcile-off-db` route walk every unsettled ledger row **sequentially and unbounded**, with one avatar-unlink pass each. Fine today (the ledger gains one row per purged account and the sweep is normally a zero-row no-op), but a long-unreconciled backlog would run the whole queue inside one HTTP request against Railway's ~60s timeout — the same failure mode D2 avoided for the purge itself by making it per-user. **Fix shape**: bound the sweep (`take: N` on `findPendingOffDbRows`, returning a `remaining` count the CLI loops on), mirroring the per-user purge's resumable shape. **Promote when**: a `retention:reconcile-off-db` run reports a nonzero `stillFailing` more than once — that is the only way a backlog accumulates — or the sweep is ever wired to a schedule.
+
+**Why:** The purge endpoint already learned this lesson per-user; the sweep inherited the un-bounded shape because its queue is normally empty.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-328 - deletion-means-deletion-R8-is-implemented-for-Memory-but-not-for-MemoryFact….md
+++ b/tracker/tasks/task-328 - deletion-means-deletion-R8-is-implemented-for-Memory-but-not-for-MemoryFact….md
@@ -1,0 +1,21 @@
+---
+id: TASK-328
+title: '"deletion means deletion" (R8) is implemented for Memory but not for MemoryFact.…'
+status: To Do
+assignee: []
+created_date: '2026-07-26 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'origin:review'
+dependencies: []
+ordinal: 328000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-26 (#1796 review, non-blocking) — **"deletion means deletion" (R8) is implemented for `Memory` but not for `MemoryFact`.** `MemoryFact.sourceMemoryIds` links a fact to the memories it was extracted from, and `memory_facts.visibility` + `is_locked` exist with the same semantics as `Memory` — but **`sourceMemoryIds` is only ever WRITTEN** (by the extraction pipeline: `FactStore`, `FactExtractionService`, `ExtractionTrigger`); verified that **no deletion path anywhere reads it**. So a soft-deleted memory leaves its derived facts at `visibility='normal'`, and `FactStore`'s retrieval (`AND f.visibility = 'normal'`) keeps serving them. **Broader than the PR that surfaced it**: this affects EVERY memory-deletion path — `/memory delete`, `/memory purge`, and the new `/history purge` propagation alike — so it is pre-existing, not introduced by #1796. **Fix shape**: cascade on `sourceMemoryIds` overlap when memories are soft-deleted, mirroring `propagateDeletionToMemories` (facts have their own `isLocked`, so the same pin-outranks-deletion carve-out applies). **Two questions to answer first**: (a) is a fact derived from several memories retired when ONE source dies, or only when all do — a fact is a distillation, not a copy; (b) facts already have their own management surface (`/memory facts` + the `memoryFacts.ts` delete routes), so does memory deletion cascading to them surprise a user who curated facts independently? **Promote when**: a user reports a character recalling something after a memory delete (the fact layer is the remaining path), or the next substantial touch to fact extraction/retrieval.
+
+**Why:** Deferred on mechanism + breadth, not origin: different service (ai-worker owns extraction), different retrieval path, and the semantic question in (a) needs an owner answer before any cascade is safe to write.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-329 - review-response-RIDERS-get-less-scrutiny-than-planned-work-and-it-shows-in-the-f.md
+++ b/tracker/tasks/task-329 - review-response-RIDERS-get-less-scrutiny-than-planned-work-and-it-shows-in-the-f.md
@@ -1,0 +1,21 @@
+---
+id: TASK-329
+title: 'review-response RIDERS get less scrutiny than planned work, and it shows in the finding…'
+status: To Do
+assignee: []
+created_date: '2026-07-26 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 329000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-26 (#1795 six-round review, self-observed) — **review-response RIDERS get less scrutiny than planned work, and it shows in the finding ledger.** Across #1795's rounds, 3 of 4 findings were additions I made in response to an EARLIER finding: `recordPurgeFailure` (written + unit-tested + never called), the `personality_owners` reach arm (added in round 1, untested until round 3 caught it), and a schema doc comment I staled by changing behaviour in a file I wasn't editing. #1796 repeated the shape — the mutation gate caught an extracted module at 52% because extraction moved code out from under a file average. Each was described as small ("one clause", "~10 lines"), and small is exactly the size that skips the does-this-need-a-test / is-the-doc-still-true check a planned change gets. **Fix shape**: a short rider checklist in `/tzurot-review-response` rule 3 (apply step) — when the fix ADDS code rather than changing it, ask the three questions a planned change answers: (a) does it need its own test, (b) does it stale a comment/doc elsewhere (incl. `schema.prisma`), (c) does moving code between files change what a coverage/mutation gate measures. Rule 3 already gates on the test suite; this is the authoring-time complement. **Promote when**: the next review-response cycle that runs past 3 rounds, or the next mutation/coverage gate failure traced to a review rider.
+
+**Why:** Self-observed pattern with a 4-instance evidence base in one session; the procedure exists and already owns the apply step, so this is a checklist addition rather than new machinery.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-33 - Align-resulterrors-compose-base-with-errorInfotechnicalMessage-RetryError-wrappe.md
+++ b/tracker/tasks/task-33 - Align-resulterrors-compose-base-with-errorInfotechnicalMessage-RetryError-wrappe.md
@@ -1,0 +1,20 @@
+---
+id: TASK-33
+title: "Align result.error's compose base with errorInfo.technicalMessage (RetryError wrapper…"
+status: To Do
+assignee: []
+created_date: '2026-07-02 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 33000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Align `result.error`'s compose base with `errorInfo.technicalMessage` (RetryError wrapper text)
+
+**Why:** `GenerationStep`'s catch composes the log-only `result.error` from the OUTER error's message (`composeFallbackAwareErrorMessage(error)`) while `errorInfo.technicalMessage` derives from the UNWRAPPED `underlyingError` — when the outer is a `RetryError`, `result.error` leads with the generic wrapper text ("… failed with non-retryable error") instead of the root cause. Pre-existing asymmetry (predates the compound-fallback work) made more visible by it. **Fix shape**: have `composeFallbackAwareErrorMessage` take the unwrapped base (or accept `underlyingError`), mirroring `withFallbackFailure`. Log/diagnostics-only impact. **Promote when**: next touching GenerationStep's error path. Surfaced 2026-07-02 (PR #1438 round-3 review, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-330 - character-reclamation-flow-orphan-sentinel-admin-commands-list-orphaned-characte.md
+++ b/tracker/tasks/task-330 - character-reclamation-flow-orphan-sentinel-admin-commands-list-orphaned-characte.md
@@ -1,0 +1,19 @@
+---
+id: TASK-330
+title: 'character reclamation flow + orphan-sentinel admin commands (list orphaned characters,…'
+status: To Do
+assignee: []
+created_date: '2026-07-26 00:00'
+labels: []
+dependencies: []
+ordinal: 330000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-26 (retention Phase 3 planning, owner call) — **character reclamation flow + orphan-sentinel admin commands** (list orphaned characters, reassign, reclaim-to-original-owner via `personalities.original_owner_discord_id`). Phase-2 design (D11) deferred these to "the Phase-3 reclamation flow"; the owner deferred them out of Phase 3's notify PR because no character has ever been re-homed, so there is nothing to reclaim and no admin surface is missing yet. Reclamation semantics are already locked in the Phase-2 doc: full restore to prior state (`owner_id` back, sentinel holds nothing, provenance cleared). **Fix shape**: admin command group (or ops CLI) driving list/reassign/reclaim against the sentinel's holdings. **Promote when**: the first real purge re-homes a character (audit ledger row with `charactersReHomed > 0`) — at that moment an orphan exists and the reclamation path stops being hypothetical.
+
+**Why:** Building admin surfaces for an empty bucket is speculative; the provenance column already captures everything reclamation needs, so deferral loses nothing.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-331 - reminder-DM-1-week-before-grace-end-the-reachable-branch-ships-single-notice-fir.md
+++ b/tracker/tasks/task-331 - reminder-DM-1-week-before-grace-end-the-reachable-branch-ships-single-notice-fir.md
@@ -1,0 +1,20 @@
+---
+id: TASK-331
+title: 'reminder DM ~1 week before grace-end (the reachable branch ships single-notice-first: one…'
+status: To Do
+assignee: []
+created_date: '2026-07-26 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 331000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-26 (retention Phase 3 planning, owner call) — **reminder DM ~1 week before grace-end** (the reachable branch ships single-notice-first: one warning, 30-day grace, purge). Council flagged "a sent DM is not received notice"; a reminder is the strongest available mitigation since Discord has no read receipts, and the owner chose to defer it rather than reject it. **Fix shape**: a `retention_reminded_at` sibling stamp + one more query arm on the notify pipeline + reminder copy — same queue/worker, second pass. **Promote when**: the first grace cycle completes (30d after the first prod notify run) and the outcome argues for a softer path — nobody returned/exported, or a user reports having missed the notice.
+
+**Why:** Single-notice keeps the first cycle's schema and copy minimal; the first real cohort's behavior is the evidence a reminder decision needs.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-332 - ContextAssemblers-userName-userId-fallback-crashes-first-provision-for-a-nameles.md
+++ b/tracker/tasks/task-332 - ContextAssemblers-userName-userId-fallback-crashes-first-provision-for-a-nameles.md
@@ -1,0 +1,20 @@
+---
+id: TASK-332
+title: "ContextAssembler's userName ?? userId fallback crashes first-provision for a nameless…"
+status: To Do
+assignee: []
+created_date: '2026-07-27 00:00'
+labels:
+  - 'area:bot-client'
+dependencies: []
+ordinal: 332000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-27 (#1810 contract-fixture cascade) — **ContextAssembler's `userName ?? userId` fallback crashes first-provision for a nameless envelope**: `getOrCreateUser(jobContext.userId, jobContext.userName ?? jobContext.userId, …)` makes the default persona's name the bare snowflake, which the `personas_name_not_snowflake` DB CHECK rejects (23514) — the create fails instead of degrading. Unreachable while bot-client always ships `userName` (the contract fixtures now model that), but the fallback is a landmine, not a degradation path. **Fix shape**: on the missing-username path, fall back to the shell-placeholder formula (`User <id>`) or make `userName` required in the envelope schema. **Promote when**: a `23514 personas_name_not_snowflake` appears in prod logs, or any envelope-schema change makes `userName` optional-in-practice. Related un-DRY note: `UserReferencePatterns.ts` and `inspect/lookup.ts` embed their own `\d{17,20}` fragments (matching the canonical range today) — consolidate onto `DISCORD_SNOWFLAKE` in the same pass.
+
+**Why:** The DB CHECK turned a bad-name bug into a crash — good guard, wrong recovery.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-333 - the-bare-ai-routes-are-a-legacy-dual-mount-of-the-internal-AI-four-one-mount-is….md
+++ b/tracker/tasks/task-333 - the-bare-ai-routes-are-a-legacy-dual-mount-of-the-internal-AI-four-one-mount-is….md
@@ -1,0 +1,20 @@
+---
+id: TASK-333
+title: 'the bare /ai/* routes are a legacy dual-mount of the internal AI four; one mount is…'
+status: To Do
+assignee: []
+created_date: '2026-07-27 00:00'
+labels:
+  - 'area:api-gateway'
+dependencies: []
+ordinal: 333000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-27 (system-model map §4; owner: known lies need backlog items) — **the bare `/ai/*` routes are a legacy dual-mount of the internal AI four; one mount is supposed to die.** **Fix shape**: pick the surviving mount, migrate any callers, delete the other, remove the map §4 entry. **Promote when**: next api-gateway internal-routes touch, or the drift-audit remediation pass.
+
+**Why:** Documented lie on the system map; leaving both mounts alive invites new callers on the doomed one.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-334 - route-manifest-comment-drift-packagesclientssrcroutesinternalts-carries-stale-th.md
+++ b/tracker/tasks/task-334 - route-manifest-comment-drift-packagesclientssrcroutesinternalts-carries-stale-th.md
@@ -1,0 +1,20 @@
+---
+id: TASK-334
+title: 'route-manifest comment drift: packages/clients/src/routes/internal.ts carries stale "the…'
+status: To Do
+assignee: []
+created_date: '2026-07-27 00:00'
+labels:
+  - 'area:clients'
+dependencies: []
+ordinal: 334000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-27 (system-model pre-work scouts; owner: known lies need backlog items) — **route-manifest comment drift**: `packages/clients/src/routes/internal.ts` carries stale "the cutover relocates this" comments for routes whose cutover already happened, and `admin.ts` has the `cleanup` docblock sitting above the `broadcast` route. **Fix shape**: tiny chore PR correcting/deleting the comments; remove the map §4 entry. **Promote when**: next clients-package touch, or fold into the drift-audit remediation.
+
+**Why:** Comments describing moved behavior actively mislead the next reader of the manifest.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-335 - ResponseOrderingService-is-single-replica-by-design-flagged-in-code-the-ordering.md
+++ b/tracker/tasks/task-335 - ResponseOrderingService-is-single-replica-by-design-flagged-in-code-the-ordering.md
@@ -1,0 +1,22 @@
+---
+id: TASK-335
+title: 'ResponseOrderingService is single-replica by design (flagged in-code) — the ordering…'
+status: To Do
+assignee: []
+created_date: '2026-07-27 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:jobs'
+  - 'area:redis'
+dependencies: []
+ordinal: 335000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-27 (system-model map §4; owner: known lies need backlog items) — **`ResponseOrderingService` is single-replica by design** (flagged in-code) — the ordering queue state lives in-process, so a second bot-client replica would break strict reply ordering. Fine today (Discord gateway keeps bot-client single-replica); becomes real work at sharding time. **Fix shape**: externalize ordering state (Redis) or partition by channel across replicas — design task, not a patch. **Promote when**: bot-client scaling/sharding lands on the roadmap. Related: the `adoptRehydratedEntry` ordering-state-leak row above.
+
+**Why:** In-code-flagged scaling blocker; tracked so the map's §4 entry has a home beyond the map.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-336 - pr-monitor-remindersh-has-no-probesh-harness-while-sibling-hooks-with-comparable.md
+++ b/tracker/tasks/task-336 - pr-monitor-remindersh-has-no-probesh-harness-while-sibling-hooks-with-comparable.md
@@ -1,0 +1,20 @@
+---
+id: TASK-336
+title: 'pr-monitor-reminder.sh has no .probe.sh harness while sibling hooks with comparable…'
+status: To Do
+assignee: []
+created_date: '2026-07-27 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 336000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-27 (reviews on the assignee-policy PRs, twice) — **`pr-monitor-reminder.sh` has no `.probe.sh` harness** while sibling hooks with comparable pattern-matching fragility (`cwd-drift-guard`, `develop-code-commit-guard`, `promise-ledger-check`) all ship one; the hook now carries case-based classification (bot-vs-human login shape, PR-number extraction, tag-push filters) that a probe would pin. **Fix shape**: colocated `.probe.sh` exercising synthetic PostToolUse payloads (gh pr create with/without stdout, tag push, bot author, colon-shaped garbage). **Promote when**: next edit to this hook, or a probe-coverage standardization pass.
+
+**Why:** Reviewer asked twice across consecutive PRs; the sibling convention makes it a real gap, not a style wish.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-34 - Consider-a-marker-countlength-cap-on-dedup-reply-stubs-10-attachment-worst-case.md
+++ b/tracker/tasks/task-34 - Consider-a-marker-countlength-cap-on-dedup-reply-stubs-10-attachment-worst-case.md
@@ -1,0 +1,20 @@
+---
+id: TASK-34
+title: 'Consider a marker-count/length cap on dedup reply-stubs (10-attachment worst case)'
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 34000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Consider a marker-count/length cap on dedup reply-stubs (10-attachment worst case)
+
+**Why:** The dedup-stub truncation fix (single truncation point, text-only cap) deliberately preserves ALL attachment filename markers in full — removing the only upper bound on combined stub size. Worst case: a reply-target with Discord's max 10 long-filename attachments produces a "lightweight" stub of ~1000+ chars in `<contextual_references>`/`<quoted_messages>`, a real (if narrow) token-budget change. Documented as intentional by the `preserves all markers in full` test in `referenceEnrichment.test.ts`. **Fix shape**: cap marker COUNT (e.g. first N + `[+K more attachments]`) rather than truncating filenames (they're the correlation hint). Needs its own design + tests. **Promote when**: marker-heavy stubs observed bloating prompts, or next touching the dedup-stub format. Surfaced 2026-07-01 (PR #1431 post-squash review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-35 - Wire-the-vision-fallback-loop-into-the-RAG-family-paths-referenced-message-histo.md
+++ b/tracker/tasks/task-35 - Wire-the-vision-fallback-loop-into-the-RAG-family-paths-referenced-message-histo.md
@@ -1,0 +1,20 @@
+---
+id: TASK-35
+title: 'Wire the vision fallback loop into the RAG-family paths (referenced-message, history…'
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels:
+  - 'area:conversation-history'
+dependencies: []
+ordinal: 35000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Wire the vision fallback loop into the RAG-family paths (referenced-message, history re-enrichment, current-message inline fallback)
+
+**Why:** Phase 4 C2b shipped `describeImageWithFallback` for the two paths that hold the auth-INPUTS bundle (`ResolveVisionConfigOptions`) at the vision call site: the direct-attachment `ImageDescriptionJob` (primary) + the extended-context `processCrossProviderVisionImages`. The RAG-family paths still use single-model `describeImage`/`processAttachments` (NO fallback): (1) `ConversationInputProcessor` current-message inline fallback (`processAttachments` at :99), (2) `enrichRagHistory` conversation-history re-enrichment (`ragVisionAuth.ts:119`), (3) referenced-message images (`AttachmentProcessor.ts:255`). Source 4 (referenced-message) is a **primary** source per the routing map, so this isn't purely secondary. All three share `resolveRagVisionAuth`'s resolve-once-reuse-many structure — they thread the pre-resolved `ResolvedVisionAuth` OUTPUT, not the INPUTS the wrapper needs. **Fix shape**: have `resolveRagVisionAuth` also expose the auth-INPUTS bundle (or `ResolvedVisionAuth` carry it), thread `visionAuth` to the three sites, and switch `AttachmentProcessor` to call `describeImageWithFallback`. **Why not now**: the resolve-once-reuse restructure across ~4 files is its own cohesive slice; the two INPUTS-holding paths deliver the headline direct-attachment fallback with no regression (legacy single-model path preserved). **Promote when**: opportunistically after C2b, or when a referenced-message/history-image vision failure should auto-fall-back. Surfaced 2026-07-01 (Phase 4 C2b routing map).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-36 - Promote-invokeVisionModels-undefined-provider-warn-to-a-hard-throw.md
+++ b/tracker/tasks/task-36 - Promote-invokeVisionModels-undefined-provider-warn-to-a-hard-throw.md
@@ -1,0 +1,19 @@
+---
+id: TASK-36
+title: "Promote invokeVisionModel's undefined-provider warn to a hard throw"
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels: []
+dependencies: []
+ordinal: 36000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Promote `invokeVisionModel`'s undefined-provider `warn` to a hard `throw`
+
+**Why:** `VisionProcessor.ts:287` warns (+ falls back to the env-default provider) when `invokeVisionModel` gets `provider === undefined`; the code comment at line 285 already pre-committed: "will be promoted to a hard error once a few weeks of clean Railway logs confirm no upstream caller fires this." Post-C2b the contract is stricter — `describeImage` (the only caller) always passes `options.provider ?? detectVisionProvider(usedModel)`, never undefined — so the branch is effectively unreachable and a hit would be a real bug worth failing loud. **Fix shape**: after confirming clean prod logs, change the `warn`+fallback to `throw`. **Promote when**: a few weeks of clean Railway logs post-C2b deploy show zero "called without explicit provider" warn hits. Surfaced 2026-07-01 (Phase 4 plan; the code comment pre-committed to this).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-37 - Backport-a-negative-cache-to-LlmConfigResolvergetFreeDefaultConfig-for-parity-wi.md
+++ b/tracker/tasks/task-37 - Backport-a-negative-cache-to-LlmConfigResolvergetFreeDefaultConfig-for-parity-wi.md
@@ -1,0 +1,20 @@
+---
+id: TASK-37
+title: 'Backport a negative cache to LlmConfigResolver.getFreeDefaultConfig() for parity with the…'
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 37000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Backport a negative cache to `LlmConfigResolver.getFreeDefaultConfig()` for parity with the vision reader
+
+**Why:** Phase 4 Slice A added a negative-result cache to `VisionConfigResolver.getFreeDefaultVisionConfig()` (skips re-querying the DB when no free-vision default is set), but its sibling `LlmConfigResolver.getFreeDefaultConfig()` — which this method mirrors — has NO negative cache: every guest-mode call with no free-text-default configured re-queries `AdminSettings`. Strict improvement in the vision path; the two "analogue" methods now diverge in caching. **Fix shape**: mirror the `noDefaultCache` + `FREE_DEFAULT_CACHE_KEY` sentinel pattern into `LlmConfigResolver.getFreeDefaultConfig()`. **Why not now**: out of Slice A's scope (vision reader); it's a text-path perf nicety, not a correctness issue. **Promote when**: next touch of `LlmConfigResolver`, or if guest-mode free-default DB re-queries show up as load. Surfaced 2026-07-01 (PR #1426 review, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-38 - Type-the-applyFastPoolDeadConnRetry-extends-result-instead-of-as-unknown-as-Pris.md
+++ b/tracker/tasks/task-38 - Type-the-applyFastPoolDeadConnRetry-extends-result-instead-of-as-unknown-as-Pris.md
@@ -1,0 +1,21 @@
+---
+id: TASK-38
+title: 'Type the applyFastPoolDeadConnRetry $extends result instead of as unknown as PrismaClient'
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 38000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Type the `applyFastPoolDeadConnRetry` `$extends` result instead of `as unknown as PrismaClient`
+
+**Why:** `applyFastPoolDeadConnRetry` (`dbTimeout.ts`) casts the `$extends()` result via `as unknown as PrismaClient` — the only production `$extends` in the repo, so no convention to follow. The cast discards Prisma's extended-client typing: if a future extension changes the fast pool's shape (another `$allOperations` hook, a model-op override), the compiler won't catch a mismatch — it checks against the lied-about `PrismaClient` type and only surfaces at runtime. Safe today (the fast pool only runs `conversationHistory.findUnique`/`.create`, grep-confirmed — no `$transaction`/`$queryRaw`). **Fix shape**: return the `$extends` inferred type (or a narrow structural interface covering just the ops the fast pool uses) and thread it through `RouteDeps.fastPrisma`. **Promote when**: a second fast-pool `$extends` hook is added, or `fastPrisma` grows a consumer beyond the 2 persist routes. Surfaced 2026-07-01 (PR #1424 release review, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-39 - Self-label-the-read-path-fast-pool-failure-symmetrically-with-the-write-path.md
+++ b/tracker/tasks/task-39 - Self-label-the-read-path-fast-pool-failure-symmetrically-with-the-write-path.md
@@ -1,0 +1,20 @@
+---
+id: TASK-39
+title: 'Self-label the read-path fast-pool failure symmetrically with the write path'
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 39000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Self-label the read-path fast-pool failure symmetrically with the write path
+
+**Why:** The two persist routes' WRITE `catch` classifies + logs `{label, sqlstate, durationMs}` via `classifyDbTimeout` before rethrowing, but `compareExisting()`'s `findUnique` (the pre-check + the P2002-race re-read) has no such wrapping. If a dead-conn hits TWICE on that read (retry exhausted at the `applyFastPoolDeadConnRetry` extension), the error propagates to `globalErrorHandler` and logs generically as `'Unhandled error:'` (`errorHandler.ts:29`) — no `label`/`sqlstate`. So a `findUnique`-triggered fast-pool 500 looks like a generic unhandled error, not the self-labeled diagnostic the write path gets. Low severity (double-dead-conn tail case; the retry resolves the common case). **Fix shape**: wrap `compareExisting`'s `findUnique` in the same classify-and-log-on-final-failure the write path uses, OR teach `globalErrorHandler` to `classifyDbTimeout` on fast-pool 500s. **Promote when**: a read-path (`findUnique`) fast-pool 500 shows up in a prod incident review missing the label. Surfaced 2026-07-01 (PR #1423 round-4 review, explicitly non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-4 - extract-the-shared-env-scoped-op-preamble-validateEnvironment-banner-prod-confir.md
+++ b/tracker/tasks/task-4 - extract-the-shared-env-scoped-op-preamble-validateEnvironment-banner-prod-confir.md
@@ -1,0 +1,21 @@
+---
+id: TASK-4
+title: 'extract the shared env-scoped-op preamble (validateEnvironment → banner → prod-confirm…'
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:db'
+dependencies: []
+ordinal: 4000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-22 — extract the shared env-scoped-op preamble (`validateEnvironment` → banner → prod-confirm gate → `getPrismaForEnv` → try/finally) into a `beginEnvScopedOp({env, dryRun, force, confirmMessage})` helper and migrate the ~6 env-scoped tooling commands (`repair-fact-timestamps`, `backfill-ltm`, `cleanup-duplicates`, `backfill-facts`, `retention:backfill-last-active`, …) onto it. The retention backfill added a 12-line clone of this preamble (CPD baseline bumped 1750→1762 to absorb it). A **0-callback** extraction (passes the 2-callback ceiling trivially); its value is realized across all consumers, not the one new command — a focused tooling change, not a retention-PR rider. **Complements** the `confirmProductionOperation`-should-throw row below: centralizing the gate in `beginEnvScopedOp` makes the discardable-boolean class unrepresentable at the call sites. Doing both lowers the CPD baseline. **Promote when**: next tooling-DRY pass, or the next env-scoped command added.
+
+**Why:** A standardized preamble cloned per command; the baseline absorbs it until the sweep DRYs all consumers.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-40 - Watch-the-tightened-fast-pool-ladders-label-rates-post-deploy-statement-5s2s-loc.md
+++ b/tracker/tasks/task-40 - Watch-the-tightened-fast-pool-ladders-label-rates-post-deploy-statement-5s2s-loc.md
@@ -1,0 +1,20 @@
+---
+id: TASK-40
+title: "Watch the tightened fast-pool ladder's label rates post-deploy (statement 5s→2s, lock…"
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 40000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Watch the tightened fast-pool ladder's label rates post-deploy (statement 5s→2s, lock 2s→1s)
+
+**Why:** #1423 tightened the fast-pool ladder to `lock 1s < statement 2s < query 3s` so the dead-conn retry fires in ~3s. The persist is a single-row INSERT (<100ms), so 2s statement / 1s lock have huge margin for the common case — but the tighter budget hasn't been validated under real CONTENTION (e.g. a burst of concurrent writes into the same channel). The beta.138 SQLSTATE self-labeling makes this cheap to check. **Watch**: after #1423 reaches prod, grep the gateway logs for `label="statement-timeout"` / `label="lock-timeout"` on the persist routes — a nonzero rate means the tighter budget clipped a legit-but-slow op under load and should be relaxed (bump `DB_FAST_STATEMENT_TIMEOUT_MS`/`DB_FAST_LOCK_TIMEOUT_MS`, both env-overridable). **Promote when**: a `statement-timeout`/`lock-timeout` label appears in prod (previously only `query-timeout-or-dead-conn` did). Surfaced 2026-07-01 (PR #1423 review, non-blocking observation).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-41 - Cache-adminSettingsfindFirst-in-LlmConfigService-TTLCache-30s.md
+++ b/tracker/tasks/task-41 - Cache-adminSettingsfindFirst-in-LlmConfigService-TTLCache-30s.md
@@ -1,0 +1,21 @@
+---
+id: TASK-41
+title: 'Cache adminSettings.findFirst in LlmConfigService (TTLCache ~30s)'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'area:bot-client'
+  - 'origin:review'
+dependencies: []
+ordinal: 41000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Cache `adminSettings.findFirst` in `LlmConfigService` (TTLCache ~30s)
+
+**Why:** S4a's `getDefaultPointerSets` adds a singleton `adminSettings.findFirst` to every `list()` call (admin: 2 queries; user: 3). The `AdminSettings` row only changes when an admin reassigns a default — the 30s `TTLCache` pattern in `bot-client/src/utils/gatewayServiceCalls.ts` (`channelSettingsCache`; its sibling `adminSettingsCache` runs 60s) is the established fix. **Fix shape**: wrap the pointer read in a TTLCache (~30s), invalidating on `setAsDefault`/`setAsFreeDefault`/delete-guard writes. **Why not now**: list isn't a hot path + an indexed singleton read is cheap; caching adds invalidation wiring. **Promote when**: list latency matters, or opportunistically when next touching `LlmConfigService.list` (e.g. Phase B). Surfaced 2026-06-29 (PR #1394 / S4a review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-42 - handleListModelOverrides-supportsVision-enrichment-sequential-await-not-Promisea.md
+++ b/tracker/tasks/task-42 - handleListModelOverrides-supportsVision-enrichment-sequential-await-not-Promisea.md
@@ -1,0 +1,20 @@
+---
+id: TASK-42
+title: 'handleListModelOverrides supportsVision enrichment: sequential await, not Promise.all'
+status: To Do
+assignee: []
+created_date: '2026-07-01 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 42000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`handleListModelOverrides` supportsVision enrichment: sequential `await`, not `Promise.all`
+
+**Why:** The override-list loop `await capabilities.supportsVision(model)` per emitted row sequentially (≤200 lookups under `?kind=all`); the sibling `user/llm-config.ts` list handler does the identical enrich via `Promise.all(map)`, and `OpenRouterModelCache` coalesces in-flight fetches (so the concurrent shape is the intended one). Flagged by #1419 review as a consistency-with-precedent gap. **Why not now**: the `Promise.all(map).flat()` rewrite pushed `routes/user/model-override.ts` over the 400-line `max-lines` cap (405), which would force an extraction (new helper + colocated test) — disproportionate for a warm-cache perf nicety. **Fix shape**: extract a `buildOverrideSummary(override, slot, capabilities)` helper (DRYs the LIST + SET emitters _and_ makes room), then `Promise.all` the LIST map. **Promote when**: next touching the override route, or when override-list latency matters. Surfaced 2026-07-01 (PR #1419 review, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-43 - Forwarded-snapshot-id-user-mentions-unresolved-rawMentionedUsers-….md
+++ b/tracker/tasks/task-43 - Forwarded-snapshot-id-user-mentions-unresolved-rawMentionedUsers-….md
@@ -1,0 +1,20 @@
+---
+id: TASK-43
+title: 'Forwarded snapshot <@id> user-mentions unresolved (rawMentionedUsers ←…'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 43000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Forwarded snapshot `<@id>` user-mentions unresolved (`rawMentionedUsers` ← `message.mentions.users`)
+
+**Why:** `RawEnvelopeBuilder.buildRawAssemblyInputs` sources `rawMentionedUsers` from `message.mentions.users` — the forward WRAPPER's parsed mentions (empty), not the snapshot's. A `<@id>` inside forwarded snapshot text therefore has no target in the worker's `contentRewriter` lookup → it stays raw/unresolved (persona name not substituted). Lower severity than the content-loss bug fixed in #1391 (the forward TEXT now reaches the AI via `rawMessageContent`; only embedded user-mentions degrade) and **non-trivial**: `MessageSnapshot` strips mention metadata (no `snapshot.mentions`), so the fix needs regex-extracting `<@id>` from the snapshot text + ID-only resolution (worker `getOrCreateUser` by discordId without a username). Channel/role mentions are NOT affected (the `MentionResolver` scans the passed snapshot content — audit-confirmed). **Fix shape**: parse `<@id>` from `getEffectiveContent(message)` in the producer, ship id-only `rawMentionedUsers` for forwards; worker resolves persona by id. **Promote when**: the envelope-hardening PR, or when a user reports unresolved mentions inside a forward. Surfaced 2026-06-29 (envelope regression audit + PR #1391 review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-44 - LinkExtractortestts-createMockMessage-duplicates-the-shared-Discord-mock-factory.md
+++ b/tracker/tasks/task-44 - LinkExtractortestts-createMockMessage-duplicates-the-shared-Discord-mock-factory.md
@@ -1,0 +1,20 @@
+---
+id: TASK-44
+title: 'LinkExtractor.test.ts createMockMessage duplicates the shared Discord mock factory'
+status: To Do
+assignee: []
+created_date: '2026-06-29 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 44000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`LinkExtractor.test.ts` `createMockMessage` duplicates the shared Discord mock factory
+
+**Why:** The local `createMockMessage` in `LinkExtractor.test.ts` reinvents guild/channel/`permissionsFor`/`members.fetch`/`isDMBased`/`isThread`/`isTextBased` stubs that `../../test/mocks/Discord.mock.ts` already provides. It exists because the shared factory's `client` field only stubs `{ user: { id } }` — no `client.guilds`/`client.channels` sub-stubs, which `fetchMessageFromLink` needs. **Fix shape**: enrich the shared factory's `client` with `guilds.cache`/`guilds.fetch`/`channels.fetch` stubs, then switch `LinkExtractor.test.ts` to the shared import. **Why not now**: enriching a shared mock used by every sibling test in `handlers/references/` has test-wide blast radius — its own change, not a cleanup-PR rider. **Promote when**: next touching the shared Discord mock, or a third `handlers/references/` test needs the client sub-stubs. Surfaced 2026-06-29 (PR #1393 claude-review, non-blocking).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-45 - STT-transcript.md
+++ b/tracker/tasks/task-45 - STT-transcript.md
@@ -1,0 +1,21 @@
+---
+id: TASK-45
+title: 'STT transcript'
+status: To Do
+assignee: []
+created_date: '2026-06-28 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:voice'
+dependencies: []
+ordinal: 45000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+STT transcript — word repetition + lost space across a boundary
+
+**Why:** User-observed (2026-06-28) in a **Mistral/Voxtral**-attributed transcript: `"...how to do it.do it safely."` — "do it" repeats across what looks like a segment boundary AND the join dropped the inter-word space (`it.do`). NOTE this is the **Mistral** path, NOT the self-hosted Parakeet path whose chunk-stitching `_merge_overlap` (`voice-engine/server.py`) was fixed in #1369 — different provider. **RUNTIME-CONFIRMED** (prod ai-worker logs 2026-06-28 18:24 UTC, jobId `audio-d7e86857`, the screenshot transcription): a **single** Voxtral call (`modelId="voxtral-mini-latest"`, `attempt 1`, no chunking), and `chars=1654` is **identical** across `MistralSttClient` → `AudioProcessor` → `AudioTranscriptionJob` — i.e. the transcript is passed through byte-for-byte unchanged. So the repetition is **Voxtral's own raw output**, NOT our code (no stitching exists on the Mistral path). Investigation (a) "do we chunk for Mistral?" → answered: no. **Remaining decision (b)**: provider-agnostic post-transcription cleanup (collapse a repeated adjacent n-gram + normalize join spacing — would also harden the Parakeet path) — risky for legit repetition ("no no no") — vs. accepting it as BYOK Voxtral quality (or trying a different Voxtral model / reporting upstream). **Promote when**: transcription-quality reports recur, or when next touching the STT pipeline. Surfaced 2026-06-28 (user-reported; runtime-confirmed same day).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-46 - Personality-level-default-config-write-routes-text-vision.md
+++ b/tracker/tasks/task-46 - Personality-level-default-config-write-routes-text-vision.md
@@ -1,0 +1,19 @@
+---
+id: TASK-46
+title: 'Personality-level default config write routes (text + vision)'
+status: To Do
+assignee: []
+created_date: '2026-06-28 00:00'
+labels: []
+dependencies: []
+ordinal: 46000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Personality-level default config write routes (text + vision)
+
+**Why:** `personality_default_configs` (text) and `personality_vision_default_configs` (vision) exist and are READ by the resolver cascade, but **no route writes either** today — there's no "set this personality's default text/vision config" API (only user-global + user-per-personality overrides have write paths). Surfaced during S2a route-threading exploration: the user-level vision writes (`defaultVisionConfigId` / `visionConfigId`) are S2b scope, but the personality-level default tables are a separate, pre-existing gap that applies to **text too** (not vision-specific). **Fix shape**: admin (or personality-owner) routes to write `PersonalityDefaultConfig` / `PersonalityVisionDefaultConfig` + the matching command. **Promote when**: a personality-default-config feature is scoped (not part of the current vision epic). Surfaced 2026-06-28 (S2a exploration). _(The route-layer kind-threading follow-up that lived here shipped in PR #1378 / S2a; the remaining vision-write paths are tracked in `active-epic.md` § S2b.)_
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-47 - Vision-cache-invalidation-when-VisionConfigResolver-gets-a-cache.md
+++ b/tracker/tasks/task-47 - Vision-cache-invalidation-when-VisionConfigResolver-gets-a-cache.md
@@ -1,0 +1,21 @@
+---
+id: TASK-47
+title: 'Vision cache invalidation when VisionConfigResolver gets a cache'
+status: To Do
+assignee: []
+created_date: '2026-06-28 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'origin:review'
+dependencies: []
+ordinal: 47000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Vision cache invalidation when `VisionConfigResolver` gets a cache
+
+**Why:** The user-vision-default/override write+clear handlers (`model-override.ts`, shipped S2b/#1379) call `invalidateUserLlmConfig`, which only invalidates `LlmConfigResolver` (scoped `kind:'text'`). `VisionConfigResolver` reads `defaultVisionConfigId` / `visionConfigId` but is **not yet cache-wired into ai-worker's `cacheInvalidation.ts`** — so there's no vision cache to go stale TODAY (no runtime hazard). When a vision cache IS wired, those handlers must also invalidate it. **Fix shape**: add `invalidateUserVisionConfig` to `LlmConfigCacheInvalidationService` + call it from the vision write/clear paths when `isVision`. **Promote when**: `VisionConfigResolver` is wired into `ai-worker/src/cacheInvalidation.ts` (likely S2c or later). Surfaced 2026-06-28 (S2b #1379 review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-48 - LLM-config-type-consolidation.md
+++ b/tracker/tasks/task-48 - LLM-config-type-consolidation.md
@@ -1,0 +1,21 @@
+---
+id: TASK-48
+title: 'LLM config type consolidation'
+status: To Do
+assignee: []
+created_date: '2026-06-27 00:00'
+labels:
+  - 'area:voice'
+  - 'area:common-types'
+dependencies: []
+ordinal: 48000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+LLM config type consolidation — `Resolved`/`Mapped` + `Database`/`Raw` near-duplicates
+
+**Why:** `ResolvedLlmConfig` (`common-types/types/configResolution.ts`) ≈ `MappedLlmConfig` (`common-types/services/LlmConfigMapper.ts`) minus `{ provider }` (was also `kind` until the legacy-column retirement dropped it) — both independently `extends ConvertedLlmParams` and re-list the same 7 DB fields (model + memory/context/message fields), so the kinship is implicit and the two can silently drift. Separately, `DatabaseLlmConfig` (`identity/PersonalityValidator.ts`) and `RawLlmConfigFromDb` (`LlmConfigMapper.ts`) are two "raw DB-ish" shapes that may overlap. **Fix shape**: express `ResolvedLlmConfig` as `Omit<MappedLlmConfig, 'provider'>` (or a shared base) so the relationship is explicit + can't drift, and audit whether `DatabaseLlmConfig`/`RawLlmConfigFromDb` can unify. The field difference IS intentional (provider stays on the personality seed) — this is cosmetic/cognitive debt, not behavioral, so it deserves its OWN diff with its own review (touches load-bearing mapper/resolver types). Note: the breadth (Mapped/Resolved/Loaded × Llm/Tts/Vision/Stt) is a deliberate per-axis-concrete choice, NOT the target here — only the within-axis near-duplication is. **Promote when**: opportunistically when next touching the mapper/resolver type stack, or as a deliberate types pass. Surfaced 2026-06-27 (vision-config epic — user flagged Mapped/Loaded layering during Phase 1).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-49 - Schema-type-unification.md
+++ b/tracker/tasks/task-49 - Schema-type-unification.md
@@ -1,0 +1,22 @@
+---
+id: TASK-49
+title: 'Schema-type unification'
+status: To Do
+assignee: []
+created_date: '2026-06-26 00:00'
+labels:
+  - 'area:common-types'
+  - 'area:tooling'
+  - 'area:jobs'
+dependencies: []
+ordinal: 49000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Schema-type unification — derive job-payload types from their Zod schemas (`z.infer<>`)
+
+**Why:** Residual from the now-complete "Tooling & Quality Ratchet" theme (all 4 CI ratchets shipped; this last sub-item didn't). Several BullMQ job payloads still declare a hand-written `interface` alongside the Zod schema (`ShapesImportJobData`, `AudioTranscriptionJobData`, etc.) — the two can drift. **Fix shape**: replace the hand-written interfaces with `type X = z.infer<typeof xSchema>` so the schema is the single source of truth. **Promote when**: next touching `common-types/types/*-job*` / queue types, or opportunistically. Surfaced 2026-06-26 (queue reconciliation — demoted from the closed tooling-ratchet theme).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-5 - dmUndeliverableSince-is-stamped-ONLY-on-release-blast-DM-failures….md
+++ b/tracker/tasks/task-5 - dmUndeliverableSince-is-stamped-ONLY-on-release-blast-DM-failures….md
@@ -1,0 +1,19 @@
+---
+id: TASK-5
+title: 'dmUndeliverableSince is stamped ONLY on release-blast DM failures…'
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:00'
+labels: []
+dependencies: []
+ordinal: 5000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-22 (retention Phase 1) — `dmUndeliverableSince` is stamped ONLY on release-blast DM failures (`handleReleaseBroadcastDeliveries`, the sole site that classifies DM failures today); persona DM replies (`DiscordResponseSender.sendViaDM`) have no try/catch and classify nothing, so a per-user unreachable code (50278/50007) on a persona reply never stamps. **Fix shape**: add `classifyDmError` at `sendViaDM` + a new service-auth `POST /api/internal/users/:discordId/dm-undeliverable` endpoint (route manifest + codegen). **Promote when**: retention Phase 2/3 needs fresher unreachability than the per-release blast provides (the blast refreshes it each release — sufficient for the 180-day window until then).
+
+**Why:** Blast-only stamp suffices for Phase 1's window; persona-DM stamping is a bigger build deferred to when the purge branch needs the freshness.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-50 - Drift-guard-the-ban-list-against-NEW-Prisma-re-exports-catch-missing-entries.md
+++ b/tracker/tasks/task-50 - Drift-guard-the-ban-list-against-NEW-Prisma-re-exports-catch-missing-entries.md
@@ -1,0 +1,25 @@
+---
+id: TASK-50
+title: 'Drift-guard the ban list against NEW Prisma re-exports (catch missing entries)'
+status: To Do
+assignee: []
+created_date: '2026-06-22 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:common-types'
+  - 'area:config-resolver'
+  - 'area:conversation-history'
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 50000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Drift-guard the ban list against NEW Prisma re-exports (catch missing entries)
+
+**Why:** #1305's runtime drift-guard test (`check-boundaries.test.ts`) asserts every entry in `BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS` is still a real `@tzurot/common-types` export — it catches STALE entries (a banned symbol renamed/removed/moved) and the old `PersonalityService` false-positive risk is gone (list pruned to `createPrismaClient`/`PrismaClient`/`Prisma`). It does NOT catch MISSING entries: a NEW Prisma-backed symbol re-exported directly from common-types that bot-client should be banned from won't be auto-added. By design today — the dedicated Prisma-backed packages (identity/conversation-history/config-resolver) have package-level depcruise bans covering moved services; only NEW direct common-types Prisma re-exports are at risk. **Fix shape**: when common-types gains a new Prisma re-export, add its symbol to the const; ideally tag Prisma-backed exports (marker/convention) and test-assert the ban list ⊇ those tags. **Promote when**: `@tzurot/common-types` gains a new Prisma-backed re-export, or the ban list is next edited. Surfaced 2026-06-22 (PR #1305 claude-review; residual of the now-shipped #1305 drift-backstop).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-51 - Honest-tooling-coverage-metric-close-real-logic-gaps.md
+++ b/tracker/tasks/task-51 - Honest-tooling-coverage-metric-close-real-logic-gaps.md
@@ -1,0 +1,21 @@
+---
+id: TASK-51
+title: 'Honest tooling coverage metric + close real-logic gaps'
+status: To Do
+assignee: []
+created_date: '2026-06-22 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:db'
+dependencies: []
+ordinal: 51000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Honest tooling coverage metric + close real-logic gaps
+
+**Why:** `@tzurot/tooling` reports ~71.7% line coverage, but it's dragged down by ~16 commander-wrapper files at 0% (`src/commands/*.ts` + `deployment/`/`cache/`/`inspect/`/`xray/formatters/`) — the SAME paths `structure.test.ts` `EXCLUDE_PATTERNS` already exempts as "thin CLI wrappers." The real `dev/*` logic is well-covered (1096 tests). **Fix shape (two parts, one PR): (1) honest metric** — mirror the 5 structure-test wrapper-exemption paths into tooling's `coverage.exclude` so the number reflects testable logic, not glue (same "measure real debt" philosophy as the CPD post-filter); **(2) real gaps** — add error-path/branch tests for the genuine under-covered dev tools: `voice/audit-references.ts` (8%), `db/fix-migration-drift.ts` (16%), `memory/backfill-ltm.ts` (39%), `utils/env-runner.ts` (40%), `gh/github-api.ts` (44%), + the untested `connection-exhaustion`/`duplicate-exports`. User-chosen approach 2026-06-22 ("honest metric + real gaps"). **Promote when**: after the epic Cluster B/C sweep, before the dependency PRs (its own PR). Surfaced 2026-06-22 (user noticed tooling <80% during #1305).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-52 - Collapse-the-double-routing-context-round-trip-in-the-character-turn-path.md
+++ b/tracker/tasks/task-52 - Collapse-the-double-routing-context-round-trip-in-the-character-turn-path.md
@@ -1,0 +1,21 @@
+---
+id: TASK-52
+title: 'Collapse the double routing-context round-trip in the character-turn path'
+status: To Do
+assignee: []
+created_date: '2026-06-21 00:00'
+labels:
+  - 'area:db'
+  - 'origin:review'
+dependencies: []
+ordinal: 52000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Collapse the double `routing-context` round-trip in the character-turn path
+
+**Why:** After PR #1289, every `/chat` / `/random` / `/character chime-in` turn makes TWO `routing-context` gateway calls per turn with identical args: `services/character/characterTurn.ts` `runCharacterTurn` step 3 (`resolveUserContext`, feeds `getAnchorMessage`) and `MessageContextBuilder.buildContext` (`resolveUserContext`, feeds `submitAndTrackJob`). They can't diverge (same user + personality) so one is redundant — the read-migration traded a Prisma read for a second gateway round-trip. **Fix shape**: thread the already-resolved `userContext` from `characterTurn.ts` into `buildChatContext` → `MessageContextBuilder.buildContext` so it skips the re-resolve (an optional pre-resolved-context param on the shared builder; keep @mention/reply paths unaffected). Deferred from #1289 to keep the read-migration diff minimal + because the builder-signature change is shared-service breadth. **Promote when**: Phase 4 teardown (#38) reworks the PersonaResolver wiring. Surfaced 2026-06-21 (PR #1289 claude-review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-53 - Guard-against-re-snapshotting-a-synthetic-recovery-fallback--personaId.md
+++ b/tracker/tasks/task-53 - Guard-against-re-snapshotting-a-synthetic-recovery-fallback--personaId.md
@@ -1,0 +1,20 @@
+---
+id: TASK-53
+title: 'Guard against re-snapshotting a synthetic recovery-fallback-* personaId'
+status: To Do
+assignee: []
+created_date: '2026-06-21 00:00'
+labels:
+  - 'origin:review'
+dependencies: []
+ordinal: 53000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Guard against re-snapshotting a synthetic `recovery-fallback-*` personaId
+
+**Why:** Double-crash edge case (PR #1288 review): if the bot crashes DURING multi-tag recovery (after `adoptRehydratedEntry`, before delivery cleanup), the live `RuntimeEntry` slot holds `personaId: 'recovery-fallback-<slug>'`. If `toSnapshot` runs on it before cleanup, the NEXT recovery reads that synthetic id as a real persona (non-empty, non-undefined) in `personaIdForSlot` and passes it through → FK violation → already swallowed by the `saveAssistantMessage` try/catch (user still gets their message; history doesn't persist). Degrades gracefully, same as the single-crash `''`/`undefined` paths. **Fix shape**: either `personaIdForSlot` treats a `recovery-fallback-` prefix as the fallback case (idempotent regenerate), OR `toSnapshot` skips synthetic ids (persists `undefined`). **Promote when**: `recovery-fallback-*` personaIds show up in logs and confuse, or opportunistically when next in `MultiTagRecovery`. Surfaced 2026-06-21 (PR #1288 review). Deferred 2026-06-21.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-54 - guardboundaries---summary-mode-not-yet-wired.md
+++ b/tracker/tasks/task-54 - guardboundaries---summary-mode-not-yet-wired.md
@@ -1,0 +1,20 @@
+---
+id: TASK-54
+title: 'guard:boundaries --summary mode not yet wired'
+status: To Do
+assignee: []
+created_date: '2026-06-17 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 54000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`guard:boundaries` `--summary` mode not yet wired
+
+**Why:** `guard:boundaries` is a registered CI gate but its `--summary` JSONL line (for the future audit-aggregator) isn't emitted yet; hard-fail works independently of `--summary`. **Promote when**: the `ops:health` aggregator is built and needs the summary line, OR opportunistically when next touching `packages/tooling/src/dev/check-boundaries.ts`. Carried from the old quick-wins list during the 2026-06-17 backlog restructure.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-55 - Evaluate-adding-component-tests-to-the-pre-push-hook.md
+++ b/tracker/tasks/task-55 - Evaluate-adding-component-tests-to-the-pre-push-hook.md
@@ -1,0 +1,21 @@
+---
+id: TASK-55
+title: 'Evaluate adding component tests to the pre-push hook'
+status: To Do
+assignee: []
+created_date: '2026-06-25 00:00'
+labels:
+  - 'area:redis'
+  - 'origin:review'
+dependencies: []
+ordinal: 55000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Evaluate adding component tests to the pre-push hook
+
+**Why:** Phase-4 PR1 (#1346) made `pnpm test:component` require a running Redis container. Pre-push does NOT currently run component tests, so there's no impact today — but once the contract tier is populated (PR3+), running component+contract in pre-push could catch seam regressions before CI. Trade-off: pre-push already flakes under memory pressure on the Steam Deck (a real-Redis dependency + heavier run would worsen it). **Fix shape**: weigh a focused/changed-package component run in pre-push vs. leaving it CI-only. **Promote when**: the contract tier is established (PR3+ landed) AND pre-push latency/flake is acceptable. Surfaced 2026-06-25 (PR #1346 claude-review).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-56 - Flow-level-integratione2e-gate-the-declared-flow-layer-in-topologycheck.md
+++ b/tracker/tasks/task-56 - Flow-level-integratione2e-gate-the-declared-flow-layer-in-topologycheck.md
@@ -1,0 +1,19 @@
+---
+id: TASK-56
+title: 'Flow-level integration/e2e gate (the "declared-flow" layer in topology:check)'
+status: To Do
+assignee: []
+created_date: '2026-06-26 00:00'
+labels: []
+dependencies: []
+ordinal: 56000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Flow-level integration/e2e gate (the "declared-flow" layer in `topology:check`)
+
+**Why:** The Test-Pyramid epic (Phases 1–4, PR1–7) populated the CONTRACT tier — every cross-service surface is verified in isolation — but there is no gate ABOVE the seam level: nothing checks a whole multi-service flow as a sequence (e.g. Discord → gateway → worker → delivery). The PR7 close-out council (GLM-5.2 / Kimi-K2.7 / Qwen-3.7, 2026-06-26; **2 of 3 to park, Qwen dissented to drop**) deferred Kimi's "declared-flow" layer (baseline the known flows in `topology:check`, presence + sunset) because with integration=1 / e2e=0 today it would "guard an empty room." **Fix shape**: a declared-flow registry + presence gate, OR — likely the cheaper solo spend — the post-deploy smoke check filed in `cold/ideas.md`. **Promote when**: a prod bug ships that passes every seam contract but fails on multi-service STATE or SEQUENCING (the precise gap a per-seam gate structurally cannot catch). Surfaced 2026-06-26 (PR #1356/#1358 epic close-out council).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-57 - Decide-document-an-unambiguous-TS-file-naming-convention.md
+++ b/tracker/tasks/task-57 - Decide-document-an-unambiguous-TS-file-naming-convention.md
@@ -1,0 +1,20 @@
+---
+id: TASK-57
+title: 'Decide + document an unambiguous TS file-naming convention'
+status: To Do
+assignee: []
+created_date: '2026-06-18 00:00'
+labels:
+  - 'area:common-types'
+dependencies: []
+ordinal: 57000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Decide + document an unambiguous TS file-naming convention
+
+**Why:** `packages/common-types/src/types/` mixes kebab-case (`gateway-context.ts`, `discord-types.ts`, `shapes-import.ts`, `api-types.ts`, `audio-provider.ts` — dominant 5:1) with camelCase (`sttProvider.ts`, `jobs.ts`, `incognito.ts`). The ambiguity caused a per-PR debate on #1260 (`summonAnonymity.ts` → `summon-anonymity.ts`). Pick one convention (kebab is dominant), document it in `02-code-standards.md`, and ideally add a `structure.test.ts`-style lint so new files conform automatically. Low priority. **Promote when**: opportunistically, or the next filename-convention review-nit. Surfaced by PR #1260. Surfaced 2026-06-18 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-58 - Incognito-toggle-1252.md
+++ b/tracker/tasks/task-58 - Incognito-toggle-1252.md
@@ -1,0 +1,20 @@
+---
+id: TASK-58
+title: 'Incognito toggle (#1252)'
+status: To Do
+assignee: []
+created_date: '2026-06-18 00:00'
+labels:
+  - 'area:redis'
+dependencies: []
+ordinal: 58000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Incognito toggle (#1252) — test-coverage gaps + cosmetic cleanup
+
+**Why:** **Test gaps** (claude-review Medium; don't block, but close before the next refactor touches these files): (1) `ConversationalRAGService.ts` ~:470-473 `summonIncognito=false` path — assert the Redis `isIncognitoActive` call runs and memory write proceeds; (2) `MessageContextBuilder.ts` epoch logic — assert a personal weigh-in (`incognito=false, isWeighInMode=true`) KEEPS `contextEpoch`; (3) `adjustContextForWeighInMode` in `services/character/characterTurn.ts` — no unit test covers the new 3-arg split shape. **Cosmetic cleanup**: standardize the `incognito ?? isWeighIn` boolean shape — `MemoryRetriever`/`ContextAssembler`/`ConversationalRAGService` use `?? Boolean(x)` while `MessageContextBuilder` uses `(… ?? …) === true`; converge on `(incognito ?? isWeighIn) === true` (matches MessageContextBuilder, prettier-stable since the parens are semantically required, house style). Also: `MemoryRetriever` LTM-skip log says "Incognito mode" even when the `isWeighIn` default drove it — neutral "Skipping LTM retrieval (anonymous summon)" is better; and `ContextBuildOptions.ts` `incognito` JSDoc leaks call-site detail ("Defaults to isWeighInMode at the call site") — describe semantics, not the caller's default. ~~**UX**: `/character random <message>` option description says "Anonymous by default" but the default there is personal — reword (needs commandManifest + int-snapshot regen).~~ ✅ Resolved in PR #1263 (reworded to "Hide your persona & memories. Defaults on with no message, off when you send one."; reviewer-confirmed against `incognito ?? isWeighInMode`). **Promote when**: next refactor touches these files, OR the user lands on preferred option wording post-verification. Surfaced by PR #1252 claude-review (rounds at 7:18 + 9:44, 2026-06-18).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-59 - Enforce-round-trip-contract-registration-for-new-fetch-edit-PUT-dashboards.md
+++ b/tracker/tasks/task-59 - Enforce-round-trip-contract-registration-for-new-fetch-edit-PUT-dashboards.md
@@ -1,0 +1,19 @@
+---
+id: TASK-59
+title: 'Enforce round-trip-contract registration for new fetch-edit-PUT dashboards'
+status: To Do
+assignee: []
+created_date: '2026-06-18 00:00'
+labels: []
+dependencies: []
+ordinal: 59000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Enforce round-trip-contract registration for new fetch-edit-PUT dashboards
+
+**Why:** `updateSchemaRoundTrip.test.ts` (the avatarData-class guard, PR #1253) requires every fetch-edit-PUT dashboard to register in its `DASHBOARDS` array, but that requirement lives only in a file comment — no structural check catches a developer who adds a new dashboard and forgets to register it. **Fix options**: (a) a structural test that enumerates known update schemas / dashboard payload-builders and asserts each is registered (hard to fully automate — registration intent can't be auto-discovered, so this risks false negatives); (b) lighter — add the round-trip registry to `04-discord.md`'s Shared Utilities table so the "check for existing utilities" habit surfaces it, plus a one-line pointer in the dashboard-creation path. (b) is the pragmatic pick. **Promote when**: the next new fetch-edit-PUT dashboard is added (that's the moment the gap would bite). Surfaced by PR #1253 round-2 claude-review. Surfaced 2026-06-18 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-6 - Railway-env-var-audit-sweep-DONE-2026-07-17-every-var-on-all-5-services-both-env.md
+++ b/tracker/tasks/task-6 - Railway-env-var-audit-sweep-DONE-2026-07-17-every-var-on-all-5-services-both-env.md
@@ -1,0 +1,22 @@
+---
+id: TASK-6
+title: 'Railway env-var audit: sweep DONE 2026-07-17 (every var on all 5 services × both envs…'
+status: To Do
+assignee: []
+created_date: '2026-07-16 00:00'
+labels:
+  - 'area:voice'
+  - 'area:tooling'
+  - 'area:docs'
+dependencies: []
+ordinal: 6000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-16 (owner request) — Railway env-var audit: **sweep DONE 2026-07-17** (every var on all 5 services × both envs traced to a live read; findings + method in `docs/local/SECRETS_AUDIT_2026-07-17.md`). ONE dead var found and REMOVED (owner, dashboard, 2026-07-17): `DEFAULT_VOICES` on voice-engine (both envs). **Residual**: encode expected per-service var sets in `setup-railway-variables.ts` so drift is checkable via `deploy:setup-vars --dry-run`. **Promote when**: next deploy-tooling touch, or the next stray-var incident.
+
+**Why:** The sweep is point-in-time; the manifest is what makes it stay true.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-60 - Partial-map-fragility-in-writeReferenceImageDescriptions.md
+++ b/tracker/tasks/task-60 - Partial-map-fragility-in-writeReferenceImageDescriptions.md
@@ -1,0 +1,19 @@
+---
+id: TASK-60
+title: 'Partial-map fragility in writeReferenceImageDescriptions'
+status: To Do
+assignee: []
+created_date: '2026-06-17 00:00'
+labels: []
+dependencies: []
+ordinal: 60000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Partial-map fragility in `writeReferenceImageDescriptions`
+
+**Why:** `writeReferenceImageDescriptions` replaces (not merges) a stored reference's `resolvedImageDescriptions` from a single `descriptionsByUrl` map. Safe today because `referenceAttachments` is assembled in one preprocessing pass covering all of a message's reference images, so the map is always complete (documented at the call site with an "intentional replace, not merge" comment). **Promote when**: a second/retry persist path is introduced that passes a _partial_ map (only some of a message's reference images) — the replace would then silently drop previously-persisted descriptions; switch to merge-by-filename or assert completeness. **Also watch**: the `logger.warn` on "no user message found" could be noisy if a job-dispatch→message-persistence timing gap exists in prod; downgrade to `debug` if observed post-deploy. Surfaced by PR #1241 claude-review. Deferred 2026-06-17.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-61 - buildDedupedReferenceStub-over-limit-content-contract.md
+++ b/tracker/tasks/task-61 - buildDedupedReferenceStub-over-limit-content-contract.md
@@ -1,0 +1,21 @@
+---
+id: TASK-61
+title: 'buildDedupedReferenceStub over-limit content contract'
+status: To Do
+assignee: []
+created_date: '2026-06-17 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 61000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`buildDedupedReferenceStub` over-limit content contract
+
+**Why:** `buildDedupedReferenceStub` returns `content` that can EXCEED `DEDUP_STUB_CONTENT` when attachment markers are present (markers are prepended AFTER the text is truncated), relying on `formatDedupedQuote` to re-apply the limit downstream. Safe today — every live render path (ai-worker `ReferencedMessageFormatter` + `xmlMetadataFormatters`; bot-client `ReferenceFormatter` ships stubs to the worker) goes through `formatDedupedQuote`, and the JSDoc documents the contract. **Promote when**: a new caller reads `stub.content` directly (logging, debugging, a new render path) without re-truncating → make the truncation self-contained inside `buildDedupedReferenceStub` (apply the combined limit there) or accept a `renderContentFn`. Surfaced by PR #1242 claude-review (rounds 3-4). Deferred 2026-06-17.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-62 - Railway-ops-tooling.md
+++ b/tracker/tasks/task-62 - Railway-ops-tooling.md
@@ -1,0 +1,20 @@
+---
+id: TASK-62
+title: 'Railway ops tooling'
+status: To Do
+assignee: []
+created_date: '2026-06-17 00:00'
+labels:
+  - 'area:tooling'
+dependencies: []
+ordinal: 62000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Railway ops tooling — sanctioned token access + GraphQL ops the CLI lacks
+
+**Why:** Railway CLI v4.11.2's `variables` only supports `--set` (no unset/delete), and reading the auth token from `~/.railway/config.json` is correctly blocked as credential exploration — so deleting a Railway env var has no in-band path (the beta.133 probe cleanup had to be hand-done in the dashboard). Two-part fix: (1) a sanctioned, auditable token path — a dedicated `RAILWAY_API_TOKEN` the user sets once (documented in `RAILWAY_CLI_REFERENCE.md`, never logged, used transiently per-call), legible as intentional tooling vs. credential scraping; project-scoped vs. account token is the open design question. (2) Wrap the CLI-missing GraphQL ops as `pnpm ops` commands (start with `variableDelete`; consider a full variable CRUD surface + redeploy/status queries) in the tooling package with mocked-HTTP tests. Endpoint `https://backboard.railway.app/graphql/v2`; `VariableDeleteInput` = projectId/environmentId/serviceId/name; IDs via `railway status --json`. Security: never log the token, `Authorization: Bearer` only, fail-fast if unset. **Promote when**: the next in-session Railway mutation need, OR a deliberate dev-tooling pass. Surfaced + triaged 2026-06-17.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-63 - Make-the-vision-system-fallback-daily-cap-a-runtime-admin-settings-knob.md
+++ b/tracker/tasks/task-63 - Make-the-vision-system-fallback-daily-cap-a-runtime-admin-settings-knob.md
@@ -1,0 +1,21 @@
+---
+id: TASK-63
+title: 'Make the vision system-fallback daily cap a runtime admin-settings knob'
+status: To Do
+assignee: []
+created_date: '2026-06-14 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 63000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Make the vision system-fallback daily cap a runtime admin-settings knob
+
+**Why:** The per-user daily cap on system-key free-vision fallback (`VISION_SYSTEM_FALLBACK_DAILY_LIMIT`, a code constant = 100) should become a runtime admin-settings item so the owner can tune it without a code change + redeploy. Gemma is $0, so the cap purely protects the shared rate-limit pool; the right value depends on observed traffic, which argues for runtime tunability. `VisionFallbackQuota` already takes `dailyLimit` as a constructor param, so the wiring is "resolve the configured value and pass it in," not a logic change — thread it through the `adminSettings` layer (DB-backed `adminSettings` + gateway admin config + bot-client admin UI), falling back to the constant default. **Start**: `services/ai-worker/src/services/VisionFallbackQuota.ts`; the `adminSettings` resolution path in ai-worker. **Promote when**: the owner wants to tune the cap from observed traffic without a deploy. Surfaced 2026-06-14; triaged 2026-06-17.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-64 - Single-flight-dedup-for-HttpPersonalityLoader-concurrent-misses.md
+++ b/tracker/tasks/task-64 - Single-flight-dedup-for-HttpPersonalityLoader-concurrent-misses.md
@@ -1,0 +1,19 @@
+---
+id: TASK-64
+title: 'Single-flight dedup for HttpPersonalityLoader concurrent misses'
+status: To Do
+assignee: []
+created_date: '2026-06-04 00:00'
+labels: []
+dependencies: []
+ordinal: 64000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Single-flight dedup for `HttpPersonalityLoader` concurrent misses
+
+**Why:** Concurrent cold-cache probes for the same `(userId, nameOrId)` each pay a gateway hop until the first response lands (thundering-herd-after-invalidation shape). Tolerable at Discord message rates. **Fix shape**: pending-promise map keyed by cache key, deleted in `finally`. **Promote when**: gateway logs show duplicate concurrent `/internal/personality/load` bursts for identical keys, or routing-read latency p95 spikes after invalidation events. Surfaced by PR #1156 claude-review. Deferred 2026-06-04.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-65 - Surgical-eviction-for-HttpPersonalityLoader-invalidation.md
+++ b/tracker/tasks/task-65 - Surgical-eviction-for-HttpPersonalityLoader-invalidation.md
@@ -1,0 +1,19 @@
+---
+id: TASK-65
+title: 'Surgical eviction for HttpPersonalityLoader invalidation'
+status: To Do
+assignee: []
+created_date: '2026-06-04 00:00'
+labels: []
+dependencies: []
+ordinal: 65000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surgical eviction for `HttpPersonalityLoader` invalidation
+
+**Why:** Personality pub/sub events carry an ID but the routing caches are `(userId, nameOrId)`-keyed, so any single invalidation does a full two-tier clear (500 + 2000 caps; rebuild = one round-trip per active probe). Fine at current scale. **Fix shape**: side-table mapping `personalityId → Set<cacheKey>` enabling targeted eviction. **Promote when**: personality edits become frequent enough that full clears across instances produce visible gateway-traffic spikes (watch the clear-applied debug log frequency vs `/internal/personality/load` volume). Surfaced by PR #1156 claude-review (both final reviewers independently). Deferred 2026-06-04.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-66 - Schema-versioning-for-BullMQ-jobs.md
+++ b/tracker/tasks/task-66 - Schema-versioning-for-BullMQ-jobs.md
@@ -1,0 +1,20 @@
+---
+id: TASK-66
+title: 'Schema versioning for BullMQ jobs'
+status: To Do
+assignee: []
+created_date: '2026-01-26 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 66000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Schema versioning for BullMQ jobs
+
+**Why:** No breaking changes yet (overlaps the job-payload contract suite — deterministic-test-quality theme candidate 2; resolve together). Surfaced 2026-01-26 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-67 - Redis-pipelining.md
+++ b/tracker/tasks/task-67 - Redis-pipelining.md
@@ -1,0 +1,20 @@
+---
+id: TASK-67
+title: 'Redis pipelining'
+status: To Do
+assignee: []
+created_date: '2026-01-26 00:00'
+labels:
+  - 'area:redis'
+dependencies: []
+ordinal: 67000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Redis pipelining
+
+**Why:** Fast enough at current traffic. Surfaced 2026-01-26 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-68 - BYOK-lastUsedAt-tracking.md
+++ b/tracker/tasks/task-68 - BYOK-lastUsedAt-tracking.md
@@ -1,0 +1,19 @@
+---
+id: TASK-68
+title: 'BYOK lastUsedAt tracking'
+status: To Do
+assignee: []
+created_date: '2026-01-26 00:00'
+labels: []
+dependencies: []
+ordinal: 68000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+BYOK `lastUsedAt` tracking
+
+**Why:** Nice-to-have, not breaking. Surfaced 2026-01-26 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-69 - Handler-factory-generator.md
+++ b/tracker/tasks/task-69 - Handler-factory-generator.md
@@ -1,0 +1,19 @@
+---
+id: TASK-69
+title: 'Handler factory generator'
+status: To Do
+assignee: []
+created_date: '2026-01-26 00:00'
+labels: []
+dependencies: []
+ordinal: 69000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Handler factory generator
+
+**Why:** Add when creating many new routes. Surfaced 2026-01-26 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-7 - ai-worker-export-job-handlers-write-raw-errormessage-into-exportjobserrorMessage.md
+++ b/tracker/tasks/task-7 - ai-worker-export-job-handlers-write-raw-errormessage-into-exportjobserrorMessage.md
@@ -1,0 +1,21 @@
+---
+id: TASK-7
+title: 'ai-worker export job handlers write raw error.message into export_jobs.errorMessage, and…'
+status: To Do
+assignee: []
+created_date: '2026-07-16 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'origin:review'
+dependencies: []
+ordinal: 7000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-16 (#1662 r2) — ai-worker export job handlers write raw `error.message` into `export_jobs.errorMessage`, and the shapes list route (`shapes/export.ts` list handler) returns that field VERBATIM to the authenticated user — provider/infra error strings (which can carry connection detail) reach end users. #1662 sanitized the gateway-side enqueue writer; the WORKER-side writers (`ShapesExportJob.ts`, `AccountExportJob.ts`) still store raw messages. **Fix shape**: a small message-taxonomy pass in the worker handlers (classify → user-safe copy, full error to logs — the `cleanupStuckExportJobs` "worker may have restarted" copy is the precedent), or stop selecting `errorMessage` on the list route and derive display copy from `status`. **Promote when**: next touch of either export job handler, or a user reports a confusing/leaky export error string.
+
+**Why:** Low-severity info-leak class: authenticated user, own jobs only — but raw infra errors don't belong in user-facing fields.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-70 - Scaling-preparation-timers.md
+++ b/tracker/tasks/task-70 - Scaling-preparation-timers.md
@@ -1,0 +1,19 @@
+---
+id: TASK-70
+title: 'Scaling preparation (timers)'
+status: To Do
+assignee: []
+created_date: '2026-01-26 00:00'
+labels: []
+dependencies: []
+ordinal: 70000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Scaling preparation (timers)
+
+**Why:** Single-instance sufficient for now. Surfaced 2026-01-26 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-71 - Denylist-batch-cache-invalidation.md
+++ b/tracker/tasks/task-71 - Denylist-batch-cache-invalidation.md
@@ -1,0 +1,19 @@
+---
+id: TASK-71
+title: 'Denylist batch cache invalidation'
+status: To Do
+assignee: []
+created_date: '2026-02-15 00:00'
+labels: []
+dependencies: []
+ordinal: 71000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Denylist batch cache invalidation
+
+**Why:** Single pubsub messages handle current scale; premature optimization for bulk ops that rarely happen. Surfaced 2026-02-15 (dated from git history).
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-72 - pnpmaction-setup-v5v6-upgrade.md
+++ b/tracker/tasks/task-72 - pnpmaction-setup-v5v6-upgrade.md
@@ -1,0 +1,19 @@
+---
+id: TASK-72
+title: 'pnpm/action-setup v5→v6 upgrade'
+status: To Do
+assignee: []
+created_date: '2026-04-17 00:00'
+labels: []
+dependencies: []
+ordinal: 72000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`pnpm/action-setup` v5→v6 upgrade
+
+**Why:** Investigation 2026-04-17: v6 only adds pnpm 11 support; we use pnpm 10.30.3 (`packageManager` in package.json). v6 replaces the bundled pnpm with a bootstrap installer (see compare v5...v6: `dist/pnpm.cjs` removed, new `src/install-pnpm/bootstrap/`), which caused `ERR_PNPM_BROKEN_LOCKFILE` in our CI. Zero benefit for us on pnpm 10.x. Revisit if: (a) we adopt pnpm 11, (b) v5 is deprecated, (c) a v6.x patch fixes the bootstrap's pnpm version resolution.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-73 - Typed-aggregated-error-for-DownloadAttachmentsStepdownloadAll.md
+++ b/tracker/tasks/task-73 - Typed-aggregated-error-for-DownloadAttachmentsStepdownloadAll.md
@@ -1,0 +1,19 @@
+---
+id: TASK-73
+title: 'Typed aggregated error for DownloadAttachmentsStep.downloadAll'
+status: To Do
+assignee: []
+created_date: '2026-04-24 00:00'
+labels: []
+dependencies: []
+ordinal: 73000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Typed aggregated error for `DownloadAttachmentsStep.downloadAll`
+
+**Why:** Per-attachment failures inside `downloadAll` are typed (`HttpError`, `AttachmentTooLargeError`), but the step-level aggregation collapses into anonymous `new Error('Failed to download N attachment(s): ...')`. Callers (`LLMGenerationHandler.processJob`'s catch) can't `instanceof`-classify without string-parsing. **Acceptable today**: failure surfaces to user as async error regardless of classification; no retry/backoff policy keys off the aggregated type. **Fix shape when needed**: introduce `AggregateAttachmentDownloadError extends Error` carrying `failures: Array<{ name: string; error: Error }>`, keep message format for log compat. **Promote when**: we want differentiated retry policy ("retry whole job if all failures are transient" vs "fast-fail if any 403") or differentiated user-facing messages by failure class. Surfaced 2026-04-24 by PR #889 Round 6 claude-review. Deferred 2026-04-24.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-74 - Reconsider-hard-fail-vs-soft-error-for-attachment-download-failures.md
+++ b/tracker/tasks/task-74 - Reconsider-hard-fail-vs-soft-error-for-attachment-download-failures.md
@@ -1,0 +1,19 @@
+---
+id: TASK-74
+title: 'Reconsider hard-fail vs soft-error for attachment download failures'
+status: To Do
+assignee: []
+created_date: '2026-04-24 00:00'
+labels: []
+dependencies: []
+ordinal: 74000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Reconsider hard-fail vs soft-error for attachment download failures
+
+**Why:** PR #889 changed semantics: old `AttachmentStorageService.downloadAndStore` used `Promise.allSettled` and returned the original Discord CDN URL as fallback on per-attachment failure (soft-error; job continued with broken URL); new `DownloadAttachmentsStep.downloadAll` throws on any failure and fails the whole job (hard-fail). New behavior is arguably more correct (old soft-error handed LLM a dead URL that produced weird responses), but it's a visible user-facing change — transient CDN hiccups that were previously silent now produce classified async errors. **Watch-item**: if users report "attachments dropped without warning" → "job failed visibly" complaints, reconsider partial-failure soft-error (continue with successful attachments, surface non-fatal warning for failed ones). **Fix shape when needed**: change `downloadAll` to keep partial successes, attach failure metadata to generation context, surface "couldn't load N of M attachments" notice. **Why deferred today**: no observed user complaints; visible errors easier to diagnose than silent corruption. Surfaced 2026-04-24 by PR #889 Round 5 claude-review. Deferred 2026-04-24.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-75 - discordCdnGuard-non-https-failure-reason-variant.md
+++ b/tracker/tasks/task-75 - discordCdnGuard-non-https-failure-reason-variant.md
@@ -1,0 +1,19 @@
+---
+id: TASK-75
+title: 'discordCdnGuard non-https failure-reason variant'
+status: To Do
+assignee: []
+created_date: '2026-04-26 00:00'
+labels: []
+dependencies: []
+ordinal: 75000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`discordCdnGuard` non-https failure-reason variant
+
+**Why:** `validateDiscordCdnUrl` returns `{ ok: false, reason: 'invalid-url' }` for both `http://cdn.discordapp.com/...` (correct host, wrong protocol) and `not-a-url` (URL constructor throws). Tagged-union accuracy nit: a future caller wanting to log "known host but http" differently has no way to distinguish. **Fix shape**: add `reason: 'non-https'` as a third failure variant. Low priority — current 4 callers (avatar/voice/import/jsonFileUtils) all just check `cdnGuard.ok`. **Why deferred**: no current consumer cares about the distinction; revisit when a consumer needs differentiated logging/UX. Surfaced 2026-04-26 by claude-bot review on #905 final round. Deferred 2026-04-26.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-76 - personalityOwnerResolver-lookup-cache-TTL-5min.md
+++ b/tracker/tasks/task-76 - personalityOwnerResolver-lookup-cache-TTL-5min.md
@@ -1,0 +1,21 @@
+---
+id: TASK-76
+title: 'personalityOwnerResolver lookup cache (TTL ~5min)'
+status: To Do
+assignee: []
+created_date: '2026-04-25 00:00'
+labels:
+  - 'area:ai-worker'
+  - 'area:db'
+dependencies: []
+ordinal: 76000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`personalityOwnerResolver` lookup cache (TTL ~5min)
+
+**Why:** `services/ai-worker/src/services/diagnostics/personalityOwnerResolver.ts:resolvePersonalityOwnerDiscordId` fires a `prisma.user.findUnique` on every AI generation request to surface owner Discord ID for diagnostic-meta. Lookup is ~1ms typical (single indexed query) and not on a profiled hot path; cache adds invalidation complexity. Options when promoted: (a) thin in-memory `TTLCache<string, string|null>` keyed by `personalityOwnerInternalId`; (b) extend `UserService` with a cached `getDiscordIdByInternalUuid` (more reusable if a second consumer surfaces). **Promote when**: generation latency tightening identifies this resolver as a material p95 contributor — profile production diagnostic logs first, optimize second. Surfaced 2026-04-25 by claude-bot on PR #898. Deferred 2026-04-27.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-77 - PipelineStepstatus-error-reachable-via-per-step-trycatch.md
+++ b/tracker/tasks/task-77 - PipelineStepstatus-error-reachable-via-per-step-trycatch.md
@@ -1,0 +1,19 @@
+---
+id: TASK-77
+title: "PipelineStep.status: 'error' reachable via per-step try/catch"
+status: To Do
+assignee: []
+created_date: '2026-04-25 00:00'
+labels: []
+dependencies: []
+ordinal: 77000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`PipelineStep.status: 'error'` reachable via per-step try/catch
+
+**Why:** Schema declares `'success' | 'skipped' | 'error'` and `extendedViews.ts` renders the ❌ icon for it, but `DiagnosticCollector.recordPostProcessing()` currently only emits `success` / `skipped` because today's post-processing transforms (`duplicate_removal`, `thinking_extraction`, `artifact_strip`, `placeholder_replacement`) are simple string ops that don't realistically throw. If a step did throw today, the whole `recordPostProcessing` call dies and `pipelineSteps` is never set — failure is invisible to the Pipeline Health view rather than surfaced in it. **Fix shape**: refactor the `recordPostProcessing` array-build so each step is wrapped in its own try/catch returning a `PipelineStep` (rather than the positional ternary today); on catch emit `{ name, status: 'error', reason: err.message }`. **Promote when**: pipeline grows steps that do real I/O (vector lookups, external API calls) — i.e. when a step _can_ legitimately fail. Surfaced 2026-04-25 by claude-bot on PR #899. Deferred 2026-04-27.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-78 - satisfies-constraint-on-PgvectorMemoryDocument.md
+++ b/tracker/tasks/task-78 - satisfies-constraint-on-PgvectorMemoryDocument.md
@@ -1,0 +1,20 @@
+---
+id: TASK-78
+title: 'satisfies constraint on PgvectorMemoryDocument'
+status: To Do
+assignee: []
+created_date: '2026-04-30 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 78000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`satisfies` constraint on `PgvectorMemoryDocument`
+
+**Why:** The implicit `PgvectorMemoryDocument[]` → `MemoryDocument[]` (RAG-layer) assignment at `MemoryRetriever.ts:~221` works today via TypeScript structural-typing widening — `Record<string, unknown>` narrows into `{ id?, createdAt?, score? }` because all RAG-layer metadata fields are optional. Risk: if `MemoryDocument.metadata` ever gains a **required** field, the type error surfaces at the assignment site (consumer) rather than at the type definition (producer). An explicit `satisfies` constraint would make the contract fail-fast at definition time. **Fix shape**: declare a structural-compatibility witness type (e.g., `PgvectorMemoryDocument satisfies StorageNarrowsToRag`) — concrete encoding TBD; needs design pass on whether to express the invariant at the type level or via a compile-time test in `*.test-d.ts`. **Promote when**: `MemoryDocument.metadata` (in `ConversationalRAGTypes.ts`) gains a required field, OR opportunistically when next touching the storage→RAG seam in `MemoryRetriever`. Surfaced 2026-04-30 PR #948 round 3. Deferred 2026-05-01.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-79 - BYOK-key-rotation-false-positive-rate-limit-block-up-to-24h.md
+++ b/tracker/tasks/task-79 - BYOK-key-rotation-false-positive-rate-limit-block-up-to-24h.md
@@ -1,0 +1,21 @@
+---
+id: TASK-79
+title: 'BYOK key rotation false-positive rate-limit block (up to 24h)'
+status: To Do
+assignee: []
+created_date: '2026-04-29 00:00'
+labels:
+  - 'area:tooling'
+  - 'area:redis'
+dependencies: []
+ordinal: 79000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+BYOK key rotation false-positive rate-limit block (up to 24h)
+
+**Why:** Rate-limit cache uses `user:<discordId>` as scope identifier. If a user rotates their OpenRouter API key after the original key hit the daily quota, the `user:<discordId>` Redis bucket stays cached as rate-limited until the original reset window expires (up to 24h via clamped TTL). The new key has its own independent quota, so the block is incorrect. **Why deferred**: rare in practice — users almost never rotate keys mid-quota. **Fix shape options**: (a) add `keyRotatedAt` timestamp to the BYOK user record; `deriveCacheKeyId` returns `user:<discordId>:<rotation-epoch>` so a new key gets a fresh cache scope; (b) operator escape valve via `pnpm ops cache:clear-rate-limit --user-id <id>`. Option (b) is cheaper if the manual escape is acceptable; option (a) is correct without operator intervention. **Promote when**: a user reports being rate-limit-blocked after rotating their key, OR alongside an api-key-management UX overhaul. Surfaced 2026-04-29 PR #943. Deferred 2026-05-01.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-8 - api-gateway-does-not-subscribe-to-UserCacheInvalidationService-broadcasts-only….md
+++ b/tracker/tasks/task-8 - api-gateway-does-not-subscribe-to-UserCacheInvalidationService-broadcasts-only….md
@@ -1,0 +1,22 @@
+---
+id: TASK-8
+title: 'api-gateway does not subscribe to UserCacheInvalidationService broadcasts — only…'
+status: To Do
+assignee: []
+created_date: '2026-07-16 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:ai-worker'
+  - 'origin:review'
+dependencies: []
+ordinal: 8000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-16 (#1661 review) — api-gateway does not subscribe to `UserCacheInvalidationService` broadcasts — only ai-worker does. Today that's correct: deletion always runs in api-gateway, which evicts its OWN process synchronously in the delete route, and the broadcast's only intended audience is ai-worker. But a second api-gateway replica would never hear about a deletion performed on the first (no synchronous call, no subscription) — reopening the post-deletion FK-violation class across api-gateway replicas specifically. The topology is documented in `UserCacheInvalidationService.ts` / `UserService.invalidateUser`'s comments. **Fix shape**: wire an api-gateway-side subscriber (same `clearCache`/`invalidateUser` wiring ai-worker's `wireUserCacheInvalidation` uses), skipping self-eviction double-work if desired. **Promote when**: api-gateway is ever scaled past one replica.
+
+**Why:** Single-replica assumption baked into the eviction topology; harmless until the replica count changes.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-80 - Make-cacheKeyId-required-in-InvokeWithRetryOptions-option-a.md
+++ b/tracker/tasks/task-80 - Make-cacheKeyId-required-in-InvokeWithRetryOptions-option-a.md
@@ -1,0 +1,20 @@
+---
+id: TASK-80
+title: 'Make cacheKeyId required in InvokeWithRetryOptions (option a)'
+status: To Do
+assignee: []
+created_date: '2026-04-29 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 80000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Make `cacheKeyId` required in `InvokeWithRetryOptions` (option a)
+
+**Why:** Option (b) — `logger.debug` opt-out log when `cacheKeyId.length === 0` — SHIPPED in PR #947, so the silent opt-out is now visible in local dev. PR #947 also added a consumer-side `assertValidCacheKeyId` call inside the else-branch as a separate guard (shape validation, not required-vs-optional). Option (a) — making the field required in the type so test fixtures must explicitly pass `''` — remains untouched. **Promote (a) when**: a 2nd production caller of `LLMInvoker.invokeWithRetry` is added (audit `services/ai-worker/src/services/` for new `invokeWithRetry` invocations). Originally surfaced 2026-04-29 PR #943; option (b) closed 2026-04-30 PR #947. Deferred 2026-05-01.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-81 - Monitor-ignoreExportsUsedInFile-true-knip-config.md
+++ b/tracker/tasks/task-81 - Monitor-ignoreExportsUsedInFile-true-knip-config.md
@@ -1,0 +1,22 @@
+---
+id: TASK-81
+title: 'Monitor ignoreExportsUsedInFile: true knip config'
+status: To Do
+assignee: []
+created_date: '2026-04-29 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:api-gateway'
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 81000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Monitor `ignoreExportsUsedInFile: true` knip config
+
+**Why:** PR #941 added `ignoreExportsUsedInFile: true` at the **global** knip config level to dampen the dominant false-positive class (option-bag/result-bag interfaces declared next to consumer functions). Risk: a genuine dead export that happens to also be used internally would be silently suppressed too. Knip supports this flag at per-workspace level. **Fix shape (when triggered)**: remove the global flag, add it per-workspace to only `services/ai-worker`, `services/api-gateway`, `services/bot-client` where the option-bag pattern dominates; leave `packages/*` workspaces stricter since they have public API surfaces. **Promote when**: a real dead-export bug that should have been caught is found by other means (review, manual audit, runtime), OR after ~5 PR cycles if the suppression starts feeling too aggressive in routine PR reviews. Surfaced 2026-04-29 PR #941 round 2. Deferred 2026-05-01.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-82 - tryResolveUserKey-no-key-negative-caching.md
+++ b/tracker/tasks/task-82 - tryResolveUserKey-no-key-negative-caching.md
@@ -1,0 +1,20 @@
+---
+id: TASK-82
+title: 'tryResolveUserKey no-key negative caching'
+status: To Do
+assignee: []
+created_date: '2026-04-27 00:00'
+labels:
+  - 'area:ai-worker'
+dependencies: []
+ordinal: 82000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`tryResolveUserKey` no-key negative caching
+
+**Why:** For `zai-coding`-with-no-key (the auto-fallthrough majority path), `tryResolveUserKey` returns `null` without cache write → every request re-reads DB. Currently accepted overhead documented in code comment at `services/ai-worker/src/services/ApiKeyResolver.ts`; `resolveApiKey`'s `source: 'system'` semantics can't be reused because `zai-coding` has no system fallback. Invariant test (do-not-cache-null-path) shipped via PR #925 — locks in current behavior so a future caching change is a deliberate, test-failure-inducing decision rather than a silent regression. **Fix shape (caching)**: introduce a distinct cache state for "no user key configured" (e.g., `source: 'absent'` discriminant or sentinel value), populate it from `tryResolveUserKey`'s null branch, short-circuit subsequent reads through the same entry-point. Touches `ApiKeyResolver`'s cache shape; likely needs co-update to `resolveApiKey` callers that peek the cache directly. **Promote when**: production logs show measurable per-request DB-read load on the fallthrough path, OR if a 2nd auto-fallthrough provider lands and the duplicate-DB-read pattern compounds. Surfaced 2026-04-27 PR #924 round 7. Deferred 2026-05-01.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-83 - Validate-other-wallet-and-gateway-responses-against-Zod-schemas-at-api-gateway-b.md
+++ b/tracker/tasks/task-83 - Validate-other-wallet-and-gateway-responses-against-Zod-schemas-at-api-gateway-b.md
@@ -1,0 +1,21 @@
+---
+id: TASK-83
+title: 'Validate other /wallet/* and gateway responses against Zod schemas at api-gateway boundary'
+status: To Do
+assignee: []
+created_date: '2026-04-26 00:00'
+labels:
+  - 'area:api-gateway'
+  - 'area:common-types'
+dependencies: []
+ordinal: 83000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Validate other `/wallet/*` and gateway responses against Zod schemas at api-gateway boundary
+
+**Why:** `/wallet/list` resolved in batch-1 cleanup PR (parses through `ListWalletKeysResponseSchema` before `sendCustomSuccess`). Same gap on other gateway endpoints with hand-coded response shapes against schemas in `common-types/schemas/api/`: `/wallet/test`, `/wallet/:provider` DELETE, admin/_ and user/_ sub-routes. **Fix shape**: same pattern — `Schema.parse(payload)` before send. Or invest in wrapping `sendCustomSuccess` with a schema-aware variant so the parse happens centrally. Folds naturally into the Observability & Telemetry theme. **Heads-up on the error path** (PR #929 round 1): `asyncHandler` catches thrown errors and includes `error.message` in the 500 response body. `ZodError.message` includes the full field path and expected/received shapes — fine for authenticated internal endpoints, but if extended to public-facing endpoints, the leak surface needs separate treatment (catch `ZodError` specifically, return generic 500). **Promote when**: extending response validation to additional `/wallet/*` or admin/user routes, OR alongside the Observability & Telemetry theme. Surfaced 2026-04-26 PR #908. Deferred 2026-05-01.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-84 - Per-instance-evictionLock-serializes-prepare-across-all-slugs.md
+++ b/tracker/tasks/task-84 - Per-instance-evictionLock-serializes-prepare-across-all-slugs.md
@@ -1,0 +1,19 @@
+---
+id: TASK-84
+title: 'Per-instance evictionLock serializes prepare() across all slugs'
+status: To Do
+assignee: []
+created_date: '2026-05-04 00:00'
+labels: []
+dependencies: []
+ordinal: 84000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Per-instance `evictionLock` serializes `prepare()` across all slugs
+
+**Why:** `ElevenLabsTtsProvider` + `MistralTtsProvider` use a per-instance promise-chain mutex for `prepare()` — correct for race protection but ALL slugs serialize on the same lock. If slug A's clone hangs, slug B's `prepare()` waits the full timeout. Worst-case latency `(N_concurrent_slow_prepares × timeout)`. **Fix**: per-slug lock map. ~30 LOC across both providers. **Promote when**: simultaneous persona switches with cold caches AND latency complaints surface, OR opportunistic when next touching either provider. Surfaced 2026-05-04 PR #967. Deferred 2026-05-07.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-85 - Harden-ttsConfigSingletonsts-module-level-state-was-extract-shared….md
+++ b/tracker/tasks/task-85 - Harden-ttsConfigSingletonsts-module-level-state-was-extract-shared….md
@@ -1,0 +1,20 @@
+---
+id: TASK-85
+title: 'Harden ttsConfigSingletons.ts module-level state (was: extract shared…'
+status: To Do
+assignee: []
+created_date: '2026-05-04 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 85000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Harden `ttsConfigSingletons.ts` module-level state (was: extract shared `SingletonFlagResolver`)
+
+**Why:** Module-level `let pendingResolutions` for cross-call state; the type system doesn't enforce prepare→finalize sequencing — silently no-ops on stale state if order flips. Re-scoped 2026-07-05: the LLM twin (`llmConfigSingletons.ts`) was deleted by the legacy-column retirement (#1499), so the shared-class extraction is moot — only the TTS file remains, and it dissolves entirely when the TTS mirror columns (`tts_configs.isDefault`/`isFreeDefault`) get their own retirement. **Promote when**: the TTS legacy-column retirement is planned (fold the deletion in), OR the sequencing fragility actually misfires. Surfaced 2026-05-04 PR #968.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-86 - Dashboard-action-naming-convention-drift-kebab-vs-snake.md
+++ b/tracker/tasks/task-86 - Dashboard-action-naming-convention-drift-kebab-vs-snake.md
@@ -1,0 +1,20 @@
+---
+id: TASK-86
+title: 'Dashboard action naming convention drift (kebab vs snake)'
+status: To Do
+assignee: []
+created_date: '2026-05-06 00:00'
+labels:
+  - 'area:db'
+dependencies: []
+ordinal: 86000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Dashboard action naming convention drift (kebab vs snake)
+
+**Why:** `DASHBOARD_ACTIONS` mixes `confirm-delete`/`cancel-delete` (kebab) with `edit_truncated`/`cancel_edit`/`view_full`/`open_editor` (snake). Pre-existing in character; persona mirrored. Strings encoded into Discord custom IDs in user channels — rename requires a migration path. ~50-80 LOC + ~1 month deprecation window. **Promote when**: a dashboard refactor pass touches customId parsing, OR a third dashboard adopts the truncation gate. Surfaced 2026-05-06 PR #984 round 4 + 7. Deferred 2026-05-07.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-87 - Extract-conditional-warning-responselog-helper-for-admin-config-delete-handlers.md
+++ b/tracker/tasks/task-87 - Extract-conditional-warning-responselog-helper-for-admin-config-delete-handlers.md
@@ -1,0 +1,21 @@
+---
+id: TASK-87
+title: 'Extract conditional-warning response/log helper for admin config-delete handlers'
+status: To Do
+assignee: []
+created_date: '2026-05-04 00:00'
+labels:
+  - 'area:voice'
+  - 'area:db'
+dependencies: []
+ordinal: 87000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Extract conditional-warning response/log helper for admin config-delete handlers
+
+**Why:** Both `admin/llm-config.ts` and `admin/tts-config.ts` now have identical `responseBody`/`logFields` ternaries (clean delete vs warning-bearing). ~20 LOC + colocated tests. Companion cleanups: skip the third `prisma.user.count` query in `checkDeleteConstraints` when blocker known; normalize blocker message asymmetry. Reviewer flagged "not worth extracting at N=2." **Promote when**: a third admin config-delete handler with the same warning-discriminator shape lands, OR opportunistic alongside any admin-routes refactor pass. Surfaced 2026-05-04 PR #978. Deferred 2026-05-07.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-88 - Distinguish-transient-vs-deterministic-failures-in-MistralTtsProvider-negative-c.md
+++ b/tracker/tasks/task-88 - Distinguish-transient-vs-deterministic-failures-in-MistralTtsProvider-negative-c.md
@@ -1,0 +1,19 @@
+---
+id: TASK-88
+title: 'Distinguish transient vs deterministic failures in MistralTtsProvider negative cache'
+status: To Do
+assignee: []
+created_date: '2026-05-04 00:00'
+labels: []
+dependencies: []
+ordinal: 88000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Distinguish transient vs deterministic failures in `MistralTtsProvider` negative cache
+
+**Why:** The 5-min negative cache catches all non-rate-limit failures uniformly. Deterministic failures (401 auth, malformed reference) get cached identically to transient failures (5xx, network blips). PR #974 added one explicit skip for `MistralReferenceAudioTooLongError`. **Fix shape**: route catch through `error.isTransient`; only set negative cache when `isTransient === true`. ~15-20 LOC + tests. **Promote when**: opportunistic alongside next `MistralTtsProvider` edit OR if cache-poisoning produces user-visible delay. Surfaced 2026-05-04 PR #974. Deferred 2026-05-07.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-89 - Smart-per-user-cache-invalidation-for-LLM-TTS-configs-cross-cutting.md
+++ b/tracker/tasks/task-89 - Smart-per-user-cache-invalidation-for-LLM-TTS-configs-cross-cutting.md
@@ -1,0 +1,20 @@
+---
+id: TASK-89
+title: 'Smart per-user cache invalidation for LLM + TTS configs (cross-cutting)'
+status: To Do
+assignee: []
+created_date: '2026-05-03 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 89000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Smart per-user cache invalidation for LLM + TTS configs (cross-cutting)
+
+**Why:** `LlmConfigService.invalidateCacheSafely()` and the `TtsConfigService` mirror both call `cacheInvalidation.invalidateAll()` on every mutation, nuking every user's TTLCache. Better pattern (`ConfigCascadeCacheInvalidationService`) exists but isn't used. Upgrade BOTH services together: enumerate affected users, publish per-user events, only invalidate-all for unenumerable changes (e.g., `setAsFreeDefault`). ~200-300 LOC across both services + tests. **Promote when**: opportunistic when next touching either config service, OR if unconditional invalidation produces measurable cache-thrash in production. Surfaced 2026-05-03. Deferred 2026-05-07.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-9 - single-flight-loser-skips-the-negative-cache-re-check-after-fall-through-A-waite.md
+++ b/tracker/tasks/task-9 - single-flight-loser-skips-the-negative-cache-re-check-after-fall-through-A-waite.md
@@ -1,0 +1,19 @@
+---
+id: TASK-9
+title: 'single-flight loser skips the negative-cache re-check after fall-through — A waiter that…'
+status: To Do
+assignee: []
+created_date: '2026-07-12 00:00'
+labels: []
+dependencies: []
+ordinal: 9000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Surfaced 2026-07-12 — single-flight loser skips the negative-cache re-check after fall-through — A waiter that falls through (winner failed) proceeds straight into its own provider call even though the winner's failure was just written to the negative cache — re-running `checkNegativeCache` after a fallen-through `enterSingleFlight` would short-circuit doomed duplicates. Value is bounded: failure entries are per-MODEL (`vision:fail:{model}:…`), so only same-model losers would hit the winner's entry; different-model losers correctly retry on their own model. **Fix shape**: one re-check + early-return in `describeImage` after the fall-through branch. **Promote when**: next VisionProcessor touch, or if fan-out failure storms show in logs. Surfaced by #1603 round-2 review (non-blocking).
+
+**Why:** Cheap short-circuit for the same-model failure case.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-90 - Split-LlmConfigService-TtsConfigService-into-QueryMutationCache-services….md
+++ b/tracker/tasks/task-90 - Split-LlmConfigService-TtsConfigService-into-QueryMutationCache-services….md
@@ -1,0 +1,20 @@
+---
+id: TASK-90
+title: 'Split LlmConfigService + TtsConfigService into Query/Mutation/Cache services…'
+status: To Do
+assignee: []
+created_date: '2026-05-03 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 90000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Split `LlmConfigService` + `TtsConfigService` into Query/Mutation/Cache services (cross-cutting)
+
+**Why:** Both services hover at ~600+ raw LOC with mixed responsibilities. Currently passes lint via skip-blanks/skip-comments. Council recommended pre-splitting; user chose mirror-as-single-file for now and split BOTH later when burden becomes real. **Fix shape**: when either crosses the lint threshold, split BOTH into `*QueryService.ts` + `*MutationService.ts` (cache wiring stays in mutation). Mirror split for both LLM and TTS in same PR for symmetry. **Promote when**: ESLint `max-lines` flags either service, OR new feature requires expansion that pushes over 400 content-lines. Surfaced 2026-05-03. Deferred 2026-05-07.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-91 - Mistral-slot-quota-empirical-verification.md
+++ b/tracker/tasks/task-91 - Mistral-slot-quota-empirical-verification.md
@@ -1,0 +1,20 @@
+---
+id: TASK-91
+title: 'Mistral slot quota empirical verification'
+status: To Do
+assignee: []
+created_date: '2026-05-02 00:00'
+labels:
+  - 'area:docs'
+dependencies: []
+ordinal: 91000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Mistral slot quota empirical verification
+
+**Why:** PR 2 ships defensive eviction code modeled on ElevenLabs' "musical chairs" pattern, but Mistral's account-level voice quota is undocumented. Smoke test (4 clones) was insufficient to probe limits. Eviction code may never fire. **Fix shape**: post-deploy, attempt many clones in single account; observe error shape + threshold; document in `docs/research/voice-cloning-2026.md`. **Promote when**: PR 2 has been in production for 2+ weeks without eviction firing AND we want to know whether to keep or remove the dead-on-arrival code. Surfaced 2026-05-02. Deferred 2026-05-07.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-92 - Memory-retrieval-Found-20-Included-0-mystery-Focus-Mode-off.md
+++ b/tracker/tasks/task-92 - Memory-retrieval-Found-20-Included-0-mystery-Focus-Mode-off.md
@@ -1,0 +1,19 @@
+---
+id: TASK-92
+title: 'Memory retrieval Found: 20 / Included: 0 mystery (Focus Mode off)'
+status: To Do
+assignee: []
+created_date: '2026-05-03 00:00'
+labels: []
+dependencies: []
+ordinal: 92000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Memory retrieval `Found: 20 / Included: 0` mystery (Focus Mode off)
+
+**Why:** Diagnostic screenshot 2026-05-03 showed 20 candidate memories scored 0.65–0.71 with zero included despite Focus Mode off. Possible: similarity-threshold misconfigured (0.72+?), token-budget logic returning 0, ranking-filter pipeline dropping candidates. Same screenshot also showed `History > 70%! Sycophancy risk!` — context-budget pressure may be related. **Fix shape**: trace `MemoryService.retrieveRelevant() → MemoryBudgetManager → final-include filter`; add structured log between each stage so drop reason is visible in diagnostic. **Promote when**: a user reports degraded memory recall, OR opportunistic during next memory-pipeline pass. Surfaced 2026-05-03. Deferred 2026-05-12.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-93 - discordjsrest261-REST-queue-stall-under-sustained-rate-limit-pressure.md
+++ b/tracker/tasks/task-93 - discordjsrest261-REST-queue-stall-under-sustained-rate-limit-pressure.md
@@ -1,0 +1,20 @@
+---
+id: TASK-93
+title: '@discordjs/rest@2.6.1 REST queue stall under sustained rate-limit pressure'
+status: To Do
+assignee: []
+created_date: '2026-05-08 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 93000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`@discordjs/rest@2.6.1` REST queue stall under sustained rate-limit pressure
+
+**Why:** Root cause of voice-transcription hang fixed in PR #1000 was `await channel.sendTyping()` blocking forever when discord.js's REST queue stalled. PR's fire-and-forget + ESLint guard prevents whole-pipeline hangs on this class of bug, but the underlying queue stall is unexplained upstream behavior. **Investigation shape**: (a) reproduce by hammering `sendTyping` against single channel under rate-limit pressure; (b) structured logging around `RequestManager` queue depth + retry counts; (c) check `@discordjs/rest@2.7.x` changelogs for queue-stall fixes; (d) decide upgrade vs. `Promise.race` timeout helper for all REST calls. **Why deferred**: blast radius — touches every REST call pattern, not just `sendTyping`. **Promote when**: another hang of the same class surfaces against a different REST endpoint, OR opportunistic during next discord.js dependency bump. Surfaced 2026-05-08. Deferred 2026-05-12.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-94 - Resolve-personalityTone-UIAPI-cap-mismatch-UI-255-API-1000.md
+++ b/tracker/tasks/task-94 - Resolve-personalityTone-UIAPI-cap-mismatch-UI-255-API-1000.md
@@ -1,0 +1,21 @@
+---
+id: TASK-94
+title: 'Resolve personalityTone UI/API cap mismatch (UI 255 / API 1000)'
+status: To Do
+assignee: []
+created_date: '2026-05-06 00:00'
+labels:
+  - 'area:bot-client'
+  - 'area:db'
+dependencies: []
+ordinal: 94000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Resolve `personalityTone` UI/API cap mismatch (UI 255 / API 1000)
+
+**Why:** After PR #983's `SHORT_PARAGRAPH_MAX_LENGTH` rename, schema caps `personalityTone` at 1000 but `services/bot-client/src/commands/character/sections.ts:74` caps UI input at 255. Same data-loss vector as PR #983's primary fix: tone 256–1000 stored via direct API gets silently truncated to 255 on dashboard edit. **Three options, all caveated**: (a) bump UI cap to 1000 — UX-questionable for a single-line input; (b) lower API to 255 — requires data audit first; (c) document asymmetry as intentional. **Fix shape pending option**: ~5 LOC for any; option (b) needs preceding audit + migration. **Promote when**: opportunistic during next character-dashboard refactor, OR if a user reports surprising tone truncation. Surfaced 2026-05-06. Deferred 2026-05-12.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-95 - STT-CHECK-constraint-companion-migration-when-4th-provider-ships.md
+++ b/tracker/tasks/task-95 - STT-CHECK-constraint-companion-migration-when-4th-provider-ships.md
@@ -1,0 +1,21 @@
+---
+id: TASK-95
+title: 'STT CHECK constraint companion migration when 4th provider ships'
+status: To Do
+assignee: []
+created_date: '2026-05-10 00:00'
+labels:
+  - 'area:voice'
+  - 'area:db'
+dependencies: []
+ordinal: 95000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+STT CHECK constraint companion migration when 4th provider ships
+
+**Why:** `valid_default_stt_provider_id` CHECK hardcodes `'mistral' | 'elevenlabs' | 'voice-engine'`. When a 4th STT provider lands (Groq, Deepgram, OpenAI Whisper-direct, etc), the migration needs a companion `ALTER TABLE users DROP CONSTRAINT ... ADD CONSTRAINT ... IN (..., 'new-provider')`. Cross-reference comment already in `sttProvider.ts` and the migration file. **Promote when**: a 4th STT provider is on the roadmap. Surfaced 2026-05-10. Deferred 2026-05-12.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-96 - MultiTagRecovery-background-run-race-with-startResultsListener-after-timeout.md
+++ b/tracker/tasks/task-96 - MultiTagRecovery-background-run-race-with-startResultsListener-after-timeout.md
@@ -1,0 +1,19 @@
+---
+id: TASK-96
+title: 'MultiTagRecovery background-run race with startResultsListener after timeout'
+status: To Do
+assignee: []
+created_date: '2026-05-16 00:00'
+labels: []
+dependencies: []
+ordinal: 96000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+MultiTagRecovery background-run race with `startResultsListener` after timeout
+
+**Why:** When recovery exceeds the 30s `Promise.race` timeout in `index.ts`, the background `recovery.run()` continues iterating through remaining entries. Each `adoptRehydratedEntry` registers new jobIds in `jobToGroup`, but during the brief window between `chatManager.submitChatJob` returning a fresh jobId and `adoptRehydratedEntry`'s `jobToGroup.set` running, a result for that new jobId could arrive (via the already-started `startResultsListener`), find `ownsJob` false, and fall through to the single-personality path — bypassing slot ordering. **Low probability**: timeout implies degraded Discord, which also implies slow result delivery, narrowing the window. **Fix shape options**: (a) thread a cancellation token through recovery so the loop bails on timeout; (b) pre-populate `jobToGroup` per slot inside `rebuildSlot` immediately after `submitChatJob`; (c) accept the race and add a stronger comment. **Promote when**: if production logs show "recovery exceeded 30s" non-zero frequency, OR if the race surfaces as a missed-ordering bug. Surfaced 2026-05-16 PR #1034.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-97 - adoptRehydratedEntry-all-terminal-path-may-leak-ordering-service-state.md
+++ b/tracker/tasks/task-97 - adoptRehydratedEntry-all-terminal-path-may-leak-ordering-service-state.md
@@ -1,0 +1,20 @@
+---
+id: TASK-97
+title: 'adoptRehydratedEntry all-terminal path may leak ordering-service state'
+status: To Do
+assignee: []
+created_date: '2026-05-16 00:00'
+labels:
+  - 'area:jobs'
+dependencies: []
+ordinal: 97000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`adoptRehydratedEntry` all-terminal path may leak ordering-service state
+
+**Why:** `MultiTagCoordinator.adoptRehydratedEntry` calls `orderingService.registerJob(channelId, groupId, ...)` unconditionally, then if all slots are terminal, immediately calls `flushEntry → deliverGroup → deleteEntry`. `flushEntry` invokes `orderingService.handleResult` which should process the registered job — but end-to-end cleanup hasn't been verified. **Risk**: if `ResponseOrderingService` doesn't clean up its internal tracking when `handleResult`'s deliverFn callback fires post-flush, the channel's ordering queue could retain a dangling reference, delaying or stalling other buffered messages. **Fix shape**: focused integration test exercising the all-terminal adoption path, asserting on `ResponseOrderingService`'s queue state post-flush. If a leak exists: skip `registerJob` when allDone is computable before registration, OR add an explicit cleanup call. **Promote when**: opportunistic during the next `ResponseOrderingService` touch, OR if recovery-related ordering issues surface in production logs. Surfaced 2026-05-16 PR #1034.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-98 - buildSentinelPersonality-type-safety-hardening.md
+++ b/tracker/tasks/task-98 - buildSentinelPersonality-type-safety-hardening.md
@@ -1,0 +1,19 @@
+---
+id: TASK-98
+title: 'buildSentinelPersonality type-safety hardening'
+status: To Do
+assignee: []
+created_date: '2026-05-16 00:00'
+labels: []
+dependencies: []
+ordinal: 98000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+`buildSentinelPersonality` type-safety hardening
+
+**Why:** `MultiTagRecovery.buildSentinelPersonality` returns a `Partial<LoadedPersonality>` shape cast via `as unknown as LoadedPersonality` — only `id`/`slug`/`displayName`/`name` are populated. The deliverError path consumes those four fields; any future caller touching other fields (e.g., `llmConfig`, `systemPrompt`) will silently observe `undefined` rather than receive a type error. **Fix shape**: replace the cast with a discriminated-union sentinel type (e.g., `LoadedPersonality | { __sentinel: true; id, slug, displayName, name }`) so consumers must explicitly handle the sentinel case, OR change `LoadedPersonality` itself to make the four "always-present" fields non-optional and the rest optional + add an `isSentinel` discriminator. **Promote when**: a downstream caller of recovery-rebuilt slots needs to access a non-sentinel field of `LoadedPersonality` (next refactor of `SlotDeliveryService` or any extension to `deliverError`). Surfaced 2026-05-16 PR #1034.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-99 - Mistral-TTS-guardrail-violations.md
+++ b/tracker/tasks/task-99 - Mistral-TTS-guardrail-violations.md
@@ -1,0 +1,20 @@
+---
+id: TASK-99
+title: 'Mistral TTS guardrail violations'
+status: To Do
+assignee: []
+created_date: '2026-05-13 00:00'
+labels:
+  - 'area:voice'
+dependencies: []
+ordinal: 99000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+Mistral TTS guardrail violations — bot-owner-visible notice
+
+**Why:** Production logs show Mistral returning `403 guardrail_violation code 1920 "Request blocked by guardrail policy"` on innocuous content (concrete example: Monty Python reference about African vs European swallows + "capital of Assyria" joke). The dispatcher correctly falls through to self-hosted, but the user has no idea their content is being content-policed by Mistral. **Fix shape (visibility)**: in `MistralTtsClient.ts`, detect the 403 + `code === 1920` shape, throw a new `MistralGuardrailError` (sibling to `MistralReferenceAudioTooLongError`) with a `userNotice` field; thread through `TtsDispatcher.buildAttemptNotice`. ~30-50 LOC + test. **Promote when**: opportunistic during next MistralTtsClient touch, OR alongside the BYOK re-eval work. Surfaced 2026-05-13.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## What

Step 1 of the owner-ratified backlog substrate migration (boundary: follow-ups → tasks, themes/ideas → docs — trial-validated 2026-07-26, ratified 2026-07-27).

- **`tracker/`** — the Backlog.md store: 335/335 live `cold/follow-ups.md` rows imported as tasks (zero parse anomalies, 100% dated, 315 promote-when triggers preserved in bodies). Labels: 187/335 (56%) carry a mechanically-derived `area:*` label across 20 areas; counting `origin:review` too, 242/335 (72%) carry at least one label. The remaining unlabeled rows are the flip-phase labeling pass's job.
- **`backlog.config.yml`** (root) — disambiguates the store from the markdown `backlog/` dir for every CLI invocation; git integration disabled (the tool never runs git; this repo's workflow owns commits).
- **Round 2 (review moderates)**: `tracker/` added to `.prettierignore` (the CLI owns those files' shape); `backlog.md` pinned at the trial-validated 1.48.0 as a root devDep with a `pnpm tracker` convenience script.

## What this PR deliberately does NOT do

**`cold/follow-ups.md` remains the authoritative surface** until the flip PR (next unit) lands: 06-backlog.md rewrite, BACKLOG.md manifest, follow-ups retirement, digest generator into `pnpm ops`, backlog-lint updates. No dual-writing in the window — the flip PR re-syncs any rows that change in the interim before deleting the markdown file.

## Verification

- `pnpm tracker task list --plain` reads all 335 through the root config (verified again post-prettier-format — the store round-trips).
- Digest generator (trial tool) produces the 58-line session-start briefing from the store (vs today's 44KB hot surface).
- Area distribution sanity-checked (db 41 · tooling 35 · bot-client 30 · ai-worker 25 · voice 23 …).
- `pnpm test` + `pnpm quality` green incl. knip (the pinned dep is script-referenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)