### PR TITLE
fix(ai-worker): sanitize shapes job errorMessage; type validation failures

### DIFF
--- a/services/ai-worker/src/jobs/ShapesImportJob.test.ts
+++ b/services/ai-worker/src/jobs/ShapesImportJob.test.ts
@@ -341,12 +341,16 @@ describe('processShapesImportJob', () => {
   });
 
   it('should fail memory_only import when resolver cannot find personality', async () => {
+    const { ShapesJobValidationError } = await import('../services/shapes/shapesErrors.js');
     mockResolvePersonality.mockRejectedValueOnce(
-      new Error('No personality found for memory_only import. Tried: slug "test-shape".')
+      new ShapesJobValidationError(
+        'No personality found for memory_only import. Tried: slug "test-shape".'
+      )
     );
 
-    // Generic Error is retryable — final attempt to trigger failure marking
-    const job = createMockJob({ importType: 'memory_only' }, { attemptsMade: 4, attempts: 5 });
+    // Validation errors are non-retryable — fails immediately on attempt 1,
+    // and the authored copy passes through to the user-visible error.
+    const job = createMockJob({ importType: 'memory_only' }, { attemptsMade: 0, attempts: 5 });
     const result = await processShapesImportJob(job, {
       prisma: mockPrisma as never,
       memoryAdapter: mockMemoryAdapter as never,
@@ -357,9 +361,12 @@ describe('processShapesImportJob', () => {
   });
 
   it('should mark import as failed on final attempt for retryable error', async () => {
+    const { GENERIC_SHAPES_JOB_ERROR_MESSAGE } = await import('./shapesCredentials.js');
     mockFetchShapeData.mockRejectedValue(new Error('Network error'));
 
-    // Generic errors are now retryable — set to final attempt so it marks failed
+    // Generic errors are retryable — set to final attempt so it marks failed.
+    // The raw infra message is sanitized to the generic copy on the way to
+    // the user-visible error field; the full error goes to logs.
     const job = createMockJob({}, { attemptsMade: 4, attempts: 5 });
     const result = await processShapesImportJob(job, {
       prisma: mockPrisma as never,
@@ -367,7 +374,7 @@ describe('processShapesImportJob', () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('Network error');
+    expect(result.error).toBe(GENERIC_SHAPES_JOB_ERROR_MESSAGE);
     expect(mockPrisma.importJob.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ status: 'failed' }),
@@ -571,12 +578,16 @@ describe('processShapesImportJob', () => {
   });
 
   it('should fail when resolver rejects (e.g. personality owned by another user)', async () => {
+    const { ShapesJobValidationError } = await import('../services/shapes/shapesErrors.js');
     mockResolvePersonality.mockRejectedValueOnce(
-      new Error('Cannot import: personality "test-shape" is owned by another user.')
+      new ShapesJobValidationError(
+        'Cannot import: personality "test-shape" is owned by another user.'
+      )
     );
 
-    // Generic Error is retryable — final attempt to trigger failure marking
-    const job = createMockJob({ importType: 'full' }, { attemptsMade: 4, attempts: 5 });
+    // Validation errors are non-retryable — fails immediately, authored copy
+    // passes through.
+    const job = createMockJob({ importType: 'full' }, { attemptsMade: 0, attempts: 5 });
     const result = await processShapesImportJob(job, {
       prisma: mockPrisma as never,
       memoryAdapter: mockMemoryAdapter as never,

--- a/services/ai-worker/src/jobs/ShapesImportJob.ts
+++ b/services/ai-worker/src/jobs/ShapesImportJob.ts
@@ -26,6 +26,7 @@ import {
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { normalizeSlugForUser, sanitizeExternalSlug } from '@tzurot/common-types/utils/slugUtils';
 import { ShapesDataFetcher } from '../services/shapes/ShapesDataFetcher.js';
+import { ShapesJobValidationError } from '../services/shapes/shapesErrors.js';
 import type { ShapesFetchGate } from '../services/shapes/shapesFetchGate.js';
 import { getDecryptedCookie, persistUpdatedCookie } from './shapesCredentials.js';
 import { claimShapesFetchSlot, handleShapesJobError } from './shapesJobHelpers.js';
@@ -110,7 +111,11 @@ export async function processShapesImportJob(
         await downloadAndStoreAvatar(prisma, personalityId, fetchResult.config.avatar);
         avatarDownloaded = true;
       } catch (error) {
-        avatarError = error instanceof Error ? error.message : String(error);
+        // downloadAndStoreAvatar swallows its own errors, so this is
+        // defense-in-depth for a future contract break. importMetadata is
+        // returned verbatim by the import status route — same sanitization
+        // boundary as errorMessage: authored copy only, raw error to logs.
+        avatarError = 'Avatar download failed — the import continued without it.';
         logger.warn(
           { err: error, personalityId },
           'Avatar download failed — continuing without avatar'
@@ -198,11 +203,11 @@ async function resolveImportUser(
   });
 
   if (user === null) {
-    throw new Error('Cannot import: user not found.');
+    throw new ShapesJobValidationError('Cannot import: user not found.');
   }
 
   if (user.defaultPersonaId === null) {
-    throw new Error(
+    throw new ShapesJobValidationError(
       'Cannot import memories: user has no default persona. Use /persona create first.'
     );
   }

--- a/services/ai-worker/src/jobs/ShapesImportResolver.ts
+++ b/services/ai-worker/src/jobs/ShapesImportResolver.ts
@@ -13,6 +13,7 @@ import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { type ShapesIncPersonalityConfig } from '@tzurot/common-types/types/shapes-import';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { ShapesJobValidationError } from '../services/shapes/shapesErrors.js';
 import { createFullPersonality } from './ShapesImportHelpers.js';
 
 const logger = createLogger('ShapesImportResolver');
@@ -56,7 +57,9 @@ async function resolveForFullImport(
     existing.ownerId !== opts.internalUserId &&
     !isBotOwner(opts.discordUserId)
   ) {
-    throw new Error(`Cannot import: personality "${opts.sourceSlug}" is owned by another user.`);
+    throw new ShapesJobValidationError(
+      `Cannot import: personality "${opts.sourceSlug}" is owned by another user.`
+    );
   }
 
   // Continuity: when no row carries the computed slug, this user may still have
@@ -127,7 +130,7 @@ async function resolveForMemoryOnly(
     }
   }
 
-  throw new Error(
+  throw new ShapesJobValidationError(
     `No personality found for memory_only import. Tried: slug "${opts.sourceSlug}"` +
       (opts.rawSourceSlug !== opts.sourceSlug ? `, raw slug "${opts.rawSourceSlug}"` : '') +
       (opts.shapesId !== '' ? `, shapesId "${opts.shapesId}"` : '') +

--- a/services/ai-worker/src/jobs/shapesCredentials.test.ts
+++ b/services/ai-worker/src/jobs/shapesCredentials.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+  GENERIC_SHAPES_JOB_ERROR_MESSAGE,
   classifyShapesError,
   getDecryptedCookie,
   persistUpdatedCookie,
@@ -9,7 +10,10 @@ import {
   ShapesBotProtectionError,
   ShapesFetchBusyError,
   ShapesFetchError,
+  ShapesJobValidationError,
   ShapesNotFoundError,
+  ShapesRateLimitError,
+  ShapesServerError,
 } from '../services/shapes/shapesErrors.js';
 
 const mockDecryptApiKey = vi.fn();
@@ -157,16 +161,44 @@ describe('classifyShapesError', () => {
     expect(result.errorMessage).toContain('Too many simultaneous shapes.inc fetches');
   });
 
-  it('should classify generic Error as retryable', () => {
-    const error = new Error('Network timeout');
+  it('should classify ShapesJobValidationError as non-retryable, keeping its authored message', () => {
+    // A failed precondition re-reads the same rows on every attempt —
+    // retrying burns BullMQ attempts for nothing; the copy tells the user
+    // what to fix.
+    const error = new ShapesJobValidationError('Cannot import: user not found.');
     const result = classifyShapesError(error);
-    expect(result.isRetryable).toBe(true);
-    expect(result.errorMessage).toBe('Network timeout');
+    expect(result.isRetryable).toBe(false);
+    expect(result.errorMessage).toBe('Cannot import: user not found.');
   });
 
-  it('should classify non-Error values as retryable', () => {
+  it('should classify ShapesRateLimitError as retryable, keeping its authored message', () => {
+    const result = classifyShapesError(new ShapesRateLimitError());
+    expect(result.isRetryable).toBe(true);
+    expect(result.errorMessage).toBe('Rate limited by shapes.inc');
+  });
+
+  it('should classify ShapesServerError as retryable, keeping its authored message', () => {
+    const result = classifyShapesError(
+      new ShapesServerError(502, 'Shapes.inc server error: HTTP 502')
+    );
+    expect(result.isRetryable).toBe(true);
+    expect(result.errorMessage).toBe('Shapes.inc server error: HTTP 502');
+  });
+
+  it('replaces a generic Error message with the user-safe copy (raw infra detail never stored)', () => {
+    // The status routes return errorMessage verbatim — a raw driver/network
+    // string (which can carry hostnames and connection detail) must not
+    // reach the user-visible column. Full error still goes to logs.
+    const error = new Error('connect ETIMEDOUT db.internal.railway:5432');
+    const result = classifyShapesError(error);
+    expect(result.isRetryable).toBe(true);
+    expect(result.errorMessage).toBe(GENERIC_SHAPES_JOB_ERROR_MESSAGE);
+    expect(result.errorMessage).not.toContain('railway');
+  });
+
+  it('replaces non-Error values with the user-safe copy', () => {
     const result = classifyShapesError('string error');
     expect(result.isRetryable).toBe(true);
-    expect(result.errorMessage).toBe('string error');
+    expect(result.errorMessage).toBe(GENERIC_SHAPES_JOB_ERROR_MESSAGE);
   });
 });

--- a/services/ai-worker/src/jobs/shapesCredentials.ts
+++ b/services/ai-worker/src/jobs/shapesCredentials.ts
@@ -13,7 +13,9 @@ import {
   ShapesAuthError,
   ShapesBotProtectionError,
   ShapesFetchError,
+  ShapesJobValidationError,
   ShapesNotFoundError,
+  isKnownShapesError,
 } from '../services/shapes/shapesErrors.js';
 
 const logger = createLogger('shapesCredentials');
@@ -78,20 +80,35 @@ interface ShapesErrorClassification {
 }
 
 /**
+ * The user-visible copy for failures outside the typed shapes-error set.
+ * Exported so tests pin the exact string the status routes will serve.
+ */
+export const GENERIC_SHAPES_JOB_ERROR_MESSAGE =
+  'The job failed unexpectedly. You can retry; if it keeps failing, contact the bot owner.';
+
+/**
  * Classify a shapes.inc error as retryable or non-retryable.
  *
  * Known non-retryable: ShapesAuthError, ShapesNotFoundError, ShapesFetchError,
  * ShapesBotProtectionError (a bot wall does not clear on retry — hammering it
- * only makes the fingerprint worse).
+ * only makes the fingerprint worse), and ShapesJobValidationError (a failed
+ * precondition re-reads the same rows on every attempt).
  * Everything else (timeouts, network failures) defaults to retryable.
+ *
+ * `errorMessage` is what markFailed stores in the user-visible errorMessage
+ * column — the import/export status routes return it verbatim. Typed shapes
+ * errors carry authored user-facing copy and pass through; anything else is
+ * raw infra detail and gets the generic copy (the full error object is
+ * already in logs via handleShapesJobError before markFailed runs).
  */
 export function classifyShapesError(error: unknown): ShapesErrorClassification {
-  const errorMessage = error instanceof Error ? error.message : String(error);
+  const errorMessage = isKnownShapesError(error) ? error.message : GENERIC_SHAPES_JOB_ERROR_MESSAGE;
   const isNonRetryable =
     error instanceof ShapesAuthError ||
     error instanceof ShapesNotFoundError ||
     error instanceof ShapesFetchError ||
-    error instanceof ShapesBotProtectionError;
+    error instanceof ShapesBotProtectionError ||
+    error instanceof ShapesJobValidationError;
 
   return { isRetryable: !isNonRetryable, errorMessage };
 }

--- a/services/ai-worker/src/jobs/shapesJobHelpers.test.ts
+++ b/services/ai-worker/src/jobs/shapesJobHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   handleShapesJobError,
   type ShapesJobErrorContext,
 } from './shapesJobHelpers.js';
+import { GENERIC_SHAPES_JOB_ERROR_MESSAGE } from './shapesCredentials.js';
 import {
   ShapesAuthError,
   ShapesFetchBusyError,
@@ -67,7 +68,10 @@ describe('handleShapesJobError', () => {
     expect(ctx.markFailed).not.toHaveBeenCalled();
   });
 
-  it('marks failed and returns failure result on final retry attempt', async () => {
+  it('marks failed with the SANITIZED copy on final retry attempt (raw infra detail stays in logs)', async () => {
+    // markFailed writes the user-visible errorMessage column the status
+    // routes return verbatim — an untyped error's raw message must not
+    // cross this seam.
     const ctx = createCtx({
       error: new Error('Network timeout'),
       job: createMockJob({ attemptsMade: 2, attempts: 3 }),
@@ -75,8 +79,8 @@ describe('handleShapesJobError', () => {
 
     const result = await handleShapesJobError(ctx);
 
-    expect(ctx.markFailed).toHaveBeenCalledWith('Network timeout');
-    expect(result).toEqual({ success: false, error: 'Network timeout' });
+    expect(ctx.markFailed).toHaveBeenCalledWith(GENERIC_SHAPES_JOB_ERROR_MESSAGE);
+    expect(result).toEqual({ success: false, error: GENERIC_SHAPES_JOB_ERROR_MESSAGE });
   });
 
   it('marks failed immediately for non-retryable errors (ShapesAuthError)', async () => {
@@ -109,8 +113,9 @@ describe('handleShapesJobError', () => {
 
     const result = await handleShapesJobError(ctx);
 
-    expect(ctx.markFailed).toHaveBeenCalledWith('fail');
-    expect(result).toEqual({ success: false, error: 'fail' });
+    // Untyped error → the sanitized copy crosses the markFailed seam.
+    expect(ctx.markFailed).toHaveBeenCalledWith(GENERIC_SHAPES_JOB_ERROR_MESSAGE);
+    expect(result).toEqual({ success: false, error: GENERIC_SHAPES_JOB_ERROR_MESSAGE });
   });
 
   it('handles non-Error values', async () => {

--- a/services/ai-worker/src/services/shapes/shapesErrors.ts
+++ b/services/ai-worker/src/services/shapes/shapesErrors.ts
@@ -11,12 +11,13 @@
  *
  * **Tier 2 — Per-job (BullMQ via ShapesExportJob/ShapesImportJob):**
  * If all per-request retries are exhausted, the error propagates to the job
- * handler. Only ShapesAuthError, ShapesNotFoundError, ShapesFetchError, and
- * ShapesBotProtectionError are non-retryable (immediate failure). Everything
- * else — including ShapesRateLimitError and ShapesServerError that survived
- * per-request retries — triggers a BullMQ job-level retry (restarts from
- * page 1). ShapesFetchBusyError is deliberately in the retryable bucket:
- * BullMQ's exponential backoff IS the wait for a free concurrency slot.
+ * handler. Only ShapesAuthError, ShapesNotFoundError, ShapesFetchError,
+ * ShapesBotProtectionError, and ShapesJobValidationError are non-retryable
+ * (immediate failure). Everything else — including ShapesRateLimitError and
+ * ShapesServerError that survived per-request retries — triggers a BullMQ
+ * job-level retry (restarts from page 1). ShapesFetchBusyError is
+ * deliberately in the retryable bucket: BullMQ's exponential backoff IS the
+ * wait for a free concurrency slot.
  */
 
 export class ShapesAuthError extends Error {
@@ -91,4 +92,41 @@ export class ShapesFetchBusyError extends Error {
     );
     this.name = 'ShapesFetchBusyError';
   }
+}
+
+/**
+ * A precondition of the import/export job is not met (user missing, no
+ * default persona, personality owned by someone else, no import target).
+ * The message is authored user-facing copy telling the user what to fix.
+ * Deterministic by nature — retrying re-reads the same rows — so it is
+ * classified non-retryable and fails the job immediately.
+ */
+export class ShapesJobValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ShapesJobValidationError';
+  }
+}
+
+/**
+ * Every shapes error type in this module carries an AUTHORED, user-facing
+ * message. classifyShapesError uses this guard to decide whether a failed
+ * job may store the error's message in the user-visible `errorMessage`
+ * column (the import/export status routes return that field verbatim):
+ * unknown errors carry raw infra detail — driver internals, hostnames,
+ * timeouts with connection strings — that belongs only in logs. A new error
+ * type missed here fails safe: its authored message is over-sanitized to
+ * the generic copy, never leaked.
+ */
+export function isKnownShapesError(error: unknown): error is Error {
+  return (
+    error instanceof ShapesAuthError ||
+    error instanceof ShapesNotFoundError ||
+    error instanceof ShapesRateLimitError ||
+    error instanceof ShapesServerError ||
+    error instanceof ShapesFetchError ||
+    error instanceof ShapesBotProtectionError ||
+    error instanceof ShapesFetchBusyError ||
+    error instanceof ShapesJobValidationError
+  );
 }


### PR DESCRIPTION
## Summary

Drain-campaign unit (tracker **TASK-7**, surfaced by the #1662 r2 review): the shapes import/export status routes return `import_jobs`/`export_jobs.errorMessage` **verbatim** to the authenticated user, and `classifyShapesError` passed raw `error.message` through for every untyped error — so driver internals, hostnames, and connection detail could reach user-facing fields. #1662 sanitized the gateway-side enqueue writer; this closes the worker-side writers.

## Design

- **One seam**: `classifyShapesError` now passes through only messages from the typed shapes-error set — all eight carry authored user-facing copy — gated by a new `isKnownShapesError` type guard colocated with the error definitions. Everything else stores generic user-safe copy. **Fail-safe direction**: a future error type missed in the guard gets over-sanitized, never leaked. The full error object was already logged by `handleShapesJobError` before `markFailed` runs, so no forensic signal is lost.
- **Ride-along the sanitization surfaced** (the fallback's first victims were legitimate copy): four job-precondition throws (user missing, no default persona, personality owned by another user, no memory_only target) were plain `Error`s. They were also mis-classified **retryable** — burning BullMQ's 5 attempts re-reading the same rows on deterministic failures. Now typed as `ShapesJobValidationError`: non-retryable (matches the BullMQ doctrine in `04-discord.md` — validation errors don't retry), authored copy passes through to the user.
- **AccountExportJob deliberately unchanged**: its status route withholds `errorMessage` entirely (read-side sanitization, documented in `account/export.ts`), so the raw stored value is operator forensics. Each flow keeps exactly one sanitization boundary.

## Class sweep

`errorMessage` read surfaces enumerated repo-wide: shapes export + shapes import status routes (fixed via the shared classify seam), account export (withholds by design), personality `errorMessage` (a different column with its own authored-copy writer — out of this class). Worker-side writers: both shapes jobs via `handleShapesJobError` + AccountExportJob (disposition above). Cross-tier fixture sweep of `tests/` found no pins on the old shapes.

## Tests

- classify: all eight typed errors pinned (authored message + retryability), untyped `Error` and non-`Error` both pinned to the exact generic copy with a negative assertion on the infra detail.
- `handleShapesJobError`: seam assertions updated — the *sanitized* copy is what crosses `markFailed`.
- Import job: validation-failure tests now use the typed error (immediate failure, authored copy through); the final-attempt retryable case pins the generic copy.

Full `pnpm test` (26/26) + `pnpm quality` green locally; all 972 ai-worker job/shapes tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
