### PR TITLE
fix: cascade memory deletion to derived facts (R8)

### DIFF
--- a/packages/conversation-history/src/index.ts
+++ b/packages/conversation-history/src/index.ts
@@ -22,3 +22,4 @@
 export { ConversationHistoryService } from './ConversationHistoryService.js';
 export { ConversationRetentionService } from './ConversationRetentionService.js';
 export { ConversationSyncService } from './ConversationSyncService.js';
+export { propagateDeletionToFacts } from './memoryDeletionPropagation.js';

--- a/packages/conversation-history/src/memoryDeletionPropagation.component.test.ts
+++ b/packages/conversation-history/src/memoryDeletionPropagation.component.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Component Test: memory-deletion propagation, fact layer (R8)
+ *
+ * The cascade is a raw-SQL join (array overlap against deleted memories), so
+ * mocked-Prisma unit tests can only assert it was invoked — whether the
+ * predicate retires exactly the right rows (any-source semantics, curation
+ * carve-outs, state exclusions, self-healing over historical deletions) is
+ * only testable against real Postgres semantics. PGlite is that boundary.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import {
+  propagateDeletionToFacts,
+  propagateDeletionToMemories,
+} from './memoryDeletionPropagation.js';
+
+describe('propagateDeletionToFacts (component)', () => {
+  let prisma: PrismaClient;
+  let pglite: PGlite;
+
+  const testUserId = '00000000-0000-0000-0000-000000000001';
+  const testPersonaId = '00000000-0000-0000-0000-000000000002';
+  const testPersonalityId = '00000000-0000-0000-0000-000000000003';
+
+  const MEM_ALIVE = '10000000-0000-0000-0000-000000000001';
+  const MEM_DELETED = '10000000-0000-0000-0000-000000000002';
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    const adapter = new PrismaPGlite(pglite);
+    prisma = new PrismaClient({ adapter }) as PrismaClient;
+
+    await seedUserWithPersona(prisma, {
+      userId: testUserId,
+      personaId: testPersonaId,
+      discordId: '111111111111111111',
+      username: 'testuser',
+      personaName: 'Test Persona',
+      personaPreferredName: 'Tester',
+      personaContent: 'A test persona',
+    });
+
+    const systemPromptId = '00000000-0000-0000-0000-000000000004';
+    await prisma.$executeRawUnsafe(`
+      INSERT INTO system_prompts (id, name, content, updated_at)
+      VALUES ('${systemPromptId}', 'Test Prompt', 'You are a test bot.', NOW())
+    `);
+    await prisma.$executeRawUnsafe(`
+      INSERT INTO personalities (id, name, slug, system_prompt_id, character_info, personality_traits, owner_id, updated_at)
+      VALUES ('${testPersonalityId}', 'TestBot', 'testbot', '${systemPromptId}', 'Test bot', 'Helpful', '${testUserId}', NOW())
+    `);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  });
+
+  beforeEach(async () => {
+    await prisma.$executeRawUnsafe('DELETE FROM memory_facts');
+    await prisma.$executeRawUnsafe('DELETE FROM memories');
+    await seedMemory(MEM_ALIVE, 'normal');
+    await seedMemory(MEM_DELETED, 'deleted');
+  });
+
+  async function seedMemory(
+    id: string,
+    visibility: string,
+    opts: { messageIds?: string[] } = {}
+  ): Promise<void> {
+    await prisma.$executeRaw`
+      INSERT INTO memories
+        (id, personality_id, persona_id, content, message_ids, senders, visibility, updated_at)
+      VALUES
+        (${id}::uuid, ${testPersonalityId}::uuid, ${testPersonaId}::uuid, 'memory content',
+         ${opts.messageIds ?? []}::text[], '{}'::text[], ${visibility}, NOW())
+    `;
+  }
+
+  async function seedFact(
+    id: string,
+    sourceMemoryIds: string[],
+    opts: {
+      visibility?: string;
+      isLocked?: boolean;
+      tier?: string;
+      forgotten?: boolean;
+      supersededAt?: string | null;
+    } = {}
+  ): Promise<void> {
+    await prisma.$executeRaw`
+      INSERT INTO memory_facts
+        (id, personality_id, persona_id, statement, salience, valid_from,
+         superseded_at, forgotten, visibility, is_locked, tier, source_memory_ids,
+         created_at, updated_at)
+      VALUES
+        (${id}::uuid, ${testPersonalityId}::uuid, ${testPersonaId}::uuid, 'a fact', 0.5,
+         '2026-01-01T00:00:00Z'::timestamptz, ${opts.supersededAt ?? null}::timestamptz,
+         ${opts.forgotten ?? false}, ${opts.visibility ?? 'normal'}, ${opts.isLocked ?? false},
+         ${opts.tier ?? 'observed'}, ${sourceMemoryIds}::text[],
+         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+    `;
+  }
+
+  async function factState(
+    id: string
+  ): Promise<{ visibility: string; forgotten: boolean; updatedAt: Date } | null> {
+    const row = await prisma.memoryFact.findUnique({
+      where: { id },
+      select: { visibility: true, forgotten: true, updatedAt: true },
+    });
+    return row;
+  }
+
+  const FACT = '20000000-0000-0000-0000-000000000001';
+
+  it('retires a fact when ANY source memory is deleted — even with living co-sources', async () => {
+    await seedFact(FACT, [MEM_DELETED, MEM_ALIVE]);
+
+    await propagateDeletionToFacts(prisma);
+
+    const fact = await factState(FACT);
+    expect(fact?.visibility).toBe('deleted');
+    // Semantic state change → updated_at must bump (dev↔prod LWW sync-worthy).
+    expect(fact?.updatedAt.getTime()).toBeGreaterThan(new Date('2026-01-01T00:00:00Z').getTime());
+  });
+
+  it('leaves a fact alone when every source memory is still living', async () => {
+    await seedFact(FACT, [MEM_ALIVE]);
+
+    await propagateDeletionToFacts(prisma);
+
+    expect((await factState(FACT))?.visibility).toBe('normal');
+  });
+
+  it('retains a LOCKED fact — a user pin outranks source deletion', async () => {
+    await seedFact(FACT, [MEM_DELETED], { isLocked: true });
+
+    await propagateDeletionToFacts(prisma);
+
+    expect((await factState(FACT))?.visibility).toBe('normal');
+  });
+
+  it('retains a CORRECTED-tier fact — a user assertion outranks source deletion', async () => {
+    await seedFact(FACT, [MEM_DELETED], { tier: 'corrected' });
+
+    await propagateDeletionToFacts(prisma);
+
+    expect((await factState(FACT))?.visibility).toBe('normal');
+  });
+
+  it('does not touch forgotten or superseded rows — their states are their own', async () => {
+    const FORGOTTEN = '20000000-0000-0000-0000-000000000002';
+    const SUPERSEDED = '20000000-0000-0000-0000-000000000003';
+    await seedFact(FORGOTTEN, [MEM_DELETED], { forgotten: true });
+    await seedFact(SUPERSEDED, [MEM_DELETED], { supersededAt: '2026-02-01T00:00:00Z' });
+
+    await propagateDeletionToFacts(prisma);
+
+    // Both already excluded from retrieval; flipping their visibility would
+    // inflate the cascade count and muddy revival semantics.
+    expect((await factState(FORGOTTEN))?.visibility).toBe('normal');
+    expect((await factState(SUPERSEDED))?.visibility).toBe('normal');
+  });
+
+  it('does not resurrect or re-touch an already-cascaded fact', async () => {
+    await seedFact(FACT, [MEM_DELETED], { visibility: 'deleted' });
+
+    await propagateDeletionToFacts(prisma);
+
+    const fact = await factState(FACT);
+    expect(fact?.visibility).toBe('deleted');
+    // No second write: updated_at keeps its original stamp.
+    expect(fact?.updatedAt.getTime()).toBe(new Date('2026-01-01T00:00:00Z').getTime());
+  });
+
+  it('propagates a message deletion through the full chain: message → memory → fact', async () => {
+    // The wiring test: real chain over the real DB, mocking nothing. A message
+    // deletion soft-deletes the derived memory, which retires the derived fact.
+    const MEM_FROM_MSG = '10000000-0000-0000-0000-000000000003';
+    await seedMemory(MEM_FROM_MSG, 'normal', { messageIds: ['999888777666555444'] });
+    await seedFact(FACT, [MEM_FROM_MSG]);
+
+    await propagateDeletionToMemories(prisma, ['999888777666555444']);
+
+    const memory = await prisma.memory.findUnique({
+      where: { id: MEM_FROM_MSG },
+      select: { visibility: true },
+    });
+    expect(memory?.visibility).toBe('deleted');
+    expect((await factState(FACT))?.visibility).toBe('deleted');
+  });
+
+  it('self-heals: retires facts leaked by deletions that predate the cascade', async () => {
+    // MEM_DELETED was deleted "before the cascade existed" (no propagation ran
+    // for it). Any later invocation — triggered by an unrelated deletion —
+    // sweeps the leak, because the predicate joins ALL deleted memories.
+    await seedFact(FACT, [MEM_DELETED]);
+    const UNRELATED = '10000000-0000-0000-0000-000000000004';
+    await seedMemory(UNRELATED, 'normal', { messageIds: ['111222333444555666'] });
+
+    await propagateDeletionToMemories(prisma, ['111222333444555666']);
+
+    expect((await factState(FACT))?.visibility).toBe('deleted');
+  });
+});

--- a/packages/conversation-history/src/memoryDeletionPropagation.test.ts
+++ b/packages/conversation-history/src/memoryDeletionPropagation.test.ts
@@ -18,15 +18,29 @@ vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
   };
 });
 
-import { propagateDeletionToMemories } from './memoryDeletionPropagation.js';
+import {
+  propagateDeletionToFacts,
+  propagateDeletionToMemories,
+} from './memoryDeletionPropagation.js';
 
-function makePrisma(overrides: { updateCount?: number; lockedCount?: number } = {}) {
+function makePrisma(
+  overrides: {
+    updateCount?: number;
+    lockedCount?: number;
+    factsRetired?: number;
+    curationRetained?: number;
+  } = {}
+) {
   const updateMany = vi.fn().mockResolvedValue({ count: overrides.updateCount ?? 1 });
   const count = vi.fn().mockResolvedValue(overrides.lockedCount ?? 0);
+  const $executeRaw = vi.fn().mockResolvedValue(overrides.factsRetired ?? 0);
+  const $queryRaw = vi.fn().mockResolvedValue([{ count: overrides.curationRetained ?? 0 }]);
   return {
-    prisma: { memory: { updateMany, count } } as unknown as PrismaClient,
+    prisma: { memory: { updateMany, count }, $executeRaw, $queryRaw } as unknown as PrismaClient,
     updateMany,
     count,
+    $executeRaw,
+    $queryRaw,
   };
 }
 
@@ -129,6 +143,62 @@ describe('propagateDeletionToMemories', () => {
     (prisma.memory.updateMany as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('db down'));
 
     await expect(propagateDeletionToMemories(prisma, ['m1'])).resolves.toBeUndefined();
+
+    expect(mockError).toHaveBeenCalledTimes(1);
+    expect(mockError.mock.calls[0][0]).toMatchObject({ err: expect.any(Error) });
+  });
+
+  describe('the fact-layer cascade', () => {
+    it('runs the fact cascade when memories were retired', async () => {
+      const { prisma, $executeRaw } = makePrisma({ updateCount: 2 });
+
+      await propagateDeletionToMemories(prisma, ['m1']);
+
+      expect($executeRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the fact cascade when the deletion touched no memories', async () => {
+      // Most turns produce no memory; a fact sweep per no-op deletion would be
+      // pure overhead on the message-delete sync path.
+      const { prisma, $executeRaw } = makePrisma({ updateCount: 0 });
+
+      await propagateDeletionToMemories(prisma, ['m1']);
+
+      expect($executeRaw).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('propagateDeletionToFacts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports retired and curation-retained counts when the cascade fired', async () => {
+    const { prisma } = makePrisma({ factsRetired: 3, curationRetained: 2 });
+
+    await propagateDeletionToFacts(prisma);
+
+    expect(mockInfo).toHaveBeenCalledTimes(1);
+    expect(mockInfo.mock.calls[0][0]).toMatchObject({ factsRetired: 3, curationRetained: 2 });
+  });
+
+  it('stays quiet — and skips the retained count — when nothing was retired', async () => {
+    // Curation-retained rows persist across invocations; counting and logging
+    // them on every no-op sweep would repeat the same warning forever.
+    const { prisma, $queryRaw } = makePrisma({ factsRetired: 0 });
+
+    await propagateDeletionToFacts(prisma);
+
+    expect(mockInfo).not.toHaveBeenCalled();
+    expect($queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failure — but LOGS it, so the miss is not silent', async () => {
+    const { prisma, $executeRaw } = makePrisma();
+    $executeRaw.mockRejectedValue(new Error('db down'));
+
+    await expect(propagateDeletionToFacts(prisma)).resolves.toBeUndefined();
 
     expect(mockError).toHaveBeenCalledTimes(1);
     expect(mockError.mock.calls[0][0]).toMatchObject({ err: expect.any(Error) });

--- a/packages/conversation-history/src/memoryDeletionPropagation.ts
+++ b/packages/conversation-history/src/memoryDeletionPropagation.ts
@@ -16,6 +16,11 @@
  * resolves message ids from, so tidying the Discord messages afterwards could
  * no longer clean up either. One implementation, both callers.
  *
+ * The chain continues one layer down: extracted facts carry their source
+ * memory ids in `source_memory_ids`, so a memory deletion also retires the
+ * facts distilled from it (`propagateDeletionToFacts`) — otherwise fact
+ * retrieval keeps serving a statement whose only evidence the user erased.
+ *
  * **Not called by time-based retention.** `cleanupOldHistory` ages conversation
  * rows out on a schedule; long-term memory is meant to OUTLIVE that window, and
  * propagating there would quietly delete every memory whose source turn got old.
@@ -57,6 +62,7 @@ export async function propagateDeletionToMemories(
         { memoriesDeleted: result.count, sourceMessages: ids.length },
         'Propagated message deletion to linked memories'
       );
+      await propagateDeletionToFacts(prisma);
     }
     const lockedRetained = await prisma.memory.count({
       where: { messageIds: { hasSome: ids }, visibility: 'normal', isLocked: true },
@@ -69,5 +75,70 @@ export async function propagateDeletionToMemories(
     }
   } catch (error) {
     logger.error({ err: error }, 'Memory deletion propagation failed (non-fatal)');
+  }
+}
+
+/**
+ * Retire the facts whose source memories have been deleted (R8, fact layer).
+ *
+ * ANY-source semantics (owner call): a fact is retired the moment any of its
+ * `source_memory_ids` points at a deleted memory — the statement's evidence is
+ * gone from the layer the user acted on, and content corroborated by surviving
+ * memories is still reachable through memory retrieval itself. Extraction
+ * REPLACES a fact's sources on re-observation, so a fact revived by fresh
+ * evidence carries only living sources and is not re-retired by this sweep.
+ *
+ * User curation outranks the cascade: locked facts and corrected-tier facts
+ * are retained — the same carve-outs every extraction write already honors.
+ * `forgotten` and superseded rows are already out of retrieval and keep their
+ * own states.
+ *
+ * The predicate is a join against ALL deleted memories rather than a list of
+ * just-deleted ids: every invocation also heals any fact a pre-cascade
+ * deletion left behind, and no caller has to plumb id lists through
+ * `updateMany` calls that don't return them. Both sides of the join are
+ * unindexed array scans — fine at current table sizes; if fact volume ever
+ * makes this show up in timings, the escalation is a GIN index on
+ * `source_memory_ids` plus id-scoped calls.
+ *
+ * Same non-fatal contract as the memory propagation above: a cascade failure
+ * must never break the deletion that triggered it.
+ */
+export async function propagateDeletionToFacts(prisma: PrismaClient): Promise<void> {
+  try {
+    const retired = await prisma.$executeRaw`
+      UPDATE memory_facts
+      SET visibility = 'deleted', updated_at = NOW()
+      FROM (SELECT id::text AS id_text FROM memories WHERE visibility = 'deleted') dm
+      WHERE memory_facts.visibility = 'normal'
+        AND memory_facts.forgotten = false
+        AND memory_facts.superseded_at IS NULL
+        AND memory_facts.is_locked = false
+        AND memory_facts.tier <> 'corrected'
+        AND dm.id_text = ANY (memory_facts.source_memory_ids)
+    `;
+    if (retired > 0) {
+      // Counted only when the cascade actually fired: curation-retained rows
+      // persist across invocations, and re-warning about the same rows on
+      // every no-op sweep would bury the lines that matter.
+      const curationRetained = await prisma.$queryRaw<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count FROM memory_facts
+        WHERE visibility = 'normal'
+          AND forgotten = false
+          AND superseded_at IS NULL
+          AND (is_locked = true OR tier = 'corrected')
+          AND EXISTS (
+            SELECT 1 FROM memories m
+            WHERE m.visibility = 'deleted'
+              AND m.id::text = ANY (memory_facts.source_memory_ids)
+          )
+      `;
+      logger.info(
+        { factsRetired: retired, curationRetained: curationRetained[0]?.count ?? 0 },
+        'Propagated memory deletion to derived facts'
+      );
+    }
+  } catch (error) {
+    logger.error({ err: error }, 'Fact deletion propagation failed (non-fatal)');
   }
 }

--- a/prisma/migrations/20260728120000_backfill_fact_deletion_cascade/migration.sql
+++ b/prisma/migrations/20260728120000_backfill_fact_deletion_cascade/migration.sql
@@ -1,0 +1,16 @@
+-- Data-only backfill (no schema change): retire facts whose source memories
+-- were deleted before the deletion cascade existed. Runtime deletions now run
+-- this same predicate via propagateDeletionToFacts (any-source semantics;
+-- locked and corrected-tier facts are user curation and are retained;
+-- forgotten/superseded rows keep their own states). Without this backfill,
+-- historical leaks would persist until the next organic memory deletion
+-- triggers the self-healing sweep.
+UPDATE memory_facts
+SET visibility = 'deleted', updated_at = NOW()
+FROM (SELECT id::text AS id_text FROM memories WHERE visibility = 'deleted') dm
+WHERE memory_facts.visibility = 'normal'
+  AND memory_facts.forgotten = false
+  AND memory_facts.superseded_at IS NULL
+  AND memory_facts.is_locked = false
+  AND memory_facts.tier <> 'corrected'
+  AND dm.id_text = ANY (memory_facts.source_memory_ids);

--- a/services/ai-worker/src/services/extraction/FactStore.component.test.ts
+++ b/services/ai-worker/src/services/extraction/FactStore.component.test.ts
@@ -375,4 +375,54 @@ describe('FactStore.findSimilarActiveFacts (component, PGLite)', () => {
     expect(revived?.supersededAt).toBeNull();
     expect(revived?.validFrom).toEqual(revivalTime);
   });
+
+  it('revives a cascade-deleted fact on fresh evidence — carrying only the NEW sources', async () => {
+    // Re-telling a fact in a new conversation is freely-given new evidence; the
+    // memory-deletion cascade must not make it unlearnable. Source replacement
+    // is load-bearing: the revived row cites only the new memory, so the
+    // cascade's self-heal sweep won't re-kill it over the deleted original.
+    const anchorId = await seedFact({ statement: 'cascade anchor', embedText: 'cascade anchor' });
+    const factId = await extractionSupersede('The user plays the harp', anchorId);
+    await prisma.$executeRaw`UPDATE memory_facts SET visibility = 'deleted' WHERE id = ${factId}::uuid`;
+
+    const newSourceMemory = '30000000-0000-0000-0000-000000000001';
+    const vec = await embeddings.getEmbedding('The user plays the harp');
+    const revivedId = await factStore.writeFactWithSupersessions(
+      {
+        personalityId: PERSONALITY,
+        personaId: PERSONA,
+        statement: 'The user plays the harp',
+        entityTags: ['user'],
+        salience: 0.5,
+        isFiction: false,
+        sourceMemoryIds: [newSourceMemory],
+        extractionJobId: 'job-revival',
+        validFrom: new Date('2026-06-20T00:00:00.000Z'),
+      },
+      [],
+      Array.from(vec ?? [])
+    );
+
+    expect(revivedId).toBe(factId); // content-hash id collides → revival path
+    const revived = await prisma.memoryFact.findUnique({ where: { id: factId } });
+    expect(revived?.visibility).toBe('normal');
+    expect(revived?.sourceMemoryIds).toEqual([newSourceMemory]);
+  });
+
+  it('a FORGOTTEN fact stays dead even when its row is also cascade-deleted', async () => {
+    // The visibility disjunct WIDENED the revival WHERE; this pins that the
+    // forgotten=false conjunct still holds against it — user removal is
+    // terminal no matter which dead-state the row is in.
+    const anchorId = await seedFact({ statement: 'forget anchor', embedText: 'forget anchor' });
+    const factId = await extractionSupersede('The user hates cilantro', anchorId);
+    await prisma.$executeRaw`
+      UPDATE memory_facts SET forgotten = true, visibility = 'deleted' WHERE id = ${factId}::uuid
+    `;
+
+    await extractionSupersede('The user hates cilantro', anchorId);
+
+    const row = await prisma.memoryFact.findUnique({ where: { id: factId } });
+    expect(row?.visibility).toBe('deleted'); // not revived
+    expect(row?.forgotten).toBe(true);
+  });
 });

--- a/services/ai-worker/src/services/extraction/FactStore.ts
+++ b/services/ai-worker/src/services/extraction/FactStore.ts
@@ -198,6 +198,11 @@ export class FactStore {
    * previously-SUPERSEDED statement collides with its dead row — the conflict
    * branch REACTIVATES it (clears the supersession marks), otherwise a
    * Seattle→Denver→Seattle sequence would end with no active fact at all.
+   * The same branch revives a row the memory-deletion cascade retired
+   * (visibility='deleted'): re-telling the fact in a new conversation is
+   * fresh, freely-given evidence, and the source replacement below means the
+   * revived row cites only the NEW memory — the cascade's self-heal sweep
+   * won't re-kill it over the deleted original.
    * Revival also refreshes valid_from to the NEW evidence time — the
    * re-assertion is newer evidence, and a revived fact must not sort by its
    * original (possibly ancient) source time. FORGOTTEN facts stay dead (user
@@ -235,12 +240,13 @@ export class FactStore {
           ON CONFLICT (id) DO UPDATE SET
             superseded_at = NULL,
             superseded_by_id = NULL,
+            visibility = 'normal',
             salience = EXCLUDED.salience,
             valid_from = EXCLUDED.valid_from,
             source_memory_ids = EXCLUDED.source_memory_ids,
             extraction_job_id = EXCLUDED.extraction_job_id,
             updated_at = EXCLUDED.updated_at
-          WHERE memory_facts.superseded_at IS NOT NULL
+          WHERE (memory_facts.superseded_at IS NOT NULL OR memory_facts.visibility = 'deleted')
             AND memory_facts.forgotten = false
             AND memory_facts.is_locked = false
             AND memory_facts.tier != 'corrected'

--- a/services/api-gateway/src/routes/user/memoryBatch.test.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.test.ts
@@ -67,6 +67,10 @@ vi.mock('../../services/MemoryActionTokenService.js', () => ({
   }),
 }));
 
+vi.mock('@tzurot/conversation-history', () => ({
+  propagateDeletionToFacts: vi.fn(),
+}));
+
 import {
   handleBatchDelete,
   handleBatchDeletePreview,
@@ -75,12 +79,14 @@ import {
 } from './memoryBatch.js';
 import { getDefaultPersonaId, getPersonalityById, parseTimeframeFilter } from './memoryHelpers.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
+import { propagateDeletionToFacts } from '@tzurot/conversation-history';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 const mockResolveProvisionedUserId = vi.mocked(resolveProvisionedUserId);
 const mockGetDefaultPersonaId = vi.mocked(getDefaultPersonaId);
 const mockGetPersonalityById = vi.mocked(getPersonalityById);
 const mockParseTimeframeFilter = vi.mocked(parseTimeframeFilter);
+const mockPropagateDeletionToFacts = vi.mocked(propagateDeletionToFacts);
 
 const TEST_USER_ID = '00000000-0000-0000-0000-000000000001';
 const TEST_PERSONA_ID = '00000000-0000-0000-0000-000000000002';
@@ -359,6 +365,8 @@ describe('memoryBatch handlers', () => {
           personalityId: TEST_PERSONALITY_ID,
         })
       );
+      // R8 fact layer rides the batch delete when memories were actually retired.
+      expect(mockPropagateDeletionToFacts).toHaveBeenCalledTimes(1);
     });
 
     it('applies timeframe filter from the token-bound payload', async () => {
@@ -546,6 +554,8 @@ describe('memoryBatch handlers', () => {
           personalityId: TEST_PERSONALITY_ID,
         })
       );
+      // R8 fact layer rides the purge when memories were actually retired.
+      expect(mockPropagateDeletionToFacts).toHaveBeenCalledTimes(1);
     });
 
     it('includes locked-preserved message when locked memories remain', async () => {

--- a/services/api-gateway/src/routes/user/memoryBatch.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.ts
@@ -31,6 +31,7 @@ import {
 } from '@tzurot/common-types/schemas/api/memory';
 import { type Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { propagateDeletionToFacts } from '@tzurot/conversation-history';
 import type { RouteDeps } from '../routeDeps.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -397,6 +398,11 @@ export const handlePurge = (deps: RouteDeps): RequestHandler => {
       },
       data: { visibility: 'deleted', updatedAt: new Date() },
     });
+
+    if (result.count > 0) {
+      // R8 fact layer: retire facts whose sources just died (fail-soft inside).
+      await propagateDeletionToFacts(prisma);
+    }
 
     logger.warn(
       {

--- a/services/api-gateway/src/routes/user/memoryBatchHelpers.test.ts
+++ b/services/api-gateway/src/routes/user/memoryBatchHelpers.test.ts
@@ -13,13 +13,19 @@ import type { RouteDeps } from '../routeDeps.js';
 vi.mock('./memoryHelpers.js', () => ({
   parseTimeframeFilter: vi.fn(),
 }));
+vi.mock('@tzurot/conversation-history', () => ({
+  propagateDeletionToFacts: vi.fn(),
+}));
 
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { propagateDeletionToFacts } from '@tzurot/conversation-history';
 import {
   requireRedis,
   resolvePersonaIdForBatch,
   executeBatchDelete,
 } from './memoryBatchHelpers.js';
+
+const mockPropagateDeletionToFacts = vi.mocked(propagateDeletionToFacts);
 
 function createMockRes() {
   return {
@@ -208,10 +214,11 @@ describe('executeBatchDelete', () => {
       timeframe: undefined,
     });
 
-    // count==0 path: zero-exit response, no updateMany call
+    // count==0 path: zero-exit response, no updateMany call, no fact cascade
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ deletedCount: 0, skippedLocked: 0 })
     );
     expect(prisma.memory.updateMany).not.toHaveBeenCalled();
+    expect(mockPropagateDeletionToFacts).not.toHaveBeenCalled();
   });
 });

--- a/services/api-gateway/src/routes/user/memoryBatchHelpers.ts
+++ b/services/api-gateway/src/routes/user/memoryBatchHelpers.ts
@@ -11,6 +11,7 @@ import type { Redis } from 'ioredis';
 import { StatusCodes } from 'http-status-codes';
 import { type Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { propagateDeletionToFacts } from '@tzurot/conversation-history';
 import type { RouteDeps } from '../routeDeps.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -139,6 +140,11 @@ export async function executeBatchDelete(params: ExecuteBatchDeleteParams): Prom
     where,
     data: { visibility: 'deleted', updatedAt: new Date() },
   });
+
+  if (result.count > 0) {
+    // R8 fact layer: retire facts whose sources just died (fail-soft inside).
+    await propagateDeletionToFacts(prisma);
+  }
 
   logger.warn(
     {

--- a/services/api-gateway/src/routes/user/memoryFacts.component.test.ts
+++ b/services/api-gateway/src/routes/user/memoryFacts.component.test.ts
@@ -309,4 +309,26 @@ describe('memoryFacts handlers (component, PGLite)', () => {
     expect(x?.tier).toBe('corrected');
     expect(res.status).toHaveBeenCalledWith(200);
   });
+
+  it('collision with a CASCADE-DELETED fact revives it VISIBLY as the correction', async () => {
+    // A row the memory-deletion cascade retired (visibility='deleted') must
+    // come back visible when the user's correction claims it — without the
+    // visibility reset the claimed row would be tier-corrected yet invisible
+    // to retrieval and the facts list, silently eating the correction.
+    const xStatement = 'The user rides a motorcycle';
+    const xId = await seedFact({ statement: xStatement });
+    await prisma.memoryFact.update({
+      where: { id: xId },
+      data: { visibility: 'deleted' },
+    });
+    const bId = await seedFact({ statement: 'The user owns some kind of vehicle' });
+
+    const { req, res } = reqRes({ id: bId }, { statement: xStatement });
+    await handleCorrectFact(deps())(req, res, () => undefined);
+
+    const x = await prisma.memoryFact.findUnique({ where: { id: xId } });
+    expect(x?.visibility).toBe('normal');
+    expect(x?.tier).toBe('corrected');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
 });

--- a/services/api-gateway/src/routes/user/memoryFacts.ts
+++ b/services/api-gateway/src/routes/user/memoryFacts.ts
@@ -288,6 +288,7 @@ export const handleCorrectFact = (deps: RouteDeps): RequestHandler => {
           superseded_at = NULL,
           superseded_by_id = NULL,
           forgotten = false,
+          visibility = 'normal',
           tier = 'corrected',
           is_locked = false,
           statement = EXCLUDED.statement,

--- a/services/api-gateway/src/routes/user/memorySingle.test.ts
+++ b/services/api-gateway/src/routes/user/memorySingle.test.ts
@@ -46,6 +46,10 @@ vi.mock('../../services/EmbeddingService.js', () => ({
   formatAsVector: (embedding: number[]) => `[${embedding.join(',')}]`,
 }));
 
+vi.mock('@tzurot/conversation-history', () => ({
+  propagateDeletionToFacts: vi.fn(),
+}));
+
 import {
   handleGetMemory,
   handleUpdateMemory,
@@ -55,6 +59,7 @@ import {
 import { getDefaultPersonaId } from './memoryHelpers.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { isEmbeddingServiceAvailable, generateEmbedding } from '../../services/EmbeddingService.js';
+import { propagateDeletionToFacts } from '@tzurot/conversation-history';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 // Test constants
@@ -80,6 +85,7 @@ const mockGenerateEmbedding = vi.mocked(generateEmbedding);
 
 const mockResolveProvisionedUserId = vi.mocked(resolveProvisionedUserId);
 const mockGetDefaultPersonaId = vi.mocked(getDefaultPersonaId);
+const mockPropagateDeletionToFacts = vi.mocked(propagateDeletionToFacts);
 
 /** Shared deps for the new (deps) => RequestHandler signature. */
 function deps(): RouteDeps {
@@ -638,6 +644,7 @@ describe('memorySingle handlers', () => {
 
       expect(res.status).toHaveBeenCalledWith(404);
       expect(mockPrisma.memory.update).not.toHaveBeenCalled();
+      expect(mockPropagateDeletionToFacts).not.toHaveBeenCalled();
     });
 
     it('should soft delete memory by setting visibility', async () => {
@@ -651,6 +658,8 @@ describe('memorySingle handlers', () => {
           visibility: 'deleted',
         }),
       });
+      // R8 fact layer rides every memory deletion.
+      expect(mockPropagateDeletionToFacts).toHaveBeenCalledWith(mockPrisma);
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/services/api-gateway/src/routes/user/memorySingle.ts
+++ b/services/api-gateway/src/routes/user/memorySingle.ts
@@ -13,6 +13,7 @@ import { StatusCodes } from 'http-status-codes';
 import { MemoryUpdateSchema, SetMemoryLockSchema } from '@tzurot/common-types/schemas/api/memory';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { propagateDeletionToFacts } from '@tzurot/conversation-history';
 import type { RouteDeps } from '../routeDeps.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -357,6 +358,9 @@ export const handleDeleteMemory = (deps: RouteDeps): RequestHandler => {
         updatedAt: new Date(),
       },
     });
+
+    // R8 fact layer: retire facts whose sources just died (fail-soft inside).
+    await propagateDeletionToFacts(prisma);
 
     logger.info({ discordUserId, memoryId }, 'Memory deleted');
     sendCustomSuccess(res, { success: true }, StatusCodes.OK);


### PR DESCRIPTION
## Summary

Closes tracker **TASK-328** (high priority, surfaced by the #1796 review): `MemoryFact.sourceMemoryIds` was write-only — no deletion path read it — so a soft-deleted memory left its extracted facts live, and fact retrieval kept serving statements whose evidence the user had erased. This affected **every** memory-deletion path: `/memory delete`, batch delete, purge, `/history purge`, and Discord message-delete sync.

## Owner decisions (ratified this session)

1. **Any-source cascade** — a fact is retired the moment any source memory is deleted. Content corroborated by surviving memories stays reachable via memory retrieval itself, so the character loses nothing the user didn't delete.
2. **Locked + corrected carve-outs** — both explicit user marks survive the cascade, matching every existing extraction-pipeline guard.
3. **Revival on fresh evidence** — re-telling the fact in a new conversation revives a cascade-deleted row; `forgotten` (explicit `/memory forget`) stays terminal.

## Design

- `propagateDeletionToFacts` lives beside its memory-layer sibling in `@tzurot/conversation-history` (one implementation, all callers). The predicate **joins all deleted memories** rather than taking just-deleted ids: every invocation self-heals leaks that predate the cascade, and no call site has to plumb id lists out of `updateMany`. Both join sides are unindexed array scans — fine at current table sizes; the escalation path (GIN index + id-scoped calls) is noted in the docstring.
- `visibility='deleted'` on facts previously had **no writer**, so the cascade claims it cleanly — fully distinct from `forgotten` (terminal) and supersession.
- Revival composes without a flag: extraction **replaces** `source_memory_ids` on re-observation, so a revived fact cites only the new living memory and the self-heal sweep can't re-kill it. The user-correction conflict branch also resets visibility so a claimed row comes back visible.
- **Data-only migration** runs the same predicate once at deploy, closing the historical leak instead of waiting for the next organic delete. Additive-safe (old code unaffected). Dev migration after merge: `pnpm ops db:migrate --env dev`.

## Class sweep (verified, not just read)

Soft-delete sites enumerated by `grep visibility: 'deleted'` across services + packages: `memorySingle.ts`, `memoryBatch.ts`, `memoryBatchHelpers.ts`, `memoryDeletionPropagation.ts` — all four now cascade (the propagation hook covers `/history purge` + sync). `sourceMemoryIds` consumers enumerated repo-wide: extraction pipeline + facts management only; no other deletion path existed.

## Tests

- **New PGLite component suite** for the cascade predicate (8 tests): any-source with living co-sources, all-living untouched, locked/corrected retained, forgotten/superseded excluded, no re-touch of already-cascaded rows, full message→memory→fact chain with nothing mocked, self-heal of pre-cascade leaks.
- **FactStore component**: revival of a cascade-deleted fact carries only the NEW sources; forgotten-stays-dead pinned against the widened revival WHERE.
- **memoryFacts component**: correction collision with a cascade-deleted row revives it *visibly*.
- **Seam assertions** at all route call sites (cascade invoked on delete, skipped on 404/zero-count paths).

Verified locally: full `pnpm test` (26/26 tasks) + `pnpm quality` green; targeted component files green (8 + 9 + 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)