### PR TITLE
fix(bot-client): resolve orphan sentinel to its display name in browse

### DIFF
--- a/services/bot-client/src/commands/character/api.test.ts
+++ b/services/bot-client/src/commands/character/api.test.ts
@@ -21,6 +21,10 @@ import {
   toCharacterData,
 } from './api.js';
 import type { EnvConfig } from '@tzurot/common-types/config/config';
+import {
+  ORPHAN_SENTINEL_DISCORD_ID,
+  ORPHAN_SENTINEL_USERNAME,
+} from '@tzurot/common-types/constants/persona';
 import type { UserClient } from '@tzurot/clients';
 
 interface StubUserClient {
@@ -540,6 +544,23 @@ describe('Character API Client', () => {
       const result = await fetchUsernames(mockClient, ['unknown-user']);
 
       expect(result.get('unknown-user')).toBe('Unknown');
+    });
+
+    it('resolves the orphan sentinel to its display name without a Discord fetch', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue({ displayName: 'Real User', username: 'realuser' });
+      const mockClient = {
+        users: { fetch: fetchMock },
+      } as unknown as Parameters<typeof fetchUsernames>[0];
+
+      const result = await fetchUsernames(mockClient, [ORPHAN_SENTINEL_DISCORD_ID, 'user-1']);
+
+      expect(result.get(ORPHAN_SENTINEL_DISCORD_ID)).toBe(ORPHAN_SENTINEL_USERNAME);
+      expect(result.get('user-1')).toBe('Real User');
+      // The sentinel's reserved id must never reach the Discord API
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith('user-1');
     });
   });
 });

--- a/services/bot-client/src/commands/character/api.ts
+++ b/services/bot-client/src/commands/character/api.ts
@@ -31,6 +31,10 @@ import {
 import { CATALOG } from '../../ux/catalog/catalog.js';
 import { renderSpec } from '../../ux/render/render.js';
 import type { EnvConfig } from '@tzurot/common-types/config/config';
+import {
+  ORPHAN_SENTINEL_DISCORD_ID,
+  ORPHAN_SENTINEL_USERNAME,
+} from '@tzurot/common-types/constants/persona';
 import { GatewayApiError, type UserClient } from '@tzurot/clients';
 import type { CharacterData } from './characterTypes.js';
 
@@ -234,6 +238,12 @@ export async function fetchUsernames(
 
   await Promise.all(
     userIds.map(async id => {
+      // The orphan sentinel's reserved discordId is not a snowflake — Discord
+      // can never resolve it, so surface its display name directly.
+      if (id === ORPHAN_SENTINEL_DISCORD_ID) {
+        names.set(id, ORPHAN_SENTINEL_USERNAME);
+        return;
+      }
       try {
         const user = await client.users.fetch(id);
         names.set(id, user.displayName ?? user.username);


### PR DESCRIPTION
## Summary

Closes TASK-320. Retention-orphaned characters showed their creator as **"Unknown"** in `/character browse`: the orphan sentinel's reserved discordId (`'orphaned-characters'`, not a snowflake) can never pass `client.users.fetch`, so it always landed in the `'Unknown'` catch fallback. With the 2026-07-27 purge having re-homed real characters to the sentinel, this is now visible in prod.

`fetchUsernames` now short-circuits the sentinel id to `ORPHAN_SENTINEL_USERNAME` (`'Orphaned Characters'`) before the Discord call — the browse owner-group header reads correctly, and the doomed API request is skipped entirely.

## Class sweep (verified, not assumed)

- `fetchUsernames` is the **only** creator-display resolver in bot-client; both browse call sites (`browse.ts:276`, `:334`) flow through it, so fixing the resolver covers every consumer.
- Swept all other `users.fetch` sites (DM prewarmer, retention/release DM workers, reaction processor) — all fetch real recipients by genuine snowflakes; the sentinel cannot reach them.
- `browseHelpers.ts:133`'s `'Unknown'` fallback now finds the sentinel's name in the map — no change needed there.
- Adjacent check: the sentinel user row is `retention_exempt = true` at bootstrap (`OrphanSentinelBootstrap.ts`), so it can never enter the retention cohort itself.

## Test plan

- New unit test pins the sentinel path: resolves to `ORPHAN_SENTINEL_USERNAME`, and asserts via mock call-count that the sentinel id **never reaches** `users.fetch` (fails pre-fix on both assertions).
- `pnpm test` (5885 tests) + `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)