### PR TITLE
refactor(ai-worker): one vocabulary for a quoted message's attachments

### DIFF
--- a/packages/common-types/src/utils/promptSanitizer.ts
+++ b/packages/common-types/src/utils/promptSanitizer.ts
@@ -32,7 +32,10 @@
  *
  * Deliberately NOT here: `voice_transcripts` / `transcript` — wrapped AFTER
  * escaping and neutralized via `neutralizeWrapperClosingTags` on every path
- * (protecting them would escape our own wrapper).
+ * (protecting them would escape our own wrapper). Note this is about those two
+ * MESSAGE-level tags only; the singular `voice` element listed below is a
+ * quote-level attachment child and IS protected through the ordinary
+ * `escapeXmlContent` mechanism, so the two are not in tension.
  */
 export const PROTECTED_TAGS = [
   // Top-level section boundaries (escaping any reaches top-level system scope)
@@ -69,6 +72,12 @@ export const PROTECTED_TAGS = [
   'image_descriptions',
   'image',
   'attachments',
+  // Per-attachment elements inside <attachments>. `image` and `voice` wrap
+  // user-derived enrichment (a vision description, a voice transcript), so a
+  // closing form in that text must not break out of the quote it sits in.
+  // `file` is self-closing (attributes only) and is classified in
+  // guard:prompt-tags' KNOWN_UNPROTECTED_TAGS instead.
+  'voice',
   // Participant boundaries (one participant must not forge another's block).
   // role/note are single-pass emissions (not inside the re-escaped persona),
   // so protecting them is clean containment with no double-escape conflict.

--- a/packages/tooling/src/dev/check-prompt-tags.ts
+++ b/packages/tooling/src/dev/check-prompt-tags.ts
@@ -85,6 +85,10 @@ export const KNOWN_UNPROTECTED_TAGS: Record<string, string> = {
   channel: 'Self-closing; channel name/type/topic attributes via escapeXml.',
   thread: 'Self-closing; thread name attribute via escapeXml.',
   time: 'Self-closing; timestamp attributes via escapeXml.',
+  file:
+    'Self-closing attachment element; filename/type attributes via escapeXml (full). ' +
+    'Never wraps content — an attachment with enrichment renders as <image>/<voice>, ' +
+    'both of which ARE protected.',
   from_id: 'Attribute-only (escapeXml) plus literal constraint text; not a content tag.',
   roles: 'Wraps <role> elements whose values are escapeXml (full).',
   guild_info: 'Attributes + child <role>s all escapeXml (full).',

--- a/services/ai-worker/src/jobs/utils/conversationLengthEstimator.ts
+++ b/services/ai-worker/src/jobs/utils/conversationLengthEstimator.ts
@@ -8,8 +8,10 @@
 
 import { type StoredReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
+import { renderAttachment } from '../../services/prompt/QuoteFormatter.js';
 import type { RawHistoryEntry } from './conversationTypes.js';
 import { resolveSpeakerInfo, type ChatLogRole } from './participantUtils.js';
+import { buildStoredAttachments } from './xmlMetadataFormatters.js';
 
 /**
  * Estimate character length for a stored reference
@@ -24,11 +26,20 @@ function estimateReferenceLength(ref: StoredReferencedMessage): number {
     length += `\n<embeds>${ref.embeds}</embeds>`.length;
   }
 
-  if (ref.attachments !== undefined && ref.attachments.length > 0) {
-    const attachmentItems = ref.attachments
-      .map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
-      .join(', ');
-    length += `\n<attachments>${attachmentItems}</attachments>`.length;
+  const attachments = buildStoredAttachments(ref);
+  if (attachments.length > 0) {
+    // Measured through the REAL producer/renderer pair rather than a local
+    // approximation of them. The marker-string estimate this replaced was wrong
+    // in three compounding ways: it omitted a persisted description entirely
+    // (the largest single term in a reference's cost), it rendered every
+    // attachment image-shaped regardless of modality, and it could only ever
+    // drift further as the renderer moved.
+    //
+    // This is the shape the rest of the estimator still needs (see TASK-370):
+    // the surrounding <quote> estimate below is still a hand-written
+    // approximation and still disagrees with the renderer on attribute names.
+    length += `\n<attachments>\n${attachments.map(renderAttachment).join('\n')}\n</attachments>`
+      .length;
   }
 
   if (ref.isForwarded === true) {

--- a/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
@@ -16,6 +16,8 @@ import {
   getFormattedMessageCharLength,
   type RawHistoryEntry,
 } from './conversationUtils.js';
+import { renderAttachment } from '../../services/prompt/QuoteFormatter.js';
+import { buildStoredAttachments } from './xmlMetadataFormatters.js';
 import { MessageRole } from '@tzurot/common-types/constants/message';
 import {
   type CrossChannelHistoryGroupEntry,
@@ -685,8 +687,8 @@ describe('Conversation Utilities', () => {
       // Should have forwarded wrapping even with no text content
       expect(result).toContain('<quoted_messages>');
       expect(result).toContain('<quote type="forward" from="Unknown">');
-      expect(result).toContain('<image_descriptions>');
-      expect(result).toContain('A beautiful sunset photo');
+      expect(result).toContain('<attachments>');
+      expect(result).toContain('<image filename="img.png">A beautiful sunset photo</image>');
       expect(result).toContain('</quote>');
       // Should NOT be empty
       expect(result).not.toMatch(/<message[^>]*><\/message>/);
@@ -718,22 +720,21 @@ describe('Conversation Utilities', () => {
       const result = formatConversationHistoryAsXml(history, 'TestBot');
 
       // Attachments should be INSIDE the quote, not at message level
-      // The quote should contain: content + image_descriptions + embeds + voice_transcript
+      // The quote should contain: content + embeds + attachments, and the
+      // attachments section now holds every modality rather than one section each.
       expect(result).toMatch(
-        /<quote type="forward" from="Unknown">.*<image_descriptions>.*<\/image_descriptions>.*<\/quote>/s
+        /<quote type="forward" from="Unknown">.*<attachments>.*<\/attachments>.*<\/quote>/s
       );
       expect(result).toMatch(
         /<quote type="forward" from="Unknown">.*<embeds>.*<\/embeds>.*<\/quote>/s
       );
-      expect(result).toMatch(
-        /<quote type="forward" from="Unknown">.*<voice_transcripts>.*<\/voice_transcripts>.*<\/quote>/s
-      );
+      expect(result).toMatch(/<attachments>.*<image .*<voice>.*<\/attachments>/s);
 
       // Attachments should NOT appear outside the quoted_messages section
       // (after </quoted_messages> and before </message>)
-      expect(result).not.toMatch(/<\/quoted_messages>\s*<image_descriptions>/);
+      expect(result).not.toMatch(/<\/quoted_messages>\s*<attachments>/);
       expect(result).not.toMatch(/<\/quoted_messages>\s*<embeds>/);
-      expect(result).not.toMatch(/<\/quoted_messages>\s*<voice_transcripts>/);
+      expect(result).not.toMatch(/<\/quoted_messages>\s*<image_descriptions>/);
     });
 
     it('should use forwardedAttachmentLines as fallback when no vision descriptions', () => {
@@ -789,11 +790,12 @@ describe('Conversation Utilities', () => {
 
       const result = formatConversationHistoryAsXml(history, 'TestBot');
 
-      // Should use vision descriptions, not attachment fallback
-      expect(result).toContain('<image_descriptions>');
-      expect(result).toContain('A beautiful sunset over the ocean');
-      // Should NOT include the fallback attachment lines
-      expect(result).not.toContain('<attachments>');
+      // Should use vision descriptions, not the persisted marker fallback.
+      expect(result).toContain(
+        '<image filename="photo.png">A beautiful sunset over the ocean</image>'
+      );
+      // The redundant marker for the SAME file must not also render — that is
+      // the invariant; the wrapper it would have rendered in is now shared.
       expect(result).not.toContain('[image/png: photo.png]');
     });
 
@@ -956,7 +958,7 @@ describe('Conversation Utilities', () => {
       const result = formatConversationHistoryAsXml(history, 'TestBot');
 
       expect(result).toContain(
-        '<image filename="embed-image-1.png">SENTINEL_REPLAY_VISION</image>'
+        '<image filename="embed-image-1.png" type="image/png">SENTINEL_REPLAY_VISION</image>'
       );
     });
 
@@ -1632,6 +1634,105 @@ describe('Conversation Utilities', () => {
       const withoutAtt = getFormattedMessageCharLength(msgWithoutAtt, 'TestBot');
 
       expect(withAtt).toBeGreaterThan(withoutAtt);
+    });
+
+    it('counts a hydrated image description in the reference length', () => {
+      // The described branch is the whole point of the estimate: a persisted
+      // vision description is the largest single term a quoted message
+      // contributes, and the marker-string estimate this replaced omitted it
+      // entirely — so the budget believed a described image cost the same as a
+      // bare filename. Sized against a long sentinel so the delta cannot be
+      // confused with attribute-level noise.
+      const description = 'A '.repeat(200) + 'lighthouse';
+
+      const base = {
+        discordMessageId: '123456',
+        authorUsername: 'bob',
+        authorDisplayName: 'Bob',
+        content: 'Message',
+        timestamp: '2025-01-01T00:00:00Z',
+        locationContext: '#general',
+        attachments: [
+          { url: 'https://example.com/p.png', contentType: 'image/png', name: 'photo.png' },
+        ],
+      };
+
+      const described: StoredReferencedMessage = {
+        ...base,
+        resolvedImageDescriptions: [{ filename: 'photo.png', description }],
+      };
+
+      const lengthOf = (ref: StoredReferencedMessage): number =>
+        getFormattedMessageCharLength(
+          { role: 'user', content: 'Reply', messageMetadata: { referencedMessages: [ref] } },
+          'TestBot'
+        );
+
+      // Compared as a ratio, not an exact figure: the undescribed arm carries a
+      // `status="undescribed"` attribute the described arm does not, so the two
+      // differ by the description MINUS a small constant. Pinning the constant
+      // would make this test a transcription of the tag syntax; the invariant
+      // worth holding is that the description is counted essentially in full.
+      // Dropped entirely, this delta goes NEGATIVE.
+      const delta = lengthOf(described) - lengthOf(base);
+      expect(delta).toBeGreaterThan(description.length * 0.9);
+    });
+
+    it('measures attachments through the real producer/renderer pair', () => {
+      // Parity pin, not an approximation check. The estimator used to hand-write
+      // its own version of the attachment markup, which drifted from the renderer
+      // in every direction at once — wrong element per modality, a `status` on
+      // files that never carry one, descriptions omitted entirely. It now calls
+      // `buildStoredAttachments` + `renderAttachment` directly, and this test
+      // fails the moment anyone reintroduces a local copy.
+      const withAttachments: StoredReferencedMessage = {
+        discordMessageId: '123456',
+        authorUsername: 'bob',
+        authorDisplayName: 'Bob',
+        content: 'Message',
+        timestamp: '2025-01-01T00:00:00Z',
+        locationContext: '#general',
+        attachments: [
+          { url: 'https://example.com/p.png', contentType: 'image/png', name: 'photo.png' },
+          {
+            url: 'https://example.com/v.ogg',
+            contentType: 'audio/ogg',
+            name: 'clip.ogg',
+            // `isVoiceMessage` is what makes this a voice message on BOTH paths.
+            // Without it this is a shared audio file and renders as <file/>.
+            isVoiceMessage: true,
+            duration: 9,
+          },
+          { url: 'https://example.com/d.pdf', contentType: 'application/pdf', name: 'doc.pdf' },
+        ],
+        resolvedImageDescriptions: [{ filename: 'photo.png', description: 'a lighthouse' }],
+      };
+      const withoutAttachments: StoredReferencedMessage = {
+        ...withAttachments,
+        attachments: undefined,
+        resolvedImageDescriptions: undefined,
+      };
+
+      const lengthOf = (ref: StoredReferencedMessage): number =>
+        getFormattedMessageCharLength(
+          { role: 'user', content: 'Reply', messageMetadata: { referencedMessages: [ref] } },
+          'TestBot'
+        );
+
+      const rendered = buildStoredAttachments(withAttachments).map(renderAttachment).join('\n');
+      const expected = `\n<attachments>\n${rendered}\n</attachments>`.length;
+
+      expect(lengthOf(withAttachments) - lengthOf(withoutAttachments)).toBe(expected);
+
+      // And the three modalities really are distinct in that rendering — the
+      // specific thing the hand-written estimate got wrong.
+      expect(rendered).toContain(
+        '<image filename="photo.png" type="image/png">a lighthouse</image>'
+      );
+      expect(rendered).toContain(
+        '<voice filename="clip.ogg" type="audio/ogg" duration="9s" status="untranscribed"/>'
+      );
+      expect(rendered).toContain('<file filename="doc.pdf" type="application/pdf"/>');
     });
 
     it('should include forwarded type in reference length', () => {

--- a/services/ai-worker/src/jobs/utils/conversationUtils.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.ts
@@ -21,7 +21,10 @@ import {
   type TimeGapConfig,
 } from '@tzurot/common-types/utils/timeGap';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
-import { formatForwardedQuote } from '../../services/prompt/QuoteFormatter.js';
+import {
+  formatForwardedQuote,
+  type RenderableAttachment,
+} from '../../services/prompt/QuoteFormatter.js';
 
 // Re-export from extracted modules for backward compatibility
 export { extractParticipants } from './participantUtils.js';
@@ -62,6 +65,31 @@ import {
  * @param allPersonalityNames - Optional set of all AI personality names in the conversation (for multi-AI collision detection)
  * @returns Formatted XML string, or empty string if message should be skipped
  */
+
+/**
+ * Adapt a forwarded message's persisted enrichment into renderable attachments.
+ *
+ * The two source arrays are the schema's own split — descriptions and transcripts
+ * are stored separately — but they describe the same kind of thing, so they merge
+ * into one ordered list here rather than staying two sections in the output.
+ * Neither array carries a content type, and transcripts carry no filename either;
+ * both are simply omitted rather than filled with a placeholder.
+ */
+function toRenderableAttachments(
+  metadata: RawHistoryEntry['messageMetadata']
+): RenderableAttachment[] {
+  return [
+    ...(metadata?.imageDescriptions ?? []).map((img): RenderableAttachment => ({
+      kind: 'image',
+      filename: img.filename,
+      description: img.description,
+    })),
+    ...(metadata?.voiceTranscripts ?? []).map((transcript): RenderableAttachment => ({
+      kind: 'voice',
+      description: transcript,
+    })),
+  ];
+}
 
 export function formatSingleHistoryEntryAsXml(
   msg: RawHistoryEntry,
@@ -130,10 +158,12 @@ export function formatSingleHistoryEntryAsXml(
     // so the shared formatter produces consistent XML across both code paths
     const forwardedQuote = formatForwardedQuote({
       textContent: msg.content,
-      imageDescriptions: msg.messageMetadata?.imageDescriptions,
       embedsXml: msg.messageMetadata?.embedsXml,
-      voiceTranscripts: msg.messageMetadata?.voiceTranscripts,
-      attachmentLines: hasAttachmentFallback ? forwardedAttachmentLines : undefined,
+      attachments: toRenderableAttachments(msg.messageMetadata),
+      // Persisted `[contentType: name]` strings — the one producer this refactor
+      // cannot restructure, because the rows already exist. See
+      // `QuoteElementOptions.legacyAttachmentLines`.
+      legacyAttachmentLines: hasAttachmentFallback ? forwardedAttachmentLines : undefined,
     });
     formattedContent = `<quoted_messages>\n${forwardedQuote}\n</quoted_messages>`;
     // Attachments already included in quote, don't duplicate at message level

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
@@ -58,77 +58,36 @@ vi.mock('@tzurot/common-types/utils/xmlBuilder', async () => {
   };
 });
 
-// Mock QuoteFormatter - pass through to real implementation for structural tests
-const { mockFormatQuoteElement, mockFormatDedupedQuote } = vi.hoisted(() => {
-  const fqe = vi.fn().mockImplementation((opts: Record<string, unknown>) => {
-    const attrs: string[] = [];
-    if (opts.type !== undefined) attrs.push(`type="${opts.type}"`);
-    if (opts.from !== undefined) attrs.push(`from="${opts.from}"`);
-    if (opts.fromId !== undefined) attrs.push(`from_id="${opts.fromId}"`);
-    if (opts.role !== undefined) attrs.push(`role="${opts.role}"`);
-    if (opts.timeFormatted !== undefined) attrs.push(`t="${opts.timeFormatted}"`);
-    const attrStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
-
-    const parts = [`<quote${attrStr}>`];
-    if (opts.content !== undefined) parts.push(`<content>${opts.content}</content>`);
-    if (opts.imageDescriptions !== undefined) {
-      const imgs = opts.imageDescriptions as { filename: string; description: string }[];
-      parts.push('<image_descriptions>');
-      for (const img of imgs) {
-        parts.push(`<image filename="${img.filename}">${img.description}</image>`);
-      }
-      parts.push('</image_descriptions>');
-    }
-    if (opts.attachmentLines !== undefined) {
-      const lines = opts.attachmentLines as string[];
-      parts.push('<attachments>');
-      parts.push(...lines);
-      parts.push('</attachments>');
-    }
-    parts.push('</quote>');
-    return parts.join('\n');
-  });
-
-  // Mirror the REAL formatDedupedQuote: render content AS-IS (no truncation). The cap now
-  // happens upstream in formatQuotedSection via the real capDedupText, so the
-  // "truncates long content" test below verifies THAT cap, not a mock-side truncation.
-  //
-  // `imageDescriptions` must be forwarded here or the mock silently swallows the
-  // very field the deduped path was fixed to carry — a stub that drops what the
-  // real function renders makes this suite blind to the bug it should catch.
-  const fdq = vi
-    .fn()
-    .mockImplementation(
-      (opts: {
-        from: string;
-        role?: string;
-        timeFormatted?: string;
-        content: string;
-        imageDescriptions?: { filename: string; description: string }[];
-      }) => {
-        // The real prefix switches on whether media rides along; mirror that or
-        // the stub asserts a wording the production path would not emit.
-        const prefix =
-          (opts.imageDescriptions?.length ?? 0) > 0
-            ? '[Referenced message — full text in the chat log; its media is described here]'
-            : '[Referenced message — full text in the chat log]';
-        return fqe({
-          from: opts.from,
-          role: opts.role,
-          timeFormatted: opts.timeFormatted,
-          content: `${prefix}\n\n${opts.content}`,
-          imageDescriptions: opts.imageDescriptions,
-        });
-      }
-    );
-
-  return { mockFormatQuoteElement: fqe, mockFormatDedupedQuote: fdq };
-});
-
-vi.mock('../../services/prompt/QuoteFormatter.js', () => ({
-  formatQuoteElement: mockFormatQuoteElement,
-  formatDedupedQuote: mockFormatDedupedQuote,
+// Spies that DELEGATE to the real QuoteFormatter rather than reimplementing it.
+//
+// Their predecessors were hand-written stand-ins that rebuilt the <quote> element
+// from scratch — a second renderer, kept in sync by hand, in the test suite for
+// the bug class that is exactly "renderers kept in sync by hand". It failed the
+// way that always fails: the stub dropped a field the real function rendered, and
+// the suite went blind to the very drop it was meant to catch (fixed once by
+// bolting `imageDescriptions` onto the stub, which bought one field and left the
+// next one just as exposed).
+//
+// Delegating keeps the call-argument assertions — the seam this suite verifies is
+// what `formatQuotedSection` HANDS the renderer — while the rendering itself is
+// the production code's, so it cannot drift.
+const { mockFormatQuoteElement, mockFormatDedupedQuote } = vi.hoisted(() => ({
+  mockFormatQuoteElement: vi.fn(),
+  mockFormatDedupedQuote: vi.fn(),
 }));
+
+vi.mock('../../services/prompt/QuoteFormatter.js', async () => {
+  const actual = await vi.importActual<typeof import('../../services/prompt/QuoteFormatter.js')>(
+    '../../services/prompt/QuoteFormatter.js'
+  );
+  mockFormatQuoteElement.mockImplementation(actual.formatQuoteElement);
+  mockFormatDedupedQuote.mockImplementation(actual.formatDedupedQuote);
+  return {
+    ...actual,
+    formatQuoteElement: mockFormatQuoteElement,
+    formatDedupedQuote: mockFormatDedupedQuote,
+  };
+});
 
 function makeEntry(overrides: Partial<RawHistoryEntry> = {}): RawHistoryEntry {
   return {
@@ -244,20 +203,19 @@ describe('xmlMetadataFormatters', () => {
       });
 
       const result = formatQuotedSection(msg, 'user', personalityName, undefined, undefined);
-      expect(result).toContain('<image_descriptions>');
-      expect(result).toContain('filename="photo.png"');
-      expect(result).toContain('A sunset over the ocean');
-      // Image attachments should NOT appear in attachmentLines
+      expect(result).toContain(
+        '<image filename="photo.png" type="image/png">A sunset over the ocean</image>'
+      );
+      // ONE element for the image, not a description plus a separate marker.
       expect(result).not.toContain('[image/png: photo.png]');
+      expect(result.match(/<image /g)).toHaveLength(1);
     });
 
-    it('keeps a marker for an image that has no description, when a sibling does', () => {
+    it('keeps an undescribed image visible when a sibling image IS described', () => {
       // Partial vision resolution: two images, one describe succeeded and one
       // failed. Failures are never persisted (visionDescriptionWriter), so the
-      // stored row carries one description for two images. Gating the marker
-      // filter on "this reference has ANY description" would drop BOTH markers
-      // and render only one image — the undescribed one vanishes entirely,
-      // which is the same silent-invisibility class this whole path just fixed.
+      // stored row carries one description for two images. The undescribed one
+      // must not vanish — that silent invisibility is the class this path fixed.
       const msg = makeEntry({
         messageMetadata: {
           referencedMessages: [
@@ -292,11 +250,16 @@ describe('xmlMetadataFormatters', () => {
 
       const result = formatQuotedSection(msg, 'user', personalityName, undefined, undefined);
 
-      expect(result).toContain('A sunset over the ocean');
-      // The described one is not ALSO a marker...
-      expect(result).not.toContain('[image/png: described.png]');
-      // ...and the undescribed one is still visible as one.
-      expect(result).toContain('[image/png: undescribed.png]');
+      // The described one carries its description...
+      expect(result).toContain(
+        '<image filename="described.png" type="image/png">A sunset over the ocean</image>'
+      );
+      // ...and the undescribed one is still present, saying why it is bare.
+      expect(result).toContain(
+        '<image filename="undescribed.png" type="image/png" status="undescribed"/>'
+      );
+      // Exactly two elements for two images — no duplicate representation.
+      expect(result.match(/<image /g)).toHaveLength(2);
     });
 
     it('shows non-image attachments alongside image descriptions', () => {
@@ -331,15 +294,13 @@ describe('xmlMetadataFormatters', () => {
       });
 
       const result = formatQuotedSection(msg, 'user', personalityName, undefined, undefined);
-      // Image description rendered
-      expect(result).toContain('A cat');
-      // Non-image attachment shown in attachmentLines
-      expect(result).toContain('[application/pdf: doc.pdf]');
-      // Image attachment NOT in attachmentLines
+      // Both modalities render, under the one wrapper.
+      expect(result).toContain('<image filename="photo.png" type="image/png">A cat</image>');
+      expect(result).toContain('<file filename="doc.pdf" type="application/pdf"/>');
       expect(result).not.toContain('[image/png: photo.png]');
     });
 
-    it('shows all attachments as lines when no image descriptions hydrated', () => {
+    it('still names an image when no description was hydrated at all', () => {
       const msg = makeEntry({
         messageMetadata: {
           referencedMessages: [
@@ -364,8 +325,90 @@ describe('xmlMetadataFormatters', () => {
       });
 
       const result = formatQuotedSection(msg, 'user', personalityName, undefined, undefined);
-      // Without hydrated descriptions, images show as attachment lines
-      expect(result).toContain('[image/png: photo.png]');
+      // Without a hydrated description the image is still named, with the reason
+      // it has no text — rather than being omitted or rendered as a bare marker.
+      expect(result).toContain(
+        '<image filename="photo.png" type="image/png" status="undescribed"/>'
+      );
+    });
+
+    it('classifies audio exactly as the live path does', () => {
+      // Regression: the stored path used to treat ANY `audio/*` as a voice
+      // message while the live path required `isVoiceMessage`. The same music
+      // clip therefore rendered `<file/>` in the turn it was posted and
+      // `<voice status="untranscribed"/>` when replayed from history — the same
+      // object speaking two vocabularies depending on which path reached it,
+      // which is the split this whole change removes. Both now call
+      // `classifyAttachment`; this pins that they agree.
+      const msg = makeEntry({
+        messageMetadata: {
+          referencedMessages: [
+            {
+              discordMessageId: '123',
+              authorUsername: 'user1',
+              authorDisplayName: 'User One',
+              content: 'audio',
+              timestamp: '2026-01-01T00:00:00.000Z',
+              locationContext: '',
+              attachments: [
+                {
+                  id: 'att-1',
+                  url: 'https://cdn.discord.com/song.mp3',
+                  contentType: 'audio/mp3',
+                  name: 'song.mp3',
+                },
+                {
+                  id: 'att-2',
+                  url: 'https://cdn.discord.com/note.ogg',
+                  contentType: 'audio/ogg',
+                  name: 'note.ogg',
+                  isVoiceMessage: true,
+                  duration: 7,
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = formatQuotedSection(msg, 'user', personalityName, undefined, undefined);
+
+      // Shared audio file: NOT a failed transcription.
+      expect(result).toContain('<file filename="song.mp3" type="audio/mp3"/>');
+      // A real voice message, with its persisted duration carried through.
+      expect(result).toContain(
+        '<voice filename="note.ogg" type="audio/ogg" duration="7s" status="untranscribed"/>'
+      );
+    });
+
+    it('keeps a description whose attachment row has gone missing', () => {
+      // Data-drift protection: a description is paid-for enrichment, so it is
+      // appended even when nothing in `attachments` matches its filename.
+      // Dropping it would re-create the exact silent-loss class this function
+      // was rewritten to close.
+      const msg = makeEntry({
+        messageMetadata: {
+          referencedMessages: [
+            {
+              discordMessageId: '123',
+              authorUsername: 'user1',
+              authorDisplayName: 'User One',
+              content: 'orphaned description',
+              timestamp: '2026-01-01T00:00:00.000Z',
+              locationContext: '',
+              attachments: [],
+              resolvedImageDescriptions: [
+                { filename: 'vanished.png', description: 'SENTINEL_ORPHAN_DESCRIPTION' },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = formatQuotedSection(msg, 'user', personalityName, undefined, undefined);
+      expect(result).toContain(
+        '<image filename="vanished.png">SENTINEL_ORPHAN_DESCRIPTION</image>'
+      );
     });
 
     it('renders deduped stubs for refs whose discordMessageId is in history', () => {
@@ -398,9 +441,10 @@ describe('xmlMetadataFormatters', () => {
       // `content`, so every one of those rows was discarded and the quoted image
       // reached the model as a bare `[image/png: …]` marker.
       //
-      // Asserted at the seam (toHaveBeenCalledWith), not just on the rendered
-      // string: this suite stubs QuoteFormatter, so a string-only assertion would
-      // be testing the stub's own rendering rather than what the caller forwarded.
+      // Asserted at the seam (toHaveBeenCalledWith) AND on the output: the seam
+      // assertion pins what this caller FORWARDS, which is the hop that dropped
+      // the descriptions, and it stays meaningful even if the renderer changes
+      // how it draws them.
       const msg = makeEntry({
         messageMetadata: {
           referencedMessages: [
@@ -437,15 +481,20 @@ describe('xmlMetadataFormatters', () => {
 
       expect(mockFormatDedupedQuote).toHaveBeenCalledWith(
         expect.objectContaining({
-          imageDescriptions: [
-            { filename: 'embed-image-1.png', description: 'SENTINEL_STORED_VISION' },
+          attachments: [
+            {
+              kind: 'image',
+              filename: 'embed-image-1.png',
+              contentType: 'image/png',
+              description: 'SENTINEL_STORED_VISION',
+            },
           ],
         })
       );
       expect(result).toContain('SENTINEL_STORED_VISION');
-      // The marker is the fallback for an UNdescribed image; with a description
-      // in hand it would be the same picture named twice.
+      // One element for the picture, never a description plus a marker.
       expect(result).not.toContain('[image/png: embed-image-1.png]');
+      expect(result.match(/<image /g)).toHaveLength(1);
     });
 
     it('renders role="bot" on a deduped stub from a non-persona bot reference', () => {

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -14,53 +14,77 @@ import {
 } from '@tzurot/common-types/utils/promptSanitizer';
 import { capDedupText } from '@tzurot/common-types/utils/referenceEnrichment';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
-import { formatQuoteElement, formatDedupedQuote } from '../../services/prompt/QuoteFormatter.js';
+import {
+  formatQuoteElement,
+  formatDedupedQuote,
+  classifyAttachment,
+  type RenderableAttachment,
+} from '../../services/prompt/QuoteFormatter.js';
 import { deriveRefRole } from '../../services/prompt/referenceRole.js';
 import type { RawHistoryEntry } from './conversationTypes.js';
 
 /**
- * Split a stored reference's media into the two renderable shapes: hydrated
- * vision descriptions, and `[contentType: name]` markers for everything else.
+ * Build a stored reference's attachments in renderable form: one element per
+ * attachment, carrying its persisted vision description when there is one.
  *
- * A described image renders as `<image_descriptions>` INSTEAD of a marker, so the
- * same picture never appears twice in two vocabularies. The suppression is
- * per-attachment, not per-reference: vision can resolve some of a message's
- * images and not others (failures are never persisted), and a whole-reference
- * gate would drop the undescribed one's marker too — leaving it with neither a
- * description nor a name, i.e. invisible. Every image ends up with exactly one
- * of the two representations.
+ * The predecessor split this into two lists — described images in one
+ * vocabulary, everything else as `[contentType: name]` markers in another —
+ * and then had to suppress a marker whenever a description existed for the
+ * same file, matching the two halves BY FILENAME. That correspondence was
+ * fragile in a specific way: the two sides defaulted a nameless attachment
+ * differently (`'image'` vs `'attachment'`), so the lookup missed and the same
+ * picture rendered twice. One element per attachment removes the lookup, and
+ * that whole bug class with it — a nameless attachment now simply has no
+ * `filename` attribute, and there is nothing to correlate.
  *
- * Correspondence is by filename because that is what `ResolvedImageDescription`
- * carries, and every producer derives it from the attachment's own `name` — so
- * the two agree by construction. The nameless fallback must be the producers'
- * `'image'`, NOT this function's marker fallback (`'attachment'`): a mismatch
- * there would fail the lookup and render a nameless image both ways. Two images
- * sharing a filename within one reference would over-suppress; Discord's own
- * naming makes that a non-case (`embed-image-1.png`, `embed-image-2.png`, …).
- *
- * Shared by the full and deduped branches on purpose. These two renderings drifted
- * once already (the deduped branch rendered neither, silently discarding every
- * `resolvedImageDescriptions` row `persistReferenceDescriptions` had written for
- * exactly this purpose); routing both through one splitter is what keeps them level.
+ * Descriptions are joined ONTO the attachment list rather than replacing it, and
+ * any description that matches no attachment is still appended: a description is
+ * paid-for enrichment, and dropping one because its attachment row went missing
+ * would re-create the class this function exists to close.
  */
-function splitStoredMedia(ref: StoredReferencedMessage): {
-  imageDescriptions?: { filename: string; description: string }[];
-  attachmentLines?: string[];
-} {
-  const imageDescs = ref.resolvedImageDescriptions;
-  const hasImageDescs = imageDescs !== undefined && imageDescs.length > 0;
-  const describedFilenames = new Set(imageDescs?.map(desc => desc.filename));
-  const attachmentsForLines = ref.attachments?.filter(
-    att => !att.contentType.startsWith('image/') || !describedFilenames.has(att.name ?? 'image')
+export function buildStoredAttachments(ref: StoredReferencedMessage): RenderableAttachment[] {
+  const descriptionsByFilename = new Map(
+    (ref.resolvedImageDescriptions ?? []).map(desc => [desc.filename, desc.description])
   );
+  const matched = new Set<string>();
 
-  return {
-    imageDescriptions: hasImageDescs ? imageDescs : undefined,
-    attachmentLines:
-      attachmentsForLines !== undefined && attachmentsForLines.length > 0
-        ? attachmentsForLines.map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
-        : undefined,
-  };
+  const attachments: RenderableAttachment[] = (ref.attachments ?? []).map(att => {
+    const common = { filename: att.name, contentType: att.contentType };
+
+    // Same classifier the live path uses — see `classifyAttachment`. These two
+    // producers must agree about what a given attachment IS, or the same file
+    // renders one way in the turn it arrives and another when replayed.
+    switch (classifyAttachment(att)) {
+      case 'image': {
+        const name = att.name;
+        const description = name !== undefined ? descriptionsByFilename.get(name) : undefined;
+        if (name !== undefined && description !== undefined) {
+          matched.add(name);
+          return { kind: 'image', ...common, description };
+        }
+        return { kind: 'image', ...common, status: 'undescribed' };
+      }
+      case 'voice':
+        // Always `untranscribed` on this path, and that is the honest rendering
+        // rather than a bug: `StoredReferencedMessage` has no audio counterpart
+        // to `resolvedImageDescriptions`, so a replayed voice reference has no
+        // transcript to carry. Saying so beats an unexplained bare element —
+        // closing the gap is a schema change (TASK-367), not a render change.
+        // The duration IS persisted, so it rides along; the live path forwards
+        // it too, and dropping it here was one more live/stored divergence.
+        return { kind: 'voice', ...common, durationSeconds: att.duration, status: 'untranscribed' };
+      case 'file':
+        return { kind: 'file', ...common };
+    }
+  });
+
+  for (const [filename, description] of descriptionsByFilename) {
+    if (!matched.has(filename)) {
+      attachments.push({ kind: 'image', filename, description });
+    }
+  }
+
+  return attachments;
 }
 
 /**
@@ -96,7 +120,7 @@ function formatStoredReferencedMessage(
     locationContext = ref.locationContext;
   }
 
-  const media = splitStoredMedia(ref);
+  const attachments = buildStoredAttachments(ref);
 
   return formatQuoteElement({
     type: ref.isForwarded === true ? 'forward' : undefined,
@@ -110,8 +134,7 @@ function formatStoredReferencedMessage(
     content: ref.content,
     locationContext,
     embedsXml: ref.embeds !== undefined && ref.embeds.length > 0 ? [ref.embeds] : undefined,
-    imageDescriptions: media.imageDescriptions,
-    attachmentLines: media.attachmentLines,
+    attachments: attachments.length > 0 ? attachments : undefined,
   });
 }
 
@@ -157,18 +180,16 @@ export function formatQuotedSection(
   );
 
   // Deduped refs: lightweight stubs with truncated content and reply-target note.
-  // Image DESCRIPTIONS still ride along — `persistReferenceDescriptions` writes
-  // them onto the stored row precisely so a quoted image survives replay, and the
+  // Media rides along in full — `persistReferenceDescriptions` writes descriptions
+  // onto the stored row precisely so a quoted image survives replay, and the
   // history entry the stub points at renders that image as a URL, not a
-  // description. Attachment MARKERS are deliberately omitted: a marker names a
-  // file the chat log already lists, which is the redundancy dedup exists to cut.
+  // description.
   //
-  // No `voiceTranscripts` here, unlike the live path — not a dropped field. The
-  // live path reads transcripts from in-memory preprocessing; a stored reference
-  // has no persisted equivalent (`StoredReferencedMessage` carries
-  // `resolvedImageDescriptions` and no audio counterpart), so there is nothing
-  // to forward. Absence is a data gap, not an omission — passing something here
-  // requires the schema to carry it first.
+  // An UNdescribed attachment now renders here too, as a `status`-carrying
+  // element. Its predecessor omitted markers on this branch as chat-log
+  // redundancy, which was true for the file's NAME and false for its existence:
+  // an attachment with no description and no marker is simply invisible, the
+  // same drop class as the descriptions this branch used to lose entirely.
   const formattedDeduped = dedupedRefs.map(ref => {
     const authorName = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
     const role = deriveRefRole(ref.authorRole, authorName, personalityName, allPersonalityNames);
@@ -180,10 +201,10 @@ export function formatQuotedSection(
           ? formatPromptTimestamp(ref.timestamp)
           : undefined,
       // Cap the stored text preview HERE (the single truncation point) — formatDedupedQuote
-      // renders as-is. Stored refs carry attachments separately (attachmentLines), so content
-      // is text-only and safe to cap directly.
+      // renders as-is. Stored refs carry their attachments as structured elements, so
+      // content is text-only and safe to cap directly.
       content: capDedupText(ref.content),
-      imageDescriptions: splitStoredMedia(ref).imageDescriptions,
+      attachments: buildStoredAttachments(ref),
     });
   });
 

--- a/services/ai-worker/src/services/AttachmentProcessor.test.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.test.ts
@@ -88,7 +88,12 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toContain('- Image (photo.png): A beautiful landscape');
+      expect(result[0]).toEqual({
+        kind: 'image',
+        filename: 'photo.png',
+        contentType: 'image/png',
+        description: 'A beautiful landscape',
+      });
       expect(mockDescribeImage).toHaveBeenCalledTimes(1);
     });
 
@@ -149,7 +154,13 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toContain('- Voice Message (10s): "Hello world"');
+      expect(result[0]).toEqual({
+        kind: 'voice',
+        filename: 'voice.ogg',
+        contentType: 'audio/ogg',
+        durationSeconds: 10,
+        description: 'Hello world',
+      });
       expect(mockTranscribeAudio).toHaveBeenCalledTimes(1);
     });
 
@@ -169,7 +180,11 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toBe('- File: document.pdf (application/pdf)');
+      expect(result[0]).toEqual({
+        kind: 'file',
+        filename: 'document.pdf',
+        contentType: 'application/pdf',
+      });
       expect(mockDescribeImage).not.toHaveBeenCalled();
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
     });
@@ -221,9 +236,13 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(3);
-      expect(result[0]).toContain('- Image (photo.png)');
-      expect(result[1]).toContain('- Voice Message (5s)');
-      expect(result[2]).toBe('- File: doc.pdf (application/pdf)');
+      expect(result[0]).toMatchObject({ kind: 'image', filename: 'photo.png' });
+      expect(result[1]).toMatchObject({ kind: 'voice', filename: 'voice.ogg', durationSeconds: 5 });
+      expect(result[2]).toEqual({
+        kind: 'file',
+        filename: 'doc.pdf',
+        contentType: 'application/pdf',
+      });
 
       // Image + voice callbacks were in-flight at the same time → concurrent dispatch.
       expect(maxInFlight).toBeGreaterThan(1);
@@ -247,7 +266,14 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toContain('- Image (broken.png) [vision processing failed]');
+      // Still rendered, and it says WHY there is no description — an attachment
+      // that silently vanishes on failure is the drop class `status` closes.
+      expect(result[0]).toEqual({
+        kind: 'image',
+        filename: 'broken.png',
+        contentType: 'image/png',
+        status: 'undescribed',
+      });
     });
 
     it('should handle voice transcription failures gracefully', async () => {
@@ -270,7 +296,13 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toContain('- Voice Message (5s) [transcription failed]');
+      expect(result[0]).toEqual({
+        kind: 'voice',
+        filename: 'voice.ogg',
+        contentType: 'audio/ogg',
+        durationSeconds: 5,
+        status: 'untranscribed',
+      });
     });
 
     it('should use preprocessed image descriptions when available', async () => {
@@ -302,7 +334,11 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toContain('- Image (photo.png): Preprocessed landscape');
+      expect(result[0]).toMatchObject({
+        kind: 'image',
+        filename: 'photo.png',
+        description: 'Preprocessed landscape',
+      });
       expect(mockDescribeImage).not.toHaveBeenCalled();
     });
 
@@ -339,7 +375,12 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toContain('- Voice Message (10s): "Preprocessed transcription"');
+      expect(result[0]).toMatchObject({
+        kind: 'voice',
+        filename: 'voice.ogg',
+        durationSeconds: 10,
+        description: 'Preprocessed transcription',
+      });
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
     });
 
@@ -374,8 +415,130 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toContain('- Image (photo.png): Inline fallback');
+      expect(result[0]).toMatchObject({
+        kind: 'image',
+        filename: 'photo.png',
+        description: 'Inline fallback',
+      });
       expect(mockDescribeImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps modality and identity when processing throws before dispatch', async () => {
+      // The last-resort path: something threw OUTSIDE the per-attachment
+      // try/catch, so the processor never got to classify its own failure.
+      // Forced here by making the preprocessed lookup throw — the one piece of
+      // work that runs before dispatch.
+      //
+      // What must survive is the SHAPE. An image that blew up must not read as
+      // an ordinary document, and it must not vanish: the predecessor rendered
+      // a nameless `<file/>` for every rejection, which is indistinguishable
+      // from a real unprocessed file and loses the fact that anything failed.
+      // Must be NON-empty: findPreprocessedByUrl early-returns on a zero-length
+      // list, so an empty array never reaches `.find` and the throw never fires.
+      const exploding = [
+        {
+          type: AttachmentType.Image,
+          description: 'unused',
+          originalUrl: 'https://example.com/other.png',
+          metadata: {
+            url: 'https://example.com/other.png',
+            name: 'other.png',
+            contentType: 'image/png',
+            size: 1,
+          },
+        },
+      ];
+      exploding.find = () => {
+        throw new Error('boom before dispatch');
+      };
+
+      const result = await processAttachmentsParallel({
+        attachments: [
+          {
+            url: 'https://example.com/photo.png',
+            contentType: 'image/png',
+            name: 'photo.png',
+            size: 1000,
+          },
+        ],
+        referenceNumber: 1,
+        personality: mockPersonality,
+        isGuestMode: false,
+        preprocessedAttachments: exploding,
+      });
+
+      expect(result).toEqual([
+        {
+          kind: 'image',
+          filename: 'photo.png',
+          contentType: 'image/png',
+          status: 'unprocessed',
+        },
+      ]);
+    });
+
+    it('preserves each modality across the pre-dispatch failure', async () => {
+      // The voice and file arms of the same fallback. Covered explicitly rather
+      // than left to "it mirrors the image arm": the whole point of the arm is
+      // that a failed voice message does not read as a document, so an untested
+      // arm is exactly where that would regress unnoticed.
+      const exploding = [
+        {
+          type: AttachmentType.Image,
+          description: 'unused',
+          originalUrl: 'https://example.com/other.png',
+          metadata: {
+            url: 'https://example.com/other.png',
+            name: 'other.png',
+            contentType: 'image/png',
+            size: 1,
+          },
+        },
+      ];
+      exploding.find = () => {
+        throw new Error('boom before dispatch');
+      };
+
+      const result = await processAttachmentsParallel({
+        attachments: [
+          {
+            url: 'https://example.com/note.ogg',
+            contentType: 'audio/ogg',
+            name: 'note.ogg',
+            size: 100,
+            isVoiceMessage: true,
+            duration: 4,
+          },
+          {
+            url: 'https://example.com/doc.pdf',
+            contentType: 'application/pdf',
+            name: 'doc.pdf',
+            size: 200,
+          },
+        ],
+        referenceNumber: 1,
+        personality: mockPersonality,
+        isGuestMode: false,
+        preprocessedAttachments: exploding,
+      });
+
+      expect(result).toEqual([
+        {
+          kind: 'voice',
+          filename: 'note.ogg',
+          contentType: 'audio/ogg',
+          // Duration comes from Discord's metadata, not from the transcription
+          // that failed — so it survives the failure.
+          durationSeconds: 4,
+          status: 'unprocessed',
+        },
+        {
+          kind: 'file',
+          filename: 'doc.pdf',
+          contentType: 'application/pdf',
+          status: 'unprocessed',
+        },
+      ]);
     });
 
     it('should treat non-voice audio files as regular files', async () => {
@@ -395,7 +558,11 @@ describe('AttachmentProcessor', () => {
       });
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toBe('- File: music.mp3 (audio/mp3)');
+      expect(result[0]).toEqual({
+        kind: 'file',
+        filename: 'music.mp3',
+        contentType: 'audio/mp3',
+      });
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
     });
   });

--- a/services/ai-worker/src/services/AttachmentProcessor.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.ts
@@ -7,7 +7,6 @@
  */
 
 import { type AIProvider } from '@tzurot/common-types/constants/ai';
-import { CONTENT_TYPES } from '@tzurot/common-types/constants/media';
 import { RETRY_CONFIG } from '@tzurot/common-types/constants/timing';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
@@ -15,6 +14,7 @@ import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { describeImage, transcribeAudio, type ProcessedAttachment } from './MultimodalProcessor.js';
 import type { VisionLoggingContext } from './multimodal/VisionProcessor.js';
+import { classifyAttachment, type RenderableAttachment } from './prompt/QuoteFormatter.js';
 import { withRetry } from '../utils/retry.js';
 
 const logger = createLogger('AttachmentProcessor');
@@ -23,10 +23,8 @@ const logger = createLogger('AttachmentProcessor');
  * Processed attachment result for a single attachment
  */
 interface ProcessedAttachmentResult {
-  /** Index of the attachment in the original array */
-  index: number;
-  /** Formatted line for the prompt */
-  line: string;
+  /** The attachment in renderable form — structured, never a pre-rendered line. */
+  attachment: RenderableAttachment;
 }
 
 /**
@@ -35,8 +33,6 @@ interface ProcessedAttachmentResult {
 interface ProcessSingleAttachmentOptions {
   /** Attachment to process */
   attachment: NonNullable<ReferencedMessage['attachments']>[0];
-  /** Index in the attachments array */
-  index: number;
   /** Reference number for logging */
   referenceNumber: number;
   /** Personality configuration */
@@ -62,7 +58,6 @@ interface ProcessSingleAttachmentOptions {
  */
 interface ProcessImageOptions {
   attachment: ProcessSingleAttachmentOptions['attachment'];
-  index: number;
   referenceNumber: number;
   personality: LoadedPersonality;
   isGuestMode: boolean;
@@ -107,7 +102,7 @@ export interface ProcessAttachmentsOptions {
  */
 export async function processAttachmentsParallel(
   options: ProcessAttachmentsOptions
-): Promise<string[]> {
+): Promise<RenderableAttachment[]> {
   const {
     attachments,
     referenceNumber,
@@ -124,10 +119,9 @@ export async function processAttachmentsParallel(
     return [];
   }
 
-  const processingPromises = attachments.map((attachment, index) =>
+  const processingPromises = attachments.map(attachment =>
     processSingleAttachment({
       attachment,
-      index,
       referenceNumber,
       personality,
       isGuestMode,
@@ -142,21 +136,53 @@ export async function processAttachmentsParallel(
 
   const results = await Promise.allSettled(processingPromises);
 
-  const attachmentLines: string[] = [];
+  const rendered: RenderableAttachment[] = [];
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
     if (result.status === 'fulfilled') {
-      attachmentLines.push(result.value.line);
+      rendered.push(result.value.attachment);
     } else {
       logger.error(
         { err: result.reason, index: i, referenceNumber },
         'Unexpected error in attachment processing'
       );
-      attachmentLines.push(`- Attachment [processing error]`);
+      const attachment = attachments[i];
+      if (attachment !== undefined) {
+        rendered.push(unprocessedAttachment(attachment));
+      }
     }
   }
 
-  return attachmentLines;
+  return rendered;
+}
+
+/**
+ * Render an attachment whose processing threw before it could classify its own
+ * failure. Keeps the modality and identity — degrading everything to a nameless
+ * `<file/>` would make a blown-up image indistinguishable from an ordinary
+ * document, and losing the element entirely is the drop class this shape closes.
+ */
+function unprocessedAttachment(
+  attachment: ProcessSingleAttachmentOptions['attachment']
+): RenderableAttachment {
+  const identity = {
+    filename: attachment.name,
+    contentType: attachment.contentType,
+    status: 'unprocessed',
+  } as const;
+
+  switch (classifyAttachment(attachment)) {
+    case 'voice':
+      // Duration survives the failure. It comes from Discord's own metadata, not
+      // from the transcription that just blew up, so there is no reason to lose
+      // it — and "a 4-second clip we could not process" is more useful to the
+      // model than "some voice message we could not process".
+      return { kind: 'voice', ...identity, durationSeconds: attachment.duration };
+    case 'image':
+      return { kind: 'image', ...identity };
+    case 'file':
+      return { kind: 'file', ...identity };
+  }
 }
 
 /** Find preprocessed result for an attachment by URL */
@@ -173,20 +199,26 @@ function findPreprocessedByUrl(
 /** Process voice message attachment */
 async function processVoiceAttachment(
   attachment: ProcessSingleAttachmentOptions['attachment'],
-  index: number,
   referenceNumber: number,
   preprocessed?: ProcessedAttachment,
   sttDispatch?: SttDispatch
 ): Promise<ProcessedAttachmentResult> {
+  // Identity only — NOT a whole RenderableVoice. `kind` and the enrichment are
+  // supplied per return site, because the type makes description and status
+  // mutually exclusive and a pre-built object cannot commit to either arm.
+  const identity = {
+    kind: 'voice',
+    filename: attachment.name,
+    contentType: attachment.contentType,
+    durationSeconds: attachment.duration,
+  } as const;
+
   if (preprocessed?.description !== undefined && preprocessed.description !== '') {
     logger.debug(
       { referenceNumber, url: attachment.url },
       'Using preprocessed voice transcription'
     );
-    return {
-      index,
-      line: `- Voice Message (${attachment.duration}s): "${preprocessed.description}"`,
-    };
+    return { attachment: { ...identity, description: preprocessed.description } };
   }
 
   try {
@@ -207,13 +239,13 @@ async function processVoiceAttachment(
         operationName: `Voice transcription (reference ${referenceNumber})`,
       }
     );
-    return { index, line: `- Voice Message (${attachment.duration}s): "${result.value.text}"` };
+    return { attachment: { ...identity, description: result.value.text } };
   } catch (error) {
     logger.error(
       { err: error, referenceNumber, url: attachment.url },
       'Voice transcription failed'
     );
-    return { index, line: `- Voice Message (${attachment.duration}s) [transcription failed]` };
+    return { attachment: { ...identity, status: 'untranscribed' } };
   }
 }
 
@@ -223,7 +255,6 @@ async function processImageAttachment(
 ): Promise<ProcessedAttachmentResult> {
   const {
     attachment,
-    index,
     referenceNumber,
     personality,
     isGuestMode,
@@ -233,9 +264,16 @@ async function processImageAttachment(
     visionProvider,
     model,
   } = options;
+  // Identity only — see the note in processVoiceAttachment.
+  const identity = {
+    kind: 'image',
+    filename: attachment.name,
+    contentType: attachment.contentType,
+  } as const;
+
   if (preprocessed?.description !== undefined && preprocessed.description !== '') {
     logger.debug({ referenceNumber, url: attachment.url }, 'Using preprocessed image description');
-    return { index, line: `- Image (${attachment.name}): ${preprocessed.description}` };
+    return { attachment: { ...identity, description: preprocessed.description } };
   }
 
   try {
@@ -262,10 +300,10 @@ async function processImageAttachment(
         operationName: `Image description (reference ${referenceNumber})`,
       }
     );
-    return { index, line: `- Image (${attachment.name}): ${result.value}` };
+    return { attachment: { ...identity, description: result.value } };
   } catch (error) {
     logger.error({ err: error, referenceNumber, url: attachment.url }, 'Image processing failed');
-    return { index, line: `- Image (${attachment.name}) [vision processing failed]` };
+    return { attachment: { ...identity, status: 'undescribed' } };
   }
 }
 
@@ -278,7 +316,6 @@ async function processSingleAttachment(
 ): Promise<ProcessedAttachmentResult> {
   const {
     attachment,
-    index,
     referenceNumber,
     personality,
     isGuestMode,
@@ -291,24 +328,28 @@ async function processSingleAttachment(
   } = options;
   const preprocessed = findPreprocessedByUrl(attachment.url, preprocessedAttachments);
 
-  if (attachment.isVoiceMessage === true) {
-    return processVoiceAttachment(attachment, index, referenceNumber, preprocessed, sttDispatch);
+  switch (classifyAttachment(attachment)) {
+    case 'voice':
+      return processVoiceAttachment(attachment, referenceNumber, preprocessed, sttDispatch);
+    case 'image':
+      return processImageAttachment({
+        attachment,
+        referenceNumber,
+        personality,
+        isGuestMode,
+        preprocessed,
+        userApiKey,
+        loggingContext,
+        visionProvider,
+        model,
+      });
+    case 'file':
+      return {
+        attachment: {
+          kind: 'file',
+          filename: attachment.name,
+          contentType: attachment.contentType,
+        },
+      };
   }
-
-  if (attachment.contentType?.startsWith(CONTENT_TYPES.IMAGE_PREFIX)) {
-    return processImageAttachment({
-      attachment,
-      index,
-      referenceNumber,
-      personality,
-      isGuestMode,
-      preprocessed,
-      userApiKey,
-      loggingContext,
-      visionProvider,
-      model,
-    });
-  }
-
-  return { index, line: `- File: ${attachment.name} (${attachment.contentType})` };
 }

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -707,9 +707,15 @@ describe('ReferencedMessageFormatter', () => {
 
       // Verify all images were processed
       expect(mockDescribeImage).toHaveBeenCalledTimes(3);
-      expect(result).toContain('- Image (image1.png): Description of image1.png');
-      expect(result).toContain('- Image (image2.png): Description of image2.png');
-      expect(result).toContain('- Image (image3.png): Description of image3.png');
+      expect(result).toContain(
+        '<image filename="image1.png" type="image/png">Description of image1.png</image>'
+      );
+      expect(result).toContain(
+        '<image filename="image2.png" type="image/png">Description of image2.png</image>'
+      );
+      expect(result).toContain(
+        '<image filename="image3.png" type="image/png">Description of image3.png</image>'
+      );
 
       // All three describeImage callbacks were in-flight simultaneously → parallel processing.
       expect(maxInFlight).toBe(3);
@@ -747,7 +753,9 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('- Image (broken.png) [vision processing failed]');
+      expect(result).toContain(
+        '<image filename="broken.png" type="image/png" status="undescribed"/>'
+      );
     });
 
     it('should handle mixed success and failure in parallel processing', async () => {
@@ -807,9 +815,15 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('- Image (image1.png): Description of image1');
-      expect(result).toContain('- Image (image2.png) [vision processing failed]');
-      expect(result).toContain('- Image (image3.png): Description of image3');
+      expect(result).toContain(
+        '<image filename="image1.png" type="image/png">Description of image1</image>'
+      );
+      expect(result).toContain(
+        '<image filename="image2.png" type="image/png" status="undescribed"/>'
+      );
+      expect(result).toContain(
+        '<image filename="image3.png" type="image/png">Description of image3</image>'
+      );
     });
   });
 
@@ -871,8 +885,12 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(mockTranscribeAudio).toHaveBeenCalledTimes(2);
-      expect(result).toContain('- Voice Message (5s): "Transcription of voice 5s"');
-      expect(result).toContain('- Voice Message (10s): "Transcription of voice 10s"');
+      expect(result).toContain(
+        '<voice filename="voice1.ogg" type="audio/ogg" duration="5s">Transcription of voice 5s</voice>'
+      );
+      expect(result).toContain(
+        '<voice filename="voice2.ogg" type="audio/ogg" duration="10s">Transcription of voice 10s</voice>'
+      );
 
       // Both transcribe callbacks were in-flight simultaneously → parallel processing.
       expect(maxInFlight).toBe(2);
@@ -912,7 +930,9 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('- Voice Message (5s) [transcription failed]');
+      expect(result).toContain(
+        '<voice filename="voice.ogg" type="audio/ogg" duration="5s" status="untranscribed"/>'
+      );
     });
   });
 
@@ -967,9 +987,13 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('- Image (photo.png): Image description');
-      expect(result).toContain('- Voice Message (5s): "Voice transcription"');
-      expect(result).toContain('- File: document.pdf (application/pdf)');
+      expect(result).toContain(
+        '<image filename="photo.png" type="image/png">Image description</image>'
+      );
+      expect(result).toContain(
+        '<voice filename="voice.ogg" type="audio/ogg" duration="5s">Voice transcription</voice>'
+      );
+      expect(result).toContain('<file filename="document.pdf" type="application/pdf"/>');
 
       // Both async processors should have been called
       expect(mockDescribeImage).toHaveBeenCalledTimes(1);
@@ -1010,7 +1034,7 @@ describe('ReferencedMessageFormatter', () => {
 
       // Should NOT transcribe non-voice messages
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
-      expect(result).toContain('- File: music.mp3 (audio/mp3)');
+      expect(result).toContain('<file filename="music.mp3" type="audio/mp3"/>');
     });
   });
 
@@ -1233,7 +1257,9 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       // Should use preprocessed description
-      expect(result).toContain('- Image (photo.png): Preprocessed: A beautiful landscape');
+      expect(result).toContain(
+        '<image filename="photo.png" type="image/png">Preprocessed: A beautiful landscape</image>'
+      );
 
       // Should NOT call vision API
       expect(mockDescribeImage).not.toHaveBeenCalled();
@@ -1295,7 +1321,7 @@ describe('ReferencedMessageFormatter', () => {
 
       // Should use preprocessed transcription
       expect(result).toContain(
-        '- Voice Message (10s): "Preprocessed: Hello, this is a test message"'
+        '<voice filename="voice.ogg" type="audio/ogg" duration="10s">Preprocessed: Hello, this is a test message</voice>'
       );
 
       // Should NOT call STT API
@@ -1338,7 +1364,9 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       // Should fall back to inline processing
-      expect(result).toContain('- Image (photo.png): Inline processed description');
+      expect(result).toContain(
+        '<image filename="photo.png" type="image/png">Inline processed description</image>'
+      );
       expect(mockDescribeImage).toHaveBeenCalledTimes(1);
     });
 
@@ -1394,7 +1422,9 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       // Should fall back since URL doesn't match
-      expect(result).toContain('- Image (photo.png): Inline fallback description');
+      expect(result).toContain(
+        '<image filename="photo.png" type="image/png">Inline fallback description</image>'
+      );
       expect(mockDescribeImage).toHaveBeenCalledTimes(1);
     });
 
@@ -1482,8 +1512,12 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       // Both should use their respective preprocessed descriptions
-      expect(result).toContain('- Image (image1.png): Description for reference 1');
-      expect(result).toContain('- Image (image2.png): Description for reference 2');
+      expect(result).toContain(
+        '<image filename="image1.png" type="image/png">Description for reference 1</image>'
+      );
+      expect(result).toContain(
+        '<image filename="image2.png" type="image/png">Description for reference 2</image>'
+      );
 
       // No inline API calls
       expect(mockDescribeImage).not.toHaveBeenCalled();
@@ -1541,7 +1575,9 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       // Should fall back to inline processing since description is empty
-      expect(result).toContain('- Image (photo.png): Inline description');
+      expect(result).toContain(
+        '<image filename="photo.png" type="image/png">Inline description</image>'
+      );
       expect(mockDescribeImage).toHaveBeenCalledTimes(1);
     });
   });
@@ -1745,14 +1781,22 @@ describe('ReferencedMessageFormatter', () => {
                 name: 'voice.ogg',
                 contentType: 'audio/ogg',
                 size: 2000,
+                duration: 6,
               },
             },
           ],
         }
       );
 
-      expect(formatted).toContain('<transcript>');
+      // Duration rides along on THIS path too. Of the voice-rendering call
+      // sites, this deduped one was the last to still drop it — the fixture had
+      // no `duration` at all, so nothing would have caught the field being
+      // wired up wrong in either direction.
+      expect(formatted).toContain('<voice filename="voice.ogg" duration="6s">');
       expect(formatted).toContain(TRANSCRIPT_SENTINEL);
+      // NOT the synthesized `audio/unknown` the dependency step stamps on
+      // preprocessed metadata — a placeholder must not render as fact.
+      expect(formatted).not.toContain('type="audio/unknown"');
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
     });
 

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -19,7 +19,9 @@ import {
   formatQuoteElement,
   formatForwardedQuote,
   formatDedupedQuote,
+  attachmentEnrichment,
   type ForwardedMessageContent,
+  type RenderableAttachment,
 } from './prompt/QuoteFormatter.js';
 import { deriveRefRole } from './prompt/referenceRole.js';
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
@@ -70,8 +72,7 @@ export interface FormattedReferences {
 
 /** The renderable enrichment children a reference's preprocessed results yield. */
 interface SplitEnrichment {
-  imageDescriptions?: { filename: string; description: string }[];
-  voiceTranscripts?: string[];
+  attachments: RenderableAttachment[];
   /**
    * Entries that CARRY something worth rendering (non-empty description).
    * The tripwire's denominator is this rather than the raw entry count: a
@@ -104,11 +105,10 @@ function splitPreprocessedEnrichment(
   preprocessed: ProcessedAttachment[] | undefined
 ): SplitEnrichment {
   if (preprocessed === undefined || preprocessed.length === 0) {
-    return { renderable: 0, rendered: 0 };
+    return { attachments: [], renderable: 0, rendered: 0 };
   }
 
-  const imageDescriptions: { filename: string; description: string }[] = [];
-  const voiceTranscripts: string[] = [];
+  const attachments: RenderableAttachment[] = [];
   let renderable = 0;
   for (const entry of preprocessed) {
     if (entry.description.length === 0) {
@@ -117,25 +117,49 @@ function splitPreprocessedEnrichment(
       continue;
     }
     renderable++;
+    // `name` is optional on AttachmentMetadata; the dependency step derives it
+    // from the URL basename, so undefined means a synthesized attachment with no
+    // filename at all. Left undefined rather than defaulted — the attribute is
+    // omitted instead of carrying an invented name.
     if (entry.type === AttachmentType.Image) {
-      // `name` is optional on AttachmentMetadata; the dependency step derives it
-      // from the URL basename, so undefined means a synthesized attachment with
-      // no filename at all — the description is still the payload worth keeping.
-      imageDescriptions.push({
-        filename: entry.metadata.name ?? 'image',
+      attachments.push({
+        kind: 'image',
+        filename: entry.metadata.name,
         description: entry.description,
       });
     } else if (entry.type === AttachmentType.Audio) {
-      voiceTranscripts.push(entry.description);
+      attachments.push({
+        kind: 'voice',
+        filename: entry.metadata.name,
+        // Duration only — deliberately NOT contentType. Per the note above, the
+        // dependency step synthesizes `audio/unknown` here, so forwarding it
+        // would render a `type` attribute that is a placeholder dressed as fact.
+        durationSeconds: entry.metadata.duration,
+        description: entry.description,
+      });
     }
+    // Any other type falls through UNRENDERED and stays counted in `renderable`,
+    // so the drop tripwire below fires. That is deliberate: silently downgrading
+    // an unknown modality to a bare <file/> would discard the description this
+    // function exists to carry, which is the exact class the tripwire watches.
   }
 
-  return {
-    imageDescriptions: imageDescriptions.length > 0 ? imageDescriptions : undefined,
-    voiceTranscripts: voiceTranscripts.length > 0 ? voiceTranscripts : undefined,
-    renderable,
-    rendered: imageDescriptions.length + voiceTranscripts.length,
-  };
+  return { attachments, renderable, rendered: attachments.length };
+}
+
+/**
+ * The semantic text an attachment contributes to a retrieval query: its
+ * enrichment only.
+ *
+ * Filenames, content types and status markers are deliberately excluded — they
+ * are metadata about the file, not about what is IN it, and an embedding query
+ * carrying `photo.png` matches on the noise rather than the content. (The
+ * previous shape fed the whole rendered line, prefix included, into the query.)
+ */
+function collectAttachmentText(attachments: RenderableAttachment[]): string[] {
+  return attachments
+    .map(attachmentEnrichment)
+    .filter((desc): desc is string => desc !== undefined && desc.length > 0);
 }
 
 /**
@@ -201,8 +225,7 @@ export class ReferencedMessageFormatter {
             timestamp:
               absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
             content: ref.content,
-            imageDescriptions: enrichment.imageDescriptions,
-            voiceTranscripts: enrichment.voiceTranscripts,
+            attachments: enrichment.attachments,
           })
         );
         // The stub's capped text copy is real signal; the reply-target
@@ -211,11 +234,7 @@ export class ReferencedMessageFormatter {
         // descriptions ride along for the same reason they ride into the
         // prompt: history has no copy of them to retrieve against.
         searchParts.push(
-          [
-            ref.content,
-            ...(enrichment.imageDescriptions ?? []).map(img => img.description),
-            ...(enrichment.voiceTranscripts ?? []),
-          ]
+          [ref.content, ...collectAttachmentText(enrichment.attachments)]
             .filter(part => part.length > 0)
             .join('\n')
         );
@@ -300,8 +319,11 @@ export class ReferencedMessageFormatter {
    * envelope). Location context, timestamps, and role metadata never
    * belong in an embedding query.
    */
-  private buildReferenceSearchText(ref: ReferencedMessage, attachmentLines: string[]): string {
-    const pieces = [ref.content, ...attachmentLines];
+  private buildReferenceSearchText(
+    ref: ReferencedMessage,
+    attachments: RenderableAttachment[]
+  ): string {
+    const pieces = [ref.content, ...collectAttachmentText(attachments)];
     if (ref.embeds !== undefined && ref.embeds.length > 0) {
       pieces.push(extractXmlTextContent(ref.embeds));
     }
@@ -324,9 +346,9 @@ export class ReferencedMessageFormatter {
     const { userApiKey, sttDispatch, visionProvider, visionModel } = apiKeys ?? {};
     const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
 
-    let attachmentLines: string[] = [];
+    let attachments: RenderableAttachment[] = [];
     if (ref.attachments && ref.attachments.length > 0) {
-      attachmentLines = await processAttachmentsParallel({
+      attachments = await processAttachmentsParallel({
         attachments: ref.attachments,
         referenceNumber: ref.referenceNumber,
         personality,
@@ -353,10 +375,10 @@ export class ReferencedMessageFormatter {
       content: ref.content || undefined,
       locationContext: ref.locationContext,
       embedsXml: ref.embeds ? [ref.embeds] : undefined,
-      attachmentLines: attachmentLines.length > 0 ? attachmentLines : undefined,
+      attachments: attachments.length > 0 ? attachments : undefined,
     });
 
-    return { element, searchText: this.buildReferenceSearchText(ref, attachmentLines) };
+    return { element, searchText: this.buildReferenceSearchText(ref, attachments) };
   }
 
   /**
@@ -380,9 +402,9 @@ export class ReferencedMessageFormatter {
     };
 
     // Process attachments if present
-    let attachmentLines: string[] = [];
+    let attachments: RenderableAttachment[] = [];
     if (ref.attachments && ref.attachments.length > 0) {
-      attachmentLines = await processAttachmentsParallel({
+      attachments = await processAttachmentsParallel({
         attachments: ref.attachments,
         referenceNumber: ref.referenceNumber,
         personality,
@@ -394,14 +416,14 @@ export class ReferencedMessageFormatter {
         model: visionModel,
       });
 
-      if (attachmentLines.length > 0) {
-        forwardedContent.attachmentLines = attachmentLines;
+      if (attachments.length > 0) {
+        forwardedContent.attachments = attachments;
       }
     }
 
     return {
       element: formatForwardedQuote(forwardedContent),
-      searchText: this.buildReferenceSearchText(ref, attachmentLines),
+      searchText: this.buildReferenceSearchText(ref, attachments),
     };
   }
 }

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
@@ -3,8 +3,10 @@ import {
   formatDedupedQuote,
   formatForwardedQuote,
   formatQuoteElement,
+  renderAttachment,
   type ForwardedMessageContent,
   type QuoteElementOptions,
+  type RenderableAttachment,
 } from './QuoteFormatter.js';
 
 describe('QuoteFormatter', () => {
@@ -118,31 +120,124 @@ describe('QuoteFormatter', () => {
       expect(result).toContain('<embeds>\n<embed>Link preview</embed>\n</embeds>');
     });
 
-    it('should format image descriptions', () => {
+    it('renders every modality under one <attachments> wrapper', () => {
       const result = formatQuoteElement({
-        imageDescriptions: [{ filename: 'sunset.png', description: 'A sunset' }],
-      });
-
-      expect(result).toContain('<image_descriptions>');
-      expect(result).toContain('<image filename="sunset.png">A sunset</image>');
-    });
-
-    it('should format voice transcripts', () => {
-      const result = formatQuoteElement({
-        voiceTranscripts: ['Hello there'],
-      });
-
-      expect(result).toContain('<voice_transcripts>');
-      expect(result).toContain('<transcript>Hello there</transcript>');
-    });
-
-    it('should format attachment lines', () => {
-      const result = formatQuoteElement({
-        attachmentLines: ['- File: doc.pdf (application/pdf)'],
+        attachments: [
+          { kind: 'image', filename: 'sunset.png', description: 'A sunset' },
+          { kind: 'voice', filename: 'clip.ogg', durationSeconds: 12, description: 'Hello there' },
+          { kind: 'file', filename: 'doc.pdf', contentType: 'application/pdf' },
+        ],
       });
 
       expect(result).toContain('<attachments>');
-      expect(result).toContain('- File: doc.pdf (application/pdf)');
+      expect(result).toContain('<image filename="sunset.png">A sunset</image>');
+      expect(result).toContain('<voice filename="clip.ogg" duration="12s">Hello there</voice>');
+      expect(result).toContain('<file filename="doc.pdf" type="application/pdf"/>');
+      // The old vocabulary is gone, not merely unused — a stray emission of it
+      // would put the same object back into two competing tag namespaces.
+      expect(result).not.toContain('<image_descriptions>');
+      expect(result).not.toContain('<voice_transcripts>');
+    });
+
+    it('states WHY an attachment carries no enrichment instead of omitting it', () => {
+      const result = formatQuoteElement({
+        attachments: [
+          { kind: 'image', filename: 'unlucky.png', status: 'undescribed' },
+          { kind: 'voice', filename: 'muffled.ogg', status: 'untranscribed' },
+        ],
+      });
+
+      // Self-closing with a reason. A bare element would leave the model unable
+      // to tell "vision failed" from "nothing worth describing" and it invents one.
+      expect(result).toContain('<image filename="unlucky.png" status="undescribed"/>');
+      expect(result).toContain('<voice filename="muffled.ogg" status="untranscribed"/>');
+    });
+
+    it('omits the filename attribute entirely when there is no real name', () => {
+      const result = formatQuoteElement({
+        attachments: [{ kind: 'image', description: 'a nameless picture' }],
+      });
+
+      // Never a synthesized placeholder: two producers inventing different ones
+      // ('image' vs 'attachment') is what made the old filename correspondence
+      // render the same picture twice.
+      expect(result).toContain('<image>a nameless picture</image>');
+      expect(result).not.toContain('filename=');
+    });
+
+    it('escapes a closing tag hidden in a description or transcript', () => {
+      const result = formatQuoteElement({
+        attachments: [
+          { kind: 'image', filename: 'x.png', description: 'sneaky </image></attachments>' },
+          { kind: 'voice', filename: 'y.ogg', description: 'sneaky </voice>' },
+        ],
+      });
+
+      // `image` and `voice` are in PROTECTED_TAGS, so escapeXmlContent neutralizes
+      // their closing forms — a crafted description cannot break out of the quote.
+      expect(result).toContain('&lt;/image&gt;&lt;/attachments&gt;');
+      expect(result).toContain('&lt;/voice&gt;');
+      expect(result).not.toContain('sneaky </image>');
+      expect(result).not.toContain('sneaky </voice>');
+    });
+
+    it('escapes a crafted filename so it cannot close the wrapper', () => {
+      const result = formatQuoteElement({
+        attachments: [{ kind: 'file', filename: '"/><script>x</script>' }],
+      });
+
+      expect(result).not.toContain('<script>');
+      expect(result).toContain('&quot;');
+    });
+
+    it('makes the per-modality invariants unwriteable (compile-time)', () => {
+      // These assertions run at TYPECHECK time (`pnpm typecheck:spec`), not at
+      // runtime — each @ts-expect-error fails the build if the union ever stops
+      // rejecting that shape. The doc comment used to be the only thing holding
+      // these; a reviewer correctly pointed out a comment is not an invariant.
+      // Each literal is on ONE line so the suppression sits directly above the
+      // property TypeScript rejects — an excess-property error is reported at
+      // the property, not at the declaration.
+      const rejected: RenderableAttachment[] = [
+        // A file never carries enrichment — the renderer would silently drop it.
+        // @ts-expect-error description is not a field on RenderableFile
+        { kind: 'file', filename: 'a.zip', description: 'ignored' },
+        // Duration belongs to voice alone.
+        // @ts-expect-error durationSeconds is not a field on RenderableImage
+        { kind: 'image', filename: 'a.png', durationSeconds: 12 },
+        // A status must name its OWN modality's failure.
+        // @ts-expect-error 'untranscribed' is not assignable to an image's status
+        { kind: 'image', filename: 'a.png', status: 'untranscribed' },
+        // @ts-expect-error 'undescribed' is not assignable to a voice's status
+        { kind: 'voice', filename: 'a.ogg', status: 'undescribed' },
+        // Enrichment is either present or explained, never both — "here is the
+        // transcript, and also we failed to transcribe it" is a contradiction.
+        // @ts-expect-error description and status are mutually exclusive
+        { kind: 'voice', filename: 'a.ogg', description: 'hi', status: 'untranscribed' },
+        // @ts-expect-error description and status are mutually exclusive
+        { kind: 'image', filename: 'a.png', description: 'a cat', status: 'undescribed' },
+      ];
+
+      expect(rejected).toHaveLength(6);
+      // The renderer's own contract, asserted for real: a file renders
+      // attribute-only, with no place for enrichment to land.
+      expect(renderAttachment({ kind: 'file', filename: 'a.zip' })).toBe(
+        '<file filename="a.zip"/>'
+      );
+    });
+
+    it('renders legacy marker strings alongside structured attachments', () => {
+      const result = formatQuoteElement({
+        attachments: [{ kind: 'image', filename: 'new.png', description: 'structured' }],
+        legacyAttachmentLines: ['[image/png: persisted.png]'],
+      });
+
+      // One wrapper holds both — the legacy slot exists only because those rows
+      // are already in the database as pre-rendered strings.
+      expect(result).toContain('<attachments>');
+      expect(result).toContain('<image filename="new.png">structured</image>');
+      expect(result).toContain('[image/png: persisted.png]');
+      expect(result.match(/<attachments>/g)).toHaveLength(1);
     });
 
     it('should escape from attribute', () => {
@@ -163,32 +258,37 @@ describe('QuoteFormatter', () => {
       expect(result).not.toContain('</character>');
     });
 
-    it('should order elements correctly: time → content → location → images → embeds → voice → attachments', () => {
+    it('should order elements correctly: time → content → location → embeds → attachments', () => {
       const result = formatQuoteElement({
         number: 1,
         from: 'User',
         timestamp: { absolute: 'Jan 1, 2025', relative: 'now' },
         content: 'Hello',
         locationContext: '<location type="guild"><server name="G"/></location>',
-        imageDescriptions: [{ filename: 'img.png', description: 'An image' }],
         embedsXml: ['<embed>E</embed>'],
-        voiceTranscripts: ['Voice'],
-        attachmentLines: ['- File: f.txt (text/plain)'],
+        attachments: [
+          { kind: 'image', filename: 'img.png', description: 'An image' },
+          { kind: 'voice', filename: 'v.ogg', description: 'Voice' },
+          { kind: 'file', filename: 'f.txt', contentType: 'text/plain' },
+        ],
       });
 
       const positions = [
         result.indexOf('<time'),
         result.indexOf('<content>'),
         result.indexOf('<location'),
-        result.indexOf('<image_descriptions>'),
         result.indexOf('<embeds>'),
-        result.indexOf('<voice_transcripts>'),
         result.indexOf('<attachments>'),
       ];
 
       for (let i = 1; i < positions.length; i++) {
         expect(positions[i]).toBeGreaterThan(positions[i - 1]);
       }
+
+      // Within <attachments>, source order is preserved across modalities — the
+      // list is one sequence, not three grouped sections.
+      expect(result.indexOf('<image ')).toBeLessThan(result.indexOf('<voice '));
+      expect(result.indexOf('<voice ')).toBeLessThan(result.indexOf('<file '));
     });
 
     it('should skip empty content', () => {
@@ -233,40 +333,46 @@ describe('QuoteFormatter', () => {
 
     it('should format an image-only forwarded message', () => {
       const content: ForwardedMessageContent = {
-        imageDescriptions: [
-          { filename: 'sunset.png', description: 'A beautiful sunset over the ocean' },
+        attachments: [
+          {
+            kind: 'image',
+            filename: 'sunset.png',
+            description: 'A beautiful sunset over the ocean',
+          },
         ],
       };
 
       const result = formatForwardedQuote(content);
 
       expect(result).toContain('<quote type="forward" from="Unknown">');
-      expect(result).toContain('<image_descriptions>');
+      expect(result).toContain('<attachments>');
       expect(result).toContain(
         '<image filename="sunset.png">A beautiful sunset over the ocean</image>'
       );
-      expect(result).toContain('</image_descriptions>');
+      expect(result).toContain('</attachments>');
       expect(result).not.toContain('<content>');
     });
 
     it('should format mixed content (text + images + embeds)', () => {
       const content: ForwardedMessageContent = {
         textContent: 'Check this out',
-        imageDescriptions: [{ filename: 'screenshot.png', description: 'An error dialog' }],
+        attachments: [
+          { kind: 'image', filename: 'screenshot.png', description: 'An error dialog' },
+        ],
         embedsXml: ['<embed title="Link Preview">Some content</embed>'],
       };
 
       const result = formatForwardedQuote(content);
 
       expect(result).toContain('<content>Check this out</content>');
-      expect(result).toContain('<image_descriptions>');
+      expect(result).toContain('<attachments>');
       expect(result).toContain('<embeds>');
-      // Content should come before images, images before embeds
+      // Content → embeds → attachments
       const contentPos = result.indexOf('<content>');
-      const imagePos = result.indexOf('<image_descriptions>');
       const embedsPos = result.indexOf('<embeds>');
-      expect(contentPos).toBeLessThan(imagePos);
-      expect(imagePos).toBeLessThan(embedsPos);
+      const attachmentsPos = result.indexOf('<attachments>');
+      expect(contentPos).toBeLessThan(embedsPos);
+      expect(embedsPos).toBeLessThan(attachmentsPos);
     });
 
     it('should handle empty content (all fields undefined)', () => {
@@ -289,7 +395,7 @@ describe('QuoteFormatter', () => {
 
     it('should escape image filenames in attributes', () => {
       const content: ForwardedMessageContent = {
-        imageDescriptions: [{ filename: 'file"name.png', description: 'A normal image' }],
+        attachments: [{ kind: 'image', filename: 'file"name.png', description: 'A normal image' }],
       };
 
       const result = formatForwardedQuote(content);
@@ -315,37 +421,37 @@ describe('QuoteFormatter', () => {
 
     it('should format voice transcripts', () => {
       const content: ForwardedMessageContent = {
-        voiceTranscripts: ['Hey, can you hear me?'],
-      };
-
-      const result = formatForwardedQuote(content);
-
-      expect(result).toContain('<voice_transcripts>');
-      expect(result).toContain('<transcript>Hey, can you hear me?</transcript>');
-    });
-
-    it('should format pre-formatted attachment lines', () => {
-      const content: ForwardedMessageContent = {
-        attachmentLines: ['- File: document.pdf (application/pdf)', '- File: data.csv (text/csv)'],
+        attachments: [{ kind: 'voice', description: 'Hey, can you hear me?' }],
       };
 
       const result = formatForwardedQuote(content);
 
       expect(result).toContain('<attachments>');
-      expect(result).toContain('- File: document.pdf (application/pdf)');
-      expect(result).toContain('- File: data.csv (text/csv)');
+      expect(result).toContain('<voice>Hey, can you hear me?</voice>');
+    });
+
+    it('should format persisted legacy marker lines', () => {
+      const content: ForwardedMessageContent = {
+        legacyAttachmentLines: ['[image/png: photo.png]', '[text/csv: data.csv]'],
+      };
+
+      const result = formatForwardedQuote(content);
+
+      expect(result).toContain('<attachments>');
+      expect(result).toContain('[image/png: photo.png]');
+      expect(result).toContain('[text/csv: data.csv]');
     });
 
     it('should format full complex forwarded message with all fields', () => {
       const content: ForwardedMessageContent = {
         textContent: 'Important message',
-        imageDescriptions: [
-          { filename: 'img1.png', description: 'First image' },
-          { filename: 'img2.jpg', description: 'Second image' },
+        attachments: [
+          { kind: 'image', filename: 'img1.png', description: 'First image' },
+          { kind: 'image', filename: 'img2.jpg', description: 'Second image' },
+          { kind: 'voice', description: 'Voice note transcript' },
+          { kind: 'file', filename: 'doc.pdf', contentType: 'application/pdf' },
         ],
         embedsXml: ['<embed>Link preview</embed>'],
-        voiceTranscripts: ['Voice note transcript'],
-        attachmentLines: ['- File: doc.pdf (application/pdf)'],
         timestamp: { absolute: 'Feb 10, 2026', relative: 'just now' },
       };
 
@@ -356,9 +462,7 @@ describe('QuoteFormatter', () => {
         '<quote type="forward"',
         '<time ',
         '<content>',
-        '<image_descriptions>',
         '<embeds>',
-        '<voice_transcripts>',
         '<attachments>',
         '</quote>',
       ];
@@ -374,21 +478,21 @@ describe('QuoteFormatter', () => {
     it('should skip empty text content', () => {
       const content: ForwardedMessageContent = {
         textContent: '',
-        imageDescriptions: [{ filename: 'img.png', description: 'An image' }],
+        attachments: [{ kind: 'image', filename: 'img.png', description: 'An image' }],
       };
 
       const result = formatForwardedQuote(content);
 
       expect(result).not.toContain('<content>');
-      expect(result).toContain('<image_descriptions>');
+      expect(result).toContain('<attachments>');
     });
 
     it('should handle multiple images', () => {
       const content: ForwardedMessageContent = {
-        imageDescriptions: [
-          { filename: 'a.png', description: 'Image A' },
-          { filename: 'b.png', description: 'Image B' },
-          { filename: 'c.png', description: 'Image C' },
+        attachments: [
+          { kind: 'image', filename: 'a.png', description: 'Image A' },
+          { kind: 'image', filename: 'b.png', description: 'Image B' },
+          { kind: 'image', filename: 'c.png', description: 'Image C' },
         ],
       };
 
@@ -430,7 +534,7 @@ describe('QuoteFormatter', () => {
         from: 'Alice',
         role: 'user',
         content: 'look at this',
-        imageDescriptions: [{ filename: 'a.png', description: 'a lighthouse at dusk' }],
+        attachments: [{ kind: 'image', filename: 'a.png', description: 'a lighthouse at dusk' }],
       });
       expect(withMedia).toContain('its media is described here');
       expect(withMedia).toContain('<image filename="a.png">a lighthouse at dusk</image>');
@@ -439,9 +543,27 @@ describe('QuoteFormatter', () => {
         from: 'Alice',
         role: 'user',
         content: '',
-        voiceTranscripts: ['hey are you around'],
+        attachments: [{ kind: 'voice', description: 'hey are you around' }],
       });
       expect(withTranscript).toContain('its media is described here');
+    });
+
+    it('names an undescribed attachment without claiming it is described', () => {
+      // The two halves pull opposite ways and both matter. The attachment must
+      // RENDER — an image with no description and no element is invisible, which
+      // is the drop this whole shape exists to close. But the marker must NOT
+      // promise a description, or the model goes looking for one that never
+      // arrived and apologises for missing it.
+      const result = formatDedupedQuote({
+        from: 'Alice',
+        role: 'user',
+        content: 'check this',
+        attachments: [{ kind: 'image', filename: 'unlucky.png', status: 'undescribed' }],
+      });
+
+      expect(result).toContain('<image filename="unlucky.png" status="undescribed"/>');
+      expect(result).not.toContain('its media is described here');
+      expect(result).toContain('[Referenced message — full text in the chat log]');
     });
 
     it('does NOT let long attachment markers truncate away the text preview', () => {

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -11,12 +11,112 @@
  * to provide context about the quote source.
  */
 
+import { CONTENT_TYPES } from '@tzurot/common-types/constants/media';
 import { type RenderedQuoteRole } from './referenceRole.js';
-import {
-  escapeXmlContent,
-  neutralizeWrapperClosingTags,
-} from '@tzurot/common-types/utils/promptSanitizer';
+import { escapeXmlContent } from '@tzurot/common-types/utils/promptSanitizer';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
+
+/**
+ * Fields every attachment carries regardless of modality.
+ *
+ * The shape is deliberately STRUCTURED rather than a pre-rendered line. A
+ * producer that hands back `- Image (photo.png): a cat` has thrown away the
+ * filename and the description as separate values, so every consumer downstream
+ * can only paste the string somewhere — which is how the same attachment came
+ * to render four different ways depending on which path reached it.
+ */
+interface AttachmentIdentity {
+  /**
+   * Original filename. OMITTED ENTIRELY when there is no real name — never
+   * synthesized. A placeholder is worse than an absence here: filenames are
+   * matched across producers (`error-screenshot-checkout.png` is often the only
+   * signal an undescribed image has left), and two producers inventing
+   * different placeholders is a correspondence bug waiting to happen.
+   */
+  filename?: string;
+  /** Discord content type, when known. */
+  contentType?: string;
+}
+
+/**
+ * Enrichment is EITHER present OR explained — never both. Expressed as a union
+ * with `never` arms so the contradiction ("here is the transcript, and also we
+ * failed to transcribe it") cannot be constructed.
+ */
+type Enrichment<TStatus extends string> =
+  { description: string; status?: never } | { description?: never; status?: TStatus };
+
+/** An image, with its vision description when one arrived. */
+export type RenderableImage = AttachmentIdentity & { kind: 'image' } & Enrichment<
+    'undescribed' | 'expired' | 'unprocessed'
+  >;
+
+/** A voice message, with its transcript when one arrived. */
+export type RenderableVoice = AttachmentIdentity & {
+  kind: 'voice';
+  /** Clip length in seconds, when known. */
+  durationSeconds?: number;
+} & Enrichment<'untranscribed' | 'expired' | 'unprocessed'>;
+
+/** Any other attachment. Never carries enrichment — nothing describes a .zip. */
+export interface RenderableFile extends AttachmentIdentity {
+  kind: 'file';
+  status?: 'unprocessed';
+}
+
+/**
+ * One attachment, in the shape the prompt renders it.
+ *
+ * A discriminated union rather than one flat interface, so the invariants are
+ * the compiler's to keep rather than a doc comment's: `durationSeconds` cannot
+ * appear on an image, `description` cannot appear on a file (the renderer would
+ * silently drop it), and a status cannot name the wrong modality's failure —
+ * `untranscribed` on an image is now unwriteable.
+ *
+ * Absent enrichment is rendered EXPLICITLY via `status` rather than by
+ * omission: a bare `<image filename="x.png"/>` leaves the model unable to tell
+ * "vision failed" from "still processing" from "nothing worth describing", so
+ * it invents one or apologises for a description that was never coming. Stated,
+ * it can say the true thing. (`expired` is for the retention work's aged-out
+ * case; `unprocessed` is the last-resort "something threw before we could
+ * classify the failure".)
+ */
+export type RenderableAttachment = RenderableImage | RenderableVoice | RenderableFile;
+
+/**
+ * Which element an attachment renders as.
+ *
+ * Lives here, beside the vocabulary it returns, because BOTH producers need the
+ * same answer and they had already drifted: the live path keyed voice on
+ * `isVoiceMessage` alone while the stored path also accepted any `audio/*`, so
+ * an ordinary music clip rendered `<file/>` in the turn it was posted and
+ * `<voice status="untranscribed"/>` when the same attachment was replayed from
+ * history. That is the exact "same object, different vocabulary per path" split
+ * this whole shape exists to remove — reintroduced, one level down, by two
+ * copies of a three-line rule.
+ *
+ * `isVoiceMessage` is the right discriminator and is available to both:
+ * producers persist it on `attachmentMetadataSchema`, so the stored path never
+ * needed a content-type fallback. An `audio/*` file WITHOUT the flag is someone
+ * sharing a sound file, not a voice message, and calling it a failed
+ * transcription tells the model something untrue.
+ *
+ * Structurally typed rather than taking `AttachmentMetadata` so this module
+ * stays free of the Discord schema — the same trick `isBotAuthoredReference`
+ * uses.
+ */
+export function classifyAttachment(attachment: {
+  isVoiceMessage?: boolean;
+  contentType?: string;
+}): RenderableAttachment['kind'] {
+  if (attachment.isVoiceMessage === true) {
+    return 'voice';
+  }
+  if (attachment.contentType?.startsWith(CONTENT_TYPES.IMAGE_PREFIX) === true) {
+    return 'image';
+  }
+  return 'file';
+}
 
 /**
  * Options for formatting a single <quote> element.
@@ -45,12 +145,21 @@ export interface QuoteElementOptions {
   locationContext?: string;
   /** Pre-formatted embed XML strings */
   embedsXml?: string[];
-  /** Image descriptions */
-  imageDescriptions?: { filename: string; description: string }[];
-  /** Voice transcripts */
-  voiceTranscripts?: string[];
-  /** Pre-formatted attachment lines */
-  attachmentLines?: string[];
+  /** This quote's attachments — images, voice, files — with their enrichment. */
+  attachments?: RenderableAttachment[];
+  /**
+   * Pre-rendered `[contentType: name]` marker strings, rendered verbatim inside
+   * <attachments>.
+   *
+   * LEGACY, and deliberately named so. Its only caller is the forwarded-history
+   * path, whose source (`messageMetadata.forwardedAttachmentLines`) is a
+   * PERSISTED `string[]` — rows already in the database that cannot be
+   * un-rendered back into `RenderableAttachment`s. Every other producer emits
+   * structured attachments. Do not add a caller: the slot is the affordance
+   * that let the vocabularies diverge, and it goes away once the producer
+   * persists structure instead of strings.
+   */
+  legacyAttachmentLines?: string[];
 }
 
 /**
@@ -62,12 +171,21 @@ export interface QuoteElementOptions {
  *   <time absolute="..." relative="..."/>     (if timestamp provided)
  *   <content>text</content>                   (if content provided and non-empty)
  *   locationContext XML                        (if provided and non-empty)
- *   <image_descriptions>...</image_descriptions>
  *   <embeds>...</embeds>
- *   <voice_transcripts>...</voice_transcripts>
- *   <attachments>...</attachments>
+ *   <attachments>
+ *     <image filename="cat.png">a cat asleep on a keyboard</image>
+ *     <image filename="unlucky.png" status="undescribed"/>
+ *     <voice filename="clip.ogg" duration="12s">hey, can you hear me</voice>
+ *     <file filename="report.pdf" type="application/pdf"/>
+ *   </attachments>
  * </quote>
  * ```
+ *
+ * Every attachment renders as ONE element under ONE wrapper, whether or not its
+ * enrichment arrived. The alternative — a described image under
+ * `<image_descriptions>` and an undescribed one under `<attachments>` — put the
+ * same object in two unrelated vocabularies chosen by whether an API call
+ * succeeded, and forced consumers to correlate the two halves by filename.
  */
 export function formatQuoteElement(opts: QuoteElementOptions): string {
   // Build opening tag attributes (data-driven to reduce branching)
@@ -95,34 +213,97 @@ export function formatQuoteElement(opts: QuoteElementOptions): string {
     }
   }
 
-  // Simple child sections. content/image-descriptions/attachmentLines carry
+  // Simple child sections. content and the attachment children carry
   // user-derived text and are escaped at emit. locationContext and embedsXml are
   // pre-formatted XML from trusted internal sources (ReferencedMessageFormatter;
   // bot-client's EmbedParser, which escapeXml's every embed field) — those two
   // are passed through verbatim; do NOT route raw user input through them.
   addNonEmpty(parts, opts.content, c => `<content>${escapeXmlContent(c)}</content>`);
   addNonEmpty(parts, opts.locationContext, loc => loc);
-  addArraySection(parts, opts.imageDescriptions, 'image_descriptions', imgs =>
-    imgs.map(
-      img =>
-        `<image filename="${escapeXml(img.filename)}">${escapeXmlContent(img.description)}</image>`
-    )
-  );
   addArraySection(parts, opts.embedsXml, 'embeds', e => e);
-  // voice_transcripts/transcript are NOT in PROTECTED_TAGS (see promptSanitizer),
-  // so escapeXmlContent alone leaves </transcript> live — neutralize the wrapper
-  // closings the same way the current-turn audio path does.
-  addArraySection(parts, opts.voiceTranscripts, 'voice_transcripts', ts =>
-    ts.map(t => `<transcript>${neutralizeWrapperClosingTags(escapeXmlContent(t))}</transcript>`)
-  );
-  // attachmentLines carry unescaped filenames / transcriptions — escape so a
-  // crafted name can't close </attachments>/</quote> and break out.
-  addArraySection(parts, opts.attachmentLines, 'attachments', a =>
-    a.map(line => escapeXmlContent(line))
-  );
+  // One <attachments> section for both producers. legacyAttachmentLines carry
+  // unescaped filenames — escape so a crafted name can't close </attachments>
+  // or </quote> and break out.
+  const attachmentItems = [
+    ...(opts.attachments ?? []).map(renderAttachment),
+    ...(opts.legacyAttachmentLines ?? []).map(line => escapeXmlContent(line)),
+  ];
+  addArraySection(parts, attachmentItems, 'attachments', items => items);
 
   parts.push('</quote>');
   return parts.join('\n');
+}
+
+/**
+ * Render one attachment as its per-modality element.
+ *
+ * The element name is written out per branch rather than interpolated from
+ * `kind`. That is not verbosity for its own sake: `pnpm ops guard:prompt-tags`
+ * finds emitted tags by scanning source for literal `<tag …>` forms, so a
+ * `` `<${kind}…>` `` template would render three structural tags the guard
+ * cannot see — a silent hole in exactly the check that decides whether user
+ * content inside them gets escaped.
+ */
+export function renderAttachment(att: RenderableAttachment): string {
+  switch (att.kind) {
+    case 'image': {
+      const attrs = joinAttrs([
+        ['filename', att.filename],
+        ['type', att.contentType],
+        ['status', att.status],
+      ]);
+      const body = renderEnrichment(att.description);
+      return body === undefined ? `<image${attrs}/>` : `<image${attrs}>${body}</image>`;
+    }
+    case 'voice': {
+      const attrs = joinAttrs([
+        ['filename', att.filename],
+        ['type', att.contentType],
+        ['duration', att.durationSeconds !== undefined ? `${att.durationSeconds}s` : undefined],
+        ['status', att.status],
+      ]);
+      const body = renderEnrichment(att.description);
+      return body === undefined ? `<voice${attrs}/>` : `<voice${attrs}>${body}</voice>`;
+    }
+    case 'file':
+      return `<file${joinAttrs([
+        ['filename', att.filename],
+        ['type', att.contentType],
+        ['status', att.status],
+      ])}/>`;
+  }
+}
+
+/**
+ * The enrichment text an attachment carries, if any.
+ *
+ * Exists because the union deliberately gives `RenderableFile` no `description`
+ * field — nothing describes a .zip — so consumers that want "whatever text this
+ * attachment contributes" need one place that knows that, rather than each
+ * re-deriving it and one of them eventually getting it wrong.
+ */
+export function attachmentEnrichment(att: RenderableAttachment): string | undefined {
+  return att.kind === 'file' ? undefined : att.description;
+}
+
+/** Join defined attribute pairs into a leading-space attribute string. */
+function joinAttrs(defs: [string, string | undefined][]): string {
+  const list = defs
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([key, val]) => `${key}="${escapeXml(val)}"`)
+    .join(' ');
+  return list.length > 0 ? ` ${list}` : '';
+}
+
+/**
+ * Escape an attachment's enrichment for use as element text. `image` and
+ * `voice` are in PROTECTED_TAGS, so `escapeXmlContent` neutralizes a closing
+ * form appearing inside a description or transcript.
+ */
+function renderEnrichment(description: string | undefined): string | undefined {
+  return description !== undefined && description.length > 0
+    ? escapeXmlContent(description)
+    : undefined;
 }
 
 /** Append formatted string if value is defined and non-empty */
@@ -151,14 +332,12 @@ function addArraySection<T>(
 export interface ForwardedMessageContent {
   /** Plain text content of the forwarded message */
   textContent?: string;
-  /** Image descriptions from vision processing */
-  imageDescriptions?: { filename: string; description: string }[];
   /** Pre-formatted embed XML strings (callers must provide well-formed XML) */
   embedsXml?: string[];
-  /** Voice message transcripts */
-  voiceTranscripts?: string[];
-  /** Pre-formatted attachment lines (non-image, non-voice) */
-  attachmentLines?: string[];
+  /** This message's attachments with their enrichment. */
+  attachments?: RenderableAttachment[];
+  /** Persisted marker strings — see `QuoteElementOptions.legacyAttachmentLines`. */
+  legacyAttachmentLines?: string[];
   /** Timestamp with both absolute date and relative time */
   timestamp?: { absolute: string; relative: string };
 }
@@ -173,10 +352,9 @@ export function formatForwardedQuote(content: ForwardedMessageContent): string {
     from: 'Unknown',
     timestamp: content.timestamp,
     content: content.textContent,
-    imageDescriptions: content.imageDescriptions,
     embedsXml: content.embedsXml,
-    voiceTranscripts: content.voiceTranscripts,
-    attachmentLines: content.attachmentLines,
+    attachments: content.attachments,
+    legacyAttachmentLines: content.legacyAttachmentLines,
   });
 }
 
@@ -224,15 +402,13 @@ export interface DedupedQuoteOptions {
    *  Rendered as-is — NOT re-truncated here. Empty → marker-only stub. */
   content: string;
   /**
-   * Vision descriptions for this reference's images. NOT redundant with the
+   * This reference's attachments with their enrichment. NOT redundant with the
    * <chat_log> copy: history renders an embed/attachment as its URL, so a
    * description dropped here is enrichment that was computed, paid for, and
    * never reaches the model. The stub's own `[image/png: name]` markers name
    * the file, not what is in it.
    */
-  imageDescriptions?: { filename: string; description: string }[];
-  /** Voice transcripts for this reference's audio — same reasoning as `imageDescriptions`. */
-  voiceTranscripts?: string[];
+  attachments?: RenderableAttachment[];
 }
 
 /**
@@ -248,8 +424,14 @@ export function formatDedupedQuote(opts: DedupedQuoteOptions): string {
   // (e.g. `I...` for `I got myself off…`) that the model reads as an unfinished sentence.
   // The text is already bounded; the markers are short metadata that must survive intact.
   // Empty content (e.g. a bot's own reply-target) → marker only, no trailing blank.
-  const hasMedia =
-    (opts.imageDescriptions?.length ?? 0) > 0 || (opts.voiceTranscripts?.length ?? 0) > 0;
+  // The "its media is described here" clause is earned only by an attachment
+  // that actually carries enrichment. An undescribed one still renders (it is
+  // signal that something was attached), but pointing the model at a
+  // description that does not exist is the failure the clause exists to avoid.
+  const hasMedia = (opts.attachments ?? []).some(att => {
+    const enrichment = attachmentEnrichment(att);
+    return enrichment !== undefined && enrichment.length > 0;
+  });
   const prefix = hasMedia ? DEDUP_REPLY_TARGET_PREFIX_WITH_MEDIA : DEDUP_REPLY_TARGET_PREFIX;
   const content = opts.content.length > 0 ? `${prefix}\n\n${opts.content}` : prefix;
 
@@ -261,7 +443,6 @@ export function formatDedupedQuote(opts: DedupedQuoteOptions): string {
     timestamp: opts.timestamp,
     timeFormatted: opts.timeFormatted,
     content,
-    imageDescriptions: opts.imageDescriptions,
-    voiceTranscripts: opts.voiceTranscripts,
+    attachments: opts.attachments,
   });
 }

--- a/tracker/tasks/task-370 - Cached-tokenCount-bypasses-the-accurate-estimator-—-budget-undercounts-every-metadata-section.md
+++ b/tracker/tasks/task-370 - Cached-tokenCount-bypasses-the-accurate-estimator-—-budget-undercounts-every-metadata-section.md
@@ -36,4 +36,39 @@ Known call sites with the `tokenCount ?? estimator` shape:
 **Acceptance**: an executable parity check. Render a message with EVERY metadata section populated, compare the budget's number against the real rendered token count, and fail on drift beyond a stated tolerance. That makes the estimator/renderer pair self-policing instead of hand-synced (task-368's class).
 
 **Exhaustive sweep still owed** (owner asked for it explicitly): enumerate every budget/truncation decision in the prompt-assembly path, not just these three, and confirm each measures the rendered form. Enumerate deterministically — grep every `tokenCount` consumer AND every call site of the estimator — rather than sampling.
+
+## CORRECTION — "the estimator is NOT the problem" is only true section-by-section
+
+Found while building TASK-365's attachment-vocabulary PR. The claim above holds
+at the level it was checked (all five sections are ACCOUNTED FOR) and fails one
+level down: `estimateReferenceLength` (same file, top) models a `<quote>` shape
+the renderer has not emitted for some time. Read side by side:
+
+| Estimator emits | `formatQuoteElement` actually emits |
+| --- | --- |
+| `author="…"` | `from="…"` |
+| `location="…"` as an ATTRIBUTE | `locationContext` as a child ELEMENT |
+| `forwarded="true"` | `type="forward"` |
+| — | `<time …/>`, `role`, `username`, `from_id`, `number` |
+| ~~`resolvedImageDescriptions` not counted at all~~ | ✅ CLOSED — see below |
+| ~~every attachment estimated as an `<image>`~~ | ✅ CLOSED — see below |
+
+So a reference's estimate can be wrong by the entire length of its vision
+descriptions — the largest single term a quoted message contributes, and exactly
+the term the retention work is about to make more common.
+
+**The attachments portion is CLOSED, and it closed by proving the fix shape.**
+TASK-365's PR-1 first tried to mirror the renderer by hand and got it wrong in
+two directions at once (every attachment estimated image-shaped: a voice message
+lost its `duration`, a plain file gained a `status` it can never carry). Two
+independent reviews caught it. The answer was not a better mirror — it was to
+delete the mirror: the estimator now calls `buildStoredAttachments` +
+`renderAttachment`, the same pair the prompt renders through, and a parity test
+in `conversationUtils.test.ts` fails the moment anyone reintroduces a local copy.
+
+**That is the template for the rest of this task.** The surrounding `<quote>`
+estimate is still hand-written and still disagrees with the renderer on
+attribute names — do the same thing to it: call `formatQuoteElement` and measure.
+It also subsumes the acceptance check written above, because a parity test
+between two renderers is unnecessary when there is only one.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-378 - Align-message-level-media-vocabulary-with-the-quote-level-attachments-shape.md
+++ b/tracker/tasks/task-378 - Align-message-level-media-vocabulary-with-the-quote-level-attachments-shape.md
@@ -1,0 +1,26 @@
+---
+id: TASK-378
+title: Align message-level media vocabulary with the quote-level <attachments> shape
+status: To Do
+assignee: []
+created_date: '2026-07-31 12:21'
+updated_date: '2026-07-31 12:21'
+labels:
+  - 'area:ai-worker'
+  - 'size:M'
+dependencies: []
+priority: medium
+ordinal: 378000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Why: quote-level media now renders as one `<attachments>` section with per-modality `<image>/<voice>/<file>` elements carrying a `status` when enrichment is absent. MESSAGE level still emits the old split — `formatImageSection` -> `<image_descriptions>`, `formatVoiceSection` -> `<voice_transcripts>` (xmlMetadataFormatters), plus RAGUtils wrapping memory transcripts in `<voice_transcripts><transcript>`. Leaving them recreates at the message level exactly the inconsistency the quote level just removed, and the owner's vocabulary constraint was "as long as it is consistent".
+
+What: move message-level sections to the same `<attachments>` vocabulary; decide RAGUtils separately (memory entries are a different surface and may want to keep a distinct wrapper).
+
+Why not done with the quote level: it is the widest model-visible surface in the prompt (every history message, over persisted metadata), so it gets its own decision and its own revert handle rather than riding along.
+
+Acceptance: one media vocabulary across quote and message level; `guard:prompt-tags` still classifies every emitted tag; conversationLengthEstimator updated in the same change.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
First of three PRs on TASK-365. This one is the **prerequisite**, not the rider — see "Why this is first" below.

## The problem

An attachment on a quoted message rendered under `<image_descriptions>` when its vision call succeeded and under `<attachments>` when it did not. Same object, two unrelated tag namespaces, selected by whether an API call worked. Voice had the identical split. And the two container names were in different registers: `<image_descriptions>` / `<voice_transcripts>` name the *derived artifact*, `<attachments>` names the *source object*.

Six render paths reached that emitter, filling different slots — three live branches (standard / forwarded / deduped), two stored (full / deduped), and a forwarded history message that is not a reference at all.

## The shape now

```xml
<attachments>
  <image filename="cat.png">a cat asleep on a keyboard</image>
  <image filename="unlucky.png" status="undescribed"/>
  <voice filename="clip.ogg" duration="12s">hey, can you hear me</voice>
  <file filename="report.pdf" type="application/pdf"/>
</attachments>
```

`status` exists because silently omitting a description leaves the model unable to tell *vision failed* from *still processing* from *nothing worth describing* — so it invents one, or apologises for a description that was never coming. Its value space (`undescribed` / `untranscribed` / `expired` / `unprocessed`) is sized for the retention work already decided, rather than a boolean that would need migrating the moment aged-out images land.

Filename is carried in **both** arms — it matters most on the undescribed arm, where it is the only signal left. When there is no real name the attribute is **omitted**, never filled with a placeholder.

`RenderableAttachment` is a discriminated union, so the per-modality invariants are the compiler's to keep rather than a doc comment's: `durationSeconds` cannot appear on an image, `description` cannot appear on a file, and a status cannot name the wrong modality's failure. Four `@ts-expect-error` assertions in `QuoteFormatter.test.ts` fail the build if the union ever stops rejecting those shapes.

## The load-bearing half

`processAttachmentsParallel` now returns structured `RenderableAttachment[]` instead of pre-rendered lines. A caller holding `"- Image (photo.png): a cat"` has no filename or description left as separate values, so it can only paste the string into `<attachments>` — that is how the divergence arose, and how it would regrow.

## Two drops that close by construction

- **The stored path correlated described-vs-undescribed BY FILENAME** across two lists, and the two sides defaulted a nameless attachment differently (`'image'` vs `'attachment'`), so the lookup missed and the same picture rendered twice. One element per attachment removes the correspondence entirely.
- **A deduped stored reference now names an undescribed attachment** instead of omitting it as chat-log redundancy. That was true of the file's *name* and false of its *existence*: an attachment with no description and no marker is invisible. Closes the absorbed follow-up from #1877's round-3 review.

## Why this is first

TASK-365 recorded PR-1 as an *output-identical collapse* with the vocabulary flip following. Reading the six paths end to end says that is not buildable: the dedup projection changes output by construction, one renderer reading `isForwarded` must pick a single `from` rule where the two paths disagree today, and the same attachment renders four different ways selected by source AND by whether vision succeeded. One renderer + byte-equality ⇒ a mode param, which the design already rejected on independent grounds.

So the vocabulary is the collapse's prerequisite. Corrected sequencing is recorded in TASK-365; the reference collapse is PR-2, message-level alignment is TASK-378.

## The estimator stopped being a second renderer

`estimateReferenceLength` used to hand-write its own version of the attachment markup. Review caught that the first pass at this got it wrong in two directions at once — every attachment estimated image-shaped, so a voice message lost its `duration` and a plain file gained a `status` it can never carry. The answer was not a better mirror but to delete the mirror: it now calls `buildStoredAttachments` + `renderAttachment`, the same pair the prompt renders through, with a parity test that fails the moment anyone reintroduces a local copy.

That closes two rows of TASK-370's drift table and demonstrates the fix shape for the rest of it (the surrounding `<quote>` estimate is still hand-written and still disagrees with the renderer on attribute names).

## Verified

- `pnpm test` — full monorepo suite green (191 files / 4118 tests in ai-worker)
- `pnpm quality` — 26/26, including `guard:prompt-tags`
- `voice` added to `PROTECTED_TAGS` (it wraps transcripts); `file` classified as self-closing in the guard's registry. Per-kind element names are written out **literally** rather than interpolated from `kind`, because that guard finds tags by scanning source for literal `<tag …>` forms — a template would have hidden all three new tags from the check that decides whether user content inside them gets escaped. Covered by a test that a crafted `</image>` / `</voice>` in a description cannot break out.
- A review finding that `renderAttachment`'s switch needed an exhaustiveness assertion was **checked and dropped**: widening `kind` to a fourth member produces `TS2366: Function lacks ending return statement`, so the compiler already enforces it.

## Also in here

- The `xmlMetadataFormatters` suite stopped hand-reimplementing the renderer in a mock — a second renderer kept in sync by hand, living inside the suite for the bug class *"renderers kept in sync by hand"*, which had already gone blind to a drop once. It spies the real one now, keeping the call-argument seam assertions.
- Reference search text is built from descriptions only; it previously fed the whole rendered line (`- Image (photo.png): `) into the embedding query.
- The `Promise.allSettled` rejection fallback keeps the attachment's modality and identity (`status: 'unprocessed'`) instead of degrading everything to a nameless `<file/>`, which read identically to an ordinary unprocessed document.

## Not done here

- `attachmentLines` survives, narrowed and renamed `legacyAttachmentLines`, for one caller: `messageMetadata.forwardedAttachmentLines` is a **persisted `string[]`** and those rows cannot be un-rendered. Deleting the affordance is one migration away, not one refactor away.
- Message-level `<image_descriptions>` / `<voice_transcripts>` are untouched → **TASK-378**. Leaving them recreates the split one level up, so consistency wants it — but it is the widest model-visible surface here, so it gets its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
