### PR TITLE
refactor: schema-audit drain batch — five pool items (doc-7 phase 1)

### DIFF
--- a/packages/tooling/src/dev/schema-audit-reads.test.ts
+++ b/packages/tooling/src/dev/schema-audit-reads.test.ts
@@ -7,7 +7,7 @@ import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { classifyReads } from './schema-audit-reads.js';
 import type { PrismaField } from './schema-audit-parser.js';
-import { withTempDir } from './schema-audit-test-helpers.js';
+import { withTempDir, projectFromPaths } from './schema-audit-test-helpers.js';
 
 describe('classifyReads', () => {
   const optionalField: PrismaField = {
@@ -35,7 +35,7 @@ const x = user.targetField ?? 'fallback';
 const y = user.targetField ?? 'another-fallback';
 `,
       path => {
-        const classifications = classifyReads([optionalField], [path]);
+        const classifications = classifyReads([optionalField], projectFromPaths([path]));
         expect(classifications[0].nullishCoalescingReads).toBe(2);
         expect(classifications[0].truthinessGuardReads).toBe(0);
       }
@@ -51,7 +51,7 @@ if (user.targetField === null) { console.log('b'); }
 if (user.targetField) { console.log('c'); }
 `,
       path => {
-        const classifications = classifyReads([optionalField], [path]);
+        const classifications = classifyReads([optionalField], projectFromPaths([path]));
         expect(classifications[0].truthinessGuardReads).toBe(3);
         expect(classifications[0].nullishCoalescingReads).toBe(0);
       }
@@ -65,7 +65,7 @@ declare const user: { targetField: string | null };
 const x = user.targetField!.length;
 `,
       path => {
-        const classifications = classifyReads([optionalField], [path]);
+        const classifications = classifyReads([optionalField], projectFromPaths([path]));
         expect(classifications[0].nonNullAssertionReads).toBe(1);
       }
     );
@@ -78,7 +78,7 @@ declare const someUnrelated: { targetField: string | null };
 const x = someUnrelated.targetField ?? 'fallback';
 `,
       path => {
-        const classifications = classifyReads([optionalField], [path]);
+        const classifications = classifyReads([optionalField], projectFromPaths([path]));
         expect(classifications[0].totalReads).toBe(0);
       }
     );
@@ -95,7 +95,7 @@ const b = true ? user.targetField : 'other';
 const c = true ? 'other' : user.targetField;
 `,
       path => {
-        const classifications = classifyReads([optionalField], [path]);
+        const classifications = classifyReads([optionalField], projectFromPaths([path]));
         // Three reads total; only the first (condition) is a truthiness-guard.
         // The other two (branches) are unclassified accesses.
         expect(classifications[0].totalReads).toBe(3);
@@ -113,7 +113,7 @@ const x = user.targetField ?? 'a';
 const y = users[0].targetField ?? 'b';
 `,
       path => {
-        const classifications = classifyReads([optionalField], [path]);
+        const classifications = classifyReads([optionalField], projectFromPaths([path]));
         // 'user' matches; 'users[0]' has receiver 'users[0]' as ElementAccess
         // which Node.isIdentifier rejects. Only the first read matches.
         expect(classifications[0].nullishCoalescingReads).toBe(1);

--- a/packages/tooling/src/dev/schema-audit-reads.ts
+++ b/packages/tooling/src/dev/schema-audit-reads.ts
@@ -12,7 +12,7 @@
  * upgrade later if false-positive rate is too high.
  */
 
-import { Project, SyntaxKind, Node, type PropertyAccessExpression } from 'ts-morph';
+import { SyntaxKind, Node, type Project, type PropertyAccessExpression } from 'ts-morph';
 import type { PrismaField } from './schema-audit-parser.js';
 
 /** Read-mode classification for a single optional column. */
@@ -30,21 +30,14 @@ export interface ReadModeClassification {
 }
 
 /**
- * Walk a set of TS source files and classify reads of `obj.field` for each
- * given (model, field) pair.
+ * Walk an already-parsed project's source files and classify reads of
+ * `obj.field` for each given (model, field) pair. Takes a `Project` (see
+ * `globSourceFiles`) so the tree is parsed once per audit run, not per pass.
  */
 export function classifyReads(
   optionalFields: PrismaField[],
-  sourceFilePaths: string[]
+  project: Project
 ): ReadModeClassification[] {
-  const project = new Project({
-    compilerOptions: { allowJs: false, skipLibCheck: true },
-    useInMemoryFileSystem: false,
-  });
-  for (const path of sourceFilePaths) {
-    project.addSourceFileAtPathIfExists(path);
-  }
-
   const classifications = new Map<string, ReadModeClassification>();
   for (const field of optionalFields) {
     classifications.set(`${field.model}.${field.field}`, {
@@ -57,6 +50,16 @@ export function classifyReads(
     });
   }
 
+  // Index by field name so each property access checks only its candidate
+  // fields — mirrors analyzeWrites' accessor grouping (the inner linear scan
+  // was O(propAccesses × optionalFields)).
+  const fieldsByName = new Map<string, PrismaField[]>();
+  for (const field of optionalFields) {
+    const list = fieldsByName.get(field.field) ?? [];
+    list.push(field);
+    fieldsByName.set(field.field, list);
+  }
+
   for (const sourceFile of project.getSourceFiles()) {
     sourceFile.forEachDescendant(node => {
       if (!Node.isPropertyAccessExpression(node)) return;
@@ -65,8 +68,7 @@ export function classifyReads(
       const receiverName = receiver.getText();
       const fieldName = node.getName();
 
-      for (const field of optionalFields) {
-        if (field.field !== fieldName) continue;
+      for (const field of fieldsByName.get(fieldName) ?? []) {
         if (!matchesModel(receiverName, field.model)) continue;
         const classification = classifications.get(`${field.model}.${field.field}`);
         if (!classification) continue;

--- a/packages/tooling/src/dev/schema-audit-report.ts
+++ b/packages/tooling/src/dev/schema-audit-report.ts
@@ -59,12 +59,17 @@ export function printMarkdownReport(args: MarkdownReportArgs): void {
     bySeverity.set(f.severity, list);
   }
 
+  // Index once for the per-finding breakdown lookups (was a linear .find()
+  // over each list per finding).
+  const readsByKey = new Map(readClassifications.map(c => [`${c.model}.${c.field}`, c]));
+  const writesByKey = new Map(writeClassifications.map(w => [`${w.model}.${w.field}`, w]));
+
   for (const severity of ['HIGH', 'MEDIUM', 'LOW']) {
     const group = bySeverity.get(severity);
     if (!group || group.length === 0) continue;
     console.log(`## ${severity}\n`);
     for (const f of group) {
-      printFindingBlock(f, readClassifications, writeClassifications);
+      printFindingBlock(f, readsByKey, writesByKey);
     }
   }
 }
@@ -102,14 +107,14 @@ function computeReadCoverageWarning(
 
 function printFindingBlock(
   f: AuditFinding,
-  reads: ReadModeClassification[],
-  writes: WriteSiteClassification[]
+  reads: Map<string, ReadModeClassification>,
+  writes: Map<string, WriteSiteClassification>
 ): void {
   console.log(`### \`${f.model}.${f.field}\` — ${f.recipe}\n`);
   console.log(`**Evidence**: ${f.evidence}\n`);
   console.log(`**Fix shape**: ${f.fixShape}\n`);
 
-  const read = reads.find(c => c.model === f.model && c.field === f.field);
+  const read = reads.get(`${f.model}.${f.field}`);
   if (read && read.totalReads > 0) {
     console.log(
       `**Read breakdown**: ${read.totalReads} total — ` +
@@ -118,7 +123,7 @@ function printFindingBlock(
         `${read.nonNullAssertionReads} non-null-assertion.\n`
     );
   }
-  const write = writes.find(w => w.model === f.model && w.field === f.field);
+  const write = writes.get(`${f.model}.${f.field}`);
   if (write && write.totalSites > 0) {
     console.log(
       `**Write breakdown**: ${write.totalSites} \`.create\`/\`.upsert\` sites — ` +

--- a/packages/tooling/src/dev/schema-audit-suppression.test.ts
+++ b/packages/tooling/src/dev/schema-audit-suppression.test.ts
@@ -127,6 +127,31 @@ describe('loadAuditConfig', () => {
     });
   });
 
+  it('throws when reviewedAt is a string but not a parseable date', async () => {
+    // The field is an accountability/staleness timestamp — "last tuesday"
+    // must fail loud, or a future freshness audit can't parse it.
+    await withTempDir(async dir => {
+      const path = join(dir, 'audit.config.json');
+      writeFileSync(
+        path,
+        JSON.stringify({ suppressions: [{ key: 'k', reason: 'r', reviewedAt: 'last tuesday' }] })
+      );
+      await expect(loadAuditConfig(path)).rejects.toThrow(/must be a parseable date/);
+    });
+  });
+
+  it('accepts an ISO-date reviewedAt', async () => {
+    await withTempDir(async dir => {
+      const path = join(dir, 'audit.config.json');
+      writeFileSync(
+        path,
+        JSON.stringify({ suppressions: [{ key: 'k', reason: 'r', reviewedAt: '2026-07-29' }] })
+      );
+      const config = await loadAuditConfig(path);
+      expect(config.suppressions[0].reviewedAt).toBe('2026-07-29');
+    });
+  });
+
   it('also validates .ts config exports', async () => {
     await withTempDir(async dir => {
       const path = join(dir, 'audit.config.ts');

--- a/packages/tooling/src/dev/schema-audit-suppression.ts
+++ b/packages/tooling/src/dev/schema-audit-suppression.ts
@@ -100,6 +100,14 @@ function assertConfigShape(value: unknown, configPath: string): SchemaAuditConfi
         `Config at ${configPath}: \`suppressions[${i}].reviewedAt\` must be a string when present.`
       );
     }
+    // reviewedAt is an accountability/staleness timestamp — "last tuesday"
+    // or a typo must fail loud, or a future freshness audit can't parse it.
+    if (typeof e.reviewedAt === 'string' && Number.isNaN(Date.parse(e.reviewedAt))) {
+      throw new Error(
+        `Config at ${configPath}: \`suppressions[${i}].reviewedAt\` must be a parseable date ` +
+          `(got "${e.reviewedAt}") — use ISO format, e.g. "2026-07-29".`
+      );
+    }
   }
   return value as SchemaAuditConfig;
 }

--- a/packages/tooling/src/dev/schema-audit-test-helpers.test.ts
+++ b/packages/tooling/src/dev/schema-audit-test-helpers.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { withTempDir } from './schema-audit-test-helpers.js';
+import { withTempDir, projectFromPaths } from './schema-audit-test-helpers.js';
 
 describe('withTempDir', () => {
   it('creates a directory and passes its path to the callback', async () => {
@@ -44,5 +44,18 @@ describe('withTempDir', () => {
     ).rejects.toThrow('boom');
     expect(capturedDir).not.toBeNull();
     expect(existsSync(capturedDir as unknown as string)).toBe(false);
+  });
+});
+
+describe('projectFromPaths', () => {
+  it('parses exactly the given paths, skipping missing files', async () => {
+    await withTempDir(dir => {
+      const real = join(dir, 'real.ts');
+      writeFileSync(real, 'export const x = 1;');
+
+      const project = projectFromPaths([real, join(dir, 'missing.ts')]);
+
+      expect(project.getSourceFiles().map(sf => sf.getFilePath())).toEqual([real]);
+    });
   });
 });

--- a/packages/tooling/src/dev/schema-audit-test-helpers.ts
+++ b/packages/tooling/src/dev/schema-audit-test-helpers.ts
@@ -10,6 +10,20 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Project } from 'ts-morph';
+
+/**
+ * Build a parsed ts-morph `Project` from explicit file paths — the input
+ * shape `classifyReads`/`analyzeWrites` take since Project construction
+ * moved to `globSourceFiles` (parse once per audit run, not per pass).
+ */
+export function projectFromPaths(paths: string[]): Project {
+  const project = new Project({ compilerOptions: { allowJs: false, skipLibCheck: true } });
+  for (const path of paths) {
+    project.addSourceFileAtPathIfExists(path);
+  }
+  return project;
+}
 
 /**
  * Run `fn` inside a fresh temp directory. The directory is created with

--- a/packages/tooling/src/dev/schema-audit-writes.test.ts
+++ b/packages/tooling/src/dev/schema-audit-writes.test.ts
@@ -7,7 +7,7 @@ import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { analyzeWrites } from './schema-audit-writes.js';
 import type { PrismaField } from './schema-audit-parser.js';
-import { withTempDir } from './schema-audit-test-helpers.js';
+import { withTempDir, projectFromPaths } from './schema-audit-test-helpers.js';
 
 describe('analyzeWrites', () => {
   const field: PrismaField = {
@@ -34,7 +34,7 @@ declare const prisma: { user: { create: (args: unknown) => unknown } };
 prisma.user.create({ data: { targetField: null, discordId: 'x' } });
 `,
       path => {
-        const classifications = analyzeWrites([field], [path]);
+        const classifications = analyzeWrites([field], projectFromPaths([path]));
         expect(classifications[0].nullLiteralSites).toBe(1);
         expect(classifications[0].valueSites).toBe(0);
       }
@@ -49,7 +49,7 @@ declare const id: string;
 prisma.user.create({ data: { targetField: id, discordId: 'x' } });
 `,
       path => {
-        const classifications = analyzeWrites([field], [path]);
+        const classifications = analyzeWrites([field], projectFromPaths([path]));
         expect(classifications[0].valueSites).toBe(1);
       }
     );
@@ -65,7 +65,7 @@ prisma.user.create({ data: { targetField: maybeId ?? undefined, discordId: 'y' }
 prisma.user.create({ data: { targetField: maybeId || null, discordId: 'z' } });
 `,
       path => {
-        const classifications = analyzeWrites([field], [path]);
+        const classifications = analyzeWrites([field], projectFromPaths([path]));
         // All 3 sites use a nullable-fallback pattern → null-set.
         expect(classifications[0].nullLiteralSites).toBe(3);
         expect(classifications[0].valueSites).toBe(0);
@@ -80,7 +80,7 @@ declare const prisma: { user: { create: (args: unknown) => unknown } };
 prisma.user.create({ data: { discordId: 'x' } });
 `,
       path => {
-        const classifications = analyzeWrites([field], [path]);
+        const classifications = analyzeWrites([field], projectFromPaths([path]));
         expect(classifications[0].omittedSites).toBe(1);
       }
     );
@@ -94,7 +94,7 @@ declare const partial: { discordId: string };
 prisma.user.create({ data: { ...partial } });
 `,
       path => {
-        const classifications = analyzeWrites([field], [path]);
+        const classifications = analyzeWrites([field], projectFromPaths([path]));
         expect(classifications[0].unclassifiableSites).toBe(1);
       }
     );
@@ -111,7 +111,7 @@ prisma.user.upsert({
 });
 `,
       path => {
-        const classifications = analyzeWrites([field], [path]);
+        const classifications = analyzeWrites([field], projectFromPaths([path]));
         expect(classifications[0].nullLiteralSites).toBe(1);
       }
     );
@@ -128,7 +128,7 @@ prisma.user.create({ data: { targetField: id, discordId: 'c' } });
 prisma.user.create({ data: { targetField: id, discordId: 'd' } });
 `,
       path => {
-        const classifications = analyzeWrites([field], [path]);
+        const classifications = analyzeWrites([field], projectFromPaths([path]));
         expect(classifications[0].nullLiteralSites).toBe(2);
         expect(classifications[0].valueSites).toBe(2);
         expect(classifications[0].totalSites).toBe(4);

--- a/packages/tooling/src/dev/schema-audit-writes.ts
+++ b/packages/tooling/src/dev/schema-audit-writes.ts
@@ -14,11 +14,11 @@
  */
 
 import {
-  Project,
   Node,
   SyntaxKind,
   type CallExpression,
   type ObjectLiteralExpression,
+  type Project,
 } from 'ts-morph';
 import type { PrismaField } from './schema-audit-parser.js';
 
@@ -128,22 +128,16 @@ function classifyInitializer(initializer: Node): WriteOutcome {
 }
 
 /**
- * Walk source files looking for `prisma.<model>.create({ data: {...} })` and
+ * Walk an already-parsed project's source files looking for
+ * `prisma.<model>.create({ data: {...} })` and
  * `prisma.<model>.upsert({ ..., create: {...} })` invocations. Classify each
- * tracked optional field at each invocation site.
+ * tracked optional field at each invocation site. Takes a `Project` (see
+ * `globSourceFiles`) so the tree is parsed once per audit run, not per pass.
  */
 export function analyzeWrites(
   optionalFields: PrismaField[],
-  sourceFilePaths: string[]
+  project: Project
 ): WriteSiteClassification[] {
-  const project = new Project({
-    compilerOptions: { allowJs: false, skipLibCheck: true },
-    useInMemoryFileSystem: false,
-  });
-  for (const path of sourceFilePaths) {
-    project.addSourceFileAtPathIfExists(path);
-  }
-
   const classifications = new Map<string, WriteSiteClassification>();
   for (const field of optionalFields) {
     classifications.set(`${field.model}.${field.field}`, {

--- a/packages/tooling/src/dev/schema-audit.test.ts
+++ b/packages/tooling/src/dev/schema-audit.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { runSchemaAudit } from './schema-audit.js';
+import { runSchemaAudit, globSourceFiles } from './schema-audit.js';
 import { withTempDir } from './schema-audit-test-helpers.js';
 
 // Local alias: e2e tests describe `dir` as "the project root" for readability.
@@ -145,6 +145,51 @@ model User {
       expect(parsed.stats).toHaveProperty('suppressedCount');
       expect(parsed.stats).toHaveProperty('findings');
       expect(Array.isArray(parsed.findings)).toBe(true);
+    });
+  });
+});
+
+describe('globSourceFiles', () => {
+  it('returns the parsed project alongside paths (single parse per audit run)', async () => {
+    await withTempDir(dir => {
+      mkdirSync(join(dir, 'src'));
+      writeFileSync(join(dir, 'src', 'a.ts'), 'export const a = 1;');
+
+      const { paths, project } = globSourceFiles(dir, ['src/**/*.ts']);
+
+      expect(paths).toHaveLength(1);
+      // The returned project already carries the parsed files — analyzers
+      // consume it directly instead of re-parsing from the paths.
+      expect(project.getSourceFiles().map(sf => sf.getFilePath())).toEqual(paths);
+    });
+  });
+
+  it('excludes *.test.ts regardless of the input glob shape', async () => {
+    await withTempDir(dir => {
+      mkdirSync(join(dir, 'src'));
+      writeFileSync(join(dir, 'src', 'a.ts'), 'export const a = 1;');
+      writeFileSync(join(dir, 'src', 'a.test.ts'), 'export const t = 1;');
+
+      const { paths } = globSourceFiles(dir, ['src/**/*.ts']);
+
+      expect(paths).toHaveLength(1);
+      expect(paths[0].endsWith('a.ts')).toBe(true);
+    });
+  });
+
+  it('a custom non-*.ts glob no longer self-excludes everything', async () => {
+    // The old suffix-substitution built the exclusion by replacing the input
+    // glob's `*.ts` with `*.test.ts`; a glob not ending in `*.ts` made that a
+    // no-op and the "exclusion" became the glob itself — excluding every file
+    // it was meant to include.
+    await withTempDir(dir => {
+      mkdirSync(join(dir, 'src'));
+      writeFileSync(join(dir, 'src', 'a.tsx'), 'export const a = 1;');
+
+      const { paths } = globSourceFiles(dir, ['src/**/*.tsx']);
+
+      expect(paths).toHaveLength(1);
+      expect(paths[0].endsWith('a.tsx')).toBe(true);
     });
   });
 });

--- a/packages/tooling/src/dev/schema-audit.ts
+++ b/packages/tooling/src/dev/schema-audit.ts
@@ -37,11 +37,9 @@ export interface SchemaAuditOptions {
   repoRoot?: string;
   schemaPath?: string;
   /**
-   * Source globs to analyze. **Each glob MUST end with `*.ts`** — the
-   * test-exclusion pattern is derived by suffix-substituting `*.ts` → `*.test.ts`.
-   * A glob that doesn't end in `*.ts` (e.g., `services/foo.tsx`) will silently
-   * include test files because the substitution becomes a no-op. File a
-   * tracker task for tightening if a real consumer hits this gap.
+   * Source globs to analyze. Test files are excluded via a glob-independent
+   * `!**\/*.test.ts` negation, so custom globs (including `*.tsx`-shaped
+   * ones) don't need any particular suffix.
    */
   sourceGlobs?: string[];
   /** Path to audit.config (defaults to ./audit.config.ts at repo root). */
@@ -67,10 +65,10 @@ export async function runSchemaAudit(options: SchemaAuditOptions = {}): Promise<
   const config = await loadAuditConfig(configPath);
   validateSuppressions(config.suppressions, fields);
 
-  const sourceFilePaths = globSourceFiles(repoRoot, sourceGlobs);
+  const { paths: sourceFilePaths, project } = globSourceFiles(repoRoot, sourceGlobs);
 
-  const readClassifications = classifyReads(optionalFields, sourceFilePaths);
-  const writeClassifications = analyzeWrites(optionalFields, sourceFilePaths);
+  const readClassifications = classifyReads(optionalFields, project);
+  const writeClassifications = analyzeWrites(optionalFields, project);
   const allFindings = generateFindings(readClassifications, writeClassifications, fields);
   const findings = applySuppressions(allFindings, config.suppressions);
   const suppressedCount = allFindings.length - findings.length;
@@ -100,21 +98,31 @@ export async function runSchemaAudit(options: SchemaAuditOptions = {}): Promise<
   process.exitCode = findings.length > 0 ? 1 : 0;
 }
 
-/** Resolve source-file paths via ts-morph's glob-aware project loader. */
-function globSourceFiles(repoRoot: string, sourceGlobs: string[]): string[] {
+/**
+ * Resolve source files via ts-morph's glob-aware project loader. Returns the
+ * PARSED project alongside the paths: the analyzers reuse it directly, so the
+ * source tree is parsed once per audit run instead of once per pass.
+ *
+ * The test exclusion is a glob-independent `!**\/*.test.ts` negation (it used
+ * to be derived by suffix-substituting each input glob's `*.ts` → `*.test.ts`,
+ * which silently no-opped — and excluded nothing — for any custom glob not
+ * ending in `*.ts`). `**\/*.test.ts` matches any filename ending in
+ * `.test.ts`, including `Foo.component.test.ts` — verified empirically.
+ *
+ * Exported for tests; production entry is {@link runSchemaAudit}.
+ */
+export function globSourceFiles(
+  repoRoot: string,
+  sourceGlobs: string[]
+): { paths: string[]; project: Project } {
   const project = new Project({ compilerOptions: { allowJs: false, skipLibCheck: true } });
-  for (const glob of sourceGlobs) {
-    // `**/*.test.ts` matches any filename ending in `.test.ts`, including
-    // `Foo.component.test.ts` / `Foo.spec.test.ts` — verified empirically. No
-    // separate `*.component.test.ts` exclusion needed.
-    project.addSourceFilesAtPaths([
-      `${repoRoot}/${glob}`,
-      `!${repoRoot}/${glob.replace(/\*\.ts$/, '*.test.ts')}`,
-      `!${repoRoot}/**/dist/**`,
-      `!${repoRoot}/**/node_modules/**`,
-    ]);
-  }
-  return project.getSourceFiles().map(sf => sf.getFilePath());
+  project.addSourceFilesAtPaths([
+    ...sourceGlobs.map(glob => `${repoRoot}/${glob}`),
+    `!${repoRoot}/**/*.test.ts`,
+    `!${repoRoot}/**/dist/**`,
+    `!${repoRoot}/**/node_modules/**`,
+  ]);
+  return { paths: project.getSourceFiles().map(sf => sf.getFilePath()), project };
 }
 
 interface JsonEmitArgs {


### PR DESCRIPTION
## Summary

Third domain batch of the follow-up pool drain (tracker `doc-7` Phase 1): five deferred items from PR #1076's review rounds, all in the schema-audit module family — shipped as the bundled pass TASK-117 explicitly named as its own promote-when ("bundled with the Project-sharing fix").

| Task | Change |
|---|---|
| TASK-114 | `globSourceFiles` returns `{ paths, project }`; `classifyReads`/`analyzeWrites` take the parsed `Project` — **one ts-morph parse per audit run instead of three** |
| TASK-115 | test exclusion is a glob-independent `!**/*.test.ts` negation — a custom non-`*.ts` glob no longer silently self-excludes everything (the old suffix substitution no-opped for `*.tsx`-shaped globs and the "exclusion" became the input glob itself) |
| TASK-116 | `classifyReads` indexes fields by name (was an `O(propAccesses × optionalFields)` inner scan ≈ 25M comparisons on this codebase), mirroring `analyzeWrites`' accessor grouping |
| TASK-117 | `printFindingBlock` takes `Map` lookups keyed `model.field` instead of a linear `.find()` per finding |
| TASK-118 | `reviewedAt` must be a parseable date (`Date.parse`), with the offending value in the error — it's an accountability timestamp a future freshness audit needs to parse |

## Behavior notes

- TASK-116's match-order is preserved: the old inner loop broke on the first same-name field in `optionalFields` order; the per-name index is built in the same insertion order, so the first match is identical.
- TASK-115 also retires the `SchemaAuditOptions.sourceGlobs` JSDoc warning that documented the old sharp edge ("each glob MUST end with `*.ts`… file a tracker task if a real consumer hits this gap" — this is that task).
- `globSourceFiles` is now exported for its own tests (three new pins: project reuse, `.test.ts` exclusion, and the custom-glob regression); analyzer tests build input via a new `projectFromPaths` helper in `schema-audit-test-helpers`.

## Verified

- `pnpm test` — 26/26 tasks green; the six schema-audit test files pass (45 tests, incl. the new pins)
- `pnpm quality` — green
- **Live run**: `pnpm ops dev:schema-audit` end-to-end against the real repo in ~10s (exit 1 = its normal findings-exist gate; report renders read/write breakdowns correctly through the new Map lookups)

## Not in this batch

The remaining doc-7 tooling-cluster candidates are bigger shapes (TASK-51 honest coverage metric, TASK-142 jscpd 5 migration, TASK-4 env-preamble extraction) — own-PR-sized, left filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)