### PR TITLE
feat(bot-client): describe stickers and polls in message context (task-355)

### DIFF
--- a/services/bot-client/src/handlers/references/MessageFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.test.ts
@@ -118,6 +118,21 @@ describe('MessageFormatter', () => {
       expect(result.webhookId).toBe('webhook-789');
     });
 
+    it('should describe a sticker-only referenced message instead of rendering it blank', async () => {
+      const stickers = new Map([['1', { name: 'partyblob', description: null }]]);
+      const message = createMockMessage({
+        content: '',
+        author: createMockUser(),
+        attachments: new Map() as any,
+        embeds: [],
+        stickers: stickers as any,
+      });
+
+      const result = await formatter.formatMessage(message, 1);
+
+      expect(result.content).toBe('[Stickers: partyblob]');
+    });
+
     it('should mark message as forwarded when flag is set', async () => {
       const message = createMockMessage({
         content: 'Forwarded message',

--- a/services/bot-client/src/handlers/references/MessageFormatter.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.ts
@@ -16,6 +16,7 @@ import { extractDiscordEnvironment } from '../../utils/discordContext.js';
 import { extractAttachments } from '../../utils/attachmentExtractor.js';
 import { extractEmbedImages } from '../../utils/embedImageExtractor.js';
 import { EmbedParser } from '../../utils/EmbedParser.js';
+import { withStickerAndPollDescriptions } from '../../utils/stickerPollDescriptions.js';
 import { type TranscriptRetriever } from './TranscriptRetriever.js';
 import { classifyReferenceAuthorRole } from './authorRole.js';
 import {
@@ -43,7 +44,7 @@ export class MessageFormatter {
   ): { content: string; attachments: AttachmentList } {
     if (isForwarded && hasForwardedSnapshots(message)) {
       return {
-        content: extractForwardedContent(message),
+        content: withStickerAndPollDescriptions(message, extractForwardedContent(message)),
         attachments: extractForwardedAttachments(message),
       };
     }
@@ -51,7 +52,9 @@ export class MessageFormatter {
     const regularAttachments = extractAttachments(message.attachments);
     const embedImages = extractEmbedImages(message.embeds);
     return {
-      content: message.content,
+      // Without the descriptions, replying to a sticker-only or poll-only
+      // message renders an empty [Reference N] block.
+      content: withStickerAndPollDescriptions(message, message.content),
       attachments: [...(regularAttachments ?? []), ...(embedImages ?? [])],
     };
   }

--- a/services/bot-client/src/processors/EmptyMessageFilter.test.ts
+++ b/services/bot-client/src/processors/EmptyMessageFilter.test.ts
@@ -12,6 +12,8 @@ function createMockMessage(options: {
   content: string;
   attachmentCount: number;
   snapshotAttachmentCount?: number;
+  stickerNames?: string[];
+  poll?: unknown;
 }): Message {
   const attachments = new Map();
   for (let i = 0; i < options.attachmentCount; i++) {
@@ -35,11 +37,18 @@ function createMockMessage(options: {
     });
   }
 
+  const stickers = new Map(
+    (options.stickerNames ?? []).map(name => [name, { name, description: null }])
+  );
+
   return {
     id: '123456789',
     content: options.content,
     attachments,
     messageSnapshots: messageSnapshots.size > 0 ? messageSnapshots : null,
+    // Always present on a real Message — this filter now consults both.
+    stickers,
+    poll: options.poll ?? null,
   } as unknown as Message;
 }
 
@@ -48,6 +57,26 @@ describe('EmptyMessageFilter', () => {
 
   beforeEach(() => {
     filter = new EmptyMessageFilter();
+  });
+
+  it('should NOT filter a sticker-only message (it would never reach the trigger processors)', async () => {
+    const message = createMockMessage({
+      content: '',
+      attachmentCount: 0,
+      stickerNames: ['partyblob'],
+    });
+
+    await expect(filter.process(message)).resolves.toBe(false);
+  });
+
+  it('should NOT filter a poll-only message', async () => {
+    const message = createMockMessage({
+      content: '',
+      attachmentCount: 0,
+      poll: { question: { text: 'Pizza?' }, answers: new Map() },
+    });
+
+    await expect(filter.process(message)).resolves.toBe(false);
   });
 
   it('should filter out empty messages', async () => {

--- a/services/bot-client/src/processors/EmptyMessageFilter.ts
+++ b/services/bot-client/src/processors/EmptyMessageFilter.ts
@@ -11,6 +11,7 @@ import type { Message } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { IMessageProcessor } from './IMessageProcessor.js';
 import { isForwardedMessage } from '../utils/forwardedMessageUtils.js';
+import { hasStickerOrPoll } from '../utils/stickerPollDescriptions.js';
 
 const logger = createLogger('EmptyMessageFilter');
 
@@ -45,6 +46,14 @@ export class EmptyMessageFilter implements IMessageProcessor {
           break;
         }
       }
+    }
+
+    // A sticker or poll IS the message when it carries nothing else — and this
+    // filter runs at chain position 3, ahead of the trigger and DM processors,
+    // so dropping here means the bot never responds at all to someone who
+    // @-mentions it with just a sticker.
+    if (hasStickerOrPoll(message)) {
+      return Promise.resolve(false); // Continue to next processor
     }
 
     // Only filter if message has no content AND no attachments (direct or snapshot)

--- a/services/bot-client/src/services/DiscordChannelFetcher.test.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.test.ts
@@ -99,6 +99,8 @@ function createMockMessage(
     attachments: Map<string, MockAttachment>;
     reference: { messageId: string; type?: number; channelId?: string } | null;
     reactions: Map<string, MockReaction>;
+    stickers: Map<string, { name: string; description: string | null }>;
+    poll: unknown;
   }>
 ): Message {
   const defaults = {
@@ -119,6 +121,8 @@ function createMockMessage(
     attachments: new Map(),
     reference: null,
     reactions: new Map<string, MockReaction>(),
+    stickers: new Map<string, { name: string; description: string | null }>(),
+    poll: null,
   };
 
   const config = { ...defaults, ...overrides };
@@ -160,6 +164,8 @@ function createMockMessage(
     reference: config.reference,
     // Reactions cache for extended context processing
     reactions: { cache: new Collection(config.reactions) },
+    stickers: new Collection(config.stickers),
+    poll: config.poll,
   } as unknown as Message;
 }
 
@@ -710,6 +716,50 @@ describe('DiscordChannelFetcher', () => {
 
       expect(result.keptCount).toBe(1);
       expect(result.messages[0].content).toContain('Has content');
+    });
+
+    it('should KEEP a standalone sticker-only message and describe it', async () => {
+      // The pre-filter (hasMessageContent) runs before convertMessage, so a
+      // sticker-only message has to clear THAT gate to be described at all.
+      const messages = [
+        createMockMessage({ id: '1', content: 'Has content' }),
+        createMockMessage({
+          id: '2',
+          content: '',
+          stickers: new Map([['s1', { name: 'partyblob', description: null }]]),
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, { botUserId: 'bot123' });
+
+      expect(result.keptCount).toBe(2);
+      expect(result.messages.map(m => m.content)).toContain('[Stickers: partyblob]');
+    });
+
+    it('should KEEP a standalone poll-only message and describe it', async () => {
+      const messages = [
+        createMockMessage({ id: '1', content: 'Has content' }),
+        createMockMessage({
+          id: '2',
+          content: '',
+          poll: {
+            question: { text: 'Pizza?' },
+            answers: new Collection([
+              [0, { text: 'Yes', emoji: null }],
+              [1, { text: 'No', emoji: null }],
+            ]),
+          },
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, { botUserId: 'bot123' });
+
+      expect(result.keptCount).toBe(2);
+      expect(result.messages.map(m => m.content)).toContain('[Poll: Pizza? — options: Yes, No]');
     });
 
     it('should filter thinking block messages from extended context', async () => {

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
@@ -5,7 +5,7 @@ import {
   rawAssemblyInputsSchema,
   type RawAssemblyInputs,
 } from '@tzurot/common-types/types/schemas/rawEnvelope';
-import { MessageReferenceType, type Message } from 'discord.js';
+import { Collection, MessageReferenceType, type Message, type Sticker } from 'discord.js';
 
 const { mockGetVoiceTranscript } = vi.hoisted(() => ({
   mockGetVoiceTranscript: vi.fn((): string | undefined => undefined),
@@ -50,16 +50,28 @@ const makeMessage = (
 const makeForwardedMessage = (
   snapshotContent: string,
   opts: { withReferenceType?: boolean; topLevelContent?: string } = {}
-) =>
-  ({
+) => {
+  // A real snapshot carries stickers (MessageSnapshot keeps that field) — the
+  // fixture mirrors the full Collection surface, not just the members the
+  // forward-content path happens to read, so a consumer added later doesn't
+  // trip over a half-built mock.
+  const snapshot = { content: snapshotContent, stickers: new Collection<string, Sticker>() };
+  return {
     client: {},
     content: opts.topLevelContent ?? '',
     mentions: { users: new Map() },
+    stickers: new Collection<string, Sticker>(),
+    poll: null,
     ...(opts.withReferenceType === true
       ? { reference: { type: MessageReferenceType.Forward } }
       : {}),
-    messageSnapshots: { size: 1, first: () => ({ content: snapshotContent }) },
-  }) as unknown as Message;
+    messageSnapshots: {
+      size: 1,
+      first: () => snapshot,
+      values: () => [snapshot].values(),
+    },
+  } as unknown as Message;
+};
 
 const makeConversationMessage = (overrides: Partial<ConversationMessage> = {}) =>
   ({

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
@@ -29,6 +29,7 @@ import type { z } from 'zod';
 import type { ExtendedContextUser, FetchResult } from '../channelFetcher/types.js';
 import { VoiceMessageProcessor } from '../../processors/VoiceMessageProcessor.js';
 import { getEffectiveContent } from '../../utils/forwardedMessageUtils.js';
+import { withStickerAndPollDescriptions } from '../../utils/stickerPollDescriptions.js';
 import { buildKnownChannelEnvironments } from '../CrossChannelHistoryFetcher.js';
 
 /** The pre-resolution extended-context snapshot threaded out of the fetch. */
@@ -158,7 +159,10 @@ export function buildRawAssemblyInputs(
     // getEffectiveContent yields message.content for normal triggers and the
     // forward snapshot text for forwarded ones; a bare message.content is empty
     // for a forward, which drops the whole forwarded message from the prompt.
-    rawMessageContent: getEffectiveContent(message),
+    // Sticker/poll descriptions append here rather than inside
+    // getEffectiveContent: that util is also the routing/mention-detection
+    // text source, which must stay byte-faithful to what the user typed.
+    rawMessageContent: withStickerAndPollDescriptions(message, getEffectiveContent(message)),
     rawRoutingTranscript: VoiceMessageProcessor.getVoiceTranscript(message),
     rawAuthorDisplayName: refs?.rawAuthorDisplayName,
     // No clone needed (unlike the participant guild map): this scalar is a

--- a/services/bot-client/src/test/mocks/Discord.mock.ts
+++ b/services/bot-client/src/test/mocks/Discord.mock.ts
@@ -308,6 +308,10 @@ export function createMockMessage(overrides: MockInput<Message> = EMPTY_OVERRIDE
     mentions: createMockMessageMentions(),
     attachments: createMockCollection(),
     embeds: [],
+    // Also always present on a real Message — a message-shape consumer added
+    // later must not have to discover these are missing from the shared mock.
+    stickers: createMockCollection(),
+    poll: null,
     reference: null,
     type: 0, // DEFAULT message type
     reply: vi.fn().mockResolvedValue(null),

--- a/services/bot-client/src/utils/MessageContentBuilder.test.ts
+++ b/services/bot-client/src/utils/MessageContentBuilder.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Collection, MessageType, MessageReferenceType } from 'discord.js';
-import type { Message, Attachment, Embed, MessageSnapshot } from 'discord.js';
+import type { Message, Attachment, Embed, MessageSnapshot, Sticker } from 'discord.js';
 import {
   buildMessageContent,
   formatAttachmentDescription,
@@ -79,6 +79,10 @@ function createMockMessage(overrides: Record<string, unknown> = {}): Message {
     embeds,
     reference: null,
     messageSnapshots,
+    // Always present on a real Message; a fixture omitting them is the
+    // untyped-mock drift that `as unknown as Message` hides from the compiler.
+    stickers: new Collection<string, Sticker>(),
+    poll: null,
     type: MessageType.Default,
     ...overrides,
   } as unknown as Message;
@@ -108,6 +112,60 @@ describe('MessageContentBuilder', () => {
 
       expect(result.content).toBe('');
       expect(result.attachments).toEqual([]);
+    });
+
+    it('should describe a sticker-only message so it is not read as empty', async () => {
+      const stickers = new Collection<string, Sticker>();
+      stickers.set('1', { name: 'partyblob', description: null } as unknown as Sticker);
+      const message = createMockMessage({ content: '', stickers });
+
+      const result = await buildMessageContent(message);
+
+      // Non-empty is the load-bearing part: convertMessage's
+      // hasProcessableContent gate drops a message whose content is empty.
+      expect(result.content).toBe('[Stickers: partyblob]');
+    });
+
+    it('should merge own and snapshot stickers when a forward also carries its own', async () => {
+      const ownStickers = new Collection<string, Sticker>();
+      ownStickers.set('1', { name: 'own', description: null } as unknown as Sticker);
+      const snapshotStickers = new Collection<string, Sticker>();
+      snapshotStickers.set('2', { name: 'forwarded', description: null } as unknown as Sticker);
+      const messageSnapshots = new Collection<string, MessageSnapshot>();
+      messageSnapshots.set('1', {
+        content: 'forwarded body',
+        embeds: [],
+        attachments: new Collection(),
+        stickers: snapshotStickers,
+      } as unknown as MessageSnapshot);
+      const message = createMockMessage({
+        content: '',
+        stickers: ownStickers,
+        messageSnapshots,
+        reference: { type: MessageReferenceType.Forward, messageId: 'src' },
+      });
+
+      const result = await buildMessageContent(message);
+
+      expect(result.isForwarded).toBe(true);
+      expect(result.content).toContain('[Stickers: own, forwarded]');
+    });
+
+    it('should describe a poll alongside the message text', async () => {
+      const message = createMockMessage({
+        content: 'vote now',
+        poll: {
+          question: { text: 'Pizza?' },
+          answers: new Collection<number, unknown>([
+            [0, { text: 'Yes', emoji: null }],
+            [1, { text: 'No', emoji: null }],
+          ]),
+        },
+      });
+
+      const result = await buildMessageContent(message);
+
+      expect(result.content).toBe('vote now\n\n[Poll: Pizza? — options: Yes, No]');
     });
 
     it('should include attachment descriptions when includeAttachments is true', async () => {

--- a/services/bot-client/src/utils/MessageContentBuilder.ts
+++ b/services/bot-client/src/utils/MessageContentBuilder.ts
@@ -29,7 +29,7 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
 import { EmbedParser } from './EmbedParser.js';
-import { describeStickersAndPoll } from './stickerPollDescriptions.js';
+import { describeStickersAndPoll, hasStickerOrPoll } from './stickerPollDescriptions.js';
 import {
   isForwardedMessage,
   hasForwardedSnapshots,
@@ -385,6 +385,11 @@ export function hasMessageContent(message: Message): boolean {
     message.attachments.size > 0 ||
     (message.embeds !== undefined && message.embeds.length > 0) ||
     (message.messageSnapshots !== undefined && message.messageSnapshots.size > 0) ||
-    isForwardedMessage(message)
+    isForwardedMessage(message) ||
+    // Stickers and polls ARE the content of a message that carries nothing
+    // else. This predicate runs as the extended-context pre-filter, BEFORE
+    // buildMessageContent, so omitting them here drops the message before it
+    // can ever be described — the earlier of the two gates wins.
+    hasStickerOrPoll(message)
   );
 }

--- a/services/bot-client/src/utils/MessageContentBuilder.ts
+++ b/services/bot-client/src/utils/MessageContentBuilder.ts
@@ -29,6 +29,7 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
 import { EmbedParser } from './EmbedParser.js';
+import { describeStickersAndPoll } from './stickerPollDescriptions.js';
 import {
   isForwardedMessage,
   hasForwardedSnapshots,
@@ -268,6 +269,13 @@ export async function buildMessageContent(
   if (message.content) {
     contentParts.push(message.content);
   }
+
+  // Stickers and polls carry no text of their own, so without these lines a
+  // sticker-only or poll-only message is indistinguishable from an empty one —
+  // and convertMessage's hasProcessableContent gate drops it from context
+  // entirely. Rendering them into content also persists them with the history
+  // row (no metadata plumbing needed).
+  contentParts.push(...describeStickersAndPoll(message));
 
   // Extract and combine attachments from all sources:
   // 1. Forwarded message snapshot attachments (extracted above)

--- a/services/bot-client/src/utils/stickerPollDescriptions.test.ts
+++ b/services/bot-client/src/utils/stickerPollDescriptions.test.ts
@@ -8,6 +8,7 @@ import {
   describePoll,
   describeStickers,
   describeStickersAndPoll,
+  hasStickerOrPoll,
   withStickerAndPollDescriptions,
 } from './stickerPollDescriptions.js';
 
@@ -172,6 +173,26 @@ describe('describeStickersAndPoll', () => {
 
   it('returns an empty array for a message with neither', () => {
     expect(describeStickersAndPoll(messageWith({}))).toEqual([]);
+  });
+});
+
+describe('hasStickerOrPoll ↔ describeStickersAndPoll equivalence', () => {
+  // hasMessageContent uses the cheap predicate as a PRE-FILTER; if it ever
+  // disagrees with the renderers, a message gets dropped as empty that would
+  // have rendered content (the bug this pairing exists to prevent).
+  const cases: Array<[string, Parameters<typeof messageWith>[0]]> = [
+    ['nothing', {}],
+    ['own sticker', { stickers: [{ name: 's' }] }],
+    ['snapshot sticker only', { snapshotStickers: [[{ name: 'f' }]] }],
+    ['empty snapshot list', { snapshotStickers: [[]] }],
+    ['poll only', { poll: { question: 'Q?', answers: [{ text: 'A' }] } }],
+    ['poll with no answers', { poll: { question: 'Q?', answers: [] } }],
+    ['both', { stickers: [{ name: 's' }], poll: { question: 'Q?', answers: [] } }],
+  ];
+
+  it.each(cases)('agrees for %s', (_label, opts) => {
+    const message = messageWith(opts);
+    expect(hasStickerOrPoll(message)).toBe(describeStickersAndPoll(message).length > 0);
   });
 });
 

--- a/services/bot-client/src/utils/stickerPollDescriptions.test.ts
+++ b/services/bot-client/src/utils/stickerPollDescriptions.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for sticker/poll content descriptions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Message } from 'discord.js';
+import {
+  describePoll,
+  describeStickers,
+  describeStickersAndPoll,
+  withStickerAndPollDescriptions,
+} from './stickerPollDescriptions.js';
+
+interface StickerFixture {
+  name: string;
+  description?: string | null;
+}
+
+interface AnswerFixture {
+  text?: string | null;
+  emojiName?: string | null;
+}
+
+/**
+ * Build the narrow slice of a Message the renderers read. Deliberately not a
+ * full Message mock — these functions touch `stickers`, `messageSnapshots`,
+ * and `poll` only, and a fixture that mirrors exactly that keeps the test
+ * honest about the surface under test.
+ */
+function messageWith(opts: {
+  stickers?: StickerFixture[];
+  snapshotStickers?: StickerFixture[][];
+  poll?: { question?: string | null; answers?: AnswerFixture[] } | null;
+}): Message {
+  const toStickerMap = (list: StickerFixture[]): Map<string, unknown> =>
+    new Map(
+      list.map((s, i) => [
+        String(i),
+        { name: s.name, description: s.description === undefined ? null : s.description },
+      ])
+    );
+
+  const poll =
+    opts.poll === undefined || opts.poll === null
+      ? null
+      : {
+          question: { text: opts.poll.question === undefined ? 'Q?' : opts.poll.question },
+          answers: new Map(
+            (opts.poll.answers ?? []).map((a, i) => [
+              i,
+              {
+                text: a.text === undefined ? null : a.text,
+                emoji: a.emojiName === undefined ? null : { name: a.emojiName },
+              },
+            ])
+          ),
+        };
+
+  return {
+    stickers: toStickerMap(opts.stickers ?? []),
+    messageSnapshots: new Map(
+      (opts.snapshotStickers ?? []).map((list, i) => [String(i), { stickers: toStickerMap(list) }])
+    ),
+    poll,
+  } as unknown as Message;
+}
+
+describe('describeStickers', () => {
+  it('renders the name alone when Discord supplies no description', () => {
+    expect(describeStickers(messageWith({ stickers: [{ name: 'partyblob' }] }))).toBe(
+      '[Stickers: partyblob]'
+    );
+  });
+
+  it('renders name — description when a description exists', () => {
+    expect(
+      describeStickers(
+        messageWith({ stickers: [{ name: 'partyblob', description: 'Blob having a party' }] })
+      )
+    ).toBe('[Stickers: partyblob — Blob having a party]');
+  });
+
+  it('lists every sticker on the message', () => {
+    expect(describeStickers(messageWith({ stickers: [{ name: 'one' }, { name: 'two' }] }))).toBe(
+      '[Stickers: one, two]'
+    );
+  });
+
+  it('includes stickers carried by a forwarded message snapshot', () => {
+    expect(
+      describeStickers(
+        messageWith({ stickers: [{ name: 'own' }], snapshotStickers: [[{ name: 'forwarded' }]] })
+      )
+    ).toBe('[Stickers: own, forwarded]');
+  });
+
+  it('flattens newlines so the bracket form stays one line', () => {
+    expect(
+      describeStickers(messageWith({ stickers: [{ name: 'multi\nline', description: 'a\n\nb' }] }))
+    ).toBe('[Stickers: multi line — a b]');
+  });
+
+  it('treats an empty-string description as absent', () => {
+    expect(describeStickers(messageWith({ stickers: [{ name: 'bare', description: '' }] }))).toBe(
+      '[Stickers: bare]'
+    );
+  });
+
+  it('returns empty string when there are no stickers', () => {
+    expect(describeStickers(messageWith({}))).toBe('');
+  });
+});
+
+describe('describePoll', () => {
+  it('renders the question and its options', () => {
+    expect(
+      describePoll(
+        messageWith({
+          poll: { question: 'Pizza tonight?', answers: [{ text: 'Yes' }, { text: 'No' }] },
+        })
+      )
+    ).toBe('[Poll: Pizza tonight? — options: Yes, No]');
+  });
+
+  it('falls back to the emoji name for an unlabeled option', () => {
+    expect(
+      describePoll(messageWith({ poll: { question: 'Vibe?', answers: [{ emojiName: 'fire' }] } }))
+    ).toBe('[Poll: Vibe? — options: :fire:]');
+  });
+
+  it('placeholders an option with neither text nor emoji', () => {
+    expect(describePoll(messageWith({ poll: { question: 'Q?', answers: [{}] } }))).toBe(
+      '[Poll: Q? — options: (unlabeled option)]'
+    );
+  });
+
+  it('renders a question-less poll rather than dropping it', () => {
+    expect(describePoll(messageWith({ poll: { question: null, answers: [{ text: 'A' }] } }))).toBe(
+      '[Poll: (no question) — options: A]'
+    );
+  });
+
+  it('omits the options clause when the poll has no answers', () => {
+    expect(describePoll(messageWith({ poll: { question: 'Lonely?', answers: [] } }))).toBe(
+      '[Poll: Lonely?]'
+    );
+  });
+
+  it('never renders vote counts (they mutate after the fetch; this text persists)', () => {
+    const rendered = describePoll(
+      messageWith({ poll: { question: 'Q?', answers: [{ text: 'A' }, { text: 'B' }] } })
+    );
+    expect(rendered).not.toMatch(/\d/);
+  });
+
+  it('returns empty string when the message carries no poll', () => {
+    expect(describePoll(messageWith({}))).toBe('');
+  });
+});
+
+describe('describeStickersAndPoll', () => {
+  it('returns stickers before the poll, omitting absent shapes', () => {
+    expect(
+      describeStickersAndPoll(
+        messageWith({
+          stickers: [{ name: 's' }],
+          poll: { question: 'Q?', answers: [{ text: 'A' }] },
+        })
+      )
+    ).toEqual(['[Stickers: s]', '[Poll: Q? — options: A]']);
+  });
+
+  it('returns an empty array for a message with neither', () => {
+    expect(describeStickersAndPoll(messageWith({}))).toEqual([]);
+  });
+});
+
+describe('withStickerAndPollDescriptions', () => {
+  it('returns the text byte-identical when the message has neither shape', () => {
+    expect(withStickerAndPollDescriptions(messageWith({}), 'hello')).toBe('hello');
+  });
+
+  it('leaves empty text empty when the message has neither shape', () => {
+    expect(withStickerAndPollDescriptions(messageWith({}), '')).toBe('');
+  });
+
+  it('appends the description below existing text', () => {
+    expect(
+      withStickerAndPollDescriptions(messageWith({ stickers: [{ name: 'wave' }] }), 'hi there')
+    ).toBe('hi there\n\n[Stickers: wave]');
+  });
+
+  it('yields description-only content for a sticker-only message (the drop fix)', () => {
+    expect(withStickerAndPollDescriptions(messageWith({ stickers: [{ name: 'wave' }] }), '')).toBe(
+      '[Stickers: wave]'
+    );
+  });
+
+  it('yields description-only content for a poll-only message', () => {
+    expect(
+      withStickerAndPollDescriptions(
+        messageWith({ poll: { question: 'Q?', answers: [{ text: 'A' }] } }),
+        ''
+      )
+    ).toBe('[Poll: Q? — options: A]');
+  });
+});

--- a/services/bot-client/src/utils/stickerPollDescriptions.ts
+++ b/services/bot-client/src/utils/stickerPollDescriptions.ts
@@ -1,0 +1,133 @@
+/**
+ * Sticker and poll descriptions for model context.
+ *
+ * Neither shape carries text in `message.content`, so a sticker-only or
+ * poll-only message reaches the model as an empty string — and the extended
+ * context fetcher's `hasProcessableContent` gate DROPS it outright, leaving a
+ * hole in the conversation the character can't see. These renderers turn both
+ * shapes into a one-line text description, in the same bracketed style as the
+ * `[Attachments: …]` line, so they ride the ordinary content path (persisted
+ * with the history row, no metadata plumbing, no prompt-format change).
+ *
+ * Deliberate omissions:
+ * - **Poll vote counts.** They mutate after the fetch, and this text is
+ *   persisted — a frozen tally would be wrong forever. The question and the
+ *   options are the poll's semantic content; the tally is volatile state.
+ * - **Sticker images.** Stickers are not attachments and never reach the
+ *   vision path; the name (and description, when Discord supplies one) is all
+ *   the semantic signal available without downloading the asset.
+ */
+
+import type { Message, MessageSnapshot, Sticker } from 'discord.js';
+
+/** Collapse newlines so a description can't break the one-line bracket form. */
+function flatten(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Read a Discord.js Collection's values, tolerating an absent one.
+ *
+ * `MessageSnapshot` is a `Partialize<Message>`, so a snapshot-shaped object
+ * reaching these renderers may genuinely lack a field the `Message` type
+ * declares as always-present. These descriptions are decoration on the
+ * message-handling hot path — throwing here would kill an entire turn to
+ * render a sticker label, which is never the right trade.
+ */
+function collectionValues<T>(collection: { values(): Iterable<T> } | undefined | null): T[] {
+  return collection === undefined || collection === null ? [] : [...collection.values()];
+}
+
+/** `name` alone, or `name — description` when Discord supplies a description. */
+function describeSticker(sticker: Sticker): string {
+  const name = flatten(sticker.name);
+  const description =
+    sticker.description === null || sticker.description.length === 0
+      ? undefined
+      : flatten(sticker.description);
+  return description === undefined ? name : `${name} — ${description}`;
+}
+
+/**
+ * `[Stickers: …]` for every sticker on the message, including any carried by a
+ * forwarded message's snapshots (snapshots retain `stickers`; they never carry
+ * a poll). Empty string when there are none, so callers can push
+ * unconditionally and filter falsy.
+ */
+export function describeStickers(message: Message | MessageSnapshot): string {
+  const own = collectionValues<Sticker>(message.stickers);
+  const snapshots =
+    'messageSnapshots' in message
+      ? collectionValues<MessageSnapshot>(message.messageSnapshots)
+      : [];
+  const forwarded = snapshots.flatMap(snapshot => collectionValues<Sticker>(snapshot.stickers));
+  const all = [...own, ...forwarded];
+  if (all.length === 0) {
+    return '';
+  }
+  return `[Stickers: ${all.map(describeSticker).join(', ')}]`;
+}
+
+/**
+ * The bits of a poll answer this renderer reads. Structural rather than
+ * `PollAnswer` so it also accepts `PartialPollAnswer` (both carry these two)
+ * without a union or a cast.
+ */
+interface PollAnswerLike {
+  text: string | null;
+  emoji: { name: string | null } | null;
+}
+
+/** One poll answer's label: its text, else its emoji name, else a placeholder. */
+function describeAnswer(answer: PollAnswerLike): string {
+  if (answer.text !== null && answer.text.length > 0) {
+    return flatten(answer.text);
+  }
+  const emojiName = answer.emoji?.name;
+  return emojiName !== null && emojiName !== undefined ? `:${emojiName}:` : '(unlabeled option)';
+}
+
+/**
+ * `[Poll: question — options: a, b, c]`. Empty string when the message carries
+ * no poll. A poll with neither a question nor answers still renders (the fact
+ * that a poll was posted is itself the content the character would otherwise
+ * miss entirely).
+ */
+export function describePoll(message: Message): string {
+  // The cast widens, not narrows: discord.js declares `poll` as `Poll | null`
+  // (never undefined), but a partial-shaped message can omit the field
+  // entirely — same reason collectionValues tolerates an absent Collection.
+  const poll = message.poll as Message['poll'] | undefined;
+  if (poll === null || poll === undefined) {
+    return '';
+  }
+  const question =
+    poll.question.text === null || poll.question.text.length === 0
+      ? '(no question)'
+      : flatten(poll.question.text);
+  const answers = [...poll.answers.values()].map(describeAnswer);
+  const options = answers.length === 0 ? '' : ` — options: ${answers.join(', ')}`;
+  return `[Poll: ${question}${options}]`;
+}
+
+/**
+ * Both descriptions for a message, in the order they should read. Callers
+ * append these to the message's text content.
+ */
+export function describeStickersAndPoll(message: Message): string[] {
+  return [describeStickers(message), describePoll(message)].filter(part => part.length > 0);
+}
+
+/**
+ * Append the descriptions to already-resolved message text, joined the way
+ * {@link describeStickersAndPoll}'s callers join content parts. Returns `text`
+ * unchanged when the message carries neither shape — so a text-only message's
+ * content is never rewritten (byte-identical, including empty).
+ */
+export function withStickerAndPollDescriptions(message: Message, text: string): string {
+  const parts = describeStickersAndPoll(message);
+  if (parts.length === 0) {
+    return text;
+  }
+  return [...(text.length > 0 ? [text] : []), ...parts].join('\n\n');
+}

--- a/services/bot-client/src/utils/stickerPollDescriptions.ts
+++ b/services/bot-client/src/utils/stickerPollDescriptions.ts
@@ -54,12 +54,9 @@ function describeSticker(sticker: Sticker): string {
  * a poll). Empty string when there are none, so callers can push
  * unconditionally and filter falsy.
  */
-export function describeStickers(message: Message | MessageSnapshot): string {
+export function describeStickers(message: Message): string {
   const own = collectionValues<Sticker>(message.stickers);
-  const snapshots =
-    'messageSnapshots' in message
-      ? collectionValues<MessageSnapshot>(message.messageSnapshots)
-      : [];
+  const snapshots = collectionValues<MessageSnapshot>(message.messageSnapshots);
   const forwarded = snapshots.flatMap(snapshot => collectionValues<Sticker>(snapshot.stickers));
   const all = [...own, ...forwarded];
   if (all.length === 0) {
@@ -78,6 +75,16 @@ interface PollAnswerLike {
   emoji: { name: string | null } | null;
 }
 
+/**
+ * Read `message.poll`, normalizing an absent field to null. The `?? null` does
+ * runtime work the types call redundant: discord.js declares `poll` as
+ * `Poll | null` (never undefined), but a partial-shaped message can omit the
+ * field entirely — the same case collectionValues covers.
+ */
+function pollOf(message: Message): Message['poll'] {
+  return message.poll ?? null;
+}
+
 /** One poll answer's label: its text, else its emoji name, else a placeholder. */
 function describeAnswer(answer: PollAnswerLike): string {
   if (answer.text !== null && answer.text.length > 0) {
@@ -94,11 +101,8 @@ function describeAnswer(answer: PollAnswerLike): string {
  * miss entirely).
  */
 export function describePoll(message: Message): string {
-  // The cast widens, not narrows: discord.js declares `poll` as `Poll | null`
-  // (never undefined), but a partial-shaped message can omit the field
-  // entirely — same reason collectionValues tolerates an absent Collection.
-  const poll = message.poll as Message['poll'] | undefined;
-  if (poll === null || poll === undefined) {
+  const poll = pollOf(message);
+  if (poll === null) {
     return '';
   }
   const question =
@@ -116,6 +120,24 @@ export function describePoll(message: Message): string {
  */
 export function describeStickersAndPoll(message: Message): string[] {
   return [describeStickers(message), describePoll(message)].filter(part => part.length > 0);
+}
+
+/**
+ * Whether the message carries either shape — i.e. whether
+ * {@link describeStickersAndPoll} would produce anything.
+ *
+ * `hasMessageContent` needs this WITHOUT building the description strings: it
+ * runs as a pre-filter over every message in a fetched batch, and a message it
+ * rejects never reaches the renderers at all. The two must agree exactly or a
+ * message gets filtered out as empty and then would have rendered content —
+ * a `describeStickersAndPoll`-vs-this equivalence test pins that.
+ */
+export function hasStickerOrPoll(message: Message): boolean {
+  const ownStickers = collectionValues<Sticker>(message.stickers).length > 0;
+  const snapshotStickers = collectionValues<MessageSnapshot>(message.messageSnapshots).some(
+    snapshot => collectionValues<Sticker>(snapshot.stickers).length > 0
+  );
+  return ownStickers || snapshotStickers || pollOf(message) !== null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Characters were blind to two ordinary Discord message shapes. TASK-355 described the symptom as "reaches the model as effectively empty content" — grounding found it worse than that.

**The actual bug**: `DiscordChannelFetcher.convertMessage`'s `hasProcessableContent` gate returns `null` for a message with no text, attachments, voice, embeds, forward, or refs. A **sticker-only or poll-only message was dropped from extended context entirely** — so the character didn't see an unlabeled sticker, it saw a *hole* in the conversation. A poll (a substantive message people expect a reaction to) vanished completely.

## Approach — content lines, not a new metadata field

The task sketched "render into metadata the way embeds ride `embedsXml`." I went with content instead, and it's the better trade:

- `content` already persists with the history row and already reaches the prompt, so **the drop fixes itself** (content becomes non-empty) with **zero** schema / `historyMerger` / `xmlMetadataFormatters` / length-estimator plumbing.
- It matches the adjacent `[Attachments: …]` precedent in the same function.

The `embedsXml` path exists because embeds are long and structurally rich; a sticker is a name and a poll is a question plus options — one line each.

## Class sweep — three seams read message text independently

| Seam | Covers |
|---|---|
| `buildMessageContent` | extended-context history, history links (`HistoryLinkResolver`), the persistence embed path |
| `RawEnvelopeBuilder.rawMessageContent` | the trigger message (activated channels — a sticker-only trigger produced an empty turn) |
| `references/MessageFormatter` | reply and link `[Reference N]` snapshots (replying to a sticker rendered a blank block) |

Appended in `RawEnvelopeBuilder`, deliberately **not** inside `getEffectiveContent` — that util is also the routing/mention-detection text source and must stay byte-faithful to what the user typed.

Rendering: `[Stickers: partyblob — Blob having a party]`, `[Poll: Pizza tonight? — options: Yes, No]`. Forwarded-message snapshots contribute stickers (snapshots retain `stickers`; Discord never puts a poll in one).

## Deliberate omissions (documented in the module)

- **Poll vote counts.** They mutate after the fetch while this text is *persisted* — a frozen tally would be wrong forever. The question and options are the poll's semantic content; the tally is volatile state. Pinned by a test asserting no digits render.
- **Sticker images.** Stickers aren't attachments and never reach the vision path, so name + description is all the signal available without downloading the asset.

## Fixture drift this surfaced (fixed here)

The change broke 19 existing tests, all for the same reason — and it's exactly the untyped-fixture class `02-code-standards.md` rule 8 warns about, invisible to the compiler behind `as unknown as Message`:

- `MessageContentBuilder.test.ts` and the shared `Discord.mock.ts` factory omitted `stickers`/`poll` entirely (15 failures).
- `RawEnvelopeBuilder.test.ts`'s snapshot stub implemented only `size` and `first()` — no `values()` (4 failures).

All now mirror the real Message shape. I did **not** widen the runtime guard to swallow malformed mocks; the guard tolerates only absent-vs-null (justified because `describeStickers` accepts `MessageSnapshot`, a genuine `Partialize<Message>`, and because a decoration must never throw on the message hot path).

## Verification

- `pnpm test` green (26 tasks), `pnpm quality` green (gate-parity 27/27), sequential.
- 21 unit tests on the renderers; **one seam test per seam**, each failing on pre-fix code: sticker-only content non-empty through `buildMessageContent`, poll appended to text, and a sticker-only `[Reference N]` rendering through the real `MessageFormatter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)