### PR TITLE
fix(bot-client): deliver errored slots in a PARTIAL multi-tag batch

### DIFF
--- a/services/bot-client/src/services/MultiTagCoordinator.test.ts
+++ b/services/bot-client/src/services/MultiTagCoordinator.test.ts
@@ -321,6 +321,51 @@ describe('MultiTagCoordinator', () => {
       expect(vi.mocked(msg.reply)).not.toHaveBeenCalled();
     });
 
+    it('delivers the errored character in-character while the PARTIAL batch proceeds', async () => {
+      // Regression: erroredOutcomes were only delivered when EVERY slot
+      // failed — in a mixed batch (Alice submits, Bob's submit throws) Bob's
+      // outcome was collected but silently dropped.
+      const msg = buildMessage();
+      chatManager.submitChatJob.mockImplementation(async ({ personality }) => {
+        if (personality.id === 'id-Bob') {
+          throw new Error('gateway write timeout');
+        }
+        return {
+          kind: 'submitted',
+          jobId: `job-${personality.name}`,
+          trackingContext: {
+            kind: 'message',
+            personality,
+            personaId: `p-${personality.name}`,
+            userMessageTime: new Date(),
+          },
+        };
+      });
+
+      await coordinator.startFanOut({
+        message: msg,
+        channel: buildChannel(),
+        slots: [
+          buildResolvedSlot(buildPersonality('Alice')), // submitted → group proceeds
+          buildResolvedSlot(buildPersonality('Bob')), // submit-errored → speaks now
+        ],
+        content: 'hi',
+        truncated: false,
+      });
+      // The errored delivery is fire-and-forget — drain the microtask queue.
+      await vi.waitFor(() => {
+        expect(slotDelivery.deliverErrorNoPersist).toHaveBeenCalledTimes(1);
+      });
+
+      // Bob's in-character error line delivered...
+      expect(slotDelivery.deliverErrorNoPersist.mock.calls[0][2].personality.id).toBe('id-Bob');
+      // ...while Alice's fan-out is fully live: entry persisted, job owned.
+      expect(persistence.putEntry).toHaveBeenCalledTimes(1);
+      expect(coordinator.ownsJob('job-Alice')).toBe(true);
+      // No system notice — this is not the all-denied shape.
+      expect(vi.mocked(msg.reply)).not.toHaveBeenCalled();
+    });
+
     it('refuses fan-out after shutdown begins', async () => {
       await coordinator.beginShutdown();
       await coordinator.startFanOut({

--- a/services/bot-client/src/services/MultiTagCoordinator.ts
+++ b/services/bot-client/src/services/MultiTagCoordinator.ts
@@ -35,14 +35,13 @@ import { ApiErrorCategory, ApiErrorType } from '@tzurot/common-types/constants/e
 import { MULTI_TAG } from '@tzurot/common-types/constants/message';
 import { type TypingChannel } from '@tzurot/common-types/types/discord-types';
 import { type LLMGenerationResult } from '@tzurot/common-types/types/schemas/generation';
-import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { PersonalityChatManager } from './character/PersonalityChatManager.js';
 import type { JobTracker } from './JobTracker.js';
 import type { ResponseOrderingService } from './ResponseOrderingService.js';
 import type { SlotDeliveryService } from './SlotDeliveryService.js';
 import type { MultiTagPersistence, SyntheticTimeoutContext } from './MultiTagPersistence.js';
-import { type ResolvedSlot, type SlotSource } from './SlotResolver.js';
+import { type ResolvedSlot } from './SlotResolver.js';
 import { recoverRealResultsAtDeadline } from './multiTagRecoveryHelpers.js';
 
 const logger = createLogger('MultiTagCoordinator');
@@ -54,11 +53,17 @@ const logger = createLogger('MultiTagCoordinator');
 export type { RuntimeEntry, RuntimeSlot } from './multiTagCoordinatorHelpers.js';
 import {
   buildSyntheticErrorResult,
+  partitionSlotSubmissions,
   toSnapshot,
   type RuntimeEntry,
   type RuntimeSlot,
+  type SlotOutcome,
 } from './multiTagCoordinatorHelpers.js';
-import { deliverGroup, deliverAllFailedNotice } from './multiTagDeliveryFlow.js';
+import {
+  deliverGroup,
+  deliverAllFailedNotice,
+  deliverErroredOutcomes,
+} from './multiTagDeliveryFlow.js';
 
 /** Input shape for startFanOut — what PersonalityTriggerProcessor builds. */
 export interface StartFanOutInput {
@@ -158,37 +163,7 @@ export class MultiTagCoordinator {
       input.slots.map(async resolved => this.submitSlot(input, resolved))
     );
 
-    // Dense slot indices: denied slots are skipped, surviving slots get
-    // 0..k-1. The ResolvedSlot input may have had non-contiguous "logical"
-    // positions (e.g., reply at 0, denied activation at 1, mention at 2 →
-    // dense becomes [0:reply, 1:mention]). Recovery uses the snapshot's
-    // dense `slotIndex` directly when rehydrating and never re-resolves
-    // from input — so the indices are stable across the entry's lifetime
-    // and the dense numbering is the canonical view.
-    const runtimeSlots: RuntimeSlot[] = [];
-    let nextIndex = 0;
-    // Collect errored outcomes (personality + classified spec) so the
-    // all-errored branch can deliver each character's own error voice.
-    // Denied outcomes need no accumulation — they render as a single system
-    // notice only when the WHOLE batch is denied.
-    const erroredOutcomes: Extract<SlotOutcome, { kind: 'errored' }>[] = [];
-    for (const submission of slotSubmissions) {
-      if (submission.kind !== 'submitted') {
-        if (submission.kind === 'errored') {
-          erroredOutcomes.push(submission);
-        }
-        continue;
-      }
-      runtimeSlots.push({
-        slotIndex: nextIndex++,
-        personality: submission.personality,
-        personaId: submission.personaId,
-        source: submission.source,
-        isAutoResponse: submission.isAutoResponse,
-        jobId: submission.jobId,
-        status: 'pending',
-      });
-    }
+    const { runtimeSlots, erroredOutcomes } = partitionSlotSubmissions(slotSubmissions);
 
     if (runtimeSlots.length === 0) {
       await deliverAllFailedNotice(
@@ -197,6 +172,20 @@ export class MultiTagCoordinator {
         this.deps
       );
       return;
+    }
+
+    if (erroredOutcomes.length > 0) {
+      // PARTIAL batch: some slots submitted, at least one submit threw. The
+      // errored characters still owe the user their in-character error line —
+      // without this, their outcomes were collected above and silently
+      // dropped. Fire-and-forget (deliverErroredOutcomes contains its own
+      // failures via allSettled): awaiting webhook sends here would widen the
+      // ownership race window the entries.set reorder below exists to close.
+      void deliverErroredOutcomes(
+        { message: input.message, channel: input.channel },
+        erroredOutcomes,
+        this.deps
+      );
     }
 
     const timeoutHandle = setTimeout(() => {
@@ -690,41 +679,3 @@ export class MultiTagCoordinator {
     await this.deps.persistence.clearSyntheticTimeout(jobId);
   }
 }
-
-/**
- * The outcome of one slot submission — a discriminated union carrying the
- * personality (and, for `errored`, the classified error) so downstream
- * handling can respond per-character instead of collapsing every failure to
- * an anonymous string.
- *
- * - `'submitted'` — a live job to coordinate.
- * - `'denied'` — a genuine refusal: the character can't respond (denylisted,
- *   NSFW-gated, or restricted here). The input was understood; the character
- *   simply isn't available. Rendered as a single system notice when the whole
- *   batch is denied.
- * - `'errored'` — an infrastructure failure: the submission threw (e.g. a
- *   gateway write-timeout while persisting the trigger message). Transient.
- *   Carries a synthetic `success:false` result so the character can deliver
- *   the error IN ITS OWN VOICE (its `errorMessage`, else a canned line).
- *
- * NOTE: the `'errored'`/`'submitted'` discriminants here are DISJOINT from
- * `RuntimeSlot.status`'s `'errored'`/`'completed'` — those are post-submission
- * job-lifecycle states (a submitted slot whose result came back failed). These
- * describe whether the submission itself succeeded; they only share spelling.
- */
-type SlotOutcome =
-  | {
-      kind: 'submitted';
-      jobId: string;
-      personality: LoadedPersonality;
-      personaId: string;
-      source: SlotSource;
-      isAutoResponse: boolean;
-    }
-  | { kind: 'denied'; personality: LoadedPersonality }
-  | {
-      kind: 'errored';
-      personality: LoadedPersonality;
-      isAutoResponse: boolean;
-      spec: LLMGenerationResult;
-    };

--- a/services/bot-client/src/services/SlotDeliveryService.ts
+++ b/services/bot-client/src/services/SlotDeliveryService.ts
@@ -226,12 +226,13 @@ export class SlotDeliveryService {
   /**
    * Deliver an in-character error line WITHOUT persisting a conversation turn.
    *
-   * Used by the multi-tag submit-failure path (`MultiTagCoordinator`'s
-   * all-errored branch): the character's `submitChatJob` threw before any
-   * user/assistant turn was created, so there is no conversation turn to
-   * attribute — fabricating a `saveAssistantMessage` entry (which needs a
-   * `personaId` this path never resolved) would record a turn that never
-   * happened. The error line still goes out the webhook as the character.
+   * Used by the multi-tag submit-failure paths (`deliverErroredOutcomes`,
+   * reached from both the all-failed notice AND a partial batch's errored
+   * slots): the character's `submitChatJob` threw before any user/assistant
+   * turn was created, so there is no conversation turn to attribute —
+   * fabricating a `saveAssistantMessage` entry (which needs a `personaId`
+   * this path never resolved) would record a turn that never happened. The
+   * error line still goes out the webhook as the character.
    */
   async deliverErrorNoPersist(
     errorContent: string,

--- a/services/bot-client/src/services/multiTagCoordinatorHelpers.test.ts
+++ b/services/bot-client/src/services/multiTagCoordinatorHelpers.test.ts
@@ -19,9 +19,11 @@ import {
 import {
   buildSlotContext,
   buildSyntheticErrorResult,
+  partitionSlotSubmissions,
   toSnapshot,
   type RuntimeEntry,
   type RuntimeSlot,
+  type SlotOutcome,
 } from './multiTagCoordinatorHelpers.js';
 
 function buildPersonality(name: string): LoadedPersonality {
@@ -225,5 +227,60 @@ describe('buildSyntheticErrorResult', () => {
 
     expect(result.personalityErrorMessage).toBeUndefined();
     expect(result.errorInfo?.userMessage).toBe(USER_ERROR_MESSAGES[ApiErrorCategory.UNKNOWN]);
+  });
+});
+
+describe('partitionSlotSubmissions', () => {
+  function submitted(name: string): SlotOutcome {
+    return {
+      kind: 'submitted',
+      jobId: `job-${name}`,
+      personality: buildPersonality(name),
+      personaId: `persona-${name}`,
+      source: 'mention',
+      isAutoResponse: false,
+    };
+  }
+
+  it('assigns DENSE indices: denied slots are skipped, survivors get 0..k-1', () => {
+    const { runtimeSlots, erroredOutcomes } = partitionSlotSubmissions([
+      submitted('Alice'),
+      { kind: 'denied', personality: buildPersonality('Denny') },
+      submitted('Bob'),
+    ]);
+
+    expect(runtimeSlots.map(s => [s.slotIndex, s.jobId])).toEqual([
+      [0, 'job-Alice'],
+      [1, 'job-Bob'],
+    ]);
+    expect(runtimeSlots.every(s => s.status === 'pending')).toBe(true);
+    expect(erroredOutcomes).toEqual([]);
+  });
+
+  it('collects errored outcomes without consuming a dense index', () => {
+    const errored: SlotOutcome = {
+      kind: 'errored',
+      personality: buildPersonality('Boom'),
+      isAutoResponse: true,
+      spec: { requestId: 'r1', success: false } as Extract<
+        SlotOutcome,
+        { kind: 'errored' }
+      >['spec'],
+    };
+    const { runtimeSlots, erroredOutcomes } = partitionSlotSubmissions([
+      errored,
+      submitted('Alice'),
+    ]);
+
+    expect(runtimeSlots.map(s => [s.slotIndex, s.jobId])).toEqual([[0, 'job-Alice']]);
+    expect(erroredOutcomes).toEqual([errored]);
+  });
+
+  it('returns both empty for an all-denied batch', () => {
+    const { runtimeSlots, erroredOutcomes } = partitionSlotSubmissions([
+      { kind: 'denied', personality: buildPersonality('Denny') },
+    ]);
+    expect(runtimeSlots).toEqual([]);
+    expect(erroredOutcomes).toEqual([]);
   });
 });

--- a/services/bot-client/src/services/multiTagCoordinatorHelpers.ts
+++ b/services/bot-client/src/services/multiTagCoordinatorHelpers.ts
@@ -141,3 +141,83 @@ export function toSnapshot(entry: RuntimeEntry): CoordinatorEntrySnapshot {
     truncated: entry.truncated,
   };
 }
+
+/**
+ * The outcome of one slot submission — a discriminated union carrying the
+ * personality (and, for `errored`, the classified error) so downstream
+ * handling can respond per-character instead of collapsing every failure to
+ * an anonymous string.
+ *
+ * - `'submitted'` — a live job to coordinate.
+ * - `'denied'` — a genuine refusal: the character can't respond (denylisted,
+ *   NSFW-gated, or restricted here). The input was understood; the character
+ *   simply isn't available. Rendered as a single system notice when the whole
+ *   batch is denied.
+ * - `'errored'` — an infrastructure failure: the submission threw (e.g. a
+ *   gateway write-timeout while persisting the trigger message). Transient.
+ *   Carries a synthetic `success:false` result so the character can deliver
+ *   the error IN ITS OWN VOICE (its `errorMessage`, else a canned line).
+ *
+ * NOTE: the `'errored'`/`'submitted'` discriminants here are DISJOINT from
+ * `RuntimeSlot.status`'s `'errored'`/`'completed'` — those are post-submission
+ * job-lifecycle states (a submitted slot whose result came back failed). These
+ * describe whether the submission itself succeeded; they only share spelling.
+ */
+export type SlotOutcome =
+  | {
+      kind: 'submitted';
+      jobId: string;
+      personality: LoadedPersonality;
+      personaId: string;
+      source: SlotSource;
+      isAutoResponse: boolean;
+    }
+  | { kind: 'denied'; personality: LoadedPersonality }
+  | {
+      kind: 'errored';
+      personality: LoadedPersonality;
+      isAutoResponse: boolean;
+      spec: LLMGenerationResult;
+    };
+
+/**
+ * Partition slot submissions into the dense runtime slots (submitted, status
+ * `'pending'`) and the errored outcomes still owed an in-character error line.
+ *
+ * Dense slot indices: denied slots are skipped, surviving slots get 0..k-1.
+ * The ResolvedSlot input may have had non-contiguous "logical" positions
+ * (e.g., reply at 0, denied activation at 1, mention at 2 → dense becomes
+ * [0:reply, 1:mention]). Recovery uses the snapshot's dense `slotIndex`
+ * directly when rehydrating and never re-resolves from input — so the indices
+ * are stable across the entry's lifetime and the dense numbering is the
+ * canonical view.
+ *
+ * Denied outcomes need no accumulation — they render as a single system
+ * notice only when the WHOLE batch is denied.
+ */
+export function partitionSlotSubmissions(slotSubmissions: SlotOutcome[]): {
+  runtimeSlots: RuntimeSlot[];
+  erroredOutcomes: Extract<SlotOutcome, { kind: 'errored' }>[];
+} {
+  const runtimeSlots: RuntimeSlot[] = [];
+  const erroredOutcomes: Extract<SlotOutcome, { kind: 'errored' }>[] = [];
+  let nextIndex = 0;
+  for (const submission of slotSubmissions) {
+    if (submission.kind !== 'submitted') {
+      if (submission.kind === 'errored') {
+        erroredOutcomes.push(submission);
+      }
+      continue;
+    }
+    runtimeSlots.push({
+      slotIndex: nextIndex++,
+      personality: submission.personality,
+      personaId: submission.personaId,
+      source: submission.source,
+      isAutoResponse: submission.isAutoResponse,
+      jobId: submission.jobId,
+      status: 'pending',
+    });
+  }
+  return { runtimeSlots, erroredOutcomes };
+}

--- a/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
@@ -12,7 +12,11 @@ import type { TypingChannel } from '@tzurot/common-types/types/discord-types';
 import type { LLMGenerationResult } from '@tzurot/common-types/types/schemas/generation';
 import type { LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { MULTI_TAG } from '@tzurot/common-types/constants/message';
-import { deliverGroup, type DeliveryFlowDeps } from './multiTagDeliveryFlow.js';
+import {
+  deliverGroup,
+  deliverErroredOutcomes,
+  type DeliveryFlowDeps,
+} from './multiTagDeliveryFlow.js';
 import type { RuntimeEntry, RuntimeSlot } from './multiTagCoordinatorHelpers.js';
 import { confirmDelivery, setDmSessionPersonality } from '../utils/gatewayServiceCalls.js';
 
@@ -456,5 +460,47 @@ describe('deliverGroup', () => {
     // Confirmation cleanup still ran despite the failed notice
     expect(vi.mocked(confirmDelivery)).toHaveBeenCalled();
     expect(persistence.deleteEntry).toHaveBeenCalled();
+  });
+});
+
+describe('deliverErroredOutcomes', () => {
+  it('contains a rejecting delivery — the sibling character still speaks', async () => {
+    // The allSettled containment is the guarantee the coordinator's
+    // fire-and-forget call relies on; pin it here rather than only in a
+    // comment. deliverErrorNoPersist swallows internally today, but the
+    // containment must hold even if it is ever refactored to throw.
+    const deliverErrorNoPersist = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('webhook send failed'))
+      .mockResolvedValue(undefined);
+    const deps = {
+      slotDelivery: { deliverErrorNoPersist } as unknown as DeliveryFlowDeps['slotDelivery'],
+    };
+    const message = {
+      id: 'msg-source',
+      guildId: 'guild-1',
+      client: { user: { id: 'bot-1' } },
+    } as unknown as Message;
+    const channel = { id: 'channel-1' } as unknown as TypingChannel;
+    const spec = (name: string): LLMGenerationResult =>
+      ({ requestId: `req-${name}`, success: false, error: 'boom' }) as LLMGenerationResult;
+
+    await expect(
+      deliverErroredOutcomes(
+        { message, channel },
+        [
+          { personality: buildPersonality('Alice'), isAutoResponse: false, spec: spec('Alice') },
+          { personality: buildPersonality('Bob'), isAutoResponse: false, spec: spec('Bob') },
+        ],
+        deps
+      )
+    ).resolves.toBeUndefined();
+
+    // Both were attempted — Alice's rejection did not drop Bob's delivery.
+    expect(deliverErrorNoPersist).toHaveBeenCalledTimes(2);
+    const deliveredIds = deliverErrorNoPersist.mock.calls.map(
+      c => (c[2] as { personality: { id: string } }).personality.id
+    );
+    expect(deliveredIds).toEqual(['id-alice', 'id-bob']);
   });
 });

--- a/services/bot-client/src/services/multiTagDeliveryFlow.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.ts
@@ -263,6 +263,48 @@ export interface ErroredSlotOutcome {
 }
 
 /**
+ * Deliver each errored character's OWN error line via its webhook
+ * (in-character), in parallel. Shared by the all-failed notice below and by
+ * the coordinator's PARTIAL-batch path (some slots submitted, others threw
+ * at submit time) — without the latter, an errored persona in a mixed batch
+ * was collected but never delivered, silently dropping its error line.
+ *
+ * **Bypasses the ordering buffer intentionally**, in both callers: these are
+ * UI feedback messages for submit-time failures known immediately, not async
+ * AI responses — routing them through `ResponseOrderingService` would also
+ * mean persisting them into the recovery snapshot for a rare edge.
+ */
+export async function deliverErroredOutcomes(
+  source: { message: Message; channel: TypingChannel },
+  erroredOutcomes: ErroredSlotOutcome[],
+  deps: Pick<DeliveryFlowDeps, 'slotDelivery'>
+): Promise<void> {
+  const { message, channel } = source;
+  // Each errored character speaks in its own voice; `allSettled` (not `all`)
+  // keeps the error-containment local — one failing send can't drop a
+  // sibling's delivery even if `deliverErrorNoPersist` is ever refactored to
+  // throw (today it swallows internally, but the guarantee shouldn't rely on
+  // that).
+  await Promise.allSettled(
+    erroredOutcomes.map(async outcome => {
+      const context: EphemeralErrorContext = {
+        message,
+        channel,
+        guildId: message.guildId,
+        clientId: message.client.user?.id,
+        personality: outcome.personality,
+        isAutoResponse: outcome.isAutoResponse,
+      };
+      await deps.slotDelivery.deliverErrorNoPersist(
+        buildErrorContent(outcome.spec),
+        outcome.spec,
+        context
+      );
+    })
+  );
+}
+
+/**
  * Nothing was submitted — every slot was denied or errored. Two shapes:
  *
  * - **Any errored**: each errored character delivers its OWN error line via
@@ -272,47 +314,20 @@ export interface ErroredSlotOutcome {
  *   error replies just adds register-noise. Bounded by MAX_TAGS upstream.
  * - **All denied**: a single system notice (no character has anything to say
  *   in-voice, and a per-persona "I'm unavailable" from each would confuse).
- *
- * **Bypasses the ordering buffer intentionally.** These are UI feedback
- * messages, not AI responses, and all-failed fan-outs are rare. Routing them
- * through `ResponseOrderingService` (a real jobId + register/handleResult
- * round-trip) isn't worth the ordering guarantee given the user only sees
- * this when their input produced no AI responses at all.
  */
 export async function deliverAllFailedNotice(
   source: { message: Message; channel: TypingChannel },
   erroredOutcomes: ErroredSlotOutcome[],
   deps: Pick<DeliveryFlowDeps, 'slotDelivery'>
 ): Promise<void> {
-  const { message, channel } = source;
+  const { message } = source;
   logger.info(
     { sourceMessageId: message.id, erroredCount: erroredOutcomes.length },
     'All multi-tag slots failed (denied or errored) — nothing to coordinate'
   );
 
   if (erroredOutcomes.length > 0) {
-    // Each errored character speaks in its own voice; `allSettled` (not `all`)
-    // keeps the error-containment local — one failing send can't drop a
-    // sibling's delivery even if `deliverErrorNoPersist` is ever refactored to
-    // throw (today it swallows internally, but the guarantee shouldn't rely on
-    // that).
-    await Promise.allSettled(
-      erroredOutcomes.map(async outcome => {
-        const context: EphemeralErrorContext = {
-          message,
-          channel,
-          guildId: message.guildId,
-          clientId: message.client.user?.id,
-          personality: outcome.personality,
-          isAutoResponse: outcome.isAutoResponse,
-        };
-        await deps.slotDelivery.deliverErrorNoPersist(
-          buildErrorContent(outcome.spec),
-          outcome.spec,
-          context
-        );
-      })
-    );
+    await deliverErroredOutcomes(source, erroredOutcomes, deps);
     return;
   }
 


### PR DESCRIPTION
## Summary

TASK-236: `erroredOutcomes` were only delivered when EVERY slot failed (`runtimeSlots.length === 0`). In a mixed batch — some slots submitted, one slot's `submitChatJob` throws (e.g. a gateway write-timeout on one persona while the others submit fine) — the errored persona's outcome was collected and then silently dropped, breaking the "every errored character speaks in its own voice" guarantee.

**Scope note** (from the task's own analysis, re-verified): post-submission job failures (`RuntimeSlot.status === 'errored'`) were already delivered via `deliverGroup`. This closes ONLY the submit-throw-in-partial-batch gap.

## Design call: immediate delivery, not the ordered burst

The task sketch suggested routing through the ordered burst. Reading the code changed the target (advisor-principle vs code-target): the all-failed path already **intentionally bypasses the ordering buffer** for these ("UI feedback messages, not AI responses"), and burst-routing would require carrying `ErroredSlotOutcome`s into the Redis recovery snapshot — schema + rehydration changes for a rare edge. The fix keeps the established posture: submit errors are known immediately and delivered immediately, in both the all-failed and partial shapes.

## Changes

- **`multiTagDeliveryFlow.ts`**: extracted `deliverErroredOutcomes` (the per-persona in-character webhook delivery, `allSettled`-contained) out of `deliverAllFailedNotice`; the notice now calls it.
- **`MultiTagCoordinator.ts`**: the partial branch fires `deliverErroredOutcomes` fire-and-forget — awaiting webhook sends there would widen the ownership race window the `entries.set` reorder exists to close.
- **max-lines extraction**: the coordinator crossed 400 lines, so `SlotOutcome` + a new pure `partitionSlotSubmissions` (the dense-index submission partition) moved to `multiTagCoordinatorHelpers.ts` (the file that exists for exactly this), with 3 new unit tests pinning dense-index skipping, errored collection, and the all-denied shape.

## Tests

- **Regression test verified failing pre-fix** (stash-checked): mixed batch → the errored persona's `deliverErrorNoPersist` fires with its personality crossing the seam, while the submitted slot's fan-out stays fully live (`putEntry` called, `ownsJob` true), and no system notice is sent.
- All 111 multi-tag tests green (coordinator 34, delivery flow 21, helpers 13, recovery 43).

## Verification

- `pnpm test` — 26 turbo tasks green; `pnpm quality` — green (the max-lines failure this PR's extraction resolves was caught by the local gate first); pre-push green.

Closes TASK-236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)