### PR TITLE
refactor(tooling): make the prod confirmation gate impossible to hold wrong

### DIFF
--- a/packages/tooling/src/db/run-migration.test.ts
+++ b/packages/tooling/src/db/run-migration.test.ts
@@ -20,7 +20,7 @@ const envRunnerMock = {
   validateEnvironment: vi.fn(),
   showEnvironmentBanner: vi.fn(),
   runPrismaCommand: vi.fn(),
-  confirmProductionOperation: vi.fn(),
+  requireProductionConfirmation: vi.fn(),
 };
 
 // Mock env-runner
@@ -110,36 +110,38 @@ describe('runMigration', () => {
       expect(envRunnerMock.runPrismaCommand).toHaveBeenCalledWith('dev', 'migrate', ['deploy']);
     });
 
-    it('should require confirmation for prod without --force', async () => {
-      envRunnerMock.confirmProductionOperation.mockResolvedValue(false);
+    it('should require confirmation for prod without --force, halting on decline', async () => {
+      // The real gate exits the process on decline (it never returns
+      // declined); the mock simulates that non-return with a sentinel.
+      envRunnerMock.requireProductionConfirmation.mockRejectedValue(new Error('exit: declined'));
 
       const { runMigration } = await import('./run-migration.js');
-      await runMigration({ env: 'prod' });
+      await expect(runMigration({ env: 'prod' })).rejects.toThrow('exit: declined');
 
-      expect(envRunnerMock.confirmProductionOperation).toHaveBeenCalledWith('run migrations');
-      expect(processExitSpy).toHaveBeenCalledWith(0);
+      expect(envRunnerMock.requireProductionConfirmation).toHaveBeenCalledWith('run migrations');
+      expect(envRunnerMock.runPrismaCommand).not.toHaveBeenCalled();
     });
 
     it('should skip confirmation for prod with --force', async () => {
       const { runMigration } = await import('./run-migration.js');
       await runMigration({ env: 'prod', force: true });
 
-      expect(envRunnerMock.confirmProductionOperation).not.toHaveBeenCalled();
+      expect(envRunnerMock.requireProductionConfirmation).not.toHaveBeenCalled();
       expect(envRunnerMock.runPrismaCommand).toHaveBeenCalledWith('prod', 'migrate', ['deploy']);
     });
 
     it('should proceed with confirmation for prod when user confirms', async () => {
-      envRunnerMock.confirmProductionOperation.mockResolvedValue(true);
+      envRunnerMock.requireProductionConfirmation.mockResolvedValue(undefined);
 
       const { runMigration } = await import('./run-migration.js');
       await runMigration({ env: 'prod' });
 
-      expect(envRunnerMock.confirmProductionOperation).toHaveBeenCalled();
+      expect(envRunnerMock.requireProductionConfirmation).toHaveBeenCalled();
       expect(envRunnerMock.runPrismaCommand).toHaveBeenCalledWith('prod', 'migrate', ['deploy']);
     });
 
     it('should show production warnings', async () => {
-      envRunnerMock.confirmProductionOperation.mockResolvedValue(true);
+      envRunnerMock.requireProductionConfirmation.mockResolvedValue(undefined);
 
       const { runMigration } = await import('./run-migration.js');
       await runMigration({ env: 'prod' });
@@ -154,7 +156,7 @@ describe('runMigration', () => {
       const { runMigration } = await import('./run-migration.js');
       await runMigration({ env: 'prod', dryRun: true });
 
-      expect(envRunnerMock.confirmProductionOperation).not.toHaveBeenCalled();
+      expect(envRunnerMock.requireProductionConfirmation).not.toHaveBeenCalled();
       expect(envRunnerMock.runPrismaCommand).toHaveBeenCalledWith('prod', 'migrate', ['status']);
     });
   });
@@ -182,7 +184,7 @@ describe('deployMigration', () => {
     const { deployMigration } = await import('./run-migration.js');
     await deployMigration({ env: 'prod' });
 
-    expect(envRunnerMock.confirmProductionOperation).not.toHaveBeenCalled();
+    expect(envRunnerMock.requireProductionConfirmation).not.toHaveBeenCalled();
     expect(envRunnerMock.runPrismaCommand).toHaveBeenCalled();
   });
 

--- a/packages/tooling/src/db/run-migration.ts
+++ b/packages/tooling/src/db/run-migration.ts
@@ -19,7 +19,7 @@ import {
   validateEnvironment,
   showEnvironmentBanner,
   runPrismaCommand,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 
 interface RunMigrationOptions {
@@ -130,11 +130,7 @@ export async function runMigration(options: RunMigrationOptions = {}): Promise<v
       // AUDIT: Log when --force bypasses confirmation for prod operations
       console.warn(chalk.yellow('⚠️  Using --force flag - confirmation bypassed for PRODUCTION'));
     } else {
-      const confirmed = await confirmProductionOperation('run migrations');
-      if (!confirmed) {
-        console.log(chalk.yellow('\n⛔ Operation cancelled'));
-        process.exit(0);
-      }
+      await requireProductionConfirmation('run migrations');
     }
   }
 

--- a/packages/tooling/src/db/run-with-env.test.ts
+++ b/packages/tooling/src/db/run-with-env.test.ts
@@ -23,13 +23,13 @@ vi.mock('node:child_process', () => ({
 const mockValidateEnvironment = vi.fn();
 const mockShowEnvironmentBanner = vi.fn();
 const mockRunWithRailway = vi.fn();
-const mockConfirmProductionOperation = vi.fn();
+const mockRequireProductionConfirmation = vi.fn();
 
 vi.mock('../utils/env-runner.js', () => ({
   validateEnvironment: mockValidateEnvironment,
   showEnvironmentBanner: mockShowEnvironmentBanner,
   runWithRailway: mockRunWithRailway,
-  confirmProductionOperation: mockConfirmProductionOperation,
+  requireProductionConfirmation: mockRequireProductionConfirmation,
 }));
 
 // Mock chalk
@@ -106,7 +106,11 @@ describe('runWithEnv', () => {
   });
 
   it('should require confirmation for prod without force', async () => {
-    mockConfirmProductionOperation.mockResolvedValue(false);
+    // The real gate exits the process on decline; mirror that through this
+    // file's process.exit spy so the existing exit-sentinel assertions hold.
+    mockRequireProductionConfirmation.mockImplementation(() => {
+      process.exit(0);
+    });
 
     const { runWithEnv } = await import('./run-with-env.js');
 
@@ -114,13 +118,13 @@ describe('runWithEnv', () => {
       'process.exit(0)'
     );
 
-    expect(mockConfirmProductionOperation).toHaveBeenCalledWith('run: some command');
+    expect(mockRequireProductionConfirmation).toHaveBeenCalledWith('run: some command');
     // Should exit before calling runWithRailway
     expect(mockRunWithRailway).not.toHaveBeenCalled();
   });
 
   it('should proceed for prod when confirmed', async () => {
-    mockConfirmProductionOperation.mockResolvedValue(true);
+    mockRequireProductionConfirmation.mockResolvedValue(undefined);
     mockRunWithRailway.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
 
     const { runWithEnv } = await import('./run-with-env.js');
@@ -129,7 +133,7 @@ describe('runWithEnv', () => {
       'process.exit(0)'
     );
 
-    expect(mockConfirmProductionOperation).toHaveBeenCalled();
+    expect(mockRequireProductionConfirmation).toHaveBeenCalled();
     expect(mockRunWithRailway).toHaveBeenCalledWith('prod', 'npx', ['prisma', 'studio']);
   });
 
@@ -142,7 +146,7 @@ describe('runWithEnv', () => {
       runWithEnv(['npx', 'prisma', 'studio'], { env: 'prod', force: true })
     ).rejects.toThrow('process.exit(0)');
 
-    expect(mockConfirmProductionOperation).not.toHaveBeenCalled();
+    expect(mockRequireProductionConfirmation).not.toHaveBeenCalled();
     expect(mockRunWithRailway).toHaveBeenCalledWith('prod', 'npx', ['prisma', 'studio']);
   });
 

--- a/packages/tooling/src/db/run-with-env.ts
+++ b/packages/tooling/src/db/run-with-env.ts
@@ -16,7 +16,7 @@ import {
   validateEnvironment,
   showEnvironmentBanner,
   runWithRailway,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 
 interface RunWithEnvOptions {
@@ -46,11 +46,7 @@ export async function runWithEnv(
 
   // Production safety check
   if (env === 'prod' && !force) {
-    const confirmed = await confirmProductionOperation(`run: ${commandParts.join(' ')}`);
-    if (!confirmed) {
-      console.log(chalk.yellow('Operation cancelled.'));
-      process.exit(0);
-    }
+    await requireProductionConfirmation(`run: ${commandParts.join(' ')}`);
   }
 
   const [command, ...args] = commandParts;

--- a/packages/tooling/src/memory/backfill-facts.test.ts
+++ b/packages/tooling/src/memory/backfill-facts.test.ts
@@ -11,7 +11,7 @@ const { queueAddMock, queueCloseMock, queryMock } = vi.hoisted(() => ({
 vi.mock('../utils/env-runner.js', () => ({
   validateEnvironment: vi.fn(),
   showEnvironmentBanner: vi.fn(),
-  confirmProductionOperation: vi.fn().mockResolvedValue(undefined),
+  requireProductionConfirmation: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('./prisma-env.js', () => ({
@@ -32,7 +32,7 @@ vi.mock('../inspect/bullmqConnection.js', () => ({
 
 import { buildWindows, buildJobData, backfillFacts } from './backfill-facts.js';
 import { createInspectorQueue } from '../inspect/bullmqConnection.js';
-import { confirmProductionOperation } from '../utils/env-runner.js';
+import { requireProductionConfirmation } from '../utils/env-runner.js';
 
 const P1 = '4f9b0f66-0000-4000-8000-0000000000a1';
 const P2 = '4f9b0f66-0000-4000-8000-0000000000a2';
@@ -174,9 +174,11 @@ describe('backfillFacts (the queue.add seam)', () => {
   });
 
   it('a declined prod confirmation ABORTS the run (the gate is real, not decorative)', async () => {
-    vi.mocked(confirmProductionOperation).mockResolvedValueOnce(false);
+    // The real gate exits the process on decline (it never returns declined);
+    // the mock simulates that non-return by rejecting with a sentinel.
+    vi.mocked(requireProductionConfirmation).mockRejectedValueOnce(new Error('exit: declined'));
 
-    await backfillFacts({ env: 'prod' });
+    await expect(backfillFacts({ env: 'prod' })).rejects.toThrow('exit: declined');
 
     expect(createInspectorQueue).not.toHaveBeenCalled();
     expect(queueAddMock).not.toHaveBeenCalled();

--- a/packages/tooling/src/memory/backfill-facts.ts
+++ b/packages/tooling/src/memory/backfill-facts.ts
@@ -26,7 +26,7 @@ import {
   type Environment,
   validateEnvironment,
   showEnvironmentBanner,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 import { getPrismaForEnv } from './prisma-env.js';
 import { getRailwayRedisUrl, createInspectorQueue } from '../inspect/bullmqConnection.js';
@@ -206,11 +206,7 @@ export async function backfillFacts(options: BackfillFactsOptions): Promise<void
   validateEnvironment(env);
   showEnvironmentBanner(env);
   if (env === 'prod' && !dryRun && !force) {
-    const confirmed = await confirmProductionOperation('enqueue fact-extraction backfill jobs');
-    if (!confirmed) {
-      console.log(chalk.yellow('\nOperation cancelled.'));
-      return;
-    }
+    await requireProductionConfirmation('enqueue fact-extraction backfill jobs');
   }
 
   const { prisma, disconnect } = await getPrismaForEnv(env);

--- a/packages/tooling/src/memory/backfill-ltm.ts
+++ b/packages/tooling/src/memory/backfill-ltm.ts
@@ -18,7 +18,7 @@ import {
   type Environment,
   validateEnvironment,
   showEnvironmentBanner,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 import { getPrismaForEnv } from './prisma-env.js';
 import { parseDateRange, printDryRunPreview } from './backfill-cli-helpers.js';
@@ -323,11 +323,7 @@ export async function backfillLongTermMemories(options: BackfillOptions): Promis
   }
 
   if (env === 'prod' && !dryRun && !force) {
-    const confirmed = await confirmProductionOperation('backfill memories');
-    if (!confirmed) {
-      console.log(chalk.yellow('\nOperation cancelled.'));
-      return;
-    }
+    await requireProductionConfirmation('backfill memories');
   }
 
   const { prisma, disconnect } = await getPrismaForEnv(env);

--- a/packages/tooling/src/memory/cleanup-duplicates.test.ts
+++ b/packages/tooling/src/memory/cleanup-duplicates.test.ts
@@ -6,7 +6,32 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Module mocks for the cleanupDuplicateMemories orchestrator tests; inert for
+// the helper tests below (those take their prisma as an argument).
+const { requireConfirmMock, orchestratorPrisma, disconnectMock } = vi.hoisted(() => ({
+  requireConfirmMock: vi.fn(),
+  orchestratorPrisma: {
+    $queryRaw: vi.fn(),
+    memory: { deleteMany: vi.fn() },
+  },
+  disconnectMock: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../utils/env-runner.js', () => ({
+  validateEnvironment: vi.fn(),
+  showEnvironmentBanner: vi.fn(),
+  requireProductionConfirmation: requireConfirmMock,
+}));
+vi.mock('./prisma-env.js', () => ({
+  getPrismaForEnv: vi
+    .fn()
+    .mockImplementation(() =>
+      Promise.resolve({ prisma: orchestratorPrisma, disconnect: disconnectMock })
+    ),
+}));
+
 import {
+  cleanupDuplicateMemories,
   findDuplicates,
   deleteDuplicates,
   displaySummary,
@@ -494,6 +519,55 @@ describe('cleanup-duplicates', () => {
       expect(output).toContain('prod');
       expect(output).toContain('100');
       expect(output).toContain('25');
+    });
+  });
+
+  describe('cleanupDuplicateMemories (orchestrator)', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      // One duplicate group so the flow reaches the prod confirmation.
+      orchestratorPrisma.$queryRaw.mockResolvedValue([
+        {
+          persona_id: 'p1',
+          personality_id: 'c1',
+          user_msg_prefix: '{user}: hello',
+          count: 2n,
+          first_created: new Date('2026-01-01T00:00:00Z'),
+          last_created: new Date('2026-01-01T00:00:30Z'),
+          all_ids: ['keep-id', 'delete-id'],
+        },
+      ]);
+      requireConfirmMock.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    it('asks for prod confirmation naming the count, and deletes when confirmed', async () => {
+      orchestratorPrisma.memory.deleteMany.mockResolvedValue({ count: 1 });
+
+      await cleanupDuplicateMemories({ env: 'prod', force: true });
+      expect(requireConfirmMock).not.toHaveBeenCalled(); // --force skips
+
+      await cleanupDuplicateMemories({ env: 'prod' });
+      expect(requireConfirmMock).toHaveBeenCalledWith('delete 1 duplicate memories');
+      expect(orchestratorPrisma.memory.deleteMany).toHaveBeenCalled();
+    });
+
+    it('deletes nothing when the prod confirmation is declined', async () => {
+      // The real gate exits the process on decline (it never returns
+      // declined); the mock simulates that non-return with a sentinel. In the
+      // real decline the exit also skips the graceful disconnect — deliberate,
+      // identical to Ctrl-C at the same prompt (see the call-site comment).
+      requireConfirmMock.mockRejectedValue(new Error('exit: declined'));
+
+      await expect(cleanupDuplicateMemories({ env: 'prod' })).rejects.toThrow('exit: declined');
+
+      expect(orchestratorPrisma.memory.deleteMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/tooling/src/memory/cleanup-duplicates.ts
+++ b/packages/tooling/src/memory/cleanup-duplicates.ts
@@ -20,7 +20,7 @@ import {
   type Environment,
   validateEnvironment,
   showEnvironmentBanner,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { getPrismaForEnv } from './prisma-env.js';
@@ -272,16 +272,15 @@ export async function cleanupDuplicateMemories(options: CleanupOptions): Promise
       return;
     }
 
-    // Handle confirmation based on environment
+    // Handle confirmation based on environment. Unlike the other prod gates,
+    // this one deliberately runs AFTER the connection is open: the prompt
+    // names the analyzed duplicate count, which the operator is vouching for.
+    // A decline exits inside the gate, skipping the graceful disconnect —
+    // acceptable for a dying CLI process (identical to Ctrl-C at this same
+    // prompt, which never ran the finally either).
     if (env === 'prod' && !force) {
       console.log('');
-      const confirmed = await confirmProductionOperation(
-        `delete ${allIdsToDelete.length} duplicate memories`
-      );
-      if (!confirmed) {
-        console.log(chalk.yellow('\nOperation cancelled.'));
-        return;
-      }
+      await requireProductionConfirmation(`delete ${allIdsToDelete.length} duplicate memories`);
     } else if (env !== 'prod') {
       const confirmed = await promptNonProdConfirmation(allIdsToDelete.length);
       if (!confirmed) {

--- a/packages/tooling/src/memory/repair-fact-timestamps.test.ts
+++ b/packages/tooling/src/memory/repair-fact-timestamps.test.ts
@@ -3,13 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const { queryMock, executeMock, confirmMock } = vi.hoisted(() => ({
   queryMock: vi.fn(),
   executeMock: vi.fn(),
-  confirmMock: vi.fn().mockResolvedValue(true),
+  confirmMock: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../utils/env-runner.js', () => ({
   validateEnvironment: vi.fn(),
   showEnvironmentBanner: vi.fn(),
-  confirmProductionOperation: confirmMock,
+  requireProductionConfirmation: confirmMock,
 }));
 
 vi.mock('./prisma-env.js', () => ({
@@ -27,7 +27,7 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  confirmMock.mockResolvedValue(true);
+  confirmMock.mockResolvedValue(undefined);
 });
 
 describe('analyzeRepairScope', () => {
@@ -100,10 +100,12 @@ describe('repairFactTimestamps', () => {
     expect(executeMock).not.toHaveBeenCalled();
   });
 
-  it('asks for production confirmation and honors a decline', async () => {
-    confirmMock.mockResolvedValue(false);
+  it('asks for production confirmation and halts on a decline', async () => {
+    // The real gate exits the process on decline (it never returns declined);
+    // the mock simulates that non-return by rejecting with a sentinel.
+    confirmMock.mockRejectedValue(new Error('exit: declined'));
 
-    await repairFactTimestamps({ env: 'prod' });
+    await expect(repairFactTimestamps({ env: 'prod' })).rejects.toThrow('exit: declined');
 
     expect(confirmMock).toHaveBeenCalledOnce();
     expect(queryMock).not.toHaveBeenCalled();

--- a/packages/tooling/src/memory/repair-fact-timestamps.ts
+++ b/packages/tooling/src/memory/repair-fact-timestamps.ts
@@ -26,7 +26,7 @@ import {
   type Environment,
   validateEnvironment,
   showEnvironmentBanner,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 import { getPrismaForEnv } from './prisma-env.js';
 
@@ -90,11 +90,7 @@ export async function repairFactTimestamps(options: RepairFactTimestampsOptions)
   validateEnvironment(env);
   showEnvironmentBanner(env);
   if (env === 'prod' && !dryRun && !force) {
-    const confirmed = await confirmProductionOperation('rewrite memory_facts.valid_from in place');
-    if (!confirmed) {
-      console.log(chalk.yellow('\nOperation cancelled.'));
-      return;
-    }
+    await requireProductionConfirmation('rewrite memory_facts.valid_from in place');
   }
 
   const { prisma, disconnect } = await getPrismaForEnv(env);

--- a/packages/tooling/src/retention/backfill-last-active.test.ts
+++ b/packages/tooling/src/retention/backfill-last-active.test.ts
@@ -3,13 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const { queryMock, executeMock, confirmMock } = vi.hoisted(() => ({
   queryMock: vi.fn(),
   executeMock: vi.fn(),
-  confirmMock: vi.fn().mockResolvedValue(true),
+  confirmMock: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../utils/env-runner.js', () => ({
   validateEnvironment: vi.fn(),
   showEnvironmentBanner: vi.fn(),
-  confirmProductionOperation: confirmMock,
+  requireProductionConfirmation: confirmMock,
 }));
 
 vi.mock('../memory/prisma-env.js', () => ({
@@ -23,7 +23,7 @@ import { analyzeScope, executeBackfill, backfillLastActive } from './backfill-la
 
 beforeEach(() => {
   vi.clearAllMocks();
-  confirmMock.mockResolvedValue(true);
+  confirmMock.mockResolvedValue(undefined);
 });
 
 describe('analyzeScope', () => {
@@ -100,10 +100,12 @@ describe('backfillLastActive', () => {
     expect(executeMock).not.toHaveBeenCalled();
   });
 
-  it('asks for production confirmation and honors a decline', async () => {
-    confirmMock.mockResolvedValue(false);
+  it('asks for production confirmation and halts on a decline', async () => {
+    // The real gate exits the process on decline (it never returns declined);
+    // the mock simulates that non-return by rejecting with a sentinel.
+    confirmMock.mockRejectedValue(new Error('exit: declined'));
 
-    await backfillLastActive({ env: 'prod' });
+    await expect(backfillLastActive({ env: 'prod' })).rejects.toThrow('exit: declined');
 
     expect(confirmMock).toHaveBeenCalledOnce();
     expect(queryMock).not.toHaveBeenCalled();

--- a/packages/tooling/src/retention/backfill-last-active.ts
+++ b/packages/tooling/src/retention/backfill-last-active.ts
@@ -45,7 +45,7 @@ import {
   type Environment,
   validateEnvironment,
   showEnvironmentBanner,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 import { getPrismaForEnv } from '../memory/prisma-env.js';
 
@@ -132,13 +132,7 @@ export async function backfillLastActive(options: BackfillLastActiveOptions): Pr
   validateEnvironment(env);
   showEnvironmentBanner(env);
   if (env === 'prod' && !dryRun && !force) {
-    const confirmed = await confirmProductionOperation(
-      'backfill users.last_active_at from history'
-    );
-    if (!confirmed) {
-      console.log(chalk.yellow('\nOperation cancelled.'));
-      return;
-    }
+    await requireProductionConfirmation('backfill users.last_active_at from history');
   }
 
   const { prisma, disconnect } = await getPrismaForEnv(env);

--- a/packages/tooling/src/retention/notify.test.ts
+++ b/packages/tooling/src/retention/notify.test.ts
@@ -9,7 +9,7 @@ const { retentionNotifyMock, getClientMock, confirmMock } = vi.hoisted(() => ({
 vi.mock('../utils/env-runner.js', () => ({
   validateEnvironment: vi.fn(),
   showEnvironmentBanner: vi.fn(),
-  confirmProductionOperation: confirmMock,
+  requireProductionConfirmation: confirmMock,
 }));
 vi.mock('../utils/gateway-client.js', () => ({ resolveServiceClientOrExit: getClientMock }));
 
@@ -36,7 +36,7 @@ describe('retentionNotify', () => {
     vi.clearAllMocks();
     process.exitCode = undefined;
     getClientMock.mockReturnValue({ retentionNotify: retentionNotifyMock });
-    confirmMock.mockResolvedValue(true);
+    confirmMock.mockResolvedValue(undefined);
   });
 
   it('dry-run resolves the cohort and never enqueues', async () => {
@@ -69,10 +69,12 @@ describe('retentionNotify', () => {
   });
 
   it('a declined confirmation enqueues nothing', async () => {
+    // The real gate exits the process on decline (it never returns declined);
+    // the mock simulates that non-return by rejecting with a sentinel.
     retentionNotifyMock.mockResolvedValue({ ok: true, data: runResult() });
-    confirmMock.mockResolvedValue(false);
+    confirmMock.mockRejectedValue(new Error('exit: declined'));
 
-    await retentionNotify({ env: 'prod' });
+    await expect(retentionNotify({ env: 'prod' })).rejects.toThrow('exit: declined');
 
     expect(retentionNotifyMock).toHaveBeenCalledTimes(1);
   });

--- a/packages/tooling/src/retention/notify.ts
+++ b/packages/tooling/src/retention/notify.ts
@@ -7,7 +7,7 @@
  * safeguards, in the order a run hits them:
  *
  *   1. `--dry-run` resolves and prints the cohort without enqueuing.
- *   2. On prod, `confirmProductionOperation` is the manual-approval gate —
+ *   2. On prod, `requireProductionConfirmation` is the manual-approval gate —
  *      `--force` skips the PROMPT only.
  *   3. The gateway refuses the run when the cohort exceeds the hard-ceiling
  *      share of the userbase; `--breaker-override` is the deliberate,
@@ -29,7 +29,7 @@ import {
   type Environment,
   validateEnvironment,
   showEnvironmentBanner,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 import { resolveServiceClientOrExit } from '../utils/gateway-client.js';
 
@@ -128,14 +128,10 @@ export async function retentionNotify(options: RetentionNotifyOptions): Promise<
   }
 
   if (env === 'prod' && !force) {
-    const confirmed = await confirmProductionOperation(
+    await requireProductionConfirmation(
       `DM a deletion warning to ${String(previewResult.data.cohortSize)} inactive users ` +
         '(starts their 30-day grace clocks)'
     );
-    if (!confirmed) {
-      console.log(chalk.yellow('\nOperation cancelled.'));
-      return;
-    }
   }
 
   const runResult = await client.retentionNotify({

--- a/packages/tooling/src/retention/purge.test.ts
+++ b/packages/tooling/src/retention/purge.test.ts
@@ -11,7 +11,7 @@ const { previewMock, purgeMock, reconcileMock, getClientMock, confirmMock } = vi
 vi.mock('../utils/env-runner.js', () => ({
   validateEnvironment: vi.fn(),
   showEnvironmentBanner: vi.fn(),
-  confirmProductionOperation: confirmMock,
+  requireProductionConfirmation: confirmMock,
 }));
 vi.mock('../utils/gateway-client.js', () => ({ resolveServiceClientOrExit: getClientMock }));
 
@@ -68,7 +68,7 @@ describe('retentionPurge', () => {
       retentionReconcileOffDb: reconcileMock,
     });
     reconcileMock.mockResolvedValue({ ok: true, data: { settled: 0, stillFailing: 0 } });
-    confirmMock.mockResolvedValue(true);
+    confirmMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -102,10 +102,12 @@ describe('retentionPurge', () => {
   });
 
   it('requires production confirmation, and purges nothing when declined', async () => {
+    // The real gate exits the process on decline (it never returns declined);
+    // the mock simulates that non-return by rejecting with a sentinel.
     previewMock.mockResolvedValue({ ok: true, data: cohort('900000000000000001') });
-    confirmMock.mockResolvedValue(false);
+    confirmMock.mockRejectedValue(new Error('exit: declined'));
 
-    await retentionPurge({ env: 'prod' });
+    await expect(retentionPurge({ env: 'prod' })).rejects.toThrow('exit: declined');
 
     expect(confirmMock).toHaveBeenCalled();
     expect(purgeMock).not.toHaveBeenCalled();

--- a/packages/tooling/src/retention/purge.ts
+++ b/packages/tooling/src/retention/purge.ts
@@ -6,7 +6,7 @@
  * run hits them:
  *
  *   1. `--dry-run` short-circuits to the read-only preview.
- *   2. On prod, `confirmProductionOperation` is the manual-approval gate that
+ *   2. On prod, `requireProductionConfirmation` is the manual-approval gate that
  *      D5 requires — `--force` skips the PROMPT only.
  *   3. The gateway refuses each call when the cohort exceeds the hard-ceiling
  *      share of the userbase; `--breaker-override` is the deliberate,
@@ -28,7 +28,7 @@ import {
   type Environment,
   validateEnvironment,
   showEnvironmentBanner,
-  confirmProductionOperation,
+  requireProductionConfirmation,
 } from '../utils/env-runner.js';
 import { resolveServiceClientOrExit } from '../utils/gateway-client.js';
 import { renderPreview } from './preview.js';
@@ -97,7 +97,8 @@ export function renderTally(tally: PurgeRunTally): void {
 }
 
 /**
- * Ask for approval on prod. Returns whether the run may proceed.
+ * Ask for approval on prod. Returns only when the run may proceed — a
+ * decline exits inside the gate.
  *
  * Note the asymmetry with the breaker: this gate is about the OPERATOR being
  * present, which `--force` legitimately asserts in a scripted context. The
@@ -108,17 +109,13 @@ async function approveOnProd(
   env: Environment,
   force: boolean,
   eligibleCount: number
-): Promise<boolean> {
+): Promise<void> {
   if (env !== 'prod' || force) {
-    return true;
+    return;
   }
-  const confirmed = await confirmProductionOperation(
+  await requireProductionConfirmation(
     `permanently erase ${String(eligibleCount)} inactive, unreachable accounts`
   );
-  if (!confirmed) {
-    console.log(chalk.yellow('\nOperation cancelled.'));
-  }
-  return confirmed;
 }
 
 /** The gateway calls this loop needs — narrowed so tests can supply a stub. */
@@ -237,9 +234,7 @@ export async function retentionPurge(options: RetentionPurgeOptions): Promise<vo
   if (preview.users.length === 0) {
     return;
   }
-  if (!(await approveOnProd(env, force, preview.totals.eligibleCount))) {
-    return;
-  }
+  await approveOnProd(env, force, preview.totals.eligibleCount);
 
   const tally = await purgeCohort(client, preview.users, {
     excludes: parseExcludes(options.exclude),

--- a/packages/tooling/src/utils/env-runner.test.ts
+++ b/packages/tooling/src/utils/env-runner.test.ts
@@ -236,4 +236,69 @@ describe('env-runner', () => {
       expect(cleaned.DATABASE_URL).toBe('postgresql://railway/db');
     });
   });
+
+  describe('requireProductionConfirmation', () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    // The prompt dynamically imports node:readline; the doMock intercepts it
+    // per-answer so each test controls what the operator "typed".
+    function mockAnswer(answer: string): void {
+      vi.doMock('node:readline', () => ({
+        default: {
+          createInterface: () => ({
+            question: (_q: string, cb: (a: string) => void) => cb(answer),
+            close: vi.fn(),
+          }),
+        },
+        createInterface: () => ({
+          question: (_q: string, cb: (a: string) => void) => cb(answer),
+          close: vi.fn(),
+        }),
+      }));
+    }
+
+    beforeEach(() => {
+      vi.resetModules();
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      // Throwing sentinel: the real exit never returns, and the code after
+      // the gate must be unreachable on decline.
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+    });
+
+    afterEach(() => {
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
+      vi.doUnmock('node:readline');
+    });
+
+    it('returns when the operator types "yes"', async () => {
+      mockAnswer('yes');
+      const { requireProductionConfirmation } = await import('./env-runner.js');
+
+      await expect(requireProductionConfirmation('erase everything')).resolves.toBeUndefined();
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('accepts "YES" case-insensitively', async () => {
+      mockAnswer('YES');
+      const { requireProductionConfirmation } = await import('./env-runner.js');
+
+      await expect(requireProductionConfirmation('erase everything')).resolves.toBeUndefined();
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('prints the cancellation and EXITS (code 0) on any other answer', async () => {
+      mockAnswer('no');
+      const { requireProductionConfirmation } = await import('./env-runner.js');
+
+      await expect(requireProductionConfirmation('erase everything')).rejects.toThrow(
+        'process.exit called'
+      );
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(logSpy.mock.calls.flat().join(' ')).toContain('Operation cancelled');
+    });
+  });
 });

--- a/packages/tooling/src/utils/env-runner.ts
+++ b/packages/tooling/src/utils/env-runner.ts
@@ -293,10 +293,8 @@ export function showEnvironmentBanner(env: Environment): void {
   console.log(color('─'.repeat(40)));
 }
 
-/**
- * Confirm production operation (returns true if confirmed)
- */
-export async function confirmProductionOperation(operation: string): Promise<boolean> {
+/** Prompt for the production confirmation phrase (internal — see below). */
+async function promptProductionConfirmation(operation: string): Promise<boolean> {
   const readline = await import('node:readline');
   const rl = readline.createInterface({
     input: process.stdin,
@@ -313,4 +311,22 @@ export async function confirmProductionOperation(operation: string): Promise<boo
       resolve(answer.toLowerCase() === 'yes');
     });
   });
+}
+
+/**
+ * The production gate: prompts, and on decline prints the cancellation and
+ * EXITS the process (code 0 — declining is a deliberate no-op, morally
+ * Ctrl-C at the prompt). Returns only when the operator confirmed.
+ *
+ * Deliberately not a boolean API: the predecessor returned `confirmed` and
+ * one caller shipped without checking it, making the prod gate decorative.
+ * A gate a caller can hold wrong isn't a gate — this shape makes the
+ * discarded-result bug unrepresentable.
+ */
+export async function requireProductionConfirmation(operation: string): Promise<void> {
+  const confirmed = await promptProductionConfirmation(operation);
+  if (!confirmed) {
+    console.log(chalk.yellow('\nOperation cancelled.'));
+    process.exit(0);
+  }
 }


### PR DESCRIPTION
## Summary

Drain-campaign unit (tracker **TASK-21**): `confirmProductionOperation` returned a boolean that callers could silently discard — `backfill-facts` once shipped its prod prompt without checking the result, making the gate decorative until review caught it. Per the structural-fix directive, the API now makes that class unrepresentable.

## Design

`requireProductionConfirmation(operation): Promise<void>` **returns only when the operator confirmed**. On decline it prints the cancellation and exits the process with code 0 — declining an interactive prod gate is a deliberate no-op, morally identical to Ctrl-C at the prompt. There is no result to ignore and no exception for a caller to accidentally swallow. The boolean prompt survives only as a private helper inside `env-runner.ts`; nothing else can import it.

Exit-in-helper over throw-on-decline was a deliberate call: the ops CLI has no top-level friendly catch, so a thrown decline would either print a stack trace on a routine "no" or force per-caller catch ceremony — reintroducing exactly the per-site pattern that failed.

## Class sweep

All **nine** call sites migrated (the task was filed at ~4; the function spread): memory `backfill-ltm`/`backfill-facts`/`repair-fact-timestamps`/`cleanup-duplicates`, retention `purge`/`notify`/`backfill-last-active`, db `run-migration`/`run-with-env`. Each decline branch (log + return/exit) collapses into the gate; `purge.ts`'s boolean-returning `approveOnProd` helper becomes void. Grep confirms zero references to the old name remain outside git history.

## Tests

- **New: the gate itself** (`env-runner.test.ts`): confirms on "yes", case-insensitive, and the decline path prints the cancellation and exits 0 (process.exit spied with a throwing sentinel so post-gate code is provably unreachable).
- All seven caller test files migrated: confirmed paths resolve void; decline paths simulate the gate's non-return with a rejecting sentinel and assert the destructive work never ran. `run-with-env`'s existing exit-sentinel idiom preserved.

Full `pnpm test` (26/26) + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)