### PR TITLE
fix: divert snowflake-shaped usernames to the shell placeholder persona

### DIFF
--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -215,8 +215,15 @@ export const DISCORD_MENTIONS = {
  */
 export const DISCORD_SNOWFLAKE = {
   /**
+   * Unanchored 17-20 digit source fragment for composing larger patterns
+   * (mention tokens, message links). Use PATTERN for whole-string validation.
+   */
+  SOURCE: String.raw`\d{17,20}`,
+
+  /**
    * Regex pattern for validating Discord snowflake IDs
-   * Matches 17-20 digit numeric strings
+   * Matches 17-20 digit numeric strings (the anchored form of SOURCE —
+   * keep the two in sync)
    */
   PATTERN: /^\d{17,20}$/,
 

--- a/packages/identity/src/UserService.component.test.ts
+++ b/packages/identity/src/UserService.component.test.ts
@@ -190,6 +190,80 @@ describe('UserService', () => {
       expect(persona?.preferredName).toBe(testUsername);
     });
 
+    it('diverts a snowflake-shaped username to the shell placeholder persona name', async () => {
+      // The nameless-envelope fallback passes the Discord ID as the username.
+      // The personas_name_not_snowflake CHECK (live in this PGLite schema)
+      // rejects a bare snowflake as a persona name — without the divert this
+      // create crashes with 23514 instead of degrading to a shell user.
+      const provisioned = await service.getOrCreateUser(testDiscordId, testDiscordId);
+
+      expect(provisioned).not.toBeNull();
+
+      const user = await prisma.user.findUnique({
+        where: { discordId: testDiscordId },
+      });
+      // users.username keeps the raw snowflake — it IS the shell marker the
+      // maintenance upgrade path keys on (username === discordId).
+      expect(user?.username).toBe(testDiscordId);
+
+      const persona = await prisma.persona.findUnique({
+        where: { id: user?.defaultPersonaId ?? '' },
+      });
+      expect(persona?.name).toBe(`User ${testDiscordId}`);
+      // Display falls back to the placeholder, never bare digits.
+      expect(persona?.preferredName).toBe(`User ${testDiscordId}`);
+    });
+
+    it('diverts a genuinely all-digit username that is NOT the discordId', async () => {
+      // Sibling case to the envelope fallback: a real Discord username that
+      // happens to be snowflake-shaped. The divert fires on shape alone.
+      // Deliberately permanent: the upgrade branch keys on
+      // username === discordId, so this persona keeps the placeholder —
+      // there is no better name to promote to.
+      const allDigitUsername = '222222222222222222';
+      const provisioned = await service.getOrCreateUser(testDiscordId, allDigitUsername);
+
+      expect(provisioned).not.toBeNull();
+
+      const user = await prisma.user.findUnique({
+        where: { discordId: testDiscordId },
+      });
+      expect(user?.username).toBe(allDigitUsername);
+
+      const persona = await prisma.persona.findUnique({
+        where: { id: user?.defaultPersonaId ?? '' },
+      });
+      // Placeholder is built from the USERNAME (the value that would have
+      // violated the CHECK), not the discordId.
+      expect(persona?.name).toBe(`User ${allDigitUsername}`);
+    });
+
+    it('upgrades a fallback-created shell user when the real username arrives', async () => {
+      const first = await service.getOrCreateUser(testDiscordId, testDiscordId);
+      expect(first).not.toBeNull();
+
+      // Fresh service instance: the 1h cache short-circuits repeat calls, and
+      // the maintenance upgrade only runs on the cache-miss path.
+      const freshService = new UserService(prisma);
+      const second = await freshService.getOrCreateUser(
+        testDiscordId,
+        testUsername,
+        testDisplayName
+      );
+      expect(second?.userId).toBe(first?.userId);
+
+      const user = await prisma.user.findUnique({
+        where: { discordId: testDiscordId },
+      });
+      expect(user?.username).toBe(testUsername);
+
+      const persona = await prisma.persona.findUnique({
+        where: { id: user?.defaultPersonaId ?? '' },
+      });
+      expect(persona?.name).toBe(testUsername);
+      expect(persona?.preferredName).toBe(testDisplayName);
+    });
+
     it('should cache user ID after first lookup', async () => {
       // Create user
       await service.getOrCreateUser(testDiscordId, testUsername);

--- a/packages/identity/src/UserService.ts
+++ b/packages/identity/src/UserService.ts
@@ -490,17 +490,30 @@ export class UserService {
     const userId = generateUserUuid(discordId);
     const personaId = generatePersonaUuid(username, userId);
     const shouldBeSuperuser = isBotOwner(discordId);
-    const personaDisplayName = displayName ?? username;
+    // A snowflake-shaped username (a nameless job envelope falling back to the
+    // Discord ID, or a genuinely all-digit Discord username) would violate the
+    // personas_name_not_snowflake CHECK and crash the create. Divert to the
+    // shell placeholder instead — users.username keeps the raw value, so when
+    // it equals the discordId the runMaintenanceTasks upgrade path later
+    // renames the placeholder to the real username, exactly like any other
+    // shell-created user.
+    const personaName = isValidDiscordId(username)
+      ? buildShellPlaceholderPersonaName(username)
+      : username;
+    // Falls back to personaName (not the raw username) so a diverted
+    // snowflake-shaped username displays as the placeholder, never bare digits.
+    const personaDisplayName = displayName ?? personaName;
     const personaContent = bio ?? '';
 
-    // Circular-FK bootstrap via single-statement CTE. See the matching
-    // comment in createShellUserWithRaceProtection for the reasoning.
+    // Circular-FK bootstrap via single-statement CTE: users.default_persona_id
+    // and personas.owner_id reference each other, so neither row can be
+    // inserted first through separate statements without deferring constraints.
     await this.prisma.$executeRaw`
       WITH new_persona AS (
         INSERT INTO personas (id, name, preferred_name, description, content, owner_id, updated_at)
         VALUES (
           ${personaId}::uuid,
-          ${username},
+          ${personaName},
           ${personaDisplayName},
           ${DEFAULT_PERSONA_DESCRIPTION},
           ${personaContent},

--- a/services/ai-worker/src/services/reference/UserReferencePatterns.test.ts
+++ b/services/ai-worker/src/services/reference/UserReferencePatterns.test.ts
@@ -4,6 +4,7 @@ import {
   RESOLVABLE_PERSONALITY_FIELDS,
   setPersonalityField,
 } from './UserReferencePatterns.js';
+import { DISCORD_SNOWFLAKE } from '@tzurot/common-types/constants/discord';
 import type { LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 
 describe('UserReferencePatterns', () => {
@@ -56,6 +57,13 @@ describe('UserReferencePatterns', () => {
         const matches = [...text.matchAll(USER_REFERENCE_PATTERNS.DISCORD_MENTION)];
 
         expect(matches).toHaveLength(0);
+      });
+
+      it('embeds the canonical snowflake digit-run (drift guard)', () => {
+        // The pattern stays a literal (the no-singleton-export lint rule
+        // forbids constructor-built regexes in exported objects), so this
+        // pins its embedded fragment to the canonical source instead.
+        expect(USER_REFERENCE_PATTERNS.DISCORD_MENTION.source).toContain(DISCORD_SNOWFLAKE.SOURCE);
       });
     });
 

--- a/services/ai-worker/src/services/reference/UserReferencePatterns.ts
+++ b/services/ai-worker/src/services/reference/UserReferencePatterns.ts
@@ -88,7 +88,10 @@ export const USER_REFERENCE_PATTERNS = {
   SHAPES_MARKDOWN: /@\[([^\]]+)\]\(user:([a-f0-9-]{36})\)/gi,
 
   // <@discord_id> - Discord mention format
-  // Captures: [1] = discord_id (snowflake, 17-20 digits)
+  // Captures: [1] = discord_id (snowflake). The embedded digit-run must match
+  // DISCORD_SNOWFLAKE.SOURCE — a drift-guard test pins the two together
+  // (a literal keeps @tzurot/no-singleton-export happy; composing via
+  // new RegExp would export constructor-built shared state).
   DISCORD_MENTION: /<@!?(\d{17,20})>/g,
 
   // @username - Simple username mention (word boundary to avoid false positives)

--- a/services/bot-client/src/commands/inspect/lookup.ts
+++ b/services/bot-client/src/commands/inspect/lookup.ts
@@ -13,6 +13,7 @@
  * never returns another user's log to a non-owner caller.
  */
 
+import { DISCORD_SNOWFLAKE } from '@tzurot/common-types/constants/discord';
 import { type DiagnosticLog as ApiDiagnosticLog } from '@tzurot/common-types/schemas/api/diagnostic';
 import { type DiagnosticPayload } from '@tzurot/common-types/types/diagnostic';
 import { normalizeDateTime } from '@tzurot/common-types/utils/dateFormatting';
@@ -35,7 +36,7 @@ const MESSAGE_LINK_REGEX = /discord\.com\/channels\/(?:@me|\d+)\/(\d+)\/(\d+)/;
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Discord snowflake ID regex (numeric, 17-20 digits) */
-const SNOWFLAKE_REGEX = /^\d{17,20}$/;
+const SNOWFLAKE_REGEX = DISCORD_SNOWFLAKE.PATTERN;
 
 /**
  * Adapt the Zod-validated diagnostic-log shape from the typed UserClient


### PR DESCRIPTION
## What

`createUserWithDefaultPersona` inserted the caller's `username` verbatim as the default persona's name. A snowflake-shaped username — the ContextAssembler nameless-envelope fallback (`userName ?? userId`), or a genuinely all-digit Discord username — violated the `personas_name_not_snowflake` CHECK and crashed provisioning with 23514 instead of degrading (surfaced by the #1810 contract-fixture cascade; the DB guard is right, the recovery was wrong).

## Why the fix moved from the task's sketch

TASK-332 proposed fixing the **caller** (pass `User <id>` from ContextAssembler) or requiring `userName` in the envelope. Reading the code showed both are worse: the maintenance upgrade path detects shell users by `users.username === discordId`, so a caller-side placeholder would write `User <id>` as the *username* and permanently orphan the placeholder persona from its upgrade. The chokepoint fix in `createUserWithDefaultPersona` diverts only the **persona name** to `buildShellPlaceholderPersonaName()` (and `preferred_name` to the same, never bare digits), while `users.username` keeps the raw value — a nameless-envelope user becomes a *proper shell user*, renamed to their real username by the existing `runMaintenanceTasks` path on first named interaction. It also covers the unfiled sibling case: a real all-digit Discord username. ContextAssembler needs no change.

Also repaired two stale comment pointers to the deleted `createShellUserWithRaceProtection` (the CTE-bootstrap reasoning is now inline).

## Rider (bundled by the task): snowflake-regex consolidation

- `DISCORD_SNOWFLAKE.SOURCE` — unanchored composable fragment beside `PATTERN`
- `inspect/lookup.ts` reuses `PATTERN` instead of its own literal
- `UserReferencePatterns.DISCORD_MENTION` stays a literal (the `@tzurot/no-singleton-export` rule correctly forbids constructor-built regexes in exported objects — first attempt tripped it) and is pinned to `SOURCE` by a new drift-guard test instead

## Tests

- **Component (PGLite, real CHECK constraint live)**: snowflake username → placeholder persona name + preferred_name, raw username preserved as the shell marker; second test drives the full shell→upgrade lifecycle (fresh service instance to bypass the 1h cache) and asserts the rename lands. The crash shape is the runtime-observed behavior from the task's origin — the CHECK is in the loaded PGLite schema, so the divert test fails without the fix.
- Drift-guard test pins the mention literal to `DISCORD_SNOWFLAKE.SOURCE`.
- Full `pnpm test` (26/26) + `pnpm test:component` (585) + `pnpm quality` green.

Closes tracker TASK-332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)