### PR TITLE
feat(bot-client): vision-describe stickers via the attachment pipeline

### DIFF
--- a/packages/common-types/src/constants/media.ts
+++ b/packages/common-types/src/constants/media.ts
@@ -55,6 +55,8 @@ export const CONTENT_TYPES = {
   IMAGE_JPG: 'image/jpeg',
   /** WebP image type */
   IMAGE_WEBP: 'image/webp',
+  /** GIF image type */
+  IMAGE_GIF: 'image/gif',
   /** WAV audio type */
   AUDIO_WAV: 'audio/wav',
   /** FLAC audio type */

--- a/packages/common-types/src/schemas/api/systemSettings.ts
+++ b/packages/common-types/src/schemas/api/systemSettings.ts
@@ -36,6 +36,8 @@ export const SystemSettingsSchema = z.object({
   factsInPromptEnabled: z.boolean(),
   /** Share GLM-4.5-Air with guests via the system z.ai coding-plan key. */
   zaiFreeTierEnabled: z.boolean(),
+  /** Vision-describe rasterizable stickers (instance-funded, cached per snowflake). */
+  stickerVisionEnabled: z.boolean(),
   /** Episodes per (channel, personality) before an extraction batch enqueues. */
   extractionBatchThreshold: z.number().int().min(1).max(50),
   /** Extraction engine — switching models MUST re-run `pnpm eval:extraction` first. */
@@ -278,6 +280,23 @@ export const SYSTEM_SETTINGS_REGISTRY: SystemSettingsRegistry = {
     liveness: 'live',
     fallback: false,
     seedSource: 'ZAI_FREE_TIER_ENABLED',
+  },
+  stickerVisionEnabled: {
+    key: 'stickerVisionEnabled',
+    label: 'Sticker Vision',
+    description:
+      'Vision-describe rasterizable stickers. Instance-funded; one call per sticker, ever.',
+    group: GROUP_MODELS_LIMITS,
+    control: 'boolean',
+    liveness: 'live',
+    // Defaults ON: the feature is the point, and the spend it authorizes is
+    // bounded by the number of DISTINCT stickers ever seen rather than by
+    // traffic — each one is described once and cached under its immutable
+    // snowflake. The switch exists to stop a surprising warmup burst, not
+    // because the steady state is expensive.
+    fallback: true,
+    // No predecessor: this setting is new, not migrated from an env var.
+    seedSource: '(none — introduced as a system setting)',
   },
   zaiHeadroomPercent: {
     key: 'zaiHeadroomPercent',

--- a/packages/common-types/src/types/schemas/discord.ts
+++ b/packages/common-types/src/types/schemas/discord.ts
@@ -59,6 +59,19 @@ export const attachmentMetadataSchema = z.object({
   duration: z.number().optional(),
   waveform: z.string().optional(),
   /**
+   * True when this entry is a Discord STICKER rendered as a synthetic
+   * attachment rather than a real message attachment.
+   *
+   * Load-bearing in three places, which is why it's a field rather than a
+   * naming convention: (1) the description is a permanently-reusable artifact
+   * keyed by the sticker's immutable snowflake, so the whole dispatch set (key,
+   * model, provider, tier) is the INSTANCE's rather than the triggering user's;
+   * (2) it renders under a `[Sticker: …]` header instead of `[Image: …]`,
+   * because calling it an image misdescribes what the user did; (3) it is what
+   * the `stickerVisionEnabled` kill switch filters on, before any download.
+   */
+  isSticker: z.boolean().optional(),
+  /**
    * Discord message ID this attachment came from (for inline image descriptions).
    * Optional because attachments in direct/triggering messages don't need source tracking.
    */

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.test.ts
@@ -39,6 +39,16 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
+// Runtime system settings. Defaults to the registry fallback (sticker vision
+// ON); the kill-switch tests flip it.
+const { systemSettingMock } = vi.hoisted(() => ({
+  systemSettingMock: vi.fn<(key: string) => unknown>(() => true),
+}));
+
+vi.mock('@tzurot/common-types/services/SystemSettingsService', () => ({
+  getSystemSetting: (key: string) => systemSettingMock(key),
+}));
+
 // Mock the attachmentFetch utility so tests control fetch / validation /
 // resize / data-URL building without hitting network or sharp. Error classes
 // (ExpiredJobError, AttachmentTooLargeError, etc.) are passed through from
@@ -613,5 +623,85 @@ describe('DownloadAttachmentsStep', () => {
     // guard would silently undercount pre-populated data URLs as 0 bytes.
     expect(job.data.context.attachments![0].size).toBeGreaterThan(0);
     expect(job.data.context.attachments![0].size).toBe(Math.ceil((dataUrl.length * 3) / 4));
+  });
+});
+
+describe('DownloadAttachmentsStep — sticker vision kill switch', () => {
+  let step: DownloadAttachmentsStep;
+
+  const stickerAttachment = {
+    id: '111222333444555666',
+    url: 'https://cdn.discordapp.com/stickers/111222333444555666.png',
+    name: 'partyblob',
+    contentType: 'image/png',
+    isSticker: true,
+  };
+  const imageAttachment = {
+    url: 'https://cdn.discordapp.com/attachments/1/2/photo.png',
+    name: 'photo.png',
+    contentType: 'image/png',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    systemSettingMock.mockReturnValue(true);
+    step = new DownloadAttachmentsStep(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('downloads sticker attachments when the switch is ON', async () => {
+    const job = createJob([stickerAttachment]);
+
+    await step.process(createContext(job));
+
+    expect(fetchAttachmentBytesMock).toHaveBeenCalledTimes(1);
+    expect(job.data.context.attachments).toHaveLength(1);
+  });
+
+  it('drops sticker attachments BEFORE any network work when the switch is OFF', async () => {
+    // "Off" has to be free, not merely quiet: a dropped sticker must never be
+    // fetched, resized, or counted against the aggregate payload cap.
+    systemSettingMock.mockReturnValue(false);
+    const job = createJob([stickerAttachment]);
+
+    await step.process(createContext(job));
+
+    expect(fetchAttachmentBytesMock).not.toHaveBeenCalled();
+    expect(job.data.context.attachments ?? []).toHaveLength(0);
+  });
+
+  it('keeps ordinary attachments when the switch is OFF', async () => {
+    // The switch is scoped to stickers — flipping it must not disable image
+    // handling generally.
+    systemSettingMock.mockReturnValue(false);
+    const job = createJob([stickerAttachment, imageAttachment]);
+
+    await step.process(createContext(job));
+
+    expect(job.data.context.attachments).toHaveLength(1);
+    expect(job.data.context.attachments![0].name).toBe('photo.png');
+  });
+
+  it('filters stickers out of the extended-context group too', async () => {
+    // Extended context is a separate array; filtering only the trigger group
+    // would leave history stickers billing while the switch reads OFF.
+    systemSettingMock.mockReturnValue(false);
+    const job = createJob([], [stickerAttachment]);
+
+    await step.process(createContext(job));
+
+    expect(fetchAttachmentBytesMock).not.toHaveBeenCalled();
+    expect(job.data.context.extendedContextAttachments ?? []).toHaveLength(0);
+  });
+
+  it('reads the sticker switch by name', async () => {
+    const job = createJob([stickerAttachment]);
+
+    await step.process(createContext(job));
+
+    expect(systemSettingMock).toHaveBeenCalledWith('stickerVisionEnabled');
   });
 });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.ts
@@ -33,6 +33,7 @@
  * MEDIA_NOT_FOUND so users see the failure list in a Discord spoiler tag.
  */
 
+import { getSystemSetting } from '@tzurot/common-types/services/SystemSettingsService';
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { IPipelineStep, GenerationContext } from '../types.js';
@@ -85,6 +86,17 @@ function hasMessageText(message: string | object | undefined): boolean {
   return false;
 }
 
+/**
+ * Drop sticker-sourced attachments when sticker vision is switched off.
+ *
+ * Filtering here rather than at the describe call is what makes "off" actually
+ * free: a dropped sticker is never downloaded, never resized, and never counted
+ * against the job's aggregate payload cap.
+ */
+function keepStickersIf(enabled: boolean, attachments: AttachmentMetadata[]): AttachmentMetadata[] {
+  return enabled ? attachments : attachments.filter(a => a.isSticker !== true);
+}
+
 export class DownloadAttachmentsStep implements IPipelineStep {
   readonly name = 'DownloadAttachments';
 
@@ -98,8 +110,30 @@ export class DownloadAttachmentsStep implements IPipelineStep {
   async process(context: GenerationContext): Promise<GenerationContext> {
     const { job } = context;
 
-    const triggerAttachments = job.data.context?.attachments ?? [];
-    const extendedAttachments = job.data.context?.extendedContextAttachments ?? [];
+    // Sticker attachments are dropped here, before any network work, when the
+    // runtime switch is off — bot-client always sends them (it has no reader for
+    // system settings), so this is the single point where the feature is on or
+    // off. Dropping them costs the message nothing: the `[Stickers: …]` line
+    // that bot-client renders into the content names every sticker regardless,
+    // so the character still knows one arrived and what it was called.
+    const stickerVisionEnabled = getSystemSetting('stickerVisionEnabled');
+    const triggerAttachments = keepStickersIf(
+      stickerVisionEnabled,
+      job.data.context?.attachments ?? []
+    );
+    const extendedAttachments = keepStickersIf(
+      stickerVisionEnabled,
+      job.data.context?.extendedContextAttachments ?? []
+    );
+
+    // Publish the filtered view BEFORE the short-circuit below. When the switch
+    // drops the only attachment on a message, the early return fires and the
+    // write-back at the end of process() never runs — leaving the dropped
+    // sticker visible to every downstream step, which is the opposite of off.
+    if (job.data.context !== undefined) {
+      job.data.context.attachments = triggerAttachments;
+      job.data.context.extendedContextAttachments = extendedAttachments;
+    }
 
     // No attachments → nothing to expire. Short-circuit before the queue-age
     // gate so text-only jobs that sit through a backpressure incident don't

--- a/services/ai-worker/src/services/MultimodalProcessor.test.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { describeImage, transcribeAudio, processAttachments } from './MultimodalProcessor.js';
 import type { AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import type { LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
+import { AIProvider } from '@tzurot/common-types/constants/ai';
+import { SYSTEM_SETTINGS_FALLBACKS } from '@tzurot/common-types/schemas/api/systemSettings';
 import { AttachmentType, CONTENT_TYPES } from '@tzurot/common-types/constants/media';
 import type { ResolveVisionConfigOptions } from './multimodal/visionAuthResolver.js';
 import type { ApiKeyResolver } from './ApiKeyResolver.js';
@@ -32,6 +34,22 @@ const {
   mockVisionCacheStoreFailure: vi.fn(),
   mockDescribeImageWithFallback: vi.fn(),
 }));
+
+// Runtime system settings. The sticker path reads `fallbackVisionModel` to pin
+// the model that writes a permanent shared-asset description.
+const { systemSettingMock } = vi.hoisted(() => ({
+  systemSettingMock: vi.fn<(key: string) => unknown>(),
+}));
+
+vi.mock('@tzurot/common-types/services/SystemSettingsService', async () => {
+  const actual = await vi.importActual<
+    typeof import('@tzurot/common-types/services/SystemSettingsService')
+  >('@tzurot/common-types/services/SystemSettingsService');
+  return {
+    ...actual,
+    getSystemSetting: (key: string) => systemSettingMock(key),
+  };
+});
 
 // Mock the Phase-4 fallback wrapper so we can assert processAttachments ROUTES the
 // visionAuth bundle to it (rather than the single-model describeImage). This is the seam
@@ -99,6 +117,15 @@ describe('MultimodalProcessor', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Pin only the operator vision floor; every other key keeps its real
+    // registry fallback. A blanket stub would hand model-valued settings a
+    // boolean, which breaks selectVisionModel for the non-sticker tests.
+    systemSettingMock.mockImplementation((key: string) =>
+      key === 'fallbackVisionModel'
+        ? 'operator/paid-vision-model'
+        : SYSTEM_SETTINGS_FALLBACKS[key as keyof typeof SYSTEM_SETTINGS_FALLBACKS]
+    );
 
     // Reset mock implementations to default
     mockModelInvoke.mockResolvedValue({
@@ -271,6 +298,161 @@ describe('MultimodalProcessor', () => {
         type: AttachmentType.Image,
         description: 'Fallback-loop description',
       });
+    });
+
+    it('funds a STICKER description from the instance, not the triggering user', async () => {
+      // A sticker description is keyed by an immutable snowflake, so it is
+      // written once and read by everyone forever. Under first-sighter-pays,
+      // whoever sights it first would decide — via their key's model — how well
+      // it is described for every future reader. The user-attributed inputs
+      // must therefore be cleared before the call.
+      vi.useRealTimers();
+      const stickerAttachment: AttachmentMetadata = {
+        id: '111222333444555666',
+        url: 'https://cdn.discordapp.com/stickers/111222333444555666.png',
+        name: 'partyblob',
+        contentType: CONTENT_TYPES.IMAGE_PNG,
+        isSticker: true,
+      };
+      const byokAuth: ResolveVisionConfigOptions = {
+        personality: mockPersonality,
+        mainProvider: AIProvider.OpenRouter,
+        mainApiKey: 'sk-user-byok-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: {
+          resolveApiKey: vi.fn(),
+          tryResolveUserKey: vi.fn(),
+        } as unknown as ApiKeyResolver,
+      };
+
+      await processAttachments([stickerAttachment], mockPersonality, {
+        isGuestMode: false,
+        visionAuth: byokAuth,
+      });
+
+      // Assert across the seam: what CROSSES to the describe call is the
+      // instance-funded shape, regardless of what the caller resolved.
+      expect(mockDescribeImageWithFallback).toHaveBeenCalledWith(
+        stickerAttachment,
+        mockPersonality,
+        expect.objectContaining({
+          isGuestMode: true,
+          userId: undefined,
+          mainApiKey: undefined,
+          mainProvider: undefined,
+        }),
+        expect.objectContaining({ loggingContext: expect.any(Object) })
+      );
+    });
+
+    it('pins a STICKER to the operator-configured vision model', async () => {
+      // The trap this guards: `asInstanceFundedAuth` sets `isGuestMode: true`
+      // for auth routing, but that flag is ALSO the tier selector — without an
+      // explicit model override, selectVisionModel free-forces every sticker
+      // onto the free floor, and the snowflake cache makes that permanent.
+      vi.useRealTimers();
+      const stickerAttachment: AttachmentMetadata = {
+        id: '111222333444555666',
+        url: 'https://cdn.discordapp.com/stickers/111222333444555666.png',
+        name: 'partyblob',
+        contentType: CONTENT_TYPES.IMAGE_PNG,
+        isSticker: true,
+      };
+
+      await processAttachments([stickerAttachment], mockPersonality, {
+        isGuestMode: false,
+        visionAuth: {
+          personality: mockPersonality,
+          mainProvider: AIProvider.OpenRouter,
+          mainApiKey: 'sk-user-byok-key',
+          isGuestMode: false,
+          userId: 'user-1',
+          apiKeyResolver: {
+            resolveApiKey: vi.fn(),
+            tryResolveUserKey: vi.fn(),
+          } as unknown as ApiKeyResolver,
+        },
+      });
+
+      expect(mockDescribeImageWithFallback).toHaveBeenCalledWith(
+        stickerAttachment,
+        mockPersonality,
+        expect.anything(),
+        expect.objectContaining({ model: 'operator/paid-vision-model' })
+      );
+    });
+
+    it('forwards an explicit caller model to the fallback chain for a NON-sticker', async () => {
+      // Latent coupling, pinned so it can't drift: the shared-dispatch refactor
+      // made this branch forward `model` to describeImageWithFallback, which it
+      // previously never received. No caller supplies `model` AND `visionAuth`
+      // together today, so this is a no-op in production — but if one ever does,
+      // the explicit model must win over selectVisionModel's dynamic resolution,
+      // which is what the field's own contract promises.
+      vi.useRealTimers();
+      const imageAttachment: AttachmentMetadata = {
+        url: 'https://cdn.discordapp.com/image1.png',
+        name: 'image1.png',
+        contentType: CONTENT_TYPES.IMAGE_PNG,
+      };
+
+      await processAttachments([imageAttachment], mockPersonality, {
+        isGuestMode: false,
+        model: 'caller/explicit-model',
+        visionAuth: {
+          personality: mockPersonality,
+          mainProvider: AIProvider.OpenRouter,
+          mainApiKey: 'sk-user-byok-key',
+          isGuestMode: false,
+          userId: 'user-1',
+          apiKeyResolver: {
+            resolveApiKey: vi.fn(),
+            tryResolveUserKey: vi.fn(),
+          } as unknown as ApiKeyResolver,
+        },
+      });
+
+      expect(mockDescribeImageWithFallback).toHaveBeenCalledWith(
+        imageAttachment,
+        mockPersonality,
+        expect.anything(),
+        expect.objectContaining({ model: 'caller/explicit-model' })
+      );
+    });
+
+    it('leaves a NON-sticker image on the caller-resolved auth', async () => {
+      // The mirror case: clearing auth for ordinary attachments would silently
+      // move every user's image description onto the system key.
+      vi.useRealTimers();
+      const imageAttachment: AttachmentMetadata = {
+        url: 'https://cdn.discordapp.com/image1.png',
+        name: 'image1.png',
+        contentType: CONTENT_TYPES.IMAGE_PNG,
+      };
+      const byokAuth: ResolveVisionConfigOptions = {
+        personality: mockPersonality,
+        mainProvider: AIProvider.OpenRouter,
+        mainApiKey: 'sk-user-byok-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: {
+          resolveApiKey: vi.fn(),
+          tryResolveUserKey: vi.fn(),
+        } as unknown as ApiKeyResolver,
+      };
+
+      await processAttachments([imageAttachment], mockPersonality, {
+        isGuestMode: false,
+        visionAuth: byokAuth,
+      });
+
+      expect(mockDescribeImageWithFallback).toHaveBeenCalledWith(
+        imageAttachment,
+        mockPersonality,
+        byokAuth,
+        expect.objectContaining({ loggingContext: expect.any(Object) })
+      );
     });
 
     it('should process single audio attachment successfully', async () => {
@@ -545,6 +727,73 @@ describe('MultimodalProcessor', () => {
           apiKey: userApiKey,
         })
       );
+    });
+
+    it('never bills a STICKER to the user key, even with no visionAuth bundle', async () => {
+      // Several callers omit the visionAuth bundle entirely (DependencyStep's
+      // legacy branch, ConversationInputProcessor's defensive branch). The
+      // instance-funded rule has to hold on those paths too, or a resolver
+      // hiccup silently reverts a permanent shared artifact to first-sighter
+      // -pays — with no error and no log line to notice it by.
+      const attachments: AttachmentMetadata[] = [
+        {
+          id: '111222333444555666',
+          url: 'https://cdn.discordapp.com/stickers/111222333444555666.png',
+          name: 'partyblob',
+          contentType: CONTENT_TYPES.IMAGE_PNG,
+          isSticker: true,
+        },
+      ];
+
+      const promise = processAttachments(attachments, mockPersonality, {
+        isGuestMode: false,
+        userApiKey: 'user-test-key-12345',
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockCreateChatModel).toHaveBeenCalled();
+      const constructorArg = mockCreateChatModel.mock.calls[0][0] as { apiKey?: string };
+      expect(constructorArg.apiKey).not.toBe('user-test-key-12345');
+    });
+
+    it('does not pair a STICKER with the personality-resolved provider', async () => {
+      // The caller resolves `visionProvider` for the PERSONALITY's vision model.
+      // A shared asset uses the operator's model instead, so carrying that
+      // provider through pairs a model with the wrong route — describeImage
+      // prefers an explicit provider over deriving one, so the mismatch reaches
+      // createChatModel and fails at the API rather than describing anything.
+      const attachments: AttachmentMetadata[] = [
+        {
+          id: '111222333444555666',
+          url: 'https://cdn.discordapp.com/stickers/111222333444555666.png',
+          name: 'partyblob',
+          contentType: CONTENT_TYPES.IMAGE_PNG,
+          isSticker: true,
+        },
+      ];
+
+      const promise = processAttachments(attachments, mockPersonality, {
+        isGuestMode: false,
+        userApiKey: 'user-test-key-12345',
+        visionProvider: AIProvider.ZaiCoding,
+        model: 'personality/own-vision-model',
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockCreateChatModel).toHaveBeenCalled();
+      const constructorArg = mockCreateChatModel.mock.calls[0][0] as {
+        provider?: string;
+        modelName?: string;
+        apiKey?: string;
+      };
+      // Not the caller's provider, and not the caller's model or key either —
+      // the whole dispatch set is replaced together.
+      expect(constructorArg.provider).not.toBe(AIProvider.ZaiCoding);
+      expect(constructorArg.apiKey).not.toBe('user-test-key-12345');
     });
 
     it('should use system key when userApiKey is undefined', async () => {

--- a/services/ai-worker/src/services/MultimodalProcessor.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.ts
@@ -14,6 +14,7 @@
 
 import { type AIProvider } from '@tzurot/common-types/constants/ai';
 import { AttachmentType, CONTENT_TYPES } from '@tzurot/common-types/constants/media';
+import { getSystemSetting } from '@tzurot/common-types/services/SystemSettingsService';
 import { RETRY_CONFIG } from '@tzurot/common-types/constants/timing';
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
@@ -88,6 +89,68 @@ export interface ProcessAttachmentOptions {
 }
 
 /**
+ * Re-shape vision auth so the call is funded and configured by the INSTANCE
+ * rather than by the user who happened to trigger it.
+ *
+ * A sticker description is keyed by the sticker's immutable snowflake, so it is
+ * written once and then read by every user and every character forever. Two
+ * consequences follow, and the second is the one that actually decides it:
+ *
+ * - Billing a BYOK user for a permanent shared artifact is surprising ("why was
+ *   I charged for a sticker I sent once?").
+ * - More importantly, under first-sighter-pays the artifact's QUALITY becomes a
+ *   lottery: whoever sights a sticker first decides, via their key's model, how
+ *   well it is described for everyone thereafter. Instance-funded means
+ *   instance-CONFIGURED — the operator's vision settings write the permanent
+ *   record.
+ *
+ * Expressed by clearing the user-attributed inputs, which routes the existing
+ * resolver down its system-key path. Deliberately NOT a new auth branch: the
+ * fallback chain, quota handling, and failure rendering all stay shared.
+ */
+function asInstanceFundedAuth(base: ResolveVisionConfigOptions): ResolveVisionConfigOptions {
+  return {
+    ...base,
+    isGuestMode: true,
+    userId: undefined,
+    mainApiKey: undefined,
+    mainProvider: undefined,
+  };
+}
+
+/**
+ * The model that writes a permanent shared-asset description.
+ *
+ * MUST be paired with {@link asInstanceFundedAuth} and passed as an explicit
+ * model override, because `isGuestMode` is not only an auth signal in this
+ * codebase — `selectVisionModel` reads it as a TIER selector and free-forces
+ * the model at every priority level, and `composeVisionTiers` uses it to pick
+ * the chain's floor. Setting it for auth purposes alone would therefore
+ * collapse every sticker onto the free vision floor, which is the exact
+ * opposite of "the operator's settings write the permanent record" — and
+ * permanently so, since the description is cached under an immutable snowflake
+ * and the canonical cache's tier-promotion can never fire for an asset whose
+ * every describe is pinned to the lowest tier.
+ *
+ * Uses the operator's configured paid floor rather than the personality's own
+ * vision model on purpose: the artifact is shared, so ONE operator-chosen model
+ * should write it regardless of which character happened to see the sticker
+ * first. That also keeps the record reproducible — the same sticker gets the
+ * same treatment everywhere.
+ *
+ * ACCEPTED LIMIT: that guarantee covers the PRIMARY attempt only. If the pinned
+ * model fails on a retryable category, the fallback chain's lower tiers still
+ * degrade to the free floor (`composeVisionTiers` picks the floor from
+ * `isGuestMode`, and the resolver force-downgrades every non-primary tier for a
+ * guest). So a sticker whose paid describe fails can still end up with a
+ * free-tier description. Deliberate: "free but described" beats "undescribed",
+ * and it matches the degradation every other guest-path call already gets.
+ */
+function sharedAssetVisionModel(): string {
+  return getSystemSetting('fallbackVisionModel');
+}
+
+/**
  * Process a single attachment (helper function for retry logic)
  */
 async function processSingleAttachment(
@@ -105,19 +168,52 @@ async function processSingleAttachment(
     visionAuth,
   } = options;
   if (attachment.contentType.startsWith(CONTENT_TYPES.IMAGE_PREFIX)) {
+    // A shared asset is instance-funded on EVERY path, not just the one the
+    // primary caller uses. Deciding it here — rather than at each
+    // `processAttachments` call site — is deliberate: several callers omit the
+    // `visionAuth` bundle entirely (DependencyStep's legacy branch,
+    // ConversationInputProcessor's defensive branch), and a rule enforced at N
+    // call sites is a rule that silently stops holding at the N+1th.
+    const isSharedAsset = attachment.isSticker === true;
+
+    // EVERY caller-supplied dispatch input is replaced for a shared asset, in
+    // one literal rather than field-by-field at the call. The caller resolved
+    // all four for the TRIGGERING USER and the PERSONALITY's vision model; a
+    // shared asset uses none of that, and overriding only some of them produces
+    // mismatched pairs — a personality's provider against the operator's model
+    // misroutes to a 401, and a stale key or tier silently un-does the
+    // instance-funding rule. Keeping them adjacent is what makes a future
+    // addition visibly belong here too.
+    const dispatch = isSharedAsset
+      ? {
+          isGuestMode: true,
+          userApiKey: undefined,
+          // Let describeImage derive it from the model below via
+          // detectVisionProvider — the Phase-4 path resolves it the same way.
+          provider: undefined,
+          // Not optional polish — see sharedAssetVisionModel: the auth re-shape
+          // sets `isGuestMode`, which doubles as a tier selector, so without an
+          // explicit model the description lands on the free floor forever.
+          model: sharedAssetVisionModel(),
+        }
+      : { isGuestMode, userApiKey, provider: visionProvider, model };
+
     // Phase-4 path: when the caller supplied auth inputs, retry down the fallback chain
     // (the wrapper resolves per-tier auth + never throws). Otherwise fall back to the
     // single-model describeImage with the pre-resolved config (legacy / no-resolver path).
+    const effectiveAuth =
+      visionAuth !== undefined && isSharedAsset ? asInstanceFundedAuth(visionAuth) : visionAuth;
     const description =
-      visionAuth !== undefined
-        ? await describeImageWithFallback(attachment, personality, visionAuth, {
+      effectiveAuth !== undefined
+        ? await describeImageWithFallback(attachment, personality, effectiveAuth, {
             loggingContext,
+            model: dispatch.model,
           })
-        : await describeImage(attachment, personality, isGuestMode, userApiKey, {
+        : await describeImage(attachment, personality, dispatch.isGuestMode, dispatch.userApiKey, {
             skipNegativeCache: true,
             loggingContext,
-            provider: visionProvider,
-            model,
+            provider: dispatch.provider,
+            model: dispatch.model,
           });
     logger.info({ name: attachment.name }, 'Processed image attachment');
     return {

--- a/services/ai-worker/src/services/RAGUtils.test.ts
+++ b/services/ai-worker/src/services/RAGUtils.test.ts
@@ -77,6 +77,29 @@ describe('RAGUtils', () => {
       expect(result).toBe('[Image: attachment]\nSome image');
     });
 
+    it('labels a sticker as a Sticker, not an Image', () => {
+      // A sticker travels the image path but the user picked a sticker; calling
+      // it an image tells the character someone uploaded a file.
+      const attachments: ProcessedAttachment[] = [
+        createAttachment(AttachmentType.Image, 'A cartoon blob celebrating', {
+          name: 'partyblob',
+          isSticker: true,
+        }),
+      ];
+
+      const result = buildAttachmentDescriptions(attachments);
+      expect(result).toBe('[Sticker: partyblob]\nA cartoon blob celebrating');
+    });
+
+    it('keeps the Image label when isSticker is absent', () => {
+      // Guards the default: the header must not flip for ordinary attachments.
+      const attachments: ProcessedAttachment[] = [
+        createAttachment(AttachmentType.Image, 'A photo', { name: 'photo.png' }),
+      ];
+
+      expect(buildAttachmentDescriptions(attachments)).toBe('[Image: photo.png]\nA photo');
+    });
+
     it('should format voice message with duration and wrap transcript in structured tags', () => {
       const attachments: ProcessedAttachment[] = [
         createAttachment(AttachmentType.Audio, 'User said hello and asked about the weather', {

--- a/services/ai-worker/src/services/RAGUtils.ts
+++ b/services/ai-worker/src/services/RAGUtils.ts
@@ -97,7 +97,11 @@ function formatProcessedAttachmentEntry(a: ProcessedAttachment): string {
   if (a.type === AttachmentType.Image) {
     const name =
       a.metadata.name !== undefined && a.metadata.name.length > 0 ? a.metadata.name : 'attachment';
-    return `[Image: ${name}]\n${a.description}`;
+    // A sticker travels the image path but is not an image the user attached —
+    // labelling it `[Image: …]` would tell the character someone uploaded a
+    // file when they picked a sticker, which changes how it reads the gesture.
+    const header = a.metadata.isSticker === true ? 'Sticker' : 'Image';
+    return `[${header}: ${name}]\n${a.description}`;
   }
   if (a.type === AttachmentType.Audio) {
     const header = buildAudioAttachmentHeader(a);

--- a/services/bot-client/src/utils/MessageContentBuilder.test.ts
+++ b/services/bot-client/src/utils/MessageContentBuilder.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Collection, MessageType, MessageReferenceType } from 'discord.js';
+import { Collection, MessageType, MessageReferenceType, StickerFormatType } from 'discord.js';
 import type { Message, Attachment, Embed, MessageSnapshot, Sticker } from 'discord.js';
 import {
   buildMessageContent,
@@ -124,6 +124,51 @@ describe('MessageContentBuilder', () => {
       // Non-empty is the load-bearing part: convertMessage's
       // hasProcessableContent gate drops a message whose content is empty.
       expect(result.content).toBe('[Stickers: partyblob]');
+    });
+
+    it('should emit a rasterizable sticker as a synthetic attachment for the vision path', async () => {
+      // The wiring seam. Every OTHER sticker fixture in this file omits
+      // `format`, so isRasterizableSticker rejects them and extractStickerImages
+      // returns undefined — meaning the `...(stickerImages ?? [])` spread into
+      // allAttachments could be deleted outright and this suite would stay
+      // green. This fixture is shaped like a real sticker precisely so that
+      // can't happen.
+      const stickers = new Collection<string, Sticker>();
+      stickers.set('111222333444555666', {
+        id: '111222333444555666',
+        name: 'partyblob',
+        description: null,
+        format: StickerFormatType.PNG,
+        url: 'https://cdn.discordapp.com/stickers/111222333444555666.png',
+      } as unknown as Sticker);
+      const message = createMockMessage({ content: '', stickers });
+
+      const result = await buildMessageContent(message);
+
+      const stickerAttachment = result.attachments.find(a => a.isSticker === true);
+      expect(stickerAttachment).toBeDefined();
+      expect(stickerAttachment?.id).toBe('111222333444555666');
+      // The text line survives alongside it — the two are complementary, and
+      // dropping the line would re-open the EmptyMessageFilter hole.
+      expect(result.content).toBe('[Stickers: partyblob]');
+    });
+
+    it('should NOT emit a Lottie sticker as an attachment (no raster form exists)', async () => {
+      const stickers = new Collection<string, Sticker>();
+      stickers.set('7', {
+        id: '7',
+        name: 'wumpus-dance',
+        description: 'Wumpus dancing',
+        format: StickerFormatType.Lottie,
+        url: 'https://cdn.discordapp.com/stickers/7.json',
+      } as unknown as Sticker);
+      const message = createMockMessage({ content: '', stickers });
+
+      const result = await buildMessageContent(message);
+
+      expect(result.attachments.some(a => a.isSticker === true)).toBe(false);
+      // Still named, so the message is never empty and the character knows.
+      expect(result.content).toBe('[Stickers: wumpus-dance — Wumpus dancing]');
     });
 
     it('should merge own and snapshot stickers when a forward also carries its own', async () => {

--- a/services/bot-client/src/utils/MessageContentBuilder.ts
+++ b/services/bot-client/src/utils/MessageContentBuilder.ts
@@ -28,6 +28,7 @@ import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/disc
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
+import { extractStickerImages } from './stickerAttachments.js';
 import { EmbedParser } from './EmbedParser.js';
 import { describeStickersAndPoll, hasStickerOrPoll } from './stickerPollDescriptions.js';
 import {
@@ -281,16 +282,29 @@ export async function buildMessageContent(
   // 1. Forwarded message snapshot attachments (extracted above)
   // 2. Regular attachments on the main message
   // 3. Embed images from main message embeds
+  // 4. Rasterizable stickers as synthetic attachments — so the vision path can
+  //    describe what the sticker actually depicts. The `[Stickers: …]` line
+  //    pushed above still names every sticker regardless; these two are
+  //    complementary, not alternatives (see stickerPollDescriptions.ts).
   const regularAttachments = extractAttachments(message.attachments);
   const embedImages = extractEmbedImages(message.embeds);
+  const stickerImages = extractStickerImages(message);
   const allAttachments: AttachmentMetadata[] = [
     ...snapshotAttachments,
     ...(regularAttachments ?? []),
     ...(embedImages ?? []),
+    ...(stickerImages ?? []),
   ];
 
   // Process voice messages and categorize attachments
   // Voice transcripts are collected separately for structured XML formatting
+  //
+  // `stickerImages` is deliberately NOT passed: this pass exists to split voice
+  // from non-voice and to build the `[Attachments: …]` text line, and a sticker
+  // is neither. Listing it there would print `[Attachments: image/png: Yipee!]`
+  // directly beneath the `[Stickers: Yipee!]` line that already named it. The
+  // stickers still reach ai-worker via `allAttachments` above — which is the
+  // field that carries them to the vision path.
   const { hasVoiceMessage, voiceTranscripts, nonVoiceAttachments } = await processVoiceAttachments({
     messageId: message.id,
     originalMessageId: message.reference?.messageId,

--- a/services/bot-client/src/utils/attachmentPlaceholders.test.ts
+++ b/services/bot-client/src/utils/attachmentPlaceholders.test.ts
@@ -80,6 +80,34 @@ describe('attachmentPlaceholders', () => {
       expect(result).toBe('[Image: attachment]');
     });
 
+    it('should label a sticker as Sticker, not Image', () => {
+      // This placeholder is PERSISTED. The post-vision upgrade that would
+      // replace it only runs when a description was produced, so with sticker
+      // vision off (or after a describe failure) this text is permanent — and
+      // `[Image: partyblob]` tells the character someone uploaded a file when
+      // they picked a sticker.
+      const attachment: AttachmentMetadata = {
+        id: '111222333444555666',
+        url: 'https://cdn.discordapp.com/stickers/111222333444555666.png',
+        contentType: 'image/png',
+        name: 'partyblob',
+        isSticker: true,
+      };
+
+      expect(generateAttachmentPlaceholder(attachment)).toBe('[Sticker: partyblob]');
+    });
+
+    it('should keep the Image label when isSticker is absent', () => {
+      // Guards the default — the branch must not flip for ordinary uploads.
+      const attachment: AttachmentMetadata = {
+        url: 'https://example.com/photo.jpg',
+        contentType: 'image/jpeg',
+        name: 'photo.jpg',
+      };
+
+      expect(generateAttachmentPlaceholder(attachment)).toBe('[Image: photo.jpg]');
+    });
+
     it('should generate placeholder for generic file', () => {
       const attachment: AttachmentMetadata = {
         url: 'https://example.com/document.pdf',

--- a/services/bot-client/src/utils/attachmentPlaceholders.ts
+++ b/services/bot-client/src/utils/attachmentPlaceholders.ts
@@ -33,7 +33,15 @@ export function generateAttachmentPlaceholder(attachment: AttachmentMetadata): s
       attachment.name !== undefined && attachment.name !== null && attachment.name.length > 0
         ? attachment.name
         : 'attachment';
-    return `[Image: ${name}]`;
+    // A sticker travels the image path but is not a file the user uploaded.
+    // This placeholder is PERSISTED with the message row, and the post-vision
+    // upgrade that would replace it only runs when a description was actually
+    // produced — so with sticker vision switched off, or after a describe
+    // failure, whatever is written here is what the character reads forever.
+    // Must match RAGUtils' `formatProcessedAttachmentEntry`, which makes the
+    // same Sticker-vs-Image distinction on the upgrade path.
+    const kind = attachment.isSticker === true ? 'Sticker' : 'Image';
+    return `[${kind}: ${name}]`;
   }
 
   // Generic file placeholder

--- a/services/bot-client/src/utils/dashboard/settings/systemSettingsConfig.ts
+++ b/services/bot-client/src/utils/dashboard/settings/systemSettingsConfig.ts
@@ -50,6 +50,7 @@ const SYSTEM_SETTING_EMOJI: Record<string, string> = {
   fallbackVisionModel: '👁️',
   fallbackTextModelFree: '🆓',
   fallbackVisionModelFree: '🖼️',
+  stickerVisionEnabled: '🏷️',
 };
 
 /** Human labels for enum choice values (fall back to the raw value). */

--- a/services/bot-client/src/utils/stickerAttachments.test.ts
+++ b/services/bot-client/src/utils/stickerAttachments.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { StickerFormatType, type Message, type Sticker } from 'discord.js';
+import { extractStickerImages, isRasterizableSticker } from './stickerAttachments.js';
+
+interface StickerFixture {
+  id: string;
+  name: string;
+  format: StickerFormatType;
+  url: string;
+}
+
+/**
+ * The slice of a sticker this module reads. Narrow on purpose — a full `Sticker`
+ * mock would assert nothing extra and would hide which fields the conversion
+ * actually depends on.
+ */
+function sticker(overrides: Partial<StickerFixture> & { id: string }): StickerFixture {
+  return {
+    name: `sticker-${overrides.id}`,
+    format: StickerFormatType.PNG,
+    url: `https://cdn.discordapp.com/stickers/${overrides.id}.png`,
+    ...overrides,
+  };
+}
+
+function messageWith(opts: {
+  stickers?: StickerFixture[];
+  snapshotStickers?: StickerFixture[][];
+}): Message {
+  const toMap = (list: StickerFixture[]): Map<string, StickerFixture> =>
+    new Map(list.map(s => [s.id, s]));
+
+  return {
+    stickers: toMap(opts.stickers ?? []),
+    messageSnapshots: new Map(
+      (opts.snapshotStickers ?? []).map((list, i) => [String(i), { stickers: toMap(list) }])
+    ),
+  } as unknown as Message;
+}
+
+describe('isRasterizableSticker', () => {
+  it.each([
+    ['PNG', StickerFormatType.PNG, true],
+    ['APNG', StickerFormatType.APNG, true],
+    ['GIF', StickerFormatType.GIF, true],
+    ['Lottie', StickerFormatType.Lottie, false],
+  ])('%s → %s', (_label, format, expected) => {
+    expect(isRasterizableSticker({ format } as unknown as Sticker)).toBe(expected);
+  });
+
+  it('treats an unknown future format as NOT rasterizable', () => {
+    // The check enumerates known raster formats rather than excluding Lottie, so
+    // a new Discord vector format defaults to safe instead of feeding a
+    // non-image document to the vision pipeline.
+    expect(isRasterizableSticker({ format: 99 } as unknown as Sticker)).toBe(false);
+  });
+});
+
+describe('extractStickerImages', () => {
+  it('returns undefined when the message has no stickers', () => {
+    // undefined rather than [] — matches extractEmbedImages so both spread alike.
+    expect(extractStickerImages(messageWith({}))).toBeUndefined();
+  });
+
+  it('returns undefined when every sticker is un-rasterizable', () => {
+    const message = messageWith({
+      stickers: [sticker({ id: '1', format: StickerFormatType.Lottie })],
+    });
+    expect(extractStickerImages(message)).toBeUndefined();
+  });
+
+  it('carries the sticker snowflake as the attachment id (the cache identity)', () => {
+    const message = messageWith({ stickers: [sticker({ id: '111222333444555666' })] });
+
+    const result = extractStickerImages(message);
+
+    expect(result).toHaveLength(1);
+    // The snowflake is what makes the description permanently reusable — a
+    // sticker's image can never change without minting a new id.
+    expect(result?.[0].id).toBe('111222333444555666');
+    expect(result?.[0].isSticker).toBe(true);
+  });
+
+  it('uses the sticker name and its CDN url', () => {
+    const message = messageWith({
+      stickers: [
+        sticker({ id: '7', name: 'partyblob', url: 'https://cdn.discordapp.com/stickers/7.png' }),
+      ],
+    });
+
+    expect(extractStickerImages(message)?.[0]).toMatchObject({
+      name: 'partyblob',
+      url: 'https://cdn.discordapp.com/stickers/7.png',
+      contentType: 'image/png',
+    });
+  });
+
+  it('marks a GIF sticker as image/gif and APNG as image/png', () => {
+    // APNG is served with a .png extension — it IS a PNG, animated — so only
+    // GIF diverges.
+    const message = messageWith({
+      stickers: [
+        sticker({ id: '1', format: StickerFormatType.GIF }),
+        sticker({ id: '2', format: StickerFormatType.APNG }),
+      ],
+    });
+
+    const result = extractStickerImages(message);
+
+    expect(result?.[0].contentType).toBe('image/gif');
+    expect(result?.[1].contentType).toBe('image/png');
+  });
+
+  it('drops only the un-rasterizable stickers from a mixed message', () => {
+    const message = messageWith({
+      stickers: [
+        sticker({ id: '1', format: StickerFormatType.Lottie }),
+        sticker({ id: '2', format: StickerFormatType.PNG }),
+      ],
+    });
+
+    const result = extractStickerImages(message);
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0].id).toBe('2');
+  });
+
+  it('includes stickers carried by a forwarded message snapshot', () => {
+    // Forwarded messages keep their stickers in snapshots; missing these would
+    // silently describe nothing for a forwarded sticker.
+    const message = messageWith({
+      stickers: [sticker({ id: 'own' })],
+      snapshotStickers: [[sticker({ id: 'forwarded' })]],
+    });
+
+    const ids = extractStickerImages(message)?.map(a => a.id);
+
+    expect(ids).toEqual(['own', 'forwarded']);
+  });
+});

--- a/services/bot-client/src/utils/stickerAttachments.ts
+++ b/services/bot-client/src/utils/stickerAttachments.ts
@@ -1,0 +1,80 @@
+/**
+ * Sticker → synthetic attachment conversion.
+ *
+ * A sticker has a stable URL and a derivable content type, which is everything
+ * the existing attachment → download → vision → describe chain needs. Rather
+ * than building a parallel describe path, stickers are handed to that chain as
+ * `AttachmentMetadata` — the same trick `embedImageExtractor.ts` already uses
+ * for embed images — so they inherit the CDN allowlist, the resize/size caps,
+ * the vision-model cascade, the failure fallbacks, and the description cache
+ * for free.
+ *
+ * Two properties of stickers shape everything here:
+ *
+ * 1. **The image is immutable per snowflake.** Changing a sticker's image
+ *    requires delete + re-upload, which mints a NEW id (`GuildStickerEditOptions`
+ *    accepts only name/description/tags — no file). So the snowflake is a
+ *    permanently valid cache key: `AttachmentMetadata.id` feeds
+ *    `deriveAttachmentCacheKey`, and the description never needs invalidating.
+ * 2. **Lottie stickers have no raster form.** Their CDN URL resolves to a
+ *    `.json` vector-animation document, not an image, so they cannot go down a
+ *    vision path at all and are excluded here. `stickerPollDescriptions.ts`
+ *    still renders their name + Discord-authored description, which is a
+ *    convenient overlap: Discord's own Lottie packs ship real descriptions, so
+ *    the un-rasterizable slice is largely the slice that needs vision least.
+ */
+
+import { StickerFormatType, type Message, type Sticker } from 'discord.js';
+import { CONTENT_TYPES } from '@tzurot/common-types/constants/media';
+import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
+import { collectAllStickers } from './stickerPollDescriptions.js';
+
+/**
+ * Whether a sticker has a raster form a vision model could look at.
+ *
+ * Enumerates the rasterizable formats rather than excluding Lottie, so a future
+ * Discord format defaults to "not rasterizable" — a new vector format would
+ * otherwise silently start feeding `.json` documents to the vision pipeline.
+ */
+export function isRasterizableSticker(sticker: Sticker): boolean {
+  return (
+    sticker.format === StickerFormatType.PNG ||
+    sticker.format === StickerFormatType.APNG ||
+    sticker.format === StickerFormatType.GIF
+  );
+}
+
+/**
+ * Content type for a rasterizable sticker's CDN URL.
+ *
+ * APNG is served with a `.png` extension (it IS a PNG, animated), so it shares
+ * PNG's type. Only GIF differs. Animated formats get their first frame
+ * described, which is an accepted limitation.
+ */
+function stickerContentType(sticker: Sticker): string {
+  return sticker.format === StickerFormatType.GIF
+    ? CONTENT_TYPES.IMAGE_GIF
+    : CONTENT_TYPES.IMAGE_PNG;
+}
+
+/**
+ * Convert a message's rasterizable stickers into synthetic image attachments.
+ *
+ * Returns `undefined` (not `[]`) when there is nothing to convert, matching
+ * `extractEmbedImages`'s contract so both can be spread the same way.
+ */
+export function extractStickerImages(message: Message): AttachmentMetadata[] | undefined {
+  const rasterizable = collectAllStickers(message).filter(isRasterizableSticker);
+  if (rasterizable.length === 0) {
+    return undefined;
+  }
+
+  return rasterizable.map(sticker => ({
+    // The snowflake IS the cache identity — see the immutability note above.
+    id: sticker.id,
+    url: sticker.url,
+    contentType: stickerContentType(sticker),
+    name: sticker.name,
+    isSticker: true,
+  }));
+}

--- a/services/bot-client/src/utils/stickerPollDescriptions.ts
+++ b/services/bot-client/src/utils/stickerPollDescriptions.ts
@@ -13,9 +13,14 @@
  * - **Poll vote counts.** They mutate after the fetch, and this text is
  *   persisted — a frozen tally would be wrong forever. The question and the
  *   options are the poll's semantic content; the tally is volatile state.
- * - **Sticker images.** Stickers are not attachments and never reach the
- *   vision path; the name (and description, when Discord supplies one) is all
- *   the semantic signal available without downloading the asset.
+ *
+ * These renderers cover EVERY sticker, including ones `stickerAttachments.ts`
+ * also sends down the vision path for a real image description. That overlap is
+ * deliberate, not redundancy to clean up: this line is what makes a
+ * sticker-only message non-empty, and `EmptyMessageFilter` drops a message with
+ * no content before any trigger processor runs. Rendering only the
+ * un-describable stickers here would re-open exactly that hole for the
+ * describable ones whenever vision is disabled or fails.
  */
 
 import type { Message, MessageSnapshot, Sticker } from 'discord.js';
@@ -55,14 +60,26 @@ function describeSticker(sticker: Sticker): string {
  * unconditionally and filter falsy.
  */
 export function describeStickers(message: Message): string {
-  const own = collectionValues<Sticker>(message.stickers);
-  const snapshots = collectionValues<MessageSnapshot>(message.messageSnapshots);
-  const forwarded = snapshots.flatMap(snapshot => collectionValues<Sticker>(snapshot.stickers));
-  const all = [...own, ...forwarded];
+  const all = collectAllStickers(message);
   if (all.length === 0) {
     return '';
   }
   return `[Stickers: ${all.map(describeSticker).join(', ')}]`;
+}
+
+/**
+ * Every sticker on a message: its own, plus any carried by a forwarded
+ * message's snapshots.
+ *
+ * Exported because `stickerAttachments.ts` needs the identical set — one walk
+ * of the snapshot structure, so the text rendering and the vision injection can
+ * never disagree about which stickers a message carries.
+ */
+export function collectAllStickers(message: Message): Sticker[] {
+  const own = collectionValues<Sticker>(message.stickers);
+  const snapshots = collectionValues<MessageSnapshot>(message.messageSnapshots);
+  const forwarded = snapshots.flatMap(snapshot => collectionValues<Sticker>(snapshot.stickers));
+  return [...own, ...forwarded];
 }
 
 /**


### PR DESCRIPTION
The **capstone for beta.187** — doc-55, owner-scheduled, council-settled 4/4. #1868 taught characters that a sticker arrived and what it was called; this lets them see what it depicts.

PR-1 of 2. This is the whole user-visible feature and is independently shippable. PR-2 adds a durable snowflake-keyed table so descriptions survive Redis restarts and the 1h TTL — deliberately separate so no table lands without a consumer.

## Approach: reuse, don't parallel

A sticker has a URL and a derivable content type, which is all `AttachmentMetadata` needs. So stickers are injected as **synthetic attachments** and ride the existing download → vision → describe chain, inheriting the CDN allowlist, size caps, resize, model cascade, failure fallbacks and description cache for free. `embedImageExtractor.ts` already does exactly this for embed images; `stickerAttachments.ts` mirrors it.

The snowflake goes in `AttachmentMetadata.id`, which `deriveAttachmentCacheKey` already prefers — so the cache key needed **zero new machinery**. And because a sticker's image is immutable per snowflake (changing it requires delete + re-upload, which mints a new id — `GuildStickerEditOptions` takes no file), that key never needs invalidating.

## Three constraints that shaped it

**Lottie stickers can't be described.** Format 3 resolves to a `.json` vector document, not an image. They're excluded and keep name-only rendering. Convenient overlap: Discord's own Lottie packs ship real authored descriptions, so the un-rasterizable slice is largely the slice needing vision least. The check *enumerates* raster formats rather than excluding Lottie, so a future Discord vector format defaults to safe.

**Descriptions are instance-funded.** A sticker description is a permanent shared artifact read by every user and character. The council's argument that decided it isn't fairness, it's correctness: under first-sighter-pays, the artifact's **quality** becomes a lottery decided by whichever BYOK key happened to see it first. Instance-funded means instance-*configured*. Implemented by clearing the user-attributed auth inputs so the existing resolver takes its system-key path — not a new auth branch, so the fallback chain and quota handling stay shared.

**`[Stickers: …]` still names every sticker, including described ones.** This looked like duplication worth removing until I traced it: that line is what makes a sticker-only message non-empty, and `EmptyMessageFilter` drops empty messages before any trigger processor runs. Rendering only the un-describable stickers there would have re-opened the exact hole #1868 took five review rounds to close — whenever vision is off or fails.

## Kill switch

`stickerVisionEnabled` (registry-first, live, **default on**) filters sticker attachments in `DownloadAttachmentsStep` **before any network work**, so "off" is genuinely free rather than merely quiet — no fetch, no resize, no aggregate-payload cost. No migration needed; the systemSettings registry is JSONB.

Spend shape worth stating plainly: one vision call per **distinct sticker, ever**. Bounded by how many stickers exist, not by traffic. Expect a warmup burst then a near-100% hit rate.

## A bug my own test caught

The kill-switch test failed first time. With the switch off and a sticker as the *only* attachment, the step's early return (`no attachments → nothing to expire`) fired **before** the write-back, so `job.data` still carried the sticker to every downstream step — the opposite of off. Fixed by publishing the filtered view before the short-circuit.

## Corrections to doc-55 (found by reading the code)

Recorded here so the next reader doesn't re-derive them; they'll be folded into doc-55 at ship:

1. ~~`VisionDescriptionWriter`, which doc-55 names, **does not exist**.~~ **CORRECTED — this claim was wrong.** It exists at `services/ai-worker/src/services/context/visionDescriptionWriter.ts` (lowercase filename); my `find -name 'VisionDescriptionWriter*'` missed it on a case-sensitive filesystem and I stated the absence as fact off a single search. doc-55 was right. The correct nuance is only that there are TWO layers: `VisionDescriptionCache` (Redis `vision:canon:{id}`, 1h TTL, tier-promoted) is the cache, and `VisionDescriptionWriter.persistTriggerDescriptions` upgrades the persisted history placeholder afterwards — which is exactly the path that leaves a mislabeled placeholder permanent when it does not run.
2. doc-55's "the only genuinely new component is the snowflake-keyed lookup" **understates it** — vision auth resolves per-request, so the system-key ruling needed an explicit force, not just a cache.
3. **A Postgres L2 for vision descriptions existed and was removed in beta.110** — "Discord attachments are ephemeral and a missing TTL turned transient failures permanent." This doesn't reverse PR-2's table (the removal reason was ephemeral *attachment* identity; sticker identity is permanent — exactly the distinction), but it hard-constrains it: **successes only, never failures**. That second clause is what actually burned us.

## Verification

- `pnpm test` 26/26 · `pnpm quality` exit 0 · `pnpm test:component` 44 files / 604 tests.
- Sticker CDN hosts verified against installed discord.js 14.27.0 + @discordjs/rest 2.6.3: png/apng → `cdn.discordapp.com`, gif → `media.discordapp.net`, both already on ai-worker's `ALLOWED_HOSTS`.
- The system-key forcing is asserted **across the seam** (`describeImageWithFallback` receives the instance-funded shape), with the mirror test proving ordinary images stay on caller-resolved auth — the failure that would silently move every user's image spend onto the system key.

## Smoke (needs a human; CI can't cover it)

Send a **non-Lottie** sticker to a character → the reply should reflect what the sticker *depicts*, not just its name. Sending the same sticker again should produce no second vision call in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
