### PR TITLE
fix(bot-client): per-click permission recheck + bare error causes (tasks 352-353)

### DIFF
--- a/services/bot-client/src/commands/admin/settings.ts
+++ b/services/bot-client/src/commands/admin/settings.ts
@@ -274,6 +274,6 @@ async function handleSettingUpdate(
     return { success: true, newData };
   } catch (error) {
     logger.error({ err: error, settingId }, 'Error updating setting');
-    return { success: false, error: 'Failed to update setting' };
+    return { success: false, error: 'unexpected error, please try again' };
   }
 }

--- a/services/bot-client/src/commands/admin/settingsSystemUpdate.ts
+++ b/services/bot-client/src/commands/admin/settingsSystemUpdate.ts
@@ -80,6 +80,6 @@ export async function handleSystemSettingUpdate(
     return { success: true, newData };
   } catch (error) {
     logger.error({ err: error, settingId }, 'Error updating system setting');
-    return { success: false, error: 'Failed to update setting' };
+    return { success: false, error: 'unexpected error, please try again' };
   }
 }

--- a/services/bot-client/src/commands/channel/settings.test.ts
+++ b/services/bot-client/src/commands/channel/settings.test.ts
@@ -138,11 +138,14 @@ describe('Channel Settings Dashboard', () => {
     const mockEditReply = vi.fn().mockResolvedValue({ id: 'message-123' });
 
     // Mock the underlying interaction - createSettingsDashboard uses this
+    // memberPermissions (channel-scoped, overwrite-aware) is the authority for
+    // BOTH the open-time check and the per-click recheck — see settings.ts.
     const mockInteraction = {
       deferred: true,
       replied: false,
       editReply: mockEditReply,
       user: { id: '123456789' },
+      memberPermissions: { has: vi.fn().mockReturnValue(hasPermission) },
     };
 
     // Create mock context that mirrors DeferredCommandContext
@@ -150,9 +153,12 @@ describe('Channel Settings Dashboard', () => {
       interaction: mockInteraction,
       user: { id: '123456789' },
       guild: null,
+      // Present because a real guild context has it, but deliberately
+      // permissive: if the open-time check ever regresses to this guild-wide
+      // source, the permission test below fails instead of passing silently.
       member: {
         permissions: {
-          has: vi.fn().mockReturnValue(hasPermission),
+          has: vi.fn().mockReturnValue(true),
         },
       },
       channel: null,
@@ -414,9 +420,13 @@ describe('Channel Settings Dashboard', () => {
   });
 
   describe('handleChannelSettingsButton', () => {
-    const createButtonInteraction = (customId: string) => ({
+    // `permitted` mirrors a real guild interaction's memberPermissions: the
+    // mutation handlers re-check Manage Messages on every click, so a fixture
+    // omitting it would read as a demoted moderator and deny everything.
+    const createButtonInteraction = (customId: string, permitted = true) => ({
       customId,
       user: { id: '123456789' },
+      memberPermissions: { has: vi.fn().mockReturnValue(permitted) },
       reply: vi.fn(),
       update: vi.fn(),
       showModal: vi.fn(),
@@ -475,7 +485,7 @@ describe('Channel Settings Dashboard', () => {
 
       expect(interaction.followUp).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: expect.stringContaining('Failed to update setting'),
+          content: expect.stringContaining('unexpected error, please try again'),
         })
       );
     });
@@ -496,6 +506,41 @@ describe('Channel Settings Dashboard', () => {
         'channel-settings::reset-cancel::channel-123',
         'channel-settings::reset-confirm::channel-123',
       ]);
+    });
+
+    it('reset-confirm is REFUSED when Manage Messages was revoked mid-session', async () => {
+      // The dashboard-open check happened while the user still had the
+      // permission; the session outlives the revocation, so the click has to
+      // re-check. Reset clears every override, so this is the worst one to let
+      // through.
+      const interaction = createButtonInteraction(
+        'channel-settings::reset-confirm::channel-123',
+        false
+      );
+      mockSessionManager.get.mockReturnValue(settingViewSession());
+      stub.clearChannelConfigOverrides.mockResolvedValue(makeOk({ cleared: true }));
+
+      await handleChannelSettingsButton(interaction as unknown as ButtonInteraction);
+
+      expect(stub.clearChannelConfigOverrides).not.toHaveBeenCalled();
+      expect(interaction.followUp).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Manage Messages') })
+      );
+    });
+
+    it('a set click is REFUSED when Manage Messages was revoked mid-session', async () => {
+      const interaction = createButtonInteraction(
+        'channel-settings::set::channel-123::maxMessages:auto',
+        false
+      );
+      mockSessionManager.get.mockReturnValue(settingViewSession());
+
+      await handleChannelSettingsButton(interaction as unknown as ButtonInteraction);
+
+      expect(stub.updateChannelConfigOverrides).not.toHaveBeenCalled();
+      expect(interaction.followUp).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Manage Messages') })
+      );
     });
 
     it('reset-confirm clears the channel overrides and re-renders from fresh data', async () => {
@@ -531,6 +576,7 @@ describe('Channel Settings Dashboard', () => {
       const interaction = {
         customId: 'channel-settings::set::channel-123::maxMessages:auto',
         user: { id: '123456789' },
+        memberPermissions: { has: vi.fn().mockReturnValue(true) },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -570,9 +616,16 @@ describe('Channel Settings Dashboard', () => {
   });
 
   describe('handleChannelSettingsModal', () => {
-    const createMockModalInteraction = (customId: string, inputValue: string) => ({
+    const createMockModalInteraction = (
+      customId: string,
+      inputValue: string,
+      permitted = true
+    ) => ({
       customId,
       user: { id: '123456789' },
+      // Modal submits route through the same update handler, so they get the
+      // same Manage Messages recheck.
+      memberPermissions: { has: vi.fn().mockReturnValue(permitted) },
       fields: {
         getTextInputValue: vi.fn().mockReturnValue(inputValue),
       },
@@ -634,6 +687,29 @@ describe('Channel Settings Dashboard', () => {
       expect(stub.updateChannelConfigOverrides).toHaveBeenCalledWith('channel-123', {
         maxAge: 7200,
       });
+    });
+
+    it('a modal submit is REFUSED when Manage Messages was revoked mid-session', async () => {
+      // The modal path shares createUpdateHandler's closure with the buttons,
+      // so it inherits the recheck — pinned here so a future modal-specific
+      // wiring change cannot quietly bypass it.
+      // '2h', not raw seconds: maxAge parses as a duration string, and an
+      // invalid value is rejected by client-side validation BEFORE the update
+      // handler runs — which would make this test pass/fail for the wrong reason.
+      const interaction = createMockModalInteraction(
+        'channel-settings::modal::channel-123::maxAge',
+        '2h',
+        false
+      );
+
+      mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxAge'));
+
+      await handleChannelSettingsModal(interaction as never);
+
+      expect(stub.updateChannelConfigOverrides).not.toHaveBeenCalled();
+      expect(interaction.followUp).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('Manage Messages') })
+      );
     });
 
     it('should update maxAge setting to "off" (disabled)', async () => {

--- a/services/bot-client/src/commands/channel/settings.ts
+++ b/services/bot-client/src/commands/channel/settings.ts
@@ -88,11 +88,19 @@ const CHANNEL_SETTINGS_CONFIG: SettingsDashboardConfig = {
  * @param context - DeferredCommandContext (already deferred by framework)
  */
 export async function handleChannelSettings(context: DeferredCommandContext): Promise<void> {
-  const { channelId, member, interaction } = context;
+  const { channelId, interaction } = context;
   const userId = context.user.id;
 
-  // Check permissions: Manage Messages required
-  if (member?.permissions.has(PermissionFlagsBits.ManageMessages) !== true) {
+  // Manage Messages required — read from `interaction.memberPermissions`, NOT
+  // `context.member.permissions`. The latter is documented as "taking only
+  // roles and owner status into account": guild-wide, blind to per-channel
+  // overwrites. This command governs ONE channel, so the channel-scoped
+  // source is the correct authority — a moderator whose role grants Manage
+  // Messages but who is denied it by an overwrite HERE should not manage this
+  // channel's settings. It also keeps this check identical in scope to the
+  // per-click recheck below; two different scopes would deny every click with
+  // a misleading "you no longer have…" for anyone using channel overwrites.
+  if (interaction.memberPermissions?.has(PermissionFlagsBits.ManageMessages) !== true) {
     await context.editReply({
       content: renderSpec(
         CATALOG.error.permissionDenied(
@@ -152,13 +160,45 @@ export async function handleChannelSettings(context: DeferredCommandContext): Pr
 }
 
 /**
+ * Re-check the Manage Messages permission that every mutation here depends on.
+ *
+ * `handleChannelSettings` checks it once when the dashboard opens, but the
+ * session outlives a permission revocation: a moderator demoted mid-session
+ * would otherwise keep mutating channel overrides until the session expired.
+ * Authority has to hold at the CLICK, not just at the open — most of all for
+ * reset, which clears every override at once.
+ *
+ * Returns a failure result to hand straight back (composed upstream as
+ * `Failed to update: …` / `Failed to reset: …`), or null when still permitted.
+ * `memberPermissions` is null outside a guild; channel settings are
+ * guild-only, so that reads as "not permitted" correctly.
+ */
+function denyIfPermissionRevoked(
+  interaction: ButtonInteraction | ModalSubmitInteraction
+): SettingUpdateResult | null {
+  if (interaction.memberPermissions?.has(PermissionFlagsBits.ManageMessages) === true) {
+    return null;
+  }
+  return {
+    success: false,
+    error: 'you no longer have the **Manage Messages** permission in this channel',
+  };
+}
+
+/**
  * Build a per-interaction update handler bound to a specific channel ID.
  * Used both by handleChannelSettings (dashboard init) and createSettingsCommandHandlers
  * (interaction routers) so the channelId binding lives in exactly one place.
  */
 function createUpdateHandler(channelId: string): SettingUpdateHandler {
-  return (interaction, session, settingId, newValue) =>
-    handleSettingUpdate(interaction, session, settingId, newValue, channelId);
+  return async (interaction, session, settingId, newValue) => {
+    const denied = denyIfPermissionRevoked(interaction);
+    if (denied !== null) {
+      logger.warn({ channelId, userId: interaction.user.id }, 'Update denied: permission revoked');
+      return denied;
+    }
+    return handleSettingUpdate(interaction, session, settingId, newValue, channelId);
+  };
 }
 
 /**
@@ -169,6 +209,11 @@ function createUpdateHandler(channelId: string): SettingUpdateHandler {
 function createResetHandler(channelId: string): SettingsResetHandler {
   return async (interaction: ButtonInteraction): Promise<SettingUpdateResult> => {
     const userId = interaction.user.id;
+    const denied = denyIfPermissionRevoked(interaction);
+    if (denied !== null) {
+      logger.warn({ channelId, userId }, 'Reset denied: permission revoked');
+      return denied;
+    }
     logger.debug({ channelId, userId }, 'Resetting channel overrides');
 
     try {
@@ -304,6 +349,6 @@ async function handleSettingUpdate(
     return { success: true, newData };
   } catch (error) {
     logger.error({ err: error, settingId, channelId }, 'Error updating setting');
-    return { success: false, error: 'Failed to update setting' };
+    return { success: false, error: 'unexpected error, please try again' };
   }
 }

--- a/services/bot-client/src/commands/settings/defaults/edit.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.ts
@@ -200,6 +200,6 @@ async function handleSettingUpdate(
     return { success: true, newData };
   } catch (error) {
     logger.error({ err: error, settingId }, 'Error updating setting');
-    return { success: false, error: 'Failed to update setting' };
+    return { success: false, error: 'unexpected error, please try again' };
   }
 }

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
@@ -143,7 +143,7 @@ describe('createSettingsUpdateHandler', () => {
     const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
     const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
 
-    expect(result).toEqual({ success: false, error: 'Failed to update setting' });
+    expect(result).toEqual({ success: false, error: 'unexpected error, please try again' });
   });
 
   it('returns newData derived from the configured sourceTier', async () => {

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
@@ -143,7 +143,7 @@ export function createSettingsUpdateHandler(
         { err: error, settingId, entityId },
         `${config.logContext} Error updating setting`
       );
-      return { success: false, error: 'Failed to update setting' };
+      return { success: false, error: 'unexpected error, please try again' };
     }
   };
 }

--- a/tracker/docs/doc-55 - Idea-Vision-describe-stickers-and-custom-emoji-via-a-write-once-asset-cache.md
+++ b/tracker/docs/doc-55 - Idea-Vision-describe-stickers-and-custom-emoji-via-a-write-once-asset-cache.md
@@ -11,6 +11,14 @@ name; custom emoji maybe, gated on cost. Owner's own proposal: cache
 descriptions in a DB keyed by the asset's snowflake so nothing is re-described.
 That instinct is right, and the grounding below makes it cheaper than expected._
 
+**SCHEDULED (owner, 2026-07-30): build this as the capstone of the NEXT release,
+not now.** Not a high current priority, but explicitly not to be put off long —
+the owner wants to keep draining the follow-up pool first and then land this so
+the release has something interesting in it beyond internal refactors. **Promote
+when**: the drain run for the next release is judged sufficient and the cut is
+being planned — this goes in BEFORE the release PR, as its headline item. Design
+is settled (both open calls decided below), so it is build-ready on promotion.
+
 ## Two grounded facts that shape the whole design
 
 _Provenance: both were read directly out of the **installed discord.js 14.27.0**


### PR DESCRIPTION
## Summary

Batch 5 of the doc-7 drain: two settings-dashboard items, both filed from #1854's review rounds (same-origin, same-module — the selector that's produced the best batches).

### TASK-352 — authorization has to hold at the click, not just at the open

`handleChannelSettings` checks Manage Messages once when the dashboard opens. Every subsequent `set` and `reset` click then trusted only `session.userId` ownership — so a moderator whose permission was revoked mid-session kept mutating channel overrides until the session expired. Reset is the worst case: it clears **every** channel-tier override at once.

Both handlers now re-check on the click. Design note on where the check lives: the interaction routers are generated by a shared factory (`createSettingsCommandHandlers`), but permission requirements differ per entity — channel needs Manage Messages, admin settings need bot-owner, user defaults need nothing. A factory-level check would be wrong, and threading a `recheckPermission` callback would be a **third** callback on a factory that already takes two, hitting `02-code-standards.md`'s 2-callback ceiling. So the guard is local to `channel/settings.ts`, where the entity's own authorization rule belongs, and both handlers already receive the interaction. Modal submits route through the same update handler and inherit it for free.

Uses `interaction.memberPermissions` (a `PermissionsBitField` on guild interactions, `null` outside a guild — and channel settings are guild-only, so null correctly reads as "not permitted"). The denial returns a `SettingUpdateResult`, which composes upstream into `Failed to update: you no longer have the **Manage Messages** permission in this channel`.

### TASK-353 — the task said four sites; there are five

Four update-handler catch branches returned `'Failed to update setting'`, which the composition site renders as **"Failed to update: Failed to update setting"**. A programmatic sweep found a fifth the task's list omitted: `utils/dashboard/settings/settingsUpdateFactory.ts:146`.

All five now return a bare cause (`'unexpected error, please try again'`), matching the reset-catch precedent #1854 already established in `channel/settings.ts`. The `Failed to update: ` prefix **stays** — sibling branches pass specific causes through it (`'Unknown setting'`, `'Failed to fetch updated settings'`, gateway passthrough), so removing the prefix would strip useful framing from those.

## Fixture drift this surfaced

Three interaction fixtures in `channel/settings.test.ts` had no `memberPermissions` at all — invisible to the compiler behind `as unknown as ButtonInteraction`, and once the recheck existed they all read as demoted moderators (6 failures). The shared `createButtonInteraction` helper now takes a `permitted` flag defaulting true; the modal fixture and one hand-built interaction were filled in. Same class as #1868's `Discord.mock.ts` gap, per `02-code-standards.md` rule 8.

Two existing tests pinned the old error text and were updated — the message text *is* the thing being fixed, so that's a deliberate spec change, not a test bent to pass.

## Verification

- `pnpm test` green (26 tasks), `pnpm quality` green (gate-parity 27/27), sequential.
- Two new denial tests (`set` refused, `reset-confirm` refused) **verified failing with the guards reverted** — both showed the gateway client being called when it shouldn't be.
- Old-token sweep: zero `'Failed to update setting'` occurrences remain anywhere in `services/bot-client/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)