### PR TITLE
fix(api-gateway): split UNAUTHORIZED (401) from FORBIDDEN (403)

### DIFF
--- a/services/api-gateway/src/routes/_generated/mounts.component.test.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.component.test.ts
@@ -86,30 +86,32 @@ describe('mounts.ts — audience-prefix routing', () => {
   });
 
   describe('admin routes — require user + owner auth', () => {
-    it('rejects unauthenticated GET /api/admin/llm-config with 403', async () => {
+    it('rejects unauthenticated GET /api/admin/llm-config with 401', async () => {
       const res = await request(app).get('/api/admin/llm-config');
-      // 403 (not 401) — middleware is composed and rejects unauthenticated.
-      expect(res.status).toBe(403);
+      // 401 — no credentials at all is an authentication failure (the user-auth
+      // middleware runs before the owner gate; an authenticated non-owner gets 403).
+      expect(res.status).toBe(401);
     });
 
-    it('rejects unauthenticated POST /api/admin/db-sync with 403', async () => {
+    it('rejects unauthenticated POST /api/admin/db-sync with 401', async () => {
       const res = await request(app).post('/api/admin/db-sync').send({});
-      // 403 (not 401) — middleware is composed and rejects unauthenticated.
-      expect(res.status).toBe(403);
+      // 401 — no credentials at all is an authentication failure (the user-auth
+      // middleware runs before the owner gate; an authenticated non-owner gets 403).
+      expect(res.status).toBe(401);
     });
   });
 
   describe('user routes — require user auth', () => {
-    it('rejects unauthenticated GET /api/user/timezone with 403', async () => {
+    it('rejects unauthenticated GET /api/user/timezone with 401', async () => {
       const res = await request(app).get('/api/user/timezone');
-      // 403 (not 401) — middleware is composed and rejects unauthenticated.
-      expect(res.status).toBe(403);
+      // 401 — missing user identity is an authentication failure.
+      expect(res.status).toBe(401);
     });
 
-    it('rejects unauthenticated GET /api/user/personality with 403', async () => {
+    it('rejects unauthenticated GET /api/user/personality with 401', async () => {
       const res = await request(app).get('/api/user/personality');
-      // 403 (not 401) — middleware is composed and rejects unauthenticated.
-      expect(res.status).toBe(403);
+      // 401 — missing user identity is an authentication failure.
+      expect(res.status).toBe(401);
     });
   });
 

--- a/services/api-gateway/src/routes/admin/createPersonality.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.ts
@@ -117,7 +117,7 @@ export const handleCreateGlobalPersonality = (deps: RouteDeps): RequestHandler =
 
     if (adminUser === null) {
       logger.warn({ discordUserId }, 'Admin user not found in database');
-      return sendError(res, ErrorResponses.unauthorized('Admin user not found in database'));
+      return sendError(res, ErrorResponses.forbidden('Admin user not found in database'));
     }
 
     // Check if personality already exists

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -485,6 +485,7 @@ describe('Admin LLM Config Routes', () => {
       });
 
       expect(response.status).toBe(403);
+      expect(response.body.error).toBe('FORBIDDEN');
       expect(response.body.message).toMatch(/admin user not found/i);
     });
 

--- a/services/api-gateway/src/routes/admin/settings.test.ts
+++ b/services/api-gateway/src/routes/admin/settings.test.ts
@@ -63,9 +63,7 @@ vi.mock('../../services/AuthMiddleware.js', async importOriginal => {
         if (mockIsBotOwner(req.userId)) {
           next();
         } else {
-          res
-            .status(403)
-            .json({ error: 'UNAUTHORIZED', message: 'Only bot owners can modify this' });
+          res.status(403).json({ error: 'FORBIDDEN', message: 'Only bot owners can modify this' });
         }
       },
   };
@@ -211,7 +209,7 @@ describe('Admin Settings Routes (Singleton)', () => {
       const response = await request(app).get('/admin/settings');
 
       expect(response.status).toBe(403);
-      expect(response.body.error).toBe('UNAUTHORIZED');
+      expect(response.body.error).toBe('FORBIDDEN');
     });
   });
 
@@ -387,7 +385,7 @@ describe('Admin Settings Routes (Singleton)', () => {
       const response = await request(app).delete('/admin/settings/config-defaults');
 
       expect(response.status).toBe(403);
-      expect(response.body.error).toBe('UNAUTHORIZED');
+      expect(response.body.error).toBe('FORBIDDEN');
     });
 
     it('should ensure singleton exists before clearing', async () => {

--- a/services/api-gateway/src/routes/admin/settings.ts
+++ b/services/api-gateway/src/routes/admin/settings.ts
@@ -139,7 +139,7 @@ export const handleGetAdminSettings = (deps: RouteDeps): RequestHandler => {
   const { prisma } = deps;
   return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     if (!isAuthorizedForRead(req.userId)) {
-      sendError(res, ErrorResponses.unauthorized('Only bot owners can view settings'));
+      sendError(res, ErrorResponses.forbidden('Only bot owners can view settings'));
       return;
     }
 

--- a/services/api-gateway/src/routes/admin/tts-config.test.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.test.ts
@@ -224,13 +224,13 @@ describe('admin/tts-config routes', () => {
   });
 
   describe('POST / (create)', () => {
-    it('returns 401 when admin user is not in DB', async () => {
+    it('returns 403 FORBIDDEN when admin user is not in DB', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue(null);
       const handler = extractHandler(buildRouter(), 'POST', '/');
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { name: 'Sys', provider: 'self-hosted' } }), res);
-      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'UNAUTHORIZED' }));
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'FORBIDDEN' }));
     });
 
     it('returns 400 NAME_COLLISION on duplicate global name', async () => {

--- a/services/api-gateway/src/routes/protected/metrics.test.ts
+++ b/services/api-gateway/src/routes/protected/metrics.test.ts
@@ -128,13 +128,12 @@ describe('Metrics Route', () => {
       return protectedApp;
     }
 
-    // Production maps `ErrorCode.UNAUTHORIZED` → HTTP 403 (FORBIDDEN), not
-    // 401 (UNAUTHORIZED). Whether that's semantically right is a separate
-    // backlog question — these tests reflect actual behavior, not aspiration.
+    // Missing/invalid service credentials are an authentication failure:
+    // `ErrorCode.UNAUTHORIZED` → HTTP 401 per RFC 7235.
     it('should reject requests without the X-Service-Auth header', async () => {
       const response = await request(buildProtectedApp()).get('/metrics');
 
-      expect(response.status).toBe(StatusCodes.FORBIDDEN);
+      expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
     });
 
     it('should reject requests with the wrong X-Service-Auth secret', async () => {
@@ -142,7 +141,7 @@ describe('Metrics Route', () => {
         .get('/metrics')
         .set('X-Service-Auth', 'wrong-secret');
 
-      expect(response.status).toBe(StatusCodes.FORBIDDEN);
+      expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
     });
 
     it('should allow requests with the correct X-Service-Auth secret', async () => {

--- a/services/api-gateway/src/routes/protected/voiceReferences.test.ts
+++ b/services/api-gateway/src/routes/protected/voiceReferences.test.ts
@@ -214,7 +214,7 @@ describe('Voice Reference Routes', () => {
 
   describe('with requireServiceAuth mounted upstream', () => {
     // Verifies the middleware-plus-router composition produces correct
-    // access control: unauthorized requests → 403, matching secret → 200.
+    // access control: unauthenticated requests → 401, matching secret → 200.
     // Documents that /voice-references requires service auth; production
     // wiring is the umbrella `app.use(requireServiceAuth())` in index.ts.
 
@@ -225,13 +225,13 @@ describe('Voice Reference Routes', () => {
       return protectedApp;
     }
 
-    // Production maps `ErrorCode.UNAUTHORIZED` → HTTP 403 (FORBIDDEN), not
-    // 401 (UNAUTHORIZED). Matches the metrics-route test's expectation
-    // for the same reason — these tests reflect actual behavior.
+    // Missing/invalid service credentials are an authentication failure:
+    // `ErrorCode.UNAUTHORIZED` → HTTP 401 per RFC 7235. Matches the
+    // metrics-route test's expectation for the same reason.
     it('should reject requests without the X-Service-Auth header', async () => {
       const response = await request(buildProtectedApp()).get('/voice-references/testbot');
 
-      expect(response.status).toBe(StatusCodes.FORBIDDEN);
+      expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
     });
 
     it('should reject requests with the wrong X-Service-Auth secret', async () => {
@@ -239,7 +239,7 @@ describe('Voice Reference Routes', () => {
         .get('/voice-references/testbot')
         .set('X-Service-Auth', 'wrong-secret');
 
-      expect(response.status).toBe(StatusCodes.FORBIDDEN);
+      expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
     });
 
     it('should allow requests with the correct X-Service-Auth secret', async () => {

--- a/services/api-gateway/src/routes/user/channel/activate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.test.ts
@@ -228,7 +228,7 @@ describe('POST /user/channel/activate', () => {
     expect(res.status).toHaveBeenCalledWith(403);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: 'UNAUTHORIZED',
+        error: 'FORBIDDEN',
       })
     );
   });

--- a/services/api-gateway/src/routes/user/channel/activate.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.ts
@@ -121,7 +121,7 @@ export const handleActivateChannel = (deps: RouteDeps): RequestHandler => {
     });
 
     if (!canView) {
-      sendError(res, ErrorResponses.unauthorized('You do not have access to this personality'));
+      sendError(res, ErrorResponses.forbidden('You do not have access to this personality'));
       return;
     }
 

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -366,7 +366,7 @@ function createUpdateHandler(
       discordUserId
     );
     if (!editPermissions.canEdit) {
-      return sendError(res, ErrorResponses.unauthorized('You can only edit your own configs'));
+      return sendError(res, ErrorResponses.forbidden('You can only edit your own configs'));
     }
     const isOwnedByRequester = config.ownerId === userId;
 
@@ -466,7 +466,7 @@ function createDeleteHandler(service: LlmConfigService) {
       discordUserId
     );
     if (!permissions.canDelete) {
-      return sendError(res, ErrorResponses.unauthorized('You can only delete your own configs'));
+      return sendError(res, ErrorResponses.forbidden('You can only delete your own configs'));
     }
     const isAdminBypass = config.ownerId !== userId;
 

--- a/services/api-gateway/src/routes/user/personality/get.ts
+++ b/services/api-gateway/src/routes/user/personality/get.ts
@@ -72,10 +72,7 @@ function createHandler(prisma: PrismaClient) {
 
     const hasAccess = await checkUserAccess(prisma, userId, personality, discordUserId);
     if (!hasAccess) {
-      return sendError(
-        res,
-        ErrorResponses.unauthorized('You do not have access to this personality')
-      );
+      return sendError(res, ErrorResponses.forbidden('You do not have access to this personality'));
     }
 
     const canEdit = await canUserEditPersonality(prisma, userId, personality.id, discordUserId);

--- a/services/api-gateway/src/routes/user/personality/helpers.ts
+++ b/services/api-gateway/src/routes/user/personality/helpers.ts
@@ -191,7 +191,7 @@ export async function resolvePersonalityForEdit<T extends { id: string; ownerId:
   if (!canEdit) {
     sendError(
       res,
-      ErrorResponses.unauthorized(`You do not have permission to ${action} this personality`)
+      ErrorResponses.forbidden(`You do not have permission to ${action} this personality`)
     );
     return null;
   }

--- a/services/api-gateway/src/routes/user/personality/update.ts
+++ b/services/api-gateway/src/routes/user/personality/update.ts
@@ -185,7 +185,7 @@ async function checkSlugUpdatePermission(options: {
       { discordUserId, currentSlug, attemptedSlug: newSlug },
       'Non-admin attempted slug update'
     );
-    sendError(res, ErrorResponses.unauthorized('Only bot admins can update personality slugs'));
+    sendError(res, ErrorResponses.forbidden('Only bot admins can update personality slugs'));
     return false;
   }
 

--- a/services/api-gateway/src/routes/user/shapes/export.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.test.ts
@@ -128,11 +128,11 @@ describe('Shapes Export Routes', () => {
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
     });
 
-    it('should return 403 when no credentials found', async () => {
+    it('should return 401 when no credentials found', async () => {
       mockPrisma.userCredential.findFirst.mockResolvedValue(null);
       const { res } = await callExportHandler({ slug: 'test-shape' });
 
-      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.status).toHaveBeenCalledWith(401);
     });
 
     it('should return 409 when export already in progress', async () => {

--- a/services/api-gateway/src/routes/user/shapes/list.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.test.ts
@@ -98,11 +98,11 @@ describe('Shapes List Routes', () => {
       return { req, res };
     }
 
-    it('should return 403 when credential not found', async () => {
+    it('should return 401 when credential not found', async () => {
       mockPrisma.userCredential.findFirst.mockResolvedValue(null);
       const { res } = await callListHandler();
 
-      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.status).toHaveBeenCalledWith(401);
     });
 
     it('should decrypt cookie and fetch from shapes.inc', async () => {

--- a/services/api-gateway/src/routes/user/tts-config.test.ts
+++ b/services/api-gateway/src/routes/user/tts-config.test.ts
@@ -326,7 +326,7 @@ describe('user/tts-config routes', () => {
       expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'NOT_FOUND' }));
     });
 
-    it('returns 401 when user is not the owner', async () => {
+    it('returns 403 FORBIDDEN when user is not the owner', async () => {
       vi.mocked(mockService.getById).mockResolvedValue({
         ...sampleRawConfig,
         ownerId: 'someone-else',
@@ -338,7 +338,7 @@ describe('user/tts-config routes', () => {
         makeMockReq({ params: { id: 'cfg-uuid-1' }, body: { description: 'new' } }),
         res
       );
-      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'UNAUTHORIZED' }));
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'FORBIDDEN' }));
     });
 
     // Bot-owner short-circuit is exercised at the helper level in
@@ -455,7 +455,7 @@ describe('user/tts-config routes', () => {
       expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'NOT_FOUND' }));
     });
 
-    it('returns 401 when user lacks delete permission', async () => {
+    it('returns 403 FORBIDDEN when user lacks delete permission', async () => {
       vi.mocked(mockService.getById).mockResolvedValue({
         ...sampleRawConfig,
         ownerId: 'someone-else',
@@ -464,7 +464,7 @@ describe('user/tts-config routes', () => {
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
-      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'UNAUTHORIZED' }));
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'FORBIDDEN' }));
       expect(mockService.delete).not.toHaveBeenCalled();
     });
 

--- a/services/api-gateway/src/routes/user/tts-config.ts
+++ b/services/api-gateway/src/routes/user/tts-config.ts
@@ -228,7 +228,7 @@ function createUpdateHandler(service: TtsConfigService) {
     }
 
     if (config.ownerId !== userId) {
-      return sendError(res, ErrorResponses.unauthorized('You can only edit your own TTS configs'));
+      return sendError(res, ErrorResponses.forbidden('You can only edit your own TTS configs'));
     }
 
     // Empty-body guard runs BEFORE the promotion helper so that a PUT with
@@ -340,10 +340,7 @@ function createDeleteHandler(service: TtsConfigService) {
       discordUserId
     );
     if (!permissions.canDelete) {
-      return sendError(
-        res,
-        ErrorResponses.unauthorized('You can only delete your own TTS configs')
-      );
+      return sendError(res, ErrorResponses.forbidden('You can only delete your own TTS configs'));
     }
 
     // User-route deletes own configs only — warning unlikely in practice

--- a/services/api-gateway/src/routes/user/voiceModels.test.ts
+++ b/services/api-gateway/src/routes/user/voiceModels.test.ts
@@ -124,7 +124,7 @@ describe('Voice Models Route', () => {
 
     const response = await request(app).get('/models');
 
-    expect(response.status).toBe(StatusCodes.FORBIDDEN);
+    expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
   });
 
   it('should return error on ElevenLabs server error', async () => {

--- a/services/api-gateway/src/routes/wallet/setKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.test.ts
@@ -224,7 +224,7 @@ describe('POST /wallet/set', () => {
       expect(mockValidateApiKey).toHaveBeenCalledWith('sk-valid-key', AIProvider.OpenRouter);
     });
 
-    it('should return 403 for invalid API key', async () => {
+    it('should return 401 for invalid API key', async () => {
       mockValidateApiKey.mockResolvedValue({
         valid: false,
         errorCode: 'INVALID_KEY',
@@ -238,7 +238,9 @@ describe('POST /wallet/set', () => {
 
       await callHandler(mockPrisma, req, res);
 
-      expect(res.status).toHaveBeenCalledWith(403);
+      // The upstream provider rejected the credential — an authentication
+      // failure (401). bot-client renders 401 and 403 identically here.
+      expect(res.status).toHaveBeenCalledWith(401);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           error: 'UNAUTHORIZED',

--- a/services/api-gateway/src/services/AuthMiddleware.test.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.test.ts
@@ -261,7 +261,7 @@ describe('authMiddleware', () => {
       expect(mockRes.status).toHaveBeenCalledWith(403);
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          error: 'UNAUTHORIZED',
+          error: 'FORBIDDEN',
           message: 'This endpoint is only available to the bot owner',
         })
       );
@@ -433,12 +433,12 @@ describe('authMiddleware', () => {
       expect(mockRes.json).not.toHaveBeenCalled();
     });
 
-    it('should return 403 when user ID is missing', () => {
+    it('should return 401 when user ID is missing', () => {
       const middleware = requireUserAuth();
       middleware(mockReq as Request, mockRes as Response, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
           error: 'UNAUTHORIZED',
@@ -447,14 +447,14 @@ describe('authMiddleware', () => {
       );
     });
 
-    it('should return 403 when user ID is empty string', () => {
+    it('should return 401 when user ID is empty string', () => {
       mockReq.headers = { 'x-user-id': '' };
 
       const middleware = requireUserAuth();
       middleware(mockReq as Request, mockRes as Response, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
     });
 
     it('should reject a declared bot user before any handler runs', () => {
@@ -465,10 +465,11 @@ describe('authMiddleware', () => {
 
       expect(mockNext).not.toHaveBeenCalled();
       expect((mockReq as Request & { userId?: string }).userId).toBeUndefined();
+      // Wrong principal type, not missing credentials — 403 FORBIDDEN
       expect(mockRes.status).toHaveBeenCalledWith(403);
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          error: 'UNAUTHORIZED',
+          error: 'FORBIDDEN',
           message: 'Bot users cannot access user routes',
         })
       );
@@ -658,7 +659,7 @@ describe('authMiddleware', () => {
       expect(mockRes.status).toHaveBeenCalledWith(403);
     });
 
-    it('should reject with 403 when req.userId is missing (defense in depth)', async () => {
+    it('should reject with 401 when req.userId is missing (defense in depth)', async () => {
       // In practice requireUserAuth runs first and 401s on missing userId —
       // this test just guards against a future refactor removing that chain.
       mockReq.userId = undefined;
@@ -668,7 +669,7 @@ describe('authMiddleware', () => {
 
       expect(mockGetOrCreateUser).not.toHaveBeenCalled();
       expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
     });
   });
 
@@ -809,7 +810,7 @@ describe('authMiddleware', () => {
       expect(mockRes.json).not.toHaveBeenCalled();
     });
 
-    it('should return 403 when service secret is invalid', () => {
+    it('should return 401 when service secret is invalid', () => {
       vi.mocked(getConfig).mockReturnValue({
         INTERNAL_SERVICE_SECRET: 'valid-service-secret',
       } as any);
@@ -820,7 +821,7 @@ describe('authMiddleware', () => {
       middleware(mockReq as Request, mockRes as Response, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.objectContaining({
           error: 'UNAUTHORIZED',
@@ -829,7 +830,7 @@ describe('authMiddleware', () => {
       );
     });
 
-    it('should return 403 when service secret is missing', () => {
+    it('should return 401 when service secret is missing', () => {
       vi.mocked(getConfig).mockReturnValue({
         INTERNAL_SERVICE_SECRET: 'valid-service-secret',
       } as any);
@@ -838,7 +839,7 @@ describe('authMiddleware', () => {
       middleware(mockReq as Request, mockRes as Response, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
     });
 
     it('should use custom message when provided', () => {
@@ -858,7 +859,7 @@ describe('authMiddleware', () => {
       );
     });
 
-    it('should return 403 when INTERNAL_SERVICE_SECRET is not configured', () => {
+    it('should return 401 when INTERNAL_SERVICE_SECRET is not configured', () => {
       vi.mocked(getConfig).mockReturnValue({
         INTERNAL_SERVICE_SECRET: undefined,
       } as any);
@@ -869,7 +870,7 @@ describe('authMiddleware', () => {
       middleware(mockReq as Request, mockRes as Response, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.status).toHaveBeenCalledWith(401);
     });
 
     it('should include timestamp in error response', () => {

--- a/services/api-gateway/src/services/AuthMiddleware.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.ts
@@ -63,7 +63,7 @@ export function isValidOwner(ownerId: string | undefined): boolean {
  * });
  * ```
  *
- * @param customMessage - Optional custom unauthorized message
+ * @param customMessage - Optional custom forbidden message
  * @returns Express middleware function
  */
 export function requireOwnerAuth(customMessage?: string) {
@@ -79,10 +79,12 @@ export function requireOwnerAuth(customMessage?: string) {
           method: req.method,
           ip: req.ip,
         },
-        '[Auth] Unauthorized access attempt'
+        '[Auth] Forbidden: non-owner access attempt'
       );
 
-      const errorResponse = ErrorResponses.unauthorized(customMessage);
+      // Owner gate, not authentication: the caller's identity is known but
+      // isn't the bot owner — 403 FORBIDDEN, never 401.
+      const errorResponse = ErrorResponses.forbidden(customMessage);
       const statusCode = getStatusCode(errorResponse.error);
 
       res.status(statusCode).json(errorResponse);
@@ -164,7 +166,7 @@ export function requireUserAuth(customMessage?: string) {
         },
         'Bot user rejected at auth boundary'
       );
-      const errorResponse = ErrorResponses.unauthorized('Bot users cannot access user routes');
+      const errorResponse = ErrorResponses.forbidden('Bot users cannot access user routes');
       res.status(getStatusCode(errorResponse.error)).json(errorResponse);
       return;
     }
@@ -307,7 +309,7 @@ export function requireProvisionedUser(prisma: PrismaClient) {
           { discordId, path: req.path },
           'getOrCreateUser refused to provision (bot user or malformed id) — rejecting request'
         );
-        const errorResponse = ErrorResponses.unauthorized(
+        const errorResponse = ErrorResponses.forbidden(
           'Cannot provision this identity for user routes'
         );
         res.status(getStatusCode(errorResponse.error)).json(errorResponse);
@@ -391,7 +393,7 @@ export function isValidServiceSecret(providedSecret: string | undefined): boolea
  * ```ts
  * // For READ operations - allow service-only, check owner for user requests
  * if (!isAuthorizedForRead(req.userId)) {
- *   sendError(res, ErrorResponses.unauthorized('Only bot owners can view this'));
+ *   sendError(res, ErrorResponses.forbidden('Only bot owners can view this'));
  *   return;
  * }
  * ```
@@ -418,7 +420,7 @@ export function isAuthorizedForRead(userId: string | undefined): boolean {
  * ```ts
  * // For WRITE operations - always require bot owner
  * if (!isAuthorizedForWrite(req.userId)) {
- *   sendError(res, ErrorResponses.unauthorized('Only bot owners can modify this'));
+ *   sendError(res, ErrorResponses.forbidden('Only bot owners can modify this'));
  *   return;
  * }
  * ```

--- a/services/api-gateway/src/types.ts
+++ b/services/api-gateway/src/types.ts
@@ -17,7 +17,10 @@ export type { GenerateRequest } from '@tzurot/common-types/types/schemas/generat
  */
 export enum ErrorCode {
   VALIDATION_ERROR = 'VALIDATION_ERROR',
+  /** Authentication missing or invalid (RFC 7235: HTTP 401) */
   UNAUTHORIZED = 'UNAUTHORIZED',
+  /** Authenticated but not allowed — ownership/permission gates (HTTP 403) */
+  FORBIDDEN = 'FORBIDDEN',
   PAYMENT_REQUIRED = 'PAYMENT_REQUIRED',
   NOT_FOUND = 'NOT_FOUND',
   CONFLICT = 'CONFLICT',

--- a/services/api-gateway/src/utils/configRouteHelpers.test.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.test.ts
@@ -19,6 +19,7 @@ vi.mock('./errorResponses.js', () => ({
     notFound: (resource: string) => ({ error: 'NOT_FOUND', message: `${resource} not found` }),
     validationError: (msg: string) => ({ error: 'VALIDATION_ERROR', message: msg }),
     unauthorized: (msg: string) => ({ error: 'UNAUTHORIZED', message: msg }),
+    forbidden: (msg: string) => ({ error: 'FORBIDDEN', message: msg }),
     nameCollision: (msg: string) => ({
       error: 'VALIDATION_ERROR',
       message: msg,
@@ -262,7 +263,7 @@ describe('findAdminUserOrSendError', () => {
     expect(mockSendError).toHaveBeenCalledWith(
       mockRes,
       expect.objectContaining({
-        error: 'UNAUTHORIZED',
+        error: 'FORBIDDEN',
         message: 'Admin user not found in database',
       })
     );

--- a/services/api-gateway/src/utils/configRouteHelpers.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.ts
@@ -198,7 +198,7 @@ export async function findAdminUserOrSendError(
 
   if (adminUser === null) {
     logger.warn({ discordUserId }, 'Admin user not found in database');
-    sendError(res, ErrorResponses.unauthorized('Admin user not found in database'));
+    sendError(res, ErrorResponses.forbidden('Admin user not found in database'));
     return null;
   }
   return adminUser;

--- a/services/api-gateway/src/utils/errorResponses.test.ts
+++ b/services/api-gateway/src/utils/errorResponses.test.ts
@@ -70,8 +70,12 @@ describe('errorResponses', () => {
       expect(getStatusCode(ErrorCode.VALIDATION_ERROR)).toBe(400);
     });
 
-    it('should return 403 for UNAUTHORIZED', () => {
-      expect(getStatusCode(ErrorCode.UNAUTHORIZED)).toBe(403);
+    it('should return 401 for UNAUTHORIZED', () => {
+      expect(getStatusCode(ErrorCode.UNAUTHORIZED)).toBe(401);
+    });
+
+    it('should return 403 for FORBIDDEN', () => {
+      expect(getStatusCode(ErrorCode.FORBIDDEN)).toBe(403);
     });
 
     it('should return 404 for NOT_FOUND', () => {
@@ -239,7 +243,7 @@ describe('errorResponses', () => {
 
         expect(response).toEqual({
           error: 'UNAUTHORIZED',
-          message: 'This endpoint is only available to the bot owner',
+          message: 'Authentication required',
           timestamp: '2025-11-02T12:00:00.000Z',
         });
       });
@@ -248,6 +252,25 @@ describe('errorResponses', () => {
         const response = ErrorResponses.unauthorized('Access denied');
 
         expect(response.message).toBe('Access denied');
+      });
+    });
+
+    describe('forbidden', () => {
+      it('should create forbidden error with the owner-gate default message', () => {
+        const response = ErrorResponses.forbidden();
+
+        expect(response).toEqual({
+          error: 'FORBIDDEN',
+          message: 'This endpoint is only available to the bot owner',
+          timestamp: '2025-11-02T12:00:00.000Z',
+        });
+      });
+
+      it('should create forbidden error with custom message', () => {
+        const response = ErrorResponses.forbidden('You can only edit your own configs');
+
+        expect(response.error).toBe('FORBIDDEN');
+        expect(response.message).toBe('You can only edit your own configs');
       });
     });
 

--- a/services/api-gateway/src/utils/errorResponses.ts
+++ b/services/api-gateway/src/utils/errorResponses.ts
@@ -17,7 +17,8 @@ export { ErrorCode };
  */
 const ERROR_STATUS_CODES: Record<ErrorCode, number> = {
   [ErrorCode.VALIDATION_ERROR]: 400,
-  [ErrorCode.UNAUTHORIZED]: 403,
+  [ErrorCode.UNAUTHORIZED]: 401,
+  [ErrorCode.FORBIDDEN]: 403,
   [ErrorCode.PAYMENT_REQUIRED]: 402,
   [ErrorCode.NOT_FOUND]: 404,
   [ErrorCode.CONFLICT]: 409,
@@ -98,13 +99,13 @@ export const ErrorResponses = {
     code: API_ERROR_SUBCODE.NAME_COLLISION,
   }),
 
-  unauthorized: (
-    message = 'This endpoint is only available to the bot owner',
-    requestId?: string
-  ) => createErrorResponse(ErrorCode.UNAUTHORIZED, message, requestId),
-
-  forbidden: (message: string, requestId?: string) =>
+  /** Authentication missing or invalid (401) — NOT for permission denials; use `forbidden` */
+  unauthorized: (message = 'Authentication required', requestId?: string) =>
     createErrorResponse(ErrorCode.UNAUTHORIZED, message, requestId),
+
+  /** Authenticated but not allowed (403) — ownership, owner-only, and access gates */
+  forbidden: (message = 'This endpoint is only available to the bot owner', requestId?: string) =>
+    createErrorResponse(ErrorCode.FORBIDDEN, message, requestId),
 
   paymentRequired: (message = 'Insufficient credits or quota', requestId?: string) =>
     createErrorResponse(ErrorCode.PAYMENT_REQUIRED, message, requestId),


### PR DESCRIPTION
## What

`ErrorCode.UNAUTHORIZED` mapped to HTTP 403 and `ErrorResponses.forbidden()` emitted `UNAUTHORIZED` — conflating authentication failures with permission denials. This PR:

- Adds `ErrorCode.FORBIDDEN` → 403 and points `forbidden()` at it (it inherits the owner-gate default message)
- Flips `UNAUTHORIZED` → 401 per RFC 7235; `unauthorized()`'s default message becomes `Authentication required`
- Reclassifies every `unauthorized()` call site by semantics (enumerated via repo-wide grep of `ErrorResponses.unauthorized(` / `.forbidden(`, all 27+11 sites reviewed with context)

## Classification

**Stay UNAUTHORIZED / now 401** (authentication missing or failed): `requireUserAuth` / `requireProvisionedUser` missing-identity checks, `requireServiceAuth` secret checks, wallet `INVALID_KEY` (upstream provider rejected the credential), shapes.inc missing/expired credentials, ElevenLabs/Mistral provider-key rejections.

**Switch to FORBIDDEN / stay 403** (authenticated but not allowed): `requireOwnerAuth` (owner gate — its "Unauthorized access attempt" log line was a naming red herring), bot-principal rejections, provisioning refusals, admin-user-not-in-DB lookups, own-config edit/delete gates (llm/tts), personality access/permission checks, channel-activate access, admin-settings read gate, slug-update admin gate.

## bot-client compatibility (swept before the flip)

The task's original "clients don't distinguish 401/403" note is stale — bot-client branches on `status === 403` in six command files. Every one maps to a gate that **stays 403** under this classification (personality get/helpers, channel activate, account delete, aliases). The apikey modal renders 401 and 403 identically. Bonus: the shapes flows' `status === 401` branches (browse, export, interactionHandlers) were written expecting 401 and **never fired** under the old mapping — they become reachable as designed.

## Verification

- api-gateway unit suite: 2654/2654 (24 pins updated to the new mapping, incl. the metrics/voiceReferences comments that explicitly deferred this exact question "to a separate backlog item")
- Component tier: 583 passed — the four `mounts.component.test.ts` unauthenticated-mount pins observed empirically (all four now 401: user-auth middleware runs before owner gates)
- Contract subset (`tests/e2e/contracts/`): 17/17; e2e grep found no status pins on these codes
- Full `pnpm test` (26/26) + `pnpm quality` green

Closes tracker TASK-108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)