### PR TITLE
refactor: fast-pool drain batch — five pool items (doc-7 phase 1)

### DIFF
--- a/docs/reference/deployment/RAILWAY_OPERATIONS.md
+++ b/docs/reference/deployment/RAILWAY_OPERATIONS.md
@@ -156,6 +156,17 @@ Railway provides two PostgreSQL connection types:
 
 **For local development**: Use `DATABASE_PUBLIC_URL` (TCP proxy)
 
+**No connection pooler may front the gateway's DB path.** The api-gateway's
+fast pool sets its `statement_timeout`/`lock_timeout`/`idle_in_transaction_session_timeout`
+GUCs via the Postgres `options` startup string, and a boot probe
+(`verifyPoolTimeouts`) **fails gateway boot** if they didn't apply — a loud
+crash beats silently reverting to unbounded-hang behavior. Poolers that strip
+startup parameters (PgBouncer in transaction mode, Prisma Accelerate, pgpool)
+therefore cause a boot crash whose error message names the stripped GUCs. If a
+pooler is ever introduced, set the GUCs another way first (per-role
+`ALTER ROLE ... SET`, or pooler passthrough config). See
+`fastPoolConnectionOptions` in `packages/common-types/src/services/poolConfig.ts`.
+
 ### Managing Variables
 
 ```bash

--- a/packages/common-types/src/services/poolConfig.test.ts
+++ b/packages/common-types/src/services/poolConfig.test.ts
@@ -147,6 +147,7 @@ describe('fastPoolConnectionOptions', () => {
     const cfg = fastPoolConnectionOptions({});
     expect(cfg.statementTimeoutMs).toBe(FAST_POOL_DEFAULTS.STATEMENT_TIMEOUT_MS);
     expect(cfg.lockTimeoutMs).toBe(FAST_POOL_DEFAULTS.LOCK_TIMEOUT_MS);
+    expect(cfg.idleInTxTimeoutMs).toBe(FAST_POOL_DEFAULTS.IDLE_IN_TX_TIMEOUT_MS);
     // Ladder invariant: lock < statement < query so exactly one fires first.
     expect(cfg.lockTimeoutMs).toBeLessThan(cfg.statementTimeoutMs);
     expect(cfg.statementTimeoutMs).toBeLessThan(cfg.poolOverrides.query_timeout);

--- a/packages/common-types/src/services/poolConfig.ts
+++ b/packages/common-types/src/services/poolConfig.ts
@@ -258,6 +258,14 @@ export interface FastPoolConfig {
  * connection FAIL ("permission denied to set parameter"). Lock-holder
  * attribution is a separate (follow-up) concern; the 55P03 vs 57014 SQLSTATE
  * split already labels lock-vs-slow-work without it.
+ *
+ * DEPLOYMENT CAVEAT: a pooler that strips startup parameters (PgBouncer in
+ * transaction mode, Prisma Accelerate, pgpool) silently discards this
+ * `options` string — and `verifyPoolTimeouts` then FAILS GATEWAY BOOT by
+ * design (a loud crash beats silently reverting to the unbounded-hang
+ * behavior these GUCs exist to prevent). If a pooler ever fronts the
+ * gateway's DB, the GUCs must be set another way (per-role `ALTER ROLE ...
+ * SET`, or pooler passthrough config) before boot will succeed.
  */
 export function fastPoolConnectionOptions(env: NodeJS.ProcessEnv = process.env): FastPoolConfig {
   const statementTimeoutMs = resolveFastStatementTimeoutMs(env);

--- a/packages/common-types/src/services/poolConfig.ts
+++ b/packages/common-types/src/services/poolConfig.ts
@@ -244,6 +244,7 @@ export interface FastPoolConfig {
   /** Resolved GUC ms values — fed to the boot `verifyPoolTimeouts` probe. */
   statementTimeoutMs: number;
   lockTimeoutMs: number;
+  idleInTxTimeoutMs: number;
 }
 
 /**
@@ -262,6 +263,9 @@ export function fastPoolConnectionOptions(env: NodeJS.ProcessEnv = process.env):
   const statementTimeoutMs = resolveFastStatementTimeoutMs(env);
   const lockTimeoutMs = resolveFastLockTimeoutMs(env);
   const queryTimeoutMs = resolveFastQueryTimeoutMs(env);
+  // Deliberately NOT env-tunable, unlike the ladder trio above: idle-in-tx is
+  // a belt-and-suspenders reaper outside the load-bearing lock < statement <
+  // query ladder, and the fast pool runs no transactions to legitimately idle in.
   const idleInTxMs = FAST_POOL_DEFAULTS.IDLE_IN_TX_TIMEOUT_MS;
 
   // The ladder lock < statement < query is load-bearing: it's what makes exactly
@@ -290,6 +294,7 @@ export function fastPoolConnectionOptions(env: NodeJS.ProcessEnv = process.env):
     },
     statementTimeoutMs,
     lockTimeoutMs,
+    idleInTxTimeoutMs: idleInTxMs,
   };
 }
 

--- a/packages/common-types/src/services/prisma.test.ts
+++ b/packages/common-types/src/services/prisma.test.ts
@@ -157,14 +157,15 @@ describe('verifyPoolTimeouts', () => {
   const fakePrisma = (rows: { name: string; setting: string }[]): PrismaClient =>
     ({ $queryRaw: vi.fn().mockResolvedValue(rows) }) as unknown as PrismaClient;
 
-  it('resolves when statement_timeout + lock_timeout match the expected ms', async () => {
+  it('resolves when all three GUCs match the expected ms', async () => {
     await expect(
       verifyPoolTimeouts(
         fakePrisma([
           { name: 'statement_timeout', setting: '5000' },
           { name: 'lock_timeout', setting: '2000' },
+          { name: 'idle_in_transaction_session_timeout', setting: '5000' },
         ]),
-        { statementTimeoutMs: 5000, lockTimeoutMs: 2000 }
+        { statementTimeoutMs: 5000, lockTimeoutMs: 2000, idleInTxTimeoutMs: 5000 }
       )
     ).resolves.toBeUndefined();
   });
@@ -175,8 +176,22 @@ describe('verifyPoolTimeouts', () => {
         fakePrisma([
           { name: 'statement_timeout', setting: '0' },
           { name: 'lock_timeout', setting: '0' },
+          { name: 'idle_in_transaction_session_timeout', setting: '0' },
         ]),
-        { statementTimeoutMs: 5000, lockTimeoutMs: 2000 }
+        { statementTimeoutMs: 5000, lockTimeoutMs: 2000, idleInTxTimeoutMs: 5000 }
+      )
+    ).rejects.toThrow(/did not apply/);
+  });
+
+  it('throws when ONLY idle_in_transaction_session_timeout diverges', async () => {
+    await expect(
+      verifyPoolTimeouts(
+        fakePrisma([
+          { name: 'statement_timeout', setting: '5000' },
+          { name: 'lock_timeout', setting: '2000' },
+          { name: 'idle_in_transaction_session_timeout', setting: '0' },
+        ]),
+        { statementTimeoutMs: 5000, lockTimeoutMs: 2000, idleInTxTimeoutMs: 5000 }
       )
     ).rejects.toThrow(/did not apply/);
   });

--- a/packages/common-types/src/services/prisma.ts
+++ b/packages/common-types/src/services/prisma.ts
@@ -162,10 +162,11 @@ export function createPrismaClient(opts?: CreatePrismaClientOptions): PrismaClie
  */
 export async function verifyPoolTimeouts(
   prisma: PrismaClient,
-  expected: { statementTimeoutMs: number; lockTimeoutMs: number }
+  expected: { statementTimeoutMs: number; lockTimeoutMs: number; idleInTxTimeoutMs: number }
 ): Promise<void> {
   const rows = await prisma.$queryRaw<{ name: string; setting: string }[]>`
-    SELECT name, setting FROM pg_settings WHERE name IN ('statement_timeout', 'lock_timeout')
+    SELECT name, setting FROM pg_settings
+    WHERE name IN ('statement_timeout', 'lock_timeout', 'idle_in_transaction_session_timeout')
   `;
   const got: Record<string, number> = {};
   for (const row of rows) {
@@ -173,11 +174,13 @@ export async function verifyPoolTimeouts(
   }
   if (
     got.statement_timeout !== expected.statementTimeoutMs ||
-    got.lock_timeout !== expected.lockTimeoutMs
+    got.lock_timeout !== expected.lockTimeoutMs ||
+    got.idle_in_transaction_session_timeout !== expected.idleInTxTimeoutMs
   ) {
     throw new Error(
       `Fast-pool DB timeouts did not apply: expected statement_timeout=` +
-        `${expected.statementTimeoutMs}ms, lock_timeout=${expected.lockTimeoutMs}ms; got ` +
+        `${expected.statementTimeoutMs}ms, lock_timeout=${expected.lockTimeoutMs}ms, ` +
+        `idle_in_transaction_session_timeout=${expected.idleInTxTimeoutMs}ms; got ` +
         `${JSON.stringify(got)}. The Postgres 'options' startup string was likely stripped ` +
         `(connection pooler?) — fix before serving traffic.`
     );

--- a/packages/conversation-history/src/ConversationHistoryService.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.ts
@@ -10,7 +10,6 @@
 
 import { MessageRole } from '@tzurot/common-types/constants/message';
 import { computeHistoryCutoff } from '@tzurot/common-types/services/historyCutoff';
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type ConversationMessage,
   type CrossChannelHistoryGroup,
@@ -24,6 +23,7 @@ import {
   conversationRecencyOrderBy,
   mapToConversationMessage,
   mapToConversationMessages,
+  type ConversationHistoryClient,
 } from './ConversationMessageMapper.js';
 import { writeReferenceImageDescriptions } from './referenceImageDescriptions.js';
 
@@ -75,7 +75,7 @@ interface AddMessageOptions {
 }
 
 export class ConversationHistoryService {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private prisma: ConversationHistoryClient) {}
 
   /**
    * Add a message to conversation history

--- a/packages/conversation-history/src/ConversationMessageMapper.ts
+++ b/packages/conversation-history/src/ConversationMessageMapper.ts
@@ -7,7 +7,7 @@
  */
 
 import { type MessageRole } from '@tzurot/common-types/constants/message';
-import { type Prisma } from '@tzurot/common-types/services/prisma';
+import { type Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { type ConversationMessage } from '@tzurot/common-types/types/conversationMessage';
 import {
   messageMetadataSchema,
@@ -16,6 +16,15 @@ import {
 import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('ConversationMessageMapper');
+
+/**
+ * Structural subset of PrismaClient that the conversation-history modules
+ * actually use. A full PrismaClient satisfies it — and so does an
+ * `$extends`-wrapped client (api-gateway's fast pool with blanket dead-conn
+ * retry), which the nominal `PrismaClient` type would force behind an
+ * `as unknown as` cast because `$extends` returns a differently-typed client.
+ */
+export type ConversationHistoryClient = Pick<PrismaClient, 'conversationHistory'>;
 
 /**
  * Prisma select object for conversation history queries

--- a/packages/conversation-history/src/index.ts
+++ b/packages/conversation-history/src/index.ts
@@ -20,6 +20,7 @@
  */
 
 export { ConversationHistoryService } from './ConversationHistoryService.js';
+export { type ConversationHistoryClient } from './ConversationMessageMapper.js';
 export { ConversationRetentionService } from './ConversationRetentionService.js';
 export { ConversationSyncService } from './ConversationSyncService.js';
 export { propagateDeletionToFacts } from './memoryDeletionPropagation.js';

--- a/packages/conversation-history/src/referenceImageDescriptions.ts
+++ b/packages/conversation-history/src/referenceImageDescriptions.ts
@@ -17,13 +17,13 @@
  */
 
 import { MessageRole } from '@tzurot/common-types/constants/message';
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type MessageMetadata,
   type ResolvedImageDescription,
   type StoredReferencedMessage,
 } from '@tzurot/common-types/types/schemas/message';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { type ConversationHistoryClient } from './ConversationMessageMapper.js';
 
 const logger = createLogger('ReferenceImageDescriptions');
 
@@ -74,7 +74,7 @@ export function collectRefImageDescriptions(
  * @returns number of stored reference entries that gained descriptions
  */
 export async function writeReferenceImageDescriptions(
-  prisma: PrismaClient,
+  prisma: ConversationHistoryClient,
   scope: ReferenceDescriptionScope,
   descriptionsByUrl: Map<string, string>
 ): Promise<number> {

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -498,6 +498,7 @@ async function main(): Promise<void> {
   await verifyPoolTimeouts(rawFastPrisma, {
     statementTimeoutMs: fastCfg.statementTimeoutMs,
     lockTimeoutMs: fastCfg.lockTimeoutMs,
+    idleInTxTimeoutMs: fastCfg.idleInTxTimeoutMs,
   });
   // Every fast-pool op retries once on a dead/stale socket (Railway silently
   // reaps idle conns). Applied at the client boundary — one place, all fast-pool

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -43,7 +43,10 @@ import {
   LlmConfigResolver,
   VisionConfigResolver,
 } from '@tzurot/config-resolver';
-import { ConversationRetentionService } from '@tzurot/conversation-history';
+import {
+  ConversationRetentionService,
+  type ConversationHistoryClient,
+} from '@tzurot/conversation-history';
 import { applyFastPoolDeadConnRetry } from './utils/dbTimeout.js';
 
 // Routes
@@ -301,7 +304,7 @@ async function initializeServices(prisma: PrismaClient): Promise<ServicesContext
 function registerRoutes(
   app: Express,
   prisma: PrismaClient,
-  fastPrisma: PrismaClient,
+  fastPrisma: ConversationHistoryClient,
   services: ServicesContext
 ): void {
   const {

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.test.ts
@@ -8,6 +8,7 @@ import request from 'supertest';
 import { MessageRole } from '@tzurot/common-types/constants/message';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { generateConversationHistoryUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { type ConversationHistoryClient } from '@tzurot/conversation-history';
 import { handlePersistAssistantMessage } from './conversationAssistantMessage.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
@@ -202,7 +203,7 @@ describe('POST /internal/conversation/assistant-message', () => {
       handlePersistAssistantMessage({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
-        fastPrisma: fast as unknown as PrismaClient,
+        fastPrisma: fast as unknown as ConversationHistoryClient,
       })
     );
 
@@ -226,5 +227,22 @@ describe('POST /internal/conversation/assistant-message', () => {
       expect.objectContaining({ label: 'lock-timeout', sqlstate: '55P03' }),
       expect.stringContaining('DB timeout')
     );
+  });
+
+  it('self-labels a fast-pool timeout on the existence-check read (symmetric with the write path)', async () => {
+    mockPrisma.conversationHistory.findUnique.mockRejectedValue(
+      Object.assign(new Error('canceling statement due to lock timeout'), { code: '55P03' })
+    );
+
+    const response = await request(app)
+      .post('/internal/conversation/assistant-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(500);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'lock-timeout', sqlstate: '55P03', id: EXPECTED_ID }),
+      'Assistant-message existence check hit a fast-pool DB timeout'
+    );
+    expect(mockPrisma.conversationHistory.create).not.toHaveBeenCalled();
   });
 });

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
@@ -30,7 +30,7 @@ import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
-import { classifyDbTimeout } from '../../utils/dbTimeout.js';
+import { logFastPoolTimeout } from '../../utils/dbTimeout.js';
 import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('internal-conversation-assistant-message');
@@ -62,10 +62,25 @@ export const handlePersistAssistantMessage = (deps: RouteDeps): RequestHandler =
     const id = generateConversationHistoryUuid(channelId, personalityId, personaId, assistantTime);
 
     const compareExisting = async (): Promise<PersistAssistantMessageResponse | null> => {
-      const existing = await prisma.conversationHistory.findUnique({
-        where: { id },
-        select: { content: true, discordMessageId: true },
-      });
+      const readStartedAt = Date.now();
+      let existing;
+      try {
+        existing = await prisma.conversationHistory.findUnique({
+          where: { id },
+          select: { content: true, discordMessageId: true },
+        });
+      } catch (error) {
+        // Same self-labeling the write path gets — without it, a read-side
+        // fast-pool failure (dead-conn retry exhausted) surfaces only as the
+        // global handler's generic 'Unhandled error:'.
+        logFastPoolTimeout(
+          logger,
+          error,
+          { durationMs: Date.now() - readStartedAt, channelId, id },
+          'Assistant-message existence check hit a fast-pool DB timeout'
+        );
+        throw error;
+      }
       if (existing === null) {
         return null;
       }
@@ -113,19 +128,12 @@ export const handlePersistAssistantMessage = (deps: RouteDeps): RequestHandler =
       if (!isRace) {
         // Self-label a fast-pool timeout for the prod diagnostic before
         // rethrowing (asyncHandler turns it into the gateway's 5xx).
-        const timeout = classifyDbTimeout(error);
-        if (timeout.label !== 'other') {
-          logger.error(
-            {
-              label: timeout.label,
-              sqlstate: timeout.sqlstate,
-              durationMs: Date.now() - startedAt,
-              channelId,
-              id,
-            },
-            'Assistant-message persist hit a fast-pool DB timeout'
-          );
-        }
+        logFastPoolTimeout(
+          logger,
+          error,
+          { durationMs: Date.now() - startedAt, channelId, id },
+          'Assistant-message persist hit a fast-pool DB timeout'
+        );
         throw error;
       }
       const raced = await compareExisting();

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
@@ -126,8 +126,8 @@ export const handlePersistAssistantMessage = (deps: RouteDeps): RequestHandler =
       // coincidental row appearing in the same window.
       const isRace = (error as { code?: string }).code === 'P2002';
       if (!isRace) {
-        // Self-label a fast-pool timeout for the prod diagnostic before
-        // rethrowing (asyncHandler turns it into the gateway's 5xx).
+        // Classify before rethrowing so the resulting 5xx carries the
+        // {label, sqlstate} diagnostic in the logs instead of a generic error.
         logFastPoolTimeout(
           logger,
           error,

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
@@ -226,6 +226,20 @@ describe('POST /internal/conversation/user-message', () => {
     );
   });
 
+  it('self-labels the dead-conn class at the handler level (client-side timeout, no sqlstate)', async () => {
+    mockPrisma.conversationHistory.create.mockRejectedValue(new Error('Query read timeout'));
+
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(500);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'query-timeout-or-dead-conn' }),
+      expect.stringContaining('DB timeout')
+    );
+  });
+
   it('self-labels a fast-pool timeout on the existence-check read (symmetric with the write path)', async () => {
     mockPrisma.conversationHistory.findUnique.mockRejectedValue(
       Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' })

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
@@ -8,6 +8,7 @@ import request from 'supertest';
 import { MessageRole } from '@tzurot/common-types/constants/message';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { generateConversationHistoryUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { type ConversationHistoryClient } from '@tzurot/conversation-history';
 import { handlePersistUserMessage } from './conversationUserMessage.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
@@ -199,7 +200,7 @@ describe('POST /internal/conversation/user-message', () => {
       handlePersistUserMessage({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
-        fastPrisma: fast as unknown as PrismaClient,
+        fastPrisma: fast as unknown as ConversationHistoryClient,
       })
     );
 
@@ -223,5 +224,22 @@ describe('POST /internal/conversation/user-message', () => {
       expect.objectContaining({ label: 'statement-timeout', sqlstate: '57014' }),
       expect.stringContaining('DB timeout')
     );
+  });
+
+  it('self-labels a fast-pool timeout on the existence-check read (symmetric with the write path)', async () => {
+    mockPrisma.conversationHistory.findUnique.mockRejectedValue(
+      Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' })
+    );
+
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(500);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'statement-timeout', sqlstate: '57014', id: EXPECTED_ID }),
+      'User-message existence check hit a fast-pool DB timeout'
+    );
+    expect(mockPrisma.conversationHistory.create).not.toHaveBeenCalled();
   });
 });

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.ts
@@ -121,8 +121,8 @@ export const handlePersistUserMessage = (deps: RouteDeps): RequestHandler => {
       // failure must surface rather than be masked by a coincidental row.
       const isRace = (error as { code?: string }).code === 'P2002';
       if (!isRace) {
-        // Self-label a fast-pool timeout for the prod diagnostic before
-        // rethrowing (asyncHandler turns it into the gateway's 5xx).
+        // Classify before rethrowing so the resulting 5xx carries the
+        // {label, sqlstate} diagnostic in the logs instead of a generic error.
         logFastPoolTimeout(
           logger,
           error,

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.ts
@@ -30,7 +30,7 @@ import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
-import { classifyDbTimeout } from '../../utils/dbTimeout.js';
+import { logFastPoolTimeout } from '../../utils/dbTimeout.js';
 import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('internal-conversation-user-message');
@@ -59,10 +59,25 @@ export const handlePersistUserMessage = (deps: RouteDeps): RequestHandler => {
     const id = generateConversationHistoryUuid(channelId, personalityId, personaId, createdAt);
 
     const compareExisting = async (): Promise<PersistUserMessageResponse | null> => {
-      const existing = await prisma.conversationHistory.findUnique({
-        where: { id },
-        select: { content: true, discordMessageId: true },
-      });
+      const readStartedAt = Date.now();
+      let existing;
+      try {
+        existing = await prisma.conversationHistory.findUnique({
+          where: { id },
+          select: { content: true, discordMessageId: true },
+        });
+      } catch (error) {
+        // Same self-labeling the write path gets — without it, a read-side
+        // fast-pool failure (dead-conn retry exhausted) surfaces only as the
+        // global handler's generic 'Unhandled error:'.
+        logFastPoolTimeout(
+          logger,
+          error,
+          { durationMs: Date.now() - readStartedAt, channelId, id },
+          'User-message existence check hit a fast-pool DB timeout'
+        );
+        throw error;
+      }
       if (existing === null) {
         return null;
       }
@@ -108,19 +123,12 @@ export const handlePersistUserMessage = (deps: RouteDeps): RequestHandler => {
       if (!isRace) {
         // Self-label a fast-pool timeout for the prod diagnostic before
         // rethrowing (asyncHandler turns it into the gateway's 5xx).
-        const timeout = classifyDbTimeout(error);
-        if (timeout.label !== 'other') {
-          logger.error(
-            {
-              label: timeout.label,
-              sqlstate: timeout.sqlstate,
-              durationMs: Date.now() - startedAt,
-              channelId,
-              id,
-            },
-            'User-message persist hit a fast-pool DB timeout'
-          );
-        }
+        logFastPoolTimeout(
+          logger,
+          error,
+          { durationMs: Date.now() - startedAt, channelId, id },
+          'User-message persist hit a fast-pool DB timeout'
+        );
         throw error;
       }
       const raced = await compareExisting();

--- a/services/api-gateway/src/routes/routeDeps.ts
+++ b/services/api-gateway/src/routes/routeDeps.ts
@@ -44,7 +44,10 @@ import type {
   LlmConfigResolver,
   VisionConfigResolver,
 } from '@tzurot/config-resolver';
-import type { ConversationRetentionService } from '@tzurot/conversation-history';
+import type {
+  ConversationHistoryClient,
+  ConversationRetentionService,
+} from '@tzurot/conversation-history';
 import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
 
 export interface RouteDeps {
@@ -58,8 +61,11 @@ export interface RouteDeps {
    * bot-client's ~20s abort. Optional: only the two persist handlers use it
    * (`deps.fastPrisma ?? deps.prisma`), and it degrades to the main pool if the
    * gateway didn't build one. See `fastPoolConnectionOptions` + `verifyPoolTimeouts`.
+   * Typed as the structural conversation-history subset: the fast pool is
+   * dedicated to conversation-event persists by design, so any other model's
+   * ops on it fail to compile (and the `$extends`-wrapped client needs no cast).
    */
-  readonly fastPrisma?: PrismaClient;
+  readonly fastPrisma?: ConversationHistoryClient;
 
   // ---- Cache-invalidation services (route-specific) ----------------------
 

--- a/services/api-gateway/src/utils/dbTimeout.test.ts
+++ b/services/api-gateway/src/utils/dbTimeout.test.ts
@@ -1,6 +1,45 @@
 import { describe, it, expect, vi } from 'vitest';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { classifyDbTimeout, withDeadConnRetry, applyFastPoolDeadConnRetry } from './dbTimeout.js';
+import { type createLogger } from '@tzurot/common-types/utils/logger';
+import {
+  classifyDbTimeout,
+  withDeadConnRetry,
+  applyFastPoolDeadConnRetry,
+  logFastPoolTimeout,
+} from './dbTimeout.js';
+
+describe('logFastPoolTimeout', () => {
+  const makeLogger = (): { error: ReturnType<typeof vi.fn> } => ({ error: vi.fn() });
+
+  it('logs the classification plus the caller fields for a labeled timeout', () => {
+    const log = makeLogger();
+
+    logFastPoolTimeout(
+      log as unknown as ReturnType<typeof createLogger>,
+      { code: '55P03' },
+      { durationMs: 12, channelId: 'chan', id: 'row' },
+      'existence check hit a fast-pool DB timeout'
+    );
+
+    expect(log.error).toHaveBeenCalledWith(
+      { label: 'lock-timeout', sqlstate: '55P03', durationMs: 12, channelId: 'chan', id: 'row' },
+      'existence check hit a fast-pool DB timeout'
+    );
+  });
+
+  it('stays silent for the other class (non-timeout failures carry their own shape)', () => {
+    const log = makeLogger();
+
+    logFastPoolTimeout(
+      log as unknown as ReturnType<typeof createLogger>,
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' }),
+      { durationMs: 5 },
+      'never logged'
+    );
+
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});
 
 describe('classifyDbTimeout', () => {
   it('labels a lock_timeout by SQLSTATE 55P03', () => {

--- a/services/api-gateway/src/utils/dbTimeout.ts
+++ b/services/api-gateway/src/utils/dbTimeout.ts
@@ -19,6 +19,7 @@
 
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { type ConversationHistoryClient } from '@tzurot/conversation-history';
 
 const retryLogger = createLogger('fast-pool-retry');
 
@@ -101,6 +102,29 @@ export function classifyDbTimeout(error: unknown): DbTimeoutClassification {
 }
 
 /**
+ * Self-label a fast-pool timeout for the prod diagnostic before the caller
+ * rethrows. No-ops on `other` — non-timeout failures (P2002, constraint
+ * violations) already carry their own diagnostic shape, and the persist
+ * routes' race handling branches on those BEFORE reaching this.
+ *
+ * Shared by the persist routes' write catches AND their existence-check
+ * reads, so a `findUnique`-triggered fast-pool failure logs the same
+ * `{label, sqlstate, durationMs}` diagnostic as a write failure instead of
+ * surfacing as a generic unhandled error.
+ */
+export function logFastPoolTimeout(
+  log: ReturnType<typeof createLogger>,
+  error: unknown,
+  fields: Record<string, unknown>,
+  message: string
+): void {
+  const timeout = classifyDbTimeout(error);
+  if (timeout.label !== 'other') {
+    log.error({ label: timeout.label, sqlstate: timeout.sqlstate, ...fields }, message);
+  }
+}
+
+/**
  * Run a fast-pool persist, retrying ONCE if the first attempt fails with the
  * dead/stale-socket class (`query-timeout-or-dead-conn`).
  *
@@ -147,8 +171,13 @@ export async function withDeadConnRetry<T>(
  * conversation-event persists by design (deterministic-UUID upsert-shaped writes
  * + pure reads). Do NOT reuse this on the main pool, where non-idempotent writes
  * would double-execute on retry.
+ *
+ * The return type is the structural `ConversationHistoryClient` subset, not
+ * `PrismaClient`: the narrow type enforces the dedication above — a consumer
+ * reaching for `$transaction`, `$queryRaw`, or any other model's ops on the
+ * fast pool fails to compile.
  */
-export function applyFastPoolDeadConnRetry(client: PrismaClient): PrismaClient {
+export function applyFastPoolDeadConnRetry(client: PrismaClient): ConversationHistoryClient {
   return client.$extends({
     query: {
       $allOperations: ({ model, operation, args, query }) =>
@@ -161,7 +190,11 @@ export function applyFastPoolDeadConnRetry(client: PrismaClient): PrismaClient {
             )
         ),
     },
-    // $extends returns a structurally-compatible but differently-typed client;
-    // the fast pool only ever runs the ops PrismaClient already exposes.
-  }) as unknown as PrismaClient;
+    // A query-only extension leaves every delegate's runtime behavior intact,
+    // but Prisma types the extended delegate's args as `Exact<...>`, which is
+    // nominally incompatible with the base delegate's `SelectSubset<...>` —
+    // so the narrowing needs a cast. Scoped to ONE model's delegate ops
+    // (unlike the former `as unknown as PrismaClient`, which also vouched for
+    // $transaction/$queryRaw and every other model the extension never sees).
+  }) as unknown as ConversationHistoryClient;
 }

--- a/tracker/tasks/task-174 - Simplify-the-conversation-persist-handlers-stale-dual-write-fallback-doc.md
+++ b/tracker/tasks/task-174 - Simplify-the-conversation-persist-handlers-stale-dual-write-fallback-doc.md
@@ -4,7 +4,7 @@ title: Simplify the conversation persist handlers' stale dual-write fallback + d
 status: To Do
 assignee: []
 created_date: '2026-06-25 00:00'
-updated_date: '2026-07-28 10:49'
+updated_date: '2026-07-30 02:16'
 labels:
   - 'area:bot-client'
   - 'area:db'
@@ -17,8 +17,9 @@ ordinal: 174000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-
 Simplify the conversation persist handlers' stale dual-write fallback + doc
 
 **Why:** `conversationUserMessage.ts` + `conversationAssistantMessage.ts` carry a "dual-write window" JSDoc + a `compareExisting`-first + `P2002`-race fallback that assume a concurrent **legacy direct writer**. That writer is gone — the 2.5d epic closed dual-write and bot-client's `saveUserMessage` now routes through the gateway (no direct Prisma), so the gateway endpoint is the sole writer. The doc is misleading and the P2002-race branch is likely dead. **Fix shape**: grep-confirm no second `conversationHistory` writer remains, then drop/simplify the compare-first + P2002 fallback and rewrite the JSDoc to describe the single-writer reality. Behavioral change to the write path → its own PR, separate from the beta.138 timeout fix. **Promote when**: next touching the persist handlers, or a dual-write-doc-confusion report. Surfaced 2026-06-25 during the fast-pool-timeout investigation.
+
+**Scope addition (PR #1866 review)**: when simplifying compareExisting, also dedupe (or delete with the fallback) the now-identical 7-line findUnique try/catch + logFastPoolTimeout wrapper duplicated across both routes — extracting it beforehand was deliberately skipped because this task likely removes compareExisting entirely.
 <!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## Summary

Batch 4 of the doc-7 follow-up-pool drain: the fast-pool cluster. Three planned tasks (38/39/40) plus two ride-alongs (176/175) whose recorded promote-trigger — "next touching the fast-pool code" — fired on this very batch (surfaced by the deferred-refs hook at commit time).

### TASK-38 — type the `$extends` result honestly

`applyFastPoolDeadConnRetry` returned `$extends(...) as unknown as PrismaClient` — a cast that vouched for `$transaction`, `$queryRaw`, and every model the extension never sees. Now:

- `@tzurot/conversation-history` exports `ConversationHistoryClient = Pick<PrismaClient, 'conversationHistory'>` (home: `ConversationMessageMapper`, the package's Prisma-shapes module — cycle-free for both the service and `referenceImageDescriptions`). `ConversationHistoryService`'s constructor accepts it; all six construction sites still satisfy it (full clients are supersets).
- `RouteDeps.fastPrisma`, `registerRoutes`, and both persist routes carry the narrow type — the pool's "conversation-event persists only" design constraint is now compile-enforced, not just documented.
- **A fully cast-free version is unachievable** — compile-verified: Prisma types extended delegates' args as `Exact<...>`, nominally incompatible with the base delegate's `SelectSubset<...>` (`TS2322`, error text in the commit). One scoped cast remains at the `$extends` seam, but it now vouches only for one model's delegate ops, whose runtime behavior the query-only extension provably preserves (`$allOperations` passes through `query(args)`).

### TASK-39 — symmetric read-path self-labeling

Both persist routes' write catches classified+logged `{label, sqlstate, durationMs}`, but `compareExisting`'s `findUnique` (the pre-check AND the P2002-race re-read) did not — a read-side fast-pool failure with the retry exhausted surfaced only as `globalErrorHandler`'s generic `Unhandled error:`. The inline write-path blocks are extracted into a shared `logFastPoolTimeout` helper, now applied at all four sites. New handler-level tests pin the read path in both routes (label + sqlstate + id cross the logger seam, create never called).

### TASK-40 — ladder-rate watch closed with evidence (no code)

The watch: after #1423 tightened the ladder (statement 5s→2s, lock 2s→1s), check whether `statement-timeout`/`lock-timeout` labels appear under real load. Evidence: a 5000-line window of the current prod gateway deployment contains **zero** occurrences of either label (the only fast-pool lines are the boot-probe verification: lock 1000ms / statement 2000ms applied), and no persist-timeout incident has surfaced in four weeks of prod operation since the ladder shipped. The labels remain self-surfacing by design in any future incident, so a standing watch task adds nothing the log line doesn't already do. Closing as done-with-evidence.

### TASK-176 (ride-along) — three #1343 review nits

1. `verifyPoolTimeouts` now asserts all **three** GUCs the options string sets — previously a pooler stripping only `idle_in_transaction_session_timeout` passed boot silently. `FastPoolConfig` carries the resolved `idleInTxTimeoutMs` for the probe; a new test pins the only-idleInTx-diverges failure.
2. Handler-level test for the `query-timeout-or-dead-conn` class (previously exercised only in `dbTimeout.test.ts`).
3. The write-catch comments in both routes now state the WHY (the 5xx carries the diagnostic label) per 02-code-standards.

### TASK-175 (ride-along) — pooler-strips-options caveat documented

`fastPoolConnectionOptions` JSDoc + the Railway runbook's Database URL Strategy section now warn that PgBouncer-txn-mode/Accelerate/pgpool strip the startup `options` string and `verifyPoolTimeouts` then fails gateway boot **by design**, with the escape hatches named (`ALTER ROLE ... SET`, pooler passthrough).

### Not folded: TASK-174

The dual-write-fallback simplification touches these same routes but its own fix shape says "behavioral change to the write path → its own PR." It stays filed and is a natural next unit.

## Verification

- `pnpm test` green (26 tasks), `pnpm quality` green (gate-parity 27/27), sequential per the resource constraint.
- Focused: dbTimeout (20 tests), both persist route suites (12/12), conversation-history (170), prisma/poolConfig (33).
- `tsc --noEmit` clean on api-gateway AND ai-worker (the other `ConversationHistoryService` consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)