### PR TITLE
fix(api-gateway): delete-preview reach uses the retention union

### DIFF
--- a/packages/common-types/src/schemas/api/account.test.ts
+++ b/packages/common-types/src/schemas/api/account.test.ts
@@ -126,7 +126,7 @@ describe('AccountDeletePreviewResponseSchema', () => {
   it('accepts a preview and pins the exact confirmation phrase', () => {
     const parsed = AccountDeletePreviewResponseSchema.safeParse({
       confirmationPhrase: ACCOUNT_DELETE_CONFIRMATION_PHRASE,
-      ownedCharacters: [{ id: 'x1', name: 'XBot', otherUsersWithMemories: 2 }],
+      ownedCharacters: [{ id: 'x1', name: 'XBot', otherUsersWithData: 2 }],
       counts: { personas: 1, characters: 1, conversationMessages: 2, memories: 3, facts: 4 },
       hasActiveExport: false,
     });
@@ -173,11 +173,11 @@ describe('DeleteAccountResponseSchema', () => {
 describe('OwnedCharacterImpactSchema', () => {
   it('requires an integer cross-user reach', () => {
     expect(
-      OwnedCharacterImpactSchema.safeParse({ id: 'x1', name: 'XBot', otherUsersWithMemories: 2 })
+      OwnedCharacterImpactSchema.safeParse({ id: 'x1', name: 'XBot', otherUsersWithData: 2 })
         .success
     ).toBe(true);
     expect(
-      OwnedCharacterImpactSchema.safeParse({ id: 'x1', name: 'XBot', otherUsersWithMemories: 1.5 })
+      OwnedCharacterImpactSchema.safeParse({ id: 'x1', name: 'XBot', otherUsersWithData: 1.5 })
         .success
     ).toBe(false);
   });

--- a/packages/common-types/src/schemas/api/account.ts
+++ b/packages/common-types/src/schemas/api/account.ts
@@ -85,9 +85,11 @@ export const AccountDeleteTokenSchema = z
 export const OwnedCharacterImpactSchema = z.object({
   id: z.string(),
   name: z.string(),
-  /** Distinct OTHER users holding memories with this character — deleting
-   *  the account deletes the character and those memories for everyone. */
-  otherUsersWithMemories: z.number().int(),
+  /** Distinct OTHER users with data involving this character (memories,
+   *  history, or facts — or an explicit co-ownership grant). Same reach
+   *  definition the retention purge uses to decide re-home vs delete;
+   *  deleting the account deletes the character and that data for everyone. */
+  otherUsersWithData: z.number().int(),
 });
 
 // GET /user/account/delete/preview

--- a/services/api-gateway/src/services/AccountDeletionService.component.test.ts
+++ b/services/api-gateway/src/services/AccountDeletionService.component.test.ts
@@ -27,6 +27,7 @@ const USER_B = 'de1e0000-0000-4000-8000-0000000000b1';
 const PERSONA_B = 'de1e0000-0000-4000-8000-0000000000b2';
 const PERSONALITY_X = 'de1e0000-0000-4000-8000-0000000000c1'; // owned by A, co-owned by B
 const PERSONALITY_Y = 'de1e0000-0000-4000-8000-0000000000c2'; // owned by B
+const PERSONALITY_Z = 'de1e0000-0000-4000-8000-0000000000c3'; // owned by A, history-only reach
 const DISCORD_A = '900000000000000071';
 const DISCORD_B = '900000000000000072';
 
@@ -72,11 +73,14 @@ describe('AccountDeletionService (component, PGLite)', () => {
       personaContent: 'Persona B content',
     });
 
-    // X owned by A (co-owned by B); Y owned by B.
+    // X owned by A (co-owned by B); Y owned by B; Z owned by A, reached by B
+    // ONLY through conversation history — the case the memories-only reach
+    // count silently missed.
     await prisma.$executeRaw`
       INSERT INTO personalities (id, name, slug, character_info, personality_traits, owner_id, updated_at)
       VALUES (${PERSONALITY_X}::uuid, 'XBot', 'xbot', 'X character', 'Curious', ${USER_A}::uuid, NOW()),
-             (${PERSONALITY_Y}::uuid, 'YBot', 'ybot', 'Y character', 'Reserved', ${USER_B}::uuid, NOW())
+             (${PERSONALITY_Y}::uuid, 'YBot', 'ybot', 'Y character', 'Reserved', ${USER_B}::uuid, NOW()),
+             (${PERSONALITY_Z}::uuid, 'ZBot', 'zbot', 'Z character', 'Quiet', ${USER_A}::uuid, NOW())
     `;
     await prisma.personalityOwner.createMany({
       data: [
@@ -115,6 +119,17 @@ describe('AccountDeletionService (component, PGLite)', () => {
           channelId: 'chan-3',
           role: 'user',
           content: 'b-with-x',
+        },
+        // B's ONLY trace on Z — no memory, no fact, no grant. Pins that the
+        // preview's reach count sees history (pre-union it reported 0 here
+        // while the retention purge would have re-homed Z as shared).
+        {
+          id: nextId(),
+          personaId: PERSONA_B,
+          personalityId: PERSONALITY_Z,
+          channelId: 'chan-4',
+          role: 'user',
+          content: 'b-with-z',
         },
       ],
     });
@@ -357,15 +372,19 @@ describe('AccountDeletionService (component, PGLite)', () => {
 
     expect(preview.confirmationPhrase).toBe('DELETE MY ACCOUNT');
     expect(preview.counts.personas).toBe(2);
-    expect(preview.counts.characters).toBe(1);
-    // A×X + A×Y (persona arm) + B×X (owned-character arm)
-    expect(preview.counts.conversationMessages).toBe(3);
+    expect(preview.counts.characters).toBe(2);
+    // A×X + A×Y (persona arm) + B×X + B×Z (owned-character arm)
+    expect(preview.counts.conversationMessages).toBe(4);
     // PA locked + PA soft-deleted + PB×X (owned-character arm)
     expect(preview.counts.memories).toBe(3);
     expect(preview.hasActiveExport).toBe(true);
-    // B's persona holds memories with X → reach of exactly one other user.
     expect(preview.ownedCharacters).toEqual([
-      expect.objectContaining({ name: 'XBot', otherUsersWithMemories: 1 }),
+      // B reaches X three ways (memory, history, co-ownership grant) and must
+      // still count as ONE distinct user.
+      expect.objectContaining({ name: 'XBot', otherUsersWithData: 1 }),
+      // B's only trace on Z is conversation history — the memories-only count
+      // reported 0 here, disagreeing with the retention purge's re-home call.
+      expect.objectContaining({ name: 'ZBot', otherUsersWithData: 1 }),
     ]);
   });
 
@@ -374,10 +393,11 @@ describe('AccountDeletionService (component, PGLite)', () => {
 
     // --- Summary numbers match the seed ---
     expect(summary.personas).toBe(2);
-    expect(summary.characters).toBe(1);
-    expect(summary.characterNames).toEqual(['XBot']);
-    expect(summary.characterSlugs).toEqual(['xbot']);
-    expect(summary.conversationMessages).toBe(3);
+    expect(summary.characters).toBe(2);
+    // deleteAccount's owned-character fetch has no orderBy — sort to compare.
+    expect([...summary.characterNames].sort()).toEqual(['XBot', 'ZBot']);
+    expect([...summary.characterSlugs].sort()).toEqual(['xbot', 'zbot']);
+    expect(summary.conversationMessages).toBe(4);
     expect(summary.memories).toBe(3);
     // Persona/character-scoped facts: 2 PA + 0 others in scope
     expect(summary.facts).toBe(2);
@@ -391,6 +411,7 @@ describe('AccountDeletionService (component, PGLite)', () => {
     expect(await prisma.user.findUnique({ where: { id: USER_A } })).toBeNull();
     expect(await prisma.persona.count({ where: { ownerId: USER_A } })).toBe(0);
     expect(await prisma.personality.findUnique({ where: { id: PERSONALITY_X } })).toBeNull();
+    expect(await prisma.personality.findUnique({ where: { id: PERSONALITY_Z } })).toBeNull();
     expect(await prisma.personalityAlias.count({ where: { personalityId: PERSONALITY_X } })).toBe(
       0
     );
@@ -400,7 +421,10 @@ describe('AccountDeletionService (component, PGLite)', () => {
     expect(
       await prisma.conversationHistory.count({
         where: {
-          OR: [{ personaId: { in: [PERSONA_A, PERSONA_A2] } }, { personalityId: PERSONALITY_X }],
+          OR: [
+            { personaId: { in: [PERSONA_A, PERSONA_A2] } },
+            { personalityId: { in: [PERSONALITY_X, PERSONALITY_Z] } },
+          ],
         },
       })
     ).toBe(0);

--- a/services/api-gateway/src/services/AccountDeletionService.test.ts
+++ b/services/api-gateway/src/services/AccountDeletionService.test.ts
@@ -85,9 +85,7 @@ describe('AccountDeletionService.preview', () => {
       memories: 2,
       facts: 1,
     });
-    expect(preview.ownedCharacters).toEqual([
-      { id: 'x1', name: 'XBot', otherUsersWithMemories: 2 },
-    ]);
+    expect(preview.ownedCharacters).toEqual([{ id: 'x1', name: 'XBot', otherUsersWithData: 2 }]);
     expect(preview.hasActiveExport).toBe(false);
   });
 

--- a/services/api-gateway/src/services/AccountDeletionService.ts
+++ b/services/api-gateway/src/services/AccountDeletionService.ts
@@ -28,6 +28,7 @@ import { type Prisma, type PrismaClient } from '@tzurot/common-types/services/pr
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { z } from 'zod';
 import { ensureOrphanSentinel } from './OrphanSentinelBootstrap.js';
+import { countCrossUserReach } from './retention/crossUserReach.js';
 import { isStillEligibleForPurge } from './retention/eligibility.js';
 import { recordPurgeSuccess } from './retention/purgeAudit.js';
 import { reHomeCrossUserCharacters } from './retention/reHome.js';
@@ -189,26 +190,6 @@ async function sweepLooseRefs(
 export class AccountDeletionService {
   constructor(private readonly prisma: PrismaClient) {}
 
-  /** Distinct OTHER users holding memories with each owned character. */
-  private async fetchOtherUserReach(
-    userId: string,
-    ownedIds: string[]
-  ): Promise<Map<string, number>> {
-    if (ownedIds.length === 0) {
-      return new Map();
-    }
-    const rows = await this.prisma.$queryRaw<{ personalityId: string; otherUsers: number }[]>`
-      SELECT m.personality_id AS "personalityId",
-             COUNT(DISTINCT p.owner_id)::int AS "otherUsers"
-      FROM memories m
-      JOIN personas p ON m.persona_id = p.id
-      WHERE m.personality_id = ANY(${ownedIds}::uuid[])
-        AND p.owner_id != ${userId}::uuid
-      GROUP BY m.personality_id
-    `;
-    return new Map(rows.map(row => [row.personalityId, row.otherUsers]));
-  }
-
   async preview(userId: string): Promise<AccountDeletePreview> {
     // Intentionally unbounded (exception to the bounded-findMany rule): the
     // deletion scope must cover the COMPLETE owned set — a paginated page
@@ -234,7 +215,10 @@ export class AccountDeletionService {
         where: { userId, status: { in: ['pending', 'in_progress'] } },
         select: { id: true },
       }),
-      this.fetchOtherUserReach(userId, ownedIds),
+      // The retention module's single reach definition — the warning shown
+      // here and the purge's re-home decision must agree on what "shared"
+      // means (memories ∪ history ∪ facts ∪ explicit grants).
+      countCrossUserReach(this.prisma, userId, ownedIds),
     ]);
 
     return {
@@ -242,7 +226,7 @@ export class AccountDeletionService {
       ownedCharacters: ownedCharacters.map(character => ({
         id: character.id,
         name: character.name,
-        otherUsersWithMemories: reach.get(character.id) ?? 0,
+        otherUsersWithData: reach.get(character.id) ?? 0,
       })),
       counts: {
         personas: personaIds.length,

--- a/services/api-gateway/src/services/retention/crossUserReach.test.ts
+++ b/services/api-gateway/src/services/retention/crossUserReach.test.ts
@@ -1,20 +1,58 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Prisma } from '@tzurot/common-types/services/prisma';
-import { findCrossUserReachIds } from './crossUserReach.js';
+import { countCrossUserReach, findCrossUserReachIds } from './crossUserReach.js';
 
 /** Join the template-strings array (call[0]) to assert on the SQL skeleton. */
 function joinSql(call: unknown[]): string {
   return (call[0] as TemplateStringsArray).join(' ');
 }
 
-function makeDb(rows: { personalityId: string }[]) {
+function makeDb(rows: { personalityId: string; otherUsers: number }[]) {
   const queryRaw = vi.fn().mockResolvedValue(rows);
   return { db: { $queryRaw: queryRaw } as unknown as Prisma.TransactionClient, queryRaw };
 }
 
+describe('countCrossUserReach', () => {
+  it('maps each reached id to its distinct other-user count', async () => {
+    const { db } = makeDb([
+      { personalityId: 'x1', otherUsers: 2 },
+      { personalityId: 'x2', otherUsers: 1 },
+    ]);
+
+    const counts = await countCrossUserReach(db, 'user-1', ['x1', 'x2', 'z1']);
+
+    expect(counts.get('x1')).toBe(2);
+    expect(counts.get('x2')).toBe(1);
+    expect(counts.has('z1')).toBe(false);
+  });
+
+  it('short-circuits without querying when the user owns nothing', async () => {
+    const { db, queryRaw } = makeDb([]);
+
+    expect((await countCrossUserReach(db, 'user-1', [])).size).toBe(0);
+    expect(queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('counts DISTINCT users across the unioned arms', async () => {
+    const { db, queryRaw } = makeDb([]);
+
+    await countCrossUserReach(db, 'user-1', ['x1']);
+
+    const sql = joinSql(queryRaw.mock.calls[0]);
+    // One user reachable via several arms (memory AND history AND a grant)
+    // must count once — the union yields (personality, user) pairs and the
+    // count collapses them.
+    expect(sql).toContain('COUNT(DISTINCT reach.other_user_id)');
+    expect(sql).toContain('GROUP BY reach.personality_id');
+  });
+});
+
 describe('findCrossUserReachIds', () => {
-  it('returns the ids other users have data on', async () => {
-    const { db } = makeDb([{ personalityId: 'x1' }, { personalityId: 'x2' }]);
+  it('returns the ids other users have data on (the keyset of the count)', async () => {
+    const { db } = makeDb([
+      { personalityId: 'x1', otherUsers: 1 },
+      { personalityId: 'x2', otherUsers: 3 },
+    ]);
 
     expect(await findCrossUserReachIds(db, 'user-1', ['x1', 'x2', 'z1'])).toEqual(['x1', 'x2']);
   });

--- a/services/api-gateway/src/services/retention/crossUserReach.ts
+++ b/services/api-gateway/src/services/retention/crossUserReach.ts
@@ -18,12 +18,18 @@
 import { type Prisma } from '@tzurot/common-types/services/prisma';
 
 /**
- * The ids among `ownedIds` that have cross-user reach — i.e. the characters a
- * retention purge re-homes instead of deleting.
+ * Distinct OTHER users with reach on each of `ownedIds`, as a
+ * personalityId → count map. Characters with zero reach are absent.
  *
- * Broadened from the memories-only `fetchOtherUserReach` to all three
- * personality-scoped tables (council). The INNER JOINs drop world/orphan rows
- * with a null `persona_id` — reach is about another USER, not un-owned content.
+ * This is the ONE reach query — `findCrossUserReachIds` derives from its
+ * keyset, and the self-serve delete preview reports its counts, so the
+ * warning a deleting user reads and the re-home decision the purge makes can
+ * never disagree on what "shared" means.
+ *
+ * Reach deliberately spans ALL THREE personality-scoped activity tables —
+ * narrowing any arm silently shrinks both the re-home decision and the
+ * delete warning. The INNER JOINs drop world/orphan rows with a null
+ * `persona_id` — reach is about another USER, not un-owned content.
  *
  * The fourth arm covers an EXPLICIT grant rather than accumulated activity: a
  * `personality_owners` row naming someone other than the owner. Inert today
@@ -37,32 +43,47 @@ import { type Prisma } from '@tzurot/common-types/services/prisma';
  * assignable to `Prisma.TransactionClient`), so the eraser can call it inside
  * its deletion transaction and the preview can call it on the base client.
  */
+export async function countCrossUserReach(
+  db: Prisma.TransactionClient,
+  userId: string,
+  ownedIds: string[]
+): Promise<Map<string, number>> {
+  if (ownedIds.length === 0) {
+    return new Map();
+  }
+  const rows = await db.$queryRaw<{ personalityId: string; otherUsers: number }[]>`
+    SELECT reach.personality_id AS "personalityId",
+           COUNT(DISTINCT reach.other_user_id)::int AS "otherUsers"
+    FROM (
+      SELECT m.personality_id, p.owner_id AS other_user_id FROM memories m
+        JOIN personas p ON m.persona_id = p.id
+        WHERE m.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
+      UNION ALL
+      SELECT ch.personality_id, p.owner_id FROM conversation_history ch
+        JOIN personas p ON ch.persona_id = p.id
+        WHERE ch.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
+      UNION ALL
+      SELECT f.personality_id, p.owner_id FROM memory_facts f
+        JOIN personas p ON f.persona_id = p.id
+        WHERE f.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
+      UNION ALL
+      SELECT po.personality_id, po.user_id FROM personality_owners po
+        WHERE po.personality_id = ANY(${ownedIds}::uuid[]) AND po.user_id != ${userId}::uuid
+    ) reach
+    GROUP BY reach.personality_id
+  `;
+  return new Map(rows.map(row => [row.personalityId, row.otherUsers]));
+}
+
+/**
+ * The ids among `ownedIds` that have cross-user reach — i.e. the characters a
+ * retention purge re-homes instead of deleting. The keyset of
+ * {@link countCrossUserReach}; see there for what counts as reach.
+ */
 export async function findCrossUserReachIds(
   db: Prisma.TransactionClient,
   userId: string,
   ownedIds: string[]
 ): Promise<string[]> {
-  if (ownedIds.length === 0) {
-    return [];
-  }
-  const rows = await db.$queryRaw<{ personalityId: string }[]>`
-    SELECT DISTINCT reach.personality_id AS "personalityId"
-    FROM (
-      SELECT m.personality_id FROM memories m
-        JOIN personas p ON m.persona_id = p.id
-        WHERE m.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
-      UNION ALL
-      SELECT ch.personality_id FROM conversation_history ch
-        JOIN personas p ON ch.persona_id = p.id
-        WHERE ch.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
-      UNION ALL
-      SELECT f.personality_id FROM memory_facts f
-        JOIN personas p ON f.persona_id = p.id
-        WHERE f.personality_id = ANY(${ownedIds}::uuid[]) AND p.owner_id != ${userId}::uuid
-      UNION ALL
-      SELECT po.personality_id FROM personality_owners po
-        WHERE po.personality_id = ANY(${ownedIds}::uuid[]) AND po.user_id != ${userId}::uuid
-    ) reach
-  `;
-  return rows.map(row => row.personalityId);
+  return Array.from((await countCrossUserReach(db, userId, ownedIds)).keys());
 }

--- a/services/bot-client/src/commands/settings/data/delete.test.ts
+++ b/services/bot-client/src/commands/settings/data/delete.test.ts
@@ -31,7 +31,7 @@ vi.mock('../../../utils/gatewayClients.js', () => ({
 
 const PREVIEW = {
   confirmationPhrase: 'DELETE MY ACCOUNT',
-  ownedCharacters: [{ id: 'x1', name: 'XBot', otherUsersWithMemories: 2 }],
+  ownedCharacters: [{ id: 'x1', name: 'XBot', otherUsersWithData: 2 }],
   counts: { personas: 2, characters: 1, conversationMessages: 10, memories: 5, facts: 3 },
   hasActiveExport: false,
 };
@@ -64,7 +64,7 @@ describe('handleDataDelete', () => {
     const description = call.embeds[0].data.description as string;
     expect(description).toContain('**2** persona(s)');
     expect(description).toContain('deleted for EVERYONE');
-    expect(description).toContain('**2** other user(s) have memories');
+    expect(description).toContain('**2** other user(s) have data');
     expect(description).toContain('export downloads stop');
     expect(description).toContain('DELETE MY ACCOUNT');
     const customIds = call.components[0].components.map(

--- a/services/bot-client/src/commands/settings/data/delete.ts
+++ b/services/bot-client/src/commands/settings/data/delete.ts
@@ -49,12 +49,12 @@ function accountDeleteModalDisplay(): DestructiveModalDisplay {
 }
 
 function characterImpactLines(
-  ownedCharacters: { name: string; otherUsersWithMemories: number }[]
+  ownedCharacters: { name: string; otherUsersWithData: number }[]
 ): string[] {
   const listed = ownedCharacters.slice(0, MAX_LISTED_CHARACTERS).map(character => {
     const reach =
-      character.otherUsersWithMemories > 0
-        ? ` — **${character.otherUsersWithMemories}** other user(s) have memories with them`
+      character.otherUsersWithData > 0
+        ? ` — **${character.otherUsersWithData}** other user(s) have data with them`
         : '';
     return `- **${escapeMarkdown(character.name)}**${reach}`;
   });
@@ -65,7 +65,7 @@ function characterImpactLines(
 }
 
 function buildWarningDescription(preview: {
-  ownedCharacters: { name: string; otherUsersWithMemories: number }[];
+  ownedCharacters: { name: string; otherUsersWithData: number }[];
   counts: {
     personas: number;
     characters: number;
@@ -90,7 +90,7 @@ function buildWarningDescription(preview: {
     lines.push(
       '',
       '⚠️ **Your owned characters are deleted for EVERYONE**, along with every',
-      "other user's memories of them:",
+      "other user's data with them:",
       ...characterImpactLines(preview.ownedCharacters)
     );
   }


### PR DESCRIPTION
## Summary

Closes TASK-321. Two cross-user-reach definitions coexisted: the self-serve delete preview's `fetchOtherUserReach` counted **memories only**, while retention's `findCrossUserReachIds` checks **memories ∪ conversation history ∪ facts ∪ explicit co-ownership grants**. Consequence (user-visible): the warning gating a destructive account deletion could say "0 other users" about a character the retention purge would re-home as *shared*. A warning on a destructive flow must not under-count.

## The fix: one query, two consumers

`countCrossUserReach` (new, in the single-sourced `retention/crossUserReach.ts` module) is now the **only** reach query — a four-arm `UNION ALL` of (personality, other-user) pairs with `COUNT(DISTINCT)`:

- `findCrossUserReachIds` (retention re-home decision) derives from its keyset — same rows, so the two surfaces structurally cannot disagree
- `AccountDeletionService.preview` reports its counts — the memories-only private method is deleted

The wire field renames `otherUsersWithMemories` → `otherUsersWithData` (no-backward-compat project rule; the old name was now a lie), with the bot-client warning copy following ("N other user(s) have data with them"). Full consumer sweep: 12 sites across 6 files, no e2e/contract or website consumers (verified by repo-wide grep including `tests/`).

## Test plan

- **Component (PGLite), the honest pin**: new `ZBot` fixture whose only cross-user trace is a conversation-history row — the memories-only count reported 0 there (fails pre-fix by construction); the assertion now pins 1. The existing `XBot` fixture doubles as the dedup pin: one user reaching via memory + history + grant counts once.
- **Unit**: `countCrossUserReach` map shape, empty-short-circuit, and `COUNT(DISTINCT)`/`GROUP BY` SQL pins; the existing four-arm/owner-exclusion skeleton pins carry over to the shared query; typed mock rows updated to the new row shape.
- Retention component suites (15 tests) green against the derived `findCrossUserReachIds`.
- `pnpm test` + `pnpm quality` green locally.

## Notes

- The count inherits the grant arm: inert today (sole writer inserts owner self-duplicates, filtered by the inequality), but when real co-ownership ships, a granted-but-inactive co-owner correctly counts as an affected user.
- Erasure-behavior unchanged — this touches only what the preview *reports*; the deletion scope and sweep logic are untouched (zero-residue component test still green with the extra character in the seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)