### PR TITLE
fix(bot-client): move the purge slug out of the customId into the footer

### DIFF
--- a/services/bot-client/src/commands/history/index.test.ts
+++ b/services/bot-client/src/commands/history/index.test.ts
@@ -250,6 +250,29 @@ describe('handleModal', () => {
     });
   });
 
+  it('should fail closed when the channelId is missing even with a valid footer', async () => {
+    // The other half of the OR: never proceed on a partial identity — a
+    // customId with no entityId segment must not purge, however valid the
+    // slug footer is.
+    mockParsePurgeSlugFromFooter.mockReturnValue('lilith');
+
+    const mockReply = vi.fn();
+    const mockInteraction = {
+      customId: 'history::destructive::modal_submit::history-purge',
+      user: { id: '123456789' },
+      message: purgeParentMessage(),
+      reply: mockReply,
+    };
+
+    await handleModal(mockInteraction as never);
+
+    expect(mockHandleDestructiveModalSubmit).not.toHaveBeenCalled();
+    expect(mockReply).toHaveBeenCalledWith({
+      content: 'Error: Invalid entity ID format.',
+      ephemeral: true,
+    });
+  });
+
   // Coverage for the closure built by `buildPurgeOperation`. The closure
   // is passed as the 3rd arg to `handleDestructiveModalSubmit` and stored for
   // the confirm-button click — exercising it here mirrors what production
@@ -414,6 +437,27 @@ describe('handleButton', () => {
 
     await handleButton(mockInteraction as never);
 
+    expect(mockUpdate).toHaveBeenCalledWith({
+      content: 'Error: Invalid entity ID format.',
+      embeds: [],
+      components: [],
+    });
+  });
+
+  it('should fail closed on confirm when the channelId is missing even with a valid footer', async () => {
+    // The other half of the OR — partial identity never proceeds.
+    mockParsePurgeSlugFromFooter.mockReturnValue('lilith');
+
+    const mockUpdate = vi.fn();
+    const mockInteraction = {
+      customId: 'history::destructive::confirm_button::history-purge',
+      message: purgeParentMessage(),
+      update: mockUpdate,
+    };
+
+    await handleButton(mockInteraction as never);
+
+    expect(mockHandleDestructiveConfirmButton).not.toHaveBeenCalled();
     expect(mockUpdate).toHaveBeenCalledWith({
       content: 'Error: Invalid entity ID format.',
       embeds: [],

--- a/services/bot-client/src/commands/history/index.test.ts
+++ b/services/bot-client/src/commands/history/index.test.ts
@@ -30,7 +30,7 @@ const mockHandleClear = vi.fn();
 const mockHandleUndo = vi.fn();
 const mockHandleStats = vi.fn();
 const mockHandlePurgeHistory = vi.fn();
-const mockParsePurgeEntityId = vi.fn();
+const mockParsePurgeSlugFromFooter = vi.fn();
 vi.mock('./clear.js', () => ({
   handleClear: (...args: unknown[]) => mockHandleClear(...args),
 }));
@@ -42,7 +42,7 @@ vi.mock('./stats.js', () => ({
 }));
 vi.mock('./purge.js', () => ({
   handlePurgeHistory: (...args: unknown[]) => mockHandlePurgeHistory(...args),
-  parsePurgeEntityId: (...args: unknown[]) => mockParsePurgeEntityId(...args),
+  parsePurgeSlugFromFooter: (...args: unknown[]) => mockParsePurgeSlugFromFooter(...args),
 }));
 
 // Mock autocomplete handlers
@@ -199,38 +199,46 @@ describe('execute', () => {
   });
 });
 
+/** Parent warning message carrying the slug footer (the customId-overflow escape hatch). */
+function purgeParentMessage(footerText: string | undefined = 'slug:lilith'): {
+  embeds: Array<{ footer: { text: string } | null }>;
+} {
+  return { embeds: [{ footer: footerText === undefined ? null : { text: footerText } }] };
+}
+
 describe('handleModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should handle modal submit for history purge', async () => {
-    mockParsePurgeEntityId.mockReturnValue({
-      personalitySlug: 'lilith',
-      channelId: 'channel-123',
-    });
+    mockParsePurgeSlugFromFooter.mockReturnValue('lilith');
     clientsForMock.mockReturnValue({
       userClient: { hardDeleteHistory: vi.fn() },
     });
 
     const mockInteraction = {
-      customId: 'history::destructive::modal_submit::history-purge::lilith_channel-123',
+      customId: 'history::destructive::modal_submit::history-purge::channel-123',
       user: { id: '123456789' },
+      message: purgeParentMessage(),
       reply: vi.fn(),
     };
 
     await handleModal(mockInteraction as never);
 
+    // The slug is read from the parent message's footer, not the customId.
+    expect(mockParsePurgeSlugFromFooter).toHaveBeenCalledWith('slug:lilith');
     expect(mockHandleDestructiveModalSubmit).toHaveBeenCalled();
   });
 
-  it('should reply with error for invalid entityId in modal', async () => {
-    mockParsePurgeEntityId.mockReturnValue(null);
+  it('should reply with error when the slug footer is missing in modal', async () => {
+    mockParsePurgeSlugFromFooter.mockReturnValue(null);
 
     const mockReply = vi.fn();
     const mockInteraction = {
-      customId: 'history::destructive::modal_submit::history-purge::invalid',
+      customId: 'history::destructive::modal_submit::history-purge::channel-123',
       user: { id: '123456789' },
+      message: { embeds: [] },
       reply: mockReply,
     };
 
@@ -250,17 +258,15 @@ describe('handleModal', () => {
     async function setupAndExtractCallback(
       hardDeleteHistoryStub: ReturnType<typeof vi.fn>
     ): Promise<() => Promise<unknown>> {
-      mockParsePurgeEntityId.mockReturnValue({
-        personalitySlug: 'lilith',
-        channelId: 'channel-123',
-      });
+      mockParsePurgeSlugFromFooter.mockReturnValue('lilith');
       clientsForMock.mockReturnValue({
         userClient: { hardDeleteHistory: hardDeleteHistoryStub },
       });
 
       await handleModal({
-        customId: 'history::destructive::modal_submit::history-purge::lilith_channel-123',
+        customId: 'history::destructive::modal_submit::history-purge::channel-123',
         user: { id: '123456789' },
+        message: purgeParentMessage(),
         reply: vi.fn(),
       } as never);
 
@@ -378,18 +384,17 @@ describe('handleButton', () => {
   });
 
   it('should handle confirm button and show modal', async () => {
-    mockParsePurgeEntityId.mockReturnValue({
-      personalitySlug: 'lilith',
-      channelId: 'channel-123',
-    });
+    mockParsePurgeSlugFromFooter.mockReturnValue('lilith');
 
     const mockInteraction = {
-      customId: 'history::destructive::confirm_button::history-purge::lilith_channel-123',
+      customId: 'history::destructive::confirm_button::history-purge::channel-123',
+      message: purgeParentMessage(),
     };
 
     await handleButton(mockInteraction as never);
 
-    // Display-only: routing derives from the button's customId in the factory.
+    // The slug rides the footer; display derives from it.
+    expect(mockParsePurgeSlugFromFooter).toHaveBeenCalledWith('slug:lilith');
     expect(mockHardDeleteModalDisplay).toHaveBeenCalledWith('lilith');
     expect(mockHandleDestructiveConfirmButton).toHaveBeenCalledWith(
       mockInteraction,
@@ -397,12 +402,13 @@ describe('handleButton', () => {
     );
   });
 
-  it('should update with error for invalid entityId on confirm', async () => {
-    mockParsePurgeEntityId.mockReturnValue(null);
+  it('should update with error when the slug footer is missing on confirm', async () => {
+    mockParsePurgeSlugFromFooter.mockReturnValue(null);
 
     const mockUpdate = vi.fn();
     const mockInteraction = {
-      customId: 'history::destructive::confirm_button::history-purge::invalid',
+      customId: 'history::destructive::confirm_button::history-purge::channel-123',
+      message: { embeds: [] },
       update: mockUpdate,
     };
 

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -188,7 +188,12 @@ async function handlePurgeConfirm(
   const personalitySlug = parsePurgeSlugFromFooter(interaction.message.embeds[0]?.footer?.text);
 
   if (channelId === undefined || personalitySlug === null) {
-    logger.warn({ channelId }, 'Purge confirm missing channelId or slug footer');
+    // customId included: when this fires, identity is partial by definition,
+    // so the raw customId is the debugging signal (channelId may be undefined).
+    logger.warn(
+      { channelId, customId: interaction.customId },
+      'Purge confirm missing channelId or slug footer'
+    );
     await interaction.update({
       content: 'Error: Invalid entity ID format.',
       embeds: [],

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -181,14 +181,14 @@ async function autocomplete(interaction: AutocompleteInteraction): Promise<void>
  */
 async function handlePurgeConfirm(
   interaction: ButtonInteraction,
-  entityId: string | undefined
+  channelId: string | undefined
 ): Promise<void> {
   // The slug lives in the warning embed's footer, not the customId (too long
-  // for the 100-char budget); entityId carries only the channelId.
+  // for the 100-char budget); the customId's entityId carries only the channelId.
   const personalitySlug = parsePurgeSlugFromFooter(interaction.message.embeds[0]?.footer?.text);
 
-  if (entityId === undefined || personalitySlug === null) {
-    logger.warn({ entityId }, 'Purge confirm missing channelId or slug footer');
+  if (channelId === undefined || personalitySlug === null) {
+    logger.warn({ channelId }, 'Purge confirm missing channelId or slug footer');
     await interaction.update({
       content: 'Error: Invalid entity ID format.',
       embeds: [],

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -26,7 +26,7 @@ import type {
 import { handleClear } from './clear.js';
 import { handleUndo } from './undo.js';
 import { handleStats } from './stats.js';
-import { handlePurgeHistory, parsePurgeEntityId } from './purge.js';
+import { handlePurgeHistory, parsePurgeSlugFromFooter } from './purge.js';
 import { handlePersonalityAutocomplete, handlePersonaAutocomplete } from './autocomplete.js';
 import { DestructiveCustomIds } from '../../utils/customIds.js';
 import {
@@ -127,17 +127,20 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
     }
 
     if (parsed.operation === HISTORY_PURGE_OPERATION && parsed.action === 'modal_submit') {
-      const entityInfo = parsed.entityId !== undefined ? parsePurgeEntityId(parsed.entityId) : null;
+      // channelId rides the customId; the slug rides the warning embed's
+      // footer (too long for the customId budget — see handlePurgeHistory).
+      const channelId = parsed.entityId;
+      const personalitySlug = parsePurgeSlugFromFooter(
+        interaction.message?.embeds[0]?.footer?.text
+      );
 
-      if (entityInfo === null) {
+      if (channelId === undefined || personalitySlug === null) {
         await interaction.reply({
           content: 'Error: Invalid entity ID format.',
           ephemeral: true,
         });
         return;
       }
-
-      const { personalitySlug, channelId } = entityInfo;
       const { userClient } = clientsFor(interaction);
       const executeOperation = buildPurgeOperation(
         userClient,
@@ -180,10 +183,12 @@ async function handlePurgeConfirm(
   interaction: ButtonInteraction,
   entityId: string | undefined
 ): Promise<void> {
-  const entityInfo = entityId !== undefined ? parsePurgeEntityId(entityId) : null;
+  // The slug lives in the warning embed's footer, not the customId (too long
+  // for the 100-char budget); entityId carries only the channelId.
+  const personalitySlug = parsePurgeSlugFromFooter(interaction.message.embeds[0]?.footer?.text);
 
-  if (entityInfo === null) {
-    logger.warn({ entityId }, 'Failed to parse entityId');
+  if (entityId === undefined || personalitySlug === null) {
+    logger.warn({ entityId }, 'Purge confirm missing channelId or slug footer');
     await interaction.update({
       content: 'Error: Invalid entity ID format.',
       embeds: [],
@@ -194,10 +199,7 @@ async function handlePurgeConfirm(
 
   // Display-only: the modal's routing customId is derived from THIS button's
   // customId inside the factory, so no source/operation is re-stated here.
-  await handleDestructiveConfirmButton(
-    interaction,
-    hardDeleteModalDisplay(entityInfo.personalitySlug)
-  );
+  await handleDestructiveConfirmButton(interaction, hardDeleteModalDisplay(personalitySlug));
 }
 
 /**

--- a/services/bot-client/src/commands/history/purge.test.ts
+++ b/services/bot-client/src/commands/history/purge.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { handlePurgeHistory, parsePurgeEntityId } from './purge.js';
+import { handlePurgeHistory, parsePurgeSlugFromFooter } from './purge.js';
 
 // Mock common-types
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -30,7 +30,8 @@ const mockBuildDestructiveWarning = vi.fn();
 const mockCreateHardDeleteConfig = vi.fn(() => ({
   source: 'history',
   operation: 'history-purge',
-  entityId: 'lilith|channel-123',
+  entityId: 'channel-123',
+  footerText: 'slug:lilith',
 }));
 vi.mock('../../utils/confirmation/confirmDestructive.js', () => ({
   buildDestructiveWarning: (...args: unknown[]) =>
@@ -99,7 +100,8 @@ describe('handlePurgeHistory', () => {
       additionalWarning: expect.stringContaining('PERMANENT'),
       source: 'history',
       operation: 'history-purge',
-      entityId: 'lilith|channel-123',
+      entityId: 'channel-123',
+      footerText: 'slug:lilith',
     });
     // The warning must state the TRUE scope (persona-scoped) — the old copy
     // claimed "All messages in this channel" while deleting only the caller's.
@@ -117,13 +119,19 @@ describe('handlePurgeHistory', () => {
     });
   });
 
-  it('should include channelId in entityId', async () => {
-    const context = createMockContext('test-personality', 'channel-456');
+  it('carries ONLY the channelId in entityId; the slug rides the footer', async () => {
+    // The slug can reach SLUG_MAX_LENGTH (50) — in the customId it blew
+    // Discord's 100-char budget and made setCustomId throw. Keeping the
+    // customId payload to the snowflake makes the overflow structurally
+    // impossible; the slug travels via the embed footer instead.
+    const longSlug = 'a'.repeat(50);
+    const context = createMockContext(longSlug, 'channel-456');
     await handlePurgeHistory(context);
 
     expect(mockCreateHardDeleteConfig).toHaveBeenCalledWith(
       expect.objectContaining({
-        entityId: 'test-personality|channel-456',
+        entityId: 'channel-456',
+        footerText: `slug:${longSlug}`,
       })
     );
   });
@@ -152,55 +160,30 @@ describe('handlePurgeHistory', () => {
   });
 });
 
-describe('parsePurgeEntityId', () => {
-  it('should parse valid entityId', () => {
-    const result = parsePurgeEntityId('lilith|channel-123');
-
-    expect(result).toEqual({
-      personalitySlug: 'lilith',
-      channelId: 'channel-123',
-    });
+describe('parsePurgeSlugFromFooter', () => {
+  it('parses the slug out of a well-formed footer', () => {
+    expect(parsePurgeSlugFromFooter('slug:lilith')).toBe('lilith');
   });
 
-  it('should handle entityId with complex personality slug', () => {
-    const result = parsePurgeEntityId('my-custom-personality|123456789012345678');
-
-    expect(result).toEqual({
-      personalitySlug: 'my-custom-personality',
-      channelId: '123456789012345678',
-    });
+  it('handles complex slugs, including ones containing colons after the prefix', () => {
+    expect(parsePurgeSlugFromFooter('slug:my-custom-personality')).toBe('my-custom-personality');
+    expect(parsePurgeSlugFromFooter('slug:a:b')).toBe('a:b');
   });
 
-  it('should return null for invalid entityId (no separator)', () => {
-    const result = parsePurgeEntityId('lilith-channel-123');
-
-    expect(result).toBeNull();
+  it('round-trips a maximum-length slug intact', () => {
+    const longSlug = 'a'.repeat(50);
+    expect(parsePurgeSlugFromFooter(`slug:${longSlug}`)).toBe(longSlug);
   });
 
-  it('should return null for invalid entityId (too many separators)', () => {
-    const result = parsePurgeEntityId('lilith|channel|123');
-
-    expect(result).toBeNull();
+  it('returns null for a missing footer (fail closed)', () => {
+    expect(parsePurgeSlugFromFooter(undefined)).toBeNull();
   });
 
-  it('should return null for empty entityId', () => {
-    const result = parsePurgeEntityId('');
-
-    expect(result).toBeNull();
+  it('returns null for a footer without the slug prefix', () => {
+    expect(parsePurgeSlugFromFooter('lilith')).toBeNull();
   });
 
-  it('should return null for entityId with only separator', () => {
-    const result = parsePurgeEntityId('|');
-
-    expect(result).toEqual({
-      personalitySlug: '',
-      channelId: '',
-    });
-  });
-
-  it('should handle single-part entityId', () => {
-    const result = parsePurgeEntityId('lilith');
-
-    expect(result).toBeNull();
+  it('returns null for an empty slug after the prefix', () => {
+    expect(parsePurgeSlugFromFooter('slug:')).toBeNull();
   });
 });

--- a/services/bot-client/src/commands/history/purge.ts
+++ b/services/bot-client/src/commands/history/purge.ts
@@ -62,9 +62,13 @@ export async function handlePurgeHistory(context: DeferredCommandContext): Promi
       // from before a deploy simply stops routing, never mis-executes.
       source: 'history',
       operation: 'history-purge',
-      // Include channelId in entityId so button handler knows which channel
-      // Use | delimiter since :: is used by customId parsing
-      entityId: `${personalitySlug}|${channelId}`,
+      // Only the channelId (a ≤20-char snowflake) rides the customId — the
+      // slug can reach SLUG_MAX_LENGTH (50), which blows Discord's 100-char
+      // customId budget and made setCustomId THROW for long-slugged
+      // characters. The slug rides the embed footer instead (the shapes
+      // pattern) and is read back from the parent message in the handlers.
+      entityId: channelId,
+      footerText: `slug:${personalitySlug}`,
     });
 
     // Build and send the warning
@@ -87,19 +91,16 @@ export async function handlePurgeHistory(context: DeferredCommandContext): Promi
 }
 
 /**
- * Parse the entityId back to personalitySlug and channelId
- * Uses | as delimiter to avoid conflict with :: in customId parsing
+ * Read the personality slug back out of the warning embed's footer
+ * (`slug:{slug}`), where handlePurgeHistory stashed it — the slug is too long
+ * for the customId budget. Null on a missing or malformed footer: the flow
+ * FAILS CLOSED, consistent with the minutes-lived customId contract.
  */
-export function parsePurgeEntityId(entityId: string): {
-  personalitySlug: string;
-  channelId: string;
-} | null {
-  const parts = entityId.split('|');
-  if (parts.length !== 2) {
+export function parsePurgeSlugFromFooter(footerText: string | undefined): string | null {
+  const prefix = 'slug:';
+  if (footerText?.startsWith(prefix) !== true) {
     return null;
   }
-  return {
-    personalitySlug: parts[0],
-    channelId: parts[1],
-  };
+  const slug = footerText.slice(prefix.length);
+  return slug.length > 0 ? slug : null;
 }

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.test.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.test.ts
@@ -133,6 +133,48 @@ describe('buildDestructiveWarning', () => {
       'This will permanently delete your conversation history.'
     );
   });
+
+  it('builds within the customId budget for a MAX-length slug riding the footer', () => {
+    // Regression pin for the history-purge overflow: a slug can reach
+    // SLUG_MAX_LENGTH (50). Embedded in entityId it blew Discord's 100-char
+    // customId cap and setCustomId THREW synchronously. The escape hatch is
+    // structural: only the snowflake channelId rides the customId; the slug
+    // rides footerText.
+    const longSlug = 'a'.repeat(50);
+    const config = createHardDeleteConfig({
+      entityType: 'conversation history',
+      entityName: longSlug,
+      additionalWarning: 'warning',
+      source: 'history',
+      operation: 'history-purge',
+      entityId: '123456789012345678901', // widest snowflake shape
+      footerText: `slug:${longSlug}`,
+    });
+
+    const result = buildDestructiveWarning(config);
+
+    const customIds = result.components[0].components.map(
+      b => (b.data as APIButtonComponentWithCustomId).custom_id
+    );
+    for (const id of customIds) {
+      expect(id.length).toBeLessThanOrEqual(100);
+    }
+    expect(result.embeds[0].data.footer?.text).toBe(`slug:${longSlug}`);
+  });
+
+  it('THROWS when a max-length slug is embedded in the entityId (the budget is real)', () => {
+    // Documents the constraint the footer pattern exists for: discord.js
+    // validates the 100-char cap at setCustomId time. If this ever stops
+    // throwing, the budget assumption changed — revisit the escape hatch.
+    const longSlug = 'a'.repeat(50);
+    expect(() =>
+      buildDestructiveWarning({
+        ...testConfig,
+        operation: 'history-purge',
+        entityId: `${longSlug}|123456789012345678901`,
+      })
+    ).toThrow();
+  });
 });
 
 describe('buildConfirmationModal', () => {

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.ts
@@ -437,6 +437,13 @@ interface HardDeleteConfigOptions {
   /** Entity identifier. */
   entityId?: string;
   /**
+   * Optional embed footer — the customId-overflow escape hatch. State too
+   * long for the 100-char customId budget (e.g. a personality slug, which
+   * can reach SLUG_MAX_LENGTH) rides here and is read back from
+   * `interaction.message` in the button/modal handlers.
+   */
+  footerText?: string;
+  /**
    * Override the confirmation phrase. Wire-contract phrases (gateway-validated
    * handshakes) MUST pass their exact server-side phrase here. When omitted,
    * the phrase is the dynamic `DELETE {ENTITY NAME}` form (spec §3.5), falling
@@ -476,12 +483,14 @@ export function hardDeleteModalDisplay(
 export function createHardDeleteConfig(
   options: HardDeleteConfigOptions
 ): DestructiveConfirmationConfig {
-  const { entityType, entityName, additionalWarning, source, operation, entityId } = options;
+  const { entityType, entityName, additionalWarning, source, operation, entityId, footerText } =
+    options;
   const display = hardDeleteModalDisplay(entityName, options.confirmationPhrase);
   return {
     source,
     operation,
     entityId,
+    footerText,
     warningTitle: `Delete ${entityType}`,
     warningDescription:
       `Are you sure you want to **permanently delete** ${entityType} for **${entityName}**?\n\n` +

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.ts
@@ -12,7 +12,8 @@
  *   parent message's `interactionMetadata` (the original slash invoker);
  *   other users' clicks are rejected with an ephemeral notice. The id is NOT
  *   carried in the customId — a snowflake would eat the 100-char budget that
- *   entityId needs (hard-delete carries `slug|channelId`).
+ *   entityId needs. State too long for that budget (e.g. a personality slug)
+ *   rides `footerText` and is read back from the parent message.
  * - The modal's customId is DERIVED from the confirm button's own customId —
  *   a re-built config can never route the modal to a different command than
  *   the button it came from (the voice-clear drift class).

--- a/services/bot-client/src/utils/customIds.ts
+++ b/services/bot-client/src/utils/customIds.ts
@@ -240,12 +240,15 @@ export const PresetCustomIds = {
  * Format: {source}::destructive::{action}::{operation}::{entityId?}
  * The source segment routes the customId to the source command's handlers.
  * Invoker ownership is NOT carried here — a Discord snowflake (~19 chars)
- * would eat the 100-char customId budget that entityId needs (hard-delete
- * carries `slug|channelId`); the Tier-B flow asserts ownership from the
- * parent message's `interactionMetadata` instead.
+ * would eat the 100-char customId budget that entityId needs; the Tier-B
+ * flow asserts ownership from the parent message's `interactionMetadata`
+ * instead.
  *
- * entityId is a single `::`-free segment; flows needing composite state pack
- * it with a `|` sub-delimiter (e.g. hard-delete's `{slug}|{channelId}`).
+ * entityId is a single `::`-free segment. Keep it SHORT (a snowflake, a
+ * fixed token): unbounded values (e.g. a personality slug, up to 50 chars)
+ * blow the 100-char cap and make setCustomId throw — such state rides the
+ * warning embed's `footerText` and is read back from the parent message
+ * (see history-purge's `parsePurgeSlugFromFooter`).
  */
 export interface DestructiveParseResult {
   /** The source command (e.g., 'history', 'character') */


### PR DESCRIPTION
## Summary

TASK-290: the history-purge customId carried `{slug}|{channelId}` as entityId. A slug can reach `SLUG_MAX_LENGTH` (50), which blows Discord's 100-char customId cap — `setCustomId` **threw synchronously** for long-slugged characters, so `/history purge` rendered the generic error instead of the warning. Invisible until someone owns a 30+-char slug (the throw lands in the handler's catch, so no crash — just a dead command for that character).

## Design call: footer pattern, not the token handshake

The task sketched a server-side token handshake (`issuePurgeToken` precedent). Reading the code changed the target: the destructive-confirmation factory **already documents `footerText` as the customId-overflow escape hatch**, and the shapes commands established the `slug:{slug}` embed-footer pattern for exactly this (04-discord). The footer approach needs no new server state, is restart-safe, and makes the overflow structurally impossible — only the ≤20-char channelId snowflake rides the customId.

## Changes

- `handlePurgeHistory`: `entityId: channelId` only; `footerText: slug:{slug}`.
- `createHardDeleteConfig` gains `footerText` passthrough (the underlying `DestructiveConfirmationConfig` already had it).
- Both handlers (confirm button, modal submit) read the slug back from the parent message's footer via the new `parsePurgeSlugFromFooter`; missing/malformed footer **fails closed** with the same validation error as before, consistent with the minutes-lived customId contract.
- `parsePurgeEntityId` retired.

## Tests

- `confirmDestructive.test.ts` regression pins run the **real** builder: a max-length slug via the footer stays within budget with the footer intact, and the OLD slug-in-entityId shape **still throws** — documenting the constraint the pattern exists for (if discord.js ever stops validating, that test tells us the budget assumption changed).
- `parsePurgeSlugFromFooter`: 6 tests incl. 50-char round-trip and fail-closed nulls.
- `index.test.ts` handlers updated to the footer flow (slug read asserted, missing-footer error paths for both button and modal).

## Verification

- History suite + confirmDestructive: 98/98
- `pnpm test` 26 tasks green; `pnpm quality` green; pre-push green

Closes TASK-290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)