### PR TITLE
fix(ai-worker): quota viability checks read the target's cache identity

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
@@ -269,27 +269,42 @@ describe('AuthStep', () => {
         isGuestMode: true,
       };
 
-      function buildCaches(overrides?: { exhausted?: boolean; rateLimitedModels?: string[] }): {
+      // Bucket-aware doom-cache mock: marks are (cacheKeyId[, model])-scoped in
+      // Redis, and a mock that ignores the bucket cannot catch a wrong-identity
+      // read. `exhausted: true` / a bare model string mark every bucket.
+      function buildCaches(overrides?: {
+        exhausted?: boolean | string[];
+        rateLimitedModels?: (string | { cacheKeyId: string; model: string })[];
+      }): {
         creditExhaustion: { isCreditExhausted: ReturnType<typeof vi.fn> };
         rateLimit: { isRateLimited: ReturnType<typeof vi.fn> };
       } {
+        const exhausted = overrides?.exhausted ?? false;
         const rateLimitedModels = overrides?.rateLimitedModels ?? [];
         return {
           creditExhaustion: {
             isCreditExhausted: vi
               .fn()
-              .mockResolvedValue(
-                overrides?.exhausted === true
-                  ? { exhausted: true, exhaustedAtMs: 0, ttlSeconds: 60 }
-                  : { exhausted: false }
+              .mockImplementation(({ cacheKeyId }: { cacheKeyId: string }) =>
+                Promise.resolve(
+                  exhausted === true || (Array.isArray(exhausted) && exhausted.includes(cacheKeyId))
+                    ? { exhausted: true, exhaustedAtMs: 0, ttlSeconds: 60 }
+                    : { exhausted: false }
+                )
               ),
           },
           rateLimit: {
             isRateLimited: vi
               .fn()
-              .mockImplementation(({ model }: { model: string }) =>
+              .mockImplementation(({ cacheKeyId, model }: { cacheKeyId: string; model: string }) =>
                 Promise.resolve(
-                  rateLimitedModels.includes(model) ? { rateLimited: true } : { rateLimited: false }
+                  rateLimitedModels.some(entry =>
+                    typeof entry === 'string'
+                      ? entry === model
+                      : entry.model === model && entry.cacheKeyId === cacheKeyId
+                  )
+                    ? { rateLimited: true }
+                    : { rateLimited: false }
                 )
               ),
           },
@@ -342,7 +357,9 @@ describe('AuthStep', () => {
           getFreeDefaultConfig: vi.fn().mockResolvedValue({ model: 'free/model' }),
           getGlobalDefaultConfig: vi.fn().mockResolvedValue(null),
         } as unknown as LlmConfigResolver;
-        const caches = buildCaches({ exhausted: true });
+        // Only the USER's account is exhausted — the system bucket is healthy,
+        // so the forced-swap target must survive its own viability check.
+        const caches = buildCaches({ exhausted: ['user:user-456'] });
 
         step = new AuthStep(mockApiKeyResolver, resolverWithFree, undefined, undefined, {
           quotaFallbackCaches: caches as never,
@@ -367,6 +384,34 @@ describe('AuthStep', () => {
 
         expect(result.config?.effectivePersonality.model).toBe(TEST_PERSONALITY.model);
         expect(result.auth?.quotaFallback).toBeUndefined();
+      });
+
+      it("a guest route's viability check reads the system bucket — the user's own doom marks are irrelevant", async () => {
+        // A guest resolves the SYSTEM key as a plain string; identity must
+        // follow that provenance. The user's `user:<id>` bucket carrying a
+        // mark for the guest's model (their BYOK history) must not veto or
+        // retarget a route that bills the shared pool.
+        vi.mocked(mockApiKeyResolver.resolveApiKey).mockResolvedValue(SYSTEM_RESULT);
+        vi.mocked(mockConfigResolver.getFreeDefaultConfig).mockResolvedValue(null);
+        const caches = buildCaches({
+          rateLimitedModels: [{ cacheKeyId: 'user:user-456', model: FREE_ROUTER_MODEL }],
+        });
+
+        step = new AuthStep(mockApiKeyResolver, mockConfigResolver, undefined, undefined, {
+          quotaFallbackCaches: caches as never,
+        });
+        const result = await step.process(buildContext());
+
+        // Guest override lands on the free router; the stale user-bucket mark
+        // must not have retargeted it away.
+        expect(result.config?.effectivePersonality.model).toBe(FREE_ROUTER_MODEL);
+        expect(result.auth?.quotaFallback).toBeUndefined();
+        expect(caches.rateLimit.isRateLimited).toHaveBeenCalledWith(
+          expect.objectContaining({ cacheKeyId: 'system' })
+        );
+        expect(caches.rateLimit.isRateLimited).not.toHaveBeenCalledWith(
+          expect.objectContaining({ cacheKeyId: 'user:user-456' })
+        );
       });
 
       it('z.ai-promoted personality: retarget resets provider, swaps to the user OpenRouter key, and clears the stale auto-promotion route', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -146,7 +146,10 @@ export class AuthStep implements IPipelineStep {
         ? null
         : await checkModelViability({
             model: llmAuth.effectivePersonality.model,
-            cacheKeyId: deriveCacheKeyId(llmAuth.resolvedApiKey, userId),
+            // Guest routes (incl. the z.ai piggyback) resolve a SYSTEM key —
+            // identity follows provenance, or a guest's check would read the
+            // user's own BYOK doom marks and veto an already-admitted route.
+            cacheKeyId: deriveCacheKeyId(llmAuth.resolvedApiKey, userId, llmAuth.isGuestMode),
             caches: this.quotaFallbackCaches,
           });
     if (viability === null || viability.viable) {
@@ -228,7 +231,7 @@ export class AuthStep implements IPipelineStep {
     }
 
     const { personality, apiKey, isGuestMode, userId, jobId, knownCategory } = options;
-    const cacheKeyId = deriveCacheKeyId(apiKey, userId);
+    const cacheKeyId = deriveCacheKeyId(apiKey, userId, isGuestMode);
     let category = knownCategory;
     if (category === undefined) {
       const viability = await checkModelViability({

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
@@ -181,7 +181,14 @@ export async function runWithAutoPromotionFallback(
       // route's key is the one that actually served the rescued request.
       logQuotaFallbackAudit(info, {
         jobId: opts.jobId,
-        cacheKeyId: deriveCacheKeyId(fallback.apiKey, opts.conversationContext.userId),
+        // Identity follows the fallback credential's own provenance field.
+        // Guest fallbacks bail at entry, so this is `user:<id>` today — but
+        // deriving from the field keeps the audit right if that gate moves.
+        cacheKeyId: deriveCacheKeyId(
+          fallback.apiKey,
+          opts.conversationContext.userId,
+          fallback.isGuestMode
+        ),
       });
       return {
         ...fallbackResult,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/promotionDemotion.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/promotionDemotion.ts
@@ -66,7 +66,10 @@ export async function tryPromotionDemotion<T extends DemotableAuth>(
 
   const fallbackViability = await checkModelViability({
     model: llmAuth.fallback.model,
-    cacheKeyId: deriveCacheKeyId(llmAuth.fallback.apiKey, userId),
+    // The fallback's own isGuestMode is the identity's provenance signal.
+    // Guarded false above (guest fallbacks bail early), but deriving from the
+    // credential's own field keeps the identity correct if the guard moves.
+    cacheKeyId: deriveCacheKeyId(llmAuth.fallback.apiKey, userId, llmAuth.fallback.isGuestMode),
     caches,
   });
   if (!fallbackViability.viable) {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.test.ts
@@ -697,6 +697,63 @@ describe('D12 availability-class entry + two-hop floor descent', () => {
     expect(result.quotaFallback?.toModel).toBe('divergent/free-floor:free');
   });
 
+  it("a guest failure's viability checks run under the system bucket, not user:<id>", async () => {
+    // A guest attempt carries the SYSTEM key as a plain string — identity
+    // must follow route provenance, or the reactive path reads a bucket the
+    // invocation path never writes (the doom marks land under `system`).
+    const primary = vi.fn().mockRejectedValue(quotaError(ApiErrorCategory.QUOTA_EXCEEDED));
+    const retry = vi.fn().mockResolvedValue(okResult);
+    const deps = buildDeps({ free: { model: 'freebie/model:free' } });
+
+    await runWithQuotaFallback({
+      primary,
+      retry,
+      opts: buildOpts({ isGuestMode: true, apiKey: 'sk-system-key' }),
+      userId: '123',
+      requestId: 'req-1',
+      deps,
+    });
+
+    expect(deps.caches.rateLimit.isRateLimited).toHaveBeenCalledWith({
+      cacheKeyId: 'system',
+      model: 'freebie/model:free',
+    });
+    expect(deps.caches.rateLimit.isRateLimited).not.toHaveBeenCalledWith(
+      expect.objectContaining({ cacheKeyId: 'user:123' })
+    );
+  });
+
+  it('hop 2 after a forced entity swap checks the floor under the SYSTEM bucket (the credentials hop-1 actually swapped to)', async () => {
+    // BYOK credit exhaustion → hop-1 forced onto the system key. The floor
+    // hop reuses those credentials, so its doom-cache read must use the
+    // post-swap identity — the pre-retarget user bucket no longer describes
+    // the route (its 429s are written under `system`).
+    const primary = vi.fn().mockRejectedValue(quotaError(ApiErrorCategory.CREDIT_EXHAUSTION));
+    const retry = vi
+      .fn()
+      .mockRejectedValueOnce(quotaError(ApiErrorCategory.SERVER_ERROR))
+      .mockResolvedValueOnce(okResult);
+    const deps = buildDeps({ free: { model: 'freebie/model:free' } });
+
+    const result = await runWithQuotaFallback({
+      primary,
+      retry,
+      opts: buildOpts(), // BYOK: isGuestMode false, user's own key
+      userId: '123',
+      requestId: 'req-1',
+      deps,
+    });
+
+    expect(result.quotaFallback?.toModel).toBe('divergent/free-floor:free');
+    expect(deps.caches.rateLimit.isRateLimited).toHaveBeenCalledWith({
+      cacheKeyId: 'system',
+      model: 'divergent/free-floor:free',
+    });
+    expect(deps.caches.rateLimit.isRateLimited).not.toHaveBeenCalledWith(
+      expect.objectContaining({ cacheKeyId: 'user:123', model: 'divergent/free-floor:free' })
+    );
+  });
+
   it('hop 2 is skipped when the floor equals the hop-1 target (dedup) — original propagates', async () => {
     const original = quotaError(ApiErrorCategory.SERVER_ERROR);
     const primary = vi.fn().mockRejectedValue(original);

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.ts
@@ -125,7 +125,11 @@ export async function runWithQuotaFallback(options: {
       throw originalError;
     }
 
-    const cacheKeyId = deriveCacheKeyId(opts.apiKey, userId);
+    // A guest attempt runs on a SYSTEM key handed over as a plain string, so
+    // identity must follow the route's provenance (isGuestMode), not the
+    // key's presence — flagless derivation filed guest failures under
+    // `user:<id>` while the invocation path writes doom marks under `system`.
+    const cacheKeyId = deriveCacheKeyId(opts.apiKey, userId, opts.isGuestMode);
     const target = await selectQuotaFallbackTarget({
       category,
       isGuestMode: opts.isGuestMode,
@@ -187,9 +191,13 @@ export async function runWithQuotaFallback(options: {
       },
       info,
       originalError,
-      // Hop-2 (floor descent) context — see executeRetarget's doc.
+      // Hop-2 (floor descent) context — see executeRetarget's doc. The hop
+      // reuses hop-1's resolved credentials, so its viability check (and its
+      // audit line) must run under THAT route's identity: a forced entity
+      // swap or degraded downgrade moved the retry onto the system key, and
+      // the pre-retarget `user:<id>` bucket no longer describes it.
       caches: deps.caches,
-      cacheKeyId,
+      cacheKeyId: deriveCacheKeyId(credentials.apiKey, userId, credentials.isGuestMode),
     });
   }
 }

--- a/services/ai-worker/src/services/RateLimitCache.ts
+++ b/services/ai-worker/src/services/RateLimitCache.ts
@@ -337,11 +337,19 @@ export function deriveCacheKeyId(
   if (hasByokKey) {
     result = userId.length > 0 ? `user:${userId}` : '';
   } else {
-    result = 'system';
+    result = SYSTEM_CACHE_KEY_ID;
   }
   assertValidCacheKeyId(result);
   return result;
 }
+
+/**
+ * The shared-pool scope identifier for system-key routes (guest mode and the
+ * forced entity swap). Exported so viability checks that KNOW their target
+ * runs on the system key can name the bucket directly instead of round-
+ * tripping a key string through `deriveCacheKeyId`.
+ */
+export const SYSTEM_CACHE_KEY_ID = 'system';
 
 /**
  * Runtime belt for the documented `cacheKeyId` format invariant. Logs `warn`

--- a/services/ai-worker/src/services/quotaFallback.test.ts
+++ b/services/ai-worker/src/services/quotaFallback.test.ts
@@ -19,27 +19,43 @@ import {
   type QuotaFallbackCaches,
 } from './quotaFallback.js';
 
+/**
+ * Doom-cache mock, BUCKET-AWARE by design: Redis marks live under a
+ * (cacheKeyId[, model]) scope, and a mock that answers the same regardless of
+ * bucket cannot see a wrong-identity read — the exact class this module's
+ * viability checks exist to get right. `exhausted: true` / a bare model
+ * string mark every bucket; pass `{ cacheKeyId }` scoping to pin identity.
+ */
 function buildCaches(overrides?: {
-  exhausted?: boolean;
-  rateLimitedModels?: string[];
+  exhausted?: boolean | string[];
+  rateLimitedModels?: (string | { cacheKeyId: string; model: string })[];
 }): QuotaFallbackCaches {
+  const exhausted = overrides?.exhausted ?? false;
   const rateLimitedModels = overrides?.rateLimitedModels ?? [];
   return {
     creditExhaustion: {
       isCreditExhausted: vi
         .fn()
-        .mockResolvedValue(
-          overrides?.exhausted === true
-            ? { exhausted: true, exhaustedAtMs: 0, ttlSeconds: 60 }
-            : { exhausted: false }
+        .mockImplementation(({ cacheKeyId }: { cacheKeyId: string }) =>
+          Promise.resolve(
+            exhausted === true || (Array.isArray(exhausted) && exhausted.includes(cacheKeyId))
+              ? { exhausted: true, exhaustedAtMs: 0, ttlSeconds: 60 }
+              : { exhausted: false }
+          )
         ),
     },
     rateLimit: {
       isRateLimited: vi
         .fn()
-        .mockImplementation(({ model }: { model: string }) =>
+        .mockImplementation(({ cacheKeyId, model }: { cacheKeyId: string; model: string }) =>
           Promise.resolve(
-            rateLimitedModels.includes(model) ? { rateLimited: true } : { rateLimited: false }
+            rateLimitedModels.some(entry =>
+              typeof entry === 'string'
+                ? entry === model
+                : entry.model === model && entry.cacheKeyId === cacheKeyId
+            )
+              ? { rateLimited: true }
+              : { rateLimited: false }
           )
         ),
     },
@@ -120,17 +136,89 @@ describe('selectQuotaFallbackTarget — the tier matrix', () => {
     expect(target?.forceSystemKey).toBe(true);
   });
 
-  it('CREDIT_EXHAUSTION + BYOK skips the exhaustion check on the target (different billing entity)', async () => {
-    // The user's account IS marked exhausted — but the forced-system-key
-    // retry bills a different account, so the mark must not veto the target.
+  it("CREDIT_EXHAUSTION + BYOK: the caller's own exhaustion mark never vetoes the forced swap", async () => {
+    // The user's account IS marked exhausted (that's what triggered the swap)
+    // — but the forced-system-key retry bills a different account, so the
+    // viability check must run under the TARGET's bucket, not the caller's.
+    const caches = buildCaches({ exhausted: ['user:123'] });
     const target = await selectQuotaFallbackTarget({
       ...base,
       category: ApiErrorCategory.CREDIT_EXHAUSTION,
       isGuestMode: false,
       configResolver: buildResolver({ free: { model: 'freebie/model:free' } }) as never,
-      caches: buildCaches({ exhausted: true }),
+      caches,
     });
     expect(target?.forceSystemKey).toBe(true);
+    // Seam pin: the exhaustion check DID run, under the system bucket.
+    expect(caches.creditExhaustion.isCreditExhausted).toHaveBeenCalledWith({
+      cacheKeyId: 'system',
+    });
+  });
+
+  it('CREDIT_EXHAUSTION + BYOK: a SYSTEM-bucket exhaustion mark vetoes the forced swap (target is doomed too)', async () => {
+    const target = await selectQuotaFallbackTarget({
+      ...base,
+      category: ApiErrorCategory.CREDIT_EXHAUSTION,
+      isGuestMode: false,
+      configResolver: buildResolver({ free: { model: 'freebie/model:free' } }) as never,
+      caches: buildCaches({ exhausted: ['system'] }),
+    });
+    expect(target).toBeNull();
+  });
+
+  it("the forced swap's rate-limit pre-check reads the TARGET's bucket, where the forced retry's 429s are written", async () => {
+    // A `system`-bucket mark on the free default means the forced retry is
+    // known-doomed — the fail-fast this pre-check exists for.
+    const vetoed = await selectQuotaFallbackTarget({
+      ...base,
+      category: ApiErrorCategory.CREDIT_EXHAUSTION,
+      isGuestMode: false,
+      configResolver: buildResolver({ free: { model: 'freebie/model:free' } }) as never,
+      caches: buildCaches({
+        rateLimitedModels: [{ cacheKeyId: 'system', model: 'freebie/model:free' }],
+      }),
+    });
+    expect(vetoed).toBeNull();
+
+    // The caller's own bucket carrying the same mark is irrelevant to a
+    // system-key target (the old wrong read) — the swap proceeds.
+    const proceeds = await selectQuotaFallbackTarget({
+      ...base,
+      category: ApiErrorCategory.CREDIT_EXHAUSTION,
+      isGuestMode: false,
+      configResolver: buildResolver({ free: { model: 'freebie/model:free' } }) as never,
+      caches: buildCaches({
+        rateLimitedModels: [{ cacheKeyId: 'user:123', model: 'freebie/model:free' }],
+      }),
+    });
+    expect(proceeds?.forceSystemKey).toBe(true);
+  });
+
+  it("a guest target's viability is judged under the system bucket even when the caller passes a user bucket", async () => {
+    // The BYOK degraded-downgrade funnels (runner + retarget route) call with
+    // isGuestMode: true while still holding the user's cacheKeyId — the free
+    // target runs on the system key regardless, so identity derives internally.
+    const vetoed = await selectQuotaFallbackTarget({
+      ...base,
+      category: ApiErrorCategory.QUOTA_EXCEEDED,
+      isGuestMode: true,
+      configResolver: buildResolver({ free: { model: 'freebie/model:free' } }) as never,
+      caches: buildCaches({
+        rateLimitedModels: [{ cacheKeyId: 'system', model: 'freebie/model:free' }],
+      }),
+    });
+    expect(vetoed).toBeNull();
+
+    const proceeds = await selectQuotaFallbackTarget({
+      ...base,
+      category: ApiErrorCategory.QUOTA_EXCEEDED,
+      isGuestMode: true,
+      configResolver: buildResolver({ free: { model: 'freebie/model:free' } }) as never,
+      caches: buildCaches({
+        rateLimitedModels: [{ cacheKeyId: 'user:123', model: 'freebie/model:free' }],
+      }),
+    });
+    expect(proceeds?.config.model).toBe('freebie/model:free');
   });
 
   it('QUOTA_EXCEEDED + BYOK → global (paid) default on the own key', async () => {

--- a/services/ai-worker/src/services/quotaFallback.ts
+++ b/services/ai-worker/src/services/quotaFallback.ts
@@ -37,7 +37,7 @@ import type { LlmConfigResolver } from '@tzurot/config-resolver';
 import { ApiError, parseApiError } from '../utils/apiErrorParser.js';
 import { RetryError } from '../utils/retry.js';
 import type { CreditExhaustionCache } from './CreditExhaustionCache.js';
-import type { RateLimitCache } from './RateLimitCache.js';
+import { SYSTEM_CACHE_KEY_ID, type RateLimitCache } from './RateLimitCache.js';
 
 const logger = createLogger('QuotaFallback');
 
@@ -179,12 +179,16 @@ export function isCausePrecedenceFailure(error: unknown): boolean {
  * The `isViable` seam (design D2): is `model` currently attemptable for this
  * account scope? Consults the same doom-caches the failure path writes.
  * Returns the blocking category on a non-viable model so proactive callers
- * can label the retarget correctly. Error semantics are CALLER-specific:
- * this function itself propagates a throwing cache (no internal catch). The
- * proactive/hop-1 paths degrade a throw to viable at their own seams (the
- * caches are an optimisation there); the floor hop (`attemptFloorHop`)
- * deliberately degrades a throw to NOT-attempted instead — fail-closed is the
- * safer call for a last-resort hop whose skip just propagates the original.
+ * can label the retarget correctly. Error semantics: the fail-open lives
+ * INSIDE `RateLimitCache.isRateLimited` / `CreditExhaustionCache.
+ * isCreditExhausted` — each catches its own Redis failure and degrades to
+ * not-blocked — so in practice this function does not throw. The caller-side
+ * degrade layers are defense-in-depth only: the proactive/hop-1 paths degrade
+ * a hypothetical throw to viable, while the floor hop (`attemptFloorHop`)
+ * degrades to NOT-attempted (fail-closed suits a last-resort hop whose skip
+ * just propagates the original). The runner's unwrapped `await
+ * selectQuotaFallbackTarget` would propagate such a throw — acceptable only
+ * because the caches fail open internally.
  */
 export async function checkModelViability(options: {
   model: string;
@@ -271,6 +275,12 @@ export async function selectQuotaFallbackTarget(options: {
   category: QuotaFallbackCategory;
   isGuestMode: boolean;
   failingModel: string;
+  /**
+   * The CALLER's cache identity (the failing route's account scope). Used for
+   * the target viability check only when the target stays on the caller's own
+   * billing entity; guest-semantics targets are checked under the system
+   * bucket regardless (derived internally — callers can't get it wrong).
+   */
   cacheKeyId: string;
   configResolver: LlmConfigResolver;
   caches: QuotaFallbackCaches;
@@ -297,20 +307,23 @@ export async function selectQuotaFallbackTarget(options: {
     return null;
   }
 
-  // Target viability: skip the credit-exhaustion check when the billing
-  // entity changes — the exhaustion mark belongs to the user's account, but
-  // the forced-system-key retry bills a different one (the cache bucket is
-  // per-user either way, so the mark would otherwise always veto this path).
-  if (forceSystemKey) {
-    const rateLimited = await caches.rateLimit.isRateLimited({ cacheKeyId, model: config.model });
-    if (rateLimited.rateLimited) {
-      return null;
-    }
-  } else {
-    const viability = await checkModelViability({ model: config.model, cacheKeyId, caches });
-    if (!viability.viable) {
-      return null;
-    }
+  // Target viability runs under the TARGET's billing identity, never the
+  // caller's. A guest-semantics target (isGuestMode, or the forced entity
+  // swap) executes on the system key, whose doom marks are written under
+  // `system` — reading the caller's `user:<id>` bucket would both miss the
+  // target's own marks (a forced retry's 429 lands under `system`) and
+  // re-attach the caller's (the exhaustion mark that triggered the swap
+  // would always veto it). With the identity right, the full viability
+  // check is coherent on every path: a `system` exhaustion mark genuinely
+  // describes the account the retarget would bill.
+  const targetCacheKeyId = forceSystemKey || isGuestMode ? SYSTEM_CACHE_KEY_ID : cacheKeyId;
+  const viability = await checkModelViability({
+    model: config.model,
+    cacheKeyId: targetCacheKeyId,
+    caches,
+  });
+  if (!viability.viable) {
+    return null;
   }
 
   return { config, forceSystemKey };


### PR DESCRIPTION
## Summary

Closes the **wrong-cache-identity class** (tracker TASK-248): doom-cache reads that derived their Redis bucket from the key's **presence** instead of its **provenance**. A guest attempt carries the SYSTEM key as a plain string, so a flagless `deriveCacheKeyId(apiKey, userId)` filed reads under `user:<id>` while the invocation path (post-#1570) writes marks under `system` — the known-doomed fail-fast never fired. Every instance was fail-safe (wasted doomed round trips against the shared free model; never a wrong answer).

## The funnel fix

`selectQuotaFallbackTarget` now derives the **target's** identity internally — `system` for guest-semantics and forced-entity-swap targets, the caller's bucket otherwise — and runs the full viability check under it. Two consequences:

- The forced-swap rate-limit pre-check now reads the bucket the forced retry's 429s are actually written to (the original TASK-248 finding).
- The credit-exhaustion check becomes coherent on the forced-swap path and is no longer skipped: a `system`-bucket exhaustion mark genuinely describes the account the retarget would bill, so it may now veto a doomed swap (behavior change, strictly fail-fast: the retry it prevents was doomed).

Internal derivation also fixes the two BYOK degraded-downgrade funnel points (`resolveTargetAndCredentials` guestTarget, `downgradeToFreeDefault`) without touching them — they pass `isGuestMode: true` while still holding the user's bucket.

## Class sweep (deterministic: grep of every `deriveCacheKeyId` call site)

| Site | Provenance | Change |
| --- | --- | --- |
| `quotaFallbackRunner.ts` failing-attempt derive | `opts.isGuestMode` | flag added (guest failures now file under `system`) |
| `quotaFallbackRunner.ts` hop-2 floor context | post-swap `credentials.isGuestMode` | hop-2 viability + audit now use the identity hop-1 actually swapped to (5th documented instance) |
| `AuthStep.ts` shared viability check | `llmAuth.isGuestMode` | flag added (4th documented instance — z.ai-admitted guest read the user's OpenRouter doom marks) |
| `AuthStep.ts` proactive path | `options.isGuestMode` | flag added |
| `promotionDemotion.ts` | `fallback.isGuestMode` | provenance-explicit (guarded false today; identity stays correct if the guard moves) |
| `autoPromotionFallback.ts` audit line | `fallback.isGuestMode` | provenance-explicit (guest fallbacks bail at entry) |
| `ConversationalRAGService.ts` | — | already correct (the #1570 fix site); unchanged |

Ride-along per the task: `checkModelViability`'s JSDoc rewritten — the fail-open lives inside the caches' own try/catch (verified), not at callers' seams.

## Tests

The suites' doom-cache mocks were **bucket-insensitive** — the exact blindness that let this class survive — and are now `(cacheKeyId, model)`-scoped. New seam pins in both directions (system-bucket marks veto; stale user-bucket marks don't) across `quotaFallback`, `quotaFallbackRunner` (guest derive + post-swap hop-2), and `AuthStep` (guest route reads `system`).

**Fail-pre-fix verified**: stashing the production diff and re-running the three suites produces 7 failures; full ai-worker suite (190 files / 4006 tests) green with the fix. `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)