### PR TITLE
fix(ai-worker): free-model router always reports vision-capable

### DIFF
--- a/services/ai-worker/src/services/ModelCapabilityChecker.test.ts
+++ b/services/ai-worker/src/services/ModelCapabilityChecker.test.ts
@@ -68,6 +68,29 @@ describe('ModelCapabilityChecker', () => {
   });
 
   describe('modelSupportsVision', () => {
+    describe('the free-model router (authoritative override)', () => {
+      it('reports vision-capable even on a full catalog cache-miss', async () => {
+        // Regression: selectVisionModel assigns 'openrouter/free' directly as
+        // the free vision fallback, but no VISION_MODEL_PATTERNS substring
+        // matches it — pre-fix, Redis-down + pattern-fallback misreported
+        // the designed-in vision fallback as non-vision.
+        vi.mocked(mockRedis.get).mockResolvedValue(null);
+
+        expect(await modelSupportsVision('openrouter/free', mockRedis)).toBe(true);
+      });
+
+      it('does not consult the catalog at all — the override is by design, not data', async () => {
+        // A router catalog row (if one ever appears) describes the router,
+        // not the vision-capable models it routes to; the answer must not
+        // depend on it.
+        vi.mocked(mockRedis.get).mockResolvedValue(null);
+
+        await modelSupportsVision('openrouter/free', mockRedis);
+
+        expect(mockRedis.get).not.toHaveBeenCalled();
+      });
+    });
+
     describe('with Redis cache available', () => {
       it('should return true for models with image input modality', async () => {
         const models = [

--- a/services/ai-worker/src/services/ModelCapabilityChecker.ts
+++ b/services/ai-worker/src/services/ModelCapabilityChecker.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Redis } from 'ioredis';
-import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { AI_DEFAULTS, FREE_ROUTER_MODEL } from '@tzurot/common-types/constants/ai';
 import { REDIS_KEY_PREFIXES } from '@tzurot/common-types/constants/queue';
 import { type OpenRouterModel } from '@tzurot/common-types/types/ai';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -155,6 +155,15 @@ async function getCapabilities(modelId: string, redis: Redis): Promise<CachedCap
  * @returns true if the model supports image input
  */
 export async function modelSupportsVision(modelId: string, redis: Redis): Promise<boolean> {
+  // The free-model router is vision-capable BY DESIGN — selectVisionModel
+  // assigns it directly as the guest/free vision fallback, so a capability
+  // query must never misreport it. Authoritative override, not a fallback:
+  // no VISION_MODEL_PATTERNS substring matches 'openrouter/free', and the
+  // router's own catalog row (if any) wouldn't describe the vision-capable
+  // models it routes to.
+  if (normalizeModelId(modelId) === FREE_ROUTER_MODEL) {
+    return true;
+  }
   const capabilities = await getCapabilities(modelId, redis);
   return capabilities.supportsVision;
 }


### PR DESCRIPTION
## Summary

TASK-194: `modelSupportsVision('openrouter/free')` could misreport non-vision on a catalog cache-miss — no `VISION_MODEL_PATTERNS` substring matches the router id, so Redis-down + pattern-fallback returned `false` for the very model the system assigns as the free vision fallback.

**Not a user-visible bug today** (re-verified per the task's own analysis): `selectVisionModel` assigns the free fallback directly without a capability gate. The fix closes the latent misreport before any future path starts gating on the capability query.

## Freshness note

The task's premise cited `MODEL_DEFAULTS.VISION_FALLBACK_FREE`; that constant has since become `FREE_ROUTER_MODEL` in `constants/ai.ts` (with the free-chat default now runtime-configurable via system settings). The premise itself held — the fix targets the current constant.

## Change

Authoritative early-return in `modelSupportsVision` when the normalized id equals `FREE_ROUTER_MODEL`, **before** the in-memory cache, Redis catalog, and pattern fallback — a router catalog row (if OpenRouter ever lists one) would describe the router, not the vision-capable models it routes to, so the answer must not depend on catalog data. Reasoning/context-length queries are deliberately untouched (no designed-in guarantee exists for those).

## Tests (both verified failing pre-fix via stash)

- vision-capable on a full catalog cache-miss (the misreport case)
- no catalog consultation at all (`redis.get` never called) — pins that the override is by design, not data

## Verification

- `ModelCapabilityChecker.test.ts`: 39/39
- `pnpm test` 26 tasks green (one flaky run retried clean), `pnpm quality` green, pre-push green

Closes TASK-194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)