### PR TITLE
fix(ai-worker): restore extended-context image descriptions (regression in beta.188)

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.ts
@@ -97,6 +97,27 @@ function keepStickersIf(enabled: boolean, attachments: AttachmentMetadata[]): At
   return enabled ? attachments : attachments.filter(a => a.isSticker !== true);
 }
 
+/**
+ * Apply the sticker filter WITHOUT inventing a value for a field that was absent.
+ *
+ * `undefined` and `[]` are different states on `extendedContextAttachments`, and
+ * a later step reads the difference: bot-client stopped shipping the field with
+ * the thin envelope, so `DependencyStep` treats absence as "derive the list from
+ * the raw envelope instead" via `?? deriveExtendedContextImages(...)`. `??` does
+ * not fall through on `[]`. Normalizing absent to empty here therefore switched
+ * OFF every extended-context image description — silently, because an empty list
+ * and a filtered-to-empty list look identical downstream.
+ *
+ * Filtering an absent list still yields absent; only a list that was really there
+ * can be really emptied.
+ */
+function filterOptional(
+  enabled: boolean,
+  attachments: AttachmentMetadata[] | undefined
+): AttachmentMetadata[] | undefined {
+  return attachments === undefined ? undefined : keepStickersIf(enabled, attachments);
+}
+
 export class DownloadAttachmentsStep implements IPipelineStep {
   readonly name = 'DownloadAttachments';
 
@@ -121,10 +142,14 @@ export class DownloadAttachmentsStep implements IPipelineStep {
       stickerVisionEnabled,
       job.data.context?.attachments ?? []
     );
-    const extendedAttachments = keepStickersIf(
+    // Absence is load-bearing on this field — see filterOptional. Keep the
+    // possibly-undefined form for the write-back; the local download work below
+    // uses the `?? []` view.
+    const extendedOptional = filterOptional(
       stickerVisionEnabled,
-      job.data.context?.extendedContextAttachments ?? []
+      job.data.context?.extendedContextAttachments
     );
+    const extendedAttachments = extendedOptional ?? [];
 
     // Publish the filtered view BEFORE the short-circuit below. When the switch
     // drops the only attachment on a message, the early return fires and the
@@ -132,7 +157,7 @@ export class DownloadAttachmentsStep implements IPipelineStep {
     // sticker visible to every downstream step, which is the opposite of off.
     if (job.data.context !== undefined) {
       job.data.context.attachments = triggerAttachments;
-      job.data.context.extendedContextAttachments = extendedAttachments;
+      job.data.context.extendedContextAttachments = extendedOptional;
     }
 
     // No attachments → nothing to expire. Short-circuit before the queue-age
@@ -214,9 +239,16 @@ export class DownloadAttachmentsStep implements IPipelineStep {
 
     // Mutate the job.data view of attachments so downstream steps see data URLs.
     // job.data is a plain object on this worker's copy of the job — safe to assign.
+    //
+    // The extended write-back stays absence-preserving for the same reason as
+    // the one above: a job carrying trigger attachments but no extended list
+    // reaches here with `extendedOptional === undefined`, and writing this
+    // group's (empty) successes would re-close the derive path for exactly
+    // those jobs.
     if (job.data.context !== undefined) {
       job.data.context.attachments = triggerResult.successes;
-      job.data.context.extendedContextAttachments = extendedResult.successes;
+      job.data.context.extendedContextAttachments =
+        extendedOptional === undefined ? undefined : extendedResult.successes;
     }
 
     return context;

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionSeam.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionSeam.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Seam test: DownloadAttachmentsStep → DependencyStep.
+ *
+ * These two steps run back-to-back in the real pipeline, and the second reads a
+ * distinction the first can erase. `DependencyStep` treats an ABSENT
+ * `extendedContextAttachments` as "derive the image list from the raw envelope"
+ * — the only path there is, since bot-client stopped shipping that field with
+ * the thin envelope. `DownloadAttachmentsStep` writes the field back on every
+ * job. If it writes `[]` where the field was absent, extended-context vision is
+ * switched off for the whole service, silently.
+ *
+ * That shipped. Both steps had thorough unit tests and neither could catch it:
+ * DependencyStep's fixtures construct the absent-field shape directly (what the
+ * BOT sends), and DownloadAttachmentsStep's helper defaults the field to `[]`
+ * (so it never fed the undefined that production sends). Only running them in
+ * order exercises the handoff — per `02-code-standards.md` § "Assert what
+ * crosses a mocked seam", this is the one wiring test that mocks only the
+ * external boundary (vision) and lets the chain run for real.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Job } from 'bullmq';
+import { JobType } from '@tzurot/common-types/constants/queue';
+import { AttachmentType } from '@tzurot/common-types/constants/media';
+import { type LLMGenerationJobData } from '@tzurot/common-types/types/jobs';
+import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
+import { DownloadAttachmentsStep } from './DownloadAttachmentsStep.js';
+import { DependencyStep } from './DependencyStep.js';
+import type { GenerationContext } from '../types.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  };
+});
+
+// Sticker vision on (registry default) — the switch has its own tests.
+vi.mock('@tzurot/common-types/services/SystemSettingsService', () => ({
+  getSystemSetting: () => true,
+}));
+
+vi.mock('../../../../redis.js', () => ({
+  redisService: { getJobResult: vi.fn() },
+  visionDescriptionCache: {
+    tryAcquireInflight: vi.fn().mockResolvedValue(true),
+    isInflight: vi.fn().mockResolvedValue(false),
+    releaseInflight: vi.fn().mockResolvedValue(undefined),
+    storeFailure: vi.fn(),
+  },
+  visionFallbackQuota: { tryConsume: () => Promise.resolve(true) },
+}));
+
+// THE external boundary — the only thing mocked. Everything between the two
+// steps runs for real.
+const mockProcessAttachments = vi.fn();
+vi.mock('../../../../services/MultimodalProcessor.js', () => ({
+  processAttachments: (...args: unknown[]) => mockProcessAttachments(...args),
+  deriveApiKeySource: (): 'system' => 'system',
+}));
+
+// The download seam `downloadOne` actually calls. Per-test controllable so the
+// all-downloads-fail arm can reject without touching the network.
+const mockDownloadImageToDataUrl = vi.fn();
+vi.mock('../../../../utils/imageToDataUrl.js', () => ({
+  downloadImageToDataUrl: (...args: unknown[]) => mockDownloadImageToDataUrl(...args),
+}));
+
+const TEST_PERSONALITY: LoadedPersonality = {
+  id: 'p-1',
+  name: 'TestBot',
+  displayName: 'Test Bot',
+  slug: 'testbot',
+  ownerId: 'owner-uuid-test',
+  systemPrompt: 'x',
+  model: 'anthropic/claude-sonnet-4',
+  provider: 'openrouter',
+  temperature: 0.7,
+  maxTokens: 2000,
+  contextWindowTokens: 8192,
+  characterInfo: 'x',
+  personalityTraits: 'x',
+  voiceEnabled: false,
+};
+
+const RAW_IMAGE = {
+  url: 'https://cdn.discordapp.com/attachments/1/2/forwarded.png',
+  contentType: 'image/png',
+  id: 'raw-img-1',
+};
+
+/**
+ * A job in the shape production actually sends: the thin envelope carries the
+ * raw image list and NO resolved `extendedContextAttachments` field.
+ */
+function thinEnvelopeJob(
+  overrides: { attachments?: LLMGenerationJobData['context']['attachments'] } = {}
+): Job<LLMGenerationJobData> {
+  return {
+    id: 'job-seam-1',
+    timestamp: Date.now(),
+    data: {
+      requestId: 'req-seam',
+      jobType: JobType.LLMGeneration,
+      personality: TEST_PERSONALITY,
+      message: 'what was in that image',
+      context: {
+        kind: 'envelope',
+        userId: 'u-1',
+        userName: 'U',
+        channelId: 'c-1',
+        // Deliberately absent — this is the whole point.
+        ...(overrides.attachments !== undefined ? { attachments: overrides.attachments } : {}),
+        rawAssemblyInputs: {
+          rawMessageContent: 'what was in that image',
+          rawExtendedContextImageAttachments: [RAW_IMAGE],
+        },
+      },
+      responseDestination: { type: 'discord', channelId: 'c-1' },
+    } as unknown as LLMGenerationJobData,
+  } as unknown as Job<LLMGenerationJobData>;
+}
+
+function contextFor(job: Job<LLMGenerationJobData>): GenerationContext {
+  return {
+    job,
+    startTime: Date.now(),
+    configOverrides: { maxImages: 10 },
+  } as unknown as GenerationContext;
+}
+
+async function runBothSteps(job: Job<LLMGenerationJobData>): Promise<GenerationContext> {
+  const afterDownload = await new DownloadAttachmentsStep(0).process(contextFor(job));
+  return new DependencyStep().process(afterDownload);
+}
+
+describe('extended-context vision survives the DownloadAttachments → Dependency handoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDownloadImageToDataUrl.mockResolvedValue({
+      dataUrl: 'data:image/png;base64,eA==',
+      bytes: 1,
+    });
+    mockProcessAttachments.mockResolvedValue([
+      {
+        type: AttachmentType.Image,
+        description: 'a whiteboard covered in equations',
+        originalUrl: RAW_IMAGE.url,
+        metadata: { url: RAW_IMAGE.url, contentType: 'image/png' },
+      },
+    ]);
+  });
+
+  it('describes envelope-derived images on a text-only job', async () => {
+    const result = await runBothSteps(thinEnvelopeJob());
+
+    expect(mockProcessAttachments).toHaveBeenCalled();
+    expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
+    expect(result.preprocessing?.extendedContextAttachments?.[0].description).toBe(
+      'a whiteboard covered in equations'
+    );
+  });
+
+  it('describes envelope-derived images when the job ALSO carries a trigger attachment', async () => {
+    // Separate arm: a job with trigger attachments skips the early return, so
+    // it reaches the post-download write-back — a second place that can erase
+    // the absent-field sentinel.
+    const result = await runBothSteps(
+      thinEnvelopeJob({
+        attachments: [
+          {
+            url: 'https://cdn.discordapp.com/attachments/9/9/trigger.png',
+            contentType: 'image/png',
+          },
+        ],
+      })
+    );
+
+    expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
+  });
+
+  it('leaves the field absent after download so the derive path stays reachable', async () => {
+    // The mechanism itself, pinned directly: whatever else DownloadAttachmentsStep
+    // does, it must not invent `[]` for a field that arrived absent.
+    const job = thinEnvelopeJob();
+    await new DownloadAttachmentsStep(0).process(contextFor(job));
+
+    expect(job.data.context.extendedContextAttachments).toBeUndefined();
+  });
+
+  it('keeps a REALLY-empty list empty when every extended download fails', async () => {
+    // The other side of the distinction. A list that arrived present and then
+    // lost every member to failed downloads must stay `[]`, not decay to
+    // `undefined` — re-deriving from the envelope would only re-attempt the
+    // same dead URLs. Absence-preserving must not become absence-inventing.
+    mockDownloadImageToDataUrl.mockRejectedValue(new Error('404 from the CDN'));
+
+    const job = thinEnvelopeJob();
+    job.data.context.extendedContextAttachments = [
+      { url: 'https://cdn.discordapp.com/attachments/3/3/gone.png', contentType: 'image/png' },
+    ];
+
+    const result = await runBothSteps(job);
+
+    expect(job.data.context.extendedContextAttachments).toEqual([]);
+    // …and the envelope's raw list is NOT resurrected in its place.
+    expect(mockProcessAttachments).not.toHaveBeenCalled();
+    expect(result.preprocessing?.extendedContextAttachments ?? []).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What's broken

Extended-context images have not been described in production since **v3.0.0-beta.188**. Every image in the chat log — forwarded or not — reaches the model as its bare fallback line (`[image/webp: name.png]`) instead of a description.

Reported by the owner against a live prod system prompt: 1224 lines, 44 forwarded quotes, **0 `<image>` elements**, 45 bracket fallback lines.

## Verified at runtime, both sides of the wire

| | |
| --- | --- |
| bot-client collected | up to **67 images** per fetch; 28 of 203 fetches carried images |
| ai-worker processed | `extendedContextAttachmentCount=0` in **66 of 66** generations |

Same ~24h window. The data is produced and then dropped between the two steps.

## Mechanism

`DependencyStep` reads **absence** as a signal. bot-client stopped shipping `extendedContextAttachments` when the thin envelope became unconditional, so an absent field means "derive the list from the raw envelope instead":

```ts
jobContext?.extendedContextAttachments ?? deriveExtendedContextImages(raw…, maxImages)
```

`??` falls through on `undefined`, not on `[]`.

`DownloadAttachmentsStep` runs immediately before it. The sticker-vision change added a publish-before-short-circuit block — correct in itself, and needed so a switched-off sticker cannot leak downstream — but it wrote `[]` back for a field that had arrived absent:

```ts
const extendedAttachments = keepStickersIf(enabled, job.data.context?.extendedContextAttachments ?? []);
job.data.context.extendedContextAttachments = extendedAttachments;   // [] where undefined was
```

Before that change the `?? []` was **local only**, the field stayed absent, and the derive path ran. After it, the derive branch is unreachable and extended-context vision is off service-wide.

## Fix

Both write-backs are absence-preserving. Filtering an absent list yields an absent list; only a list that was really there can be really emptied. The second write-back (post-download) needed the same treatment — a job carrying trigger attachments skips the early return and reaches it with the extended list absent.

## Why no test caught it

Both steps are thoroughly unit-tested. Neither could catch this, because each pins the seam using a fixture that models the *other* side wrong:

- `DependencyStep.test.ts` — *"derives the image list from the raw envelope when the payload field is absent (thin payload)"*, with `// No extendedContextAttachments — thin payload shape.` It pins what **bot-client** sends. That state no longer reaches the step.
- `DownloadAttachmentsStep.test.ts` — the job helper **defaults the field to `[]`**, so it never fed the `undefined` production sends; the empty-case assertion is `?? []` `.toHaveLength(0)`, which passes either way.
- **No test ran the two steps in sequence.**

This is the class `.claude/rules/02-code-standards.md` § "Assert what crosses a mocked seam" exists for: a test that mocks the seam it is meant to verify cannot catch a wiring bug at that seam. Line coverage was green — both lines executed, and neither test could see that one had changed what the other received.

`extendedContextVisionSeam.test.ts` adds the missing wiring test: it runs both steps in order, mocks only the external vision boundary, and covers both write-backs. **Verified to fail on the shipped code** (3/3 red with the fix reverted).

## Verification

- `pnpm --filter @tzurot/ai-worker test` — 195 files, 4169 tests green
- `pnpm quality` — green
- New seam test fails pre-fix, passes post-fix

## Smoke (owner)

Post a forwarded message carrying an image, then in a **new** message ask the character what the image showed. Expected: it can describe it. Today it sees only the filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)