### PR TITLE
fix(api-gateway): bound the reconcile-off-db sweep to batches

### DIFF
--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -833,7 +833,8 @@ describe('RetentionPurgeResponseSchema', () => {
 describe('RetentionReconcileOffDbResponseSchema', () => {
   it('accepts a zero-work sweep (the common case)', () => {
     expect(
-      RetentionReconcileOffDbResponseSchema.safeParse({ settled: 0, stillFailing: 0 }).success
+      RetentionReconcileOffDbResponseSchema.safeParse({ settled: 0, stillFailing: 0, remaining: 0 })
+        .success
     ).toBe(true);
   });
 
@@ -843,7 +844,11 @@ describe('RetentionReconcileOffDbResponseSchema', () => {
 
   it('rejects negative counters', () => {
     expect(
-      RetentionReconcileOffDbResponseSchema.safeParse({ settled: 0, stillFailing: -1 }).success
+      RetentionReconcileOffDbResponseSchema.safeParse({
+        settled: 0,
+        stillFailing: -1,
+        remaining: 0,
+      }).success
     ).toBe(false);
   });
 });

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -407,13 +407,18 @@ export type RetentionPurgeResponse = z.infer<typeof RetentionPurgeResponseSchema
 // ============================================================================
 
 /**
- * Replays the off-DB cleanup (avatar unlink) for every audit-ledger row whose
- * reconciliation is still owed. Idempotent — an already-settled ledger is a
- * zero-row no-op — so it is safe to run at the end of every purge run.
+ * Replays the off-DB cleanup (avatar unlink) for audit-ledger rows whose
+ * reconciliation is still owed, ONE BOUNDED BATCH per call — a backlog must
+ * not run the whole queue inside one ~60s HTTP request. Idempotent — an
+ * already-settled ledger is a zero-row no-op — so it is safe to run at the
+ * end of every purge run. `remaining` counts rows the call did NOT attempt
+ * (rows that failed in-batch stay queued but are not "remaining"); the CLI
+ * loops while it is nonzero.
  */
 export const RetentionReconcileOffDbResponseSchema = z.object({
   settled: z.number().int().nonnegative(),
   stillFailing: z.number().int().nonnegative(),
+  remaining: z.number().int().nonnegative(),
 });
 
 // ============================================================================

--- a/packages/tooling/src/retention/purge.test.ts
+++ b/packages/tooling/src/retention/purge.test.ts
@@ -204,6 +204,24 @@ describe('retentionPurge', () => {
     expect(reconcileMock).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces off-DB rows the bounded reconcile did not attempt', async () => {
+    // The endpoint sweeps one batch; a bigger backlog must be reported, not
+    // silently under-drained (it self-heals next run, but say so).
+    previewMock.mockResolvedValue({ ok: true, data: cohort('900000000000000001') });
+    purgeMock.mockResolvedValue(PURGED('900000000000000001'));
+    reconcileMock.mockResolvedValue({
+      ok: true,
+      data: { settled: 50, stillFailing: 0, remaining: 30 },
+    });
+    const logSpy = vi.mocked(console.log);
+
+    await retentionPurge({ env: 'dev' });
+
+    const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(output).toContain('not attempted: 30');
+    expect(output).toContain('reconcile-off-db');
+  });
+
   it('does nothing (and does not prompt) when the cohort is empty', async () => {
     previewMock.mockResolvedValue({
       ok: true,

--- a/packages/tooling/src/retention/purge.test.ts
+++ b/packages/tooling/src/retention/purge.test.ts
@@ -67,7 +67,10 @@ describe('retentionPurge', () => {
       retentionPurge: purgeMock,
       retentionReconcileOffDb: reconcileMock,
     });
-    reconcileMock.mockResolvedValue({ ok: true, data: { settled: 0, stillFailing: 0 } });
+    reconcileMock.mockResolvedValue({
+      ok: true,
+      data: { settled: 0, stillFailing: 0, remaining: 0 },
+    });
     confirmMock.mockResolvedValue(undefined);
   });
 

--- a/packages/tooling/src/retention/purge.ts
+++ b/packages/tooling/src/retention/purge.ts
@@ -253,6 +253,16 @@ export async function retentionPurge(options: RetentionPurgeOptions): Promise<vo
       )
     );
   }
+  // The endpoint sweeps one bounded batch; a backlog beyond it self-heals on
+  // the next run, but say so instead of silently under-reporting the queue.
+  if (reconciled.ok && reconciled.data.remaining > 0) {
+    console.log(
+      chalk.yellow(
+        `  off-DB rows not attempted: ${String(reconciled.data.remaining)} — ` +
+          'run retention:reconcile-off-db to drain the rest.'
+      )
+    );
+  }
 
   renderTally(tally);
 }

--- a/packages/tooling/src/retention/reconcile-off-db.test.ts
+++ b/packages/tooling/src/retention/reconcile-off-db.test.ts
@@ -89,6 +89,23 @@ describe('retentionReconcileOffDb', () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it('reports cap-exhaustion distinctly — no phantom "failures above" advice', async () => {
+    // A >1000-row backlog with ZERO failures exhausts the per-run cap; the
+    // message must say so instead of pointing at failures that don't exist.
+    reconcileMock.mockResolvedValue({
+      ok: true,
+      data: { settled: 50, stillFailing: 0, remaining: 500 },
+    });
+
+    await retentionReconcileOffDb({ env: 'dev' });
+
+    expect(reconcileMock).toHaveBeenCalledTimes(20); // MAX_BATCHES
+    const output = logged.join('\n');
+    expect(output).toContain('batch cap');
+    expect(output).not.toContain('failures above');
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it('stops looping on an in-batch failure and reports the unattempted rest', async () => {
     // Failed rows stay at the head of the queue — looping past a failing
     // batch would burn iterations re-attempting the same rows.

--- a/packages/tooling/src/retention/reconcile-off-db.test.ts
+++ b/packages/tooling/src/retention/reconcile-off-db.test.ts
@@ -34,7 +34,10 @@ describe('retentionReconcileOffDb', () => {
   });
 
   it('reports an empty queue as an explicit all-clear', async () => {
-    reconcileMock.mockResolvedValue({ ok: true, data: { settled: 0, stillFailing: 0 } });
+    reconcileMock.mockResolvedValue({
+      ok: true,
+      data: { settled: 0, stillFailing: 0, remaining: 0 },
+    });
 
     await retentionReconcileOffDb({ env: 'dev' });
 
@@ -43,7 +46,10 @@ describe('retentionReconcileOffDb', () => {
   });
 
   it('reports what it settled', async () => {
-    reconcileMock.mockResolvedValue({ ok: true, data: { settled: 3, stillFailing: 0 } });
+    reconcileMock.mockResolvedValue({
+      ok: true,
+      data: { settled: 3, stillFailing: 0, remaining: 0 },
+    });
 
     await retentionReconcileOffDb({ env: 'dev' });
 
@@ -51,7 +57,10 @@ describe('retentionReconcileOffDb', () => {
   });
 
   it('surfaces rows that are still failing rather than reporting success', async () => {
-    reconcileMock.mockResolvedValue({ ok: true, data: { settled: 1, stillFailing: 2 } });
+    reconcileMock.mockResolvedValue({
+      ok: true,
+      data: { settled: 1, stillFailing: 2, remaining: 0 },
+    });
 
     await retentionReconcileOffDb({ env: 'prod' });
 
@@ -64,6 +73,37 @@ describe('retentionReconcileOffDb', () => {
     await retentionReconcileOffDb({ env: 'prod' });
 
     expect(process.exitCode).toBe(1);
+  });
+
+  it('loops batches while the endpoint reports unattempted rows, summing totals', async () => {
+    // The endpoint sweeps one bounded batch per call; the CLI walks the queue.
+    reconcileMock
+      .mockResolvedValueOnce({ ok: true, data: { settled: 50, stillFailing: 0, remaining: 70 } })
+      .mockResolvedValueOnce({ ok: true, data: { settled: 50, stillFailing: 0, remaining: 20 } })
+      .mockResolvedValueOnce({ ok: true, data: { settled: 20, stillFailing: 0, remaining: 0 } });
+
+    await retentionReconcileOffDb({ env: 'dev' });
+
+    expect(reconcileMock).toHaveBeenCalledTimes(3);
+    expect(logged.join('\n')).toContain('120');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('stops looping on an in-batch failure and reports the unattempted rest', async () => {
+    // Failed rows stay at the head of the queue — looping past a failing
+    // batch would burn iterations re-attempting the same rows.
+    reconcileMock.mockResolvedValue({
+      ok: true,
+      data: { settled: 10, stillFailing: 2, remaining: 40 },
+    });
+
+    await retentionReconcileOffDb({ env: 'prod' });
+
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+    const output = logged.join('\n');
+    expect(output).toContain('still failing');
+    expect(output).toContain('not attempted');
+    expect(output).toContain('40');
   });
 
   it('stops before any gateway call when credentials cannot be resolved', async () => {

--- a/packages/tooling/src/retention/reconcile-off-db.ts
+++ b/packages/tooling/src/retention/reconcile-off-db.ts
@@ -45,6 +45,7 @@ export async function retentionReconcileOffDb(options: RetentionReconcileOptions
   let settled = 0;
   let stillFailing = 0;
   let remaining = 0;
+  let sawFailure = false;
   for (let batch = 0; batch < MAX_BATCHES; batch++) {
     const result = await client.retentionReconcileOffDb();
     if (!result.ok) {
@@ -55,7 +56,10 @@ export async function retentionReconcileOffDb(options: RetentionReconcileOptions
     settled += result.data.settled;
     stillFailing += result.data.stillFailing;
     remaining = result.data.remaining;
-    if (remaining === 0 || result.data.stillFailing > 0) {
+    if (result.data.stillFailing > 0) {
+      sawFailure = true;
+    }
+    if (remaining === 0 || sawFailure) {
       break;
     }
     console.log(chalk.dim(`  …batch settled ${String(result.data.settled)}, continuing`));
@@ -76,9 +80,15 @@ export async function retentionReconcileOffDb(options: RetentionReconcileOptions
     );
   }
   if (remaining > 0) {
+    // Two distinct reasons rows went unattempted: the loop stopped on an
+    // in-batch failure, or a very large backlog exhausted the per-run cap
+    // with zero failures — the advice differs.
     console.log(
       chalk.yellow(
-        `  not attempted: ${String(remaining)} — re-run after resolving the failures above.`
+        sawFailure
+          ? `  not attempted: ${String(remaining)} — re-run after resolving the failures above.`
+          : `  not attempted: ${String(remaining)} — hit the per-run batch cap; re-run to ` +
+              'continue draining the backlog.'
       )
     );
   }

--- a/packages/tooling/src/retention/reconcile-off-db.ts
+++ b/packages/tooling/src/retention/reconcile-off-db.ts
@@ -36,14 +36,31 @@ export async function retentionReconcileOffDb(options: RetentionReconcileOptions
     return;
   }
 
-  const result = await client.retentionReconcileOffDb();
-  if (!result.ok) {
-    console.error(chalk.red(`\nOff-DB reconciliation failed (${result.kind}): ${result.error}`));
-    process.exitCode = 1;
-    return;
+  // The endpoint sweeps ONE bounded batch per call; loop while it reports
+  // unattempted rows. Stop on any in-batch failure — the head of the queue
+  // stays pending on failure, so looping past a failing batch would burn
+  // iterations re-attempting the same rows (the operator investigates via
+  // gateway logs first). The iteration cap is a plain runaway backstop.
+  const MAX_BATCHES = 20;
+  let settled = 0;
+  let stillFailing = 0;
+  let remaining = 0;
+  for (let batch = 0; batch < MAX_BATCHES; batch++) {
+    const result = await client.retentionReconcileOffDb();
+    if (!result.ok) {
+      console.error(chalk.red(`\nOff-DB reconciliation failed (${result.kind}): ${result.error}`));
+      process.exitCode = 1;
+      return;
+    }
+    settled += result.data.settled;
+    stillFailing += result.data.stillFailing;
+    remaining = result.data.remaining;
+    if (remaining === 0 || result.data.stillFailing > 0) {
+      break;
+    }
+    console.log(chalk.dim(`  …batch settled ${String(result.data.settled)}, continuing`));
   }
 
-  const { settled, stillFailing } = result.data;
   if (settled + stillFailing === 0) {
     console.log(chalk.green('\nNothing owed — every purge has completed its off-DB cleanup.'));
     return;
@@ -55,6 +72,13 @@ export async function retentionReconcileOffDb(options: RetentionReconcileOptions
       chalk.red(
         `  still failing: ${String(stillFailing)} — check the gateway logs for the ` +
           'underlying avatar-unlink error; the ledger keeps them queued for the next run.'
+      )
+    );
+  }
+  if (remaining > 0) {
+    console.log(
+      chalk.yellow(
+        `  not attempted: ${String(remaining)} — re-run after resolving the failures above.`
       )
     );
   }

--- a/services/api-gateway/src/routes/conformance/fixtures/internal.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/internal.ts
@@ -342,7 +342,7 @@ export const internalFixtures: Record<string, ConformanceEntry> = {
 
   retentionReconcileOffDb: {
     // An empty audit ledger is the steady state: the sweep finds nothing owed
-    // and returns { settled: 0, stillFailing: 0 } — zero seed needed.
+    // and returns { settled: 0, stillFailing: 0, remaining: 0 } — zero seed needed.
   },
 
   getModels: {

--- a/services/api-gateway/src/routes/internal/retentionReconcileOffDb.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionReconcileOffDb.test.ts
@@ -26,19 +26,19 @@ function createMockReqRes() {
 
 describe('POST /internal/retention/reconcile-off-db', () => {
   it('returns the sweep tally in the manifest-declared shape', async () => {
-    reconcileMock.mockResolvedValue({ settled: 3, stillFailing: 1 });
+    reconcileMock.mockResolvedValue({ settled: 3, stillFailing: 1, remaining: 0 });
     const { req, res } = createMockReqRes();
 
     await handleRetentionReconcileOffDb({} as RouteDeps)(req, res, vi.fn());
 
     expect(res.status).toHaveBeenCalledWith(200);
     const payload = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(payload).toEqual({ settled: 3, stillFailing: 1 });
+    expect(payload).toEqual({ settled: 3, stillFailing: 1, remaining: 0 });
     expect(RetentionReconcileOffDbResponseSchema.safeParse(payload).success).toBe(true);
   });
 
   it('is a 200 no-op on an empty ledger — the purge CLI calls it every run', async () => {
-    reconcileMock.mockResolvedValue({ settled: 0, stillFailing: 0 });
+    reconcileMock.mockResolvedValue({ settled: 0, stillFailing: 0, remaining: 0 });
     const { req, res } = createMockReqRes();
 
     await handleRetentionReconcileOffDb({} as RouteDeps)(req, res, vi.fn());
@@ -47,6 +47,7 @@ describe('POST /internal/retention/reconcile-off-db', () => {
     expect((res.json as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual({
       settled: 0,
       stillFailing: 0,
+      remaining: 0,
     });
   });
 });

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { RetentionPurgeService, BREAKER_HARD_FRACTION } from './RetentionPurgeService.js';
+import {
+  RetentionPurgeService,
+  BREAKER_HARD_FRACTION,
+  RECONCILE_BATCH_SIZE,
+} from './RetentionPurgeService.js';
 
 const mockErase = vi.hoisted(() => vi.fn());
 const mockCleanupOffDb = vi.hoisted(() => vi.fn());
@@ -334,5 +338,74 @@ describe('RetentionPurgeService.purgeUser', () => {
     });
 
     expect(mockCreateLog).not.toHaveBeenCalled();
+  });
+});
+
+describe('RetentionPurgeService.reconcileOffDb', () => {
+  function makeReconcilePrisma(opts: { totalPending: number; rows: unknown[] }) {
+    const count = vi.fn().mockResolvedValue(opts.totalPending);
+    const findMany = vi.fn().mockResolvedValue(opts.rows);
+    const update = vi.fn().mockResolvedValue({});
+    return {
+      prisma: { retentionPurgeLog: { count, findMany, update } } as unknown as PrismaClient,
+      count,
+      findMany,
+      update,
+    };
+  }
+
+  const row = (n: number) => ({
+    id: `audit-${String(n)}`,
+    targetDiscordId: `90000000000000000${String(n)}`,
+    offDbPending: { characterSlugs: [`slug-${String(n)}`] },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sweeps ONE bounded batch and reports the unattempted rows as remaining', async () => {
+    // A long-unreconciled backlog must not run the whole queue in one ~60s
+    // HTTP request — the per-user purge's own lesson (D2).
+    const { prisma, findMany } = makeReconcilePrisma({
+      totalPending: 120,
+      rows: Array.from({ length: RECONCILE_BATCH_SIZE }, (_, i) => row(i)),
+    });
+    mockCleanupOffDb.mockResolvedValue(true);
+
+    const result = await new RetentionPurgeService({ prisma }).reconcileOffDb();
+
+    // The bound crosses the seam into the query.
+    expect(findMany.mock.calls[0][0].take).toBe(RECONCILE_BATCH_SIZE);
+    expect(result).toEqual({
+      settled: RECONCILE_BATCH_SIZE,
+      stillFailing: 0,
+      remaining: 120 - RECONCILE_BATCH_SIZE,
+    });
+  });
+
+  it('counts an in-batch failure as stillFailing, not remaining', async () => {
+    // Attempted-but-failed rows stay queued for a future run, but calling
+    // them "remaining" would make the CLI loop re-attempt them immediately.
+    const { prisma, update } = makeReconcilePrisma({
+      totalPending: 2,
+      rows: [row(1), row(2)],
+    });
+    mockCleanupOffDb.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const result = await new RetentionPurgeService({ prisma }).reconcileOffDb();
+
+    expect(result).toEqual({ settled: 1, stillFailing: 1, remaining: 0 });
+    // Both attempts settled their ledger outcome.
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a zero-work no-op on an empty queue', async () => {
+    const { prisma } = makeReconcilePrisma({ totalPending: 0, rows: [] });
+
+    const result = await new RetentionPurgeService({ prisma }).reconcileOffDb();
+
+    expect(result).toEqual({ settled: 0, stillFailing: 0, remaining: 0 });
+    expect(mockCleanupOffDb).not.toHaveBeenCalled();
   });
 });

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.ts
@@ -25,7 +25,12 @@ import {
   type PurgeCohortRow,
   type PurgeReason,
 } from './eligibility.js';
-import { findPendingOffDbRows, recordPurgeFailure, settleOffDb } from './purgeAudit.js';
+import {
+  countPendingOffDbRows,
+  findPendingOffDbRows,
+  recordPurgeFailure,
+  settleOffDb,
+} from './purgeAudit.js';
 
 const logger = createLogger('RetentionPurgeService');
 
@@ -35,6 +40,14 @@ const logger = createLogger('RetentionPurgeService');
  * decides).
  */
 export const BREAKER_WARN_FRACTION = 0.15;
+
+/**
+ * Max ledger rows one reconcile-off-db call attempts. Each row is one avatar
+ * unlink; 50 keeps the worst-case call comfortably inside the platform's
+ * ~60s request timeout while clearing any realistic backlog in one batch
+ * (the queue is normally empty; the CLI loops on `remaining`).
+ */
+export const RECONCILE_BATCH_SIZE = 50;
 
 /**
  * Cohort share at which the purge REFUSES to run without an explicit
@@ -261,11 +274,15 @@ export class RetentionPurgeService {
   }
 
   /**
-   * Retry the off-DB cleanup for every ledger row that still owes it (D15).
-   * Returns how many rows were settled and how many are still failing.
+   * Retry the off-DB cleanup for ledger rows that still owe it (D15), bounded
+   * to one batch per call so a long-unreconciled backlog can't run the whole
+   * queue inside one HTTP request (the per-user purge's own lesson).
+   * `remaining` counts the rows this call did NOT attempt — the CLI loops on
+   * it; rows that failed IN this batch stay queued but are not "remaining".
    */
-  async reconcileOffDb(): Promise<{ settled: number; stillFailing: number }> {
-    const pending = await findPendingOffDbRows(this.prisma);
+  async reconcileOffDb(): Promise<{ settled: number; stillFailing: number; remaining: number }> {
+    const totalPending = await countPendingOffDbRows(this.prisma);
+    const pending = await findPendingOffDbRows(this.prisma, RECONCILE_BATCH_SIZE);
     const eraser = new AccountEraserService(this.deps);
     let settled = 0;
     let stillFailing = 0;
@@ -285,7 +302,7 @@ export class RetentionPurgeService {
         logger.warn({ logId: row.id }, 'Off-DB reconciliation retry still failing');
       }
     }
-    return { settled, stillFailing };
+    return { settled, stillFailing, remaining: Math.max(0, totalPending - pending.length) };
   }
 
   /**

--- a/services/api-gateway/src/services/retention/purgeAudit.test.ts
+++ b/services/api-gateway/src/services/retention/purgeAudit.test.ts
@@ -102,7 +102,7 @@ describe('findPendingOffDbRows', () => {
   it('queries only committed purges whose off-DB work is unsettled', async () => {
     const { prisma, findMany } = makePrisma();
 
-    await findPendingOffDbRows(prisma);
+    await findPendingOffDbRows(prisma, 50);
 
     // db_outcome filter matters: a 'failed' row is terminal by construction, so
     // including it would make the sweep retry a row that can never settle.
@@ -110,6 +110,9 @@ describe('findPendingOffDbRows', () => {
       dbOutcome: 'success',
       offDbReconciled: { not: 'done' },
     });
+    // The bound must reach the query — an unbounded sweep is the ~60s-timeout
+    // failure mode the per-user purge already learned to avoid.
+    expect(findMany.mock.calls[0][0].take).toBe(50);
   });
 
   it('extracts the slugs from the stored JSON', async () => {
@@ -117,7 +120,7 @@ describe('findPendingOffDbRows', () => {
       { id: 'a1', targetDiscordId: '900000000000000001', offDbPending: { characterSlugs: ['x'] } },
     ]);
 
-    const rows = await findPendingOffDbRows(prisma);
+    const rows = await findPendingOffDbRows(prisma, 50);
 
     expect(rows).toEqual([
       { id: 'a1', targetDiscordId: '900000000000000001', characterSlugs: ['x'] },
@@ -138,7 +141,7 @@ describe('findPendingOffDbRows', () => {
       },
     ]);
 
-    const rows = await findPendingOffDbRows(prisma);
+    const rows = await findPendingOffDbRows(prisma, 50);
 
     expect(rows.map(row => row.characterSlugs)).toEqual([[], [], [], ['good']]);
   });

--- a/services/api-gateway/src/services/retention/purgeAudit.ts
+++ b/services/api-gateway/src/services/retention/purgeAudit.ts
@@ -123,25 +123,42 @@ export async function settleOffDb(
   });
 }
 
+/** The shared retry-queue filter — every pending-off-DB read uses this shape. */
+const PENDING_OFF_DB_WHERE = {
+  dbOutcome: 'success',
+  offDbReconciled: { not: 'done' },
+} as const;
+
 /**
  * Rows whose off-DB cleanup is still owed — the retry queue.
  *
  * Filtered to committed purges: a `failed` DB outcome never owed off-DB work,
- * so including it would make the sweep retry nothing forever. Unindexed and
- * unbounded on purpose — the ledger gains one row per purged account, so this
- * is a seq scan over a table measured in tens.
+ * so including it would make the sweep retry nothing forever. Unindexed on
+ * purpose (the ledger gains one row per purged account — a seq scan over a
+ * table measured in tens), but BOUNDED: a long-unreconciled backlog must not
+ * run the whole queue inside one HTTP request against the platform's ~60s
+ * timeout — the same lesson the purge itself learned per-user.
  */
-export async function findPendingOffDbRows(prisma: PrismaClient): Promise<PendingOffDbRow[]> {
+export async function findPendingOffDbRows(
+  prisma: PrismaClient,
+  take: number
+): Promise<PendingOffDbRow[]> {
   const rows = await prisma.retentionPurgeLog.findMany({
-    where: { dbOutcome: 'success', offDbReconciled: { not: 'done' } },
+    where: PENDING_OFF_DB_WHERE,
     select: { id: true, targetDiscordId: true, offDbPending: true },
     orderBy: { purgedAt: 'asc' },
+    take,
   });
   return rows.map(row => ({
     id: row.id,
     targetDiscordId: row.targetDiscordId,
     characterSlugs: extractSlugs(row.offDbPending),
   }));
+}
+
+/** Size of the retry queue — lets a bounded sweep report what it didn't reach. */
+export async function countPendingOffDbRows(prisma: PrismaClient): Promise<number> {
+  return prisma.retentionPurgeLog.count({ where: PENDING_OFF_DB_WHERE });
 }
 
 /**


### PR DESCRIPTION
## Summary

TASK-327: `reconcileOffDb` (and its `/internal/retention/reconcile-off-db` route) walked every unsettled purge-ledger row sequentially and **unbounded** inside one HTTP request. Fine while the queue is its normal empty-to-tens self, but a long-unreconciled backlog would blow the platform's ~60s request timeout — the exact failure mode the per-user purge itself was designed around (D2). This applies the same resumable-batch lesson to the sweep.

## Changes

- **`findPendingOffDbRows` now takes an explicit bound** (`RECONCILE_BATCH_SIZE = 50` — each row is one avatar unlink, comfortably inside the timeout). New `countPendingOffDbRows` shares a single `PENDING_OFF_DB_WHERE` constant so the queue filter can't drift between the two reads.
- **Response gains `remaining`** — rows the call did *not* attempt. Deliberate semantics: rows that failed in-batch stay queued for a future run but are not "remaining," so a CLI loop can't spin forever re-attempting a persistently-failing queue head.
- **CLI loops batches** while `remaining > 0`, stops on any in-batch failure (the operator investigates the avatar-unlink error before burning retries), carries a runaway cap of 20 batches, aggregates totals, and reports the unattempted rest.
- `retention:purge`'s unconditional end-of-run reconcile call reads the response additively — unchanged behavior on the normal small queue.

## Tests

- Service seam: bounded batch with `take` pinned crossing into the query, `remaining` arithmetic (120 pending → 50 attempted → 70 remaining), failed-in-batch counted as `stillFailing` not `remaining`, empty-queue no-op without touching the eraser.
- CLI: three-batch continuation summing totals, stop-on-failure with the not-attempted report.
- Interface sweep per `02-code-standards.md` rule 8: every fixture carrying the old two-field shape updated (route test, CLI mocks, purge-CLI mock, schema tests, conformance fixture comment), and the contract subset run green (`tests/e2e/contracts/` 17/17).

## Verification

- Retention suites 28/28; `pnpm test` 26 tasks green; `pnpm quality` green; pre-push green (full 14-package rebuild).

Closes TASK-327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)