### PR TITLE
refactor: persist routes document replay idempotency, not dual-write (task-174)

### DIFF
--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -244,9 +244,9 @@ export const internalRoutes = {
    * POST /api/internal/conversation/assistant-message
    * Bot-client persists the assistant turn after Discord delivery succeeds
    * (the gateway derives the deterministic row id, +1ms timestamp, and token
-   * count). Idempotent upsert-with-compare — during the dual-write window an
-   * existing row is compared, not overwritten, and `matched: false` is the
-   * divergence signal.
+   * count). Idempotent against replays — a redelivery resolves to the same
+   * deterministic id, an existing row is compared rather than overwritten,
+   * and `matched: false` flags content drift between attempts.
    */
   persistAssistantMessage: {
     audience: 'internal',

--- a/packages/conversation-history/src/ConversationSyncService.ts
+++ b/packages/conversation-history/src/ConversationSyncService.ts
@@ -76,9 +76,8 @@ export class ConversationSyncService {
    * against a snapshot of observed Discord messages.
    *
    * This is THE sync algorithm — api-gateway's `/internal/conversation/sync`
-   * endpoint and bot-client's legacy direct path both delegate here, so the
-   * two paths cannot drift during the dual-write window. Idempotent:
-   * re-running an already-applied snapshot finds zero work.
+   * endpoint is its only caller. Idempotent: re-running an already-applied
+   * snapshot finds zero work.
    *
    * Errors are swallowed into logs (matching the defensive style of the
    * individual operations below) — sync is opportunistic and must never fail

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.test.ts
@@ -89,7 +89,7 @@ describe('POST /internal/conversation/assistant-message', () => {
     expect(createCall.data.tokenCount).toBeGreaterThan(0);
   });
 
-  it('reports matched=true without writing when an identical row exists (dual-write)', async () => {
+  it('reports matched=true without writing when an identical row exists (idempotent replay)', async () => {
     mockPrisma.conversationHistory.findUnique.mockResolvedValue({
       content: VALID_BODY.content,
       discordMessageId: VALID_BODY.chunkMessageIds,
@@ -104,7 +104,7 @@ describe('POST /internal/conversation/assistant-message', () => {
     expect(mockPrisma.conversationHistory.create).not.toHaveBeenCalled();
   });
 
-  it('reports matched=false when the existing row diverges (burn-in signal)', async () => {
+  it('reports matched=false when the existing row diverges (replay drift signal)', async () => {
     mockPrisma.conversationHistory.findUnique.mockResolvedValue({
       content: 'different content',
       discordMessageId: VALID_BODY.chunkMessageIds,

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
@@ -4,15 +4,16 @@
  * Persists the assistant conversation-history row after bot-client confirms
  * Discord delivery. The gateway owns the write: it derives the assistant
  * timestamp (user message + 1ms — preserves chronological ordering), the
- * deterministic row UUID, and the token count. Delegates the create to
- * ConversationHistoryService.addMessage — the SAME code path bot-client's
- * legacy direct write uses — so the two paths produce identical rows by
- * construction during the dual-write window.
+ * deterministic row UUID, and the token count. This endpoint is the SOLE
+ * creator of assistant history rows (bot-client has no Prisma; ai-worker
+ * only updates existing rows).
  *
- * Idempotent: when the row already exists (bot-client's legacy write is
- * authoritative during dual-write and normally lands first), this handler
- * compares instead of writing and reports `matched` — a `false` there is the
- * burn-in divergence signal.
+ * Idempotent against replays (see conversationPersistShared.ts): an
+ * at-least-once redelivery — a retry, or MultiTagRecovery re-running a
+ * delivery after deploy-orphan rehydration — resolves to the same
+ * deterministic id, so this handler compares instead of writing and reports
+ * `matched`; a `false` there means the replay carried different content
+ * (drift between attempts), which is a bug signal.
  *
  * **Authentication**: `X-Service-Auth` enforcement happens upstream via the
  * global `requireServiceAuth()` on `/internal/*` in api-gateway's index.
@@ -31,6 +32,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { logFastPoolTimeout } from '../../utils/dbTimeout.js';
+import { fetchExistingConversationRow } from './conversationPersistShared.js';
 import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('internal-conversation-assistant-message');
@@ -62,25 +64,13 @@ export const handlePersistAssistantMessage = (deps: RouteDeps): RequestHandler =
     const id = generateConversationHistoryUuid(channelId, personalityId, personaId, assistantTime);
 
     const compareExisting = async (): Promise<PersistAssistantMessageResponse | null> => {
-      const readStartedAt = Date.now();
-      let existing;
-      try {
-        existing = await prisma.conversationHistory.findUnique({
-          where: { id },
-          select: { content: true, discordMessageId: true },
-        });
-      } catch (error) {
-        // Same self-labeling the write path gets — without it, a read-side
-        // fast-pool failure (dead-conn retry exhausted) surfaces only as the
-        // global handler's generic 'Unhandled error:'.
-        logFastPoolTimeout(
-          logger,
-          error,
-          { durationMs: Date.now() - readStartedAt, channelId, id },
-          'Assistant-message existence check hit a fast-pool DB timeout'
-        );
-        throw error;
-      }
+      const existing = await fetchExistingConversationRow(
+        prisma,
+        id,
+        logger,
+        'Assistant-message existence check hit a fast-pool DB timeout',
+        { channelId }
+      );
       if (existing === null) {
         return null;
       }
@@ -94,7 +84,7 @@ export const handlePersistAssistantMessage = (deps: RouteDeps): RequestHandler =
             contentMatch: existing.content === content,
             chunkIdsMatch: chunkIdsMatch(existing.discordMessageId, chunkMessageIds),
           },
-          'Assistant-message dual-write DIVERGED from existing row'
+          'Assistant-message persist replay DIVERGED from existing row'
         );
       }
       return { id, created: false, matched };
@@ -119,11 +109,11 @@ export const handlePersistAssistantMessage = (deps: RouteDeps): RequestHandler =
         timestamp: assistantTime,
       });
     } catch (error) {
-      // Only the unique-violation race gets the compare fallback: the legacy
-      // writer landed between our existence check and the create, so the row
-      // exists and comparing is the correct outcome. Any other failure
-      // (FK violation, transient DB error) must surface, not be masked by a
-      // coincidental row appearing in the same window.
+      // Only the unique-violation race gets the compare fallback: a duplicate
+      // delivery of the same event landed between our existence check and the
+      // create, so the row exists and comparing is the correct outcome. Any
+      // other failure (FK violation, transient DB error) must surface, not be
+      // masked by a coincidental row appearing in the same window.
       const isRace = (error as { code?: string }).code === 'P2002';
       if (!isRace) {
         // Classify before rethrowing so the resulting 5xx carries the

--- a/services/api-gateway/src/routes/internal/conversationPersistShared.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationPersistShared.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the shared persist-route read helper.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { type ConversationHistoryClient } from '@tzurot/conversation-history';
+import { type createLogger } from '@tzurot/common-types/utils/logger';
+import { fetchExistingConversationRow } from './conversationPersistShared.js';
+
+const asClient = (findUnique: ReturnType<typeof vi.fn>): ConversationHistoryClient =>
+  ({ conversationHistory: { findUnique } }) as unknown as ConversationHistoryClient;
+
+const makeLogger = (): { error: ReturnType<typeof vi.fn> } => ({ error: vi.fn() });
+const asLogger = (log: { error: ReturnType<typeof vi.fn> }): ReturnType<typeof createLogger> =>
+  log as unknown as ReturnType<typeof createLogger>;
+
+describe('fetchExistingConversationRow', () => {
+  it('returns the selected row when it exists', async () => {
+    const row = { content: 'hi', discordMessageId: ['1'] };
+    const findUnique = vi.fn().mockResolvedValue(row);
+
+    const result = await fetchExistingConversationRow(
+      asClient(findUnique),
+      'row-id',
+      asLogger(makeLogger()),
+      'msg',
+      { channelId: 'c' }
+    );
+
+    expect(result).toBe(row);
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: 'row-id' },
+      select: { content: true, discordMessageId: true },
+    });
+  });
+
+  it('returns null when no row exists (no logging)', async () => {
+    const log = makeLogger();
+
+    const result = await fetchExistingConversationRow(
+      asClient(vi.fn().mockResolvedValue(null)),
+      'row-id',
+      asLogger(log),
+      'msg',
+      {}
+    );
+
+    expect(result).toBeNull();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('self-labels a fast-pool timeout and rethrows', async () => {
+    const log = makeLogger();
+    const timeoutError = Object.assign(new Error('canceling statement due to statement timeout'), {
+      code: '57014',
+    });
+
+    await expect(
+      fetchExistingConversationRow(
+        asClient(vi.fn().mockRejectedValue(timeoutError)),
+        'row-id',
+        asLogger(log),
+        'existence check hit a fast-pool DB timeout',
+        { channelId: 'c' }
+      )
+    ).rejects.toBe(timeoutError);
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'statement-timeout',
+        sqlstate: '57014',
+        id: 'row-id',
+        channelId: 'c',
+      }),
+      'existence check hit a fast-pool DB timeout'
+    );
+  });
+
+  it('rethrows non-timeout errors without logging (they carry their own shape)', async () => {
+    const log = makeLogger();
+    const p2002 = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+
+    await expect(
+      fetchExistingConversationRow(
+        asClient(vi.fn().mockRejectedValue(p2002)),
+        'id',
+        asLogger(log),
+        'msg',
+        {}
+      )
+    ).rejects.toBe(p2002);
+
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/routes/internal/conversationPersistShared.ts
+++ b/services/api-gateway/src/routes/internal/conversationPersistShared.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared pieces of the two conversation-event persist routes
+ * (user-message / assistant-message).
+ *
+ * Both routes are idempotent against REPLAYS: the row id is a deterministic
+ * UUID over (channel, personality, persona, timestamp) with a stable
+ * timestamp, so an at-least-once redelivery of the same event — a bot-client
+ * retry, or MultiTagRecovery re-running a delivery after a deploy-orphan
+ * rehydration — resolves to the same id, and the handler compares instead of
+ * writing. The compare happens twice per request: an existence pre-check, and
+ * a re-read when the create loses a duplicate-delivery race (P2002).
+ */
+
+import { type ConversationHistoryClient } from '@tzurot/conversation-history';
+import { type createLogger } from '@tzurot/common-types/utils/logger';
+import { logFastPoolTimeout } from '../../utils/dbTimeout.js';
+
+/** The columns the persist routes compare a replay against. */
+export interface ExistingConversationRow {
+  content: string;
+  discordMessageId: string[];
+}
+
+/**
+ * Fetch the existing row for a persist id, self-labeling a fast-pool timeout
+ * before rethrowing — the same `{label, sqlstate, durationMs}` diagnostic the
+ * write path logs, so a read-side failure never surfaces as a generic
+ * unhandled error.
+ */
+export async function fetchExistingConversationRow(
+  prisma: ConversationHistoryClient,
+  id: string,
+  logger: ReturnType<typeof createLogger>,
+  message: string,
+  logFields: Record<string, unknown>
+): Promise<ExistingConversationRow | null> {
+  const startedAt = Date.now();
+  try {
+    return await prisma.conversationHistory.findUnique({
+      where: { id },
+      select: { content: true, discordMessageId: true },
+    });
+  } catch (error) {
+    logFastPoolTimeout(
+      logger,
+      error,
+      { durationMs: Date.now() - startedAt, id, ...logFields },
+      message
+    );
+    throw error;
+  }
+}

--- a/services/api-gateway/src/routes/internal/conversationSync.ts
+++ b/services/api-gateway/src/routes/internal/conversationSync.ts
@@ -5,13 +5,10 @@
  * fetched for a channel+personality; the gateway runs the diff against DB
  * state and applies the writes (content updates, soft-deletes).
  *
- * The algorithm lives in ConversationSyncService.runSync (common-types) —
- * the same implementation bot-client's legacy direct path delegates to — so
- * the two paths cannot drift during the dual-write window. Idempotent:
- * re-posting an already-applied snapshot finds zero work, which is exactly
- * what the dual-write verification expects (nonzero counts here mean the
- * legacy path and this endpoint disagreed — the burn-in signal, logged
- * client-side from the response).
+ * The algorithm lives in ConversationSyncService.runSync
+ * (@tzurot/conversation-history); this endpoint is its only caller.
+ * Idempotent: re-posting an already-applied snapshot finds zero work, so
+ * at-least-once delivery of the same snapshot is harmless.
  *
  * **Authentication**: `X-Service-Auth` enforcement happens upstream via the
  * global `requireServiceAuth()` on `/internal/*` in api-gateway's index.

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
@@ -110,7 +110,7 @@ describe('POST /internal/conversation/user-message', () => {
     expect(response.body.created).toBe(true);
   });
 
-  it('reports matched=true without writing when an identical row exists (dual-write)', async () => {
+  it('reports matched=true without writing when an identical row exists (idempotent replay)', async () => {
     mockPrisma.conversationHistory.findUnique.mockResolvedValue({
       content: VALID_BODY.content,
       discordMessageId: [VALID_BODY.discordMessageId],
@@ -125,7 +125,7 @@ describe('POST /internal/conversation/user-message', () => {
     expect(mockPrisma.conversationHistory.create).not.toHaveBeenCalled();
   });
 
-  it('reports matched=false when the existing row diverges (burn-in signal)', async () => {
+  it('reports matched=false when the existing row diverges (replay drift signal)', async () => {
     mockPrisma.conversationHistory.findUnique.mockResolvedValue({
       content: 'different content',
       discordMessageId: [VALID_BODY.discordMessageId],

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.ts
@@ -5,14 +5,16 @@
  * a Discord event, so this gateway (the Discord-event data authority) owns
  * the write — bot-client calls it synchronously pre-submission, preserving
  * strict ordering (the next message's history query always sees this row)
- * with no locks. Delegates to ConversationHistoryService.addMessage — the
- * same code path bot-client's legacy direct write uses — so the two paths
- * produce identical rows by construction during the dual-write window.
+ * with no locks. This endpoint is the SOLE creator of user-message history
+ * rows (bot-client has no Prisma; ai-worker only updates existing rows).
  *
- * Idempotent: when the row already exists (legacy write is authoritative
- * during dual-write), compares instead of writing and reports `matched`;
- * `matched: false` is the burn-in divergence signal. A create race against
- * the legacy writer (P2002) falls back to compare; other errors surface.
+ * Idempotent against replays (see conversationPersistShared.ts): an
+ * at-least-once redelivery of the same event resolves to the same
+ * deterministic id, so the handler compares instead of writing and reports
+ * `matched` — a `false` there means a replay carried different content
+ * (drift between attempts), which is a bug signal. A create that loses a
+ * duplicate-delivery race (P2002) falls back to compare; other errors
+ * surface.
  *
  * **Authentication**: `X-Service-Auth` enforcement happens upstream via the
  * global `requireServiceAuth()` on `/internal/*` in api-gateway's index.
@@ -31,6 +33,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { logFastPoolTimeout } from '../../utils/dbTimeout.js';
+import { fetchExistingConversationRow } from './conversationPersistShared.js';
 import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('internal-conversation-user-message');
@@ -59,38 +62,26 @@ export const handlePersistUserMessage = (deps: RouteDeps): RequestHandler => {
     const id = generateConversationHistoryUuid(channelId, personalityId, personaId, createdAt);
 
     const compareExisting = async (): Promise<PersistUserMessageResponse | null> => {
-      const readStartedAt = Date.now();
-      let existing;
-      try {
-        existing = await prisma.conversationHistory.findUnique({
-          where: { id },
-          select: { content: true, discordMessageId: true },
-        });
-      } catch (error) {
-        // Same self-labeling the write path gets — without it, a read-side
-        // fast-pool failure (dead-conn retry exhausted) surfaces only as the
-        // global handler's generic 'Unhandled error:'.
-        logFastPoolTimeout(
-          logger,
-          error,
-          { durationMs: Date.now() - readStartedAt, channelId, id },
-          'User-message existence check hit a fast-pool DB timeout'
-        );
-        throw error;
-      }
+      const existing = await fetchExistingConversationRow(
+        prisma,
+        id,
+        logger,
+        'User-message existence check hit a fast-pool DB timeout',
+        { channelId }
+      );
       if (existing === null) {
         return null;
       }
-      // Deliberately lightweight: content + trigger id only. Both write paths
-      // construct messageMetadata from the same bot-side object, so metadata
-      // divergence could only come from serialization differences — not worth
-      // a deep JSONB comparison for the burn-in signal.
+      // Deliberately lightweight: content + trigger id only. A replay builds
+      // messageMetadata from the same bot-side object, so metadata divergence
+      // could only come from serialization differences — not worth a deep
+      // JSONB comparison for a drift signal.
       const matched =
         existing.content === content && existing.discordMessageId[0] === discordMessageId;
       if (!matched) {
         logger.warn(
           { id, channelId, contentMatch: existing.content === content },
-          'User-message dual-write DIVERGED from existing row'
+          'User-message persist replay DIVERGED from existing row'
         );
       }
       return { id, created: false, matched };
@@ -116,9 +107,10 @@ export const handlePersistUserMessage = (deps: RouteDeps): RequestHandler => {
         timestamp: createdAt,
       });
     } catch (error) {
-      // Only the unique-violation race gets the compare fallback (the legacy
-      // writer landed between our existence check and the create); any other
-      // failure must surface rather than be masked by a coincidental row.
+      // Only the unique-violation race gets the compare fallback (a duplicate
+      // delivery of the same event landed between our existence check and the
+      // create); any other failure must surface rather than be masked by a
+      // coincidental row.
       const isRace = (error as { code?: string }).code === 'P2002';
       if (!isRace) {
         // Classify before rethrowing so the resulting 5xx carries the


### PR DESCRIPTION
## Summary

TASK-174 as filed said the persist handlers' compare-first + P2002 fallback was "likely dead" along with the dual-write JSDoc describing it. The freshness-check confirmed half and refuted half:

- **Confirmed dead**: the legacy direct writer. bot-client has no Prisma (guard-enforced), and ai-worker's only `ConversationHistoryService` uses are reads (`PrismaContextDataSource`) and updates onto existing rows (`VisionDescriptionWriter`). The gateway endpoints are the sole row creators.
- **Refuted**: the fallback being dead. It is the live idempotency mechanism for **at-least-once replays** — `ConversationPersistence.ts` deliberately keys the deterministic UUID on a stable timestamp so "a fresh new Date() per write would produce a different id on every retry," and `MultiTagRecovery` re-runs `saveAssistantMessage` after deploy-orphan rehydration. Dropping compare-first/P2002 would break replay dedup.

So the change is **documentation + dedup, zero control flow**:

- Both persist route headers, the P2002 branch comments, and the `DIVERGED` warn messages now describe the single-writer + replay reality (`matched: false` = content drift between attempts, a bug signal — not a dual-write burn-in signal).
- `conversationSync.ts`, the route-manifest comment in `packages/clients/internal.ts`, and `ConversationSyncService.runSync`'s JSDoc lose their dual-write archaeology. The "only caller" claims are grep-verified (sync service constructed only by the gateway route; bot-client's `SyncExecutor` calls the endpoint).
- The `findUnique` try/catch + fast-pool self-labeling wrapper — byte-identical across both routes since #1866, and flagged by that PR's review — is extracted to `conversationPersistShared.ts` with its own test suite. #1866 deferred this extraction *only* because TASK-174 might delete `compareExisting`; the freshness-check proves it permanent, so the dedup lands here.
- Test names re-pinned: `(dual-write)` → `(idempotent replay)`, `(burn-in signal)` → `(replay drift signal)`.

## Verification

- `pnpm test` green (26 tasks) and `pnpm quality` green (gate-parity 27/27), sequential.
- Focused: all 17 internal-route test files (118 tests), including the new `conversationPersistShared` suite (row / null / timeout-label-rethrow / non-timeout-silent-rethrow).
- Old-token sweep: zero `dual-write` / `burn-in` occurrences remain in source across api-gateway, bot-client, clients, and conversation-history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)