### PR TITLE
refactor(clients): share buildQueryString, widen numeric query params (tasks 120/122/123/124)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -45,7 +45,13 @@ fi
 # run the codegen, stage the regenerated files. Keeps the committed
 # _generated/ artifacts in lock-step with the manifest so reviewers see
 # both halves of every change in the same diff.
-STAGED_MANIFEST=$(git diff --cached --name-only | grep -E '^packages/clients/src/routes/' || true)
+# Test files are excluded: they can't change the manifest the codegen reads, so
+# a test-only edit triggers a regen whose output is byte-identical and re-stages
+# unchanged files. Narrowing to non-test sources keeps the hook silent on the
+# commits where it has nothing to do.
+STAGED_MANIFEST=$(git diff --cached --name-only |
+    grep -E '^packages/clients/src/routes/.*\.ts$' |
+    grep -v '\.test\.ts$' || true)
 
 if [ -n "$STAGED_MANIFEST" ]; then
     echo "Route manifest changed - regenerating client classes..."

--- a/packages/clients/src/clients/_generated/owner-client.ts
+++ b/packages/clients/src/clients/_generated/owner-client.ts
@@ -14,17 +14,9 @@
  */
 
 import { z } from 'zod';
-import { callGateway, type GatewayResult } from '../transport.js';
+import { callGateway, type GatewayResult, buildQueryString } from '../transport.js';
 import { ROUTE_MANIFEST } from '../../routes/manifest.js';
 import { type ActorDiscordId } from '../../routes/types.js';
-
-function buildQueryString(entries: Array<[string, string | undefined]>): string {
-  const defined = entries.filter((e): e is [string, string] => e[1] !== undefined);
-  if (defined.length === 0) return '';
-  const qs = new URLSearchParams();
-  for (const [k, v] of defined) qs.set(k, v);
-  return '?' + qs.toString();
-}
 
 export interface OwnerClientOptions {
   /** Full gateway base URL, e.g. https://api-gateway.example.com. */

--- a/packages/clients/src/clients/_generated/service-client.ts
+++ b/packages/clients/src/clients/_generated/service-client.ts
@@ -14,16 +14,8 @@
  */
 
 import { z } from 'zod';
-import { callGateway, type GatewayResult } from '../transport.js';
+import { callGateway, type GatewayResult, buildQueryString } from '../transport.js';
 import { ROUTE_MANIFEST } from '../../routes/manifest.js';
-
-function buildQueryString(entries: Array<[string, string | undefined]>): string {
-  const defined = entries.filter((e): e is [string, string] => e[1] !== undefined);
-  if (defined.length === 0) return '';
-  const qs = new URLSearchParams();
-  for (const [k, v] of defined) qs.set(k, v);
-  return '?' + qs.toString();
-}
 
 export interface ServiceClientOptions {
   /** Full gateway base URL, e.g. https://api-gateway.example.com. */
@@ -233,7 +225,7 @@ export class ServiceClient {
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */
-  async recentUsers(options: { sinceDays?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.recentUsers.output>>> {
+  async recentUsers(options: { sinceDays?: number | string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.recentUsers.output>>> {
     const fullPath = '/api/internal/users/recent' + buildQueryString([['sinceDays', options.sinceDays]]);
     return callGateway({
       baseUrl: this.baseUrl,
@@ -334,7 +326,7 @@ export class ServiceClient {
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */
-  async getModels(options: { inputModality?: string; outputModality?: string; search?: string; limit?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.getModels.output>>> {
+  async getModels(options: { inputModality?: string; outputModality?: string; search?: string; limit?: number | string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.getModels.output>>> {
     const fullPath = '/api/internal/models' + buildQueryString([['inputModality', options.inputModality], ['outputModality', options.outputModality], ['search', options.search], ['limit', options.limit]]);
     return callGateway({
       baseUrl: this.baseUrl,

--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -14,18 +14,10 @@
  */
 
 import { z } from 'zod';
-import { callGateway, type GatewayResult } from '../transport.js';
+import { callGateway, type GatewayResult, buildQueryString } from '../transport.js';
 import { ROUTE_MANIFEST } from '../../routes/manifest.js';
 import { type ActorDiscordId, type SubjectDiscordId } from '../../routes/types.js';
 import type { GatewayUser } from '@tzurot/common-types/types/gateway-context';
-
-function buildQueryString(entries: Array<[string, string | undefined]>): string {
-  const defined = entries.filter((e): e is [string, string] => e[1] !== undefined);
-  if (defined.length === 0) return '';
-  const qs = new URLSearchParams();
-  for (const [k, v] of defined) qs.set(k, v);
-  return '?' + qs.toString();
-}
 
 export interface UserClientOptions {
   /** Full gateway base URL, e.g. https://api-gateway.example.com. */

--- a/packages/clients/src/clients/errors.test.ts
+++ b/packages/clients/src/clients/errors.test.ts
@@ -89,6 +89,92 @@ describe('parseErrorResponse — wrong-shape JSON fallback', () => {
 
     const parsed = await parseErrorResponse(response);
 
-    expect(parsed).toEqual({ message: 'HTTP 502' });
+    expect(parsed).toEqual({ message: 'HTTP 502', rawText: '{"message":123}' });
+  });
+});
+
+describe('parseErrorResponse — raw body capture for operator logs', () => {
+  it('captures the raw body of a non-JSON upstream error page', async () => {
+    // The motivating case: an nginx/CDN page reaching the client as a 502. The
+    // status alone can't tell an operator WHICH hop failed; the body can.
+    const response = new Response('<html><body><h1>502 Bad Gateway</h1>nginx</body></html>', {
+      status: 502,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const parsed = await parseErrorResponse(response);
+
+    expect(parsed.message).toBe('HTTP 502');
+    expect(parsed.rawText).toContain('502 Bad Gateway');
+    expect(parsed.rawText).toContain('nginx');
+  });
+
+  it('omits rawText when the gateway returned its own structured error', async () => {
+    // The gateway's `message` already carries the detail — duplicating the body
+    // into every failed-request log line would be pure noise.
+    const parsed = await parseErrorResponse(
+      jsonResponse({ error: 'NOT_FOUND', message: 'Persona not found' }, 404)
+    );
+
+    expect(parsed.message).toBe('Persona not found');
+    expect(parsed.rawText).toBeUndefined();
+  });
+
+  it('omits rawText for an empty body', async () => {
+    const parsed = await parseErrorResponse(new Response('', { status: 401 }));
+
+    expect(parsed).toEqual({ message: 'HTTP 401' });
+  });
+
+  it('truncates a large body rather than logging it whole', async () => {
+    const parsed = await parseErrorResponse(new Response('x'.repeat(5000), { status: 500 }));
+
+    expect(parsed.rawText).toHaveLength(512);
+  });
+
+  it('drops an orphan at the LOW end of the high-surrogate range', async () => {
+    // U+10000 encodes as 𐀀 — its high half is the first high
+    // surrogate, so this pins `>=` rather than `>`. A lone surrogate can't be
+    // written into the body directly: the response decoder would substitute
+    // U+FFFD. Only a real astral character split by OUR cut produces one.
+    const body = 'x'.repeat(511) + '\u{10000}' + 'tail';
+    const parsed = await parseErrorResponse(new Response(body, { status: 500 }));
+
+    // 511, not 1: the orphan comes off the END of the cut.
+    expect(parsed.rawText).toHaveLength(511);
+    expect(parsed.rawText).toBe('x'.repeat(511));
+  });
+
+  it('drops an orphan at the HIGH end of the high-surrogate range', async () => {
+    // U+10FC00 encodes as 􏰀 — last high surrogate, pinning `<=`.
+    const body = 'x'.repeat(511) + '\u{10FC00}' + 'tail';
+    const parsed = await parseErrorResponse(new Response(body, { status: 500 }));
+
+    expect(parsed.rawText).toHaveLength(511);
+  });
+
+  it('keeps a complete surrogate pair that ends exactly at the cap', async () => {
+    // The cut lands after the emoji's LOW surrogate, so nothing is orphaned and
+    // the full 512 units must survive. Guards against the guard over-firing on
+    // any code unit in the surrogate block.
+    const body = 'x'.repeat(510) + '😀' + 'tail';
+    const parsed = await parseErrorResponse(new Response(body, { status: 500 }));
+
+    expect(parsed.rawText).toHaveLength(512);
+    expect(parsed.rawText?.endsWith('😀')).toBe(true);
+  });
+
+  it('returns the status-only message when the body stream is unreadable', async () => {
+    // A connection dropped mid-response: `.text()` itself rejects. The parse
+    // must degrade to the status rather than propagating the throw into the
+    // transport's error path (which would be reported as a network failure).
+    const response = {
+      status: 500,
+      text: () => Promise.reject(new Error('stream closed')),
+    } as unknown as Response;
+
+    const parsed = await parseErrorResponse(response);
+
+    expect(parsed).toEqual({ message: 'HTTP 500' });
   });
 });

--- a/packages/clients/src/clients/errors.ts
+++ b/packages/clients/src/clients/errors.ts
@@ -58,6 +58,26 @@ const ErrorBodySchema = z
 export interface ParsedErrorResponse {
   message: string;
   code?: ApiErrorSubcode;
+  /**
+   * Raw response body, truncated to {@link RAW_ERROR_BODY_MAX_CHARS}. Set ONLY
+   * when the body could not be read as a structured gateway error. Absent when
+   * the gateway's own JSON shape parsed (its `message` already carries the
+   * detail) and when the body was empty.
+   *
+   * Two distinct triggers, and the second is easy to overlook:
+   *   1. The body is not JSON at all — an nginx 502 page, a CDN HTML block
+   *      page, a proxy's plain-text complaint. This is the intended target.
+   *   2. The body IS a JSON object but a present field has the wrong type
+   *      (`{"message": 123}`). `ErrorBodySchema` is passthrough with every
+   *      field optional, so this is the only way a JSON body fails it — but
+   *      it means a JSON-shaped body can reach the log raw. Narrow, not
+   *      impossible.
+   *
+   * For operator logs, never for user-facing text: the user still sees
+   * `HTTP <status>`. Callers forward it into structured logging so "why did
+   * the gateway 502?" has an answer beyond the status code.
+   */
+  rawText?: string;
 }
 
 /**
@@ -106,30 +126,95 @@ export class GatewayApiError extends Error {
 }
 
 /**
- * Parse error from API response. Returns both the human-readable message
- * and the optional machine-readable sub-code. Falls back to `HTTP <status>`
- * for the message when the body isn't JSON.
+ * Cap on the retained {@link ParsedErrorResponse.rawText}. Upstream error pages
+ * are unbounded (an nginx default 502 page is small, but a CDN block page or a
+ * verbose proxy trace is not), and this string lands in a structured log line
+ * on every failed request — enough to identify the responder, not enough to
+ * flood the log.
+ */
+const RAW_ERROR_BODY_MAX_CHARS = 512;
+
+/**
+ * Truncate without splitting a surrogate pair. `String.prototype.slice` cuts by
+ * UTF-16 code unit, so a cut landing between the halves of an astral character
+ * (an emoji in an upstream error page) would emit a lone surrogate into the log.
+ * Dropping the orphaned leading half costs one character of an excerpt that is
+ * already explicitly an excerpt.
+ */
+function truncateForLog(text: string): string {
+  // No length guard: `slice` already no-ops on a short string, and the orphan
+  // check cannot misfire on one. A decoded body is well-formed UTF-16 (the
+  // decoder substitutes U+FFFD for malformed bytes), so its final code unit is
+  // never a lone HIGH surrogate — only a cut we make ourselves can orphan one.
+  // `charCodeAt` on an empty string yields NaN, which compares false.
+  const cut = text.slice(0, RAW_ERROR_BODY_MAX_CHARS);
+  const lastUnit = cut.charCodeAt(cut.length - 1);
+  const endsOnOrphanedHighSurrogate = lastUnit >= 0xd800 && lastUnit <= 0xdbff;
+  return endsOnOrphanedHighSurrogate ? cut.slice(0, -1) : cut;
+}
+
+/**
+ * Parse error from API response. Returns the human-readable message, the
+ * optional machine-readable sub-code, and — when the body wasn't a structured
+ * gateway error — the raw body text for operator logs. Falls back to
+ * `HTTP <status>` for the message when the body isn't the expected JSON.
+ *
+ * Reads the body as TEXT and parses that, rather than calling `response.json()`
+ * directly: a `Response` body is a single-use stream, so a failed `.json()`
+ * leaves nothing for a later `.text()` to recover. Text-first is what makes
+ * `rawText` reachable on the very paths that need it.
  *
  * The gateway only emits `code` values from the `ApiErrorSubcode` union.
  * Unrecognized strings on the wire would type-widen to `string`, but in
  * practice both sides compile against the same `@tzurot/common-types`
  * version so the cast is safe.
+ *
+ * @param sanitizeBody Applied to the FULL body before truncation, for callers
+ *   that must keep specific strings out of the log. Order is the whole point:
+ *   sanitizing the truncated excerpt instead would miss a value straddling the
+ *   cutoff, since a partial string no longer matches the string being removed —
+ *   leaving a fragment of it in the log. Doing it here, inside the function
+ *   that owns the truncation, keeps "rawText is sanitized AND bounded" a single
+ *   invariant rather than two call-site obligations that can be sequenced wrong.
  */
-export async function parseErrorResponse(response: Response): Promise<ParsedErrorResponse> {
+export async function parseErrorResponse(
+  response: Response,
+  sanitizeBody?: (fullBody: string) => string
+): Promise<ParsedErrorResponse> {
+  const fallback = `HTTP ${response.status}`;
+
+  let text: string;
   try {
-    const raw: unknown = await response.json();
-    const parsed = ErrorBodySchema.safeParse(raw);
-    if (!parsed.success) {
-      // Body parsed as JSON but didn't match the expected error shape
-      // (e.g. nginx returned a different JSON envelope). Fall back to
-      // the status-derived message — callers branch on `status`, not
-      // the message text.
-      return { message: `HTTP ${response.status}` };
-    }
-    // Prefer message (human-readable) over error (code like "VALIDATION_ERROR")
-    const message = parsed.data.message ?? parsed.data.error ?? `HTTP ${response.status}`;
-    return { message, code: parsed.data.code as ApiErrorSubcode | undefined };
+    text = await response.text();
   } catch {
-    return { message: `HTTP ${response.status}` };
+    // Body stream unreadable (connection dropped mid-response). There is no
+    // body to report — the status is all the information that exists.
+    return { message: fallback };
   }
+
+  // An empty body carries no diagnostic value; omit rawText rather than
+  // logging an empty field on every bodyless 4xx.
+  const unstructured =
+    text.length === 0
+      ? { message: fallback }
+      : { message: fallback, rawText: truncateForLog(sanitizeBody?.(text) ?? text) };
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return unstructured;
+  }
+
+  const parsed = ErrorBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    // Body parsed as JSON but didn't match the expected error shape
+    // (e.g. nginx returned a different JSON envelope). Fall back to
+    // the status-derived message — callers branch on `status`, not
+    // the message text — and keep the body for operators.
+    return unstructured;
+  }
+  // Prefer message (human-readable) over error (code like "VALIDATION_ERROR")
+  const message = parsed.data.message ?? parsed.data.error ?? fallback;
+  return { message, code: parsed.data.code as ApiErrorSubcode | undefined };
 }

--- a/packages/clients/src/clients/transport.test.ts
+++ b/packages/clients/src/clients/transport.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
-import { callGateway } from './transport.js';
+import { buildQueryString, callGateway } from './transport.js';
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -38,6 +38,45 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe('buildQueryString', () => {
+  it('returns an empty string when every entry is undefined', () => {
+    // Generated methods concatenate the result unconditionally, so the
+    // no-params case must produce '' and not a bare '?'.
+    expect(buildQueryString([['a', undefined]])).toBe('');
+    expect(buildQueryString([])).toBe('');
+  });
+
+  it('skips undefined entries while keeping the defined ones', () => {
+    expect(
+      buildQueryString([
+        ['a', '1'],
+        ['b', undefined],
+        ['c', '3'],
+      ])
+    ).toBe('?a=1&c=3');
+  });
+
+  it('serializes a number identically to its pre-stringified form', () => {
+    // The point of accepting `number`: callers holding a number get the same
+    // wire output as callers who stringified first, so the widening can't
+    // change what the gateway receives.
+    expect(buildQueryString([['sinceDays', 30]])).toBe(
+      buildQueryString([['sinceDays', String(30)]])
+    );
+    expect(buildQueryString([['sinceDays', 30]])).toBe('?sinceDays=30');
+  });
+
+  it('keeps a zero value rather than dropping it as falsy', () => {
+    // The filter tests `!== undefined`, not truthiness — `0` is a legitimate
+    // value for a numeric param and must survive.
+    expect(buildQueryString([['offset', 0]])).toBe('?offset=0');
+  });
+
+  it('percent-encodes values that need it', () => {
+    expect(buildQueryString([['search', 'a b&c']])).toBe('?search=a+b%26c');
+  });
 });
 
 describe('callGateway', () => {
@@ -237,6 +276,155 @@ describe('callGateway', () => {
       expect.objectContaining({ path: baseOpts.path, method: 'GET', kind: 'http', status: 403 }),
       'Request failed'
     );
+  });
+
+  it('forwards the upstream error-page body to onWarn as rawText', async () => {
+    // The seam this batch exists to close: parseErrorResponse can now recover
+    // the body, but that only helps operators if callGateway forwards it into
+    // the log fields.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(
+      new Response('<html><h1>502 Bad Gateway</h1>nginx</html>', {
+        status: 502,
+        headers: { 'Content-Type': 'text/html' },
+      })
+    );
+
+    await callGateway({ ...baseOpts, onWarn });
+
+    expect(onWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'http',
+        status: 502,
+        rawText: expect.stringContaining('nginx') as unknown as string,
+      }),
+      'Request failed'
+    );
+  });
+
+  it('redacts the service secret if an upstream responder echoes it back', async () => {
+    // The reflection case: a proxy that includes the request headers in its
+    // error body would otherwise put the shared secret straight into a log.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(
+      new Response('400 Bad Request\nX-Service-Auth: secret-123\n', { status: 400 })
+    );
+
+    await callGateway({ ...baseOpts, onWarn });
+
+    const fields = onWarn.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(fields.rawText).not.toContain('secret-123');
+    expect(fields.rawText).toContain('[redacted]');
+  });
+
+  it('redacts an echoed username in both its encoded and decoded forms', async () => {
+    // Username headers travel encodeURIComponent-encoded, so a responder can
+    // echo either shape depending on whether it decoded before rendering.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(
+      new Response('rejected for user caf%C3%A9user and also caféuser', { status: 431 })
+    );
+
+    await callGateway({
+      ...baseOpts,
+      headers: { 'X-User-Username': encodeURIComponent('caféuser') },
+      onWarn,
+    });
+
+    const fields = onWarn.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(fields.rawText).not.toContain('caf%C3%A9user');
+    expect(fields.rawText).not.toContain('caféuser');
+  });
+
+  it('redacts a secret that straddles the truncation boundary', async () => {
+    // Ordering regression: truncating first and redacting the excerpt leaves a
+    // PARTIAL secret that exact-match redaction can no longer find, so the
+    // fragment survives into the log. Redaction must run against the full body.
+    // 505 filler chars puts the secret across the 512-char cutoff.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(`${'x'.repeat(505)}secret-123 trailing`, { status: 400 })
+    );
+
+    await callGateway({ ...baseOpts, onWarn });
+
+    const fields = onWarn.mock.calls[0]?.[0] as Record<string, unknown>;
+    // Not just the whole secret — no prefix of it may survive either.
+    expect(fields.rawText).not.toContain('secret-');
+  });
+
+  it('skips a never-log header that is absent or empty, leaving the body intact', async () => {
+    // The skip guard is load-bearing in two ways that both mangle the log if it
+    // stops working: an EMPTY value would make `split('')` explode the body
+    // into single characters joined by the marker, and an ABSENT one would
+    // coerce to the literal string "undefined" and redact that word wherever it
+    // legitimately appears. The body contains both a plain sentence and the
+    // word "undefined" so either failure is visible.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(
+      new Response('upstream reported undefined behaviour', { status: 502 })
+    );
+
+    await callGateway({
+      ...baseOpts,
+      headers: { 'X-User-Username': '' },
+      onWarn,
+    });
+
+    const fields = onWarn.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(fields.rawText).toBe('upstream reported undefined behaviour');
+  });
+
+  it('does not split a surrogate pair at the truncation boundary', async () => {
+    // An emoji straddling the cutoff would otherwise leave a lone high
+    // surrogate in the logged string.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(new Response(`${'x'.repeat(511)}😀 tail`, { status: 502 }));
+
+    await callGateway({ ...baseOpts, onWarn });
+
+    const fields = onWarn.mock.calls[0]?.[0] as Record<string, unknown>;
+    const text = fields.rawText as string;
+    const lastUnit = text.charCodeAt(text.length - 1);
+    expect(lastUnit >= 0xd800 && lastUnit <= 0xdbff).toBe(false);
+  });
+
+  it('leaves non-sensitive header values intact in rawText', async () => {
+    // Guards against the redaction becoming blanket: `X-User-Id` is safe to log
+    // by the same rule, and redacting `application/json` or `false` would
+    // corrupt the very text rawText exists to preserve.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(
+      new Response('<html>upstream said application/json was false for 123456789012345678</html>', {
+        status: 502,
+      })
+    );
+
+    await callGateway({
+      ...baseOpts,
+      method: 'POST',
+      body: { a: 1 },
+      headers: { 'X-User-Id': '123456789012345678', 'X-User-Is-Bot': 'false' },
+      onWarn,
+    });
+
+    const fields = onWarn.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(fields.rawText).toContain('application/json');
+    expect(fields.rawText).toContain('false');
+    expect(fields.rawText).toContain('123456789012345678');
+    expect(fields.rawText).not.toContain('[redacted]');
+  });
+
+  it('omits rawText entirely when the gateway returned a structured error', async () => {
+    // Absent, not `undefined`: a key that appears only when it carries
+    // information is what makes the log searchable.
+    const onWarn = vi.fn();
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ message: 'Forbidden' }, { status: 403 }));
+
+    await callGateway({ ...baseOpts, onWarn });
+
+    const fields = onWarn.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect('rawText' in fields).toBe(false);
   });
 
   it('invokes onWarn for schema-validation failures with kind:schema', async () => {

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -105,6 +105,84 @@ export interface TransportOptions {
 }
 
 /**
+ * Build a `?a=1&b=2` query string from entries, skipping `undefined` values
+ * and returning `''` when nothing survives (so callers can concatenate
+ * unconditionally).
+ *
+ * Lives here rather than inline in each generated client so the three clients
+ * share one implementation — notably one place to widen the accepted value
+ * type. `number` is accepted alongside `string` because a route whose query
+ * schema is `z.coerce.number()` narrows to a number server-side; forcing its
+ * callers to pre-stringify leaked a wire-encoding detail into call sites.
+ * The wire form is a string either way.
+ */
+export function buildQueryString(entries: [string, string | number | undefined][]): string {
+  const defined = entries.filter((e): e is [string, string | number] => e[1] !== undefined);
+  if (defined.length === 0) {
+    return '';
+  }
+  const qs = new URLSearchParams();
+  for (const [key, value] of defined) {
+    qs.set(key, String(value));
+  }
+  return '?' + qs.toString();
+}
+
+/**
+ * Request headers whose VALUES must never survive into a log line.
+ *
+ * `rawText` is the body of a responder we do NOT control (our own gateway
+ * always answers in the structured shape, so it never populates `rawText`) —
+ * which means its content is unauditable, and some proxies echo the request
+ * back in an error body. These three are what we send that would matter:
+ * the shared service secret, and the two user-context fields `00-critical.md`
+ * lists as never-log.
+ *
+ * Deliberately NOT every header we send. `X-User-Id` is safe to log by the
+ * same rule, and blanket redaction would corrupt the text it exists to
+ * preserve — `X-User-Is-Bot` is `'false'` and `Content-Type` is
+ * `'application/json'`, both of which occur naturally in an HTML error page.
+ */
+const NEVER_LOG_HEADERS = ['X-Service-Auth', 'X-User-Username', 'X-User-DisplayName'] as const;
+
+/**
+ * Replace any value we ourselves transmitted with a marker before the body
+ * reaches a log.
+ *
+ * This is exact-string replacement, not pattern-matching: we are not guessing
+ * what a secret looks like, we are checking for the specific strings this
+ * request carried. That makes it precise (no false redaction of unrelated
+ * text) and complete for the reflection case (any echo of those values is
+ * caught regardless of where in the body it appears).
+ *
+ * Username headers travel `encodeURIComponent`-encoded, so a responder could
+ * echo either form; both are redacted when they differ. Short values are
+ * redacted too — over-redacting a truncated error fragment costs a mangled log
+ * line, while under-redacting costs a rule violation.
+ */
+function redactTransmittedValues(rawText: string, headers: Record<string, string>): string {
+  let redacted = rawText;
+  for (const name of NEVER_LOG_HEADERS) {
+    const sent = headers[name];
+    if (sent === undefined || sent.length === 0) {
+      continue;
+    }
+    const forms = new Set<string>([sent]);
+    try {
+      forms.add(decodeURIComponent(sent));
+    } catch {
+      // Malformed percent-encoding — the sent form is the only one to redact.
+    }
+    for (const form of forms) {
+      // split/join rather than a RegExp: the value is arbitrary text and would
+      // otherwise need escaping to avoid being read as a pattern.
+      redacted = redacted.split(form).join('[redacted]');
+    }
+  }
+  return redacted;
+}
+
+/**
  * Classify an error thrown by `fetch` into the failure envelope: a timeout
  * (the `AbortSignal.timeout` fired) vs a genuine network error (DNS/TLS/reset).
  * Kept separate from {@link callGateway} so the main request flow stays under
@@ -247,8 +325,26 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
     });
 
     if (!response.ok) {
-      const parsed = await parseErrorResponse(response);
-      onWarn?.({ path, method, kind: 'http', status: response.status }, 'Request failed');
+      // Redaction is handed to the parser rather than applied to its result:
+      // it must run against the FULL body, before truncation, or a value
+      // straddling the cutoff survives as an unmatchable fragment.
+      const parsed = await parseErrorResponse(response, body =>
+        redactTransmittedValues(body, headers)
+      );
+      // `rawText` is present only when the body wasn't a structured gateway
+      // error (nginx/CDN page). Spread conditionally so the field is absent
+      // rather than `undefined` on the common path — a key that only appears
+      // when it carries information is far easier to search logs for.
+      onWarn?.(
+        {
+          path,
+          method,
+          kind: 'http',
+          status: response.status,
+          ...(parsed.rawText !== undefined && { rawText: parsed.rawText }),
+        },
+        'Request failed'
+      );
       return {
         ok: false,
         kind: 'http',

--- a/packages/tooling/src/codegen/client-builder.test.ts
+++ b/packages/tooling/src/codegen/client-builder.test.ts
@@ -212,14 +212,81 @@ describe('buildClientClass — UserClient', () => {
     expect(src).toContain(`'X-User-DisplayName': encodeURIComponent(this.user.displayName)`);
   });
 
-  it('embeds the buildQueryString helper inline (self-contained file)', () => {
+  it('omits the buildQueryString import when no route declares query params', () => {
+    // userRoutes' only member has no `query` — importing the helper here would
+    // leave an unused import in the generated file.
     const src = buildClientClass({
       className: 'UserClient',
       flavor: 'user',
       audience: 'user',
       routes: userRoutes,
     });
-    expect(src).toContain(`function buildQueryString`);
+    expect(src).not.toContain('buildQueryString');
+  });
+});
+
+describe('buildClientClass — buildQueryString wiring', () => {
+  it('imports buildQueryString for an acceptsSubject route with NO query map', () => {
+    // `acceptsSubject` contributes a `userId` query entry on its own, so the
+    // method calls the helper even though the route declares no `query`. An
+    // import check that consulted only `route.query` emitted the call without
+    // the import — a generated file referencing an unimported symbol.
+    const subjectOnlyRoutes: Record<string, RouteDef> = {
+      getThing: {
+        audience: 'user',
+        method: 'get',
+        path: '/thing/:id',
+        id: 'getThing',
+        output: z.object({ id: z.string() }),
+        acceptsSubject: true,
+      },
+    };
+    const src = buildClientClass({
+      className: 'UserClient',
+      flavor: 'user',
+      audience: 'user',
+      routes: subjectOnlyRoutes,
+    });
+    expect(src).toContain('+ buildQueryString(');
+    expect(src).toContain(`buildQueryString } from '../transport.js'`);
+  });
+
+  it('omits the import for a service client, whose routes expose no subject', () => {
+    // The mirror case: `acceptsSubject` is inert on the service flavor (no
+    // actor, so no subject parameter), so the method emits no call and the
+    // import would be unused. Guards the opposite failure from the one above.
+    const serviceRoutes: Record<string, RouteDef> = {
+      pingService: {
+        audience: 'internal',
+        method: 'get',
+        path: '/ping',
+        id: 'pingService',
+        output: z.object({ ok: z.boolean() }),
+        serviceOnly: true,
+        acceptsSubject: true,
+      },
+    };
+    const src = buildClientClass({
+      className: 'ServiceClient',
+      flavor: 'service',
+      audience: 'internal',
+      routes: serviceRoutes,
+    });
+    expect(src).not.toContain('buildQueryString');
+  });
+
+  it('imports buildQueryString from the transport instead of inlining a copy', () => {
+    const src = buildClientClass({
+      className: 'OwnerClient',
+      flavor: 'owner',
+      audience: 'admin',
+      routes: adminRoutes,
+    });
+    expect(src).toContain(`buildQueryString } from '../transport.js'`);
+    // The inline copy must be GONE, not merely accompanied by the import — a
+    // local declaration would shadow the import and silently keep three copies
+    // of the helper in the tree.
+    expect(src).not.toContain(`function buildQueryString`);
   });
 });
 

--- a/packages/tooling/src/codegen/client-builder.ts
+++ b/packages/tooling/src/codegen/client-builder.ts
@@ -10,7 +10,12 @@
 import type { Audience, RouteDef } from '@tzurot/clients';
 
 import { AUTOGEN_HEADER } from './header.js';
-import { type ClientFlavor, buildMethod, pathPrefixForAudience } from './method-builder.js';
+import {
+  type ClientFlavor,
+  buildMethod,
+  emitsQueryString,
+  pathPrefixForAudience,
+} from './method-builder.js';
 
 export interface ClientBuildOptions {
   /** 'ServiceClient' | 'OwnerClient' | 'UserClient' — used as class name. */
@@ -58,6 +63,15 @@ function buildImports(flavor: ClientFlavor, routes: Record<string, RouteDef>): s
   // `@tzurot/common-types/types/gateway-context` subpath (the root barrel is
   // being retired) — a one-way dependency, no cycle.
   const transportSymbols: string[] = ['callGateway', 'type GatewayResult'];
+  // Imported, not inlined: one shared implementation across the three clients
+  // means one place to change the accepted value type. Conditional because a
+  // client whose methods never call the helper would otherwise carry an unused
+  // import — and the condition is `emitsQueryString`, the same predicate
+  // `buildMethod` uses to decide whether to emit the call, so the import and
+  // the call cannot disagree.
+  if (Object.values(routes).some(r => emitsQueryString(r, flavor))) {
+    transportSymbols.push('buildQueryString');
+  }
   const manifestSymbols: string[] = ['ROUTE_MANIFEST'];
   const typeSymbols: string[] = [];
 
@@ -79,8 +93,6 @@ function buildImports(flavor: ClientFlavor, routes: Record<string, RouteDef>): s
     lines.push(`import type { GatewayUser } from '@tzurot/common-types/types/gateway-context';`);
   }
 
-  lines.push('');
-  lines.push(buildQueryHelper());
   return lines.join('\n');
 }
 
@@ -135,22 +147,5 @@ function buildClassDecl(className: string, flavor: ClientFlavor): string {
     ...ctorAssigns,
     `  }`,
     '',
-  ].join('\n');
-}
-
-/**
- * Inline query-string helper used by generated methods. Kept inside the
- * generated file (vs. importing from common-types) so the file is fully
- * self-contained — handy when reading the generated source in isolation.
- */
-function buildQueryHelper(): string {
-  return [
-    `function buildQueryString(entries: Array<[string, string | undefined]>): string {`,
-    `  const defined = entries.filter((e): e is [string, string] => e[1] !== undefined);`,
-    `  if (defined.length === 0) return '';`,
-    `  const qs = new URLSearchParams();`,
-    `  for (const [k, v] of defined) qs.set(k, v);`,
-    `  return '?' + qs.toString();`,
-    `}`,
   ].join('\n');
 }

--- a/packages/tooling/src/codegen/method-builder.test.ts
+++ b/packages/tooling/src/codegen/method-builder.test.ts
@@ -285,9 +285,74 @@ describe('buildMethod — user flavor', () => {
     };
     const out = buildMethod(route, { flavor: 'user', pathPrefix: '/api/user' });
     // Required `personalityId` forces the options bag to be required;
-    // optional limit/sort get `?` markers.
-    expect(out).toContain(`options: { limit?: string; sort?: string; personalityId: string }`);
+    // optional limit/sort get `?` markers. `limit` is number-typed, so it also
+    // accepts a number (see the numeric-widening block below).
+    expect(out).toContain(
+      `options: { limit?: number | string; sort?: string; personalityId: string }`
+    );
     expect(out).toContain(`['limit', options.limit]`);
     expect(out).toContain(`['personalityId', options.personalityId]`);
+  });
+});
+
+describe('buildMethod — numeric query params', () => {
+  it('widens a z.coerce.number() query param to `number | string`', () => {
+    // The server coerces the string back to a number, so callers naturally
+    // hold a number; without the union every numeric call site writes
+    // `String(n)` and the wire encoding leaks into the caller.
+    const route: RouteDef = {
+      ...baseRoute,
+      query: { sinceDays: z.coerce.number().int().positive().optional() },
+    };
+    const out = buildMethod(route, { flavor: 'user', pathPrefix: '/api/user' });
+    expect(out).toContain(`options: { sinceDays?: number | string } = {}`);
+  });
+
+  it('widens a required numeric query param and keeps it required', () => {
+    // The width of the value type and the required-ness marker are independent
+    // decisions; widening must not accidentally make the param optional.
+    const route: RouteDef = {
+      ...baseRoute,
+      query: { days: z.coerce.number() },
+    };
+    const out = buildMethod(route, { flavor: 'user', pathPrefix: '/api/user' });
+    expect(out).toContain(`options: { days: number | string }`);
+    expect(out).not.toContain('days?: number | string');
+    expect(out).not.toContain('number | string } = {}');
+  });
+
+  it('sees through a .optional().default() wrapper pair to the numeric schema', () => {
+    // The two wrappers compose in either order, so the unwrap loops rather
+    // than peeling exactly one layer.
+    const route: RouteDef = {
+      ...baseRoute,
+      query: { limit: z.coerce.number().optional().default(25) },
+    };
+    const out = buildMethod(route, { flavor: 'user', pathPrefix: '/api/user' });
+    expect(out).toContain(`options: { limit?: number | string } = {}`);
+  });
+
+  it('sees through the wrappers in the opposite order too', () => {
+    // The unwrap treats ZodOptional and ZodDefault identically at each step, so
+    // it is order-agnostic by construction — this pins that property rather
+    // than leaving it as an untested consequence of the loop's shape.
+    const route: RouteDef = {
+      ...baseRoute,
+      query: { limit: z.coerce.number().default(25).optional() },
+    };
+    const out = buildMethod(route, { flavor: 'user', pathPrefix: '/api/user' });
+    expect(out).toContain(`options: { limit?: number | string } = {}`);
+  });
+
+  it('leaves non-numeric query params as plain string', () => {
+    // Guards against the widening being applied to every param — an enum or a
+    // string must NOT gain a `number` arm.
+    const route: RouteDef = {
+      ...baseRoute,
+      query: { sort: z.enum(['asc', 'desc']).optional(), search: z.string().optional() },
+    };
+    const out = buildMethod(route, { flavor: 'user', pathPrefix: '/api/user' });
+    expect(out).toContain(`options: { sort?: string; search?: string } = {}`);
+    expect(out).not.toContain('number');
   });
 });

--- a/packages/tooling/src/codegen/method-builder.ts
+++ b/packages/tooling/src/codegen/method-builder.ts
@@ -12,6 +12,13 @@ import { z } from 'zod';
 import { resolveQueryShape, type Audience, type RouteDef } from '@tzurot/clients';
 
 /**
+ * Loop bound for {@link unwrapZodModifiers}. Real query schemas nest at most
+ * two wrappers (`.optional().default(x)`); the cap only exists so a malformed
+ * schema can't hang the generator.
+ */
+const MAX_ZOD_WRAPPER_DEPTH = 8;
+
+/**
  * Detect whether a Zod schema is marked optional. `z.string()` is required,
  * `z.string().optional()` is optional. Defaulted schemas (`z.string().default(...)`)
  * are also treated as optional since the caller can omit them.
@@ -23,6 +30,37 @@ import { resolveQueryShape, type Audience, type RouteDef } from '@tzurot/clients
  */
 function isOptionalZod(schema: z.ZodTypeAny): boolean {
   return schema instanceof z.ZodOptional || schema instanceof z.ZodDefault;
+}
+
+/**
+ * Strip `.optional()` / `.default()` wrappers to reach the schema that decides
+ * the VALUE type. Loops because the wrappers compose in either order
+ * (`.optional().default(x)` is legal), and bounds the loop so a pathological
+ * schema can't spin the generator.
+ */
+function unwrapZodModifiers(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current = schema;
+  for (let depth = 0; depth < MAX_ZOD_WRAPPER_DEPTH; depth += 1) {
+    if (!(current instanceof z.ZodOptional || current instanceof z.ZodDefault)) {
+      return current;
+    }
+    current = current.unwrap() as z.ZodTypeAny;
+  }
+  return current;
+}
+
+/**
+ * The client-facing TypeScript type for one query param.
+ *
+ * Query values are strings on the wire, so `string` is the base. A param whose
+ * schema is number-typed (`z.coerce.number()`) also accepts `number`, because
+ * the server narrows it to a number and callers naturally hold one — without
+ * the union every numeric call site has to write `String(n)`, which is the
+ * wire encoding leaking upward. `buildQueryString` stringifies, so both arms
+ * serialize identically.
+ */
+function queryFieldType(schema: z.ZodTypeAny): string {
+  return unwrapZodModifiers(schema) instanceof z.ZodNumber ? 'number | string' : 'string';
 }
 
 /**
@@ -53,6 +91,31 @@ export interface MethodBuildOptions {
   flavor: ClientFlavor;
   /** URL prefix mounted at the gateway, e.g. '/api/user'. */
   pathPrefix: string;
+}
+
+/**
+ * Whether a route exposes the `subject` parameter, which the generated method
+ * forwards as a `userId` query entry. Service clients have no actor and
+ * therefore no subject, so the flavor is part of the decision.
+ */
+function acceptsSubjectParam(route: RouteDef, flavor: ClientFlavor): boolean {
+  return route.acceptsSubject === true && flavor !== 'service';
+}
+
+/**
+ * Whether this route's generated method will contain a `buildQueryString(...)`
+ * call. TWO independent sources contribute query entries — an `acceptsSubject`
+ * route contributes `userId` even with no `query` map, and a declared `query`
+ * contributes its keys — so a check that consults only one of them is wrong for
+ * routes carrying the other.
+ *
+ * Exported because `buildImports` decides whether to import the helper and
+ * `buildMethod` decides whether to call it. Those two answers must be the same
+ * answer, not two implementations that happen to agree: when they drifted, the
+ * generated file referenced an unimported symbol.
+ */
+export function emitsQueryString(route: RouteDef, flavor: ClientFlavor): boolean {
+  return acceptsSubjectParam(route, flavor) || resolveQueryShape(route.query) !== undefined;
 }
 
 /**
@@ -92,7 +155,7 @@ export function buildMethod(route: RouteDef, options: MethodBuildOptions): strin
   const pathParamNames = extractPathParams(route.path);
   const hasInput = route.input !== undefined;
   const hasQuery = route.query !== undefined;
-  const acceptsSubject = route.acceptsSubject === true && flavor !== 'service';
+  const acceptsSubject = acceptsSubjectParam(route, flavor);
 
   // -- Method-signature parameters -----------------------------------------
 
@@ -264,13 +327,12 @@ function buildOptionsType(route: RouteDef, acceptsSubject: boolean): string {
   const shape = resolveQueryShape(route.query);
   if (shape !== undefined) {
     for (const [key, schema] of Object.entries(shape)) {
-      // All query params are strings at the wire level; their narrower
-      // typing lives in the route's Zod schema (validated server-side).
       // Required vs optional is derived from the schema's Zod wrapper:
       // `z.string()` is required (the server returns 400 on missing),
       // `z.string().optional()` or `z.string().default(...)` are optional.
+      // The value type comes from the unwrapped schema — see queryFieldType.
       const marker = isOptionalZod(schema) ? '?' : '';
-      fields.push(`${key}${marker}: string`);
+      fields.push(`${key}${marker}: ${queryFieldType(schema)}`);
     }
   }
   return `{ ${fields.join('; ')} }`;

--- a/packages/tooling/src/codegen/routes.ts
+++ b/packages/tooling/src/codegen/routes.ts
@@ -1,7 +1,7 @@
 /**
  * Route-codegen orchestrator.
  *
- * Reads ROUTE_MANIFEST from @tzurot/common-types, partitions by audience,
+ * Reads ROUTE_MANIFEST from @tzurot/clients, partitions by audience,
  * generates one client class per flavor (Service / Owner / User), and
  * either writes them to disk or compares them against the on-disk
  * versions (drift-detection mode for CI).

--- a/services/bot-client/src/services/StartupDMPrewarmer.test.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.test.ts
@@ -259,6 +259,8 @@ describe('StartupDMPrewarmer', () => {
 
     await prewarmer.run();
 
-    expect(mockRecentUsers).toHaveBeenCalledWith({ sinceDays: '30' });
+    // Passed as a number, not a pre-stringified one: the generated signature
+    // accepts `number | string` for coerce-number query params.
+    expect(mockRecentUsers).toHaveBeenCalledWith({ sinceDays: 30 });
   });
 });

--- a/services/bot-client/src/services/StartupDMPrewarmer.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.ts
@@ -186,7 +186,7 @@ export class StartupDMPrewarmer {
     | { kind: 'fatal'; err: Error }
   > {
     try {
-      const result = await getServiceClient().recentUsers({ sinceDays: String(SINCE_DAYS) });
+      const result = await getServiceClient().recentUsers({ sinceDays: SINCE_DAYS });
       if (result.ok) {
         return { kind: 'success', ids: result.data.discordIds };
       }

--- a/services/bot-client/src/utils/modelAutocomplete.test.ts
+++ b/services/bot-client/src/utils/modelAutocomplete.test.ts
@@ -95,9 +95,11 @@ describe('modelAutocomplete', () => {
       expect(getModelsMock).toHaveBeenCalledWith({ outputModality: 'image' });
     });
 
-    it('passes search and stringifies limit', async () => {
+    it('passes search and forwards limit as a number', async () => {
+      // The generated signature accepts `number | string` for this
+      // coerce-number param, so no call-site stringification.
       await fetchModels({ search: 'claude', limit: 50 });
-      expect(getModelsMock).toHaveBeenCalledWith({ search: 'claude', limit: '50' });
+      expect(getModelsMock).toHaveBeenCalledWith({ search: 'claude', limit: 50 });
     });
 
     it('returns [] when the client returns an error result', async () => {
@@ -135,7 +137,7 @@ describe('modelAutocomplete', () => {
     it('requests text models with the default limit', async () => {
       getModelsMock.mockResolvedValue(okModels(sampleTextModels));
       const models = await fetchTextModels();
-      expect(getModelsMock).toHaveBeenCalledWith({ outputModality: 'text', limit: '25' });
+      expect(getModelsMock).toHaveBeenCalledWith({ outputModality: 'text', limit: 25 });
       expect(models).toEqual(sampleTextModels);
     });
 
@@ -144,7 +146,7 @@ describe('modelAutocomplete', () => {
       expect(getModelsMock).toHaveBeenCalledWith({
         outputModality: 'text',
         search: 'gpt',
-        limit: '25',
+        limit: 25,
       });
     });
   });
@@ -153,7 +155,7 @@ describe('modelAutocomplete', () => {
     it('requests vision models with the default limit', async () => {
       getModelsMock.mockResolvedValue(okModels(sampleVisionModels));
       const models = await fetchVisionModels();
-      expect(getModelsMock).toHaveBeenCalledWith({ inputModality: 'image', limit: '25' });
+      expect(getModelsMock).toHaveBeenCalledWith({ inputModality: 'image', limit: 25 });
       expect(models).toEqual(sampleVisionModels);
     });
   });

--- a/services/bot-client/src/utils/modelAutocomplete.ts
+++ b/services/bot-client/src/utils/modelAutocomplete.ts
@@ -59,7 +59,7 @@ export async function fetchModels(
     inputModality?: string;
     outputModality?: string;
     search?: string;
-    limit?: string;
+    limit?: number;
   } = {};
 
   if (options.textOnly === true) {
@@ -73,9 +73,7 @@ export async function fetchModels(
     query.search = options.search;
   }
   if (options.limit !== undefined && options.limit > 0) {
-    // String for the URL query param; the route manifest coerces it back to a
-    // number (z.coerce.number).
-    query.limit = String(options.limit);
+    query.limit = options.limit;
   }
 
   if (options.strict === true) {


### PR DESCRIPTION
Drain batch 6 — the route-codegen / generated-client cluster. All five members came from **PR #1090's review rounds** against one module family, the same same-origin/same-module shape that made batch #1864 the highest-yield so far.

## Freshness-check first — two of five were stale

Per the drain campaign's grep-the-premise rule, every task was verified against the code before building. Two had drifted:

| Task | Filed claim | Reality |
| --- | --- | --- |
| **TASK-122** | "the pre-commit trigger greps `packages/common-types/src/routes/`, a directory that no longer exists — auto-regen is silently DEAD" | **Already fixed.** The hook greps `^packages/clients/src/routes/` and stages the right `_generated/` dirs. Only the `.test.ts` skip and a stale docstring remained. |
| **TASK-123** | two gaps: required-ness loss AND numeric-narrowing loss | **Half already fixed** — `buildOptionsType` derives required-ness from `isOptionalZod`. Only numeric narrowing remained. |
| **TASK-125** | `asActor`/`asSubject` accept empty strings | **Fully shipped**, guards + tests present. Closed as done, no code in this PR. |

TASK-123's promote-when ("numeric-coerce causes call-site friction") had **fired**: four call sites manually stringify, two of them carrying comments that explain the workaround.

## What changed

**`buildQueryString` — three copies → one (TASK-120).** Moved to `transport.ts` and exported; the codegen emits an import instead of an inlined body. The import is conditional on the client having any query param, so a query-less client doesn't carry an unused import. −29 lines of generated duplication.

**Numeric query params generate `number | string` (TASK-123).** `buildOptionsType` now consults the unwrapped schema: number-typed → `number | string`, everything else → `string`. Widening happens in one place because TASK-120 landed first — the shared helper takes `string | number` and stringifies. Two call sites dropped their `String(...)`:

- `StartupDMPrewarmer` → `recentUsers({ sinceDays: SINCE_DAYS })`
- `modelAutocomplete` → `query.limit = options.limit`

Exactly the two `z.coerce.number()` params in the manifest widened (`sinceDays`, `getModels.limit`); enums and strings are untouched, and a test guards against over-widening. The `memory`/`facts` `limit`/`offset` params are genuinely `z.string()` server-side, so their `.toString()` calls correctly stay.

**`parseErrorResponse` keeps the upstream body (TASK-124).** An nginx 502 or CDN block page previously reduced to `HTTP 502` with the body discarded, so an operator couldn't tell which hop failed. Now the body is read as **text first** and parsed from that — this is the load-bearing detail: a `Response` body is a single-use stream, so the old `json()`-first shape left nothing for a later `.text()` to recover, which is why the task's original one-line fix shape wouldn't have worked. `callGateway` forwards it to `onWarn` as `rawText`, truncated to 512 chars, and omitted entirely when the gateway's own JSON parsed or the body was empty (an absent key is searchable; an always-present `undefined` is noise). User-facing text is unchanged — still `HTTP <status>`.

**Pre-commit trigger skips `*.test.ts` (TASK-122).** A test-only edit under `routes/` can't change the manifest, so it triggered a regen producing byte-identical output and re-staged unchanged files. Verified all four cases by hand (test-only → empty, manifest → match, mixed → non-test only, and the empty case exits 0 so `set -e` won't kill the hook).

**Docstring fix (TASK-122).** `routes.ts` claimed it reads `ROUTE_MANIFEST` from `@tzurot/common-types`; it's been `@tzurot/clients` since the routes-package refactor.

## On the changed test assertions

Six existing assertions changed **with the behavior they pin**, not to make anything pass:

- five pinned stringified query values (`sinceDays: '30'`, `limit: '25'`) → now numeric, which is the point of the change
- `client-builder`'s "embeds the buildQueryString helper inline" → now asserts the import **and** `not.toContain('function buildQueryString')`, because an import accompanied by a surviving local declaration would shadow it and silently keep three copies

## Verification

- `pnpm test` 26/26 packages green; `pnpm quality` exit 0.
- **Numeric-widening tests confirmed to fail pre-fix**: reverted `queryFieldType`'s call site and re-ran — 3 of 4 failed, the 4th being the over-widening guard that correctly passes both ways.
- Zod introspection (`instanceof z.ZodNumber` after unwrapping `.optional()`/`.default()`) verified empirically against the installed Zod 4, including the `.optional().default()` pair in both orders — not inferred from docs.
- Regenerated `_generated/` diff reviewed line by line: only the import swap and the two intended signature widenings.

## Task dispositions

- **Closed**: TASK-120, 122, 123, 124 (shipped), TASK-125 (already shipped, verified with tests).
- **Left filed**: TASK-132 (per-call `timeoutMs`) — same `buildOptionsType` territory and the natural next unit, but it changes autocomplete timeout behavior on a user-visible latency path and touches a second service; it deserves its own review rather than riding a mechanical codegen PR. Same call as TASK-174 vs #1866. TASK-129 (`authShape`) stays gated — still needs a second bespoke-auth route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)