### PR TITLE
fix: stop rendering key-test failures as API Key Valid

### DIFF
--- a/packages/common-types/src/schemas/api/wallet.test.ts
+++ b/packages/common-types/src/schemas/api/wallet.test.ts
@@ -13,6 +13,7 @@ import {
   SetWalletKeyResponseSchema,
   SetWalletKeySchema,
   TestWalletKeySchema,
+  WalletKeyValidationErrorCodeSchema,
 } from './wallet.js';
 
 /** Helper to create valid wallet key data */
@@ -135,6 +136,21 @@ describe('Wallet API Contract Tests', () => {
     });
   });
 
+  describe('WalletKeyValidationErrorCodeSchema', () => {
+    it.each(['INVALID_KEY', 'MISSING_PERMISSIONS', 'QUOTA_EXCEEDED', 'TIMEOUT', 'UNKNOWN'])(
+      'should accept the validator vocabulary member %s',
+      code => {
+        expect(WalletKeyValidationErrorCodeSchema.safeParse(code).success).toBe(true);
+      }
+    );
+
+    it('should reject values outside the vocabulary', () => {
+      expect(WalletKeyValidationErrorCodeSchema.safeParse('RATE_LIMITED').success).toBe(false);
+      expect(WalletKeyValidationErrorCodeSchema.safeParse('').success).toBe(false);
+      expect(WalletKeyValidationErrorCodeSchema.safeParse(undefined).success).toBe(false);
+    });
+  });
+
   describe('TestWalletKeyResponseSchema', () => {
     it('should accept valid test response for valid key', () => {
       const data = {
@@ -156,6 +172,35 @@ describe('Wallet API Contract Tests', () => {
       };
       const result = TestWalletKeyResponseSchema.safeParse(data);
       expect(result.success).toBe(true);
+    });
+
+    it('should carry errorCode through parsing (strip-mode survival)', () => {
+      // The generated client parses responses through this schema in strip
+      // mode — an undeclared field would be silently deleted, and bot-client's
+      // transient-vs-invalid branch reads errorCode. Pin its survival here.
+      const data = {
+        valid: false,
+        provider: 'openrouter',
+        error: 'HTTP 503',
+        errorCode: 'UNKNOWN',
+        timestamp: '2025-01-20T15:30:00.000Z',
+      };
+      const result = TestWalletKeyResponseSchema.safeParse(data);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.errorCode).toBe('UNKNOWN');
+      }
+    });
+
+    it('should reject an errorCode outside the validator vocabulary', () => {
+      const data = {
+        valid: false,
+        provider: 'openrouter',
+        errorCode: 'SOMETHING_ELSE',
+        timestamp: '2025-01-20T15:30:00.000Z',
+      };
+      const result = TestWalletKeyResponseSchema.safeParse(data);
+      expect(result.success).toBe(false);
     });
 
     it('should accept response without optional credits and error', () => {

--- a/packages/common-types/src/schemas/api/wallet.ts
+++ b/packages/common-types/src/schemas/api/wallet.ts
@@ -60,11 +60,29 @@ export type RemoveWalletKeyResponse = z.infer<typeof RemoveWalletKeyResponseSche
 // Tests a stored API key's validity
 // ============================================================================
 
+/**
+ * Classification vocabulary shared with the gateway's per-provider key
+ * validators (`apiKeyValidation/types.ts` aliases this type). The split that
+ * matters to consumers: TIMEOUT and UNKNOWN mean the provider couldn't be
+ * reached or answered abnormally (5xx) — the key was never actually judged —
+ * while the other codes are verdicts about the key itself.
+ */
+export const WalletKeyValidationErrorCodeSchema = z.enum([
+  'INVALID_KEY',
+  'MISSING_PERMISSIONS',
+  'QUOTA_EXCEEDED',
+  'TIMEOUT',
+  'UNKNOWN',
+]);
+
+export type WalletKeyValidationErrorCode = z.infer<typeof WalletKeyValidationErrorCodeSchema>;
+
 export const TestWalletKeyResponseSchema = z.object({
   valid: z.boolean(),
   provider: AIProviderSchema,
   credits: z.number().optional(), // Available credits if valid and provider supports it
   error: z.string().optional(), // Error message if invalid
+  errorCode: WalletKeyValidationErrorCodeSchema.optional(), // Classification when invalid
   timestamp: z.string(), // ISO date string
 });
 

--- a/services/api-gateway/src/routes/wallet/testKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/testKey.test.ts
@@ -227,6 +227,7 @@ describe('POST /wallet/test', () => {
       mockValidateApiKey.mockResolvedValue({
         valid: false,
         error: 'Invalid API key',
+        errorCode: 'INVALID_KEY',
       });
 
       const { req, res } = createMockReqRes({ provider: AIProvider.OpenRouter });
@@ -239,6 +240,27 @@ describe('POST /wallet/test', () => {
           valid: false,
           provider: AIProvider.OpenRouter,
           error: 'Invalid API key',
+          errorCode: 'INVALID_KEY',
+        })
+      );
+    });
+
+    it('should forward a transient classification so consumers can distinguish it', async () => {
+      mockValidateApiKey.mockResolvedValue({
+        valid: false,
+        error: 'HTTP 503',
+        errorCode: 'UNKNOWN',
+      });
+
+      const { req, res } = createMockReqRes({ provider: AIProvider.OpenRouter });
+
+      await callHandler(mockPrisma, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          valid: false,
+          errorCode: 'UNKNOWN',
         })
       );
     });

--- a/services/api-gateway/src/routes/wallet/testKey.ts
+++ b/services/api-gateway/src/routes/wallet/testKey.ts
@@ -88,6 +88,9 @@ export const handleTestWalletKey = (deps: WalletTestDeps): RequestHandler => {
           valid: false,
           provider,
           error: validation.error,
+          // Classification crosses the wire so bot-client can distinguish
+          // "your key was rejected" from "the provider couldn't be reached"
+          errorCode: validation.errorCode,
           timestamp: new Date().toISOString(),
         },
         StatusCodes.OK // Still 200, but valid=false indicates the key is invalid

--- a/services/api-gateway/src/utils/apiKeyValidation/types.ts
+++ b/services/api-gateway/src/utils/apiKeyValidation/types.ts
@@ -7,13 +7,14 @@
  * for callers that don't care about the per-provider files.
  */
 
-/** Error codes returned from validation. */
-export type ValidationErrorCode =
-  | 'INVALID_KEY'
-  | 'MISSING_PERMISSIONS'
-  | 'QUOTA_EXCEEDED'
-  | 'TIMEOUT'
-  | 'UNKNOWN';
+import type { WalletKeyValidationErrorCode } from '@tzurot/common-types/schemas/api/wallet';
+
+/**
+ * Error codes returned from validation. Aliases the wire-schema enum so the
+ * vocabulary the validators emit and the one the /wallet/test response
+ * declares cannot drift apart.
+ */
+export type ValidationErrorCode = WalletKeyValidationErrorCode;
 
 /** Result of API key validation. */
 export interface ApiKeyValidationResult {

--- a/services/bot-client/src/commands/settings/apikey/test.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.test.ts
@@ -147,8 +147,10 @@ describe('handleTestKey', () => {
     });
   });
 
-  it('should handle validation failure', async () => {
-    stub.testWalletKey.mockResolvedValue(makeErr(401, 'Invalid API key'));
+  it('should handle a gateway-level HTTP failure', async () => {
+    // Transport/server error from the gateway itself (NOT the normal failed
+    // validation, which arrives as 200 + valid:false — see the tests below).
+    stub.testWalletKey.mockResolvedValue(makeErr(500, 'Internal error'));
 
     const context = createMockContext('openrouter');
     await handleTestKey(context);
@@ -163,6 +165,95 @@ describe('handleTestKey', () => {
       ],
     });
   });
+
+  it('should render the invalid embed for 200 + valid:false (the real wire shape)', async () => {
+    // The gateway reports failed validation as HTTP 200 with valid:false —
+    // result.ok is true. Pre-fix, this rendered "✅ API Key Valid" for a key
+    // the provider had just rejected.
+    stub.testWalletKey.mockResolvedValue(
+      makeOk(
+        mockTestWalletKeyResponse({
+          valid: false,
+          provider: AIProvider.OpenRouter,
+          error: 'Invalid API key',
+          errorCode: 'INVALID_KEY',
+        })
+      )
+    );
+
+    const context = createMockContext('openrouter');
+    await handleTestKey(context);
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: '❌ API Key Invalid',
+            fields: expect.arrayContaining([
+              expect.objectContaining({ name: 'Error', value: 'Invalid API key' }),
+            ]),
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should render the invalid embed when valid:false carries no errorCode', async () => {
+    stub.testWalletKey.mockResolvedValue(
+      makeOk(
+        mockTestWalletKeyResponse({
+          valid: false,
+          provider: AIProvider.OpenRouter,
+          error: 'Quota exhausted',
+        })
+      )
+    );
+
+    const context = createMockContext('openrouter');
+    await handleTestKey(context);
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({ title: '❌ API Key Invalid' }),
+        }),
+      ],
+    });
+  });
+
+  it.each(['TIMEOUT', 'UNKNOWN'] as const)(
+    "should render couldn't-verify (not Invalid) for transient %s",
+    async errorCode => {
+      // TIMEOUT/UNKNOWN mean the provider was unreachable or errored (5xx) —
+      // the key was never judged, so "Invalid" would be wrong and alarming.
+      stub.testWalletKey.mockResolvedValue(
+        makeOk(
+          mockTestWalletKeyResponse({
+            valid: false,
+            provider: AIProvider.OpenRouter,
+            error: 'HTTP 503',
+            errorCode,
+          })
+        )
+      );
+
+      const context = createMockContext('openrouter');
+      await handleTestKey(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining("Couldn't verify"),
+      });
+      expect(mockEditReply).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeds: expect.arrayContaining([
+            expect.objectContaining({
+              data: expect.objectContaining({ title: '❌ API Key Invalid' }),
+            }),
+          ]),
+        })
+      );
+    }
+  );
 
   it('should map a 429 rate-limit to a retry message, not "API Key Invalid"', async () => {
     stub.testWalletKey.mockResolvedValue(makeErr(429, 'Too many API key operations'));

--- a/services/bot-client/src/commands/settings/apikey/test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.ts
@@ -15,8 +15,32 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
+import { CATALOG } from '../../../ux/catalog/catalog.js';
+import { renderSpec } from '../../../ux/render/render.js';
 
 const logger = createLogger('settings-apikey-test');
+
+/** The ❌ embed for a key the provider actually rejected (invalid / permissions / quota). */
+function buildKeyInvalidEmbed(provider: AIProvider, error: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setColor(DISCORD_COLORS.ERROR)
+    .setTitle('❌ API Key Invalid')
+    .setDescription(`Your **${getProviderDisplayName(provider)}** API key failed validation.`)
+    .addFields({
+      name: 'Error',
+      value: error,
+      inline: false,
+    })
+    .addFields({
+      name: '💡 What to do',
+      value:
+        '• Check if your key is still valid\n' +
+        '• Ensure you have credits/quota remaining\n' +
+        '• Use `/settings apikey set` to update your key',
+      inline: false,
+    })
+    .setTimestamp();
+}
 
 /**
  * Handle /settings apikey test <provider> subcommand
@@ -51,31 +75,34 @@ export async function handleTestKey(context: DeferredCommandContext): Promise<vo
         return;
       }
 
-      // Handle validation errors - need to try parsing the error response for details
-      const embed = new EmbedBuilder()
-        .setColor(DISCORD_COLORS.ERROR)
-        .setTitle('❌ API Key Invalid')
-        .setDescription(`Your **${getProviderDisplayName(provider)}** API key failed validation.`)
-        .addFields({
-          name: 'Error',
-          value: result.error,
-          inline: false,
-        })
-        .addFields({
-          name: '💡 What to do',
-          value:
-            '• Check if your key is still valid\n' +
-            '• Ensure you have credits/quota remaining\n' +
-            '• Use `/settings apikey set` to update your key',
-          inline: false,
-        })
-        .setTimestamp();
-
-      await context.editReply({ embeds: [embed] });
+      // Transport/HTTP-level failure (the gateway itself errored)
+      await context.editReply({ embeds: [buildKeyInvalidEmbed(provider, result.error)] });
       return;
     }
 
     const data = result.data;
+
+    // The gateway reports a failed validation as 200 + valid:false — an
+    // ok result does NOT mean the key passed.
+    if (!data.valid) {
+      // TIMEOUT/UNKNOWN mean the provider couldn't be reached (timeout, 5xx):
+      // the key was never judged, so "Invalid" would be wrong and alarming.
+      if (data.errorCode === 'TIMEOUT' || data.errorCode === 'UNKNOWN') {
+        await context.editReply({
+          content: renderSpec(
+            CATALOG.error.transient(
+              `Couldn't verify your **${getProviderDisplayName(provider)}** key — the provider didn't respond normally (${data.error ?? 'no details'}). Your key wasn't judged invalid.`
+            )
+          ),
+        });
+        return;
+      }
+
+      await context.editReply({
+        embeds: [buildKeyInvalidEmbed(provider, data.error ?? 'Validation failed')],
+      });
+      return;
+    }
 
     // Success - key is valid
     const embed = new EmbedBuilder()


### PR DESCRIPTION
## Summary

Surfaced while auditing TASK-105 (key-validator 5xx-as-transient classification): the gateway reports a failed `/wallet/test` validation as **HTTP 200 + `valid: false`**, but bot-client's `handleTestKey` only branched on `result.ok` — so `/settings apikey test` on a stored key the provider had just **rejected** rendered the green "✅ API Key Valid" embed. Code-read finding (labeled as such, not runtime-observed); the schema (`valid: z.boolean()`) parses the failure shape cleanly, so nothing downstream could have intercepted it.

**Why nobody hit it at set-time**: `/settings apikey set` validates before storing, so a stored key can only fail this way by rotting *after* storage (revoked, expired, quota-dead) — which is precisely the population the test command exists for.

**How the tests missed it (rule 7's mocked-seam class)**: the unit test mocked the failure as `makeErr(401, ...)` — an HTTP error the real route never sends for a failed validation. The new regression tests mock the actual wire shape (200 + `valid:false`) and fail on the pre-fix code.

## Changes

- **bot-client `handleTestKey`**: branches on `data.valid`; provider-rejected shapes render the ❌ Invalid embed (extracted to `buildKeyInvalidEmbed`, shared with the transport-failure path); transient shapes (`TIMEOUT`/`UNKNOWN` — provider unreachable or 5xx, the key was never judged) render a couldn't-verify notice via `CATALOG.error.transient` (no new raw content literal; the shrink-only allowlist is untouched).
- **Gateway `/wallet/test`**: forwards the validator's `errorCode` (previously dropped at this seam).
- **common-types**: `WalletKeyValidationErrorCodeSchema` enum on the response schema; the gateway's `ValidationErrorCode` now aliases it so the two vocabularies cannot drift. Schema test pins `errorCode` strip-mode survival (the typed-client field-deletion class).

## TASK-105 audit record

All four provider validators (openrouter/mistral/zaiCoding/elevenlabs) already classify uniformly: 401/403 → `INVALID_KEY`, quota → `QUOTA_EXCEEDED`, timeout → `TIMEOUT`, **any other non-ok incl. 5xx → `UNKNOWN`, never `INVALID_KEY`**. `setKey`'s consumer maps `UNKNOWN`/`TIMEOUT` to a 400 validation response, not "invalid key." The test-key display seam was the one place the distinction got dropped — closed here.

## Verification

- New regression tests fail pre-fix (200+valid:false previously rendered the ✅ embed)
- Targeted: bot-client apikey suite 10/10, gateway testKey 13/13, common-types wallet 39/39
- `pnpm test` (26 tasks) + `pnpm quality` green sequentially; test-audit ratchet satisfied with a direct vocabulary test for the new schema export

🤖 Generated with [Claude Code](https://claude.com/claude-code)