### PR TITLE
fix(ai-worker): stop quoted reasoning delimiters from eating the visible reply

### DIFF
--- a/packages/common-types/src/utils/codeSpanDetection.test.ts
+++ b/packages/common-types/src/utils/codeSpanDetection.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { isInsideCodeSpan } from './codeSpanDetection.js';
+
+/** Offset of `needle` in `text`, asserted to exist so a typo fails loudly. */
+function offsetOf(text: string, needle: string): number {
+  const index = text.indexOf(needle);
+  expect(index).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+describe('isInsideCodeSpan', () => {
+  describe('plain text', () => {
+    it('reports false for an offset in ordinary prose', () => {
+      const text = 'The answer is <thinking> according to the docs.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+    });
+
+    it('reports false for offset zero regardless of content', () => {
+      expect(isInsideCodeSpan('`backticked`', 0)).toBe(false);
+    });
+
+    it('reports false for a negative offset', () => {
+      expect(isInsideCodeSpan('anything', -1)).toBe(false);
+    });
+
+    it('reports false for empty text', () => {
+      expect(isInsideCodeSpan('', 5)).toBe(false);
+    });
+  });
+
+  describe('inline code', () => {
+    it('reports true inside an inline span', () => {
+      const text = 'Models emit a `</think>` marker before answering.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '</think>'))).toBe(true);
+    });
+
+    it('reports false after the span closes', () => {
+      const text = 'A `</think>` marker, then <thinking> in prose.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+    });
+
+    it('reports true for an unterminated span on the same line', () => {
+      // The production trigger: the model opened an inline span and the tag
+      // followed immediately, with the closing backtick lines later.
+      const text = 'the fragment `<thinking>\nI am a\n???`. Not a prompt.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(true);
+    });
+
+    it('does not let an unmatched backtick leak past a newline', () => {
+      const text = 'A stray ` backtick here.\nThen <thinking> on the next line.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+    });
+
+    it('handles several spans on one line', () => {
+      const text = 'Use `a` then `b` and finally <thinking> plainly.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+      expect(isInsideCodeSpan(text, offsetOf(text, 'b'))).toBe(true);
+    });
+  });
+
+  describe('fenced blocks', () => {
+    it('reports true inside a fence', () => {
+      const text = 'Example:\n```\n<thinking>\n```\nDone.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(true);
+    });
+
+    it('reports false after the fence closes', () => {
+      const text = '```\ncode\n```\nNow <thinking> in prose.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+    });
+
+    it('reports true inside a language-tagged fence', () => {
+      const text = '```xml\n<thinking>reasoning</thinking>\n```';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(true);
+    });
+
+    it('treats single backticks inside a fence as literal content', () => {
+      const text = '```\na ` lone backtick\n```\nThen <thinking> in prose.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+    });
+
+    it('reports true for an unterminated fence', () => {
+      const text = 'Look:\n```\n<thinking> and the fence never closes';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(true);
+    });
+
+    it('clears a pending inline span when a fence opens', () => {
+      // Without the reset, the unmatched backtick before the fence would keep
+      // reporting `true` for every later offset outside the fence.
+      const text = 'A stray ` then\n```\nfenced\n```\nplain <thinking> here.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+    });
+  });
+});

--- a/packages/common-types/src/utils/codeSpanDetection.ts
+++ b/packages/common-types/src/utils/codeSpanDetection.ts
@@ -17,6 +17,16 @@
  * mention is genuinely ambiguous and this predicate will report `false` for it;
  * callers that need to handle that case need a second discriminator (position,
  * for instance).
+ *
+ * Known simplification: fence detection is position-agnostic. Real Markdown
+ * fences are line-anchored, but any literal triple backtick toggles state here,
+ * so a reply using ``` inline ("she typed ``` by mistake") flips the scan into
+ * fence mode for the rest of the string. That is tolerable because it fails
+ * toward preserving content: an over-eager fence makes callers decline to
+ * extract, and the worst outcome is reasoning that stays visible rather than a
+ * reply that loses text. Line-anchoring it would be stricter and is fine to add
+ * — but only with a caller that needs the precision, since the loose form has
+ * the safer failure direction.
  */
 
 /**

--- a/packages/common-types/src/utils/codeSpanDetection.ts
+++ b/packages/common-types/src/utils/codeSpanDetection.ts
@@ -1,0 +1,71 @@
+/**
+ * Code-span detection for control-syntax parsers.
+ *
+ * Any parser that scans model output for control syntax (reasoning tags,
+ * wrapper tags, delimiters) has a blind spot: content that *quotes* the syntax
+ * is indistinguishable from content that *uses* it. That matters here because
+ * the product hosts AI characters, so replies routinely discuss model
+ * internals — a character explaining what `<thinking>` means emits the same
+ * bytes as a model actually opening a reasoning block.
+ *
+ * Markdown gives one reliable signal for "this is a mention, not a delimiter":
+ * the author wrapped it in code markup. This predicate answers whether a given
+ * offset sits inside inline code (`` `like this` ``) or a fenced block
+ * (```` ``` ````), so a parser can skip quoted occurrences.
+ *
+ * It is deliberately a *positive* signal only. An unfenced, unbackticked
+ * mention is genuinely ambiguous and this predicate will report `false` for it;
+ * callers that need to handle that case need a second discriminator (position,
+ * for instance).
+ */
+
+/**
+ * Whether `index` falls inside inline code or a fenced code block.
+ *
+ * Single left-to-right scan; the two states interact, so they cannot be
+ * counted independently:
+ * - A triple backtick toggles fence state and clears inline state — a stray
+ *   inline backtick must not leak across a fence boundary.
+ * - Inside a fence, single backticks are literal content and are ignored.
+ * - Outside a fence, a single backtick toggles inline state, and a newline
+ *   clears it: inline code does not span lines in Markdown, so without the
+ *   reset one unmatched backtick would mark the whole rest of the document
+ *   as code.
+ *
+ * @param text - The full text being scanned
+ * @param index - Offset within `text` to classify
+ * @returns true when the offset is inside code markup
+ */
+export function isInsideCodeSpan(text: string, index: number): boolean {
+  if (index <= 0) {
+    return false;
+  }
+
+  let inFence = false;
+  let inInline = false;
+  let cursor = 0;
+
+  while (cursor < index) {
+    if (text.startsWith('```', cursor)) {
+      inFence = !inFence;
+      inInline = false;
+      cursor += 3;
+      continue;
+    }
+
+    if (inFence) {
+      cursor += 1;
+      continue;
+    }
+
+    const char = text[cursor];
+    if (char === '`') {
+      inInline = !inInline;
+    } else if (char === '\n') {
+      inInline = false;
+    }
+    cursor += 1;
+  }
+
+  return inFence || inInline;
+}

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -454,6 +454,24 @@ The answer is 42.`;
       expect(result.thinkingContent).toBeNull();
     });
 
+    it('skips a quoted closing-tag candidate and extracts from the next real one', () => {
+      // The one branch this change turned from a single match into a loop, so
+      // it is the one that could be accidentally right. Every other case has
+      // either no quoted tag or only a quoted tag; this has both, in order.
+      const content =
+        'The docs mention `</think>` as the delimiter. ' +
+        'Actual internal reasoning that is long enough to pass the minimum length check.' +
+        '</think>Real answer.';
+      const result = extractThinkingBlocks(content);
+
+      expect(result.visibleContent).toBe('Real answer.');
+      expect(result.blockCount).toBe(1);
+      // The quoted example rides along into thinkingContent, because the real
+      // tag's prefix starts at position 0 and necessarily spans it. Harmless —
+      // thinkingContent is diagnostic/spoiler output, never the reply.
+      expect(result.thinkingContent).toContain('Actual internal reasoning');
+    });
+
     it('KNOWN LIMIT: an unquoted mid-response opening tag leaks its literal text', () => {
       // The other side of the same trade. Declining to extract means the tag
       // itself now renders to the user rather than being consumed along with

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -502,6 +502,18 @@ The answer is 42.`;
             expect(result.thinkingContent).toBeNull();
             expect(result.blockCount).toBe(0);
           });
+
+          it(`preserves a complete <${tag}>…</${tag}> pair quoted in ${label}`, () => {
+            // The likeliest shape of all: demonstrating the syntax means
+            // writing both halves. Unguarded, the example's body is filed as
+            // reasoning and disappears from the reply entirely.
+            const content = wrap(`<${tag}>example reasoning</${tag}>`);
+            const result = extractThinkingBlocks(content);
+
+            expect(result.visibleContent).toBe(content);
+            expect(result.thinkingContent).toBeNull();
+            expect(result.blockCount).toBe(0);
+          });
         }
       }
     });
@@ -1380,6 +1392,13 @@ describe('hasThinkingBlocks', () => {
     // reply contains reasoning when the model was only talking about a tag.
     expect(hasThinkingBlocks('The answer is Paris. <think>Wait, let me reconsider...')).toBe(false);
     expect(hasThinkingBlocks('Models emit a `<thinking>` marker first.')).toBe(false);
+    expect(hasThinkingBlocks('Use `<think>x</think>` like so.')).toBe(false);
+  });
+
+  it('should still return true when a real pair sits alongside a quoted one', () => {
+    // The gate skips quoted matches rather than bailing on the first one, so a
+    // reply that reasons AND shows an example still reports as reasoning.
+    expect(hasThinkingBlocks('Use `<think>x</think>` like so.<think>real</think>')).toBe(true);
   });
 
   it('should return true for additional tag types', () => {

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -428,6 +428,21 @@ The answer is 42.`;
       expect(result.visibleContent).toBe('before the answer.');
     });
 
+    it('preserves a quoted tag at the very start of the response', () => {
+      // Boundary the table fixtures do not reach: they always put prose before
+      // the quote, so the tag never lands near offset 0 — which is where the
+      // code-span scan's own early return lives. Here the backtick occupies
+      // offset 0 and the tag starts at 1, so the head anchor sees a backtick
+      // where it requires `<` and declines, and the scan still reports quoted.
+      const opening = '`<think>` is what the model emits before answering.';
+      expect(extractThinkingBlocks(opening).visibleContent).toBe(opening);
+      expect(extractThinkingBlocks(opening).thinkingContent).toBeNull();
+
+      const closing = '`</think>` is the terminator it writes afterwards.';
+      expect(extractThinkingBlocks(closing).visibleContent).toBe(closing);
+      expect(extractThinkingBlocks(closing).thinkingContent).toBeNull();
+    });
+
     it('preserves a quoted stutter-shaped fragment at the start of a line', () => {
       // The chimera-artifact cleanup eats a whole `token. </tag>` fragment and
       // runs before the orphan pass, so without its own gate it corrupts the

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  KNOWN_THINKING_TAGS,
   extractThinkingBlocks,
   hasThinkingBlocks,
   extractApiReasoningContent,
@@ -348,14 +349,17 @@ The answer is 42.`;
       expect(result.blockCount).toBe(0);
     });
 
-    it('should still extract unclosed tag mid-response (content exists before tag)', () => {
-      // When there's visible content before the unclosed tag, extraction is safe
+    it('should NOT extract an unclosed tag mid-response (the model is quoting it)', () => {
+      // A tag preceded by real prose is the model TALKING about the tag, not
+      // opening a reasoning block — every unclosed case observed in production
+      // is head-anchored. Extracting here truncated a user-visible reply
+      // mid-sentence and refiled the remainder as reasoning.
       const content = 'The answer is Paris. <think>Wait, let me reconsider...';
       const result = extractThinkingBlocks(content);
 
-      expect(result.thinkingContent).toBe('Wait, let me reconsider...');
-      expect(result.visibleContent).toBe('The answer is Paris.');
-      expect(result.blockCount).toBe(1);
+      expect(result.thinkingContent).toBeNull();
+      expect(result.visibleContent).toBe(content);
+      expect(result.blockCount).toBe(0);
     });
 
     it('should handle GLM 4.5 Air glitch — unclosed tag with full response inside', () => {
@@ -370,6 +374,121 @@ The answer is 42.`;
       expect(result.visibleContent).toContain('The capital of France is Paris');
       expect(result.visibleContent).not.toContain('<think>');
       expect(result.blockCount).toBe(0);
+    });
+  });
+
+  describe('quoted control syntax', () => {
+    // This product hosts AI characters, so replies routinely DISCUSS model
+    // internals — a character explaining what <thinking> means emits the same
+    // bytes as a model opening a reasoning block. Two discriminators separate
+    // them, and each covers what the other cannot:
+    //   - opening tags: position (a real unclosed block is head-anchored)
+    //   - closing tags: code markup (the Kimi K2.5 shape is mid-line too, so
+    //     position cannot tell them apart)
+
+    it('preserves a reply that quotes an opening tag inside inline code', () => {
+      const reply = [
+        'Okay. Now I see it. All four.',
+        '',
+        'The third one is where it gets strange — someone started a new',
+        'incognito chat, and the entire user message was just the fragment',
+        '`<thinking>',
+        'I am a',
+        '???`. That is not a question. That is not a prompt.',
+        '',
+        'Which means the fourth screenshot is the interesting one.',
+      ].join('\n');
+
+      const result = extractThinkingBlocks(reply);
+
+      expect(result.visibleContent).toBe(reply);
+      expect(result.thinkingContent).toBeNull();
+      expect(result.blockCount).toBe(0);
+    });
+
+    it('preserves a reply that mentions a closing tag inside inline code', () => {
+      const reply =
+        'Models like DeepSeek emit their reasoning and then terminate it with a `</think>` marker before the real answer begins. That is why you sometimes see it leak.';
+
+      const result = extractThinkingBlocks(reply);
+
+      expect(result.visibleContent).toBe(reply);
+      expect(result.thinkingContent).toBeNull();
+      expect(result.blockCount).toBe(0);
+    });
+
+    it('KNOWN LIMIT: an unfenced closing tag mid-prose is still consumed', () => {
+      // Positionally identical to the Kimi K2.5 shape this path exists to
+      // serve, with no code markup to separate them. Extraction stays the
+      // default when the only available signal is absent — pinned so the
+      // boundary is visible rather than discovered.
+      const content = 'Some models close their reasoning with </think> before the answer.';
+      const result = extractThinkingBlocks(content);
+
+      expect(result.visibleContent).toBe('before the answer.');
+    });
+
+    it('preserves a quoted stutter-shaped fragment at the start of a line', () => {
+      // The chimera-artifact cleanup eats a whole `token. </tag>` fragment and
+      // runs before the orphan pass, so without its own gate it corrupts the
+      // reply first — leaving a dangling backtick and a mangled sentence.
+      const content = 'Some notes:\n`eh. </think>` shows the shape some models emit.';
+      const result = extractThinkingBlocks(content);
+
+      expect(result.visibleContent).toBe(content);
+      expect(result.thinkingContent).toBeNull();
+    });
+
+    it('KNOWN LIMIT: an unquoted mid-response opening tag leaks its literal text', () => {
+      // The other side of the same trade. Declining to extract means the tag
+      // itself now renders to the user rather than being consumed along with
+      // the rest of the reply. Cosmetic leak on a path never observed in
+      // production, against data loss on one that was — pinned so the choice
+      // is legible rather than looking like an oversight.
+      const content = 'The answer is Paris. <think>Wait, let me reconsider...';
+      const result = extractThinkingBlocks(content);
+
+      expect(result.visibleContent).toContain('<think>');
+      expect(result.thinkingContent).toBeNull();
+    });
+
+    describe('every known tag, in every quoting shape', () => {
+      // The tag vocabulary grows with each model revision, and every addition
+      // widens the surface on which a QUOTED delimiter can be mistaken for a
+      // real one. Driving this table off the exported constant means a newly
+      // added tag inherits the coverage instead of arriving unguarded.
+      const quotingShapes = [
+        {
+          label: 'inline backticks',
+          wrap: (tag: string): string => `Models emit a \`${tag}\` marker before answering.`,
+        },
+        {
+          label: 'a fenced block',
+          wrap: (tag: string): string => `Like so:\n\`\`\`\n${tag}\n\`\`\`\nThat is the shape.`,
+        },
+      ];
+
+      for (const tag of KNOWN_THINKING_TAGS) {
+        for (const { label, wrap } of quotingShapes) {
+          it(`preserves <${tag}> quoted in ${label}`, () => {
+            const content = wrap(`<${tag}>`);
+            const result = extractThinkingBlocks(content);
+
+            expect(result.visibleContent).toBe(content);
+            expect(result.thinkingContent).toBeNull();
+            expect(result.blockCount).toBe(0);
+          });
+
+          it(`preserves </${tag}> quoted in ${label}`, () => {
+            const content = wrap(`</${tag}>`);
+            const result = extractThinkingBlocks(content);
+
+            expect(result.visibleContent).toBe(content);
+            expect(result.thinkingContent).toBeNull();
+            expect(result.blockCount).toBe(0);
+          });
+        }
+      }
     });
   });
 
@@ -558,16 +677,16 @@ Sarcasm is just encrypted honesty.`;
       expect(result.blockCount).toBe(1);
     });
 
-    it('should strip leading stray punctuation after truncated thinking extraction', () => {
-      // When an unclosed tag is removed, visible content may start with stray punctuation
-      // left over from the truncated reasoning (e.g., "., " or ", " fragments)
+    it('should preserve a mid-response unclosed tag rather than extracting it', () => {
+      // This case used a mid-response unclosed tag as its vehicle for testing
+      // leading-punctuation cleanup, which the complete-tag cases below cover
+      // directly. Mid-response extraction is the truncation bug, so the whole
+      // reply must survive.
       const content = 'Some visible text. <think>Unclosed thinking that was truncated';
       const result = extractThinkingBlocks(content);
 
-      // The unclosed tag content is extracted as thinking
-      expect(result.thinkingContent).toBe('Unclosed thinking that was truncated');
-      // Visible content should be clean
-      expect(result.visibleContent).toBe('Some visible text.');
+      expect(result.thinkingContent).toBeNull();
+      expect(result.visibleContent).toBe(content);
     });
 
     it('should strip leading punctuation when visible content starts with stray period', () => {
@@ -1238,6 +1357,14 @@ describe('hasThinkingBlocks', () => {
 
   it('should return true for unclosed tags (fallback detection)', () => {
     expect(hasThinkingBlocks('<think>unclosed content')).toBe(true);
+  });
+
+  it('should return false for a tag quoted mid-prose (mirrors the extractor anchor)', () => {
+    // The detector shares the extractor's head anchor on purpose. Reporting
+    // true here would make `hasReasoningTagsInContent` tell /inspect that a
+    // reply contains reasoning when the model was only talking about a tag.
+    expect(hasThinkingBlocks('The answer is Paris. <think>Wait, let me reconsider...')).toBe(false);
+    expect(hasThinkingBlocks('Models emit a `<thinking>` marker first.')).toBe(false);
   });
 
   it('should return true for additional tag types', () => {

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -24,6 +24,7 @@
  * 3. Logged for debugging purposes
  */
 
+import { isInsideCodeSpan } from '@tzurot/common-types/utils/codeSpanDetection';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('ThinkingExtraction');
@@ -46,8 +47,14 @@ interface ThinkingExtraction {
  *
  * CONSTRAINT: Tag names must use only [a-z_] characters (no regex
  * metacharacters), since names are interpolated directly into patterns.
+ *
+ * Exported so the quoted-delimiter guard suite can enumerate the vocabulary
+ * rather than restate it. Every name added here widens the surface on which a
+ * reply that merely QUOTES the tag could be mistaken for one that uses it, so
+ * the guard must grow with the list automatically — a hand-maintained copy in
+ * the tests would drift on exactly the revision that needed it.
  */
-const KNOWN_THINKING_TAGS = [
+export const KNOWN_THINKING_TAGS = [
   'think', // DeepSeek R1, Qwen QwQ, GLM-4.x, Kimi K2
   'thinking', // Claude prompted, some distilled models
   'ant_thinking', // Legacy Anthropic format
@@ -284,19 +291,28 @@ function normalizeThinkingTagNamespaces(content: string): string {
 }
 
 /**
- * Pattern to match unclosed thinking tags (model truncation or errors).
- * Matches opening tag followed by content until end of string.
- * Only used as a fallback when no complete tags are found.
+ * Pattern to match an unclosed thinking tag at the HEAD of a response (model
+ * truncation or errors). Only used as a fallback when no complete tags are found.
+ *
+ * The `^\s*` anchor is load-bearing, and matches the convention every Pass-1
+ * pattern above already relies on: a genuine unclosed reasoning block is a
+ * PREFIX phenomenon — the model opened its reasoning and never closed it, so
+ * nothing precedes the tag. A tag appearing after real prose is, by definition,
+ * the model TALKING about the tag. Without the anchor, a reply quoting
+ * `<thinking>` had everything from that point to end-of-string consumed as
+ * reasoning, truncating the user-visible message mid-sentence.
  */
-const UNCLOSED_TAG_PATTERN = new RegExp(`<(${TAG_ALT})>([\\s\\S]*)$`, 'gi');
+const HEAD_UNCLOSED_TAG_PATTERN = new RegExp(`^\\s*<(${TAG_ALT})>([\\s\\S]*)$`, 'i');
 
 /**
- * Pattern to match orphan closing tags with preceding content (no opening tag).
- * Some models (e.g., Kimi K2.5) may output thinking content without an opening tag,
- * just closing with </think>. This captures the content before the closing tag.
- * Matches: "thinking content here</think>visible response"
+ * Pattern to detect an opening thinking tag anywhere in the content.
+ *
+ * Diagnostic only — never used to strip. It reports the case the head anchor
+ * above declines to act on, so a genuine mid-response unclosed block (not yet
+ * observed in production, but not impossible) would surface in logs instead of
+ * silently rendering its raw tag.
  */
-const ORPHAN_CLOSING_TAG_PATTERN = new RegExp(`^([\\s\\S]*?)<\\/(${TAG_ALT})>`, 'i');
+const ANY_OPENING_TAG_PATTERN = new RegExp(`<(${TAG_ALT})>`, 'gi');
 
 /**
  * Pattern to clean up "chimera artifacts" - short garbage fragments before orphan closing tags.
@@ -309,9 +325,13 @@ const CHIMERA_ARTIFACT_PATTERN = new RegExp(
 );
 
 /**
- * Pattern to remove any remaining orphan closing tags.
+ * Pattern matching a thinking closing tag anywhere in the content.
+ *
+ * Serves both consumers of orphan closing tags: `extractOrphanClosingTag`
+ * enumerates candidates with it, and `cleanupVisibleContent` removes whatever
+ * survives. Both skip occurrences inside code markup — see `isInsideCodeSpan`.
  */
-const ORPHAN_CLOSING_TAG_CLEANUP = new RegExp(`<\\/(${TAG_ALT})>`, 'gi');
+const CLOSING_TAG_PATTERN = new RegExp(`<\\/(${TAG_ALT})>`, 'gi');
 
 /**
  * Pattern to clean up OpenAI "Harmony" format tokens that leak from GPT-OSS-120B.
@@ -325,95 +345,126 @@ const HARMONY_TOKEN_PATTERN = /<\|(?:start|end|channel|separator|im_start|im_end
 /** Minimum content length to extract from orphan closing tags */
 const MIN_ORPHAN_CONTENT_LENGTH = 20;
 
-/** Opening tag pattern for stripping bare tags without capturing content */
-const OPENING_TAG_PATTERN = new RegExp(`<(${TAG_ALT})>`, 'gi');
-
 /**
- * Extract content from unclosed thinking tags (model truncation fallback).
+ * Strip a head-anchored unclosed thinking tag, keeping its body visible.
  *
- * When the unclosed tag would consume the entire response (no visible content
- * remains after extraction), this is likely a model glitch (e.g. GLM 4.5 Air
- * forgetting to close the tag) rather than genuine truncated reasoning. In that
- * case, we strip the opening tag and keep all content visible.
+ * An unclosed opening tag means the model opened a reasoning block and never
+ * closed it — either a glitch (GLM 4.5 Air) or truncation. In both cases the
+ * body is the response the user is waiting for, so the tag is removed and
+ * everything after it stays visible rather than being filed as reasoning.
+ * Only the leading tag is removed: a later occurrence is prose the model wrote
+ * and must survive verbatim.
  *
- * @returns Object with extracted thinking and remaining visible, or null if no match
+ * @returns Content with the leading tag removed, or null when no head tag matched
  */
-function extractUnclosedTag(
-  visibleContent: string
-): { thinkingContent: string; visibleContent: string } | null {
-  UNCLOSED_TAG_PATTERN.lastIndex = 0;
-  const match = UNCLOSED_TAG_PATTERN.exec(visibleContent);
+function stripHeadUnclosedTag(visibleContent: string): string | null {
+  const match = HEAD_UNCLOSED_TAG_PATTERN.exec(visibleContent);
   if (match === null) {
     return null;
   }
 
-  const tagName = match[1];
-  const content = match[2].trim();
-  if (content.length === 0) {
+  const body = match[2];
+  if (body.trim().length === 0) {
     return null;
   }
 
   logger.warn(
-    { tagName, contentLength: content.length },
-    'Found unclosed thinking tag - content may be incomplete'
+    { tagName: match[1], contentLength: body.length },
+    'Found unclosed thinking tag at start of response — stripping tag, keeping content visible'
   );
 
-  UNCLOSED_TAG_PATTERN.lastIndex = 0;
-  const cleaned = visibleContent.replace(UNCLOSED_TAG_PATTERN, '');
+  return body;
+}
 
-  // If extraction would leave visible content empty, this is likely a model glitch
-  // (e.g. GLM 4.5 Air). Strip the opening tag instead and keep content visible.
-  if (cleaned.trim().length === 0) {
-    logger.warn(
-      { contentLength: content.length },
-      'Unclosed tag would consume entire response — keeping content visible'
-    );
-    return {
-      thinkingContent: '',
-      visibleContent: visibleContent.replace(OPENING_TAG_PATTERN, '').trim(),
-    };
+/**
+ * Report an opening thinking tag that the head anchor declined to act on.
+ *
+ * Every unclosed-tag case observed in production has been head-anchored, so a
+ * mid-response one is expected to be a quotation. This log exists so that
+ * assumption is falsifiable: if a model genuinely opens reasoning mid-response,
+ * it shows up here instead of silently rendering a raw tag to the user.
+ */
+function logDeclinedMidResponseTag(visibleContent: string): void {
+  ANY_OPENING_TAG_PATTERN.lastIndex = 0;
+  const match = ANY_OPENING_TAG_PATTERN.exec(visibleContent);
+  if (match === null) {
+    return;
   }
 
-  return { thinkingContent: content, visibleContent: cleaned };
+  logger.info(
+    {
+      tagName: match[1],
+      tagOffset: match.index,
+      quoted: isInsideCodeSpan(visibleContent, match.index),
+      contentLength: visibleContent.length,
+    },
+    'Opening thinking tag mid-response — treated as quoted prose, left visible'
+  );
 }
 
 /**
  * Extract content from orphan closing tags (no opening tag).
+ *
+ * Some models (e.g. Kimi K2.5) emit reasoning with no opening tag and simply
+ * terminate it with `</think>`, so the closing tag sits mid-line, mid-text —
+ * positionally identical to a reply that merely MENTIONS the tag. Code markup
+ * is the only signal that separates the two, so candidates inside a backtick
+ * span or fenced block are skipped and the next one is considered.
+ *
  * @returns Extracted content and cleaned visible content, or null if no match
  */
 function extractOrphanClosingTag(
   visibleContent: string
 ): { content: string; cleaned: string } | null {
-  const match = ORPHAN_CLOSING_TAG_PATTERN.exec(visibleContent);
-  if (match === null) {
-    return null;
+  CLOSING_TAG_PATTERN.lastIndex = 0;
+  for (const match of visibleContent.matchAll(CLOSING_TAG_PATTERN)) {
+    const tagOffset = match.index;
+    if (isInsideCodeSpan(visibleContent, tagOffset)) {
+      continue;
+    }
+
+    const content = visibleContent.slice(0, tagOffset).trim();
+    if (content.length < MIN_ORPHAN_CONTENT_LENGTH) {
+      return null;
+    }
+
+    logger.warn(
+      { tagName: match[1], contentLength: content.length },
+      'Found orphan closing tag - extracted preceding content as thinking'
+    );
+
+    return { content, cleaned: visibleContent.slice(tagOffset + match[0].length) };
   }
 
-  const content = match[1].trim();
-  const tagName = match[2];
-
-  if (content.length < MIN_ORPHAN_CONTENT_LENGTH) {
-    return null;
-  }
-
-  logger.warn(
-    { tagName, contentLength: content.length },
-    'Found orphan closing tag - extracted preceding content as thinking'
-  );
-
-  const cleaned = visibleContent.replace(ORPHAN_CLOSING_TAG_PATTERN, '');
-  return { content, cleaned };
+  return null;
 }
 
 /**
  * Clean up visible content after extraction.
  */
 function cleanupVisibleContent(content: string): string {
-  // Clean chimera artifacts
-  let result = content.replace(CHIMERA_ARTIFACT_PATTERN, '');
+  // Clean chimera artifacts — skipping quoted ones, same as the orphan pass
+  // below. This pattern eats a whole `token. </tag>` fragment, so a quoted
+  // example starting a line loses its text and leaves a dangling backtick.
+  // The stutter it targets is one merged model's quirk; the false positive
+  // lands on every model, which is why the gate is worth more than the pass.
+  // Test the CLOSING TAG's position, not the match start: this pattern's match
+  // begins at the preceding newline, which sits outside the backtick span the
+  // quoted tag lives in, so gating on `offset` would never fire.
+  let result = content.replace(
+    CHIMERA_ARTIFACT_PATTERN,
+    (match: string, _tagName: string, offset: number) =>
+      isInsideCodeSpan(content, offset + match.lastIndexOf('</')) ? match : ''
+  );
 
-  // Remove remaining orphan closing tags
-  result = result.replace(ORPHAN_CLOSING_TAG_CLEANUP, '');
+  // Remove remaining orphan closing tags — except ones the model quoted inside
+  // code markup, where deleting the tag would corrupt the quotation it wrote.
+  const beforeOrphanCleanup = result;
+  result = beforeOrphanCleanup.replace(
+    CLOSING_TAG_PATTERN,
+    (match: string, _tagName: string, offset: number) =>
+      isInsideCodeSpan(beforeOrphanCleanup, offset) ? match : ''
+  );
 
   // Remove OpenAI Harmony format token leakage (GPT-OSS-120B)
   result = result.replace(HARMONY_TOKEN_PATTERN, '');
@@ -450,14 +501,13 @@ function extractFromReasoningDetail(detail: ReasoningDetail): string | null {
  * Attempts unclosed tags first, then orphan closing tags.
  */
 function tryFallbackExtraction(thinkingParts: string[], visibleContent: string): string {
-  // Try unclosed tags (e.g. model truncation or GLM 4.5 Air glitch)
-  const unclosed = extractUnclosedTag(visibleContent);
-  if (unclosed !== null) {
-    if (unclosed.thinkingContent.length > 0) {
-      thinkingParts.push(unclosed.thinkingContent);
-    }
-    return unclosed.visibleContent;
+  // Try a head-anchored unclosed tag (model truncation or GLM 4.5 Air glitch)
+  const stripped = stripHeadUnclosedTag(visibleContent);
+  if (stripped !== null) {
+    return stripped;
   }
+
+  logDeclinedMidResponseTag(visibleContent);
 
   // Try orphan closing tags (no opening tag, e.g. Kimi K2.5)
   const orphan = extractOrphanClosingTag(visibleContent);
@@ -620,9 +670,10 @@ export function hasThinkingBlocks(content: string): boolean {
     }
   }
 
-  // Also check for unclosed tags
-  UNCLOSED_TAG_PATTERN.lastIndex = 0;
-  if (UNCLOSED_TAG_PATTERN.test(normalized)) {
+  // Also check for a head-anchored unclosed tag. Mirrors the extractor's own
+  // anchor so diagnostics don't report reasoning for a reply that merely quotes
+  // a tag mid-prose — `hasReasoningTagsInContent` would otherwise over-report.
+  if (HEAD_UNCLOSED_TAG_PATTERN.test(normalized)) {
     return true;
   }
 

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -526,6 +526,51 @@ function tryFallbackExtraction(thinkingParts: string[], visibleContent: string):
 }
 
 /**
+ * Pass 2 — extract every complete `<tag>…</tag>` pair that is not quoted.
+ *
+ * A quoted complete pair is the most natural way a reply demonstrates the
+ * syntax (`` `<think>like this</think>` ``), and it needs the same code-markup
+ * gate as the fallback paths — otherwise the example's body is filed as
+ * reasoning and vanishes from the reply.
+ *
+ * The gate is applied TWICE, against different strings, which is why this reads
+ * as two passes rather than one: enumeration indexes into `normalized`, while
+ * removal re-matches over `visibleContent` (already shortened by Pass 1), so an
+ * offset from one does not address the other.
+ *
+ * Skipping (rather than bailing) means a reply that both reasons AND shows an
+ * example still yields its real reasoning.
+ *
+ * @param thinkingParts - Accumulator, appended in place
+ * @returns `visibleContent` with the unquoted pairs removed
+ */
+function extractCompleteTagPairs(
+  normalized: string,
+  visibleContent: string,
+  thinkingParts: string[]
+): string {
+  let remaining = visibleContent;
+
+  for (const pattern of THINKING_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of normalized.matchAll(pattern)) {
+      const thinkContent = match[1].trim();
+      if (!isInsideCodeSpan(normalized, match.index) && thinkContent.length > 0) {
+        thinkingParts.push(thinkContent);
+      }
+    }
+
+    pattern.lastIndex = 0;
+    const beforeStrip = remaining;
+    remaining = beforeStrip.replace(pattern, (matchText: string, _body: string, offset: number) =>
+      isInsideCodeSpan(beforeStrip, offset) ? matchText : ''
+    );
+  }
+
+  return remaining;
+}
+
+/**
  * Extract thinking blocks from AI response content.
  *
  * Models like DeepSeek R1, Qwen QwQ, GLM-4.x, and Claude with prompted thinking
@@ -623,18 +668,7 @@ export function extractThinkingBlocks(content: string): ThinkingExtraction {
   // in Pass 1, once as its own tag match in Pass 2. Edge case is not
   // user-visible (it only affects `showThinking` output) and would require
   // a pathological input shape. Left as-is intentionally.
-  for (const pattern of THINKING_PATTERNS) {
-    pattern.lastIndex = 0;
-    const matches = normalized.matchAll(pattern);
-    for (const match of matches) {
-      const thinkContent = match[1].trim();
-      if (thinkContent.length > 0) {
-        thinkingParts.push(thinkContent);
-      }
-    }
-    pattern.lastIndex = 0;
-    visibleContent = visibleContent.replace(pattern, '');
-  }
+  visibleContent = extractCompleteTagPairs(normalized, visibleContent, thinkingParts);
 
   // Fallback extraction (only if no complete tags found)
   if (thinkingParts.length === 0) {
@@ -671,8 +705,13 @@ export function hasThinkingBlocks(content: string): boolean {
   const normalized = normalizeThinkingTagNamespaces(content);
   for (const pattern of THINKING_PATTERNS) {
     pattern.lastIndex = 0; // Reset regex state
-    if (pattern.test(normalized)) {
-      return true;
+    for (const match of normalized.matchAll(pattern)) {
+      // Mirrors the extractor's code-markup gate: a quoted pair is an example,
+      // and reporting it here would tell /inspect a reply contains reasoning
+      // that the extractor deliberately left alone.
+      if (!isInsideCodeSpan(normalized, match.index)) {
+        return true;
+      }
     }
   }
 

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -425,6 +425,12 @@ function extractOrphanClosingTag(
 
     const content = visibleContent.slice(0, tagOffset).trim();
     if (content.length < MIN_ORPHAN_CONTENT_LENGTH) {
+      // Bail entirely rather than trying the next candidate. Too little text
+      // before the FIRST real closing tag means this is stray garbage (the
+      // chimera stutter shape), not reasoning — and the right handler for that
+      // is the blanket cleanup pass, which strips the tag and keeps the text.
+      // Searching on would find a later tag and misfile everything before it,
+      // including the garbage, as thinking.
       return null;
     }
 

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -668,6 +668,14 @@ export function extractThinkingBlocks(content: string): ThinkingExtraction {
   // in Pass 1, once as its own tag match in Pass 2. Edge case is not
   // user-visible (it only affects `showThinking` output) and would require
   // a pathological input shape. Left as-is intentionally.
+  //
+  // The same two-string split bounds the quote gate inside: it is evaluated
+  // against `normalized` when collecting and against the post-Pass-1 string
+  // when removing, so where a Pass-1 extractor stripped a head prefix the two
+  // scans could in principle disagree about whether an occurrence is quoted.
+  // Same blast radius as above — only `thinkingParts` bucketing, never
+  // `visibleContent` — because the removal side is the one the reply sees and
+  // it always scans the string it is about to modify.
   visibleContent = extractCompleteTagPairs(normalized, visibleContent, thinkingParts);
 
   // Fallback extraction (only if no complete tags found)

--- a/tracker/tasks/task-365 - Reference-rendering-has-FOUR-hand-synced-paths-live-stored-x-full-deduped.md
+++ b/tracker/tasks/task-365 - Reference-rendering-has-FOUR-hand-synced-paths-live-stored-x-full-deduped.md
@@ -71,4 +71,65 @@ attachment whose vision call FAILED renders with neither marker nor description
 `fullRender minus content`, the attachment renders exactly as the full path does
 and the gap closes by construction. **Add it to the acceptance check**: a
 deduped reference with an UNdescribed attachment must still name that attachment.
+
+## GROUNDING PASS — three corrections from reading the code
+
+Read end to end before building, per "principle from advisors, target from the
+code". The verdict holds; three specifics in the framing above are wrong or
+understated, and the third changes what the open owner question actually is.
+
+**1. It is not four paths — the live renderer has THREE branches.**
+`ReferencedMessageFormatter.formatReferencedMessages` dispatches deduped /
+forwarded / standard. So the matrix is (live × {deduped, forwarded, standard}) ×
+(stored × {full, deduped}) = five render paths, not four. `formatForwardedQuote`
+is a thin wrapper over the same core, so it collapses for free — but it must be
+in the enumeration or the sweep misses it.
+
+**2. `formatQuoteElement` is ALREADY the one XML renderer.** Every path calls it
+(`QuoteFormatter.ts`). The divergence is not two renderers emitting different
+XML — it is which SLOT each caller fills:
+
+| Path | fills | emits |
+| --- | --- | --- |
+| live standard + forwarded | `attachmentLines: string[]` | `<attachments>` |
+| live deduped | `imageDescriptions` / `voiceTranscripts` | `<image_descriptions>`, `<voice_transcripts>` |
+| stored (both) | `imageDescriptions` + attachment markers | `<image_descriptions>` + `<attachments>` |
+
+So the "same reference renders different XML per path" split runs THROUGH the
+live renderer, not just between live and stored — the deduped branch already
+speaks the stored path's vocabulary while its own sibling branches do not.
+
+**3. The vocabulary question has a concrete mechanical cause**, which makes the
+owner's call narrower than "unify the XML". `processAttachmentsParallel`
+(`AttachmentProcessor.ts:108`) returns `Promise<string[]>` — pre-RENDERED lines
+(`- Image (photo.png): …`). A caller holding strings has no structured filename
+or description left to place, so it can only fill `<attachments>`. The live
+deduped branch escapes this precisely because `splitPreprocessedEnrichment`
+gives it structured entries instead.
+
+**The unification is therefore: make `processAttachmentsParallel` return
+structured results and let the renderer format them** — not a change to the XML
+emitter, which is already shared. The owner call stands (it is model-visible:
+`<attachments>` lines become `<image_descriptions>` entries for the standard and
+forwarded branches) but it is one upstream return-type change, not a rewrite of
+the emitter.
+
+**Type divergence the `ResolvedReference` union must absorb** — the two source
+schemas (`packages/common-types/src/types/schemas/message.ts`) name the same
+domain object with different fields, which is the drift underneath everything
+above:
+
+| | `ReferencedMessage` (live) | `StoredReferencedMessage` |
+| --- | --- | --- |
+| author identity | `discordUserId` | `authorDiscordId` |
+| numbering | `referenceNumber` | positional |
+| bot signals | `webhookId`, `authorIsBot` | — |
+| dedup flag | `isDeduplicated` | — |
+| persona | — | `resolvedPersonaId` / `resolvedPersonaName` |
+| images | — | `resolvedImageDescriptions` |
+
+Also confirmed by reading: `buildDedupedReferenceStub` drops `attachments` AND
+`isForwarded` from its reconstruction — so a forwarded reference that also
+dedupes loses its forwarded-ness silently. Third instance of the same class,
+found without a bug report, and it closes by construction under the projection.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-365 - Reference-rendering-has-FOUR-hand-synced-paths-live-stored-x-full-deduped.md
+++ b/tracker/tasks/task-365 - Reference-rendering-has-FOUR-hand-synced-paths-live-stored-x-full-deduped.md
@@ -132,4 +132,51 @@ Also confirmed by reading: `buildDedupedReferenceStub` drops `attachments` AND
 `isForwarded` from its reconstruction — so a forwarded reference that also
 dedupes loses its forwarded-ness silently. Third instance of the same class,
 found without a bug report, and it closes by construction under the projection.
+
+## CONVERGE TOWARD THE STORED PATH, NOT AWAY FROM IT
+
+The framing above (and the council's) implicitly treats the two renderers as
+peers to be merged. Reading `xmlMetadataFormatters.formatStoredReferencedMessage`
+end to end says otherwise: **the stored full path is already very close to the
+canonical `renderReference` this task wants**, and the live path is the outlier.
+
+Concretely, the stored path already does three things the live path does not:
+
+1. **Forwarded is a MODE, not a separate function.** It renders forwarding as
+   `type: ref.isForwarded ? 'forward' : undefined` on the one renderer. The live
+   path has a whole separate `formatForwardedReference` method that duplicates
+   the timestamp/attachment/embeds handling of `formatStandardReference`. Kimi's
+   `renderReference(ref, mode)` shape is *already implemented* on the stored
+   side; the live side is what has to give.
+2. **Media splitting is correct and per-attachment.** `splitStoredMedia` emits a
+   description OR a marker per image, never both and never neither. The live
+   path has no equivalent — its deduped branch carries descriptions while its
+   own content string separately carries markers for the same image, an overlap
+   its comment admits is intentional-for-now.
+3. **Persona hydration** (`resolvedPersonaName` / `resolvedPersonaId` →
+   `from` / `from_id`) has no live counterpart at all.
+
+So the migration direction flips: lift `formatStoredReferencedMessage`'s shape
+into the shared `renderReference`, then make the LIVE path produce a
+`ResolvedReference` that feeds it — rather than treating the live formatter as
+the base and teaching it about stored rows.
+
+**Two more divergences the union must decide, both model-visible:**
+
+- **`number`.** `[Reference N]` numbering is live-only (`StoredReferencedMessage`
+  has no `referenceNumber`); the stored path renders quotes unnumbered. Either
+  the stored path starts numbering positionally or the attribute stays
+  conditional — this is a prompt-shape decision, so it belongs with the owner's
+  vocabulary call rather than being settled silently by whichever branch the
+  refactor happens to write first.
+- **`username`.** The live deduped stub passes it; the stored deduped branch does
+  not. Same quote, one attribute apart.
+
+**Do NOT "fix" the missing `voiceTranscripts` on the stored deduped branch.**
+Its comment is correct and worth preserving through the refactor: the live path
+reads transcripts from in-memory preprocessing, and `StoredReferencedMessage`
+has no audio counterpart to `resolvedImageDescriptions`. That is a schema gap
+owned by TASK-367 (persist the built reference), not a dropped field here — and
+a projection that "inherits every field by construction" must not paper over it
+by emitting an empty section.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-365 - Reference-rendering-has-FOUR-hand-synced-paths-live-stored-x-full-deduped.md
+++ b/tracker/tasks/task-365 - Reference-rendering-has-FOUR-hand-synced-paths-live-stored-x-full-deduped.md
@@ -172,6 +172,22 @@ the base and teaching it about stored rows.
 - **`username`.** The live deduped stub passes it; the stored deduped branch does
   not. Same quote, one attribute apart.
 
+**bot-client's stub deletion — VERIFIED dead, and here is the chain**, because
+the obvious read says otherwise and the next person will hit the same scare.
+`ReferenceFormatter.appendDedupedStub` pushes the stub into `s.references`,
+which reaches `ConversationPersistence`, whose line ~271 writes
+`referencedMessages: convertToStoredReferences(referencedMessages)` — a DB
+write, not a log line. That looks like the stub being persisted.
+
+It is not reachable. `PersonalityChatManager` calls `saveUserMessage` WITHOUT a
+`referencedMessages` argument (the arg was removed as a no-op — the thin
+envelope never carries that field), so the optional param is undefined and the
+`if (referencedMessages && ...)` guard never opens on the live path. The
+enriched array's only live consumers are log lines. Stored reference rows come
+from `DiscordChannelFetcher` instead — a different path entirely.
+
+So the deletion is safe. Trace the guard, not just the write.
+
 **Do NOT "fix" the missing `voiceTranscripts` on the stored deduped branch.**
 Its comment is correct and worth preserving through the refactor: the live path
 reads transcripts from in-memory preprocessing, and `StoredReferencedMessage`

--- a/tracker/tasks/task-373 - Audit-content-that-QUOTES-our-control-syntax-—-every-parse-site-not-just-thinking-tags.md
+++ b/tracker/tasks/task-373 - Audit-content-that-QUOTES-our-control-syntax-—-every-parse-site-not-just-thinking-tags.md
@@ -32,4 +32,42 @@ ordinal: 373000
 **Test shape (applies to every site found)**: feed content that QUOTES the delimiter mid-prose and assert the output is unchanged — nothing extracted, nothing truncated. Verify RED where the site is actually broken.
 
 **Discriminators worth evaluating once, then applying consistently** (rather than per-site ad hoc): position heuristics (real control syntax is a prefix/suffix phenomenon; quoted syntax is mid-text), code-fence and inline-backtick awareness, and proportion guards (refuse an extraction that would consume most of the response).
+
+## SCOPE UPDATE — what #1880 closed, and what it settled for the rest of the sweep
+
+`thinkingExtraction.ts` is **done**: the unclosed-tag path (position anchor), the
+orphan-closing-tag path (code markup), and the `ORPHAN_CLOSING_TAG_CLEANUP` +
+`CHIMERA_ARTIFACT_PATTERN` erasure passes are all gated, with a table-driven
+guard over `KNOWN_THINKING_TAGS` × quoting shape so a new tag inherits coverage.
+
+Three results that carry to every remaining site, so they are not re-derived:
+
+1. **The proportion guard is evidence-rejected. Do not re-propose it.** The
+   production reply had ~2/3 of its text before the quoted tag, so extraction
+   consumed only ~1/3 — no threshold loose enough to spare genuine truncation
+   would have fired.
+2. **The discriminator is per-site by necessity, not by sloppiness.** Position
+   works only where the real signal is a prefix/suffix phenomenon; where the
+   real shape is mid-text (the Kimi K2.5 orphan tag), code markup is the ONLY
+   separator. Expect to pick per site and justify the pick from that site's own
+   observed real cases.
+3. **`isInsideCodeSpan` exists** (`packages/common-types/src/utils/codeSpanDetection.ts`)
+   — inline backticks + fenced blocks, single left-to-right scan. Reuse it;
+   do not write a second one.
+
+**Perf caveat, from #1880's round-2 review — a member of this task, since this
+task owns the reuse.** `isInsideCodeSpan` re-scans from offset 0 on every call,
+so a caller that invokes it once per candidate match is O(n·m). Irrelevant at
+Discord reply lengths (low thousands of chars, few candidates), which is why
+#1880 left it alone. It stops being irrelevant at the sites THIS task targets —
+`promptSanitizer` runs over the full assembled prompt, not one reply. Before
+wiring it into a whole-prompt path, either hoist the scan (compute code-span
+ranges once per string and binary-search offsets) or confirm the call count is
+bounded. Measure at the site; do not optimize blind.
+
+**Check TASK-375 before designing a discriminator for the unfenced-quote gap.**
+The remaining gap (an unfenced `</think>` mid-prose is still consumed) exists
+ONLY to keep the Kimi K2.5 orphan path working. If that model is out of
+rotation, deleting the path closes the gap by construction — a cheaper and more
+honest answer than a cleverer heuristic.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-374 - Detect-machine-capability-and-load-at-runtime-instead-of-hard-coding-low-resource-mode.md
+++ b/tracker/tasks/task-374 - Detect-machine-capability-and-load-at-runtime-instead-of-hard-coding-low-resource-mode.md
@@ -1,0 +1,28 @@
+---
+id: TASK-374
+title: >-
+  Detect machine capability and load at runtime instead of hard-coding
+  low-resource mode
+status: To Do
+assignee: []
+created_date: '2026-07-31 01:50'
+labels:
+  - 'size:M'
+dependencies: []
+priority: low
+ordinal: 374000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Owner-requested, low priority side project: "instead of hard coding in the repo instructions to manage low resource mode for my Steam Deck, we should have tooling that determines system load and inherent capabilities."
+
+Why: today the constraint lives as prose in .claude/rules/05-tooling.md (never run pnpm test and pnpm quality in parallel; never run test:integration locally) plus a manual LOW_RESOURCE_MODE=1 env flag. Prose is advisory — it depends on the agent remembering, and it is wrong on any machine that is NOT the Steam Deck, which makes it a portability tax as well as a reliability one. It also cannot react to the actual state of the box: the same command is fine on an idle machine and an OOM kill with a browser and the IDE open.
+
+What: a small ops helper that reads inherent capability (core count, total RAM) and current load (available RAM, load average) and derives the knobs the heavy commands need - vitest maxWorkers/pool, whether a chained run must serialize, whether to refuse a known-OOM command outright. Consumed by the test/quality scripts so the decision is made from measurement rather than from a rule the reader has to recall.
+
+Acceptance: heavy commands pick their own concurrency from measured capability; LOW_RESOURCE_MODE becomes an override rather than the mechanism; the Steam-Deck-specific prose in 05-tooling.md shrinks to a pointer at the tool.
+
+Note: low priority and explicitly a side project - do not let it preempt product work.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-375 - Does-CHIMERA_ARTIFACT_PATTERN-still-earn-its-keep-now-that-tng-r1t-chimera-is-gone.md
+++ b/tracker/tasks/task-375 - Does-CHIMERA_ARTIFACT_PATTERN-still-earn-its-keep-now-that-tng-r1t-chimera-is-gone.md
@@ -25,4 +25,34 @@ What to check before removing: whether any model currently in rotation emits the
 Outcome is one of: (a) remove the pattern and its three tests with the evidence recorded in the removing commit, or (b) keep it and note in its docstring which live model justifies it, so the next reader does not re-ask.
 
 Note the shape of the risk if removed wrongly: the stutter leaks a garbage fragment into a user-visible reply. Cosmetic, recoverable, low blast radius - which is why this is worth resolving rather than carrying forever.
+
+## WIDENED — the same question owns `extractOrphanClosingTag` (Kimi K2.5)
+
+Surfaced by #1880's round-2 review, which flagged the remaining unfenced-quote
+gap as "the most likely source of a future bug report": a reply saying
+_"...and then it just prints `</think>` before answering"_ **without** backticks
+still loses everything before the tag. #1880 pinned that as a KNOWN LIMIT
+because no signal separates it from the real Kimi K2.5 shape (reasoning, then a
+bare `</think>`, then the answer) — both are mid-line, mid-text prose.
+
+But that framing assumes the Kimi K2.5 path still has to exist. It is the
+**same lifecycle question as the chimera pattern, one model later**: a
+model-specific extraction whose cost (eating a user's prose) is
+model-independent. If nothing in rotation still emits a bare orphan closing tag,
+retiring `extractOrphanClosingTag` **closes the unfenced-quote gap by
+construction** — no discriminator needed, because the ambiguity only exists to
+serve a path nobody needs.
+
+So resolve both together, on the same evidence sweep:
+
+- Does any live model emit the chimera stutter shape?
+- Does any live model emit a bare orphan `</think>` with no opening tag?
+
+Both answers come from prod logs + `/inspect` raw content, not from reasoning
+about the model list. A "no" on the second is worth materially more than a "no"
+on the first: it deletes an ambiguity this codebase currently cannot resolve.
+
+Order note: this is the cheap structural answer to a gap TASK-373 would
+otherwise try to solve with a cleverer discriminator. Check the lifecycle
+question BEFORE designing one.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-375 - Does-CHIMERA_ARTIFACT_PATTERN-still-earn-its-keep-now-that-tng-r1t-chimera-is-gone.md
+++ b/tracker/tasks/task-375 - Does-CHIMERA_ARTIFACT_PATTERN-still-earn-its-keep-now-that-tng-r1t-chimera-is-gone.md
@@ -1,0 +1,28 @@
+---
+id: TASK-375
+title: >-
+  Does CHIMERA_ARTIFACT_PATTERN still earn its keep now that tng-r1t-chimera is
+  gone?
+status: To Do
+assignee: []
+created_date: '2026-07-31 02:17'
+labels:
+  - 'size:S'
+dependencies: []
+priority: low
+ordinal: 375000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Surfaced during PR #1880 (quoted-control-syntax fix). The pattern in services/ai-worker/src/utils/thinkingExtraction.ts targets a stutter shape observed in the merged tng-r1t-chimera model. Owner note during that review: "the Chimera model is dead to me now that it is gone from the OpenRouter Free tier."
+
+Why this is a question and not a deletion: the pattern runs on EVERY response, not only chimera ones, so its cost is model-independent even though its benefit is model-specific. #1880 confirmed a real false positive at runtime - a quoted `token. </tag>` fragment at the start of a line was eaten, leaving a dangling backtick and a mangled sentence - and gated it on isInsideCodeSpan. That closes the observed corruption; it does not answer whether the pass is still buying anything.
+
+What to check before removing: whether any model currently in rotation emits the stutter shape (short token + period immediately before an orphan closing tag). Evidence source is prod logs plus the /inspect raw-content diagnostics, not reasoning about which models we think we run. 00-critical is explicit that "this seems unnecessary" is a reason to verify, not to delete, and the KEEP-list lesson applies: wired-in is not the same as live.
+
+Outcome is one of: (a) remove the pattern and its three tests with the evidence recorded in the removing commit, or (b) keep it and note in its docstring which live model justifies it, so the next reader does not re-ask.
+
+Note the shape of the risk if removed wrongly: the stutter leaks a garbage fragment into a user-visible reply. Cosmetic, recoverable, low blast radius - which is why this is worth resolving rather than carrying forever.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-376 - Watch-logDeclinedMidResponseTag-info-line-volume-after-the-quoted-tag-fix-deploys.md
+++ b/tracker/tasks/task-376 - Watch-logDeclinedMidResponseTag-info-line-volume-after-the-quoted-tag-fix-deploys.md
@@ -1,0 +1,26 @@
+---
+id: TASK-376
+title: >-
+  Watch logDeclinedMidResponseTag info-line volume after the quoted-tag fix
+  deploys
+status: To Do
+assignee: []
+created_date: '2026-07-31 03:06'
+labels:
+  - 'size:S'
+dependencies: []
+priority: low
+ordinal: 376000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Surfaced by #1880 round-3 review. The new logger.info in thinkingExtraction.tryFallbackExtraction fires whenever fallback extraction runs AND a mid-response opening thinking tag is present. Fallback runs on most replies that contain no complete tag pair, so the exec runs often; the log itself only fires on a literal angle-bracket tag, which should be rare.
+
+Why it was added rather than skipped: the mid-response-unclosed-tag case is unobserved, not impossible. Declining to extract there is a deliberate trade, and this line is the only way we would learn the declined case is real rather than theoretical. It is permanent observability (feat), not scaffolding (debug) - do not sweep it as stale instrumentation.
+
+Observable to check: after the fix reaches prod, look at ai-worker logs for "Opening thinking tag mid-response". Two outcomes worth acting on - (a) high volume means the exec/scan pair is running hotter than expected and the line should drop to debug or gain a rate limit; (b) any occurrence where quoted=false is genuinely interesting, because it is the unobserved genuine-mid-response-reasoning case and would justify revisiting the position discriminator.
+
+Outcome (b) is the valuable one. If it never fires with quoted=false over a reasonable window, that is positive evidence the head-anchor assumption is correct, and worth recording in the task before closing.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
Fixes **TASK-372** (prod, owner-reported) and closes the two data-loss paths of **TASK-373**'s sweep.

## The bug

A character reply that *quoted* a reasoning delimiter had part of itself consumed as reasoning. The trigger is ordinary for this product — the bot hosts AI characters, so replies routinely discuss model internals.

I reproduced both paths against the pre-fix code before designing anything:

| Input | Pre-fix `visibleContent` |
| --- | --- |
| Reply quoting `` `<thinking>` `` mid-prose | **truncated at the backtick**; remainder refiled as reasoning |
| Reply merely mentioning `` `</think>` `` | **opening 72 chars deleted**; reply starts mid-word |

The first is the reported bug: `UNCLOSED_TAG_PATTERN` matched the quoted opening tag and captured `[\s\S]*$`. The existing guard only fires when extraction leaves visible content **empty**, so it catches a tag at position 0 and structurally cannot catch one quoted mid-response.

The second was filed as a suspicion under TASK-373 and is now runtime-confirmed data loss — and it is the easier one to hit, since it needs no unclosed tag at all.

## The discriminator differs per path, and the evidence forces it

- **Opening tags → position.** Every observed real case (GLM 4.5 Air's unclosed-tag glitch, max-tokens truncation, the malformed-closer case) is head-anchored. This restores the `^\s*` guarantee all three Pass-1 GLM patterns already document as load-bearing — `UNCLOSED_TAG_PATTERN` was the one pattern that never got it. With the anchor, the old mid-response extract branch becomes unreachable and is deleted.
- **Closing tags → code markup.** Position cannot work here: Kimi K2.5's real bug puts `</think>` mid-line, mid-text, exactly where a quotation sits. New `isInsideCodeSpan` (common-types, beside `promptSanitizer` — the next parse site that will need it) covers inline backticks and fenced blocks.
- **Proportion guard — evaluated and rejected.** The production reply had ~2/3 of its text before the tag, so extraction took only ~1/3; no threshold loose enough to spare genuine truncation would have fired. Recorded so the sibling audit doesn't re-litigate it.

**Known limit, pinned by a test:** an *unfenced* closing tag mid-prose is still consumed. It is positionally identical to the Kimi shape with no signal to separate them, so extraction stays the default. Visible boundary rather than a discovered one.

## Two tests are rewritten, not deleted

Flagging explicitly, since `00-critical.md` forbids editing tests to make them pass — these are the inverse case, tests that encoded an invariant production disproved:

- `'should still extract unclosed tag mid-response'` — its comment asserted *"When there's visible content before the unclosed tag, extraction is safe"*. That is the false claim, sitting in a test comment.
- `'should strip leading stray punctuation…'` used a mid-response unclosed tag as its vehicle; its actual subject is already covered by three complete-tag cases beside it.

Both now assert the reply survives intact.

## Structural guard

The replacement suite is **table-driven over `KNOWN_THINKING_TAGS` × quoting shape** (inline backticks, fenced block) × (opening, closing). The file's own docstrings note the vocabulary grows with every GLM revision, and each addition widens this exact surface — driving the table off the constant means a new tag inherits quoted-form coverage instead of arriving unguarded.

Also fixed along the way: `hasThinkingBlocks` no longer over-reports quoted tags to `/inspect` diagnostics, and the orphan cleanup no longer deletes a quoted closing tag from an otherwise-intact reply.

## Verified

- `thinkingExtraction.test.ts`: 122 → 161 tests, all green. The two predicted failures were the **only** ones — Kimi K2.5, chimera, all three GLM Pass-1 extractors, and every head-anchored unclosed case pass unchanged, which is the regression bar for the discriminator being right.
- `codeSpanDetection.test.ts`: 15 tests (inline, fenced, unterminated, fence/inline interaction).
- Full `pnpm test` green (all packages), then `pnpm quality` green (27/27 checks), run sequentially.
- `pnpm knip` clean — exporting `KNOWN_THINKING_TAGS` for the guard table reads as used.

**Not CI-verifiable**: the Discord round trip. Smoke item added at ship — ask a character to quote a `<thinking>` tag, and separately to mention `</think>` in prose; the reply must arrive whole with the tags intact.

Second commit is an unrelated one-file backlog entry (TASK-374, owner-requested during this session) riding along rather than needing its own push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)