### PR TITLE
fix: omit authorRole stamp when client identity is unknown

### DIFF
--- a/services/bot-client/src/handlers/references/authorRole.test.ts
+++ b/services/bot-client/src/handlers/references/authorRole.test.ts
@@ -86,11 +86,41 @@ describe('classifyReferenceAuthorRole', () => {
     );
   });
 
-  it('does not crash or misclassify when clientUserId is undefined', () => {
-    // Degraded path (client.user not ready): a webhook can't be confirmed as ours.
+  it('omits the stamp when clientUserId is undefined and an applicationId is present', () => {
+    // Degraded path (client.user not ready — startup / gateway reconnect): our own
+    // persona's webhook is indistinguishable from a foreign bot. The stamp persists
+    // into stored history, so a hard-coded 'bot' would durably attribute the
+    // persona's own line to a third-party bot — omit and let the worker's
+    // name-match fallback decide at render time.
     expect(
       classifyReferenceAuthorRole(
         signals({ webhookId: 'wh-1', applicationId: OUR_BOT_ID, clientUserId: undefined })
+      )
+    ).toBeUndefined();
+
+    // Same for a foreign applicationId: without clientUserId there is no way to
+    // tell the two cases apart, so neither may be stamped.
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-2', applicationId: 'some-other-bot', clientUserId: undefined })
+      )
+    ).toBeUndefined();
+  });
+
+  it('still classifies decidable cases when clientUserId is undefined', () => {
+    // A known proxy is identified by its applicationId alone → 'user' regardless.
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-pk', applicationId: PROXY_ID, clientUserId: undefined }),
+        PROXY_IDS
+      )
+    ).toBe('user');
+
+    // No applicationId at all: the assistant check could never match even with a
+    // known clientUserId, so 'bot' is decidable without it.
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-x', applicationId: null, clientUserId: undefined })
       )
     ).toBe('bot');
   });

--- a/services/bot-client/src/handlers/references/authorRole.ts
+++ b/services/bot-client/src/handlers/references/authorRole.ts
@@ -33,11 +33,18 @@ export interface AuthorRoleSignals {
  * - **bot** — any other webhook/bot: a non-persona automation. The catch-all for
  *   "not clearly our persona, not clearly an unproxied human", which is also where
  *   proxied messages land until their `applicationId` is added to KNOWN_PROXY_APP_IDS.
+ * - **undefined** — signals insufficient to classify: the message carries an
+ *   `applicationId` but `clientUserId` is unset (`client.user` is null before
+ *   ClientReady and during gateway reconnects), so our own persona's webhook is
+ *   indistinguishable from a foreign bot. The stamp persists into stored
+ *   conversation history, so a wrong 'bot' here would be DURABLE — omit it and
+ *   let ai-worker's name-match fallback (prompt/referenceRole.ts) decide at
+ *   render time instead.
  */
 export function classifyReferenceAuthorRole(
   signals: AuthorRoleSignals,
   knownProxyAppIds: ReadonlySet<string> = KNOWN_PROXY_APP_ID_SET
-): ReferenceAuthorRole {
+): ReferenceAuthorRole | undefined {
   const isMachineAuthored = signals.webhookId !== null || signals.authorIsBot;
   if (!isMachineAuthored) {
     return 'user';
@@ -47,6 +54,9 @@ export function classifyReferenceAuthorRole(
   }
   if (signals.applicationId !== null && knownProxyAppIds.has(signals.applicationId)) {
     return 'user';
+  }
+  if (signals.applicationId !== null && signals.clientUserId === undefined) {
+    return undefined;
   }
   return 'bot';
 }


### PR DESCRIPTION
## Summary

TASK-170: `classifyReferenceAuthorRole` hard-coded `'bot'` for any webhook reference when `clientUserId` was undefined — and `client.user` is unset before ClientReady fires and during gateway reconnects. In that window, a reference to **our own persona's** webhook reply was classified as a third-party bot, and because `authorRole` persists into stored conversation-history snapshots, the mislabel was durable: later turns re-read `role='bot'` and attribute the persona's own prior line to a foreign bot. The old test pinned this path with the comment "does not misclassify," which was itself wrong for the own-persona case.

## Fix

When an `applicationId` is present but `clientUserId` is not, own-persona and foreign-bot are genuinely indistinguishable — so the classifier now returns `undefined` (the stamp is omitted; the schema field is already optional) and ai-worker's documented name-match fallback (`prompt/referenceRole.ts`, built for exactly the absent-stamp case) decides at render time. Decidable cases in the same window keep their verdicts:

- known proxy `applicationId` (PluralKit/TupperBox) → `'user'` — decided by allowlist alone
- `applicationId: null` → `'bot'` — the assistant check could never match even with a known client id
- human-authored → `'user'` — client identity irrelevant

## Tests

- The degraded-path test now asserts the omission for both own-app-id and foreign-app-id (fails pre-fix: both returned `'bot'`)
- A sibling test pins that decidable cases (proxy, null applicationId) keep classifying in the same window
- `MessageFormatter` pins unaffected (they use a defined client id); full `pnpm test` + `pnpm quality` green sequentially

## Blast radius

bot-client only, no schema change (`authorRole` was already optional both places it appears). The mislabeled window is startup + reconnects — narrow, but each occurrence was a permanently-wrong stored row; existing wrong rows age out of the conversation-history window naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)