### PR TITLE
docs: rider checklist, variant-token sweep rule, publish-race note

### DIFF
--- a/.claude/rules/10-working-posture.md
+++ b/.claude/rules/10-working-posture.md
@@ -54,6 +54,9 @@ After any scripted or multi-site edit, grep for a distinctive token of the NEW
 text before trusting a green test run — a passing suite cannot prove an edit
 applied when the edit's own assertions have a trivially-true branch. Assert
 every scripted replacement's target; prefer the Edit tool below ~5 replaces.
+After a bulk rename/move, also grep for the OLD token in its variant forms —
+bare basename, each prefix depth, backticked mention — before declaring the
+sweep complete; the canonical-form grep alone has under-swept three times.
 
 ## Filters are for known output shapes
 

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-07-27'
+lastUpdated: '2026-07-29'
 ---
 
 # Git Workflow Procedures
@@ -405,6 +405,13 @@ What it does (release-flow steps 7–8):
 **Release-channel convention** (what the command enforces): the newest release holds
 `latest` (`prerelease=false`); every older beta is `prerelease=true`. **Do NOT** mark
 the newest tag `--prerelease` — that's mutually exclusive with `latest`.
+
+**Known-benign race — publish right after the merge.** Publishing while Railway is
+still swapping prod containers can 502 the release webhooks at Railway's edge
+(GitHub delivers once, never retries). This is expected and self-healing: the
+hourly reconcile sweep picks the release up and sends the DM blast with ≤1h lag.
+Don't re-publish, don't debug the webhook delivery, and don't wait for the deploy
+to settle before publishing — the lag is the designed absorption path.
 
 Verify: `gh release list --limit 5 --json tagName,isPrerelease,isLatest --jq '.[] | {tagName, isPrerelease, isLatest}'`
 — the newest must read `prerelease=false / latest=true`, every older beta `prerelease=true / latest=false`.

--- a/.claude/skills/tzurot-review-response/SKILL.md
+++ b/.claude/skills/tzurot-review-response/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-review-response
 description: 'PR review-response iteration: classify each finding by EDIT SHAPE (trivial → auto-apply as a test-gated fixup commit; semantic → ASK), check reviewer-vs-agent signal conflict, batch-present the four sections, cap at 3 automated rounds. Invoke with /tzurot-review-response the moment a claude-review or human reviewer posts findings on a PR — before applying anything.'
-lastUpdated: '2026-07-28'
+lastUpdated: '2026-07-29'
 ---
 
 # Review-Response Iteration
@@ -85,6 +85,14 @@ For items that passed rules 1 and 2 (trivial-shape + no conflict):
 2. Run the package-level test for the modified file (e.g., `pnpm --filter bot-client test`).
 3. Tests pass → keep the fixup commit.
 4. Tests fail → **escalate to ASK immediately**, with the test failure output attached. A trivial-shape edit that breaks tests is the signal that the whitelist mis-classified it; escalation preserves the safety net.
+
+**Rider checklist — when the fix ADDS code rather than changing it.** Review-response riders systematically get less scrutiny than planned work: "one clause" / "~10 lines" is exactly the size that skips the checks a planned change gets (observed as 3 of 4 findings in one PR's review rounds — an added-but-never-called function, an arm added untested, a doc comment staled from a file the fix didn't touch). Before committing any rider that adds code (or moves it between files), answer the three questions a planned change answers:
+
+- (a) Does the addition need its own test? (New function/branch → yes by default; "it's small" is not an exemption.)
+- (b) Does it stale a comment or doc elsewhere — including `schema.prisma` doc comments and files the fix doesn't touch?
+- (c) Does moving code between files change what a coverage or mutation gate measures? (Extraction can drop a module below a per-file gate that the old file's average was hiding.)
+
+Rule 3's test gate catches breakage; this checklist is the authoring-time complement that catches absence.
 
 Fixup commits autosquash naturally on the next `git rebase -i --autosquash`. This is the correct escape valve for a rebase-only workflow — `git revert` is not available on rewritten-history branches, but fixup-drop during interactive rebase is cheap and native.
 


### PR DESCRIPTION
## Summary

Three process-doc drain items batched into one review-gated pass (all touch `.claude/` load-bearing surfaces, so PR rather than direct commit):

### TASK-329 — review-response rider checklist
`/tzurot-review-response` rule 3 gains an authoring-time checklist for review fixes that **add** code rather than change it: (a) does the addition need its own test, (b) does it stale a comment/doc elsewhere (incl. `schema.prisma`), (c) does moving code between files change what a coverage/mutation gate measures. Evidence base: 3 of 4 findings in #1795's six-round review were riders I added in response to earlier findings (a never-called function, an untested arm, a staled doc comment), and #1796's mutation-gate failure was extraction moving code out from under a file average. Rule 3's test gate catches breakage; this catches absence.

### TASK-339 — variant-token forms in presence-then-test
`10-working-posture.md` § Presence-then-test now also requires grepping for the **OLD** token's variant forms (bare basename, each prefix depth, backticked mention) after a bulk rename/move. The canonical-form-only grep under-swept three times across the substrate sessions (#1823 missed `services/` then `*.yml`; the step-4 migration missed bare `themes/` and `ideas.md` mentions).

### TASK-295 — publish-race note (option a, zero-code)
`/tzurot-git-workflow` publish step documents the publish-right-after-merge race as known-benign: release webhooks can 502 at Railway's edge during the prod container handoff (GitHub never retries), and the hourly reconcile sweep absorbs it with ≤1h DM lag — by design (beta.169 evidence: all three webhooks 502'd, the reconcile delivered). Option (b) (wait for deploy before publishing) declined: it adds a wait step to every release to shave ≤1h off a once-per-release DM lag that the reconcile already handles.

Line budgets: rules 1964/2270 after the +3-line addition.

## Verification

`pnpm quality` green (27/27 checks incl. lines:check, backlog lint, workflow-sync). Doc-only diff — no test-path impact; pre-push hook confirmed docs-only and ran the budget/backlog/sync checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)