### PR TITLE
refactor(ai-worker): require explicit provider at the vision invoke seam

### DIFF
--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -187,12 +187,16 @@ interface InvokeVisionModelOptions {
    */
   visionParams?: VisionTierParams;
   /**
-   * Explicit provider for the vision call. When provided, overrides the
-   * `config.AI_PROVIDER` env-default lookup inside `createChatModel`. Required
-   * for cross-provider personalities (e.g., main=z.ai-coding, vision=OpenRouter)
-   * where the env-default would route to the wrong provider's API.
+   * Provider for the vision call — deliberately non-optional. Every vision
+   * call across every upstream path (DependencyStep, ConversationalRAGService,
+   * ConversationInputProcessor, ImageDescriptionJob) reaches invokeVisionModel,
+   * and an absent provider would make `createChatModel` fall back to the
+   * env-default `AI_PROVIDER`, silently misrouting cross-provider
+   * personalities (e.g., main=z.ai-coding, vision=OpenRouter → 401 Missing
+   * Authentication). Callers derive it from the resolved vision model:
+   * `options.provider ?? detectVisionProvider(usedModel)`.
    */
-  provider?: AIProvider;
+  provider: AIProvider;
   /**
    * The image to send to the provider — a `data:` URL of worker-fetched bytes,
    * or (on download-fallback) the original remote URL. Kept SEPARATE from
@@ -216,26 +220,6 @@ async function invokeVisionModel(
 ): Promise<string> {
   const { systemPrompt, userApiKey, provider, loggingContext, personalityName, visionParams } =
     options;
-
-  // Single-chokepoint silent-fallback signal: every vision call across every
-  // upstream path (DependencyStep, ConversationalRAGService, ConversationInput-
-  // Processor, ImageDescriptionJob) eventually reaches here. A warn here
-  // captures any caller that didn't thread `visionProvider` through, which
-  // means `createChatModel` will fall back to the env-default `AI_PROVIDER`.
-  // For cross-provider personalities (main=z.ai, vision=OpenRouter) that
-  // silently misroutes the request and reproduces the exact 401 the upstream
-  // resolver fix exists to prevent. Will be promoted to a hard error once
-  // a few weeks of clean Railway logs confirm no upstream caller fires this.
-  if (provider === undefined) {
-    logger.warn(
-      {
-        personalityName,
-        modelName,
-        apiKeySource: loggingContext.apiKeySource,
-      },
-      'invokeVisionModel called without explicit provider — misrouting risk for cross-provider personalities'
-    );
-  }
 
   // Explicitly-set vision-config params win; the low factual-captioning
   // temperature stays the default for anything unset (descriptions feed


### PR DESCRIPTION
## What

Promotes `invokeVisionModel`'s undefined-provider warn to a hard error, per the code comment's own pre-commitment ("will be promoted to a hard error once a few weeks of clean Railway logs confirm no upstream caller fires this") — but at the **type level** instead of a runtime throw: `InvokeVisionModelOptions.provider` is now non-optional, and the warn branch is deleted.

## Why type-level instead of the promised runtime throw

`invokeVisionModel` is module-private with exactly one caller (`describeImage` via `invokeVisionModelForDescribe`), which already derives `options.provider ?? detectVisionProvider(usedModel)` — and `detectVisionProvider` is total (OpenRouter catch-all). A runtime throw would be dead code by type-narrowing, testable only through cast gymnastics. Making the field required turns the failure the warn guarded against (silent env-default fallback → misrouted cross-provider call → 401) into a compile error, which is strictly louder.

## Gate evidence (verified, not just read)

- **Prod logs**: swept 25 ai-worker production deployments (2026-07-08 → 2026-07-28, ~3 weeks) for the warn's distinctive `misrouting` token via per-deployment `railway logs --filter` — zero hits across all 25. Filter mechanism sanity-checked against a known-present token first.
- **Code contract**: repo-wide grep confirms the single caller; `detectVisionProvider(modelName: string): AIProvider` has no undefined-returning path.
- **Seam coverage**: existing model-routing tests pin the derived provider crossing to `createChatModel` (`provider: 'zai-coding'` / `'openrouter'` when the caller omits it) — behavior is unchanged, so no new tests.
- `pnpm test` (26/26 tasks) + `pnpm quality` green locally.

Closes tracker TASK-36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)