### PR TITLE
fix(backlog): note area-count overlap in the digest; codify size/priority labels

### DIFF
--- a/.claude/rules/06-backlog.md
+++ b/.claude/rules/06-backlog.md
@@ -42,6 +42,7 @@ pnpm ops backlog:digest                                                     # th
 
 - **A task description carries why, what, and acceptance** — same bar as any backlog entry. `Promote when: <event>` is an optional annotation (see the admission bar).
 - **Labels**: `area:<package-or-domain>` (db, redis, voice, bot-client, …). Label at filing; the digest's per-area counts are the jump-around index.
+- **Size + priority** (set at filing; every existing task carries them): `size:S` (<~1hr, one file) / `size:M` (a PR) / `size:L` (multi-PR or needs design) labels, plus the CLI priority field — `high` (prod-correctness / data-rights adjacent) · `medium` (real improvement, no urgency) · `low` (gated, speculative, or watch items). The drain query: `pnpm tracker task list -l size:S --priority high --plain`.
 - **Finishing**: `-s Done` at ship (digest and queries exclude Done); archive during periodic sweeps. For **obsolete** or **ruled-out** exits, archive with the reason in the removing commit — same evidence bar as before.
 - **Integrity is gated**: `pnpm ops backlog` (in `pnpm quality` + CI) fails on any task file whose frontmatter won't parse — a broken task silently vanishes from every query, which is the failure mode that killed the old table. Prefer CLI edits over hand edits for anything touching frontmatter.
 

--- a/packages/tooling/src/dev/backlogDigest.test.ts
+++ b/packages/tooling/src/dev/backlogDigest.test.ts
@@ -117,6 +117,7 @@ describe('runBacklogDigest', () => {
 
     const out = logSpy.mock.calls.flat().join('\n');
     expect(out).toContain('3 open tasks (1 in progress)');
+    expect(out).toContain('multi-area tasks count once per area');
     expect(out).toContain('- db: 2');
     expect(out).toContain('- (no area label yet): 1');
     // Oldest surface leads with the oldest filing date

--- a/packages/tooling/src/dev/backlogDigest.ts
+++ b/packages/tooling/src/dev/backlogDigest.ts
@@ -7,8 +7,9 @@
  * as part of the session-start load).
  *
  * Three surfaces, in priority order:
- *  - **By area** — per-`area:*`-label counts, so any slice of the haystack is
- *    one query away (`pnpm tracker task list -l area:<x> --plain`).
+ *  - **By area** — per-`area:*`-label counts (a multi-area task counts in each
+ *    of its areas, so the column can sum past the open total), so any slice of
+ *    the haystack is one query away (`pnpm tracker task list -l area:<x> --plain`).
  *  - **Oldest 20** — the aging escalation. Aging escalates, never deletes
  *    (`.claude/rules/06-backlog.md` § Staleness); this surface exists so the
  *    oldest items get a conscious decision instead of sinking. The old
@@ -92,7 +93,10 @@ export async function runBacklogDigest(options: DigestOptions = {}): Promise<voi
   );
   lines.push('');
 
-  lines.push('## By area (jump anywhere: pnpm tracker task list -l area:<x> --plain)');
+  // Multi-area tasks count once per area, so these can sum past the open total.
+  lines.push(
+    '## By area — multi-area tasks count once per area (jump: pnpm tracker task list -l area:<x> --plain)'
+  );
   const { areas, unlabeled } = countByArea(open);
   for (const [area, count] of areas) {
     lines.push(`- ${area}: ${count}`);


### PR DESCRIPTION
## What

TASK-338 (surfaced by #1823's round-5 review): `countByArea` counts a multi-area task once per area, so the digest's By-area column can sum past the open-task total. Intentional — tasks legitimately span areas — but unstated, so a reader could expect the counts to sum. The digest header now says so, and the test pins the note.

Rides along: `.claude/rules/06-backlog.md` § The tracker store documents the `size:S/M/L` labels + priority field that the step-3 labeling pass (committed directly as `14cd2dc59`) applied to every open task, including the drain query (`pnpm tracker task list -l size:S --priority high --plain`).

## Verified

- `pnpm --filter @tzurot/tooling test` — 1706/1706 green, including the new header-note assertion.
- `pnpm quality` — full chain green (lines:check headroom for the rules addition: 1958/2270).
- `pnpm ops backlog:digest` against the real store shows the new header with zero unlabeled tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)