### PR TITLE
fix(bot-client): brand-neutral user copy + runtime-branded webhook name

### DIFF
--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -998,7 +998,7 @@
     {
       "name": "help",
       "category": "Help",
-      "description": "Learn what Tzurot is and browse every command",
+      "description": "Learn what the bot is and browse every command",
       "handlers": {
         "execute": true,
         "autocomplete": true,
@@ -1026,12 +1026,12 @@
           {
             "type": 1,
             "name": "getting-started",
-            "description": "What Tzurot is and the first commands to try",
+            "description": "What the bot is and the first commands to try",
             "options": []
           }
         ],
         "name": "help",
-        "description": "Learn what Tzurot is and browse every command",
+        "description": "Learn what the bot is and browse every command",
         "type": 1
       }
     },
@@ -2337,7 +2337,7 @@
           {
             "type": 1,
             "name": "import",
-            "description": "Import a shapes.inc character into Tzurot",
+            "description": "Import a shapes.inc character",
             "options": [
               {
                 "autocomplete": true,
@@ -2573,7 +2573,7 @@
               {
                 "type": 1,
                 "name": "purge",
-                "description": "Permanently delete ALL Tzurot cloned voices",
+                "description": "Permanently delete ALL cloned voices",
                 "options": []
               }
             ]

--- a/services/bot-client/src/commands/help/index.test.ts
+++ b/services/bot-client/src/commands/help/index.test.ts
@@ -69,7 +69,7 @@ describe('Help Command', () => {
   describe('command definition', () => {
     it('should have correct name and description', () => {
       expect(data.name).toBe('help');
-      expect(data.description).toBe('Learn what Tzurot is and browse every command');
+      expect(data.description).toBe('Learn what the bot is and browse every command');
     });
 
     it('splits into commands + getting-started subcommands', () => {

--- a/services/bot-client/src/commands/help/index.ts
+++ b/services/bot-client/src/commands/help/index.ts
@@ -407,7 +407,7 @@ async function showAllCommands(
 // [command]`, making room for `/help getting-started` (and future sections).
 const commandData = new SlashCommandBuilder()
   .setName('help')
-  .setDescription('Learn what Tzurot is and browse every command')
+  .setDescription('Learn what the bot is and browse every command')
   .addSubcommand(subcommand =>
     subcommand
       .setName('commands')
@@ -423,7 +423,7 @@ const commandData = new SlashCommandBuilder()
   .addSubcommand(subcommand =>
     subcommand
       .setName('getting-started')
-      .setDescription('What Tzurot is and the first commands to try')
+      .setDescription('What the bot is and the first commands to try')
   );
 
 /** Discord caps an autocomplete choice's display name at 100 characters. */

--- a/services/bot-client/src/commands/shapes/index.ts
+++ b/services/bot-client/src/commands/shapes/index.ts
@@ -6,7 +6,7 @@
  * - /shapes auth - Authenticate with shapes.inc session cookie
  * - /shapes logout - Remove stored credentials
  * - /shapes browse - Browse owned shapes with sort and detail view
- * - /shapes import <slug> - Import character into Tzurot
+ * - /shapes import <slug> - Import a shapes.inc character
  * - /shapes export <slug> - Export character data as JSON
  * - /shapes status - View credential status and import history
  */
@@ -73,7 +73,7 @@ export default defineCommand({
     .addSubcommand(subcommand =>
       subcommand
         .setName('import')
-        .setDescription('Import a shapes.inc character into Tzurot')
+        .setDescription('Import a shapes.inc character')
         .addStringOption(option =>
           option
             .setName('slug')

--- a/services/bot-client/src/commands/voice/voices/browse.test.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.test.ts
@@ -200,7 +200,7 @@ describe('handleBrowseVoices', () => {
       embeds: [
         expect.objectContaining({
           data: expect.objectContaining({
-            description: expect.stringContaining('No Tzurot-cloned voices'),
+            description: expect.stringContaining('No cloned voices'),
           }),
         }),
       ],

--- a/services/bot-client/src/commands/voice/voices/browse.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.ts
@@ -108,11 +108,11 @@ function buildVoiceBrowsePage(
     }),
     empty: {
       noItems:
-        'No Tzurot-cloned voices found. Voices are auto-cloned when you talk ' +
+        'No cloned voices found. Voices are auto-cloned when you talk ' +
         `to a character with voice enabled — your audio provider account(s) have **${totalVoices}** voices total.`,
     },
     footerSegments: [
-      `${pluralize(tzurotCount, { singular: 'Tzurot voice', plural: 'Tzurot voices' })} / ${totalVoices} total across audio providers`,
+      `${pluralize(tzurotCount, { singular: 'cloned voice', plural: 'cloned voices' })} / ${totalVoices} total across audio providers`,
     ],
     // Browse stays BLURPLE even with provider warnings (§2.3 — color encodes
     // surface kind, not state); the ⚠️ warnings field is the signal.
@@ -132,7 +132,7 @@ function buildVoiceBrowsePage(
       name: '💡 Management',
       value: [
         '`/voice voices delete <voice>` - Remove a single voice',
-        '`/voice voices purge` - Permanently delete all Tzurot voices',
+        '`/voice voices purge` - Permanently delete all cloned voices',
       ].join('\n'),
       inline: false,
     });

--- a/services/bot-client/src/commands/voice/voices/purge.test.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.test.ts
@@ -150,7 +150,7 @@ describe('handlePurgeVoices', () => {
 
     const callArg = mockBuildDestructiveWarning.mock.calls[0]?.[0] as
       { entityName?: string } | undefined;
-    expect(callArg?.entityName).toBe('all your Tzurot voices');
+    expect(callArg?.entityName).toBe('all your cloned voices');
     // Specifically, no digits — defends against regression where the count returns
     expect(callArg?.entityName).not.toMatch(/\d/);
   });
@@ -161,7 +161,7 @@ describe('handlePurgeVoices', () => {
     await handlePurgeVoices(createMockContext());
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: 'No Tzurot voices to purge.',
+      content: 'No cloned voices to purge.',
     });
     expect(mockBuildDestructiveWarning).not.toHaveBeenCalled();
   });

--- a/services/bot-client/src/commands/voice/voices/purge.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.ts
@@ -46,7 +46,7 @@ export const VOICE_PURGE_OPERATION = 'voice-purge';
  * Entity name shared by the warning config and the modal-submit validation so
  * the dynamic confirmation phrase can't drift between the two.
  */
-const VOICE_PURGE_ENTITY_NAME = 'all your Tzurot voices';
+const VOICE_PURGE_ENTITY_NAME = 'all your cloned voices';
 
 /**
  * Handle /voice voices purge
@@ -69,7 +69,7 @@ export async function handlePurgeVoices(context: DeferredCommandContext): Promis
     }
 
     if (result.data.voices.length === 0) {
-      await context.editReply({ content: 'No Tzurot voices to purge.' });
+      await context.editReply({ content: 'No cloned voices to purge.' });
       return;
     }
 

--- a/services/bot-client/src/commands/voice/voices/subcommandBuilder.ts
+++ b/services/bot-client/src/commands/voice/voices/subcommandBuilder.ts
@@ -31,6 +31,6 @@ export function buildVoiceVoicesSubcommandGroup(
         )
     )
     .addSubcommand(subcommand =>
-      subcommand.setName('purge').setDescription('Permanently delete ALL Tzurot cloned voices')
+      subcommand.setName('purge').setDescription('Permanently delete ALL cloned voices')
     );
 }

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
@@ -1250,7 +1250,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
     "type": 1,
   },
   {
-    "description": "What Tzurot is and the first commands to try",
+    "description": "What the bot is and the first commands to try",
     "description_localizations": undefined,
     "name": "getting-started",
     "name_localizations": undefined,
@@ -2885,7 +2885,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
     "type": 1,
   },
   {
-    "description": "Import a shapes.inc character into Tzurot",
+    "description": "Import a shapes.inc character",
     "description_localizations": undefined,
     "name": "import",
     "name_localizations": undefined,
@@ -3196,7 +3196,7 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
         "type": 1,
       },
       {
-        "description": "Permanently delete ALL Tzurot cloned voices",
+        "description": "Permanently delete ALL cloned voices",
         "description_localizations": undefined,
         "name": "purge",
         "name_localizations": undefined,

--- a/services/bot-client/src/utils/WebhookManager.test.ts
+++ b/services/bot-client/src/utils/WebhookManager.test.ts
@@ -61,7 +61,7 @@ function createMockTextChannel(
   mockChannel.id = id;
   mockChannel.type = ChannelType.GuildText;
   mockChannel.client = {
-    user: { id: clientUserId },
+    user: { id: clientUserId, username: 'TestBot' },
   };
   mockChannel.fetchWebhooks = vi.fn().mockResolvedValue({
     find: vi.fn((fn: (wh: Webhook) => boolean) => existingWebhooks.find(fn)),
@@ -327,7 +327,7 @@ describe('WebhookManager', () => {
 
         expect(channel.fetchWebhooks).toHaveBeenCalled();
         expect(channel.createWebhook).toHaveBeenCalledWith({
-          name: 'Tzurot Personalities',
+          name: 'TestBot Personalities',
           reason: 'Multi-personality bot system',
         });
         expect(webhook.id).toBe('new-webhook');

--- a/services/bot-client/src/utils/WebhookManager.ts
+++ b/services/bot-client/src/utils/WebhookManager.ts
@@ -135,8 +135,11 @@ export class WebhookManager {
     // Create new webhook if none exists
     if (webhook === undefined) {
       logger.info({ channelId: cacheKey }, 'Creating new webhook');
+      // Brand from the bot's own identity (dev = Rotzot, prod = Tzurot) —
+      // webhook lookup above matches by owner id, not name, so existing
+      // webhooks keep working regardless of the name they were created with.
       webhook = await targetChannel.createWebhook({
-        name: 'Tzurot Personalities',
+        name: `${targetChannel.client.user?.username ?? 'Bot'} Personalities`,
         reason: 'Multi-personality bot system',
       });
     }

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.test.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.test.ts
@@ -415,7 +415,7 @@ describe('handleDestructiveModalSubmit', () => {
 describe('dynamicDeletePhrase', () => {
   it('builds DELETE {NAME} uppercased', () => {
     expect(dynamicDeletePhrase('lilith')).toBe('DELETE LILITH');
-    expect(dynamicDeletePhrase('all your Tzurot voices')).toBe('DELETE ALL YOUR TZUROT VOICES');
+    expect(dynamicDeletePhrase('all your cloned voices')).toBe('DELETE ALL YOUR CLONED VOICES');
   });
 
   it('falls back to the fixed phrase when the dynamic form is too long to type', () => {

--- a/services/bot-client/src/utils/maintenanceResponses.ts
+++ b/services/bot-client/src/utils/maintenanceResponses.ts
@@ -24,7 +24,7 @@ const logger = createLogger('maintenanceResponses');
 
 /** User-facing maintenance notice (bot-client adds the emoji; the gateway's JSON stays plain). */
 export const MAINTENANCE_USER_MESSAGE =
-  '🔧 Tzurot is down for a quick maintenance window — back in a few minutes!';
+  '🔧 The bot is down for a quick maintenance window — back in a few minutes!';
 
 /** Reaction used to acknowledge guild mentions during the window. */
 export const MAINTENANCE_REACTION = '🔧';


### PR DESCRIPTION
## Summary

Closes TASK-313. The dev app is Rotzot, so hardcoded "Tzurot" in user-facing bot-client copy misbrands every dev surface (owner report, `/help getting-started` on dev). Full sweep of all 22 brand mentions in bot-client production code.

## What changed (11 sites, 6 files)

**Brand-neutral wording** (runtime copy + static command descriptions — descriptions are deploy-time static, so env-driven branding would fork the command manifest and component snapshots per environment, which the task explicitly rules out):
- `/help` top-level + `getting-started` descriptions → "the bot"
- `/shapes import` description → drops "into Tzurot"
- `/voice voices purge` description + empty-state + destructive-confirmation entity → "cloned voices" (the typed phrase becomes `DELETE ALL YOUR CLONED VOICES`)
- `/voice voices browse` empty-state, footer count, management hint → "cloned voice(s)"
- Maintenance-window notice → "The bot is down…"

**Runtime-branded** (surface is dynamic, client in scope):
- Channel webhook base name → `` `${client.user.username} Personalities` `` (dev = "Rotzot Personalities", prod = "Tzurot Personalities" — zero prod-visible change). Webhook lookup matches by **owner id**, not name, so existing webhooks keep working regardless of creation name.

## Deliberately untouched (with reasons)

- Operator log line (`Starting Tzurot v3 Bot Client`) — project name in an operator log, not user copy.
- `/help` embed's existing runtime branding (`client.user.username ?? 'Tzurot'`) — already the correct pattern; the fallback is the prod brand.
- `TTS_VOICE_NAME_PREFIX = 'tzurot-'` and the `tzurotCount` API field — the literal provider-side voice-name prefix is a technical marker and an IDOR guard (`voices.ts` verifies the prefix before delete), identical in both envs; renaming it would orphan every existing cloned voice.
- Code comments using "Tzurot" as examples (webhookNaming, MessageContextBuilder) — documentation, not copy.

## Test plan

- 6 test files' string pins updated alongside the copy; WebhookManager mock now carries a username so the test asserts the real name composition.
- `pnpm test:component` run per the command-structure rule: 3 CommandHandler snapshots + the commandManifest snapshot updated — diffs verified to contain **only** the three description strings.
- Repo-wide grep confirms no stale brand strings remain in code or snapshots.
- `pnpm test` + `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)