### PR TITLE
refactor(common-types): shared avatarUrlPath kills the avatar-URL drift class

### DIFF
--- a/packages/common-types/src/utils/avatarUrl.test.ts
+++ b/packages/common-types/src/utils/avatarUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { avatarUrlPath, AVATAR_URL_PREFIX } from './avatarUrl.js';
+
+describe('avatarUrlPath', () => {
+  it('builds the legacy shape without a cache-bust timestamp', () => {
+    expect(avatarUrlPath('cold')).toBe('/avatars/cold.png');
+  });
+
+  it('builds the path-versioned shape with a cache-bust timestamp', () => {
+    expect(avatarUrlPath('cold', 1705827727111)).toBe('/avatars/cold-1705827727111.png');
+  });
+
+  it('URI-encodes the slug (SSRF defense-in-depth on the dynamic segment)', () => {
+    // A slug like this can't pass creation-time validation, but the helper
+    // must not rely on that — encoding is unconditional.
+    expect(avatarUrlPath('../etc/passwd')).toBe('/avatars/..%2Fetc%2Fpasswd.png');
+    expect(avatarUrlPath('a b?c#d', 5)).toBe('/avatars/a%20b%3Fc%23d-5.png');
+  });
+
+  it('exposes the prefix the gateway mounts the avatar router at', () => {
+    expect(AVATAR_URL_PREFIX).toBe('/avatars');
+  });
+});

--- a/packages/common-types/src/utils/avatarUrl.ts
+++ b/packages/common-types/src/utils/avatarUrl.ts
@@ -1,0 +1,30 @@
+/**
+ * Public avatar URL path construction — the single producer of the two URL
+ * shapes the gateway's avatar route parses:
+ *
+ * 1. Legacy: `/avatars/{slug}.png`
+ * 2. Path-versioned: `/avatars/{slug}-{timestamp}.png` — Discord's CDN
+ *    ignores query params but treats different paths as new resources, so
+ *    cache-busting rides the filename.
+ *
+ * Consumers prepend their own base (public gateway URL for Discord-facing
+ * avatars, internal gateway URL for service-to-service fetches). The slug is
+ * always URI-encoded here — SSRF defense-in-depth applies to every dynamic
+ * path segment regardless of how trusted the source is, and centralizing the
+ * shape keeps producers from drifting against the gateway's filename parser.
+ */
+
+/** The URL path prefix the gateway mounts the avatar router at. */
+export const AVATAR_URL_PREFIX = '/avatars';
+
+/**
+ * Build the avatar URL path for a personality slug.
+ *
+ * @param slug - The personality slug (encoded here; pass it raw).
+ * @param cacheBustMs - Optional versioning timestamp (epoch ms, typically the
+ *   row's `updatedAt`); when present, produces the path-versioned shape.
+ */
+export function avatarUrlPath(slug: string, cacheBustMs?: number): string {
+  const version = cacheBustMs !== undefined ? `-${cacheBustMs}` : '';
+  return `${AVATAR_URL_PREFIX}/${encodeURIComponent(slug)}${version}.png`;
+}

--- a/packages/identity/src/personality/PersonalityDefaults.ts
+++ b/packages/identity/src/personality/PersonalityDefaults.ts
@@ -5,6 +5,7 @@
 
 import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
 import { PLACEHOLDERS } from '@tzurot/common-types/constants/message';
+import { avatarUrlPath } from '@tzurot/common-types/utils/avatarUrl';
 import {
   mapLlmConfigFromDb,
   type MappedLlmConfig,
@@ -188,8 +189,7 @@ export function deriveAvatarUrl(
   }
 
   // Path-based versioning: timestamp in filename forces Discord CDN to fetch fresh image
-  const timestamp = updatedAt.getTime();
-  return `${publicUrl}/avatars/${encodeURIComponent(slug)}-${timestamp}.png`;
+  return `${publicUrl}${avatarUrlPath(slug, updatedAt.getTime())}`;
 }
 
 /**

--- a/services/api-gateway/src/routes/public/avatars.ts
+++ b/services/api-gateway/src/routes/public/avatars.ts
@@ -37,6 +37,8 @@ export function createAvatarRouter(prisma: PrismaClient): Router {
   // Supports two URL formats for cache-busting:
   // 1. Legacy: /avatars/{slug}.png
   // 2. Path-versioned: /avatars/{slug}-{timestamp}.png (Discord CDN cache-busting)
+  // Both shapes are produced by common-types `utils/avatarUrl.ts` (avatarUrlPath) —
+  // change the format there and here together.
   //
   // Versioned files are stored WITH timestamps in the filename for direct URL-to-file mapping.
   // When a new version is fetched from DB, old versions are cleaned up asynchronously.

--- a/services/api-gateway/src/utils/avatarPaths.test.ts
+++ b/services/api-gateway/src/utils/avatarPaths.test.ts
@@ -10,6 +10,7 @@ import {
   ensureAvatarDir,
   AVATAR_ROOT,
 } from './avatarPaths.js';
+import { avatarUrlPath, AVATAR_URL_PREFIX } from '@tzurot/common-types/utils/avatarUrl';
 
 // Mock fs/promises
 vi.mock('fs/promises', () => ({
@@ -134,6 +135,28 @@ describe('avatarPaths', () => {
       const result2 = await ensureAvatarDir('123bot');
       expect(result2).toBe('/data/avatars/1');
       expect(mockMkdir).toHaveBeenCalledWith('/data/avatars/1', { recursive: true });
+    });
+  });
+
+  describe('producer/parser round-trip (avatarUrlPath contract)', () => {
+    // The common-types helper is the sole producer of the URL shapes this
+    // parser accepts; a hyphenated slug is the case the greedy
+    // VERSIONED_FILENAME_PATTERN exists for, so pin the contract end to end
+    // rather than each side in isolation.
+    function filenameOf(urlPath: string): string {
+      return urlPath.slice(`${AVATAR_URL_PREFIX}/`.length);
+    }
+
+    it('round-trips a hyphenated slug through the path-versioned shape', () => {
+      const filename = filenameOf(avatarUrlPath('my-personality', 1705827727111));
+      expect(extractSlugFromFilename(filename)).toBe('my-personality');
+      expect(extractTimestampFromFilename(filename)).toBe(1705827727111);
+    });
+
+    it('round-trips a hyphenated slug through the legacy shape', () => {
+      const filename = filenameOf(avatarUrlPath('my-personality'));
+      expect(extractSlugFromFilename(filename)).toBe('my-personality');
+      expect(extractTimestampFromFilename(filename)).toBeNull();
     });
   });
 

--- a/services/bot-client/src/commands/character/export.ts
+++ b/services/bot-client/src/commands/character/export.ts
@@ -7,6 +7,7 @@
 import { AttachmentBuilder } from 'discord.js';
 import { type EnvConfig, getConfig } from '@tzurot/common-types/config/config';
 import { characterExportOptions } from '@tzurot/common-types/generated/commandOptions';
+import { avatarUrlPath } from '@tzurot/common-types/utils/avatarUrl';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
@@ -76,7 +77,7 @@ function buildExportData(character: ExportCharacterData): Record<string, unknown
  */
 async function fetchAvatarData(slug: string): Promise<Buffer | null> {
   const config = getConfig();
-  const avatarUrl = `${config.GATEWAY_URL}/avatars/${encodeURIComponent(slug)}.png`;
+  const avatarUrl = `${config.GATEWAY_URL}${avatarUrlPath(slug)}`;
 
   try {
     const response = await fetch(avatarUrl);


### PR DESCRIPTION
## Summary

Closes tracker TASK-299's remaining scope. The slug-encoding fix at both producers already shipped; what remained was the drift-killer: the two producers of public avatar URLs — `character/export.ts`'s avatar fetch and identity's `deriveAvatarUrl` — each hand-built the path shape, and the class has history (one site silently lacked `encodeURIComponent` until a review sweep caught it; a third site existed and was retired).

## Change

`avatarUrlPath(slug, cacheBustMs?)` in `common-types/utils/avatarUrl.ts` now owns both shapes the gateway's filename parser accepts:

- legacy `/avatars/{slug}.png` (export fetch — internal URL, no cache-buster)
- path-versioned `/avatars/{slug}-{timestamp}.png` (deriveAvatarUrl — Discord CDN cache-busting)

Producers compose the path onto their own base URL — the base (public vs internal gateway) is deliberately NOT part of the helper, which is exactly why the earlier extraction was deferred; the shared kernel is the path shape only. Encoding is unconditional and pinned by test (including path-traversal-shaped inputs). The gateway parser's comment now names the helper so the producer↔parser coupling is discoverable from the consuming side.

## Verification

New colocated test (4 cases incl. encoding pins); identity + bot-client export suites green (outputs unchanged — pure extraction); full pre-push gate green across 14 affected packages; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)