### PR TITLE
test(ai-worker): pin the deriveRefRole fallback's two bounding invariants

### DIFF
--- a/services/ai-worker/src/services/prompt/referenceRole.test.ts
+++ b/services/ai-worker/src/services/prompt/referenceRole.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { UNKNOWN_USER_NAME } from '@tzurot/common-types/constants/message';
 import { deriveRefRole } from './referenceRole.js';
 
 describe('deriveRefRole name matching (fallback path)', () => {
@@ -99,5 +100,28 @@ describe('deriveRefRole', () => {
     // Documented degraded behavior: without the full personality set, only the active
     // personality's own messages resolve to assistant in the fallback window.
     expect(deriveRefRole(undefined, 'Lila ▽', 'Lilith')).toBe('user');
+  });
+
+  it('falls back to user for a third-party bot, which the instruction calls a person', () => {
+    // Accepted transition-window degradation, NOT a missed case. Without a stamp
+    // there is no bot-authorship signal, so third-party automation is
+    // indistinguishable from a human here and reads as "user". Only reachable
+    // when an old bot-client produced the reference mid-rolling-deploy — the
+    // stamped path renders role="bot" (see ReferencedMessageFormatter's
+    // non-persona-automation case).
+    expect(deriveRefRole(undefined, 'MEE6', 'Lilith')).toBe('user');
+  });
+
+  it('resolves an identity-stripped forwarded reference to user, never assistant', () => {
+    // Discord strips author identity from message snapshots, so SnapshotFormatter
+    // stamps UNKNOWN_USER_NAME rather than a real display name. That is what bounds
+    // the name-collision edge: a forwarded reference carries no author name to
+    // collide with a personality's, so it cannot be promoted to assistant no matter
+    // how long it lives. Pinning it here keeps that reasoning honest if the
+    // placeholder ever changes to something a personality name could prefix.
+    expect(deriveRefRole(undefined, UNKNOWN_USER_NAME, 'Lilith')).toBe('user');
+    expect(deriveRefRole(undefined, UNKNOWN_USER_NAME, 'Lilith', new Set(['Lilith', 'Lila']))).toBe(
+      'user'
+    );
   });
 });

--- a/tracker/tasks/task-162 - quotedmessages-deduped-stubs-miss-the-roleassistant-signal.md
+++ b/tracker/tasks/task-162 - quotedmessages-deduped-stubs-miss-the-roleassistant-signal.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-162
 title: <quoted_messages> deduped stubs miss the role="assistant" signal
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-23 00:00'
-updated_date: '2026-07-28 10:49'
+updated_date: '2026-07-30 21:48'
 labels:
   - 'area:ai-worker'
   - 'size:S'

--- a/tracker/tasks/task-164 - deriveRefRole-name-match-fallback-can-promote-a-name-colliding-human-to-assistan.md
+++ b/tracker/tasks/task-164 - deriveRefRole-name-match-fallback-can-promote-a-name-colliding-human-to-assistan.md
@@ -22,4 +22,35 @@ ordinal: 164000
 `deriveRefRole` name-match fallback can promote a name-colliding human to `assistant` in the fallback window
 
 **Why:** `deriveRefRole` (`services/ai-worker/src/services/prompt/referenceRole.ts`) name-matches without a bot-authorship guard (dropped for symmetry with the stored path), so within the bounded fallback window a human whose display name prefixes a personality's would read as `role="assistant"`. Bounded: needs a name collision AND the reference lacking `authorRole` (pre-classifier stored history ~30d, or a rolling-deploy window). The module doc documents the tradeoff. **NOT fully bounded — forwarded refs are permanent**: the release-PR review (#1324) sharpened this — forwarded references (`SnapshotFormatter`, see the row below) NEVER carry `authorRole` because Discord strips `applicationId` from message snapshots, so a forwarded message whose author's display-name prefix-matches a personality reads as `role="assistant"` _indefinitely_, not just during the 30-day aging window. The aging closes only the stored-history path; the forwarded path stays open until the bot-authorship guard is threaded. **Fix shape (if needed)**: thread a bot-authorship signal into the fallback so only machine-authored refs name-match. **Promote when**: ~30 days after beta.136 ships (≈2026-07-24, when pre-classifier stored history has aged out and only the live deploy-window + permanent forwarded-ref paths remain) — re-evaluate whether the guard is worth adding, OR if a name-collision mislabel is observed. Surfaced 2026-06-24 by PR #1321 round-3 claude-review; forwarded-ref permanence sharpened by PR #1324 release review.
+
+**GROUNDING 2026-07-30 — the "NOT fully bounded / forwarded refs are permanent"
+escalation above is FALSE, on two independent grounds.** Verified in code, not
+inferred:
+
+1. **Forwarded refs carry no author name to collide with.**
+   `SnapshotFormatter` (`services/bot-client/src/handlers/references/SnapshotFormatter.ts:103-104`)
+   stamps `authorUsername`/`authorDisplayName` as `UNKNOWN_USER_NAME`
+   (`'Unknown User'`), not the real author. A name collision needs a real name;
+   there isn't one. Confirmed against installed discord.js 14.27.0:
+   `MessageSnapshot` retains only attachments/client/components/content/
+   createdTimestamp/editedTimestamp/embeds/flags/mentions/stickers/type — no
+   `author`, no `applicationId`, no `webhookId`.
+2. **The live forwarded path never calls `deriveRefRole` at all.**
+   `ReferencedMessageFormatter` branches on `ref.isForwarded` into
+   `formatForwardedReference`, which builds a `ForwardedMessageContent` and calls
+   `formatForwardedQuote` — that helper hardcodes `from: 'Unknown'` and passes NO
+   `role`. A live forwarded reference renders no role attribute whatsoever, so it
+   cannot be promoted to `assistant` by any path.
+
+Both grounds are now pinned by a test (`referenceRole.test.ts` — "resolves an
+identity-stripped forwarded reference to user, never assistant"), so if the
+placeholder ever changes to something a personality name could prefix, the test
+fails rather than the reasoning silently rotting.
+
+**Net: the item IS fully bounded, and its own promote-when date has passed**
+(≈2026-07-24; pre-classifier stored history has aged out). The entire remaining
+exposure is a rolling-deploy window of minutes that ALSO requires a human whose
+display name prefixes a personality's. Whether that residual justifies threading
+a bot-authorship guard is a quality/user-visible call and therefore the owner's,
+per `06-backlog.md` — surfaced 2026-07-30, awaiting that call.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-165 - SnapshotFormatter-forwarded-references-always-read-as-roleuser.md
+++ b/tracker/tasks/task-165 - SnapshotFormatter-forwarded-references-always-read-as-roleuser.md
@@ -20,4 +20,24 @@ ordinal: 165000
 `SnapshotFormatter` forwarded references always read as `role="user"`
 
 **Why:** Discord message snapshots strip author identity (no `applicationId` or bot flags), so `SnapshotFormatter.formatSnapshot` can't stamp `authorRole` — a forwarded persona voice/text message reads as `role="user"`, not `assistant`, in the worker's fallback. Known Discord-API limitation (a code comment documents it at the construction site). **Fix shape**: none possible until Discord surfaces author identity on snapshots; if/when it does, classify forwarded refs the same as live refs. **Promote when**: Discord exposes `applicationId`/author-bot flags on message snapshots, OR a forwarded-persona-message self-reply spiral is observed. Surfaced 2026-06-24 by PR #1321 round-3 claude-review.
+
+**Re-verified 2026-07-30 — blocker CONFIRMED, still correctly filed.** Checked
+against installed discord.js 14.27.0 rather than assumed: `MessageSnapshot`
+(`typings/index.d.ts:7388`) retains exactly attachments · client · components ·
+content · createdTimestamp · editedTimestamp · embeds · flags · mentions ·
+stickers · type. No `author`, no `applicationId`, no `webhookId` — so the stated
+fix ("none possible until Discord surfaces author identity") still holds. Re-check
+this list rather than re-deriving the argument when discord.js v15 lands.
+
+**Title is imprecise about the LIVE path.** Forwarded refs read `role="user"` only
+on the STORED path (`xmlMetadataFormatters` → `formatStoredReferencedMessage`,
+where `authorName` is `UNKNOWN_USER_NAME` and the fallback yields `user`). On the
+LIVE path they get NO role attribute at all: `ReferencedMessageFormatter` routes
+`isForwarded` to `formatForwardedQuote`, which hardcodes `from: 'Unknown'` and
+emits no `role`. Worth knowing before anyone "fixes" the live path expecting to
+find a wrong role there.
+
+**Adjacent, and buildable now:** `MessageSnapshot` DOES retain `stickers`, so the
+sticker-awareness gap in `SnapshotFormatter` (TASK-359) is not blocked by this
+limitation — the data is present, we simply don't read it.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-166 - Live-path-deriveRefRole-fallback-thread-allPersonalityNames-document-the-botuser.md
+++ b/tracker/tasks/task-166 - Live-path-deriveRefRole-fallback-thread-allPersonalityNames-document-the-botuser.md
@@ -3,10 +3,10 @@ id: TASK-166
 title: >-
   Live-path deriveRefRole: thread allPersonalityNames + document the bot-to-user
   fallback
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-24 00:00'
-updated_date: '2026-07-28 10:49'
+updated_date: '2026-07-30 21:48'
 labels:
   - 'area:bot-client'
   - 'size:S'


### PR DESCRIPTION
## What

An audit of the `#1321` reference-role cluster (TASK-162 through TASK-166) found most of it already shipped, one escalation factually wrong, and one genuine gap. This PR lands the gap and records the evidence for the rest.

Two characterization pins in `referenceRole.test.ts`. **These are pins, not regression tests** — both pass against unchanged code. They exist so that the reasoning which *bounds* TASK-164 fails loudly if the code moves out from under it.

## The finding: TASK-164's escalation is false, twice over

TASK-164 was escalated by the #1324 release review from "bounded 30-day edge" to "**NOT fully bounded — forwarded refs are permanent**," on the grounds that forwarded references never carry `authorRole`, so a forwarded message whose author's display name prefix-matches a personality would read as `role="assistant"` indefinitely.

That premise doesn't hold, on two independent grounds:

1. **There is no author name to collide with.** `SnapshotFormatter` stamps `authorUsername`/`authorDisplayName` as `UNKNOWN_USER_NAME` (`'Unknown User'`), not the real author — `SnapshotFormatter.ts:103-104`. A name collision needs a name.
2. **The live forwarded path never calls `deriveRefRole` at all.** `ReferencedMessageFormatter` branches on `ref.isForwarded` into `formatForwardedReference`, which calls `formatForwardedQuote` — and that helper hardcodes `from: 'Unknown'` and passes no `role`. A live forwarded reference renders no role attribute whatsoever.

Verified against installed **discord.js 14.27.0**: `MessageSnapshot` (`typings/index.d.ts:7388`) retains only `attachments · client · components · content · createdTimestamp · editedTimestamp · embeds · flags · mentions · stickers · type`. No `author`, no `applicationId`, no `webhookId`.

So TASK-164 **is** fully bounded, and its own promote-when date (≈2026-07-24) has passed. The entire remaining exposure is a rolling-deploy window of minutes that *also* requires a human whose display name prefixes a personality's.

**One call for you**: whether that residual justifies threading a bot-authorship guard. Per `06-backlog.md` that's a quality/user-visible decision and therefore yours, not mine — I've left the task filed with the analysis rather than ruling it out.

## Cluster dispositions

| Task | Disposition |
| --- | --- |
| **TASK-162** | **Closed — already shipped.** The deduped path derives `role` via `deriveRefRole` and passes it to `formatDedupedQuote` (`xmlMetadataFormatters.ts:125`), landed in `44613ba35`. Never marked Done. |
| **TASK-163** | Left filed. Needs a real TupperBox-proxied message observed; no code work available. |
| **TASK-164** | Premise corrected (above). Filed pending your call on the guard. |
| **TASK-165** | Blocker **re-verified**, not assumed — recorded with the retained-field list so the next reader re-checks against discord.js v15 rather than re-deriving. Also corrected: its title is accurate for the *stored* path only; on the live path forwarded refs get **no** role, not `role="user"`. |
| **TASK-166** | **Closed — already shipped.** Both live-path `deriveRefRole` sites thread `apiKeys?.allPersonalityNames`. Its remaining ask was the third-party-bot fallback test, which this PR adds. |

## Adjacent finding

`MessageSnapshot` **does** retain `stickers`. So the sticker-awareness gap in `SnapshotFormatter` (TASK-359, filed during the beta.187 sticker work) is *not* blocked by this Discord limitation — the data is there, we just don't read it. Recorded on TASK-165; not built here.

## Verification

`pnpm test` (26 packages) and `pnpm quality` both green, run sequentially. Targeted: `referenceRole.test.ts` 17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)