### PR TITLE
test: widen test:audit to *Loader.ts + PersonalityLoader component test

### DIFF
--- a/.github/baselines/test-coverage-baseline.json
+++ b/.github/baselines/test-coverage-baseline.json
@@ -1,15 +1,21 @@
 {
-  "version": 11,
-  "lastUpdated": "2026-06-25T21:36:40.265Z",
+  "version": 12,
+  "lastUpdated": "2026-07-29T10:42:51.225Z",
   "services": {
     "detectedPrismaServices": [
+      "packages/common-types/src/services/SystemSettingsService.ts",
       "packages/conversation-history/src/ConversationHistoryService.ts",
+      "packages/conversation-history/src/ConversationRetentionService.ts",
       "packages/conversation-history/src/ConversationSyncService.ts",
       "packages/identity/src/UserService.ts",
+      "packages/identity/src/personality/PersonalityLoader.ts",
       "services/ai-worker/src/services/LongTermMemoryService.ts",
-      "services/api-gateway/src/services/ConversationRetentionService.ts",
+      "services/ai-worker/src/services/extraction/FactExtractionService.ts",
+      "services/api-gateway/src/services/AccountDeletionService.ts",
       "services/api-gateway/src/services/LlmConfigService.ts",
-      "services/api-gateway/src/services/TtsConfigService.ts"
+      "services/api-gateway/src/services/TtsConfigService.ts",
+      "services/api-gateway/src/services/retention/RetentionNotifyService.ts",
+      "services/api-gateway/src/services/retention/RetentionPurgeService.ts"
     ],
     "knownGaps": []
   },
@@ -22,9 +28,9 @@
   },
   "meta": {
     "toolVersion": "test-audit/1.0",
-    "configHash": "d3f26f6a5928",
+    "configHash": "b97e8ab63c1f",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "018f535fb0a9ae40d1cadfd29714e12a62b793e3",
-    "generatedAt": "2026-06-25T21:36:40.265Z"
+    "generatedFromSha": "e7b21540382657c75cbe6662788d47906a238daf",
+    "generatedAt": "2026-07-29T10:42:51.225Z"
   }
 }

--- a/packages/identity/src/personality/PersonalityLoader.component.test.ts
+++ b/packages/identity/src/personality/PersonalityLoader.component.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Component Test: PersonalityLoader
+ *
+ * Runs the loader against a REAL database (PGlite in-memory PostgreSQL). The
+ * colocated unit test covers every logic branch over a mocked client; this
+ * tier pins the query semantics the mocks cannot verify:
+ * - `mode: 'insensitive'` actually matching case-insensitively in Postgres
+ * - `userId: null` in the alias where-clause matching IS NULL rows (the
+ *   global tier) rather than nothing
+ * - the personal→global alias fallthrough over real rows
+ * - name-beats-slug prioritization and same-name scoring over real candidates
+ * - the AdminSettings global-default POINTER resolving through a real FK
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
+import type { PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { PersonalityLoader } from './PersonalityLoader.js';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+
+describe('PersonalityLoader (PGlite)', () => {
+  let prisma: PrismaClient;
+  let pglite: PGlite;
+  let loader: PersonalityLoader;
+
+  // Users
+  const ownerId = '00000000-0000-0000-0000-000000000001';
+  const ownerDiscordId = '222222222222222222';
+  const otherId = '00000000-0000-0000-0000-000000000002';
+  const otherDiscordId = '333333333333333333';
+
+  // Personalities
+  const pubId = '00000000-0000-0000-0000-000000000010';
+  const privId = '00000000-0000-0000-0000-000000000011';
+  const namedEchoId = '00000000-0000-0000-0000-000000000012';
+  const sluggedEchoId = '00000000-0000-0000-0000-000000000013';
+  const twinPublicId = '00000000-0000-0000-0000-000000000014';
+  const twinPrivateId = '00000000-0000-0000-0000-000000000015';
+  const geminiOldId = '00000000-0000-0000-0000-000000000016';
+  const geminiNewId = '00000000-0000-0000-0000-000000000017';
+
+  const systemPromptId = '00000000-0000-0000-0000-000000000020';
+  const globalCfgId = '00000000-0000-0000-0000-000000000030';
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    const adapter = new PrismaPGlite(pglite);
+    prisma = new PrismaClient({ adapter }) as PrismaClient;
+
+    await seedUserWithPersona(prisma, {
+      userId: ownerId,
+      personaId: '00000000-0000-0000-0000-0000000000a1',
+      discordId: ownerDiscordId,
+      username: 'owner',
+      personaName: 'owner',
+    });
+    await seedUserWithPersona(prisma, {
+      userId: otherId,
+      personaId: '00000000-0000-0000-0000-0000000000a2',
+      discordId: otherDiscordId,
+      username: 'other',
+      personaName: 'other',
+    });
+
+    await prisma.systemPrompt.create({
+      data: { id: systemPromptId, name: 'Prompt', content: 'Test prompt.' },
+    });
+
+    const base = {
+      systemPromptId,
+      ownerId,
+      characterInfo: 'info',
+      personalityTraits: 'traits',
+    };
+    await prisma.personality.createMany({
+      data: [
+        { id: pubId, name: 'Lumen', slug: 'lumen', isPublic: true, ...base },
+        { id: privId, name: 'Shade', slug: 'shade', isPublic: false, ...base },
+        // Name-vs-slug collision: 'echo' as a NAME on one row, as a SLUG on another
+        { id: namedEchoId, name: 'Echo', slug: 'echo-original', isPublic: true, ...base },
+        { id: sluggedEchoId, name: 'Reverb', slug: 'echo', isPublic: true, ...base },
+        // Same-name scoring: public must beat private
+        { id: twinPublicId, name: 'Twin', slug: 'twin-pub', isPublic: true, ...base },
+        { id: twinPrivateId, name: 'Twin', slug: 'twin-priv', isPublic: false, ...base },
+        // Same-name, same-score: oldest createdAt must win
+        {
+          id: geminiOldId,
+          name: 'Gemini',
+          slug: 'gemini-old',
+          isPublic: true,
+          createdAt: new Date('2024-01-01T00:00:00Z'),
+          ...base,
+        },
+        {
+          id: geminiNewId,
+          name: 'Gemini',
+          slug: 'gemini-new',
+          isPublic: true,
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+          ...base,
+        },
+      ],
+    });
+
+    await prisma.personalityAlias.createMany({
+      data: [
+        // Global tier (userId null) → the public personality
+        { id: '00000000-0000-0000-0000-000000000040', alias: 'lux', personalityId: pubId },
+        // OTHER user's personal alias with the SAME text → the private
+        // personality they cannot access (fallthrough fixture)
+        {
+          id: '00000000-0000-0000-0000-000000000041',
+          alias: 'lux',
+          personalityId: privId,
+          userId: otherId,
+        },
+        // Owner's personal alias → their own private personality
+        {
+          id: '00000000-0000-0000-0000-000000000042',
+          alias: 'mine',
+          personalityId: privId,
+          userId: ownerId,
+        },
+      ],
+    });
+
+    await prisma.llmConfig.create({
+      data: {
+        id: globalCfgId,
+        name: 'Global Default',
+        model: 'anthropic/claude-haiku-4.5',
+        provider: 'openrouter',
+        advancedParameters: { temperature: 0.4 },
+        isGlobal: true,
+        ownerId,
+      },
+    });
+
+    loader = new PersonalityLoader(prisma);
+  }, 30000);
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  }, 30000);
+
+  describe('loadFromDatabase — lookup semantics over real rows', () => {
+    it('matches names case-insensitively (Prisma insensitive mode against Postgres)', async () => {
+      const personality = await loader.loadFromDatabase('LUMEN');
+      expect(personality?.id).toBe(pubId);
+    });
+
+    it('matches aliases case-insensitively', async () => {
+      const personality = await loader.loadFromDatabase('LUX');
+      expect(personality?.id).toBe(pubId);
+    });
+
+    it('prefers a NAME match over another row having it as a slug', async () => {
+      const personality = await loader.loadFromDatabase('echo');
+      expect(personality?.id).toBe(namedEchoId);
+    });
+
+    it('still resolves the slug when no name collides with it', async () => {
+      const personality = await loader.loadFromDatabase('twin-priv');
+      expect(personality?.id).toBe(twinPrivateId);
+    });
+
+    it('scores public over private when two rows share a name', async () => {
+      const personality = await loader.loadFromDatabase('Twin');
+      expect(personality?.id).toBe(twinPublicId);
+    });
+
+    it('breaks equal-score name ties by oldest createdAt', async () => {
+      const personality = await loader.loadFromDatabase('Gemini');
+      expect(personality?.id).toBe(geminiOldId);
+    });
+
+    it('returns null when nothing matches', async () => {
+      expect(await loader.loadFromDatabase('nonexistent')).toBeNull();
+    });
+  });
+
+  describe('loadFromDatabase — alias tiers', () => {
+    it('resolves a global alias (userId IS NULL row) for a user with no personal alias', async () => {
+      const personality = await loader.loadFromDatabase('lux', ownerDiscordId);
+      expect(personality?.id).toBe(pubId);
+    });
+
+    it('resolves the requesting user personal alias to their private personality', async () => {
+      const personality = await loader.loadFromDatabase('mine', ownerDiscordId);
+      expect(personality?.id).toBe(privId);
+    });
+
+    it('does not leak a personal alias to another user', async () => {
+      // 'mine' exists only as the owner's personal row; no global fallback.
+      expect(await loader.loadFromDatabase('mine', otherDiscordId)).toBeNull();
+    });
+
+    it('falls through personal→global when the personal target is inaccessible', async () => {
+      // The other user's personal 'lux' points at the owner's PRIVATE
+      // personality; access-filtering must fall through to the global 'lux'.
+      const personality = await loader.loadFromDatabase('lux', otherDiscordId);
+      expect(personality?.id).toBe(pubId);
+    });
+  });
+
+  describe('loadFromDatabase — access control over real rows', () => {
+    it('lets the owner load their private personality by id', async () => {
+      const personality = await loader.loadFromDatabase(privId, ownerDiscordId);
+      expect(personality?.id).toBe(privId);
+    });
+
+    it('denies another registered user the private personality', async () => {
+      expect(await loader.loadFromDatabase(privId, otherDiscordId)).toBeNull();
+    });
+
+    it('restricts a user with no database row to public personalities only', async () => {
+      expect(await loader.loadFromDatabase(privId, '444444444444444444')).toBeNull();
+      const publicOne = await loader.loadFromDatabase(pubId, '444444444444444444');
+      expect(publicOne?.id).toBe(pubId);
+    });
+
+    it('applies no filter on internal calls (no userId)', async () => {
+      const personality = await loader.loadFromDatabase(privId);
+      expect(personality?.id).toBe(privId);
+    });
+  });
+
+  describe('loadGlobalDefaultConfig — AdminSettings pointer', () => {
+    it('returns null while the pointer is unset', async () => {
+      await prisma.adminSettings.upsert({
+        where: { id: ADMIN_SETTINGS_SINGLETON_ID },
+        create: { id: ADMIN_SETTINGS_SINGLETON_ID },
+        update: { globalDefaultLlmConfigId: null },
+      });
+
+      expect(await loader.loadGlobalDefaultConfig()).toBeNull();
+    });
+
+    it('resolves the pointer relation and maps advancedParameters', async () => {
+      await prisma.adminSettings.upsert({
+        where: { id: ADMIN_SETTINGS_SINGLETON_ID },
+        create: { id: ADMIN_SETTINGS_SINGLETON_ID, globalDefaultLlmConfigId: globalCfgId },
+        update: { globalDefaultLlmConfigId: globalCfgId },
+      });
+
+      const config = await loader.loadGlobalDefaultConfig();
+      expect(config?.model).toBe('anthropic/claude-haiku-4.5');
+      expect(config?.temperature).toBe(0.4);
+    });
+  });
+
+  describe('loadAllFromDatabase', () => {
+    it('returns every personality including private ones (internal operation)', async () => {
+      const all = await loader.loadAllFromDatabase();
+      const ids = all.map(p => p.id);
+      expect(ids).toContain(pubId);
+      expect(ids).toContain(privId);
+    });
+  });
+});

--- a/packages/tooling/src/test/audit-unified.ts
+++ b/packages/tooling/src/test/audit-unified.ts
@@ -73,7 +73,10 @@ function findServiceFiles(projectRoot: string): string[] {
   ];
 
   for (const dir of serviceDirs) {
-    const files = findFiles(dir, /Service\.ts$/);
+    // Loader.ts included: delegation splits (Service orchestrates, Loader holds
+    // the actual this.prisma.* calls — e.g. identity's PersonalityLoader) would
+    // otherwise let the Prisma-touching class escape the component-test ratchet.
+    const files = findFiles(dir, /(?:Service|Loader)\.ts$/);
     for (const file of files) {
       // Skip test files (`.component.test.ts` ends with `.test.ts`, so one check covers both)
       if (file.endsWith('.test.ts')) continue;

--- a/packages/tooling/src/test/audit-version.ts
+++ b/packages/tooling/src/test/audit-version.ts
@@ -19,5 +19,8 @@
  *   v3 — serviceDirs: added `packages/identity` + `packages/conversation-history`
  *        (Prisma-service packages extracted into standalone packages, previously
  *        outside the scan scope) so their component-test coverage is ratcheted.
+ *   v4 — file glob widened to `*(Service|Loader).ts`: delegation splits put the
+ *        actual Prisma calls in a Loader (identity's PersonalityLoader) that the
+ *        Service-only glob never scanned.
  */
-export const TEST_AUDIT_IMPL_VERSION = 3;
+export const TEST_AUDIT_IMPL_VERSION = 4;


### PR DESCRIPTION
## Summary

TASK-177: the component-test ratchet's file glob only matched `*Service.ts`, so a delegation split — Service orchestrates, **Loader** holds the actual `this.prisma.*` calls — let the Prisma-touching class escape the ratchet. Live case: identity's `PersonalityLoader` (9 Prisma call sites). Its coverage rode `PersonalityService.component.test.ts`; deleting that file would have gone undetected.

## Changes

- **Glob widened** to `*(Service|Loader).ts` in `findServiceFiles`; `TEST_AUDIT_IMPL_VERSION` 3→4 so the configHash drift gate forced the baseline refresh (verified: it fired before `--update`).
- **New `PersonalityLoader.component.test.ts`** (18 tests over PGLite) — chosen over `@audit-ignore`/`knownGaps`, which would have preserved exactly the blindness the task exists to remove. It pins the real-DB semantics the mocked unit tier structurally cannot verify: `mode: 'insensitive'` matching in actual Postgres, `userId: null` resolving the IS NULL global alias tier, personal→global alias fallthrough when the personal target is inaccessible, name-beats-slug prioritization, public-beats-private same-name scoring with oldest-createdAt tiebreak, and the AdminSettings global-default **pointer** relation (set and unset paths, each test upserting its own state).
- **Baseline v12** — `knownGaps` stays **empty**: the widened scan found 13 Prisma services, all covered. The six services newly appearing in `detectedPrismaServices` (SystemSettingsService, ConversationRetentionService, FactExtractionService, AccountDeletionService, RetentionNotifyService, RetentionPurgeService) all already had component tests — only the informational detected-list was stale from v11 (2026-06-25).

## Enumeration (sweep evidence)

`find` over the audit's six scanned dirs for `*Loader.ts` (non-test): exactly 4 files. `PersonalityLoader` (identity) is the only one with Prisma usage; `personaReferenceLoader` (ai-worker), `HttpPersonalityLoader` and `IPersonalityLoader` (bot-client) have none and auto-exempt via the existing `hasPrismaUsage` classification.

## Verification

- New component test: 18/18 green (run via root `vitest.component.config.ts`)
- `pnpm ops test:audit` post-change: 33 services scanned, 13 Prisma, 0 gaps
- `pnpm test` — 26 turbo tasks green; `pnpm quality` — green (27/27 gate parity); pre-push gate green

Closes TASK-177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)