### PR TITLE
test(tooling): guard the three protected-index registries against drift

### DIFF
--- a/packages/tooling/src/db/check-migration-safety.test.ts
+++ b/packages/tooling/src/db/check-migration-safety.test.ts
@@ -108,6 +108,23 @@ describe('checkMigrationSafety', () => {
     expect(output).toContain('idx_memories_embedding');
   });
 
+  it('should detect dropped memories_chunk_group_id_idx without recreate', async () => {
+    vol.fromJSON({
+      '/migrations/20240106_bad_partial/migration.sql': `
+        DROP INDEX "memories_chunk_group_id_idx";
+        -- oops, forgot the partial recreate
+      `,
+    });
+
+    const { checkMigrationSafety } = await import('./check-migration-safety.js');
+    await checkMigrationSafety({ migrationsPath: '/migrations' });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    const output = consoleLogSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('DANGEROUS MIGRATIONS DETECTED');
+    expect(output).toContain('memories_chunk_group_id_idx');
+  });
+
   it('should pass when index is dropped and recreated in same file', async () => {
     vol.fromJSON({
       '/migrations/20240103_safe_migration/migration.sql': `

--- a/packages/tooling/src/db/check-migration-safety.ts
+++ b/packages/tooling/src/db/check-migration-safety.ts
@@ -20,8 +20,15 @@ interface ProtectedIndex {
   description: string;
 }
 
-// Indexes that must be recreated if dropped
-const PROTECTED_INDEXES: ProtectedIndex[] = [
+/**
+ * Indexes that must be recreated if dropped. The name set must agree with
+ * prisma/drift-ignore.json `protectedIndexes` and inspect-database.ts —
+ * protectedIndexRegistries.test.ts enforces the agreement. Exported for that
+ * guard test only.
+ *
+ * @internal
+ */
+export const PROTECTED_INDEXES: ProtectedIndex[] = [
   {
     name: 'idx_memories_embedding',
     dropPattern: /DROP\s+INDEX.*idx_memories_embedding/i,
@@ -33,6 +40,12 @@ const PROTECTED_INDEXES: ProtectedIndex[] = [
     dropPattern: /DROP\s+INDEX.*idx_memory_facts_embedding/i,
     createPattern: /CREATE\s+INDEX.*idx_memory_facts_embedding/i,
     description: 'IVFFlat vector index for fact similarity retrieval (384 dims)',
+  },
+  {
+    name: 'memories_chunk_group_id_idx',
+    dropPattern: /DROP\s+INDEX.*memories_chunk_group_id_idx/i,
+    createPattern: /CREATE\s+INDEX.*memories_chunk_group_id_idx/i,
+    description: 'Partial index for chunk retrieval (WHERE chunk_group_id IS NOT NULL)',
   },
 ];
 

--- a/packages/tooling/src/db/inspect-database.ts
+++ b/packages/tooling/src/db/inspect-database.ts
@@ -37,9 +37,16 @@ function getDatabaseHost(): string {
   }
 }
 
-// Known drift patterns - indexes that Prisma can't represent in schema.prisma
-// These are EXPECTED to exist but will show as "drift" if Prisma detects them
-const PROTECTED_INDEXES = [
+/**
+ * Known drift patterns - indexes that Prisma can't represent in schema.prisma.
+ * These are EXPECTED to exist but will show as "drift" if Prisma detects them.
+ * The name set must agree with prisma/drift-ignore.json `protectedIndexes` and
+ * check-migration-safety.ts — protectedIndexRegistries.test.ts enforces the
+ * agreement. Exported for that guard test only.
+ *
+ * @internal
+ */
+export const PROTECTED_INDEXES = [
   {
     name: 'idx_memories_embedding',
     table: 'memories',

--- a/packages/tooling/src/db/protectedIndexRegistries.test.ts
+++ b/packages/tooling/src/db/protectedIndexRegistries.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Registry-agreement guard for the protected-index lists.
+ *
+ * Three surfaces know which indexes Prisma can't represent and must never be
+ * silently dropped: `prisma/drift-ignore.json` (`protectedIndexes` — DROP
+ * suppression + recreate SQL), `check-migration-safety.ts` (drop-without-
+ * recreate scan over migration files), and `inspect-database.ts` (live-DB
+ * presence report). They are hand-maintained; every table that joined the
+ * family so far shipped with at least one list missed, which is exactly the
+ * drift this test kills: adding an index to one registry without the others
+ * now fails the suite with the missing names in the diff.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { PROTECTED_INDEXES as SAFETY_REGISTRY } from './check-migration-safety.js';
+import { PROTECTED_INDEXES as INSPECT_REGISTRY } from './inspect-database.js';
+
+const DRIFT_IGNORE_PATH = fileURLToPath(
+  new URL('../../../../prisma/drift-ignore.json', import.meta.url)
+);
+
+interface DriftIgnoreFile {
+  protectedIndexes: { name: string; recreateSQL?: string }[];
+  ignorePatterns: { pattern: string; reason: string; action: string }[];
+}
+
+const driftIgnore = JSON.parse(readFileSync(DRIFT_IGNORE_PATH, 'utf-8')) as DriftIgnoreFile;
+
+const names = (list: { name: string }[]): string[] => list.map(e => e.name).sort();
+
+describe('protected-index registries', () => {
+  it('drift-ignore.json and check-migration-safety.ts agree on the name set', () => {
+    expect(names(SAFETY_REGISTRY)).toEqual(names(driftIgnore.protectedIndexes));
+  });
+
+  it('drift-ignore.json and inspect-database.ts agree on the name set', () => {
+    expect(names(INSPECT_REGISTRY)).toEqual(names(driftIgnore.protectedIndexes));
+  });
+
+  it('every protectedIndexes entry has its DROP-suppression ignorePattern', () => {
+    // protectedIndexes entries promise recovery SQL, but the DROP suppression
+    // itself lives in ignorePatterns — an entry added without its DROP strip
+    // would let Prisma's generated migration drop the index after all.
+    //
+    // Limitation: this and the recreateSQL check below match by SUBSTRING, so
+    // an index whose name is a prefix of another's (idx_foo vs idx_foo_v2)
+    // could false-pass against the wrong entry. If a name like that ever joins
+    // the family, tighten these to boundary-anchored matches.
+    for (const entry of driftIgnore.protectedIndexes) {
+      const covered = driftIgnore.ignorePatterns.some(
+        p => p.pattern.includes(entry.name) && p.pattern.includes('DROP INDEX')
+      );
+      expect.soft(covered, `${entry.name} has no DROP INDEX ignorePattern`).toBe(true);
+    }
+  });
+
+  it('every protectedIndexes entry carries recreate SQL naming its own index', () => {
+    for (const entry of driftIgnore.protectedIndexes) {
+      expect.soft(entry.recreateSQL, `${entry.name} is missing recreateSQL`).toBeTruthy();
+      expect
+        .soft(
+          entry.recreateSQL?.includes(entry.name),
+          `${entry.name}'s recreateSQL does not reference the index name`
+        )
+        .toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes TASK-223. `prisma/drift-ignore.json` `protectedIndexes`, `check-migration-safety.ts` `PROTECTED_INDEXES`, and `inspect-database.ts` `PROTECTED_INDEXES` are three hand-synced lists — every table that joined the family so far shipped with at least one list missed (memory_facts needed a review catch for two of them). The new guard test pins name-set agreement across all three, so the next index addition fails the suite with the missing names in the diff instead of drifting silently.

## The guard's first catch, fixed in the same change

`check-migration-safety.ts` was missing `memories_chunk_group_id_idx` (2 of 3 entries) — a migration dropping the partial index without recreating it would have passed the safety scan while the other two registries knew better. Added with the standard drop/create pattern pair.

Verified against all 118 existing migrations: `pnpm ops db:check-safety` stays green — the historical chunk-group drops are all `-- REMOVED:` sanitizer comments, which the scan already strips before matching.

## What the test asserts

1. drift-ignore ↔ check-migration-safety name-set equality
2. drift-ignore ↔ inspect-database name-set equality
3. Every `protectedIndexes` entry has its DROP-suppression `ignorePattern` (the entry promises recovery SQL, but the DROP strip lives in the other array — an entry added without it would let Prisma's generated migration drop the index after all)
4. Every entry's `recreateSQL` exists and names its own index

Fails pre-fix by construction: assertion 1 was red on the current tree (2 names vs 3).

## Notes

- The two `PROTECTED_INDEXES` consts are now exported, marked as guard-test-only in their doc comments (same idiom as `analyzeMigrationSafety`'s `@internal` export).
- Considered single-sourcing all three registries from `drift-ignore.json` instead of guarding the sync — rejected for this PR: it changes runtime behavior of load-bearing DB tooling for a class the guard already kills, and the per-surface shapes genuinely differ (regex pairs vs recreate SQL vs table metadata).

## Test plan

- New guard suite (4 tests) green; `pnpm ops db:check-safety` green over the real migrations dir with the new pattern.
- `pnpm test` + `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)