### PR TITLE
fix(ai-worker): render image descriptions on deduped references (task-364)

### DIFF
--- a/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
@@ -903,6 +903,63 @@ describe('Conversation Utilities', () => {
       expect(result).toContain('Replying to your earlier message');
     });
 
+    /**
+     * Enrichment traceability, stored half — PAID WORK MUST APPEAR.
+     *
+     * The live half lives in ReferencedMessageFormatter.test.ts; this is the same
+     * invariant on the replay path, and it runs the REAL chain
+     * (formatConversationHistoryAsXml → xmlMetadataFormatters → QuoteFormatter)
+     * with nothing between the stored row and the prompt XML stubbed out. The
+     * matching test in xmlMetadataFormatters.test.ts asserts at the seam because
+     * that suite mocks QuoteFormatter; this one asserts on the real output.
+     */
+    it.each([
+      ['a full quote', 'msg-not-in-history'],
+      ['a DEDUPED stub', 'msg-already-in-history'],
+    ])('renders a hydrated image description into %s', (_label, quotedMessageId) => {
+      const referencedMessage: StoredReferencedMessage = {
+        discordMessageId: quotedMessageId,
+        authorUsername: 'bob',
+        authorDisplayName: 'Bob',
+        content: 'look at this',
+        timestamp: '2025-01-01T00:00:00Z',
+        locationContext: '',
+        attachments: [
+          {
+            url: 'https://cdn.discord.com/embed-image-1.png',
+            contentType: 'image/png',
+            name: 'embed-image-1.png',
+          },
+        ],
+        resolvedImageDescriptions: [
+          { filename: 'embed-image-1.png', description: 'SENTINEL_REPLAY_VISION' },
+        ],
+      };
+
+      const history: RawHistoryEntry[] = [
+        {
+          id: 'internal-uuid-1',
+          role: 'user',
+          content: 'the original post',
+          personaName: 'Bob',
+          discordMessageId: ['msg-already-in-history'],
+        },
+        {
+          id: 'internal-uuid-2',
+          role: 'user',
+          content: 'Replying to your earlier message',
+          personaName: 'Alice',
+          messageMetadata: { referencedMessages: [referencedMessage] },
+        },
+      ];
+
+      const result = formatConversationHistoryAsXml(history, 'TestBot');
+
+      expect(result).toContain(
+        '<image filename="embed-image-1.png">SENTINEL_REPLAY_VISION</image>'
+      );
+    });
+
     it('should keep quoted messages that are NOT in conversation history', () => {
       const quotedMessageId = 'msg-not-in-history';
 

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
@@ -92,15 +92,32 @@ const { mockFormatQuoteElement, mockFormatDedupedQuote } = vi.hoisted(() => {
   // Mirror the REAL formatDedupedQuote: render content AS-IS (no truncation). The cap now
   // happens upstream in formatQuotedSection via the real capDedupText, so the
   // "truncates long content" test below verifies THAT cap, not a mock-side truncation.
+  //
+  // `imageDescriptions` must be forwarded here or the mock silently swallows the
+  // very field the deduped path was fixed to carry — a stub that drops what the
+  // real function renders makes this suite blind to the bug it should catch.
   const fdq = vi
     .fn()
     .mockImplementation(
-      (opts: { from: string; role?: string; timeFormatted?: string; content: string }) => {
+      (opts: {
+        from: string;
+        role?: string;
+        timeFormatted?: string;
+        content: string;
+        imageDescriptions?: { filename: string; description: string }[];
+      }) => {
+        // The real prefix switches on whether media rides along; mirror that or
+        // the stub asserts a wording the production path would not emit.
+        const prefix =
+          (opts.imageDescriptions?.length ?? 0) > 0
+            ? '[Referenced message — full text in the chat log; its media is described here]'
+            : '[Referenced message — full text in the chat log]';
         return fqe({
           from: opts.from,
           role: opts.role,
           timeFormatted: opts.timeFormatted,
-          content: `[Referenced message — full text in the chat log]\n\n${opts.content}`,
+          content: `${prefix}\n\n${opts.content}`,
+          imageDescriptions: opts.imageDescriptions,
         });
       }
     );
@@ -234,6 +251,54 @@ describe('xmlMetadataFormatters', () => {
       expect(result).not.toContain('[image/png: photo.png]');
     });
 
+    it('keeps a marker for an image that has no description, when a sibling does', () => {
+      // Partial vision resolution: two images, one describe succeeded and one
+      // failed. Failures are never persisted (visionDescriptionWriter), so the
+      // stored row carries one description for two images. Gating the marker
+      // filter on "this reference has ANY description" would drop BOTH markers
+      // and render only one image — the undescribed one vanishes entirely,
+      // which is the same silent-invisibility class this whole path just fixed.
+      const msg = makeEntry({
+        messageMetadata: {
+          referencedMessages: [
+            {
+              discordMessageId: '123',
+              authorUsername: 'user1',
+              authorDisplayName: 'User One',
+              content: 'two images',
+              timestamp: '2026-01-01T00:00:00.000Z',
+              locationContext: '',
+              attachments: [
+                {
+                  id: 'att-1',
+                  url: 'https://cdn.discord.com/described.png',
+                  contentType: 'image/png',
+                  name: 'described.png',
+                },
+                {
+                  id: 'att-2',
+                  url: 'https://cdn.discord.com/undescribed.png',
+                  contentType: 'image/png',
+                  name: 'undescribed.png',
+                },
+              ],
+              resolvedImageDescriptions: [
+                { filename: 'described.png', description: 'A sunset over the ocean' },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = formatQuotedSection(msg, 'user', personalityName, undefined, undefined);
+
+      expect(result).toContain('A sunset over the ocean');
+      // The described one is not ALSO a marker...
+      expect(result).not.toContain('[image/png: described.png]');
+      // ...and the undescribed one is still visible as one.
+      expect(result).toContain('[image/png: undescribed.png]');
+    });
+
     it('shows non-image attachments alongside image descriptions', () => {
       const msg = makeEntry({
         messageMetadata: {
@@ -325,6 +390,62 @@ describe('xmlMetadataFormatters', () => {
       expect(result).toContain('[Referenced message — full text in the chat log]');
       expect(result).toContain('Duplicated message that is in history');
       expect(result).toContain('from="User One"');
+    });
+
+    it('carries hydrated image descriptions across the deduped seam', () => {
+      // `persistReferenceDescriptions` writes resolvedImageDescriptions onto the
+      // stored row for exactly this moment. The deduped branch used to pass only
+      // `content`, so every one of those rows was discarded and the quoted image
+      // reached the model as a bare `[image/png: …]` marker.
+      //
+      // Asserted at the seam (toHaveBeenCalledWith), not just on the rendered
+      // string: this suite stubs QuoteFormatter, so a string-only assertion would
+      // be testing the stub's own rendering rather than what the caller forwarded.
+      const msg = makeEntry({
+        messageMetadata: {
+          referencedMessages: [
+            {
+              discordMessageId: 'already-in-history',
+              authorUsername: 'user1',
+              authorDisplayName: 'User One',
+              content: 'look at this',
+              timestamp: '2026-01-01T00:00:00.000Z',
+              locationContext: '',
+              attachments: [
+                {
+                  id: 'att-1',
+                  url: 'https://cdn.discord.com/embed-image-1.png',
+                  contentType: 'image/png',
+                  name: 'embed-image-1.png',
+                },
+              ],
+              resolvedImageDescriptions: [
+                { filename: 'embed-image-1.png', description: 'SENTINEL_STORED_VISION' },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = formatQuotedSection(
+        msg,
+        'user',
+        personalityName,
+        new Set(['already-in-history']),
+        undefined
+      );
+
+      expect(mockFormatDedupedQuote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          imageDescriptions: [
+            { filename: 'embed-image-1.png', description: 'SENTINEL_STORED_VISION' },
+          ],
+        })
+      );
+      expect(result).toContain('SENTINEL_STORED_VISION');
+      // The marker is the fallback for an UNdescribed image; with a description
+      // in hand it would be the same picture named twice.
+      expect(result).not.toContain('[image/png: embed-image-1.png]');
     });
 
     it('renders role="bot" on a deduped stub from a non-persona bot reference', () => {

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -19,6 +19,51 @@ import { deriveRefRole } from '../../services/prompt/referenceRole.js';
 import type { RawHistoryEntry } from './conversationTypes.js';
 
 /**
+ * Split a stored reference's media into the two renderable shapes: hydrated
+ * vision descriptions, and `[contentType: name]` markers for everything else.
+ *
+ * A described image renders as `<image_descriptions>` INSTEAD of a marker, so the
+ * same picture never appears twice in two vocabularies. The suppression is
+ * per-attachment, not per-reference: vision can resolve some of a message's
+ * images and not others (failures are never persisted), and a whole-reference
+ * gate would drop the undescribed one's marker too — leaving it with neither a
+ * description nor a name, i.e. invisible. Every image ends up with exactly one
+ * of the two representations.
+ *
+ * Correspondence is by filename because that is what `ResolvedImageDescription`
+ * carries, and every producer derives it from the attachment's own `name` — so
+ * the two agree by construction. The nameless fallback must be the producers'
+ * `'image'`, NOT this function's marker fallback (`'attachment'`): a mismatch
+ * there would fail the lookup and render a nameless image both ways. Two images
+ * sharing a filename within one reference would over-suppress; Discord's own
+ * naming makes that a non-case (`embed-image-1.png`, `embed-image-2.png`, …).
+ *
+ * Shared by the full and deduped branches on purpose. These two renderings drifted
+ * once already (the deduped branch rendered neither, silently discarding every
+ * `resolvedImageDescriptions` row `persistReferenceDescriptions` had written for
+ * exactly this purpose); routing both through one splitter is what keeps them level.
+ */
+function splitStoredMedia(ref: StoredReferencedMessage): {
+  imageDescriptions?: { filename: string; description: string }[];
+  attachmentLines?: string[];
+} {
+  const imageDescs = ref.resolvedImageDescriptions;
+  const hasImageDescs = imageDescs !== undefined && imageDescs.length > 0;
+  const describedFilenames = new Set(imageDescs?.map(desc => desc.filename));
+  const attachmentsForLines = ref.attachments?.filter(
+    att => !att.contentType.startsWith('image/') || !describedFilenames.has(att.name ?? 'image')
+  );
+
+  return {
+    imageDescriptions: hasImageDescs ? imageDescs : undefined,
+    attachmentLines:
+      attachmentsForLines !== undefined && attachmentsForLines.length > 0
+        ? attachmentsForLines.map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
+        : undefined,
+  };
+}
+
+/**
  * Format a single stored reference as a <quote> element.
  *
  * Uses the shared formatQuoteElement() for consistent XML structure across
@@ -51,12 +96,7 @@ function formatStoredReferencedMessage(
     locationContext = ref.locationContext;
   }
 
-  // If hydrated image descriptions exist, only show non-image attachments in attachmentLines
-  const imageDescs = ref.resolvedImageDescriptions;
-  const hasImageDescs = imageDescs !== undefined && imageDescs.length > 0;
-  const attachmentsForLines = hasImageDescs
-    ? ref.attachments?.filter(att => !att.contentType.startsWith('image/'))
-    : ref.attachments;
+  const media = splitStoredMedia(ref);
 
   return formatQuoteElement({
     type: ref.isForwarded === true ? 'forward' : undefined,
@@ -70,11 +110,8 @@ function formatStoredReferencedMessage(
     content: ref.content,
     locationContext,
     embedsXml: ref.embeds !== undefined && ref.embeds.length > 0 ? [ref.embeds] : undefined,
-    imageDescriptions: imageDescs,
-    attachmentLines:
-      attachmentsForLines !== undefined && attachmentsForLines.length > 0
-        ? attachmentsForLines.map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
-        : undefined,
+    imageDescriptions: media.imageDescriptions,
+    attachmentLines: media.attachmentLines,
   });
 }
 
@@ -119,7 +156,19 @@ export function formatQuotedSection(
     formatStoredReferencedMessage(ref, personalityName, allPersonalityNames)
   );
 
-  // Deduped refs: lightweight stubs with truncated content and reply-target note
+  // Deduped refs: lightweight stubs with truncated content and reply-target note.
+  // Image DESCRIPTIONS still ride along — `persistReferenceDescriptions` writes
+  // them onto the stored row precisely so a quoted image survives replay, and the
+  // history entry the stub points at renders that image as a URL, not a
+  // description. Attachment MARKERS are deliberately omitted: a marker names a
+  // file the chat log already lists, which is the redundancy dedup exists to cut.
+  //
+  // No `voiceTranscripts` here, unlike the live path — not a dropped field. The
+  // live path reads transcripts from in-memory preprocessing; a stored reference
+  // has no persisted equivalent (`StoredReferencedMessage` carries
+  // `resolvedImageDescriptions` and no audio counterpart), so there is nothing
+  // to forward. Absence is a data gap, not an omission — passing something here
+  // requires the schema to carry it first.
   const formattedDeduped = dedupedRefs.map(ref => {
     const authorName = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
     const role = deriveRefRole(ref.authorRole, authorName, personalityName, allPersonalityNames);
@@ -134,6 +183,7 @@ export function formatQuotedSection(
       // renders as-is. Stored refs carry attachments separately (attachmentLines), so content
       // is text-only and safe to cap directly.
       content: capDedupText(ref.content),
+      imageDescriptions: splitStoredMedia(ref).imageDescriptions,
     });
   });
 

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -9,17 +9,26 @@ import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/messa
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 
 // Use vi.hoisted() to create mocks that persist across test resets
-const { mockDescribeImage, mockTranscribeAudio, mockFormatTimestampWithDelta } = vi.hoisted(() => ({
-  mockDescribeImage: vi.fn(),
-  mockTranscribeAudio: vi.fn(),
-  mockFormatTimestampWithDelta: vi.fn(),
-}));
+const { mockDescribeImage, mockTranscribeAudio, mockFormatTimestampWithDelta, mockLogger } =
+  vi.hoisted(() => ({
+    mockDescribeImage: vi.fn(),
+    mockTranscribeAudio: vi.fn(),
+    mockFormatTimestampWithDelta: vi.fn(),
+    mockLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  }));
 
 // Mock the MultimodalProcessor module
 vi.mock('./MultimodalProcessor.js', () => ({
   describeImage: mockDescribeImage,
   transcribeAudio: mockTranscribeAudio,
 }));
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return { ...actual, createLogger: () => mockLogger };
+});
 
 // Mock formatTimestampWithDelta for consistent test output
 vi.mock('@tzurot/common-types/utils/dateFormatting', async () => {
@@ -1638,6 +1647,207 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(searchText).toBe('first message\n\nthird message');
+    });
+  });
+
+  /**
+   * Enrichment traceability — the economic invariant: PAID WORK MUST APPEAR.
+   *
+   * Vision and transcription cost money and latency before this renderer runs.
+   * Whatever reaches it must come out the other side, in every render mode. The
+   * assertion is deliberately NOT a field-by-field parity check: the two bugs of
+   * this class dropped two DIFFERENT fields (`authorRole`, then image
+   * descriptions), so enumerating fields only ever catches the last one. A
+   * sentinel that must survive catches whichever field goes next.
+   *
+   * Line coverage was green through both bugs — the dropped values executed,
+   * they just went nowhere. This is an oracle, not more coverage.
+   *
+   * The stored half of the matrix lives in xmlMetadataFormatters.test.ts.
+   */
+  describe('enrichment traceability: paid work must appear (live path)', () => {
+    const VISION_SENTINEL = 'SENTINEL_VISION_a7f3c9';
+    const TRANSCRIPT_SENTINEL = 'SENTINEL_TRANSCRIPT_b2e8d1';
+
+    function refWithImage(overrides: Partial<ReferencedMessage> = {}): ReferencedMessage {
+      return {
+        referenceNumber: 1,
+        discordMessageId: 'msg-1',
+        discordUserId: 'user-1',
+        authorUsername: 'testuser',
+        authorDisplayName: 'Test User',
+        content: 'look at this',
+        embeds: '',
+        timestamp: '2025-12-06T00:00:00Z',
+        locationContext: '',
+        attachments: [
+          {
+            url: 'https://cdn.example.com/embed-image-1.png',
+            contentType: 'image/png',
+            name: 'embed-image-1.png',
+            size: 1000,
+          },
+        ],
+        ...overrides,
+      };
+    }
+
+    /** One vision description, already produced by the dependency stage. */
+    const preprocessedImage = {
+      1: [
+        {
+          type: AttachmentType.Image,
+          description: VISION_SENTINEL,
+          originalUrl: 'https://cdn.example.com/embed-image-1.png',
+          metadata: {
+            url: 'https://cdn.example.com/embed-image-1.png',
+            name: 'embed-image-1.png',
+            contentType: 'image/png',
+            size: 1000,
+          },
+        },
+      ],
+    };
+
+    it.each([
+      ['a full reference', false],
+      ['a DEDUPED reference', true],
+    ])('renders a preprocessed vision description into %s', async (_label, isDeduplicated) => {
+      const { formatted, searchText } = await formatter.formatReferencedMessages(
+        // The stub builder strips `attachments`, so the deduped case models the
+        // real wire shape: descriptions arrive ONLY via preprocessing.
+        [refWithImage(isDeduplicated ? { isDeduplicated: true, attachments: undefined } : {})],
+        mockPersonality,
+        false,
+        preprocessedImage
+      );
+
+      expect(formatted).toContain(VISION_SENTINEL);
+      // Retrieval sees it too — history has no copy of a description to match on.
+      expect(searchText).toContain(VISION_SENTINEL);
+      // ...and no new spend was incurred to get it there.
+      expect(mockDescribeImage).not.toHaveBeenCalled();
+    });
+
+    it('renders a preprocessed voice transcript into a deduped reference', async () => {
+      const { formatted } = await formatter.formatReferencedMessages(
+        [refWithImage({ isDeduplicated: true, attachments: undefined, content: '' })],
+        mockPersonality,
+        false,
+        {
+          1: [
+            {
+              type: AttachmentType.Audio,
+              description: TRANSCRIPT_SENTINEL,
+              originalUrl: 'https://cdn.example.com/voice.ogg',
+              metadata: {
+                url: 'https://cdn.example.com/voice.ogg',
+                name: 'voice.ogg',
+                contentType: 'audio/ogg',
+                size: 2000,
+              },
+            },
+          ],
+        }
+      );
+
+      expect(formatted).toContain('<transcript>');
+      expect(formatted).toContain(TRANSCRIPT_SENTINEL);
+      expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    });
+
+    it('pairs the count: every description handed in comes back out', async () => {
+      const descriptions = ['SENTINEL_ONE', 'SENTINEL_TWO', 'SENTINEL_THREE'];
+      const { formatted } = await formatter.formatReferencedMessages(
+        [refWithImage({ isDeduplicated: true, attachments: undefined })],
+        mockPersonality,
+        false,
+        {
+          1: descriptions.map((description, i) => ({
+            type: AttachmentType.Image,
+            description,
+            originalUrl: `https://cdn.example.com/img-${i}.png`,
+            metadata: {
+              url: `https://cdn.example.com/img-${i}.png`,
+              name: `img-${i}.png`,
+              contentType: 'image/png',
+              size: 1000,
+            },
+          })),
+        }
+      );
+
+      for (const description of descriptions) {
+        expect(formatted).toContain(description);
+      }
+      expect(formatted.match(/<image filename=/g)).toHaveLength(descriptions.length);
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('warns when enrichment with real content reaches the renderer and is dropped', async () => {
+      // The tripwire itself, modelled on the shape it exists to catch: a result
+      // carrying a real description that the splitter has no arm for. That is
+      // what a THIRD enrichment type would look like on the day it is added and
+      // the deduped branch is not taught about it — work computed, work
+      // discarded — and the silence around it was why a human was the only
+      // detector the first two times.
+      //
+      // The cast is the point: `AttachmentType` has only Image and Audio today,
+      // so the unhandled arm is not otherwise constructible. Pinning it now
+      // means the warn is proven to fire before anyone needs it to.
+      await formatter.formatReferencedMessages(
+        [refWithImage({ isDeduplicated: true, attachments: undefined })],
+        mockPersonality,
+        false,
+        {
+          1: [
+            {
+              type: 'video' as AttachmentType,
+              description: 'a clip the splitter cannot render yet',
+              originalUrl: 'https://cdn.example.com/clip.mp4',
+              metadata: {
+                url: 'https://cdn.example.com/clip.mp4',
+                name: 'clip.mp4',
+                contentType: 'video/mp4',
+                size: 1000,
+              },
+            },
+          ],
+        }
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ referenceNumber: 1, renderable: 1, rendered: 0 }),
+        expect.stringContaining('not reaching the prompt')
+      );
+    });
+
+    it('stays silent when a transcription legitimately produces nothing', async () => {
+      // A silent audio clip transcribes to '' on SUCCESS. Nothing was dropped,
+      // so the tripwire must not fire — otherwise ordinary traffic generates
+      // warn noise and the signal that matters gets tuned out.
+      await formatter.formatReferencedMessages(
+        [refWithImage({ isDeduplicated: true, attachments: undefined })],
+        mockPersonality,
+        false,
+        {
+          1: [
+            {
+              type: AttachmentType.Audio,
+              description: '',
+              originalUrl: 'https://cdn.example.com/silence.ogg',
+              metadata: {
+                url: 'https://cdn.example.com/silence.ogg',
+                name: 'silence.ogg',
+                contentType: 'audio/ogg',
+                size: 500,
+              },
+            },
+          ],
+        }
+      );
+
+      expect(mockLogger.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -8,6 +8,7 @@
 
 import { type AIProvider } from '@tzurot/common-types/constants/ai';
 import { TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
+import { AttachmentType } from '@tzurot/common-types/constants/media';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
@@ -33,7 +34,7 @@ const logger = createLogger('ReferencedMessageFormatter');
  * bot's own words read as a turn to continue. Kept as a named constant so the wording
  * is visible alongside the other prompt-text constants instead of buried inline.
  */
-const CONTEXTUAL_REFERENCES_INSTRUCTION = `<instruction>Messages the user's current message is replying to or quoting — read them only to understand what the user is responding to. A quote's role says who wrote it: role="assistant" is one of your own earlier lines (context, never a turn to continue or extend); role="user" is a person; role="character" is a different AI character — a conversation peer, not you and not the human you're replying to; role="bot" is a non-character bot or automated webhook. Respond to the user's current message. A stubbed quote's full text appears in <chat_log>.</instruction>`;
+const CONTEXTUAL_REFERENCES_INSTRUCTION = `<instruction>Messages the user's current message is replying to or quoting — read them only to understand what the user is responding to. A quote's role says who wrote it: role="assistant" is one of your own earlier lines (context, never a turn to continue or extend); role="user" is a person; role="character" is a different AI character — a conversation peer, not you and not the human you're replying to; role="bot" is a non-character bot or automated webhook. Respond to the user's current message. A stubbed quote's full text appears in <chat_log>; any media it describes appears only in the quote itself.</instruction>`;
 
 /**
  * Context for reference formatting. `userApiKey` is the key for
@@ -65,6 +66,76 @@ interface ReferenceVisionAuth {
 export interface FormattedReferences {
   formatted: string;
   searchText: string;
+}
+
+/** The renderable enrichment children a reference's preprocessed results yield. */
+interface SplitEnrichment {
+  imageDescriptions?: { filename: string; description: string }[];
+  voiceTranscripts?: string[];
+  /**
+   * Entries that CARRY something worth rendering (non-empty description).
+   * The tripwire's denominator is this rather than the raw entry count: a
+   * successful-but-empty transcription (a silent audio clip) has nothing to
+   * render and is not a drop, and counting it as one would warn on every
+   * occurrence of ordinary traffic.
+   */
+  renderable: number;
+  /** Of those, how many actually produced a rendered child. */
+  rendered: number;
+}
+
+/**
+ * Split already-preprocessed reference attachments into renderable children.
+ *
+ * This is the READ side only — every result here was produced (and paid for) by
+ * the dependency-job stage; nothing new is computed, so a deduped stub still
+ * triggers zero vision/STT calls.
+ *
+ * The deduped branch needs its own splitter rather than reusing
+ * `processAttachmentsParallel`: that helper walks `ref.attachments` and looks
+ * preprocessing up by URL, and `buildDedupedReferenceStub` strips `attachments`
+ * from the stub, so it would find nothing to walk. The preprocessed entries
+ * carry their own metadata and are self-sufficient. Discriminating on
+ * `ProcessedAttachment.type` (not `metadata.contentType`) is deliberate — the
+ * dependency step synthesizes metadata with a placeholder `image/unknown` /
+ * `audio/unknown` content type, so a content-type test would misroute audio.
+ */
+function splitPreprocessedEnrichment(
+  preprocessed: ProcessedAttachment[] | undefined
+): SplitEnrichment {
+  if (preprocessed === undefined || preprocessed.length === 0) {
+    return { renderable: 0, rendered: 0 };
+  }
+
+  const imageDescriptions: { filename: string; description: string }[] = [];
+  const voiceTranscripts: string[] = [];
+  let renderable = 0;
+  for (const entry of preprocessed) {
+    if (entry.description.length === 0) {
+      // Nothing to render and nothing lost — a silent audio clip transcribes to
+      // '' on SUCCESS. Not counted as renderable, so it never trips the drop warn.
+      continue;
+    }
+    renderable++;
+    if (entry.type === AttachmentType.Image) {
+      // `name` is optional on AttachmentMetadata; the dependency step derives it
+      // from the URL basename, so undefined means a synthesized attachment with
+      // no filename at all — the description is still the payload worth keeping.
+      imageDescriptions.push({
+        filename: entry.metadata.name ?? 'image',
+        description: entry.description,
+      });
+    } else if (entry.type === AttachmentType.Audio) {
+      voiceTranscripts.push(entry.description);
+    }
+  }
+
+  return {
+    imageDescriptions: imageDescriptions.length > 0 ? imageDescriptions : undefined,
+    voiceTranscripts: voiceTranscripts.length > 0 ? voiceTranscripts : undefined,
+    renderable,
+    rendered: imageDescriptions.length + voiceTranscripts.length,
+  };
 }
 
 /**
@@ -99,9 +170,23 @@ export class ReferencedMessageFormatter {
 
     // Process each reference into XML
     for (const ref of references) {
-      // Deduped stubs: lightweight quote with reply-target note (no attachment processing)
+      // Deduped stubs: lightweight quote with reply-target note. No NEW
+      // attachment work is done — but media enrichment already computed by the
+      // dependency stage IS rendered here, because <chat_log> carries the
+      // embed/attachment URL and never its description.
+      //
+      // The stub's `content` also carries `[image/png: name]` markers folded in
+      // by `buildDedupedReferenceStub`. That overlap is intentional for now: the
+      // marker is the FALLBACK for an image whose description never arrived, and
+      // the builder can't know whether it will. Filenames match across the two,
+      // so they read as one image, not two. (The stored path in
+      // `xmlMetadataFormatters` drops its markers instead — it can, because it
+      // sees both at once. Collapsing that asymmetry is the projection refactor.)
       if (ref.isDeduplicated === true) {
         const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
+        const preprocessedForRef = preprocessedAttachments?.[ref.referenceNumber];
+        const enrichment = splitPreprocessedEnrichment(preprocessedForRef);
+        this.warnOnDroppedEnrichment(ref.referenceNumber, enrichment);
         referenceElements.push(
           formatDedupedQuote({
             number: ref.referenceNumber,
@@ -116,12 +201,24 @@ export class ReferencedMessageFormatter {
             timestamp:
               absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
             content: ref.content,
+            imageDescriptions: enrichment.imageDescriptions,
+            voiceTranscripts: enrichment.voiceTranscripts,
           })
         );
         // The stub's capped text copy is real signal; the reply-target
         // marker the quote renderer adds is not, so contribute the raw
-        // content only (empty for a bot's own reply-target).
-        searchParts.push(ref.content);
+        // content only (empty for a bot's own reply-target). Media
+        // descriptions ride along for the same reason they ride into the
+        // prompt: history has no copy of them to retrieve against.
+        searchParts.push(
+          [
+            ref.content,
+            ...(enrichment.imageDescriptions ?? []).map(img => img.description),
+            ...(enrichment.voiceTranscripts ?? []),
+          ]
+            .filter(part => part.length > 0)
+            .join('\n')
+        );
         continue;
       }
 
@@ -174,6 +271,26 @@ export class ReferencedMessageFormatter {
         .filter(part => part.length > 0)
         .join('\n\n'),
     };
+  }
+
+  /**
+   * Tripwire for the enrichment-drop class: preprocessed results reached this
+   * renderer but produced fewer rendered children than there were results.
+   *
+   * It exists because the drop it guards was invisible — four vision calls ran,
+   * succeeded, cost 47s, and were discarded with zero log output, so the only
+   * detector in the system was a human noticing the character couldn't see the
+   * images. With the deduped branch rendering them this should never fire; if a
+   * future field goes missing the same way, it says so instead.
+   */
+  private warnOnDroppedEnrichment(referenceNumber: number, enrichment: SplitEnrichment): void {
+    if (enrichment.renderable > enrichment.rendered) {
+      logger.warn(
+        { referenceNumber, renderable: enrichment.renderable, rendered: enrichment.rendered },
+        '[ReferencedMessageFormatter] Preprocessed reference enrichment was not rendered — ' +
+          'vision/transcription work was paid for and is not reaching the prompt'
+      );
+    }
   }
 
   /**

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
@@ -417,6 +417,33 @@ describe('QuoteFormatter', () => {
       expect(result).toContain('role="assistant"');
     });
 
+    it('promises media only when media actually rides along', () => {
+      // The marker is a claim about where to look. On a text-only stub, naming
+      // media sends the model hunting for something that was never attached;
+      // on a stub that carries descriptions, staying silent about them points
+      // it at <chat_log>, where images exist only as URLs.
+      const textOnly = formatDedupedQuote({ from: 'Alice', role: 'user', content: 'just words' });
+      expect(textOnly).toContain('[Referenced message — full text in the chat log]');
+      expect(textOnly).not.toContain('media');
+
+      const withMedia = formatDedupedQuote({
+        from: 'Alice',
+        role: 'user',
+        content: 'look at this',
+        imageDescriptions: [{ filename: 'a.png', description: 'a lighthouse at dusk' }],
+      });
+      expect(withMedia).toContain('its media is described here');
+      expect(withMedia).toContain('<image filename="a.png">a lighthouse at dusk</image>');
+
+      const withTranscript = formatDedupedQuote({
+        from: 'Alice',
+        role: 'user',
+        content: '',
+        voiceTranscripts: ['hey are you around'],
+      });
+      expect(withTranscript).toContain('its media is described here');
+    });
+
     it('does NOT let long attachment markers truncate away the text preview', () => {
       // Regression: a reply-target with two long image-filename markers + short text. The
       // content is already text-capped upstream (buildDedupedReferenceStub); formatDedupedQuote

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -190,8 +190,22 @@ export function formatForwardedQuote(content: ForwardedMessageContent): string {
 const DEDUP_REPLY_TARGET_PREFIX = '[Referenced message — full text in the chat log]';
 
 /**
+ * Variant used when the stub carries media descriptions. The extra clause is
+ * load-bearing, not decoration: the chat-log copy of an embed or attachment
+ * carries the raw URL, never a description, so media enrichment has no
+ * counterpart there and "full text in the chat log" would send the model
+ * somewhere the answer has never been.
+ *
+ * Conditional rather than unconditional so a text-only stub — the common case —
+ * neither pays the tokens nor invites the model to hunt for media that isn't there.
+ */
+const DEDUP_REPLY_TARGET_PREFIX_WITH_MEDIA =
+  '[Referenced message — full text in the chat log; its media is described here]';
+
+/**
  * Options for formatting a deduplicated reference stub.
- * Lightweight — no attachments, embeds, or location context.
+ * Lightweight — no embeds or location context (both are reproduced verbatim in
+ * <chat_log>), but media descriptions ARE carried: they exist nowhere else.
  */
 export interface DedupedQuoteOptions {
   /** Reference number (real-time refs only) */
@@ -209,6 +223,16 @@ export interface DedupedQuoteOptions {
   /** Original message content, already text-capped upstream (`buildDedupedReferenceStub`).
    *  Rendered as-is — NOT re-truncated here. Empty → marker-only stub. */
   content: string;
+  /**
+   * Vision descriptions for this reference's images. NOT redundant with the
+   * <chat_log> copy: history renders an embed/attachment as its URL, so a
+   * description dropped here is enrichment that was computed, paid for, and
+   * never reaches the model. The stub's own `[image/png: name]` markers name
+   * the file, not what is in it.
+   */
+  imageDescriptions?: { filename: string; description: string }[];
+  /** Voice transcripts for this reference's audio — same reasoning as `imageDescriptions`. */
+  voiceTranscripts?: string[];
 }
 
 /**
@@ -224,10 +248,10 @@ export function formatDedupedQuote(opts: DedupedQuoteOptions): string {
   // (e.g. `I...` for `I got myself off…`) that the model reads as an unfinished sentence.
   // The text is already bounded; the markers are short metadata that must survive intact.
   // Empty content (e.g. a bot's own reply-target) → marker only, no trailing blank.
-  const content =
-    opts.content.length > 0
-      ? `${DEDUP_REPLY_TARGET_PREFIX}\n\n${opts.content}`
-      : DEDUP_REPLY_TARGET_PREFIX;
+  const hasMedia =
+    (opts.imageDescriptions?.length ?? 0) > 0 || (opts.voiceTranscripts?.length ?? 0) > 0;
+  const prefix = hasMedia ? DEDUP_REPLY_TARGET_PREFIX_WITH_MEDIA : DEDUP_REPLY_TARGET_PREFIX;
+  const content = opts.content.length > 0 ? `${prefix}\n\n${opts.content}` : prefix;
 
   return formatQuoteElement({
     number: opts.number,
@@ -237,5 +261,7 @@ export function formatDedupedQuote(opts: DedupedQuoteOptions): string {
     timestamp: opts.timestamp,
     timeFormatted: opts.timeFormatted,
     content,
+    imageDescriptions: opts.imageDescriptions,
+    voiceTranscripts: opts.voiceTranscripts,
   });
 }


### PR DESCRIPTION
## The bug

Post an image or link-embed **without** triggering the bot, then reply to it to trigger. Vision describes the images successfully — and the model never sees a word of it. The character answers *"I can see the URLs for four images, but the content isn't rendering for me."*

Runtime-confirmed in prod (2026-07-30, job `image-823aead4-…-ref1-image`):

```
Processing image description job ... imageCount=4
4x Invoking vision model ... qwen/qwen3.7-plus
Image description completed ... processingTimeMs=47774 imageCount=4   ← SUCCESS
DependencyStep ... referencedAttachmentCount=4 totalPreprocessed=4    ← available
```

…and the rendered prompt: `[image/png: embed-image-1..4.png]`. Nothing else.

**This is worse than not describing.** Four vision calls and 47.8s of latency were paid for, then thrown away — with zero log output. The only detector in the system was the owner reading Discord.

Two `/inspect` captures of the same workflow, same day, pin the regression to the beta.187 window:

|                            | 14:14 (working)                             | 18:24 (broken)                       |
| -------------------------- | ------------------------------------------- | ------------------------------------ |
| reply-target render        | FULL quote + `Attachments:` w/ descriptions | DEDUPED stub + bare `[image/png: …]` |
| `<image filename=` in prompt | 20                                          | 0                                    |

## Mechanism

The deduped-reference branch passed only `content` — in **both** renderers, live (`ReferencedMessageFormatter`) and stored (`xmlMetadataFormatters`). The stub's own premise is the trap:

> `[Referenced message — full text in the chat log]`

True for text, **false for media**. The chat-log copy of an embed renders the image URL, never a description, so pointing the model at the log for images sends it somewhere the answer has never been. `persistReferenceDescriptions` writes `resolvedImageDescriptions` for exactly this case — and only the non-deduped path ever read them.

## The fix

Three render sites, plus the wording:

1. **`QuoteFormatter.DedupedQuoteOptions`** accepts `imageDescriptions` + `voiceTranscripts` and forwards them. `formatQuoteElement` already rendered both — the deduped path simply never passed them.
2. **Live deduped branch** builds them from the preprocessed results, **not** from `ref.attachments`: `buildDedupedReferenceStub` strips `attachments`, so `processAttachmentsParallel` (which walks attachments and looks preprocessing up by URL) has nothing to walk. No new spend — the descriptions already exist; this is the read side, and the existing "deduped stubs never call vision" invariant still holds (asserted).
3. **Stored deduped branch** passes `resolvedImageDescriptions`. Full and deduped now share one `splitStoredMedia` splitter, so they can't drift again.
4. **Wording** — the stub marker and the `<contextual_references>` instruction now say where media lives. `searchText` carries descriptions too, so retrieval can match on them.

## Why the test looks like this

This is the **second** field the deduped path has silently dropped (`authorRole` was the first, task-162). A field-parity allowlist would have caught only the field we already know about, and all three council models independently rejected that shape as rubber-stamp-prone.

So the oracle is economic rather than structural — **paid work must appear**: mock the vision boundary to return sentinels, assert the sentinels reach the prompt across the full matrix, (deduped × full) × (live × stored). It catches whichever field goes next.

**All five new tests verified RED with the fix reverted** (reverted the single `formatDedupedQuote` pass-through, ran; then the stored caller separately, ran). The stored-seam test asserts at `toHaveBeenCalledWith` because that suite stubs `QuoteFormatter` — a string assertion there would be testing the stub's own rendering; the real-chain assertion lives in `conversationUtils.test.ts`, which runs the whole path unmocked.

Also fixed: the local `formatDedupedQuote` stub in `xmlMetadataFormatters.test.ts` swallowed `imageDescriptions`, which would have kept that suite blind to this exact bug.

## Observability

A `warn` fires when preprocessed enrichment reaches a renderer and produces no rendered child. Post-fix it should never fire — it exists so the next dropped field shows up in logs instead of only in the owner's Discord.

## Verification

- `pnpm test` — 4046 ai-worker tests, 191 files, green
- `pnpm quality` — full chain green
- Five new tests confirmed failing pre-fix

## Known, deliberate, not fixed here

- The live deduped stub still carries `[image/png: name]` markers in `content` alongside the descriptions. The marker is the honest **fallback** when a description never arrived, and `buildDedupedReferenceStub` can't know whether one will; filenames match so they read as one image. The stored path drops its markers instead (it sees both at once). Collapsing that asymmetry is the projection refactor — **TASK-365**, same release.
- **What in beta.187 flipped dedup on for this shape is still unidentified** — every file on the reference/dedup/persist path in the release diff is comment-or-type-only. This fix makes the dedup state irrelevant to correctness rather than explaining it, which is the right posture either way: the render must be correct in both states. Tracked as open in TASK-364.
- **TASK-367** (descriptions keyed to the trigger row, so a re-ask never heals) ships next in this release — that's why the owner's re-ask still failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)