### PR TITLE
fix(api-gateway): add the UUID gate to the resolve-cascade route

### DIFF
--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -507,6 +507,25 @@ describe('/user/config-overrides routes', () => {
         undefined
       );
     });
+
+    it('should reject non-UUID personalityId with 400, matching the sibling mutators', async () => {
+      // Without the shared UUID gate, a malformed id reached the resolver and
+      // surfaced as a Prisma uuid-cast error (500-shaped) instead of a 400.
+      const router = createConfigOverrideRoutes(mockDeps);
+      const handler = getHandler(router, 'get', '/resolve/:personalityId');
+      const { req, res } = createMockReqRes({}, { personalityId: 'not-a-uuid' });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'VALIDATION_ERROR',
+          message: 'Invalid personalityId format',
+        })
+      );
+      expect(mockResolveOverrides).not.toHaveBeenCalled();
+    });
   });
 
   describe('PATCH /:personalityId', () => {

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -35,7 +35,6 @@ import {
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
-import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest, ProvisionedRequest } from '../../types.js';
 import { type RouteDeps } from '../routeDeps.js';
 import { pruneEmptyPersonalityConfig } from './pruneEmptyPersonalityConfig.js';
@@ -188,7 +187,10 @@ export const handleClearUserDefaults = (deps: RouteDeps): RequestHandler => {
 export const handleResolveCascade = (deps: RouteDeps): RequestHandler => {
   const cascadeResolver = deps.cascadeResolver;
   return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-    const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
+    const personalityId = getValidatedPersonalityId(req, res);
+    if (personalityId === null) {
+      return;
+    }
     const queryResult = resolveQuerySchema.safeParse(req.query);
     if (!queryResult.success) {
       sendError(res, ErrorResponses.validationError('Invalid channelId format'));


### PR DESCRIPTION
## What

`handleResolveCascade` (GET `/user/config-overrides/resolve/:personalityId`) read the route param via bare `getRequiredParam`, while its sibling mutators (PATCH/DELETE `/:personalityId`) validate through `getValidatedPersonalityId`. A malformed id on the GET path flowed into the cascade resolver and died as a Prisma uuid-cast error (500-shaped) instead of a 400.

One-line fix: use the shared helper (null-early-return shape, identical to the siblings) and drop the now-unused `getRequiredParam` import.

## Test

New test in the GET resolve block mirrors the PATCH block's non-UUID pin: 400 + `VALIDATION_ERROR` + `Invalid personalityId format`, **and** asserts the resolver seam is never called. 29/29 in the file; full `pnpm test` + `pnpm quality` green.

This is deliberately its own tiny PR (not a ride-along) because it changes the route's error contract (500 → 400 on malformed ids).

Closes tracker TASK-220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)