### PR TITLE
refactor(ai-worker): one renderer for a quoted reference, dedup as projection

### DIFF
--- a/packages/common-types/src/utils/dateFormatting.test.ts
+++ b/packages/common-types/src/utils/dateFormatting.test.ts
@@ -5,7 +5,6 @@ import {
   formatRelativeTime,
   formatMemoryTimestamp,
   formatRelativeTimeDelta,
-  formatTimestampWithDelta,
   formatPromptTimestamp,
   formatDateShort,
   formatDateTimeCompact,
@@ -201,41 +200,6 @@ describe('dateFormatting', () => {
 
     it('should return empty string for invalid date', () => {
       expect(formatRelativeTimeDelta('not-a-date')).toBe('');
-    });
-  });
-
-  describe('formatTimestampWithDelta', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date('2025-01-27T12:00:00Z'));
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('should return both absolute and relative formats', () => {
-      const date = new Date('2025-01-13T12:00:00Z'); // 14 days ago
-      const result = formatTimestampWithDelta(date, 'UTC');
-
-      expect(result.absolute).toBe('Mon, Jan 13, 2025');
-      expect(result.relative).toBe('2 weeks ago');
-    });
-
-    it('should handle recent timestamps', () => {
-      const date = new Date('2025-01-27T11:55:00Z'); // 5 minutes ago
-      const result = formatTimestampWithDelta(date, 'UTC');
-
-      expect(result.absolute).toBe('Mon, Jan 27, 2025');
-      expect(result.relative).toBe('5 minutes ago');
-    });
-
-    it('should handle old timestamps', () => {
-      const date = new Date('2024-01-27T12:00:00Z'); // 1 year ago
-      const result = formatTimestampWithDelta(date, 'UTC');
-
-      expect(result.absolute).toBe('Sat, Jan 27, 2024');
-      expect(result.relative).toBe('1 year ago');
     });
   });
 

--- a/packages/common-types/src/utils/dateFormatting.ts
+++ b/packages/common-types/src/utils/dateFormatting.ts
@@ -295,46 +295,6 @@ export function formatRelativeTimeDelta(timestamp: Date | string | number): stri
 }
 
 /**
- * Result type for memory timestamp with delta
- */
-interface TimestampWithDelta {
-  /** Absolute date (e.g., "Mon, Jan 15, 2025") */
-  absolute: string;
-  /** Relative time delta (e.g., "2 weeks ago") */
-  relative: string;
-}
-
-/**
- * Format a timestamp with both absolute date and relative time delta
- *
- * This is the recommended function for LTM memory formatting as it provides
- * both the precise date and a human-readable temporal distance.
- *
- * Example:
- * {
- *   absolute: "Mon, Jan 15, 2025",
- *   relative: "2 weeks ago"
- * }
- *
- * Used for:
- * - LTM memory entries in prompts
- * - Referenced message formatting
- *
- * @param timestamp - Timestamp to format
- * @param timezone - Optional IANA timezone. Defaults to APP_SETTINGS.TIMEZONE
- * @returns Object with both absolute and relative formats
- */
-export function formatTimestampWithDelta(
-  timestamp: Date | string | number,
-  timezone?: string
-): TimestampWithDelta {
-  return {
-    absolute: formatMemoryTimestamp(timestamp, timezone),
-    relative: formatRelativeTimeDelta(timestamp),
-  };
-}
-
-/**
  * Format a timestamp for prompt display with unified format
  *
  * Format: "YYYY-MM-DD (Day) HH:MM • relative"

--- a/packages/common-types/src/utils/referenceEnrichment.test.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { INTERVALS } from '../constants/timing.js';
-import { TEXT_LIMITS } from '../constants/discord.js';
 import type { ReferencedMessage } from '../types/schemas/message.js';
 import {
   appendVoiceTranscripts,
-  buildDedupedReferenceStub,
-  capDedupText,
   isBotAuthoredReference,
   isDuplicateReference,
   stripBotVoiceAttachments,
@@ -97,129 +94,6 @@ describe('isDuplicateReference', () => {
         undefined
       )
     ).toBe(true);
-  });
-});
-
-// Defaults to non-bot: bot-authored stubs are now marker-only (empty content), so the
-// dedup-content assertions below need a user-authored reference to keep their text.
-function fullReference(content: string, botAuthored = false): ReferencedMessage {
-  return {
-    referenceNumber: 3,
-    discordMessageId: 'msg-9',
-    ...(botAuthored ? { webhookId: 'wh-1', authorIsBot: true } : {}),
-    discordUserId: 'user-1',
-    authorUsername: 'someone',
-    authorDisplayName: 'Someone',
-    content,
-    embeds: '<embed>stuff</embed>',
-    timestamp: '2026-06-01T11:59:00.000Z',
-    locationContext: '<location>here</location>',
-    attachments: [{ url: 'https://cdn/x.png', contentType: 'image/png', name: 'x.png' }],
-    isForwarded: true,
-  };
-}
-
-describe('capDedupText', () => {
-  it('returns text at or under the limit unchanged (no ellipsis)', () => {
-    const short = 'X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT);
-    expect(capDedupText(short)).toBe(short);
-    expect(capDedupText('hi')).toBe('hi');
-    expect(capDedupText('')).toBe('');
-  });
-
-  it('caps over-limit text to DEDUP_STUB_CONTENT chars + ellipsis', () => {
-    const long = 'X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 100);
-    const capped = capDedupText(long);
-    expect(capped).toBe('X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...');
-    expect(capped).not.toContain('X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 1));
-  });
-});
-
-describe('buildDedupedReferenceStub', () => {
-  it('strips embeds/location/flags and folds the attachment marker into content', () => {
-    const stub = buildDedupedReferenceStub(fullReference('short content'));
-    expect(stub).toEqual({
-      referenceNumber: 3,
-      discordMessageId: 'msg-9',
-      discordUserId: 'user-1',
-      authorUsername: 'someone',
-      authorDisplayName: 'Someone',
-      // marker first (truncation-safe), then the original text
-      content: '[image/png: x.png]\n\nshort content',
-      embeds: '',
-      timestamp: '2026-06-01T11:59:00.000Z',
-      locationContext: '',
-      isDeduplicated: true,
-    });
-  });
-
-  it('renders attachment markers alone for an image-only reply-target (empty text)', () => {
-    const stub = buildDedupedReferenceStub(fullReference(''));
-    expect(stub.content).toBe('[image/png: x.png]');
-  });
-
-  it('emits one marker per attachment, using contentType + name', () => {
-    const ref = fullReference('look at these');
-    ref.attachments = [
-      { url: 'https://cdn/a.jpg', contentType: 'image/jpeg', name: 'a.jpg' },
-      { url: 'https://cdn/v.ogg', contentType: 'audio/ogg' }, // no name → 'attachment'
-    ];
-    const stub = buildDedupedReferenceStub(ref);
-    expect(stub.content).toBe('[image/jpeg: a.jpg]\n[audio/ogg: attachment]\n\nlook at these');
-  });
-
-  it('leaves content untouched (no leading newlines) when there are no attachments', () => {
-    const ref = fullReference('plain text');
-    ref.attachments = undefined;
-    const stub = buildDedupedReferenceStub(ref);
-    expect(stub.content).toBe('plain text');
-  });
-
-  it('truncates the text portion but keeps the leading marker', () => {
-    const long = 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 10);
-    const stub = buildDedupedReferenceStub(fullReference(long));
-    expect(stub.content).toBe(
-      '[image/png: x.png]\n\n' + 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...'
-    );
-  });
-
-  it('preserves all markers in full even when they alone exceed the content budget', () => {
-    // Several long-named attachments whose markers TOGETHER blow past
-    // DEDUP_STUB_CONTENT. buildDedupedReferenceStub must NOT truncate the
-    // markers (only the text portion is truncated) — they carry the
-    // filename→history correlation that downstream re-truncation
-    // (formatDedupedQuote) is told to protect by keeping them first.
-    const ref = fullReference('hi');
-    const longName = (n: number) => `${'really-long-attachment-name-'.repeat(2)}${n}.png`;
-    ref.attachments = [
-      { url: 'https://cdn/1.png', contentType: 'image/png', name: longName(1) },
-      { url: 'https://cdn/2.png', contentType: 'image/png', name: longName(2) },
-      { url: 'https://cdn/3.png', contentType: 'image/png', name: longName(3) },
-    ];
-    const expectedMarkers = ref.attachments
-      .map(att => `[${att.contentType}: ${att.name}]`)
-      .join('\n');
-
-    // Sanity-check the test actually exercises the over-budget case.
-    expect(expectedMarkers.length).toBeGreaterThan(TEXT_LIMITS.DEDUP_STUB_CONTENT);
-
-    const stub = buildDedupedReferenceStub(ref);
-    // Every marker survives untruncated, markers-first, with the short text after.
-    expect(stub.content).toBe(`${expectedMarkers}\n\nhi`);
-  });
-
-  it('emits a marker-only stub (empty content) for the bot’s own reply-target', () => {
-    // A snippet of the bot's own prior text is the "continue this fragment" trigger;
-    // the full message is in <chat_log> regardless, so bot-authored stubs carry no
-    // preview and no attachment markers. The marker is prepended downstream.
-    const stub = buildDedupedReferenceStub(fullReference('the bot said this earlier', true));
-    expect(stub.content).toBe('');
-  });
-
-  it('preserves authorIsBot/webhookId so the formatter can derive role="assistant"', () => {
-    const stub = buildDedupedReferenceStub(fullReference('x', true));
-    expect(stub.authorIsBot).toBe(true);
-    expect(stub.webhookId).toBe('wh-1');
   });
 });
 

--- a/packages/common-types/src/utils/referenceEnrichment.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.ts
@@ -13,7 +13,6 @@
  * envelope reference snapshots and retrieves transcripts DB-only.
  */
 
-import { TEXT_LIMITS } from '../constants/discord.js';
 import { CONTENT_TYPES } from '../constants/media.js';
 import { INTERVALS } from '../constants/timing.js';
 import type { AttachmentMetadata } from '../types/schemas/discord.js';
@@ -134,75 +133,6 @@ export function stripBotVoiceAttachments(reference: ReferencedMessage): Referenc
   return kept.length === reference.attachments.length
     ? reference
     : { ...reference, attachments: kept };
-}
-
-/**
- * The SINGLE truncation point for dedup-stub previews. Caps a TEXT preview to
- * `DEDUP_STUB_CONTENT` (+ `…`). Applied to text ONLY — never to text-with-markers — so
- * attachment markers (folded in separately, after this) can't eat the budget and squeeze
- * the text to a misleading fragment. `formatDedupedQuote` renders the result as-is: every
- * caller must cap here first (both `buildDedupedReferenceStub` and the stored-history path
- * in `xmlMetadataFormatters.formatQuotedSection`).
- */
-export function capDedupText(text: string): string {
-  const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
-  return text.length > limit ? text.substring(0, limit) + '...' : text;
-}
-
-/**
- * Collapse a full reference into the minimal deduplicated stub: truncated
- * content (with attachment markers), no embeds/location. The stub keeps the
- * reference number — numbering is assigned before the dedup decision, so stubs
- * consume numbers and downstream `[Reference N]` links stay stable.
- *
- * Attachment markers (`[contentType: name]`) are folded into the content so an
- * image-only reply-target doesn't collapse to an empty quote — without them the
- * model sees nothing and reports "no image," even though the full message (with
- * its rendered image description) is in the history the stub points at. The
- * marker's filename lets the model correlate the stub with that history entry.
- *
- * With attachments present the returned `content` can exceed `DEDUP_STUB_CONTENT`
- * (markers are prepended AFTER the text is truncated) — that's intentional and FINAL:
- * `formatDedupedQuote` renders it as-is. It must NOT re-apply the limit to the combined
- * markers+text, or long image-filename markers eat the whole budget and squeeze the text
- * hint to a misleading fragment (`I...` for `I got myself off…`). The text is capped here
- * (this is the single truncation point); the markers are short metadata kept whole.
- */
-export function buildDedupedReferenceStub(reference: ReferencedMessage): ReferencedMessage {
-  // Bot-authored stubs carry NO preview. A snippet of the model's own prior text
-  // is exactly the "continue this fragment" trigger; the full message is in
-  // <chat_log> regardless, so the marker (added downstream) is enough. User
-  // reply-targets keep a short preview — genuine content the model may need.
-  let content = '';
-  if (!isBotAuthoredReference(reference)) {
-    const truncatedContent = capDedupText(reference.content);
-    // Markers go FIRST (before the truncated text). The text already has its FULL
-    // DEDUP_STUB_CONTENT budget above; markers are appended without eating it, because
-    // formatDedupedQuote renders this as-is (no second truncation). The full message the
-    // stub points at is in history regardless; the marker filenames are the correlation
-    // hint that must survive.
-    const attachmentMarkers = (reference.attachments ?? [])
-      .map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
-      .join('\n');
-    content = [attachmentMarkers, truncatedContent].filter(s => s.length > 0).join('\n\n');
-  }
-  return {
-    referenceNumber: reference.referenceNumber,
-    discordMessageId: reference.discordMessageId,
-    discordUserId: reference.discordUserId,
-    authorUsername: reference.authorUsername,
-    authorDisplayName: reference.authorDisplayName,
-    // authorIsBot/webhookId still gate the content-emptying above; authorRole is the
-    // carried-through classification the formatter renders as the <quote role> signal.
-    authorIsBot: reference.authorIsBot,
-    webhookId: reference.webhookId,
-    authorRole: reference.authorRole,
-    content,
-    embeds: '',
-    timestamp: reference.timestamp,
-    locationContext: '',
-    isDeduplicated: true,
-  };
 }
 
 /** Retrieves the transcript for one voice attachment, or null when unavailable. */

--- a/packages/tooling/src/dev/check-prompt-tags.ts
+++ b/packages/tooling/src/dev/check-prompt-tags.ts
@@ -84,7 +84,6 @@ export const KNOWN_UNPROTECTED_TAGS: Record<string, string> = {
   category: 'Self-closing; category name attribute via escapeXml.',
   channel: 'Self-closing; channel name/type/topic attributes via escapeXml.',
   thread: 'Self-closing; thread name attribute via escapeXml.',
-  time: 'Self-closing; timestamp attributes via escapeXml.',
   file:
     'Self-closing attachment element; filename/type attributes via escapeXml (full). ' +
     'Never wraps content — an attachment with enrichment renders as <image>/<voice>, ' +

--- a/services/ai-worker/src/jobs/utils/conversationLengthEstimator.ts
+++ b/services/ai-worker/src/jobs/utils/conversationLengthEstimator.ts
@@ -8,45 +8,27 @@
 
 import { type StoredReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
-import { renderAttachment } from '../../services/prompt/QuoteFormatter.js';
+import { renderReference } from '../../services/prompt/RenderableReference.js';
 import type { RawHistoryEntry } from './conversationTypes.js';
 import { resolveSpeakerInfo, type ChatLogRole } from './participantUtils.js';
-import { buildStoredAttachments } from './xmlMetadataFormatters.js';
+import { fromStoredReference } from './xmlMetadataFormatters.js';
 
 /**
- * Estimate character length for a stored reference
+ * Character length of a stored reference, measured by rendering it.
+ *
+ * Not an approximation of the renderer — the renderer. The hand-written
+ * estimate this replaced was wrong in every direction at once: it invented
+ * attribute names the emitter never used (`author=`, `location=`), it added a
+ * phantom ` forwarded="true"` for forwards while the emitter writes
+ * `type="forward"`, and it could only drift further as the renderer moved.
+ *
+ * Deliberately measures the FULL render even for a reference the prompt will
+ * dedupe: this estimator has no view of the history-id set that decides that,
+ * so it over-estimates rather than guessing — the conservative direction for a
+ * budget.
  */
-function estimateReferenceLength(ref: StoredReferencedMessage): number {
-  const authorName = ref.authorDisplayName || ref.authorUsername;
-  let length =
-    `<quote number="1" author="${authorName}" location="${ref.locationContext}">\n${ref.content}\n</quote>`
-      .length;
-
-  if (ref.embeds !== undefined && ref.embeds.length > 0) {
-    length += `\n<embeds>${ref.embeds}</embeds>`.length;
-  }
-
-  const attachments = buildStoredAttachments(ref);
-  if (attachments.length > 0) {
-    // Measured through the REAL producer/renderer pair rather than a local
-    // approximation of them. The marker-string estimate this replaced was wrong
-    // in three compounding ways: it omitted a persisted description entirely
-    // (the largest single term in a reference's cost), it rendered every
-    // attachment image-shaped regardless of modality, and it could only ever
-    // drift further as the renderer moved.
-    //
-    // This is the shape the rest of the estimator still needs (see TASK-370):
-    // the surrounding <quote> estimate below is still a hand-written
-    // approximation and still disagrees with the renderer on attribute names.
-    length += `\n<attachments>\n${attachments.map(renderAttachment).join('\n')}\n</attachments>`
-      .length;
-  }
-
-  if (ref.isForwarded === true) {
-    length += ' forwarded="true"'.length;
-  }
-
-  return length;
+function estimateReferenceLength(ref: StoredReferencedMessage, personalityName: string): number {
+  return renderReference(fromStoredReference(ref, personalityName)).length;
 }
 
 /**
@@ -81,7 +63,10 @@ function resolveSpeakerForEstimation(
 /**
  * Estimate length for referenced messages section
  */
-function estimateReferencedMessagesLength(refs: StoredReferencedMessage[]): number {
+function estimateReferencedMessagesLength(
+  refs: StoredReferencedMessage[],
+  personalityName: string
+): number {
   if (refs.length === 0) {
     return 0;
   }
@@ -91,7 +76,7 @@ function estimateReferencedMessagesLength(refs: StoredReferencedMessage[]): numb
 
   // Add length for each reference
   for (const ref of refs) {
-    length += estimateReferenceLength(ref) + 1; // +1 for newline
+    length += estimateReferenceLength(ref, personalityName) + 1; // +1 for newline
   }
 
   return length;
@@ -244,7 +229,7 @@ export function getFormattedMessageCharLength(
   const metadata = msg.messageMetadata;
   if (metadata !== undefined) {
     if (isUser && metadata.referencedMessages !== undefined) {
-      totalLength += estimateReferencedMessagesLength(metadata.referencedMessages);
+      totalLength += estimateReferencedMessagesLength(metadata.referencedMessages, personalityName);
     }
     totalLength += estimateImageDescriptionsLength(metadata.imageDescriptions);
     totalLength += estimateEmbedsLength(metadata.embedsXml);

--- a/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
@@ -17,7 +17,8 @@ import {
   type RawHistoryEntry,
 } from './conversationUtils.js';
 import { renderAttachment } from '../../services/prompt/QuoteFormatter.js';
-import { buildStoredAttachments } from './xmlMetadataFormatters.js';
+import { renderReference } from '../../services/prompt/RenderableReference.js';
+import { buildStoredAttachments, fromStoredReference } from './xmlMetadataFormatters.js';
 import { MessageRole } from '@tzurot/common-types/constants/message';
 import {
   type CrossChannelHistoryGroupEntry,
@@ -599,8 +600,9 @@ describe('Conversation Utilities', () => {
 
       expect(result).toContain('<quoted_messages>');
       expect(result).toContain('</quoted_messages>');
-      // Uses shared <quote> element structure via formatQuoteElement
-      expect(result).toContain('<quote from="Bob" role="user"');
+      // Uses the shared <quote> element structure via renderReference. The
+      // username rides along because it differs from the display name.
+      expect(result).toContain('<quote from="Bob" username="bob" role="user"');
       expect(result).toContain('<content>Original message</content>');
     });
 
@@ -990,7 +992,7 @@ describe('Conversation Utilities', () => {
 
       // Quoted messages section should be present since the quoted message is NOT in history
       expect(result).toContain('<quoted_messages>');
-      expect(result).toContain('<quote from="Bob" role="user"');
+      expect(result).toContain('<quote from="Bob" username="bob" role="user"');
       expect(result).toContain('<content>Message from a different conversation</content>');
     });
 
@@ -1069,7 +1071,7 @@ describe('Conversation Utilities', () => {
       const result = formatConversationHistoryAsXml(history, 'TestBot');
 
       // The quoted message should have role="assistant" since it's from TestBot
-      expect(result).toContain('<quote from="TestBot" role="assistant"');
+      expect(result).toContain('<quote from="TestBot" username="testbot" role="assistant"');
     });
 
     it('should infer role="user" for quoted messages from other users', () => {
@@ -1096,7 +1098,7 @@ describe('Conversation Utilities', () => {
       const result = formatConversationHistoryAsXml(history, 'TestBot');
 
       // The quoted message should have role="user" since it's from Bob (not TestBot)
-      expect(result).toContain('<quote from="Bob" role="user"');
+      expect(result).toContain('<quote from="Bob" username="bob" role="user"');
     });
 
     it('should format multiple messages in order', () => {
@@ -1733,6 +1735,44 @@ describe('Conversation Utilities', () => {
         '<voice filename="clip.ogg" type="audio/ogg" duration="9s" status="untranscribed"/>'
       );
       expect(rendered).toContain('<file filename="doc.pdf" type="application/pdf"/>');
+    });
+
+    it('measures the WHOLE quote through the real renderer, not just its attachments', () => {
+      // The strongest form of the parity pin. Everything outside <attachments>
+      // used to be a hand-written string in the estimator that had drifted off
+      // the emitter entirely — it invented `author=` and `location=` attributes
+      // the renderer has never emitted, and added a phantom ` forwarded="true"`
+      // where the renderer writes `type="forward"`. Exact equality is what
+      // catches that; a greater-than assertion cannot.
+      const ref: StoredReferencedMessage = {
+        discordMessageId: '123456',
+        authorUsername: 'bob',
+        authorDisplayName: 'Bob',
+        authorRole: 'user',
+        content: 'Original message content',
+        embeds: '<embed>\n<title>A link</title>\n</embed>',
+        timestamp: '2025-01-01T00:00:00Z',
+        locationContext: '<location type="guild">\n<server name="G"/>\n</location>',
+        isForwarded: true,
+        attachments: [
+          { url: 'https://example.com/p.png', contentType: 'image/png', name: 'photo.png' },
+        ],
+        resolvedImageDescriptions: [{ filename: 'photo.png', description: 'a lighthouse' }],
+      };
+
+      const withRef = getFormattedMessageCharLength(
+        { role: 'user', content: 'Reply', messageMetadata: { referencedMessages: [ref] } },
+        'TestBot'
+      );
+      const withoutRef = getFormattedMessageCharLength(
+        { role: 'user', content: 'Reply' },
+        'TestBot'
+      );
+
+      const wrapper = '\n<quoted_messages>\n</quoted_messages>'.length;
+      const quote = renderReference(fromStoredReference(ref, 'TestBot')).length;
+
+      expect(withRef - withoutRef).toBe(wrapper + quote + 1); // +1 for the joining newline
     });
 
     it('should include forwarded type in reference length', () => {

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
@@ -71,21 +71,21 @@ vi.mock('@tzurot/common-types/utils/xmlBuilder', async () => {
 // Delegating keeps the call-argument assertions — the seam this suite verifies is
 // what `formatQuotedSection` HANDS the renderer — while the rendering itself is
 // the production code's, so it cannot drift.
-const { mockFormatQuoteElement, mockFormatDedupedQuote } = vi.hoisted(() => ({
-  mockFormatQuoteElement: vi.fn(),
-  mockFormatDedupedQuote: vi.fn(),
+const { mockRenderReference, mockDedupeReference } = vi.hoisted(() => ({
+  mockRenderReference: vi.fn(),
+  mockDedupeReference: vi.fn(),
 }));
 
-vi.mock('../../services/prompt/QuoteFormatter.js', async () => {
-  const actual = await vi.importActual<typeof import('../../services/prompt/QuoteFormatter.js')>(
-    '../../services/prompt/QuoteFormatter.js'
-  );
-  mockFormatQuoteElement.mockImplementation(actual.formatQuoteElement);
-  mockFormatDedupedQuote.mockImplementation(actual.formatDedupedQuote);
+vi.mock('../../services/prompt/RenderableReference.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../services/prompt/RenderableReference.js')
+  >('../../services/prompt/RenderableReference.js');
+  mockRenderReference.mockImplementation(actual.renderReference);
+  mockDedupeReference.mockImplementation(actual.dedupeReference);
   return {
     ...actual,
-    formatQuoteElement: mockFormatQuoteElement,
-    formatDedupedQuote: mockFormatDedupedQuote,
+    renderReference: mockRenderReference,
+    dedupeReference: mockDedupeReference,
   };
 });
 
@@ -479,7 +479,7 @@ describe('xmlMetadataFormatters', () => {
         undefined
       );
 
-      expect(mockFormatDedupedQuote).toHaveBeenCalledWith(
+      expect(mockDedupeReference).toHaveBeenCalledWith(
         expect.objectContaining({
           attachments: [
             {
@@ -498,8 +498,8 @@ describe('xmlMetadataFormatters', () => {
     });
 
     it('renders role="bot" on a deduped stub from a non-persona bot reference', () => {
-      // Stored authorRole flows through the deduped path too — regression guard against
-      // the role attribute being dropped between deriveRefRole and formatDedupedQuote.
+      // Stored authorRole flows through the deduped path too — regression guard
+      // against the role attribute being dropped across the projection.
       const msg = makeEntry({
         messageMetadata: {
           referencedMessages: [

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -7,19 +7,21 @@
  */
 
 import { type StoredReferencedMessage } from '@tzurot/common-types/types/schemas/message';
-import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
 import {
   escapeXmlContent,
   neutralizeWrapperClosingTags,
 } from '@tzurot/common-types/utils/promptSanitizer';
-import { capDedupText } from '@tzurot/common-types/utils/referenceEnrichment';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
 import {
-  formatQuoteElement,
-  formatDedupedQuote,
-  classifyAttachment,
+  buildRenderableAttachments,
   type RenderableAttachment,
 } from '../../services/prompt/QuoteFormatter.js';
+import {
+  dedupeReference,
+  promptTime,
+  renderReference,
+  type RenderableReference,
+} from '../../services/prompt/RenderableReference.js';
 import { deriveRefRole } from '../../services/prompt/referenceRole.js';
 import type { RawHistoryEntry } from './conversationTypes.js';
 
@@ -48,34 +50,22 @@ export function buildStoredAttachments(ref: StoredReferencedMessage): Renderable
   );
   const matched = new Set<string>();
 
-  const attachments: RenderableAttachment[] = (ref.attachments ?? []).map(att => {
-    const common = { filename: att.name, contentType: att.contentType };
-
-    // Same classifier the live path uses — see `classifyAttachment`. These two
-    // producers must agree about what a given attachment IS, or the same file
-    // renders one way in the turn it arrives and another when replayed.
-    switch (classifyAttachment(att)) {
-      case 'image': {
-        const name = att.name;
-        const description = name !== undefined ? descriptionsByFilename.get(name) : undefined;
-        if (name !== undefined && description !== undefined) {
-          matched.add(name);
-          return { kind: 'image', ...common, description };
-        }
-        return { kind: 'image', ...common, status: 'undescribed' };
-      }
-      case 'voice':
-        // Always `untranscribed` on this path, and that is the honest rendering
-        // rather than a bug: `StoredReferencedMessage` has no audio counterpart
-        // to `resolvedImageDescriptions`, so a replayed voice reference has no
-        // transcript to carry. Saying so beats an unexplained bare element —
-        // closing the gap is a schema change (TASK-367), not a render change.
-        // The duration IS persisted, so it rides along; the live path forwards
-        // it too, and dropping it here was one more live/stored divergence.
-        return { kind: 'voice', ...common, durationSeconds: att.duration, status: 'untranscribed' };
-      case 'file':
-        return { kind: 'file', ...common };
+  // Only images can be enriched here, and that is honest rather than a gap in
+  // this function: `StoredReferencedMessage` has no audio counterpart to
+  // `resolvedImageDescriptions`, so a replayed voice reference has no transcript
+  // to carry and renders `status="untranscribed"`. Closing THAT is a schema
+  // change (TASK-367), not a render change — and a shared builder that quietly
+  // emitted an empty transcript section would paper over it.
+  const attachments = buildRenderableAttachments(ref.attachments ?? [], att => {
+    const name = att.name;
+    if (name === undefined) {
+      return undefined;
     }
+    const description = descriptionsByFilename.get(name);
+    if (description !== undefined) {
+      matched.add(name);
+    }
+    return description;
   });
 
   for (const [filename, description] of descriptionsByFilename) {
@@ -88,54 +78,50 @@ export function buildStoredAttachments(ref: StoredReferencedMessage): Renderable
 }
 
 /**
- * Format a single stored reference as a <quote> element.
+ * Adapt a stored history reference into the canonical renderable shape.
  *
- * Uses the shared formatQuoteElement() for consistent XML structure across
- * all quote formatting paths (real-time refs, history refs, forwarded messages).
- *
- * @param ref - The stored referenced message
- * @param personalityName - Name of the active AI personality (to infer role)
- * @param allPersonalityNames - Optional set of all AI personality names in the conversation
- * @returns Formatted XML string
+ * The one place the stored schema is read. `number` stays absent by design — a
+ * replayed quote has no `[Reference N]` marker in the current message to point
+ * at, so numbering it would invent a referent.
  */
-function formatStoredReferencedMessage(
+export function fromStoredReference(
   ref: StoredReferencedMessage,
   personalityName: string,
   allPersonalityNames?: Set<string>
-): string {
-  // Use hydrated persona name if available, fall back to original Discord display name
-  const authorName = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
-  const role = deriveRefRole(ref.authorRole, authorName, personalityName, allPersonalityNames);
+): RenderableReference {
+  // Hydrated persona name where one resolved, else the Discord display name.
+  const from = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
 
-  // Format location if present (should be XML formatted by bot-client using shared formatLocationAsXml)
-  // Skip legacy Markdown format (from old stored data) - detectable by "**Server**" or
-  // "This conversation is taking place" patterns that predate XML formatting
-  let locationContext: string | undefined;
-  if (
-    ref.locationContext !== undefined &&
-    ref.locationContext.length > 0 &&
-    !ref.locationContext.includes('**Server**') &&
-    !ref.locationContext.includes('This conversation is taking place')
-  ) {
-    locationContext = ref.locationContext;
-  }
-
-  const attachments = buildStoredAttachments(ref);
-
-  return formatQuoteElement({
-    type: ref.isForwarded === true ? 'forward' : undefined,
-    from: authorName,
+  return {
+    isForwarded: ref.isForwarded,
+    from,
     fromId: ref.resolvedPersonaId,
-    role,
-    timeFormatted:
-      ref.timestamp !== undefined && ref.timestamp.length > 0
-        ? formatPromptTimestamp(ref.timestamp)
-        : undefined,
+    username: ref.authorUsername,
+    role: deriveRefRole(ref.authorRole, from, personalityName, allPersonalityNames),
+    time: promptTime(ref.timestamp),
     content: ref.content,
-    locationContext,
+    locationContext: usableLocationContext(ref.locationContext),
     embedsXml: ref.embeds !== undefined && ref.embeds.length > 0 ? [ref.embeds] : undefined,
-    attachments: attachments.length > 0 ? attachments : undefined,
-  });
+    attachments: buildStoredAttachments(ref),
+  };
+}
+
+/**
+ * Location context, unless it predates XML formatting.
+ *
+ * Legacy stored rows carry a Markdown location block that would render as prose
+ * inside the quote. Detectable by two phrases the old format always contained.
+ */
+function usableLocationContext(locationContext: string | undefined): string | undefined {
+  if (
+    locationContext === undefined ||
+    locationContext.length === 0 ||
+    locationContext.includes('**Server**') ||
+    locationContext.includes('This conversation is taking place')
+  ) {
+    return undefined;
+  }
+  return locationContext;
 }
 
 /** Format quoted messages section for XML output */
@@ -174,39 +160,17 @@ export function formatQuotedSection(
     return '';
   }
 
-  // Full refs: existing behavior
   const formattedFull = fullRefs.map(ref =>
-    formatStoredReferencedMessage(ref, personalityName, allPersonalityNames)
+    renderReference(fromStoredReference(ref, personalityName, allPersonalityNames))
   );
 
-  // Deduped refs: lightweight stubs with truncated content and reply-target note.
-  // Media rides along in full — `persistReferenceDescriptions` writes descriptions
-  // onto the stored row precisely so a quoted image survives replay, and the
-  // history entry the stub points at renders that image as a URL, not a
-  // description.
-  //
-  // An UNdescribed attachment now renders here too, as a `status`-carrying
-  // element. Its predecessor omitted markers on this branch as chat-log
-  // redundancy, which was true for the file's NAME and false for its existence:
-  // an attachment with no description and no marker is simply invisible, the
-  // same drop class as the descriptions this branch used to lose entirely.
-  const formattedDeduped = dedupedRefs.map(ref => {
-    const authorName = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
-    const role = deriveRefRole(ref.authorRole, authorName, personalityName, allPersonalityNames);
-    return formatDedupedQuote({
-      from: authorName,
-      role,
-      timeFormatted:
-        ref.timestamp !== undefined && ref.timestamp.length > 0
-          ? formatPromptTimestamp(ref.timestamp)
-          : undefined,
-      // Cap the stored text preview HERE (the single truncation point) — formatDedupedQuote
-      // renders as-is. Stored refs carry their attachments as structured elements, so
-      // content is text-only and safe to cap directly.
-      content: capDedupText(ref.content),
-      attachments: buildStoredAttachments(ref),
-    });
-  });
+  // Deduped refs are the SAME reference, projected — not a second build. Media
+  // rides along in full: `persistReferenceDescriptions` writes descriptions onto
+  // the stored row precisely so a quoted image survives replay, and the history
+  // entry the stub points at renders that image as a URL, not a description.
+  const formattedDeduped = dedupedRefs.map(ref =>
+    renderReference(dedupeReference(fromStoredReference(ref, personalityName, allPersonalityNames)))
+  );
 
   const allFormatted = [...formattedFull, ...formattedDeduped].join('\n');
   return `\n<quoted_messages>\n${allFormatted}\n</quoted_messages>`;

--- a/services/ai-worker/src/services/PromptBuilder.test.ts
+++ b/services/ai-worker/src/services/PromptBuilder.test.ts
@@ -50,19 +50,6 @@ vi.mock('@tzurot/common-types/config/config', async () => {
   };
 });
 
-vi.mock('@tzurot/common-types/utils/dateFormatting', async () => {
-  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/dateFormatting')>(
-    '@tzurot/common-types/utils/dateFormatting'
-  );
-  return {
-    ...actual,
-    formatTimestampWithDelta: vi.fn((_date: Date) => ({
-      absolute: 'Mon, Jan 15, 2024',
-      relative: '2 weeks ago',
-    })),
-  };
-});
-
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -9,11 +9,11 @@ import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/messa
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 
 // Use vi.hoisted() to create mocks that persist across test resets
-const { mockDescribeImage, mockTranscribeAudio, mockFormatTimestampWithDelta, mockLogger } =
+const { mockDescribeImage, mockTranscribeAudio, mockFormatPromptTimestamp, mockLogger } =
   vi.hoisted(() => ({
     mockDescribeImage: vi.fn(),
     mockTranscribeAudio: vi.fn(),
-    mockFormatTimestampWithDelta: vi.fn(),
+    mockFormatPromptTimestamp: vi.fn(),
     mockLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
   }));
 
@@ -30,14 +30,14 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   return { ...actual, createLogger: () => mockLogger };
 });
 
-// Mock formatTimestampWithDelta for consistent test output
+// Mock formatPromptTimestamp for consistent test output
 vi.mock('@tzurot/common-types/utils/dateFormatting', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/dateFormatting')>(
     '@tzurot/common-types/utils/dateFormatting'
   );
   return {
     ...actual,
-    formatTimestampWithDelta: mockFormatTimestampWithDelta,
+    formatPromptTimestamp: mockFormatPromptTimestamp,
   };
 });
 
@@ -49,10 +49,7 @@ describe('ReferencedMessageFormatter', () => {
     vi.clearAllMocks();
 
     // Restore default mock implementations after mockReset clears them
-    mockFormatTimestampWithDelta.mockReturnValue({
-      absolute: 'Fri, Dec 6, 2025',
-      relative: 'just now',
-    });
+    mockFormatPromptTimestamp.mockReturnValue('2025-12-06 (Fri) 00:00 • just now');
 
     formatter = new ReferencedMessageFormatter();
     mockPersonality = {
@@ -202,8 +199,12 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      // Should contain time tag with absolute and relative attributes
-      expect(result).toContain('<time absolute="Fri, Dec 6, 2025" relative="just now"/>');
+      // One timestamp format across every quote path: the t attribute, built by
+      // the same helper <message> uses in <chat_log>. The live paths used to
+      // render a <time absolute relative/> child instead, so the same quote
+      // carried its timestamp two different ways depending on its source.
+      expect(result).toContain('t="2025-12-06 (Fri) 00:00 • just now"');
+      expect(result).not.toContain('<time');
     });
   });
 
@@ -230,7 +231,7 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(result).toContain(
-        '<quote number="1" from="Test User" username="testuser" role="user">'
+        '<quote number="1" from="Test User" username="testuser" role="user"'
       );
       expect(result).toContain('</quote>');
       // Location is now pre-formatted XML from bot-client (DRY with current message context)
@@ -238,7 +239,7 @@ describe('ReferencedMessageFormatter', () => {
       expect(result).toContain('<server name="Test Guild"/>');
       expect(result).toContain('<channel name="general" type="text"/>');
       // Time now includes both absolute date and relative time (mocked)
-      expect(result).toContain('<time absolute="Fri, Dec 6, 2025" relative="just now"/>');
+      expect(result).toContain('t="2025-12-06 (Fri) 00:00 • just now"');
       expect(result).toContain('<content>Hello world!</content>');
     });
 
@@ -291,7 +292,7 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(result).toContain(
-        '<quote number="1" from="Test User" username="testuser" role="user">'
+        '<quote number="1" from="Test User" username="testuser" role="user"'
       );
       // Empty content should not generate <content> tag
       expect(result).not.toContain('<content>');
@@ -329,10 +330,10 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('<quote number="1" from="User One" username="user1" role="user">');
+      expect(result).toContain('<quote number="1" from="User One" username="user1" role="user"');
       expect(result).toContain('First message');
 
-      expect(result).toContain('<quote number="2" from="User Two" username="user2" role="user">');
+      expect(result).toContain('<quote number="2" from="User Two" username="user2" role="user"');
       expect(result).toContain('Second message');
     });
 
@@ -360,9 +361,7 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain(
-        '<quote number="1" from="Test Bot" username="Test Bot" role="assistant">'
-      );
+      expect(result).toContain('<quote number="1" from="Test Bot" role="assistant"');
       expect(result).toContain('<content>Something I said earlier</content>');
     });
 
@@ -395,9 +394,7 @@ describe('ReferencedMessageFormatter', () => {
         { allPersonalityNames: new Set(['Ha-Shem', 'Test Bot']) }
       );
 
-      expect(result).toContain(
-        '<quote number="1" from="Ha-Shem" username="Ha-Shem" role="character">'
-      );
+      expect(result).toContain('<quote number="1" from="Ha-Shem" role="character"');
       // The legend text mentions role="assistant"; assert on the quote attribute shape.
       expect(result).not.toContain('from="Ha-Shem" username="Ha-Shem" role="assistant"');
     });
@@ -426,7 +423,7 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('<quote number="1" from="SomeBot" username="SomeBot" role="bot">');
+      expect(result).toContain('<quote number="1" from="SomeBot" role="bot"');
     });
 
     it('falls back to role="user" when authorRole is absent and the author is not a persona', async () => {
@@ -453,7 +450,7 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('<quote number="1" from="Someone" username="someone" role="user">');
+      expect(result).toContain('<quote number="1" from="Someone" username="someone" role="user"');
     });
 
     it('falls back to role="assistant" when authorRole is absent but the author matches the active personality', async () => {
@@ -508,7 +505,7 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('<quote number="1" from="Alice" username="alice123" role="user">');
+      expect(result).toContain('<quote number="1" from="Alice" username="alice123" role="user"');
       expect(result).toContain('[Referenced message — full text in the chat log]');
       expect(result).toContain('Some truncated content...');
       expect(result).toContain('</quote>');
@@ -562,9 +559,7 @@ describe('ReferencedMessageFormatter', () => {
         references,
         mockPersonality
       );
-      expect(result).toContain(
-        '<quote number="1" from="Test Bot" username="Test Bot" role="assistant">'
-      );
+      expect(result).toContain('<quote number="1" from="Test Bot" role="assistant"');
       expect(result).toContain('[Referenced message — full text in the chat log]');
     });
 
@@ -589,7 +584,7 @@ describe('ReferencedMessageFormatter', () => {
         references,
         mockPersonality
       );
-      expect(result).toContain('<quote number="1" from="SomeBot" username="SomeBot" role="bot">');
+      expect(result).toContain('<quote number="1" from="SomeBot" role="bot"');
     });
 
     it('should not process attachments for deduped stubs', async () => {
@@ -644,7 +639,7 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      expect(result).toContain('<time absolute="Fri, Dec 6, 2025" relative="just now"/>');
+      expect(result).toContain('t="2025-12-06 (Fri) 00:00 • just now"');
     });
   });
 
@@ -1070,7 +1065,7 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(result).toContain(
-        '<quote number="1" from="Test User" username="testuser" role="user">'
+        '<quote number="1" from="Test User" username="testuser" role="user"'
       );
       expect(result).toContain('Just text');
       expect(result).not.toContain('<attachments>');
@@ -1098,7 +1093,7 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(result).toContain(
-        '<quote number="1" from="Test User" username="testuser" role="user">'
+        '<quote number="1" from="Test User" username="testuser" role="user"'
       );
       expect(result).toContain('Just text');
       expect(result).not.toContain('<attachments>');
@@ -1125,10 +1120,17 @@ describe('ReferencedMessageFormatter', () => {
         mockPersonality
       );
 
-      // Forwarded messages use shared QuoteFormatter format
-      expect(result).toContain('<quote type="forward" from="Unknown">');
+      // A forwarded reference is now rendered by the SAME renderer as any
+      // other, with forwarding as a field on it. It therefore keeps its
+      // reference number, role and location, all of which the old
+      // forwarded-only wrapper dropped — and `from` is the author the
+      // reference actually carries ('Unknown User', because Discord strips
+      // author identity from message snapshots) rather than a literal the
+      // wrapper hardcoded because it had nothing to render.
+      expect(result).toContain('<quote number="1" type="forward" from="Unknown User" role="user"');
       expect(result).not.toContain('forwarded="true"');
       expect(result).toContain('<content>This is a forwarded message</content>');
+      expect(result).toContain('(forwarded message)');
     });
 
     it('should format regular (non-forwarded) messages without forwarded attribute', async () => {
@@ -1155,7 +1157,7 @@ describe('ReferencedMessageFormatter', () => {
 
       // Should NOT have forwarded attribute
       expect(result).toContain(
-        '<quote number="1" from="Test User" username="testuser" role="user">'
+        '<quote number="1" from="Test User" username="testuser" role="user"'
       );
       expect(result).not.toContain('forwarded="true"');
       expect(result).not.toContain('type="forward"');
@@ -1196,11 +1198,11 @@ describe('ReferencedMessageFormatter', () => {
 
       // First reference - regular
       expect(result).toContain(
-        '<quote number="1" from="Test User" username="testuser" role="user">'
+        '<quote number="1" from="Test User" username="testuser" role="user"'
       );
 
-      // Second reference - forwarded (uses shared QuoteFormatter format)
-      expect(result).toContain('<quote type="forward" from="Unknown">');
+      // Second reference - forwarded, and now numbered like every other quote
+      expect(result).toContain('<quote number="2" type="forward" from="Unknown User" role="user"');
       expect(result).toContain('<content>Forwarded message</content>');
     });
   });

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -12,17 +12,20 @@ import { AttachmentType } from '@tzurot/common-types/constants/media';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
-import { formatTimestampWithDelta } from '@tzurot/common-types/utils/dateFormatting';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 import {
-  formatQuoteElement,
-  formatForwardedQuote,
-  formatDedupedQuote,
   attachmentEnrichment,
-  type ForwardedMessageContent,
+  buildRenderableAttachments,
   type RenderableAttachment,
 } from './prompt/QuoteFormatter.js';
+import {
+  dedupeReference,
+  promptTime,
+  referenceSearchText,
+  renderReference,
+  type RenderableReference,
+} from './prompt/RenderableReference.js';
 import { deriveRefRole } from './prompt/referenceRole.js';
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
 import { extractXmlTextContent } from '../utils/xmlTextExtractor.js';
@@ -70,57 +73,50 @@ export interface FormattedReferences {
   searchText: string;
 }
 
-/** The renderable enrichment children a reference's preprocessed results yield. */
-interface SplitEnrichment {
-  attachments: RenderableAttachment[];
-  /**
-   * Entries that CARRY something worth rendering (non-empty description).
-   * The tripwire's denominator is this rather than the raw entry count: a
-   * successful-but-empty transcription (a silent audio clip) has nothing to
-   * render and is not a drop, and counting it as one would warn on every
-   * occurrence of ordinary traffic.
-   */
-  renderable: number;
-  /** Of those, how many actually produced a rendered child. */
-  rendered: number;
-}
-
 /**
- * Split already-preprocessed reference attachments into renderable children.
+ * Build a deduped reference's attachments from enrichment the dependency stage
+ * already produced.
  *
- * This is the READ side only — every result here was produced (and paid for) by
- * the dependency-job stage; nothing new is computed, so a deduped stub still
- * triggers zero vision/STT calls.
+ * READ side only — every description here was computed (and paid for) upstream,
+ * so a deduped stub still triggers zero vision/STT calls. That is the whole
+ * reason this exists instead of `processAttachmentsParallel`, which computes
+ * what it cannot find.
  *
- * The deduped branch needs its own splitter rather than reusing
- * `processAttachmentsParallel`: that helper walks `ref.attachments` and looks
- * preprocessing up by URL, and `buildDedupedReferenceStub` strips `attachments`
- * from the stub, so it would find nothing to walk. The preprocessed entries
- * carry their own metadata and are self-sufficient. Discriminating on
- * `ProcessedAttachment.type` (not `metadata.contentType`) is deliberate — the
- * dependency step synthesizes metadata with a placeholder `image/unknown` /
- * `audio/unknown` content type, so a content-type test would misroute audio.
+ * Correlation is by URL. Discriminating a preprocessed entry by
+ * `ProcessedAttachment.type` rather than `metadata.contentType` is deliberate —
+ * the dependency step synthesizes a placeholder `image/unknown` / `audio/unknown`
+ * content type, so a content-type test would misroute audio. The rendered
+ * `type` attribute comes from the reference's OWN attachment list, which
+ * carries the real one.
  */
-function splitPreprocessedEnrichment(
+function buildDedupedAttachments(
+  ref: ReferencedMessage,
   preprocessed: ProcessedAttachment[] | undefined
-): SplitEnrichment {
-  if (preprocessed === undefined || preprocessed.length === 0) {
-    return { attachments: [], renderable: 0, rendered: 0 };
-  }
+): RenderableAttachment[] {
+  const results = preprocessed ?? [];
+  const matched = new Set<ProcessedAttachment>();
 
-  const attachments: RenderableAttachment[] = [];
-  let renderable = 0;
-  for (const entry of preprocessed) {
-    if (entry.description.length === 0) {
-      // Nothing to render and nothing lost — a silent audio clip transcribes to
-      // '' on SUCCESS. Not counted as renderable, so it never trips the drop warn.
+  const attachments = buildRenderableAttachments(ref.attachments ?? [], att => {
+    const hit = results.find(entry => entry.originalUrl === att.url);
+    if (hit === undefined || hit.description.length === 0) {
+      return undefined;
+    }
+    matched.add(hit);
+    return hit.description;
+  });
+
+  // Enrichment whose attachment row is missing still renders. A description is
+  // paid-for work; dropping one because the correlation missed is exactly the
+  // class this module exists to close. Modality comes from the entry's own
+  // `type`; the content type does not, per the note above.
+  //
+  // Any OTHER modality is deliberately left unrendered and stays counted, so
+  // the drop tripwire fires: silently downgrading an unknown type to a bare
+  // image would misdescribe it AND discard the description.
+  for (const entry of results) {
+    if (matched.has(entry) || entry.description.length === 0) {
       continue;
     }
-    renderable++;
-    // `name` is optional on AttachmentMetadata; the dependency step derives it
-    // from the URL basename, so undefined means a synthesized attachment with no
-    // filename at all. Left undefined rather than defaulted — the attribute is
-    // omitted instead of carrying an invented name.
     if (entry.type === AttachmentType.Image) {
       attachments.push({
         kind: 'image',
@@ -131,35 +127,32 @@ function splitPreprocessedEnrichment(
       attachments.push({
         kind: 'voice',
         filename: entry.metadata.name,
-        // Duration only — deliberately NOT contentType. Per the note above, the
-        // dependency step synthesizes `audio/unknown` here, so forwarding it
-        // would render a `type` attribute that is a placeholder dressed as fact.
         durationSeconds: entry.metadata.duration,
         description: entry.description,
       });
     }
-    // Any other type falls through UNRENDERED and stays counted in `renderable`,
-    // so the drop tripwire below fires. That is deliberate: silently downgrading
-    // an unknown modality to a bare <file/> would discard the description this
-    // function exists to carry, which is the exact class the tripwire watches.
   }
 
-  return { attachments, renderable, rendered: attachments.length };
+  return attachments;
 }
 
 /**
- * The semantic text an attachment contributes to a retrieval query: its
- * enrichment only.
+ * How much enrichment the dependency stage produced for this reference.
  *
- * Filenames, content types and status markers are deliberately excluded — they
- * are metadata about the file, not about what is IN it, and an embedding query
- * carrying `photo.png` matches on the noise rather than the content. (The
- * previous shape fed the whole rendered line, prefix included, into the query.)
+ * The denominator for the drop tripwire below. Empty descriptions are excluded:
+ * a silent audio clip transcribes to `''` on SUCCESS, so counting it would warn
+ * on ordinary traffic.
  */
-function collectAttachmentText(attachments: RenderableAttachment[]): string[] {
-  return attachments
-    .map(attachmentEnrichment)
-    .filter((desc): desc is string => desc !== undefined && desc.length > 0);
+function countAvailableEnrichment(preprocessed: ProcessedAttachment[] | undefined): number {
+  return (preprocessed ?? []).filter(entry => entry.description.length > 0).length;
+}
+
+/** How much of it survived into the rendered attachments. */
+function countRenderedEnrichment(attachments: RenderableAttachment[]): number {
+  return attachments.filter(att => {
+    const text = attachmentEnrichment(att);
+    return text !== undefined && text.length > 0;
+  }).length;
 }
 
 /**
@@ -178,8 +171,7 @@ export class ReferencedMessageFormatter {
    * @param personality - Personality configuration for vision/transcription models
    * @param isGuestMode - Whether the user is in guest mode (no BYOK API key)
    * @param preprocessedAttachments - Pre-processed attachments keyed by reference number (avoids inline API calls)
-   * @param userApiKey - User's BYOK API key (for BYOK users)
-   * @param sttDispatch - Resolved STT dispatch (provider + matching BYOK key)
+   * @param apiKeys - Vision/STT auth plus the personality-name set for role derivation
    * @returns The prompt XML plus the plain-text search rendering
    */
   async formatReferencedMessages(
@@ -192,79 +184,31 @@ export class ReferencedMessageFormatter {
     const referenceElements: string[] = [];
     const searchParts: string[] = [];
 
-    // Process each reference into XML
     for (const ref of references) {
-      // Deduped stubs: lightweight quote with reply-target note. No NEW
-      // attachment work is done — but media enrichment already computed by the
-      // dependency stage IS rendered here, because <chat_log> carries the
-      // embed/attachment URL and never its description.
-      //
-      // The stub's `content` also carries `[image/png: name]` markers folded in
-      // by `buildDedupedReferenceStub`. That overlap is intentional for now: the
-      // marker is the FALLBACK for an image whose description never arrived, and
-      // the builder can't know whether it will. Filenames match across the two,
-      // so they read as one image, not two. (The stored path in
-      // `xmlMetadataFormatters` drops its markers instead — it can, because it
-      // sees both at once. Collapsing that asymmetry is the projection refactor.)
-      if (ref.isDeduplicated === true) {
-        const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
-        const preprocessedForRef = preprocessedAttachments?.[ref.referenceNumber];
-        const enrichment = splitPreprocessedEnrichment(preprocessedForRef);
-        this.warnOnDroppedEnrichment(ref.referenceNumber, enrichment);
-        referenceElements.push(
-          formatDedupedQuote({
-            number: ref.referenceNumber,
-            from: ref.authorDisplayName,
-            username: ref.authorUsername,
-            role: deriveRefRole(
-              ref.authorRole,
-              ref.authorDisplayName || ref.authorUsername,
-              personality.displayName,
-              apiKeys?.allPersonalityNames
-            ),
-            timestamp:
-              absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
-            content: ref.content,
-            attachments: enrichment.attachments,
-          })
-        );
-        // The stub's capped text copy is real signal; the reply-target
-        // marker the quote renderer adds is not, so contribute the raw
-        // content only (empty for a bot's own reply-target). Media
-        // descriptions ride along for the same reason they ride into the
-        // prompt: history has no copy of them to retrieve against.
-        searchParts.push(
-          [ref.content, ...collectAttachmentText(enrichment.attachments)]
-            .filter(part => part.length > 0)
-            .join('\n')
-        );
-        continue;
-      }
-
-      // Forwarded messages use the shared QuoteFormatter for consistency
-      if (ref.isForwarded === true) {
-        const forwarded = await this.formatForwardedReference(
-          ref,
-          personality,
-          isGuestMode,
-          preprocessedAttachments?.[ref.referenceNumber],
-          apiKeys
-        );
-        referenceElements.push(forwarded.element);
-        searchParts.push(forwarded.searchText);
-        continue;
-      }
-
-      // Non-forwarded messages: standard quote format
-      const standard = await this.formatStandardReference(
+      const renderable = await this.fromLiveReference(
         ref,
         personality,
         isGuestMode,
         preprocessedAttachments?.[ref.referenceNumber],
         apiKeys
       );
-      referenceElements.push(standard.element);
-      searchParts.push(standard.searchText);
+
+      // Dedup is a projection of the reference above, never a second build —
+      // so a field this formatter learns to carry reaches the stub for free.
+      referenceElements.push(
+        renderReference(ref.isDeduplicated === true ? dedupeReference(renderable) : renderable)
+      );
+
+      // Search text comes from the PRE-projection reference: the stub's prose
+      // marker and its truncation are prompt-shaping, not semantic content.
+      searchParts.push(
+        referenceSearchText(
+          renderable,
+          ref.embeds !== undefined && ref.embeds.length > 0
+            ? extractXmlTextContent(ref.embeds)
+            : undefined
+        )
+      );
     }
 
     const formattedText = referenceElements.join('\n');
@@ -293,77 +237,24 @@ export class ReferencedMessageFormatter {
   }
 
   /**
-   * Tripwire for the enrichment-drop class: preprocessed results reached this
-   * renderer but produced fewer rendered children than there were results.
+   * Adapt a live reference into the canonical renderable shape.
    *
-   * It exists because the drop it guards was invisible — four vision calls ran,
-   * succeeded, cost 47s, and were discarded with zero log output, so the only
-   * detector in the system was a human noticing the character couldn't see the
-   * images. With the deduped branch rendering them this should never fire; if a
-   * future field goes missing the same way, it says so instead.
+   * The one place the live schema is read. Everything downstream — full,
+   * forwarded, and deduped alike — sees the same object, which is why
+   * forwarding is now an attribute on it rather than a separate render method
+   * that quietly dropped the number, role, username and location.
    */
-  private warnOnDroppedEnrichment(referenceNumber: number, enrichment: SplitEnrichment): void {
-    if (enrichment.renderable > enrichment.rendered) {
-      logger.warn(
-        { referenceNumber, renderable: enrichment.renderable, rendered: enrichment.rendered },
-        '[ReferencedMessageFormatter] Preprocessed reference enrichment was not rendered — ' +
-          'vision/transcription work was paid for and is not reaching the prompt'
-      );
-    }
-  }
-
-  /**
-   * Semantic text of one reference for the retrieval query: message text,
-   * attachment description/transcription lines, and embed text (embeds are
-   * pre-formatted XML, so tag-strip JUST that piece — content only, no
-   * envelope). Location context, timestamps, and role metadata never
-   * belong in an embedding query.
-   */
-  private buildReferenceSearchText(
-    ref: ReferencedMessage,
-    attachments: RenderableAttachment[]
-  ): string {
-    const pieces = [ref.content, ...collectAttachmentText(attachments)];
-    if (ref.embeds !== undefined && ref.embeds.length > 0) {
-      pieces.push(extractXmlTextContent(ref.embeds));
-    }
-    return pieces
-      .map(piece => piece.trim())
-      .filter(piece => piece.length > 0)
-      .join('\n');
-  }
-
-  /**
-   * Format a standard (non-forwarded) reference as XML.
-   */
-  private async formatStandardReference(
+  private async fromLiveReference(
     ref: ReferencedMessage,
     personality: LoadedPersonality,
     isGuestMode: boolean,
-    preprocessedForRef?: ProcessedAttachment[],
+    preprocessedForRef: ProcessedAttachment[] | undefined,
     apiKeys?: ReferenceVisionAuth
-  ): Promise<{ element: string; searchText: string }> {
-    const { userApiKey, sttDispatch, visionProvider, visionModel } = apiKeys ?? {};
-    const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
-
-    let attachments: RenderableAttachment[] = [];
-    if (ref.attachments && ref.attachments.length > 0) {
-      attachments = await processAttachmentsParallel({
-        attachments: ref.attachments,
-        referenceNumber: ref.referenceNumber,
-        personality,
-        isGuestMode,
-        preprocessedAttachments: preprocessedForRef,
-        userApiKey,
-        sttDispatch,
-        visionProvider,
-        model: visionModel,
-      });
-    }
-
-    const element = formatQuoteElement({
+  ): Promise<RenderableReference> {
+    return {
       number: ref.referenceNumber,
-      from: ref.authorDisplayName,
+      isForwarded: ref.isForwarded,
+      from: ref.authorDisplayName || ref.authorUsername,
       username: ref.authorUsername,
       role: deriveRefRole(
         ref.authorRole,
@@ -371,59 +262,86 @@ export class ReferencedMessageFormatter {
         personality.displayName,
         apiKeys?.allPersonalityNames
       ),
-      timestamp: absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
-      content: ref.content || undefined,
+      time: promptTime(ref.timestamp),
+      content: ref.content,
       locationContext: ref.locationContext,
-      embedsXml: ref.embeds ? [ref.embeds] : undefined,
-      attachments: attachments.length > 0 ? attachments : undefined,
-    });
-
-    return { element, searchText: this.buildReferenceSearchText(ref, attachments) };
+      embedsXml: ref.embeds !== undefined && ref.embeds.length > 0 ? [ref.embeds] : undefined,
+      attachments: await this.buildAttachments(
+        ref,
+        personality,
+        isGuestMode,
+        preprocessedForRef,
+        apiKeys
+      ),
+    };
   }
 
   /**
-   * Format a forwarded reference using the shared QuoteFormatter.
-   * Ensures consistent XML output between the message link path and chat history path.
+   * A reference's attachments — computed for a full render, read-only for a
+   * deduped one.
+   *
+   * The split is about SPEND, not shape: a stub must not trigger a vision or
+   * transcription call for an attachment whose full copy is already in
+   * <chat_log>. Both arms return the same structure.
    */
-  private async formatForwardedReference(
+  private async buildAttachments(
     ref: ReferencedMessage,
     personality: LoadedPersonality,
     isGuestMode: boolean,
-    preprocessedForRef?: ProcessedAttachment[],
+    preprocessedForRef: ProcessedAttachment[] | undefined,
     apiKeys?: ReferenceVisionAuth
-  ): Promise<{ element: string; searchText: string }> {
-    const { userApiKey, sttDispatch, visionProvider, visionModel } = apiKeys ?? {};
-    const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
-
-    const forwardedContent: ForwardedMessageContent = {
-      textContent: ref.content ?? undefined,
-      timestamp: absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
-      embedsXml: ref.embeds ? [ref.embeds] : undefined,
-    };
-
-    // Process attachments if present
-    let attachments: RenderableAttachment[] = [];
-    if (ref.attachments && ref.attachments.length > 0) {
-      attachments = await processAttachmentsParallel({
-        attachments: ref.attachments,
-        referenceNumber: ref.referenceNumber,
-        personality,
-        isGuestMode,
-        preprocessedAttachments: preprocessedForRef,
-        userApiKey,
-        sttDispatch,
-        visionProvider,
-        model: visionModel,
-      });
-
-      if (attachments.length > 0) {
-        forwardedContent.attachments = attachments;
-      }
+  ): Promise<RenderableAttachment[]> {
+    if (ref.isDeduplicated === true) {
+      const attachments = buildDedupedAttachments(ref, preprocessedForRef);
+      this.warnOnDroppedEnrichment(
+        ref.referenceNumber,
+        countAvailableEnrichment(preprocessedForRef),
+        countRenderedEnrichment(attachments)
+      );
+      return attachments;
     }
 
-    return {
-      element: formatForwardedQuote(forwardedContent),
-      searchText: this.buildReferenceSearchText(ref, attachments),
-    };
+    if (ref.attachments === undefined || ref.attachments.length === 0) {
+      return [];
+    }
+
+    const { userApiKey, sttDispatch, visionProvider, visionModel } = apiKeys ?? {};
+    return processAttachmentsParallel({
+      attachments: ref.attachments,
+      referenceNumber: ref.referenceNumber,
+      personality,
+      isGuestMode,
+      preprocessedAttachments: preprocessedForRef,
+      userApiKey,
+      sttDispatch,
+      visionProvider,
+      model: visionModel,
+    });
+  }
+
+  /**
+   * Tripwire for the enrichment-drop class: preprocessed results reached this
+   * renderer but produced fewer enriched children than there were results.
+   *
+   * It exists because the drop it guards was invisible — four vision calls ran,
+   * succeeded, cost 47s, and were discarded with zero log output, so the only
+   * detector in the system was a human noticing the character couldn't see the
+   * images. The projection makes the old drop unreachable, but one route
+   * survives: enrichment for an attachment that classifies as a `file` has
+   * nowhere to go, because `RenderableFile` carries no description. If that
+   * ever happens, this says so instead of swallowing it.
+   */
+  private warnOnDroppedEnrichment(
+    referenceNumber: number,
+    available: number,
+    rendered: number
+  ): void {
+    if (available > rendered) {
+      logger.warn(
+        { referenceNumber, renderable: available, rendered },
+        '[ReferencedMessageFormatter] Preprocessed reference enrichment was not rendered — ' +
+          'vision/transcription work was paid for and is not reaching the prompt'
+      );
+    }
   }
 }

--- a/services/ai-worker/src/services/context/referenceEnricher.test.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.test.ts
@@ -48,38 +48,43 @@ describe('enrichRawReferences', () => {
     expect(result[0].isDeduplicated).toBeUndefined();
   });
 
-  it('stubs a reference whose id is in the assembled history', async () => {
+  it('flags a reference whose id is in the assembled history, and changes nothing else', async () => {
+    const raw = rawRef({ content: 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 40) });
     const result = await enrichRawReferences({
-      rawReferences: [rawRef({ content: 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 5) })],
+      rawReferences: [raw],
+      history: [historyRow('ref-1', new Date(NOW - 5_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    // The enricher sets the FLAG and nothing else. Emptying the content,
+    // capping the preview and dropping embeds/location used to happen here, in
+    // a field-by-field rebuild — which is exactly how fields nobody remembered
+    // to list went missing. It is a render-time projection now, so everything
+    // downstream still has the full reference to project FROM.
+    expect(result[0].isDeduplicated).toBe(true);
+    expect(result[0].content).toBe('x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 40));
+    expect(result[0].embeds).toBe(raw.embeds);
+    expect(result[0].locationContext).toBe(raw.locationContext);
+  });
+
+  it('keeps the attachments on a deduped reference so the renderer can still draw them', async () => {
+    // The regression this pins: the old stub STRIPPED `attachments`, so the
+    // renderer had only preprocessing results to go on and an attachment whose
+    // vision call never ran was simply invisible.
+    const attachments = [
+      { url: 'https://cdn/board.png', contentType: 'image/png', name: 'board.png' },
+    ];
+    const result = await enrichRawReferences({
+      rawReferences: [rawRef({ content: '', attachments })],
       history: [historyRow('ref-1', new Date(NOW - 5_000))],
       retrieveTranscript: noTranscript,
       nowMs: NOW,
     });
     expect(result[0].isDeduplicated).toBe(true);
-    expect(result[0].content).toBe('x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...');
-    expect(result[0].embeds).toBe('');
-    expect(result[0].locationContext).toBe('');
+    expect(result[0].attachments).toEqual(attachments);
   });
 
-  it('keeps the image attachment marker when stubbing a duplicate image-only reply-target', async () => {
-    const result = await enrichRawReferences({
-      rawReferences: [
-        rawRef({
-          content: '', // image-only message — without the marker the stub is blank
-          attachments: [
-            { url: 'https://cdn/board.png', contentType: 'image/png', name: 'board.png' },
-          ],
-        }),
-      ],
-      history: [historyRow('ref-1', new Date(NOW - 5_000))],
-      retrieveTranscript: noTranscript,
-      nowMs: NOW,
-    });
-    expect(result[0].isDeduplicated).toBe(true);
-    expect(result[0].content).toBe('[image/png: board.png]');
-  });
-
-  it('emits a marker-only stub for the bot’s own deduped voice reply-target', async () => {
+  it('strips the bot’s own TTS audio before the dedup decision', async () => {
     const result = await enrichRawReferences({
       rawReferences: [
         rawRef({
@@ -95,11 +100,13 @@ describe('enrichRawReferences', () => {
       nowMs: NOW,
     });
     expect(result[0].isDeduplicated).toBe(true);
-    // A bot-authored reply-target is the model's own prior line; a snippet of it is a
-    // "continue this fragment" trigger, and the full message is in <chat_log>. So the
-    // bot's deduped stub is marker-only — no audio marker AND no text preview. (The
-    // audio-strip still applies to non-deduped bot quotes, which keep their text.)
-    expect(result[0].content).toBe('');
+    // A personality reply's `audio/*` attachment is TTS *delivery* of its own
+    // text, not content the model attached — so it is dropped here, on both
+    // render branches. Withholding the TEXT preview is a separate decision and
+    // lives with the renderer (`dedupeReference` keys it on role="assistant"),
+    // which is why the content survives this step intact.
+    expect(result[0].attachments).toEqual([]);
+    expect(result[0].content).toBe('You are allowed to be furious about this');
   });
 
   it('stubs a recent webhook reference via the time fallback', async () => {
@@ -158,10 +165,12 @@ describe('enrichRawReferences', () => {
       retrieveTranscript: noTranscript,
       nowMs: NOW,
     });
-    // Mirrors the bot-side formatter loop: isDeduplicated branch wins over
-    // the forwarded branch, so the stub drops the isForwarded flag too.
+    // Dedup wins over the forwarded pass-through, as it does on the bot side —
+    // but the forwarded flag SURVIVES now. The old stub rebuilt the reference
+    // without it, so a forwarded reference that also deduped silently lost its
+    // forwarded-ness: the third instance of the dropped-field class.
     expect(result[0].isDeduplicated).toBe(true);
-    expect(result[0].isForwarded).toBeUndefined();
+    expect(result[0].isForwarded).toBe(true);
     expect(result[0].content).toBe('forwarded snapshot content');
   });
 

--- a/services/ai-worker/src/services/context/referenceEnricher.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.ts
@@ -34,7 +34,6 @@ import { type ConversationMessage } from '@tzurot/common-types/types/conversatio
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import {
   appendVoiceTranscripts,
-  buildDedupedReferenceStub,
   isBotAuthoredReference,
   isDuplicateReference,
   stripBotVoiceAttachments,
@@ -96,7 +95,14 @@ export async function enrichRawReferences(
       );
 
       if (duplicate) {
-        return buildDedupedReferenceStub(raw);
+        // Flag only. The stub SHAPE — emptying the content, capping the
+        // preview, folding in attachment markers, dropping embeds and location
+        // — used to be built here, field by field, which is precisely how
+        // fields nobody remembered to list went missing (the quoted role, then
+        // the attachments, then the forwarded flag). It is a render-time
+        // projection now (`dedupeReference`), where the full reference is still
+        // in hand and subtraction is the only operation.
+        return { ...raw, isDeduplicated: true };
       }
 
       if (raw.isForwarded === true) {

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  formatDedupedQuote,
+  buildRenderableAttachments,
   formatForwardedQuote,
   formatQuoteElement,
   renderAttachment,
@@ -77,26 +77,6 @@ describe('QuoteFormatter', () => {
       });
 
       expect(result).toContain('t="2025-01-25 (Sat) 14:30 • just now"');
-    });
-
-    it('should include structured timestamp as child element', () => {
-      const result = formatQuoteElement({
-        from: 'User',
-        timestamp: { absolute: 'Fri, Dec 6, 2025', relative: 'just now' },
-        content: 'Hello',
-      });
-
-      expect(result).toContain('<time absolute="Fri, Dec 6, 2025" relative="just now"/>');
-    });
-
-    it('should skip timestamp child when absolute or relative is empty', () => {
-      const result = formatQuoteElement({
-        from: 'User',
-        timestamp: { absolute: '', relative: 'just now' },
-        content: 'Hello',
-      });
-
-      expect(result).not.toContain('<time');
     });
 
     it('should include location context', () => {
@@ -258,11 +238,11 @@ describe('QuoteFormatter', () => {
       expect(result).not.toContain('</character>');
     });
 
-    it('should order elements correctly: time → content → location → embeds → attachments', () => {
+    it('should order elements correctly: content → location → embeds → attachments', () => {
       const result = formatQuoteElement({
         number: 1,
         from: 'User',
-        timestamp: { absolute: 'Jan 1, 2025', relative: 'now' },
+        timeFormatted: '2025-01-01 (Wed) 09:00 • now',
         content: 'Hello',
         locationContext: '<location type="guild"><server name="G"/></location>',
         embedsXml: ['<embed>E</embed>'],
@@ -274,7 +254,6 @@ describe('QuoteFormatter', () => {
       });
 
       const positions = [
-        result.indexOf('<time'),
         result.indexOf('<content>'),
         result.indexOf('<location'),
         result.indexOf('<embeds>'),
@@ -404,21 +383,6 @@ describe('QuoteFormatter', () => {
       expect(result).toContain('filename="file&quot;name.png"');
     });
 
-    it('should include timestamp when provided', () => {
-      const content: ForwardedMessageContent = {
-        textContent: 'Hello',
-        timestamp: { absolute: 'Mon, Jan 15, 2024', relative: '2 weeks ago' },
-      };
-
-      const result = formatForwardedQuote(content);
-
-      expect(result).toContain('<time absolute="Mon, Jan 15, 2024" relative="2 weeks ago"/>');
-      // Time should come before content
-      const timePos = result.indexOf('<time');
-      const contentPos = result.indexOf('<content>');
-      expect(timePos).toBeLessThan(contentPos);
-    });
-
     it('should format voice transcripts', () => {
       const content: ForwardedMessageContent = {
         attachments: [{ kind: 'voice', description: 'Hey, can you hear me?' }],
@@ -452,7 +416,6 @@ describe('QuoteFormatter', () => {
           { kind: 'file', filename: 'doc.pdf', contentType: 'application/pdf' },
         ],
         embedsXml: ['<embed>Link preview</embed>'],
-        timestamp: { absolute: 'Feb 10, 2026', relative: 'just now' },
       };
 
       const result = formatForwardedQuote(content);
@@ -460,7 +423,6 @@ describe('QuoteFormatter', () => {
       // Verify all sections present and ordered
       const sections = [
         '<quote type="forward"',
-        '<time ',
         '<content>',
         '<embeds>',
         '<attachments>',
@@ -504,81 +466,85 @@ describe('QuoteFormatter', () => {
     });
   });
 
-  describe('formatDedupedQuote', () => {
-    it('prepends the referenced-message marker before a user reply-target preview', () => {
-      const result = formatDedupedQuote({ from: 'Alice', role: 'user', content: 'some text' });
-      expect(result).toContain('[Referenced message — full text in the chat log]');
-      expect(result).toContain('some text');
-      expect(result).toContain('role="user"');
-    });
+  describe('buildRenderableAttachments', () => {
+    const image = { name: 'photo.png', contentType: 'image/png' };
+    const voice = { name: 'clip.ogg', contentType: 'audio/ogg', isVoiceMessage: true, duration: 7 };
+    const music = { name: 'song.mp3', contentType: 'audio/mpeg' };
+    const doc = { name: 'report.pdf', contentType: 'application/pdf' };
 
-    it('renders a marker-only stub (no preview) when content is empty', () => {
-      // The bot's-own-reply-target case: no self-preview to invite continuation.
-      const result = formatDedupedQuote({ from: 'Lilith', role: 'assistant', content: '' });
-      expect(result).toContain(
-        '<content>[Referenced message — full text in the chat log]</content>'
+    const none = (): string | undefined => undefined;
+
+    it('pairs each attachment with the enrichment the caller finds for it', () => {
+      const built = buildRenderableAttachments([image, voice], att =>
+        att.name === 'photo.png' ? 'a cat' : 'hello there'
       );
-      expect(result).toContain('role="assistant"');
+
+      expect(built).toEqual([
+        { kind: 'image', filename: 'photo.png', contentType: 'image/png', description: 'a cat' },
+        {
+          kind: 'voice',
+          filename: 'clip.ogg',
+          contentType: 'audio/ogg',
+          durationSeconds: 7,
+          description: 'hello there',
+        },
+      ]);
     });
 
-    it('promises media only when media actually rides along', () => {
-      // The marker is a claim about where to look. On a text-only stub, naming
-      // media sends the model hunting for something that was never attached;
-      // on a stub that carries descriptions, staying silent about them points
-      // it at <chat_log>, where images exist only as URLs.
-      const textOnly = formatDedupedQuote({ from: 'Alice', role: 'user', content: 'just words' });
-      expect(textOnly).toContain('[Referenced message — full text in the chat log]');
-      expect(textOnly).not.toContain('media');
-
-      const withMedia = formatDedupedQuote({
-        from: 'Alice',
-        role: 'user',
-        content: 'look at this',
-        attachments: [{ kind: 'image', filename: 'a.png', description: 'a lighthouse at dusk' }],
-      });
-      expect(withMedia).toContain('its media is described here');
-      expect(withMedia).toContain('<image filename="a.png">a lighthouse at dusk</image>');
-
-      const withTranscript = formatDedupedQuote({
-        from: 'Alice',
-        role: 'user',
-        content: '',
-        attachments: [{ kind: 'voice', description: 'hey are you around' }],
-      });
-      expect(withTranscript).toContain('its media is described here');
+    it('names the absence per modality rather than emitting a bare element', () => {
+      expect(buildRenderableAttachments([image, voice], none)).toEqual([
+        { kind: 'image', filename: 'photo.png', contentType: 'image/png', status: 'undescribed' },
+        {
+          kind: 'voice',
+          filename: 'clip.ogg',
+          contentType: 'audio/ogg',
+          durationSeconds: 7,
+          status: 'untranscribed',
+        },
+      ]);
     });
 
-    it('names an undescribed attachment without claiming it is described', () => {
-      // The two halves pull opposite ways and both matter. The attachment must
-      // RENDER — an image with no description and no element is invisible, which
-      // is the drop this whole shape exists to close. But the marker must NOT
-      // promise a description, or the model goes looking for one that never
-      // arrived and apologises for missing it.
-      const result = formatDedupedQuote({
-        from: 'Alice',
-        role: 'user',
-        content: 'check this',
-        attachments: [{ kind: 'image', filename: 'unlucky.png', status: 'undescribed' }],
-      });
-
-      expect(result).toContain('<image filename="unlucky.png" status="undescribed"/>');
-      expect(result).not.toContain('its media is described here');
-      expect(result).toContain('[Referenced message — full text in the chat log]');
+    it('treats an empty description as absent — a silent clip is not a transcript', () => {
+      expect(buildRenderableAttachments([voice], () => '')).toEqual([
+        {
+          kind: 'voice',
+          filename: 'clip.ogg',
+          contentType: 'audio/ogg',
+          durationSeconds: 7,
+          status: 'untranscribed',
+        },
+      ]);
     });
 
-    it('does NOT let long attachment markers truncate away the text preview', () => {
-      // Regression: a reply-target with two long image-filename markers + short text. The
-      // content is already text-capped upstream (buildDedupedReferenceStub); formatDedupedQuote
-      // must render it WHOLE — re-truncating the combined markers+text left a misleading "I..."
-      // that the model read as an unfinished sentence.
-      const content =
-        '[image/jpeg: SPOILER_PXL_20260701_221008932.jpg]\n' +
-        '[image/jpeg: SPOILER_PXL_20260701_222104453.jpg]\n\n' +
-        'I got myself off with this fucker';
-      const result = formatDedupedQuote({ from: 'Lila', role: 'user', content });
-      // The real text survives intact — no misleading 1-char "I..." fragment.
-      expect(result).toContain('I got myself off with this fucker');
-      expect(result).not.toContain('I...</content>');
+    it('keeps duration on a voice message whether or not a transcript arrived', () => {
+      const [transcribed] = buildRenderableAttachments([voice], () => 'hi');
+      const [silent] = buildRenderableAttachments([voice], none);
+
+      expect(transcribed).toMatchObject({ durationSeconds: 7 });
+      expect(silent).toMatchObject({ durationSeconds: 7 });
+    });
+
+    it('classifies on isVoiceMessage, not on audio/* — a music file is not a failed transcript', () => {
+      expect(buildRenderableAttachments([music], none)).toEqual([
+        { kind: 'file', filename: 'song.mp3', contentType: 'audio/mpeg' },
+      ]);
+    });
+
+    it('renders a plain file with no enrichment slot at all', () => {
+      // Deliberate: nothing describes a .zip, so the union gives RenderableFile
+      // no description field. A caller that finds enrichment for one is warned
+      // by its own count check (see warnOnDroppedEnrichment) rather than
+      // silently misrendering it.
+      expect(buildRenderableAttachments([doc], () => 'a quarterly report')).toEqual([
+        { kind: 'file', filename: 'report.pdf', contentType: 'application/pdf' },
+      ]);
+    });
+
+    it('omits the filename entirely when there is no real name', () => {
+      const [built] = buildRenderableAttachments([{ contentType: 'image/png' }], () => 'a cat');
+
+      expect(built).toEqual({ kind: 'image', contentType: 'image/png', description: 'a cat' });
+      expect(renderAttachment(built)).toBe('<image type="image/png">a cat</image>');
     });
   });
 });

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -119,6 +119,59 @@ export function classifyAttachment(attachment: {
 }
 
 /**
+ * The Discord-side fields an attachment must expose to be rendered. Structural
+ * rather than `AttachmentMetadata` for the same reason `classifyAttachment` is —
+ * this module stays free of the Discord schema.
+ */
+export interface AttachmentSource {
+  contentType?: string;
+  name?: string;
+  isVoiceMessage?: boolean;
+  duration?: number;
+}
+
+/**
+ * Build one renderable element per attachment, pairing each with whatever
+ * enrichment the caller can find for it.
+ *
+ * `describe` is the ONE thing that differs between producers: the live path
+ * correlates preprocessing results by URL, the stored path correlates persisted
+ * descriptions by filename. Everything after that — classify, pick the arm,
+ * name the absence — was two copies of the same fifteen lines, and they had
+ * already drifted once (see `classifyAttachment`). A miss returns the
+ * modality's own "no enrichment" status rather than a bare element, so the
+ * model can tell "we have no transcript" from "there was nothing here".
+ *
+ * Enrichment for an attachment that classifies as `file` is DROPPED, because
+ * `RenderableFile` has no slot for it. That is a real (if rare) loss, so
+ * callers pair this with a count check — see `warnOnDroppedEnrichment`.
+ */
+export function buildRenderableAttachments<T extends AttachmentSource>(
+  attachments: readonly T[],
+  describe: (attachment: T) => string | undefined
+): RenderableAttachment[] {
+  return attachments.map((att): RenderableAttachment => {
+    const identity = { filename: att.name, contentType: att.contentType };
+    const found = describe(att);
+    // Narrowed to a variable rather than tested inline per arm: a boolean flag
+    // would not narrow `string | undefined` down to the union's `description: string`.
+    const description = found !== undefined && found.length > 0 ? found : undefined;
+    switch (classifyAttachment(att)) {
+      case 'image':
+        return description !== undefined
+          ? { kind: 'image', ...identity, description }
+          : { kind: 'image', ...identity, status: 'undescribed' };
+      case 'voice':
+        return description !== undefined
+          ? { kind: 'voice', ...identity, durationSeconds: att.duration, description }
+          : { kind: 'voice', ...identity, durationSeconds: att.duration, status: 'untranscribed' };
+      case 'file':
+        return { kind: 'file', ...identity };
+    }
+  });
+}
+
+/**
  * Options for formatting a single <quote> element.
  * Callers populate the fields relevant to their context.
  */
@@ -135,10 +188,16 @@ export interface QuoteElementOptions {
   username?: string;
   /** Speaker role: assistant (the responding persona's own line), character (a sibling persona), user (a person), or bot (other automation) */
   role?: RenderedQuoteRole;
-  /** Pre-formatted timestamp string (for t="" attribute on <quote>) */
+  /**
+   * Pre-formatted timestamp for the `t=""` attribute — always via
+   * `formatPromptTimestamp`, the same helper `<message>` uses in `<chat_log>`.
+   *
+   * There used to be a second slot here (a `{absolute, relative}` pair rendered
+   * as a `<time/>` child) that only the live paths filled, so the same quote
+   * carried its timestamp as a child element or as an attribute depending on
+   * which renderer reached it. One slot, one format.
+   */
   timeFormatted?: string;
-  /** Structured timestamp (for <time> child element) */
-  timestamp?: { absolute: string; relative: string };
   /** Text content */
   content?: string;
   /** Location context XML (pre-formatted) */
@@ -168,7 +227,6 @@ export interface QuoteElementOptions {
  * Output format:
  * ```xml
  * <quote [number="N"] [type="forward"] [from="Name"] [username="user"] [role="user|assistant|character|bot"] [t="..."]>
- *   <time absolute="..." relative="..."/>     (if timestamp provided)
  *   <content>text</content>                   (if content provided and non-empty)
  *   locationContext XML                        (if provided and non-empty)
  *   <embeds>...</embeds>
@@ -204,14 +262,6 @@ export function formatQuoteElement(opts: QuoteElementOptions): string {
     .join(' ');
 
   const parts: string[] = [`<quote${attrs.length > 0 ? ' ' + attrs : ''}>`];
-
-  // Structured timestamp as child element
-  if (opts.timestamp !== undefined) {
-    const { absolute, relative } = opts.timestamp;
-    if (absolute.length > 0 && relative.length > 0) {
-      parts.push(`<time absolute="${escapeXml(absolute)}" relative="${escapeXml(relative)}"/>`);
-    }
-  }
 
   // Simple child sections. content and the attachment children carry
   // user-derived text and are escaped at emit. locationContext and embedsXml are
@@ -326,8 +376,18 @@ function addArraySection<T>(
 }
 
 /**
- * Normalized content for a forwarded message.
- * Both code paths build this DTO, then call formatForwardedQuote().
+ * Normalized content for a forwarded HISTORY MESSAGE.
+ *
+ * One consumer only: `conversationUtils.formatSingleHistoryEntryAsXml`, which
+ * renders a forwarded message from its own persisted `messageMetadata`. It is
+ * NOT a reference — there is no `ReferencedMessage` anywhere in that path — so
+ * it cannot take a `RenderableReference`; it is a second, legitimate consumer
+ * of the shared emitter.
+ *
+ * Forwarded *references* used to come through here too, which is why the author
+ * is hardcoded: the wrapper had no author to render. That cost them their
+ * reference number, role, username and location on every forwarded reply. They
+ * now go through `renderReference`, which reads `isForwarded` as a field.
  */
 export interface ForwardedMessageContent {
   /** Plain text content of the forwarded message */
@@ -338,111 +398,20 @@ export interface ForwardedMessageContent {
   attachments?: RenderableAttachment[];
   /** Persisted marker strings — see `QuoteElementOptions.legacyAttachmentLines`. */
   legacyAttachmentLines?: string[];
-  /** Timestamp with both absolute date and relative time */
-  timestamp?: { absolute: string; relative: string };
 }
 
 /**
- * Format a forwarded message as a <quote> element.
- * Thin wrapper over formatQuoteElement() for the forwarded message use case.
+ * Format a forwarded history message as a <quote type="forward"> element.
+ * The forwarding message carries no author for the forwarded content itself,
+ * so `from` is a literal here rather than a dropped field.
  */
 export function formatForwardedQuote(content: ForwardedMessageContent): string {
   return formatQuoteElement({
     type: 'forward',
     from: 'Unknown',
-    timestamp: content.timestamp,
     content: content.textContent,
     embedsXml: content.embedsXml,
     attachments: content.attachments,
     legacyAttachmentLines: content.legacyAttachmentLines,
-  });
-}
-
-/**
- * Prefix for deduplicated reference stubs. Order-agnostic (points to <chat_log>
- * rather than "above" — references are assembled BEFORE <chat_log>) and drops
- * the "reply target" Discord-UI jargon, which read as a task to the model.
- */
-// Prose marker — avoids literal tag syntax so it isn't escaped when it rides
-// through escapeXmlContent inside <content>.
-const DEDUP_REPLY_TARGET_PREFIX = '[Referenced message — full text in the chat log]';
-
-/**
- * Variant used when the stub carries media descriptions. The extra clause is
- * load-bearing, not decoration: the chat-log copy of an embed or attachment
- * carries the raw URL, never a description, so media enrichment has no
- * counterpart there and "full text in the chat log" would send the model
- * somewhere the answer has never been.
- *
- * Conditional rather than unconditional so a text-only stub — the common case —
- * neither pays the tokens nor invites the model to hunt for media that isn't there.
- */
-const DEDUP_REPLY_TARGET_PREFIX_WITH_MEDIA =
-  '[Referenced message — full text in the chat log; its media is described here]';
-
-/**
- * Options for formatting a deduplicated reference stub.
- * Lightweight — no embeds or location context (both are reproduced verbatim in
- * <chat_log>), but media descriptions ARE carried: they exist nowhere else.
- */
-export interface DedupedQuoteOptions {
-  /** Reference number (real-time refs only) */
-  number?: number;
-  /** Author display name */
-  from: string;
-  /** Author username (real-time refs only) */
-  username?: string;
-  /** Speaker role — `assistant` (the responding persona's own line), `character` (a sibling persona), `user` (a person), `bot` (other automation). */
-  role?: RenderedQuoteRole;
-  /** Structured timestamp as child element */
-  timestamp?: { absolute: string; relative: string };
-  /** Pre-formatted timestamp as attribute */
-  timeFormatted?: string;
-  /** Original message content, already text-capped upstream (`buildDedupedReferenceStub`).
-   *  Rendered as-is — NOT re-truncated here. Empty → marker-only stub. */
-  content: string;
-  /**
-   * This reference's attachments with their enrichment. NOT redundant with the
-   * <chat_log> copy: history renders an embed/attachment as its URL, so a
-   * description dropped here is enrichment that was computed, paid for, and
-   * never reaches the model. The stub's own `[image/png: name]` markers name
-   * the file, not what is in it.
-   */
-  attachments?: RenderableAttachment[];
-}
-
-/**
- * Format a deduplicated reference as a lightweight <quote> stub. Renders the (already
- * text-capped, via `capDedupText` at the caller) content as-is and prepends the reply-target
- * note — does NOT truncate, so markers can't cannibalize the text preview.
- */
-export function formatDedupedQuote(opts: DedupedQuoteOptions): string {
-  // Do NOT truncate here. `opts.content` is already TEXT-capped upstream by
-  // `buildDedupedReferenceStub` (it truncates the text to DEDUP_STUB_CONTENT, THEN prepends
-  // the attachment markers). Re-applying the limit to the COMBINED markers+text let long
-  // image-filename markers eat the whole budget, leaving a misleading 1-char text fragment
-  // (e.g. `I...` for `I got myself off…`) that the model reads as an unfinished sentence.
-  // The text is already bounded; the markers are short metadata that must survive intact.
-  // Empty content (e.g. a bot's own reply-target) → marker only, no trailing blank.
-  // The "its media is described here" clause is earned only by an attachment
-  // that actually carries enrichment. An undescribed one still renders (it is
-  // signal that something was attached), but pointing the model at a
-  // description that does not exist is the failure the clause exists to avoid.
-  const hasMedia = (opts.attachments ?? []).some(att => {
-    const enrichment = attachmentEnrichment(att);
-    return enrichment !== undefined && enrichment.length > 0;
-  });
-  const prefix = hasMedia ? DEDUP_REPLY_TARGET_PREFIX_WITH_MEDIA : DEDUP_REPLY_TARGET_PREFIX;
-  const content = opts.content.length > 0 ? `${prefix}\n\n${opts.content}` : prefix;
-
-  return formatQuoteElement({
-    number: opts.number,
-    from: opts.from,
-    username: opts.username,
-    role: opts.role,
-    timestamp: opts.timestamp,
-    timeFormatted: opts.timeFormatted,
-    content,
-    attachments: opts.attachments,
   });
 }

--- a/services/ai-worker/src/services/prompt/RenderableReference.test.ts
+++ b/services/ai-worker/src/services/prompt/RenderableReference.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the canonical reference shape, its renderer, and the dedup projection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
+import {
+  dedupeReference,
+  promptTime,
+  referenceSearchText,
+  renderReference,
+  type RenderableReference,
+} from './RenderableReference.js';
+
+function reference(over: Partial<RenderableReference> = {}): RenderableReference {
+  return {
+    number: 3,
+    from: 'Vladlena',
+    fromId: 'persona-uuid',
+    username: 'vlad',
+    role: 'user',
+    time: '2026-07-20 (Mon) • 1 week ago',
+    content: 'the original message text',
+    locationContext: '<location type="guild">\n<server name="Guild"/>\n</location>',
+    embedsXml: ['<embed>\n<title>An embed</title>\n</embed>'],
+    attachments: [
+      { kind: 'image', filename: 'photo.png', contentType: 'image/png', description: 'a cat' },
+    ],
+    ...over,
+  };
+}
+
+describe('renderReference', () => {
+  it('renders every drawn field onto the quote', () => {
+    const xml = renderReference(reference());
+
+    expect(xml).toContain(
+      '<quote number="3" from="Vladlena" from_id="persona-uuid" username="vlad" role="user" t="2026-07-20 (Mon) • 1 week ago">'
+    );
+    expect(xml).toContain('<content>the original message text</content>');
+    expect(xml).toContain('<server name="Guild"/>');
+    expect(xml).toContain('<title>An embed</title>');
+    expect(xml).toContain('<image filename="photo.png" type="image/png">a cat</image>');
+  });
+
+  it('renders forwarding from the FIELD, not from a caller-supplied mode', () => {
+    expect(renderReference(reference({ isForwarded: true }))).toContain('type="forward"');
+    expect(renderReference(reference({ isForwarded: false }))).not.toContain('type="forward"');
+    expect(renderReference(reference())).not.toContain('type="forward"');
+  });
+
+  it('keeps a forwarded reference every OTHER attribute too', () => {
+    // The forwarded path used to run through a wrapper that hardcoded the
+    // author and dropped number/role/username/location on every forwarded reply.
+    const xml = renderReference(reference({ isForwarded: true }));
+
+    expect(xml).toContain('number="3"');
+    expect(xml).toContain('from="Vladlena"');
+    expect(xml).toContain('username="vlad"');
+    expect(xml).toContain('role="user"');
+    expect(xml).toContain('<server name="Guild"/>');
+  });
+
+  describe('username', () => {
+    it('is emitted when it differs from the rendered name', () => {
+      expect(renderReference(reference({ from: 'Vladlena', username: 'vlad' }))).toContain(
+        'username="vlad"'
+      );
+    });
+
+    it('is omitted when it duplicates the rendered name', () => {
+      expect(renderReference(reference({ from: 'vlad', username: 'vlad' }))).not.toContain(
+        'username='
+      );
+    });
+
+    it('is omitted when empty or absent', () => {
+      expect(renderReference(reference({ username: '' }))).not.toContain('username=');
+      expect(renderReference(reference({ username: undefined }))).not.toContain('username=');
+    });
+  });
+
+  it('omits empty sections rather than emitting hollow ones', () => {
+    const xml = renderReference(
+      reference({ content: '', locationContext: undefined, embedsXml: undefined, attachments: [] })
+    );
+
+    expect(xml).not.toContain('<content>');
+    expect(xml).not.toContain('<embeds>');
+    expect(xml).not.toContain('<attachments>');
+  });
+});
+
+describe('promptTime', () => {
+  it('formats a usable timestamp', () => {
+    expect(promptTime('2026-07-20T14:32:00Z')).toContain('2026-07-20');
+  });
+
+  it('returns undefined rather than an empty t="" attribute', () => {
+    expect(promptTime(undefined)).toBeUndefined();
+    expect(promptTime('')).toBeUndefined();
+    expect(promptTime('not a date')).toBeUndefined();
+  });
+});
+
+describe('dedupeReference', () => {
+  it('inherits EVERY field except the three it subtracts', () => {
+    // The structural guard on the whole projection. A field-by-field rebuild —
+    // the shape this replaced, and the source of three separate dropped-field
+    // bugs — fails here the moment someone adds a field to the reference and
+    // forgets to copy it, because this walks the object's own keys rather than
+    // a list someone has to remember to update.
+    const full = reference({ isForwarded: true });
+    const stub = dedupeReference(full);
+    const subtracted = new Set(['content', 'locationContext', 'embedsXml']);
+
+    for (const key of Object.keys(full) as (keyof RenderableReference)[]) {
+      if (subtracted.has(key)) {
+        continue;
+      }
+      expect(stub[key], `field "${key}" was not inherited by the projection`).toEqual(full[key]);
+    }
+
+    expect(stub.locationContext).toBeUndefined();
+    expect(stub.embedsXml).toBeUndefined();
+    expect(stub.content).not.toBe(full.content);
+  });
+
+  it('drops location and embeds from the rendered stub', () => {
+    const xml = renderReference(dedupeReference(reference()));
+
+    expect(xml).not.toContain('<server name="Guild"/>');
+    expect(xml).not.toContain('<embeds>');
+  });
+
+  it('keeps attachments — their enrichment exists nowhere else', () => {
+    const xml = renderReference(dedupeReference(reference()));
+
+    expect(xml).toContain('<image filename="photo.png" type="image/png">a cat</image>');
+  });
+
+  it('names an UNDESCRIBED attachment instead of omitting it', () => {
+    const xml = renderReference(
+      dedupeReference(
+        reference({
+          attachments: [{ kind: 'image', filename: 'broken.png', contentType: 'image/png' }],
+        })
+      )
+    );
+
+    expect(xml).toContain('<image filename="broken.png" type="image/png"/>');
+  });
+
+  it('prepends the plain marker when no attachment carries enrichment', () => {
+    const stub = dedupeReference(
+      reference({ attachments: [{ kind: 'file', filename: 'report.pdf' }] })
+    );
+
+    expect(stub.content).toContain('[Referenced message — full text in the chat log]');
+    expect(stub.content).not.toContain('its media is described here');
+  });
+
+  it('earns the media clause only from actual enrichment', () => {
+    const described = dedupeReference(reference());
+    const undescribed = dedupeReference(
+      reference({ attachments: [{ kind: 'image', filename: 'x.png', status: 'undescribed' }] })
+    );
+
+    expect(described.content).toContain('its media is described here');
+    expect(undescribed.content).not.toContain('its media is described here');
+  });
+
+  describe('the preview', () => {
+    it('is withheld for OUR OWN persona — a fragment of its own text reads as "continue this"', () => {
+      const stub = dedupeReference(
+        reference({ role: 'assistant', content: 'my earlier line', attachments: [] })
+      );
+
+      expect(stub.content).not.toContain('my earlier line');
+      expect(stub.content).toBe('[Referenced message — full text in the chat log]');
+    });
+
+    it('is KEPT for a third-party bot — not our text, so the trap does not apply', () => {
+      const stub = dedupeReference(reference({ role: 'bot', content: 'a webhook posted this' }));
+
+      expect(stub.content).toContain('a webhook posted this');
+    });
+
+    it('is kept for a person', () => {
+      expect(dedupeReference(reference({ role: 'user' })).content).toContain(
+        'the original message text'
+      );
+    });
+
+    it('is kept for a sibling persona', () => {
+      const stub = dedupeReference(reference({ role: 'character', content: 'sibling said this' }));
+
+      expect(stub.content).toContain('sibling said this');
+    });
+
+    it('is capped, and the cap applies to the text alone', () => {
+      const long = 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 50);
+      const stub = dedupeReference(reference({ content: long }));
+
+      expect(stub.content).toContain('x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...');
+      expect(stub.content).not.toContain('x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 1));
+    });
+
+    it('leaves a marker-only stub with no trailing blank line', () => {
+      const stub = dedupeReference(reference({ content: '' }));
+
+      expect(stub.content.endsWith('\n')).toBe(false);
+    });
+  });
+});
+
+describe('referenceSearchText', () => {
+  it('carries the message text and every attachment description', () => {
+    const text = referenceSearchText(
+      reference({
+        attachments: [
+          { kind: 'image', filename: 'a.png', description: 'a cat' },
+          { kind: 'voice', filename: 'b.ogg', description: 'hello there' },
+        ],
+      })
+    );
+
+    expect(text).toBe('the original message text\na cat\nhello there');
+  });
+
+  it('appends embed text when the caller extracted some', () => {
+    expect(referenceSearchText(reference(), 'An embed')).toContain('An embed');
+  });
+
+  it('excludes filenames, statuses and content types — metadata is query noise', () => {
+    const text = referenceSearchText(
+      reference({
+        content: '',
+        attachments: [
+          { kind: 'image', filename: 'photo.png', contentType: 'image/png', status: 'undescribed' },
+          { kind: 'file', filename: 'report.pdf', contentType: 'application/pdf' },
+        ],
+      })
+    );
+
+    expect(text).toBe('');
+  });
+
+  it('drops empty and whitespace-only pieces', () => {
+    expect(referenceSearchText(reference({ content: '   ', attachments: [] }), '  ')).toBe('');
+  });
+});

--- a/services/ai-worker/src/services/prompt/RenderableReference.ts
+++ b/services/ai-worker/src/services/prompt/RenderableReference.ts
@@ -1,0 +1,231 @@
+/**
+ * Renderable Reference
+ *
+ * ONE canonical shape for a quoted message, and ONE function that renders it.
+ *
+ * A quoted reference used to be rendered by five hand-synced paths — live
+ * {standard, forwarded, deduped} × stored {full, deduped} — each filling the
+ * emitter's slots slightly differently. That produced the same bug three times:
+ * a field that one path carried and another silently omitted (the quote's role,
+ * then its attachments, then its forwarded-ness). Each fix added the missing
+ * field to the one path that had lost it.
+ *
+ * The shape here removes the class instead. Producers adapt their source into a
+ * `RenderableReference` — `fromLiveReference` (a private method on
+ * `ReferencedMessageFormatter`, because building a live reference's attachments
+ * may need to CALL vision/STT) and `fromStoredReference` (a module function in
+ * `xmlMetadataFormatters`), each living beside its own data source.
+ * `renderReference` is the only thing that emits. A new field reaches every path
+ * by construction — or fails to compile.
+ *
+ * Dedup is a PROJECTION of the full render, not a parallel reconstruction: see
+ * `dedupeReference`.
+ */
+
+import { TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
+import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
+import {
+  attachmentEnrichment,
+  formatQuoteElement,
+  type RenderableAttachment,
+} from './QuoteFormatter.js';
+import { type RenderedQuoteRole } from './referenceRole.js';
+
+/**
+ * A quoted message, in the shape the prompt renders it.
+ *
+ * Membership rule: a field belongs here **iff the emitter draws it**. The
+ * criterion is drawn-ness, not divergence — which is why `discordUserId`,
+ * `authorDiscordId`, `webhookId`, `authorIsBot` and `discordMessageId` are
+ * absent despite differing between the two source schemas. They drive upstream
+ * dedup and role decisions and never reach a tag.
+ *
+ * Identity arrives PRE-RESOLVED. Adapters do the persona hydration and the role
+ * derivation; the renderer stays pure, so it can be exercised without a
+ * database and cannot grow a second opinion about who wrote something.
+ */
+export interface RenderableReference {
+  /**
+   * Renders `number="N"` for the `[Reference N]` markers bot-client leaves in
+   * the user's message text. Live references only — a quote replayed from
+   * history has no link in the current message to resolve, so numbering it
+   * would invent a referent.
+   */
+  number?: number;
+  /**
+   * Renders `type="forward"`. A FIELD, deliberately, not a `mode` parameter on
+   * the renderer: a mode would be a second source of truth that can disagree
+   * with the reference it describes.
+   */
+  isForwarded?: boolean;
+  /** Author display name — the persona name where one is resolved. */
+  from: string;
+  /** Author persona UUID, for `<participants>` ID binding, when resolved. */
+  fromId?: string;
+  /** Discord username. Emitted only when it differs from `from` (see `renderReference`). */
+  username?: string;
+  role: RenderedQuoteRole;
+  /** Pre-formatted timestamp — build it with `promptTime` so every path agrees. */
+  time?: string;
+  content: string;
+  /** Pre-formatted `<location>` XML (trusted internal source). */
+  locationContext?: string;
+  /** Pre-formatted embed XML (trusted internal source). */
+  embedsXml?: string[];
+  attachments: RenderableAttachment[];
+}
+
+/**
+ * Format a reference's timestamp for the `t=""` attribute, or undefined when
+ * there isn't a usable one.
+ *
+ * The single entry point on purpose: `formatPromptTimestamp` returns `''` for an
+ * unparseable date, which would otherwise render an empty `t=""`.
+ */
+export function promptTime(timestamp: string | undefined): string | undefined {
+  if (timestamp === undefined || timestamp.length === 0) {
+    return undefined;
+  }
+  const formatted = formatPromptTimestamp(timestamp);
+  return formatted.length > 0 ? formatted : undefined;
+}
+
+/**
+ * Render a reference as its `<quote>` element. The only emitter.
+ */
+export function renderReference(ref: RenderableReference): string {
+  return formatQuoteElement({
+    number: ref.number,
+    type: ref.isForwarded === true ? 'forward' : undefined,
+    from: ref.from,
+    fromId: ref.fromId,
+    username: informativeUsername(ref),
+    role: ref.role,
+    timeFormatted: ref.time,
+    content: ref.content,
+    locationContext: ref.locationContext,
+    embedsXml: ref.embedsXml,
+    attachments: ref.attachments,
+  });
+}
+
+/**
+ * The username, when it adds anything.
+ *
+ * A `username="vlad"` beside `from="vlad"` is a duplicated token that tells the
+ * model nothing. The live path emitted it unconditionally and the stored path
+ * never emitted it at all — the same quote, one attribute apart, decided by
+ * which renderer got there.
+ */
+function informativeUsername(ref: RenderableReference): string | undefined {
+  if (ref.username === undefined || ref.username.length === 0 || ref.username === ref.from) {
+    return undefined;
+  }
+  return ref.username;
+}
+
+/**
+ * Prefix for deduplicated reference stubs. Order-agnostic (points to <chat_log>
+ * rather than "above" — references are assembled BEFORE <chat_log>) and drops
+ * the "reply target" Discord-UI jargon, which read as a task to the model.
+ */
+// Prose marker — avoids literal tag syntax so it isn't escaped when it rides
+// through escapeXmlContent inside <content>.
+const DEDUP_PREFIX = '[Referenced message — full text in the chat log]';
+
+/**
+ * Variant used when the stub carries media enrichment. The extra clause is
+ * load-bearing, not decoration: the chat-log copy of an embed or attachment
+ * carries the raw URL, never a description, so media enrichment has no
+ * counterpart there and "full text in the chat log" would send the model
+ * somewhere the answer has never been.
+ *
+ * Conditional rather than unconditional so a text-only stub — the common case —
+ * neither pays the tokens nor invites the model to hunt for media that isn't there.
+ */
+const DEDUP_PREFIX_WITH_MEDIA =
+  '[Referenced message — full text in the chat log; its media is described here]';
+
+/**
+ * Cap a dedup stub's text preview. The SINGLE truncation point: `renderReference`
+ * renders whatever it is given as-is.
+ *
+ * It applies to the text ALONE, which used to matter more than it does now — the
+ * previous stub folded `[image/png: name]` markers into the same string, and
+ * capping the combination let long filenames eat the whole budget and leave a
+ * misleading one-character fragment (`I...` for `I got myself off…`). Attachments
+ * are structural elements now, so there is nothing left to crowd the text out;
+ * the cap stays because a stub is meant to be a hint, not a copy.
+ */
+function capDedupText(text: string): string {
+  const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
+  return text.length > limit ? text.substring(0, limit) + '...' : text;
+}
+
+/**
+ * Project a reference onto its deduplicated stub.
+ *
+ * SUBTRACTION from the canonical reference, never a field-by-field rebuild.
+ * That is the whole point: its predecessor listed the fields it wanted and so
+ * silently lost every field nobody remembered to list (the role, then the
+ * attachments, then the forwarded flag). Here a field that does not appear
+ * below is inherited, and adding a fourth exclusion is a conspicuous edit to
+ * this function rather than an omission nobody can see.
+ *
+ * The exclusion set has exactly three members, and each has the same
+ * justification — <chat_log> reproduces it verbatim, so the stub would be
+ * paying twice:
+ *
+ * - `content` → the marker, plus a capped preview;
+ * - `locationContext`;
+ * - `embedsXml`.
+ *
+ * Media enrichment is deliberately NOT excluded. History renders an attachment
+ * as its URL, so a description dropped here is enrichment that was computed,
+ * paid for, and never reaches the model.
+ */
+export function dedupeReference(ref: RenderableReference): RenderableReference {
+  const hasMedia = ref.attachments.some(att => {
+    const enrichment = attachmentEnrichment(att);
+    return enrichment !== undefined && enrichment.length > 0;
+  });
+
+  // No preview of OUR OWN persona's prior words: a fragment of the model's own
+  // text is the "continue this" trigger, and the full line is in <chat_log>
+  // regardless. Keyed on the rendered role rather than "was this authored by a
+  // bot", which is a broader question with a different answer — it also
+  // silenced third-party bots and proxy-relayed humans, neither of whom is the
+  // model reading the prompt.
+  const preview = ref.role === 'assistant' ? '' : capDedupText(ref.content);
+  const prefix = hasMedia ? DEDUP_PREFIX_WITH_MEDIA : DEDUP_PREFIX;
+
+  return {
+    ...ref,
+    content: preview.length > 0 ? `${prefix}\n\n${preview}` : prefix,
+    locationContext: undefined,
+    embedsXml: undefined,
+  };
+}
+
+/**
+ * The semantic text a reference contributes to a memory-retrieval query: its
+ * own text plus its attachments' enrichment.
+ *
+ * Built from the reference BEFORE dedup projection, so a stubbed quote
+ * contributes its real content rather than the truncated preview and the
+ * stub's prose marker. Never built by tag-stripping the rendered XML —
+ * that leaked the instruction boilerplate into every reply-shaped query.
+ */
+export function referenceSearchText(ref: RenderableReference, embedText?: string): string {
+  const pieces = [
+    ref.content,
+    ...ref.attachments
+      .map(attachmentEnrichment)
+      .filter((text): text is string => text !== undefined),
+    ...(embedText !== undefined ? [embedText] : []),
+  ];
+  return pieces
+    .map(piece => piece.trim())
+    .filter(piece => piece.length > 0)
+    .join('\n');
+}

--- a/services/ai-worker/src/utils/xmlTextExtractor.test.ts
+++ b/services/ai-worker/src/utils/xmlTextExtractor.test.ts
@@ -30,13 +30,12 @@ describe('extractXmlTextContent', () => {
 
   it('should return empty string for structural-only XML', () => {
     const xml = `<contextual_references>
-<quote number="1">
-<author display_name="User" username="user"/>
+<quote number="1" from="User" username="user" role="user" t="2025-11-04 (Tue) 09:12 • 2 months ago">
 <location type="guild">
 <server name="Test Guild"/>
 <channel name="general" type="text"/>
 </location>
-<time absolute="Mon, Nov 4, 2025" relative="2 months ago"/>
+<image filename="photo.png" status="undescribed"/>
 </quote>
 </contextual_references>`;
     const result = extractXmlTextContent(xml);

--- a/services/bot-client/src/handlers/MessageReferenceExtractor.test.ts
+++ b/services/bot-client/src/handlers/MessageReferenceExtractor.test.ts
@@ -267,9 +267,10 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
   });
 
   describe('Deduplication', () => {
-    it('should preserve REPLY references in history as deduped stubs', async () => {
-      // Replies in conversation history are preserved as lightweight stubs
-      // so the AI knows which message the user is responding to.
+    it('still emits a REPLY reference that is already in history', async () => {
+      // A reply whose target is already in the chat log is not dropped — the AI
+      // still needs to know WHICH message the user is responding to. It ships
+      // as the full snapshot; ai-worker decides whether to stub it.
       const referencedMessage = createMockMessage({
         id: 'referenced-123',
         content: 'Already in history - preserved as stub',
@@ -297,9 +298,8 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
 
       const references = await dedupExtractor.extractReferences(message);
 
-      // Deduped reply should be preserved as a stub with isDeduplicated flag
       expect(references.length).toBe(1);
-      expect(references[0].isDeduplicated).toBe(true);
+      expect(references[0].isDeduplicated).toBeUndefined();
       expect(references[0].content).toBe('Already in history - preserved as stub');
     });
 
@@ -343,12 +343,11 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
       const notDeduped = await extract([]); // ref NOT in history → full reference
       const deduped = await extract(['referenced-123']); // ref in history → stubbed
 
-      // The dedup decision DID diverge the local enriched references...
-      expect(notDeduped.references[0].isDeduplicated).not.toBe(true);
-      expect(deduped.references[0].isDeduplicated).toBe(true);
-
-      // ...but the SHIPPED envelope fields are byte-identical — the dedup decision
-      // (and therefore getChannelHistory) leaves no trace on the wire.
+      // The dedup decision now leaves no trace ANYWHERE on this side — not just
+      // on the wire. It used to diverge the local enriched references (full vs.
+      // stub); that stub reached two log statements and nothing else, while
+      // giving the stub shape a second home to drift in.
+      expect(deduped.references).toEqual(notDeduped.references);
       expect(deduped.rawReferences).toEqual(notDeduped.rawReferences);
       expect(deduped.updatedContent).toEqual(notDeduped.updatedContent);
     });

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
@@ -367,8 +367,12 @@ describe('ReferenceFormatter', () => {
     });
   });
 
-  describe('Deduplicated Stubs', () => {
-    it('should produce minimal ReferencedMessage for deduped metadata', async () => {
+  // Deduplication is DECIDED here (the crawler's metadata routes it) but no
+  // longer SHAPED here. ai-worker re-runs the decision against its own assembled
+  // history and projects the stub at render time, so this side ships the full
+  // snapshot and lets the worker subtract.
+  describe('Deduplicated References', () => {
+    it('emits the FULL snapshot for a deduped reference', async () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'deduped-1',
@@ -392,16 +396,16 @@ describe('ReferenceFormatter', () => {
 
       expect(result.references).toHaveLength(1);
       const ref = result.references[0];
-      expect(ref.isDeduplicated).toBe(true);
+      // Not flagged here: the flag is the WORKER's, set when its own dedup
+      // re-run agrees. Flagging it on this side would be a second opinion.
+      expect(ref.isDeduplicated).toBeUndefined();
       expect(ref.content).toBe('This is the original message content');
-      expect(ref.embeds).toBe('');
-      expect(ref.locationContext).toBe('');
       expect(ref.referenceNumber).toBe(1);
-      // Should NOT call messageFormatter.formatMessage
+      // Still skips the enrichment path — a deduped reference needs no transcripts.
       expect(mockMessageFormatter.formatMessage).not.toHaveBeenCalled();
     });
 
-    it('should truncate long content in deduped stubs to ~100 chars', async () => {
+    it("does NOT truncate the content — capping is the renderer's single decision", async () => {
       const longContent = 'A'.repeat(200);
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
@@ -424,12 +428,10 @@ describe('ReferenceFormatter', () => {
 
       const result = await formatter.format('', crawledMessages, 10);
 
-      const ref = result.references[0];
-      expect(ref.content.length).toBeLessThanOrEqual(103); // 100 + '...'
-      expect(ref.content.endsWith('...')).toBe(true);
+      expect(result.references[0].content).toBe(longContent);
     });
 
-    it('should not truncate short content in deduped stubs', async () => {
+    it('leaves short content alone too', async () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'deduped-short',
@@ -454,11 +456,11 @@ describe('ReferenceFormatter', () => {
       expect(result.references[0].content).toBe('Short');
     });
 
-    it('should fold the attachment marker into an image-only deduped stub (empty text)', async () => {
-      // Image-only reply target: empty text + one image attachment. The deduped
-      // stub the bot ships to the worker must carry the attachment marker so the
-      // model can correlate it with the (image-described) history entry; without
-      // it the stub collapses to an empty quote and the model reports "no image."
+    it('ships an image-only reference with its attachments INTACT', async () => {
+      // The stub this replaced folded a `[image/png: photo.png]` text marker
+      // into the content and dropped the attachment list. That cost the worker
+      // the only structured record of what was attached, so an image whose
+      // vision call never ran rendered as nothing at all.
       vi.mocked(mockMessageFormatter.buildRawReference).mockReturnValueOnce({
         reference: {
           referenceNumber: 1,
@@ -499,8 +501,10 @@ describe('ReferenceFormatter', () => {
       const result = await formatter.format('', crawledMessages, 10);
 
       const ref = result.references[0];
-      expect(ref.isDeduplicated).toBe(true);
-      expect(ref.content).toBe('[image/png: photo.png]');
+      expect(ref.content).toBe('');
+      expect(ref.attachments).toEqual([
+        { url: 'https://cdn/photo.png', contentType: 'image/png', name: 'photo.png' },
+      ]);
     });
 
     it('should use snapshot content for deduped forwarded messages', async () => {
@@ -544,7 +548,6 @@ describe('ReferenceFormatter', () => {
 
       expect(result.references).toHaveLength(1);
       const ref = result.references[0];
-      expect(ref.isDeduplicated).toBe(true);
       // Should use snapshot content, not empty message.content
       expect(ref.content).toBe('Forwarded snapshot content here');
     });
@@ -607,7 +610,7 @@ describe('ReferenceFormatter', () => {
   });
 
   describe('collectRaw (raw assembly envelope)', () => {
-    it('returns full pre-dedup raw snapshots alongside stubbed enriched references', async () => {
+    it('returns the same full snapshot on both sides for a deduped reference', async () => {
       const longContent = 'B'.repeat(200);
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
@@ -626,11 +629,11 @@ describe('ReferenceFormatter', () => {
 
       const result = await formatter.format('content', crawledMessages, 10, { collectRaw: true });
 
-      // Enriched side: stubbed (truncated, isDeduplicated).
-      expect(result.references[0].isDeduplicated).toBe(true);
-      expect(result.references[0].content.length).toBeLessThan(longContent.length);
-      // Raw side: FULL content, same reference number — the worker re-derives
-      // dedup against its own hydrated history.
+      // Both sides carry the full snapshot now. The enriched side used to hold
+      // a truncated stub, which existed only to reach two log statements — the
+      // envelope has always carried `rawReferences` alone, and the worker
+      // re-derives dedup against its own hydrated history.
+      expect(result.references[0].content).toBe(longContent);
       expect(result.rawReferences).toHaveLength(1);
       expect(result.rawReferences?.[0].content).toBe(longContent);
       expect(result.rawReferences?.[0].referenceNumber).toBe(result.references[0].referenceNumber);

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.ts
@@ -9,7 +9,6 @@ import type { Message } from 'discord.js';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { MessageLinkParser } from '@tzurot/common-types/utils/messageLinkParser';
-import { buildDedupedReferenceStub } from '@tzurot/common-types/utils/referenceEnrichment';
 import { isForwardedMessage, type ReferenceMetadata } from './types.js';
 import { type MessageFormatter } from './MessageFormatter.js';
 import { type SnapshotFormatter } from './SnapshotFormatter.js';
@@ -98,7 +97,7 @@ export class ReferenceFormatter {
     const state: FormatState = { references, rawReferences, collectRaw, linkMap, nextNumber: 1 };
     for (const { message, metadata } of selected) {
       if (metadata.isDeduplicated === true) {
-        this.appendDedupedStub(message, metadata, state);
+        this.appendDedupedReference(message, metadata, state);
       } else if (isForwardedMessage(message)) {
         this.appendForwardedSnapshots(message, metadata, state);
       } else {
@@ -124,16 +123,20 @@ export class ReferenceFormatter {
     };
   }
 
-  /** Deduped: enriched side gets a stub; raw side gets the full snapshot. */
-  private appendDedupedStub(message: Message, metadata: ReferenceMetadata, s: FormatState): void {
-    // Build the full raw snapshot first and derive the stub from it via the
-    // shared kernel — the same stub the worker-side assembler produces when
-    // its own dedup re-run agrees, so the two shapes cannot drift.
+  /** Deduped: the full snapshot, on both sides. */
+  private appendDedupedReference(
+    message: Message,
+    metadata: ReferenceMetadata,
+    s: FormatState
+  ): void {
+    // No stub is built here any more. Deduplication is decided and rendered
+    // worker-side (ai-worker re-runs it against its OWN assembled history), and
+    // the thin envelope carries `rawReferences` only — so a stub built here
+    // reached nothing but two log statements while giving the stub shape a
+    // second, drift-prone home.
     const raw = this.messageFormatter.buildRawReference(message, s.nextNumber).reference;
-    s.references.push(buildDedupedReferenceStub(raw));
+    s.references.push(raw);
     if (s.collectRaw) {
-      // The raw side never stubs: the worker re-derives dedup against its
-      // OWN hydrated history, so it needs the full pre-dedup snapshot.
       s.rawReferences.push(raw);
     }
     this.trackLink(metadata, s.nextNumber, s.linkMap);


### PR DESCRIPTION
TASK-365 PR-2 — the collapse. PR-1 (#1881) gave a quoted message's *attachments* one vocabulary; this does the same one level up, for the reference itself.

Five hand-synced paths rendered a quoted reference — live {standard, forwarded, deduped} × stored {full, deduped} — each filling `formatQuoteElement`'s slots differently. That produced the same bug three times: a field one path carried and another silently dropped (TASK-162 the quote's role, TASK-364 its attachments, and — found by reading, not by bug report — its forwarded-ness).

Now: one canonical `RenderableReference`, two adapters that read the two source schemas, one `renderReference(ref)` with **no mode param**, and dedup as **subtraction** from the canonical render rather than a field-by-field rebuild. A new field reaches every path by construction, or fails to compile.

## Acceptance: the enumerated changelist

Byte-equality was proven unachievable during grounding (the projection changes deduped output by definition, and one renderer must pick one rule where two paths disagree). The acceptance test is instead: **every output difference appears below**. Verified by rendering all six paths before and after against fixed fixtures and diffing.

| | Change | Why |
| --- | --- | --- |
| A | **One timestamp format.** Live quotes rendered a `<time absolute relative/>` child; stored quotes a `t=""` attribute. Now `t=""` everywhere. | Same quote, two renderings, chosen by path. Converged on the helper `<message>` already uses in `<chat_log>` — cheaper and strictly more informative (date + weekday + clock + relative vs. date + relative). |
| B | **Forwarded references keep `number`, `role`, `username`, `locationContext`**, and `from` is the author the reference carries (`Unknown User`) rather than a hardcoded `Unknown`. | They routed through a wrapper with no author to render, which dropped the rest as collateral — including the `(forwarded from #channel)` marker `SnapshotFormatter` computes and then threw away. |
| C | **Deduped stubs render attachments structurally**, not as `[image/png: name]` markers folded into `content`. | A described image used to appear twice — once as a marker, once as an element. The marker noise also rode into the memory-retrieval query. |
| D | **A deduped attachment with no description is now visible** (`<image … status="undescribed"/>`). | Previously the live deduped path rendered only what preprocessing produced, so an undescribed attachment was simply absent. This is the follow-up absorbed into TASK-365 from #1877's review. |
| E | **"No preview of the bot's own words" narrows from any bot/webhook to `role="assistant"`.** | The rationale is the model reading its own fragment as "continue this". Third-party bots and proxy-relayed humans are neither, and were being silenced by a broader predicate. Stored deduped quotes of our own personas now get the suppression they never had. |
| F | **`username` is emitted only when it differs from the rendered name** (was: always on live, never on stored). | Same quote, one attribute apart, decided by which renderer got there. |
| G | **Forwarded + deduped keeps `type="forward"`.** | Third instance of the dropped-field class; closes by construction. |
| H | Deduped subtracts a **named three-member set** (`content` → marker, `locationContext`, `embedsXml`) instead of rebuilding. | No output change today. The change is that a *new* field is inherited by default, and adding a fourth exclusion becomes a conspicuous edit. |
| I | **`from_id` returns to stored deduped quotes.** | The stub's rebuild dropped it, costing the model its `<participants>` ID binding. |
| J | **Live deduped attachments gain their `type` attribute.** | They were built from synthesized preprocessing metadata that omits content type; they now come from the reference's real attachment list. |
| K | **Search text is built from the pre-projection reference** — full content, no stub marker, embeds included on every path. | The stub's prose marker and truncation are prompt-shaping, not semantic content. A reference now contributes the same retrieval text whether or not it happens to dedupe. |
| L | **Budget estimates get accurate.** `estimateReferenceLength` renders the quote instead of approximating it. | It invented `author=` and `location=` attributes the emitter never wrote, and a phantom ` forwarded="true"` where the emitter writes `type="forward"`. Pinned by exact equality, not a greater-than. |
| M | **A live quote's `from` falls back to the username when the display name is empty** (was: bare `authorDisplayName`, so an empty one rendered `from=""`). | Parity with the stored path, and with the expression `deriveRefRole` was already given two lines below. Missed in the first pass of this table — caught by review, not by the snapshot diff, because the fixtures all carry a display name. |

`conversationUtils`' forwarded *history message* path is unchanged — it is not a reference (no `ReferencedMessage` in it), so it stays a second consumer of the shared emitter and of the persisted `legacyAttachmentLines` slot.

## Deletions

Same lesson PR-1 ended on: when two things must agree, one of them should not exist.

- `formatDedupedQuote` + `DedupedQuoteOptions` → the projection
- `splitPreprocessedEnrichment` and the bespoke half of `buildStoredAttachments` → one `buildRenderableAttachments` kernel (single `describe` callback; each caller keeps its own orphan-enrichment tail, because an unmatched stored description and an unmatched `ProcessedAttachment` are different shapes)
- `formatQuoteElement`'s `timestamp` slot and `<time>` emitter; `formatTimestampWithDelta` + `TimestampWithDelta` (no other callers); the `time` entry in `KNOWN_UNPROTECTED_TAGS`
- `buildDedupedReferenceStub` and `capDedupText` leave `common-types` entirely — the stub's whole body moved to the projection, leaving `{...raw, isDeduplicated: true}` inline in `referenceEnricher`
- **bot-client's stub construction.** Re-verified dead this cycle, guard included: the enriched `references` array reaches a count at `MessageContextBuilder.ts:399` and a count+boolean at `gatewayServiceCalls.ts:245`, and nothing else. `PersonalityChatManager` never passes it to `saveUserMessage`, so the `ConversationPersistence` write is unreachable. The envelope has always carried `rawReferences` alone.

## Deliberately not here

**Live persona hydration** (bundled into PR-2 by the recorded design). Deferring on mechanism, not effort: it needs a Prisma client inside `ConversationInputProcessor`/`ReferencedMessageFormatter`, neither of which has one, plus a per-turn batch resolve — an upstream data-availability change with its own failure mode, not a render change. The canonical type already has the `from`/`fromId` slots, so it lands afterwards as an adapter-only change against one renderer and cannot regenerate the divergence class. Filed as PR-3 on TASK-365.

**bot-client's enriched `references` array is dead work** — building it runs `appendTranscriptsWithRetriever` (Redis + DB) per reference per message to feed two log counts. Filed separately; the collapse does not depend on it.

## Testing

- `pnpm test` (all packages) + `pnpm quality` sequentially, both green. Contract tier run separately (`tests/e2e/contracts/`, 17 passed) per the cross-service shape rule.
- New `RenderableReference.test.ts` carries the structural guard on the projection: it walks the reference's **own keys** and asserts every non-subtracted one is inherited, so a future field that a rebuild would drop fails here without anyone updating a list.
- `buildRenderableAttachments` covered per modality, including the classify-on-`isVoiceMessage` rule (a music file is not a failed transcription) and the deliberate no-enrichment-slot-on-files case.
- The estimator parity pin is now exact and spans the whole `<quote>`, not just its attachments.
- Seam mock in `xmlMetadataFormatters.test.ts` retargeted from the deleted stub renderer to `dedupeReference`, still delegating to the real implementation.

**Smoke (CI cannot reach Discord):** reply to a message that quotes an image and is already in the chat log → the character describes the image, and the quote carries one `<image>` element rather than a description plus a duplicate marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
