### PR TITLE
refactor(api-gateway): retire dead memory route factories

### DIFF
--- a/services/api-gateway/src/routes/user/memory.test.ts
+++ b/services/api-gateway/src/routes/user/memory.test.ts
@@ -3,9 +3,8 @@
  *
  * Tests LTM (Long-Term Memory) management endpoints:
  * - GET /stats - Get memory statistics for a personality
- * - GET /focus - Get focus mode status
- * - POST /focus - Enable/disable focus mode
  * - POST /search - Semantic search of memories
+ * - GET /list - Paginated list of memories for browsing
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -83,8 +82,9 @@ const mockPrisma = {
   $queryRaw: vi.fn(),
 };
 
-import { createMemoryRoutes } from './memory.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
+import { handleGetStats } from './memory.js';
+import { handleSearch } from './memorySearch.js';
+import { handleList } from './memoryList.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
@@ -110,15 +110,6 @@ function createMockReqRes(body: Record<string, unknown> = {}, query: Record<stri
   } as unknown as Response;
 
   return { req, res };
-}
-
-// Helper to get handler from router
-function getHandler(
-  router: ReturnType<typeof createMemoryRoutes>,
-  method: 'get' | 'post' | 'delete',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
 }
 
 describe('/user/memory routes', () => {
@@ -149,37 +140,18 @@ describe('/user/memory routes', () => {
     mockPrisma.memory.findMany.mockResolvedValue([]);
   });
 
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createMemoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have GET /stats route registered', () => {
-      const router = createMemoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'get', '/stats')).toBeDefined();
-    });
-  });
-
+  // Route wiring (paths, middleware, registration order) is owned by the
+  // generated mounts.ts — `pnpm ops codegen:routes --check` pins it against
+  // the manifest, so these tests exercise the handlers directly.
   describe('GET /user/memory/stats', () => {
     it('should reject missing personalityId', async () => {
-      const router = createMemoryRoutes({
+      const handler = handleGetStats({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -193,14 +165,13 @@ describe('/user/memory routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createMemoryRoutes({
+      const handler = handleGetStats({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(404);
     });
@@ -211,14 +182,13 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce({ id: TEST_USER_ID }) // First call - check user
         .mockResolvedValueOnce({ defaultPersonaId: null }); // Second call - get default persona
 
-      const router = createMemoryRoutes({
+      const handler = handleGetStats({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -245,14 +215,13 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce({ createdAt: oldestDate }) // oldest
         .mockResolvedValueOnce({ createdAt: newestDate }); // newest
 
-      const router = createMemoryRoutes({
+      const handler = handleGetStats({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -285,15 +254,14 @@ describe('/user/memory routes', () => {
           ),
       };
 
-      const router = createMemoryRoutes({
+      const handler = handleGetStats({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         redis: mockRedis as unknown as import('ioredis').Redis,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -313,26 +281,16 @@ describe('/user/memory routes', () => {
       mockPrisma.$queryRaw.mockResolvedValue([]);
     });
 
-    it('should have POST /search route registered', () => {
-      const router = createMemoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'post', '/search')).toBeDefined();
-    });
-
     it('should return 503 when embedding service is not available', async () => {
       mockIsEmbeddingServiceAvailable.mockReturnValue(false);
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(503);
       expect(res.json).toHaveBeenCalledWith(
@@ -343,14 +301,13 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject missing query', async () => {
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({}, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -362,14 +319,13 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject empty query', async () => {
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: '' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -380,15 +336,14 @@ describe('/user/memory routes', () => {
     });
 
     it('should return 400 for query exceeding max length', async () => {
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const longQuery = 'a'.repeat(501); // Exceeds 500 char limit
       const { req, res } = createMockReqRes({ query: longQuery }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -406,14 +361,13 @@ describe('/user/memory routes', () => {
         defaultPersonaId: null,
       });
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -440,14 +394,13 @@ describe('/user/memory routes', () => {
       ];
       mockPrisma.$queryRaw.mockResolvedValue(mockResults);
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockGenerateEmbedding).toHaveBeenCalledWith('test search');
       expect(mockPrisma.$queryRaw).toHaveBeenCalled();
@@ -486,14 +439,13 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce([]) // semantic search - no results
         .mockResolvedValueOnce(textResults); // text search - has results
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'Draco' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(2);
       expect(res.status).toHaveBeenCalledWith(200);
@@ -518,14 +470,13 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce([]) // semantic search
         .mockResolvedValueOnce([]); // text search
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'nonexistent' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(2);
       expect(res.status).toHaveBeenCalledWith(200);
@@ -539,14 +490,13 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject limit exceeding max 50', async () => {
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search', limit: 100 }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       // MemorySearchSchema validates limit with .max(50), so 100 is rejected
       expect(res.status).toHaveBeenCalledWith(400);
@@ -561,14 +511,13 @@ describe('/user/memory routes', () => {
     it('should handle embedding generation error', async () => {
       mockGenerateEmbedding.mockRejectedValue(new Error('OpenAI API error'));
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith(
@@ -592,15 +541,14 @@ describe('/user/memory routes', () => {
       }));
       mockPrisma.$queryRaw.mockResolvedValue(mockResults);
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       // Request with limit=5, but API returns 6 to check for hasMore
       const { req, res } = createMockReqRes({ query: 'test search', limit: 5 }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       // The response should only include 5 results (not 6)
@@ -623,14 +571,13 @@ describe('/user/memory routes', () => {
       ];
       mockPrisma.$queryRaw.mockResolvedValue(textResults);
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search', preferTextSearch: true }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       // Should NOT call generateEmbedding when preferTextSearch is true
       expect(mockGenerateEmbedding).not.toHaveBeenCalled();
@@ -647,14 +594,13 @@ describe('/user/memory routes', () => {
     it('should return 503 when embedding service returns null', async () => {
       mockGenerateEmbedding.mockResolvedValue(null);
 
-      const router = createMemoryRoutes({
+      const handler = handleSearch({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(503);
       expect(res.json).toHaveBeenCalledWith(
@@ -666,26 +612,16 @@ describe('/user/memory routes', () => {
   });
 
   describe('GET /user/memory/list', () => {
-    it('should have GET /list route registered', () => {
-      const router = createMemoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'get', '/list')).toBeDefined();
-    });
-
     it('should return empty list when user has no persona', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ defaultPersonaId: null });
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -722,14 +658,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(2);
       mockPrisma.memory.findMany.mockResolvedValue(mockMemories);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '10', offset: '0' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -758,14 +693,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.memory.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -780,14 +714,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '100' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.memory.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -800,14 +733,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.memory.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -820,14 +752,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(25);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '10', offset: '10' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.memory.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -853,14 +784,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(25);
       mockPrisma.memory.findMany.mockResolvedValue(mockMemories);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '10', offset: '0' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -873,14 +803,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { sort: 'updatedAt', order: 'asc' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.memory.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -893,14 +822,13 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes({
+      const handler = handleList({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, {});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.memory.findMany).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/services/api-gateway/src/routes/user/memory.ts
+++ b/services/api-gateway/src/routes/user/memory.ts
@@ -2,48 +2,22 @@
  * User Memory Routes
  * LTM (Long-Term Memory) management endpoints
  *
- * GET /user/memory/stats - Get memory statistics for a personality
- * GET /user/memory/list - Paginated list of memories for browsing
- * POST /user/memory/search - Semantic search of memories
- * POST /user/memory/delete/preview - Preview batch delete; issues PreviewToken
- * POST /user/memory/delete - Execute batch delete using PreviewToken
- * POST /user/memory/purge/token - Validate confirmation phrase; issues PurgeToken
- * POST /user/memory/purge - Execute purge using PurgeToken
- * GET /user/memory/:id - Get a single memory
- * PATCH /user/memory/:id - Update memory content
- * DELETE /user/memory/:id - Delete a single memory
- * PUT /user/memory/:id/lock - Set memory lock state explicitly (idempotent on retry)
- *
- * Memory-mode sub-routes (incognito at /user/memory/incognito, fresh at
- * /user/memory/fresh): status/enable/disable each, plus incognito's forget.
+ * This module owns only the stats handler; its siblings (memoryList,
+ * memorySearch, memorySingle, memoryBatch, memoryIncognito, memoryFresh)
+ * own the rest of the /user/memory/* surface. The generated mounts.ts
+ * registers every handler export directly — there is no local router
+ * factory.
  */
 
-import { Router, type RequestHandler, type Response } from 'express';
+import { type RequestHandler, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { RouteDeps } from '../routeDeps.js';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { MemoryModeSessionManager } from '../../services/MemoryModeSessionManager.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import type { ProvisionedRequest } from '../../types.js';
-import { handleSearch } from './memorySearch.js';
-import { handleList } from './memoryList.js';
-import {
-  handleGetMemory,
-  handleUpdateMemory,
-  handleSetMemoryLock,
-  handleDeleteMemory,
-} from './memorySingle.js';
-import {
-  handleBatchDelete,
-  handleBatchDeletePreview,
-  handleIssuePurgeToken,
-  handlePurge,
-} from './memoryBatch.js';
-import { createIncognitoRoutes } from './memoryIncognito.js';
-import { createFreshRoutes } from './memoryFresh.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { getDefaultPersonaId, getPersonalityById } from './memoryHelpers.js';
 
@@ -142,44 +116,3 @@ export const handleGetStats = (deps: RouteDeps): RequestHandler => {
     );
   });
 };
-
-/**
- * Mount all /user/memory/* routes onto a fresh router. Each handler is the
- * (deps: RouteDeps) => RequestHandler shape that codegen emits — once the
- * generated mounts.ts is wired up, the codegen will register these routes
- * identically and this factory becomes the legacy path to delete.
- *
- * Registration order matters: literal paths (`/stats`, `/list`, `/search`,
- * `/delete*`, `/purge*`) must come before `/:id` so they don't get
- * shadowed by the parameterised route.
- */
-export function createMemoryRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const { prisma, redis } = deps;
-
-  // Memory-mode routes (require Redis)
-  if (redis !== undefined) {
-    router.use('/incognito', createIncognitoRoutes(prisma, redis));
-    router.use('/fresh', createFreshRoutes(prisma, redis));
-  }
-
-  const requireProvisioned = requireProvisionedUser(prisma);
-  router.get('/stats', requireUserAuth(), requireProvisioned, handleGetStats(deps));
-  router.get('/list', requireUserAuth(), requireProvisioned, handleList(deps));
-  router.post('/search', requireUserAuth(), requireProvisioned, handleSearch(deps));
-  router.post(
-    '/delete/preview',
-    requireUserAuth(),
-    requireProvisioned,
-    handleBatchDeletePreview(deps)
-  );
-  router.post('/delete', requireUserAuth(), requireProvisioned, handleBatchDelete(deps));
-  router.post('/purge/token', requireUserAuth(), requireProvisioned, handleIssuePurgeToken(deps));
-  router.post('/purge', requireUserAuth(), requireProvisioned, handlePurge(deps));
-  router.get('/:id', requireUserAuth(), requireProvisioned, handleGetMemory(deps));
-  router.patch('/:id', requireUserAuth(), requireProvisioned, handleUpdateMemory(deps));
-  router.delete('/:id', requireUserAuth(), requireProvisioned, handleDeleteMemory(deps));
-  router.put('/:id/lock', requireUserAuth(), requireProvisioned, handleSetMemoryLock(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/memoryFresh.test.ts
+++ b/services/api-gateway/src/routes/user/memoryFresh.test.ts
@@ -47,8 +47,7 @@ const mockRedis = {
   mget: vi.fn().mockResolvedValue([]),
 };
 
-import { createFreshRoutes } from './memoryFresh.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
+import { handleGetFreshStatus, handleEnableFresh, handleDisableFresh } from './memoryFresh.js';
 import { REDIS_KEY_PREFIXES } from '@tzurot/common-types/constants/queue';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { Redis } from 'ioredis';
@@ -71,8 +70,12 @@ function createMockReqRes(body: Record<string, unknown> = {}, query: Record<stri
   return { req, res };
 }
 
-function buildRouter() {
-  return createFreshRoutes(mockPrisma as unknown as PrismaClient, mockRedis as unknown as Redis);
+// Standard handler deps (prisma + redis) — the shape mounts.ts wires in prod.
+function modeDeps() {
+  return {
+    prisma: mockPrisma as unknown as PrismaClient,
+    redis: mockRedis as unknown as Redis,
+  };
 }
 
 describe('/user/memory/fresh routes', () => {
@@ -90,24 +93,18 @@ describe('/user/memory/fresh routes', () => {
     mockRedis.get.mockResolvedValue(null);
   });
 
-  describe('route factory', () => {
-    it('registers GET, POST, and DELETE at the root', () => {
-      const router = buildRouter();
-      expect(findRoute(router, 'get', '/')).toBeDefined();
-      expect(findRoute(router, 'post', '/')).toBeDefined();
-      expect(findRoute(router, 'delete', '/')).toBeDefined();
-    });
-  });
-
+  // Route wiring (paths, middleware, registration) is owned by the generated
+  // mounts.ts — `pnpm ops codegen:routes --check` pins it against the
+  // manifest, so these tests exercise the handlers directly.
   describe('POST / (enable)', () => {
     it('stores the session under the fresh: prefix and says memories are kept', async () => {
-      const handler = getRouteHandler(buildRouter(), 'post', '/');
+      const handler = handleEnableFresh(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         duration: '1h',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockRedis.setex).toHaveBeenCalledWith(
         `${REDIS_KEY_PREFIXES.FRESH}${TEST_DISCORD_USER_ID}:${TEST_PERSONALITY_ID}`,
@@ -124,10 +121,10 @@ describe('/user/memory/fresh routes', () => {
     });
 
     it('supports the global "all" scope', async () => {
-      const handler = getRouteHandler(buildRouter(), 'post', '/');
+      const handler = handleEnableFresh(modeDeps());
       const { req, res } = createMockReqRes({ personalityId: 'all', duration: 'forever' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockRedis.set).toHaveBeenCalledWith(
         `${REDIS_KEY_PREFIXES.FRESH}${TEST_DISCORD_USER_ID}:all`,
@@ -143,10 +140,10 @@ describe('/user/memory/fresh routes', () => {
 
   describe('DELETE / (disable)', () => {
     it('deletes the fresh session and says memories will be used again', async () => {
-      const handler = getRouteHandler(buildRouter(), 'delete', '/');
+      const handler = handleDisableFresh(modeDeps());
       const { req, res } = createMockReqRes({ personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockRedis.del).toHaveBeenCalledWith(
         `${REDIS_KEY_PREFIXES.FRESH}${TEST_DISCORD_USER_ID}:${TEST_PERSONALITY_ID}`
@@ -162,10 +159,10 @@ describe('/user/memory/fresh routes', () => {
 
   describe('GET / (status)', () => {
     it('scans the fresh: keyspace, not incognito', async () => {
-      const handler = getRouteHandler(buildRouter(), 'get', '/');
+      const handler = handleGetFreshStatus(modeDeps());
       const { req, res } = createMockReqRes();
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockRedis.scan).toHaveBeenCalledWith(
         '0',

--- a/services/api-gateway/src/routes/user/memoryFresh.ts
+++ b/services/api-gateway/src/routes/user/memoryFresh.ts
@@ -10,14 +10,12 @@
  * DELETE /user/memory/fresh - Disable fresh mode
  *
  * All three are the shared memory-mode handlers (see memoryModeHandlers.ts);
- * the ai-worker checks the `fresh:` Redis keys at retrieval time.
+ * the ai-worker checks the `fresh:` Redis keys at retrieval time. The
+ * generated mounts.ts registers the handler exports directly — there is no
+ * local router factory.
  */
 
-import { Router } from 'express';
-import type { Redis } from 'ioredis';
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
-import { createMemoryModeHandlers, type MemoryModeDeps } from './memoryModeHandlers.js';
+import { createMemoryModeHandlers } from './memoryModeHandlers.js';
 
 const freshHandlers = createMemoryModeHandlers('fresh', {
   alreadyActive: name =>
@@ -39,19 +37,3 @@ export const handleEnableFresh = freshHandlers.handleEnable;
 
 /** DELETE /api/user/memory/fresh */
 export const handleDisableFresh = freshHandlers.handleDisable;
-
-/**
- * Legacy aggregator-style factory — preserved for the existing top-level
- * user-router wiring. The generated mounts.ts uses the named handler exports
- * above directly.
- */
-export function createFreshRoutes(prisma: PrismaClient, redis: Redis): Router {
-  const router = Router();
-  const deps: MemoryModeDeps = { prisma, redis };
-
-  router.get('/', requireUserAuth(), requireProvisionedUser(prisma), handleGetFreshStatus(deps));
-  router.post('/', requireUserAuth(), requireProvisionedUser(prisma), handleEnableFresh(deps));
-  router.delete('/', requireUserAuth(), requireProvisionedUser(prisma), handleDisableFresh(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/memoryIncognito.test.ts
+++ b/services/api-gateway/src/routes/user/memoryIncognito.test.ts
@@ -62,12 +62,11 @@ const mockRedis = {
 };
 
 import {
-  createIncognitoRoutes,
   handleGetIncognitoStatus,
   handleEnableIncognito,
   handleDisableIncognito,
+  handleIncognitoForget,
 } from './memoryIncognito.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { Redis } from 'ioredis';
 
@@ -96,13 +95,12 @@ function createMockReqRes(body: Record<string, unknown> = {}, query: Record<stri
   return { req, res };
 }
 
-// Helper to get handler from router
-function getHandler(
-  router: ReturnType<typeof createIncognitoRoutes>,
-  method: 'get' | 'post' | 'delete',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
+// Standard handler deps (prisma + redis) — the shape mounts.ts wires in prod.
+function modeDeps() {
+  return {
+    prisma: mockPrisma as unknown as PrismaClient,
+    redis: mockRedis as unknown as Redis,
+  };
 }
 
 describe('/user/memory/incognito routes', () => {
@@ -127,66 +125,17 @@ describe('/user/memory/incognito routes', () => {
     mockRedis.get.mockResolvedValue(null);
   });
 
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have GET / route registered', () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-
-      expect(findRoute(router, 'get', '/')).toBeDefined();
-    });
-
-    it('should have POST / route registered', () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-
-      expect(findRoute(router, 'post', '/')).toBeDefined();
-    });
-
-    it('should have DELETE / route registered', () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-
-      expect(findRoute(router, 'delete', '/')).toBeDefined();
-    });
-
-    it('should have POST /forget route registered', () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-
-      expect(findRoute(router, 'post', '/forget')).toBeDefined();
-    });
-  });
-
+  // Route wiring (paths, middleware, registration) is owned by the generated
+  // mounts.ts — `pnpm ops codegen:routes --check` pins it against the
+  // manifest, so these tests exercise the handlers directly.
   describe('GET /user/memory/incognito (status)', () => {
     it('should return inactive status when no sessions', async () => {
       mockRedis.scan.mockResolvedValue(['0', []]);
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'get', '/');
+      const handler = handleGetIncognitoStatus(modeDeps());
       const { req, res } = createMockReqRes();
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -211,14 +160,10 @@ describe('/user/memory/incognito routes', () => {
       ]);
       mockRedis.mget.mockResolvedValue([JSON.stringify(session)]);
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'get', '/');
+      const handler = handleGetIncognitoStatus(modeDeps());
       const { req, res } = createMockReqRes();
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -236,14 +181,10 @@ describe('/user/memory/incognito routes', () => {
 
   describe('POST /user/memory/incognito (enable)', () => {
     it('should reject missing personalityId', async () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({ duration: '1h' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -254,14 +195,10 @@ describe('/user/memory/incognito routes', () => {
     });
 
     it('should reject missing duration', async () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({ personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -272,17 +209,13 @@ describe('/user/memory/incognito routes', () => {
     });
 
     it('should reject invalid duration', async () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         duration: 'invalid',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -295,17 +228,13 @@ describe('/user/memory/incognito routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_NONEXISTENT_ID, // Valid UUID format, but not in DB
         duration: '1h',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(404);
       expect(res.json).toHaveBeenCalledWith(
@@ -318,17 +247,13 @@ describe('/user/memory/incognito routes', () => {
     it('should enable incognito mode with TTL', async () => {
       mockRedis.get.mockResolvedValue(null); // No existing session
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         duration: '1h',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockRedis.setex).toHaveBeenCalledWith(
         expect.stringContaining(TEST_PERSONALITY_ID),
@@ -349,17 +274,13 @@ describe('/user/memory/incognito routes', () => {
     it('should enable incognito for "all" without TTL', async () => {
       mockRedis.get.mockResolvedValue(null);
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: 'all',
         duration: 'forever',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       // 'forever' uses SET not SETEX
       expect(mockRedis.set).toHaveBeenCalledWith(
@@ -380,17 +301,13 @@ describe('/user/memory/incognito routes', () => {
       };
       mockRedis.get.mockResolvedValue(JSON.stringify(existingSession));
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         duration: '4h', // Different duration
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       // Should NOT create new session
       expect(mockRedis.setex).not.toHaveBeenCalled();
@@ -407,17 +324,13 @@ describe('/user/memory/incognito routes', () => {
     it('should return wasAlreadyActive: false when creating new session', async () => {
       mockRedis.get.mockResolvedValue(null);
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/');
+      const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         duration: '1h',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith(
@@ -430,14 +343,10 @@ describe('/user/memory/incognito routes', () => {
 
   describe('DELETE /user/memory/incognito (disable)', () => {
     it('should reject missing personalityId', async () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'delete', '/');
+      const handler = handleDisableIncognito(modeDeps());
       const { req, res } = createMockReqRes({});
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -450,16 +359,12 @@ describe('/user/memory/incognito routes', () => {
     it('should disable incognito mode', async () => {
       mockRedis.del.mockResolvedValue(1);
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'delete', '/');
+      const handler = handleDisableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockRedis.del).toHaveBeenCalledWith(expect.stringContaining(TEST_PERSONALITY_ID));
       expect(res.status).toHaveBeenCalledWith(200);
@@ -473,16 +378,12 @@ describe('/user/memory/incognito routes', () => {
     it('should return disabled=false when session did not exist', async () => {
       mockRedis.del.mockResolvedValue(0);
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'delete', '/');
+      const handler = handleDisableIncognito(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -495,14 +396,10 @@ describe('/user/memory/incognito routes', () => {
 
   describe('POST /user/memory/incognito/forget', () => {
     it('should reject missing personalityId', async () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({ timeframe: '15m' });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -513,14 +410,10 @@ describe('/user/memory/incognito routes', () => {
     });
 
     it('should reject missing timeframe', async () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({ personalityId: TEST_PERSONALITY_ID });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -531,17 +424,13 @@ describe('/user/memory/incognito routes', () => {
     });
 
     it('should reject invalid timeframe', async () => {
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         timeframe: 'invalid',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -560,17 +449,13 @@ describe('/user/memory/incognito routes', () => {
       mockPrisma.memory.findMany.mockResolvedValue([]);
       mockPrisma.memory.deleteMany.mockResolvedValue({ count: 0 });
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         timeframe: '15m',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       // Without the visibility filter, already-soft-deleted rows are re-counted
       // and the reported "forgot N memories" total is inflated.
@@ -593,17 +478,13 @@ describe('/user/memory/incognito routes', () => {
         defaultPersonaId: null, // No persona
       });
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         timeframe: '15m',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -619,17 +500,13 @@ describe('/user/memory/incognito routes', () => {
       ]);
       mockPrisma.memory.deleteMany.mockResolvedValue({ count: 5 });
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         timeframe: '15m',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(mockPrisma.memory.deleteMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
@@ -650,17 +527,13 @@ describe('/user/memory/incognito routes', () => {
       mockPrisma.memory.findMany.mockResolvedValue([]);
       mockPrisma.memory.deleteMany.mockResolvedValue({ count: 0 });
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
         timeframe: '15m',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       // Verify isLocked: false is in the where clause
       expect(mockPrisma.memory.deleteMany).toHaveBeenCalledWith({
@@ -677,17 +550,13 @@ describe('/user/memory/incognito routes', () => {
       ]);
       mockPrisma.memory.deleteMany.mockResolvedValue({ count: 10 });
 
-      const router = createIncognitoRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockRedis as unknown as Redis
-      );
-      const handler = getHandler(router, 'post', '/forget');
+      const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({
         personalityId: 'all',
         timeframe: '1h',
       });
 
-      await handler(req, res);
+      await handler(req, res, vi.fn());
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
@@ -700,10 +569,10 @@ describe('/user/memory/incognito routes', () => {
   });
 
   describe('redis-missing 503 guards (handler factories)', () => {
-    // The factory handlers each guard `deps.redis === undefined` and short-
-    // circuit with 503 before constructing the IncognitoSessionManager.
-    // These exercise the guard branch that route-factory tests don't reach
-    // (createIncognitoRoutes always passes a redis instance).
+    // The handlers each guard `deps.redis === undefined` and short-circuit
+    // with 503 before constructing the IncognitoSessionManager. These
+    // exercise the guard branch the modeDeps()-based tests don't reach
+    // (modeDeps() always includes a redis instance).
 
     it('handleGetIncognitoStatus returns 503 when redis is undefined', async () => {
       const handler = handleGetIncognitoStatus({ prisma: mockPrisma as unknown as PrismaClient });

--- a/services/api-gateway/src/routes/user/memoryIncognito.ts
+++ b/services/api-gateway/src/routes/user/memoryIncognito.ts
@@ -10,16 +10,15 @@
  *
  * Status/enable/disable are the shared memory-mode handlers (see
  * memoryModeHandlers.ts — fresh mode uses the same machinery); `forget` is
- * write-side-specific and lives here.
+ * write-side-specific and lives here. The generated mounts.ts registers the
+ * handler exports directly — there is no local router factory.
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import type { Redis } from 'ioredis';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { IncognitoForgetRequestSchema } from '@tzurot/common-types/types/memory-modes';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -163,35 +162,3 @@ export const handleDisableIncognito = incognitoHandlers.handleDisable;
 /** POST /api/user/memory/incognito/forget */
 export const handleIncognitoForget = (deps: MemoryModeDeps): RequestHandler =>
   asyncHandler((req: ProvisionedRequest, res: Response) => handleForget(deps.prisma, req, res));
-
-/**
- * Legacy aggregator-style factory — preserved for the existing top-level
- * user-router wiring. The generated mounts.ts uses the named handler exports
- * above directly.
- */
-export function createIncognitoRoutes(prisma: PrismaClient, redis: Redis): Router {
-  const router = Router();
-  const deps: MemoryModeDeps = { prisma, redis };
-
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    handleGetIncognitoStatus(deps)
-  );
-  router.post('/', requireUserAuth(), requireProvisionedUser(prisma), handleEnableIncognito(deps));
-  router.delete(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    handleDisableIncognito(deps)
-  );
-  router.post(
-    '/forget',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    handleIncognitoForget(deps)
-  );
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/memorySingle.ts
+++ b/services/api-gateway/src/routes/user/memorySingle.ts
@@ -3,9 +3,8 @@
  * CRUD operations for individual memories
  *
  * Handlers follow the (deps: RouteDeps) => RequestHandler shape so codegen
- * can wire them up from the route manifest. The legacy
- * `createMemoryRoutes(deps)` factory in memory.ts mounts them today; the
- * generated mounts.ts will mount them once the cutover lands.
+ * can wire them up from the route manifest; the generated mounts.ts is the
+ * sole mounting path.
  */
 
 import type { RequestHandler, Response } from 'express';


### PR DESCRIPTION
## Summary

Closes tracker TASK-316 ("confirm which memory-fresh routing path prod mounts; delete the dead one"). The answer: **the generated `mounts.ts` is the only live path** — `createMemoryRoutes`, `createFreshRoutes`, and `createIncognitoRoutes` had zero production consumers. Verified three ways before deleting:

- No `'/memory'` mount string exists anywhere in production code, and there is no top-level user aggregator router (`index.ts` records the aggregator mounts as removed post-conformance).
- The only production import from `memory.ts` is `mounts.ts` pulling `handleGetStats` directly.
- The factories' "preserved for the existing top-level user-router wiring" comments were stale — their only consumers were their own test suites, which extracted the handlers back out of factory-built routers via `expressRouterUtils`.

This is the same class as #1836's bare `/ai/*` dual-mount retirement, applied to the memory family.

## Changes

- **Deleted** the three factories plus their now-unused imports (`Router`, auth middlewares, sibling-handler imports); all handler exports stay — they're what `mounts.ts` registers.
- **Migrated the three test suites** (52 call sites) from factory-built router extraction to direct handler construction. Route-registration existence tests go with the factories: wiring (paths, middleware, order) is owned by `mounts.ts` and pinned by `pnpm ops codegen:routes --check`.
- Handler invocations gain the explicit `next` argument the `RequestHandler` type requires — the old extraction util was loosely typed and hid the third parameter (caught by `typecheck:spec`).
- Stale-doc sweep: `memorySingle.ts`'s "factory mounts them today" comment, both mode-file headers, `memory.ts`'s module header, and `memory.test.ts`'s header (listed a `/focus` route this file never tested).

## Out of scope (filed)

~17 other test suites still consume `expressRouterUtils` against their own families' factories — whether those factories are equally dead is **TASK-346** (per-family audit, this PR is the migration pattern). `expressRouterUtils` itself stays until its last consumer migrates.

## Verification

Three migrated suites: 55/55 green. Full api-gateway unit suite: 190 files / 2646 tests green. `pnpm quality` green (includes `codegen:routes --check`, knip, depcruise). Net **−325 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)