### PR TITLE
fix(bot-client): in-flight overlap guard for createIntervalScheduler

### DIFF
--- a/services/bot-client/src/utils/intervalScheduler.test.ts
+++ b/services/bot-client/src/utils/intervalScheduler.test.ts
@@ -116,4 +116,80 @@ describe('createIntervalScheduler', () => {
 
     expect(run).toHaveBeenCalledTimes(1);
   });
+
+  describe('in-flight overlap guard', () => {
+    it('skips a tick — with a warn — while the previous run is still in flight', async () => {
+      // A run cycle outlasting intervalMs: a promise that never resolves.
+      const run = vi.fn().mockImplementation(() => new Promise<void>(() => {}));
+      const { scheduler, logger } = make(run);
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+      expect(run).toHaveBeenCalledTimes(1); // startup run, still unresolved
+
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS * 2);
+      // Two ticks fired while the startup run was in flight — both skipped.
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith('Previous run still in flight — skipping this tick');
+    });
+
+    it('resumes running on the next tick after the long run completes', async () => {
+      let finishRun!: () => void;
+      const run = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            finishRun = resolve;
+          })
+      );
+      const { scheduler } = make(run);
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS + INTERVAL_MS);
+      expect(run).toHaveBeenCalledTimes(1); // interval tick skipped, run 1 in flight
+
+      finishRun();
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+      // Flag cleared on completion — the cadence resumes, nothing stacked.
+      expect(run).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not skip when runs complete within the interval (the normal case)', async () => {
+      const { scheduler, run, logger } = make();
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS + INTERVAL_MS * 2);
+
+      expect(run).toHaveBeenCalledTimes(3);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('keeps guarding across stop-then-restart while a run is still executing', async () => {
+      // The flag deliberately survives stop(): the guard protects the RUN,
+      // not the scheduler generation. Resetting it on stop() would let a
+      // restart overlap the still-executing old run — the exact bug guarded.
+      let finishRun!: () => void;
+      const run = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            finishRun = resolve;
+          })
+      );
+      const { scheduler } = make(run);
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+      expect(run).toHaveBeenCalledTimes(1); // in flight, unresolved
+
+      scheduler.stop();
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS + INTERVAL_MS);
+      // Old run still executing — the new generation's ticks keep skipping.
+      expect(run).toHaveBeenCalledTimes(1);
+
+      finishRun();
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+      // Old run resolved — the restarted scheduler's next tick runs normally.
+      expect(run).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/services/bot-client/src/utils/intervalScheduler.ts
+++ b/services/bot-client/src/utils/intervalScheduler.ts
@@ -49,6 +49,28 @@ export function createIntervalScheduler<Args extends unknown[]>(
   const { intervalMs, startupDelayMs, logger, run } = options;
   let interval: ReturnType<typeof setInterval> | null = null;
   let startupTimeout: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = false;
+
+  // A run cycle outlasting intervalMs must not overlap the next tick — the
+  // consumers are idempotent but not reentrant (a slow DB call under one
+  // cycle would stack a second identical cycle on top). Skip-and-log keeps
+  // the cadence honest: the next tick after the long run completes picks up.
+  // The flag deliberately survives stop(): it guards the RUN, not the
+  // scheduler generation — a stop-then-restart while a run is still executing
+  // must keep skipping until that run resolves, or the restart reintroduces
+  // exactly the overlap this guard exists to prevent.
+  const guardedRun = async (...args: Args): Promise<void> => {
+    if (inFlight) {
+      logger.warn('Previous run still in flight — skipping this tick');
+      return;
+    }
+    inFlight = true;
+    try {
+      await run(...args);
+    } finally {
+      inFlight = false;
+    }
+  };
 
   return {
     start(...args: Args): void {
@@ -58,12 +80,12 @@ export function createIntervalScheduler<Args extends unknown[]>(
       }
 
       interval = setInterval(() => {
-        void run(...args);
+        void guardedRun(...args);
       }, intervalMs);
 
       startupTimeout = setTimeout(() => {
         startupTimeout = null;
-        void run(...args);
+        void guardedRun(...args);
       }, startupDelayMs);
 
       logger.info({ intervalHours: intervalMs / (60 * 60 * 1000) }, 'Scheduler started');


### PR DESCRIPTION
## Summary

Drain-campaign unit (tracker **TASK-2**, surfaced by the #1797 review): `createIntervalScheduler` had no in-flight overlap guard — a `run` cycle outlasting `intervalMs` would stack a second identical cycle on top. The consumers (verification cleanup, secret-rotation nag, retention nag) are idempotent but not reentrant. Unreachable at current cadences (6h/24h intervals vs seconds-long checks), but the factory's docstring explicitly advertises itself as the seam for future periodic checks, so the footgun was live for any fast-cadence adopter.

The guard skips-and-logs the overlapping tick (`try/finally` clears the flag, so a rejecting run can't wedge the scheduler); the cadence resumes on the first tick after the long run completes.

## Scope call

TASK-2 paired this with collapsing `buildPreview`'s per-user reach lookup into one grouped query. That half is deliberately **not** here: it rewrites retention SQL that completed its runtime verification on 2026-07-27, for latency nobody experiences (post-purge cohort is ~0). The task is retargeted to that half with its promote-when intact (cohort large enough that preview latency is noticeable).

## Tests

Three new fake-timer cases in the existing suite: overlap tick skipped with the warn, cadence resumes after the long run resolves (flag cleared), and the normal within-interval case never warns. 9/9 green; full `pnpm test` (26/26) + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)