### PR TITLE
fix(ai-worker): derive a deduped stub's exclusion set from what the chat log renders

### DIFF
--- a/services/ai-worker/src/jobs/utils/conversationUtils.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.ts
@@ -61,7 +61,9 @@ import {
  *
  * @param msg - Raw history entry to format
  * @param personalityName - Name of the AI personality (for marking its own messages)
- * @param historyMessageIds - Optional set of Discord message IDs already in history (for quote deduplication)
+ * @param historyEntries - Optional Discord-message-ID → history entry index. The
+ *   key decides quote deduplication; the entry answers what the chat log already
+ *   renders for a deduped quote, so the stub can subtract what would be a repeat.
  * @param allPersonalityNames - Optional set of all AI personality names in the conversation (for multi-AI collision detection)
  * @returns Formatted XML string, or empty string if message should be skipped
  */
@@ -94,7 +96,7 @@ function toRenderableAttachments(
 export function formatSingleHistoryEntryAsXml(
   msg: RawHistoryEntry,
   personalityName: string,
-  historyMessageIds?: Set<string>,
+  historyEntries?: Map<string, RawHistoryEntry>,
   allPersonalityNames?: Set<string>
 ): string {
   const speakerInfo = resolveSpeakerInfo(msg, personalityName, allPersonalityNames);
@@ -127,16 +129,14 @@ export function formatSingleHistoryEntryAsXml(
     msg,
     normalizedRole,
     personalityName,
-    historyMessageIds,
+    historyEntries,
     allPersonalityNames
   );
   const imageSection = formatImageSection(msg);
   const embedsSection = formatEmbedsSection(msg);
-  // The bot's own voice output (assistant role) is TTS of its message text, so
-  // its transcript merely duplicates `content`. Only render transcripts for
-  // inbound (user) voice, where the transcript is the sole record of what was
-  // said. Without this guard, the bot's lines appear twice in the chat log.
-  const voiceSection = normalizedRole === 'assistant' ? '' : formatVoiceSection(msg);
+  // Assistant transcripts are suppressed inside formatVoiceSection — the rule
+  // belongs with the renderer so `chatLogEnrichmentFor` gets the same answer.
+  const voiceSection = formatVoiceSection(msg, normalizedRole);
   const reactionsSection = formatReactionsSection(msg);
 
   // For forwarded messages, use shared QuoteFormatter for consistency
@@ -186,24 +186,43 @@ interface FormatConversationHistoryOptions {
 }
 
 /**
- * Build set of Discord message IDs for quote deduplication
- * This prevents duplicating quoted content that's already in the conversation.
- * Uses discordMessageId (Discord snowflakes) NOT id (internal database UUIDs) because
- * referenced messages are identified by their Discord message ID.
+ * Index history by Discord message ID for quote deduplication.
+ *
+ * Uses discordMessageId (Discord snowflakes) NOT id (internal database UUIDs)
+ * because referenced messages are identified by their Discord message ID. A
+ * chunked message carries several IDs and each one maps back to the same entry.
+ *
+ * The ENTRY rather than a bare ID because two different questions are asked of
+ * this: whether a quote is already in the conversation (dedup), and what the
+ * chat log renders for it (how much of the quote is then redundant). The second
+ * needs the entry, and answering it by assumption is what let a stub print the
+ * same vision description twice.
  */
-export function buildHistoryMessageIdSet(history: RawHistoryEntry[]): Set<string> {
-  const historyMessageIds = new Set<string>();
+export function buildHistoryEntryIndex(history: RawHistoryEntry[]): Map<string, RawHistoryEntry> {
+  const byDiscordId = new Map<string, RawHistoryEntry>();
   for (const msg of history) {
     // Each message may have multiple Discord IDs (for chunked messages)
     if (msg.discordMessageId !== undefined) {
       for (const discordId of msg.discordMessageId) {
         if (discordId.length > 0) {
-          historyMessageIds.add(discordId);
+          byDiscordId.set(discordId, msg);
         }
       }
     }
   }
-  return historyMessageIds;
+  return byDiscordId;
+}
+
+/**
+ * Build set of Discord message IDs for quote deduplication.
+ *
+ * The ID-only projection of {@link buildHistoryEntryIndex}, for consumers that
+ * genuinely only ask membership (the shipped-message set that filters
+ * already-in-prompt memories). Delegating keeps one definition of which IDs a
+ * history entry contributes.
+ */
+export function buildHistoryMessageIdSet(history: RawHistoryEntry[]): Set<string> {
+  return new Set(buildHistoryEntryIndex(history).keys());
 }
 
 /**
@@ -276,7 +295,7 @@ export function formatConversationHistoryAsXml(
     return '';
   }
 
-  const historyMessageIds = buildHistoryMessageIdSet(history);
+  const historyEntries = buildHistoryEntryIndex(history);
   const allPersonalityNames = collectPersonalityNames(history, personalityName);
 
   const messages: string[] = [];
@@ -291,7 +310,7 @@ export function formatConversationHistoryAsXml(
     const formatted = formatSingleHistoryEntryAsXml(
       msg,
       personalityName,
-      historyMessageIds,
+      historyEntries,
       allPersonalityNames
     );
     if (formatted.length > 0) {

--- a/services/ai-worker/src/jobs/utils/historyTokenMeasure.test.ts
+++ b/services/ai-worker/src/jobs/utils/historyTokenMeasure.test.ts
@@ -134,7 +134,7 @@ describe('measureHistoryEntryTokens', () => {
     const dedupedRender = formatSingleHistoryEntryAsXml(
       entry,
       PERSONALITY,
-      new Set(['1399000000000000001'])
+      new Map([['1399000000000000001', { role: 'user', content: '' }]])
     );
 
     // Pinning WHICH form gets measured. The two differ, so this would catch a

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
@@ -12,8 +12,10 @@ import {
   formatEmbedsSection,
   formatVoiceSection,
   formatReactionsSection,
+  chatLogEnrichmentFor,
 } from './xmlMetadataFormatters.js';
 import type { RawHistoryEntry } from './conversationTypes.js';
+import { enrichmentKey } from '../../services/prompt/QuoteFormatter.js';
 
 // Mock common-types
 vi.mock('@tzurot/common-types/utils/dateFormatting', async () => {
@@ -95,6 +97,23 @@ function makeEntry(overrides: Partial<RawHistoryEntry> = {}): RawHistoryEntry {
     content: 'Test message',
     ...overrides,
   } as RawHistoryEntry;
+}
+
+/**
+ * A history index whose entry carries no enrichment of its own.
+ *
+ * The default for a dedup fixture, and the case the whole feature is built for:
+ * the chat log renders that message's attachment as a bare URL, so a deduped
+ * stub must keep the description it was handed. Pass `metadata` to build the
+ * opposite case — an entry whose own rendering already carries it.
+ */
+function historyIndex(
+  id: string,
+  metadata?: RawHistoryEntry['messageMetadata']
+): Map<string, RawHistoryEntry> {
+  return new Map([
+    [id, makeEntry({ discordMessageId: [id], content: '', messageMetadata: metadata })],
+  ]);
 }
 
 describe('xmlMetadataFormatters', () => {
@@ -440,7 +459,7 @@ describe('xmlMetadataFormatters', () => {
         },
       });
 
-      const historyIds = new Set(['already-in-history']);
+      const historyIds = historyIndex('already-in-history');
       const result = formatQuotedSection(msg, 'user', personalityName, historyIds, undefined);
       expect(result).toContain('<quoted_messages>');
       expect(result).toContain('[Referenced message — full text in the chat log]');
@@ -492,7 +511,7 @@ describe('xmlMetadataFormatters', () => {
         msg,
         'user',
         personalityName,
-        new Set(['already-in-history']),
+        historyIndex('already-in-history'),
         undefined
       );
 
@@ -506,7 +525,12 @@ describe('xmlMetadataFormatters', () => {
               description: 'SENTINEL_STORED_VISION',
             },
           ],
-        })
+        }),
+        // The second seam argument, and the one the stub cannot derive alone:
+        // what the chat-log entry itself renders. Empty here — that entry has no
+        // enrichment of its own — so nothing is subtracted and the description
+        // rides along, which is what the output assertion below then confirms.
+        new Set()
       );
       expect(result).toContain('SENTINEL_STORED_VISION');
       // One element for the picture, never a description plus a marker.
@@ -533,7 +557,7 @@ describe('xmlMetadataFormatters', () => {
         },
       });
 
-      const historyIds = new Set(['already-in-history']);
+      const historyIds = historyIndex('already-in-history');
       const result = formatQuotedSection(msg, 'user', personalityName, historyIds, undefined);
       expect(result).toContain('role="bot"');
     });
@@ -555,7 +579,7 @@ describe('xmlMetadataFormatters', () => {
         },
       });
 
-      const historyIds = new Set(['in-history']);
+      const historyIds = historyIndex('in-history');
       const result = formatQuotedSection(msg, 'user', personalityName, historyIds, undefined);
       // Should contain truncated content with '...'
       expect(result).toContain('X'.repeat(100) + '...');
@@ -586,7 +610,7 @@ describe('xmlMetadataFormatters', () => {
         },
       });
 
-      const historyIds = new Set(['in-history']);
+      const historyIds = historyIndex('in-history');
       const result = formatQuotedSection(msg, 'user', personalityName, historyIds, undefined);
       expect(result).toContain('<quoted_messages>');
       // Full ref for User Two
@@ -661,16 +685,70 @@ describe('xmlMetadataFormatters', () => {
   describe('formatVoiceSection', () => {
     it('returns empty string when no voiceTranscripts', () => {
       const msg = makeEntry();
-      expect(formatVoiceSection(msg)).toBe('');
+      expect(formatVoiceSection(msg, 'user')).toBe('');
     });
 
     it('formats voice transcripts', () => {
       const msg = makeEntry({
         messageMetadata: { voiceTranscripts: ['Hello, this is a test'] },
       });
-      const result = formatVoiceSection(msg);
+      const result = formatVoiceSection(msg, 'user');
       expect(result).toContain('<voice_transcripts>');
       expect(result).toContain('<transcript>Hello, this is a test</transcript>');
+    });
+
+    it('suppresses the assistant own-TTS transcript', () => {
+      // Its transcript merely duplicates `content`. The guard lives in the
+      // renderer rather than the caller so `chatLogEnrichmentFor` — which has to
+      // ask the same question — cannot get a different answer.
+      const msg = makeEntry({
+        messageMetadata: { voiceTranscripts: ['the bot reading its own reply'] },
+      });
+      expect(formatVoiceSection(msg, 'assistant')).toBe('');
+    });
+  });
+
+  describe('chatLogEnrichmentFor', () => {
+    it('reports the descriptions and transcripts the entry itself renders', () => {
+      const entry = makeEntry({
+        messageMetadata: {
+          imageDescriptions: [{ filename: 'a.png', description: 'a whiteboard' }],
+          voiceTranscripts: ['spoken words'],
+        },
+      });
+      expect(chatLogEnrichmentFor(entry, 'TestBot', undefined)).toEqual(
+        new Set([enrichmentKey('image', 'a whiteboard'), enrichmentKey('voice', 'spoken words')])
+      );
+    });
+
+    it('reports nothing for an entry carrying no enrichment', () => {
+      expect(chatLogEnrichmentFor(makeEntry(), 'TestBot', undefined).size).toBe(0);
+    });
+
+    it('excludes the assistant transcript the chat log suppresses', () => {
+      // Derived, not restated: the transcript is present in the metadata but the
+      // renderer declines to emit it, so it is NOT carried and a quote of it
+      // still has to bring its own copy.
+      const entry = makeEntry({
+        role: 'assistant',
+        messageMetadata: {
+          imageDescriptions: [{ filename: 'a.png', description: 'a whiteboard' }],
+          voiceTranscripts: ['the bot reading its own reply'],
+        },
+      });
+      expect(chatLogEnrichmentFor(entry, 'TestBot', undefined)).toEqual(
+        new Set([enrichmentKey('image', 'a whiteboard')])
+      );
+    });
+
+    it('reports nothing for an entry the chat log declines to render at all', () => {
+      const entry = makeEntry({
+        role: 'system',
+        messageMetadata: {
+          imageDescriptions: [{ filename: 'a.png', description: 'a whiteboard' }],
+        },
+      });
+      expect(chatLogEnrichmentFor(entry, 'TestBot', undefined).size).toBe(0);
     });
   });
 

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -12,16 +12,26 @@ import {
   neutralizeWrapperClosingTags,
 } from '@tzurot/common-types/utils/promptSanitizer';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
+import { enrichmentKey } from '../../services/prompt/QuoteFormatter.js';
 import { dedupeReference, renderReference } from '../../services/prompt/RenderableReference.js';
 import { fromStoredReference } from '../../services/prompt/storedReference.js';
-import type { RawHistoryEntry } from './conversationTypes.js';
+import type { InlineImageDescription, RawHistoryEntry } from './conversationTypes.js';
+import { resolveSpeakerInfo } from './participantUtils.js';
 
-/** Format quoted messages section for XML output */
+/**
+ * Format quoted messages section for XML output.
+ *
+ * Takes the history ENTRIES rather than their ids alone. The id set answers
+ * "is this quote already in the chat log?", which decides dedup; the entry
+ * answers "and what does the chat log actually render for it?", which decides
+ * how much of the quote is redundant. Only the second can be derived, so only
+ * the second stops the stub asserting things about a renderer it cannot see.
+ */
 export function formatQuotedSection(
   msg: RawHistoryEntry,
   normalizedRole: string,
   personalityName: string,
-  historyMessageIds: Set<string> | undefined,
+  historyEntries: Map<string, RawHistoryEntry> | undefined,
   allPersonalityNames: Set<string> | undefined
 ): string {
   if (normalizedRole !== 'user') {
@@ -41,7 +51,7 @@ export function formatQuotedSection(
   const dedupedRefs: StoredReferencedMessage[] = [];
 
   for (const ref of allRefs) {
-    if (historyMessageIds?.has(ref.discordMessageId) === true) {
+    if (historyEntries?.has(ref.discordMessageId) === true) {
       dedupedRefs.push(ref);
     } else {
       fullRefs.push(ref);
@@ -57,28 +67,119 @@ export function formatQuotedSection(
   );
 
   // Deduped refs are the SAME reference, projected — not a second build. Media
-  // rides along in full: the worker writes each reference's descriptions and
+  // rides along by default: the worker writes each reference's descriptions and
   // transcripts onto this row when it builds them, precisely so quoted media
-  // survives replay, and the history entry the stub points at renders that
-  // image as a URL, not a description.
-  const formattedDeduped = dedupedRefs.map(ref =>
-    renderReference(dedupeReference(fromStoredReference(ref, personalityName, allPersonalityNames)))
-  );
+  // survives replay, and the history entry the stub points at usually renders
+  // that image as a bare URL. Usually, not always — so the exception is
+  // computed from the entry rather than assumed away.
+  const formattedDeduped = dedupedRefs.map(ref => {
+    const entry = historyEntries?.get(ref.discordMessageId);
+    return renderReference(
+      dedupeReference(
+        fromStoredReference(ref, personalityName, allPersonalityNames),
+        entry === undefined
+          ? undefined
+          : chatLogEnrichmentFor(entry, personalityName, allPersonalityNames)
+      )
+    );
+  });
 
   const allFormatted = [...formattedFull, ...formattedDeduped].join('\n');
   return `\n<quoted_messages>\n${allFormatted}\n</quoted_messages>`;
 }
 
+/**
+ * The enrichment text this entry's own chat-log rendering already carries.
+ *
+ * Answers "would the model read this description anyway, without the quote?" —
+ * the question a deduped stub needs before deciding whether to repeat media it
+ * was handed. DERIVED, not asserted: it asks the two section renderers whether
+ * they emit for this entry and reads the strings they would emit, so a change
+ * to what history renders moves this with it. The predecessor was a sentence in
+ * a docstring claiming history "renders that image as a URL, not a
+ * description", which was true for a message nobody had triggered on and false
+ * for one that had been a trigger itself — `injectImageDescriptions` populates
+ * `imageDescriptions` on exactly those entries.
+ *
+ * Empty when the entry renders nothing (an unresolvable speaker, an assistant's
+ * own TTS transcript), which is the correct answer rather than a missing one:
+ * nothing is in the chat log to subtract against.
+ */
+export function chatLogEnrichmentFor(
+  msg: RawHistoryEntry,
+  personalityName: string,
+  allPersonalityNames: Set<string> | undefined
+): Set<string> {
+  const carried = new Set<string>();
+
+  // Resolved rather than passed in: an entry the chat log declines to render at
+  // all (resolveSpeakerInfo returns null) contributes nothing, and that is the
+  // same question the renderer asks first.
+  const speakerInfo = resolveSpeakerInfo(msg, personalityName, allPersonalityNames);
+  if (speakerInfo === null) {
+    return carried;
+  }
+
+  for (const img of renderedImageDescriptions(msg)) {
+    carried.add(enrichmentKey('image', img.description));
+  }
+  for (const transcript of renderedVoiceTranscripts(msg, speakerInfo.normalizedRole)) {
+    carried.add(enrichmentKey('voice', transcript));
+  }
+
+  return carried;
+}
+
+/**
+ * The image descriptions this entry contributes to the chat log — empty when it
+ * contributes none.
+ *
+ * ONE decision with two readers: `formatImageSection` draws these,
+ * `chatLogEnrichmentFor` reports them. Sharing the selection rather than having
+ * the second ask the first "did you emit?" and then re-read the source keeps a
+ * single condition, and skips building an XML string only to measure it.
+ */
+function renderedImageDescriptions(msg: RawHistoryEntry): InlineImageDescription[] {
+  return msg.messageMetadata?.imageDescriptions ?? [];
+}
+
+/**
+ * The voice transcripts this entry contributes to the chat log.
+ *
+ * The bot's own voice output (assistant role) is TTS of its message text, so its
+ * transcript merely duplicates `content` — without this the bot's lines appear
+ * twice in the chat log. Suppression lives HERE, in the shared selection, so the
+ * renderer and the enrichment report cannot reach different answers.
+ *
+ * SCOPE: this covers the message-level render only. A FORWARDED entry renders
+ * its attachments through `toRenderableAttachments` instead, which maps
+ * transcripts unconditionally — so on that path the two would diverge if an
+ * assistant-role entry could ever carry `voiceTranscripts`. It cannot: the only
+ * writers are bot-client's inbound-voice builder (user messages by
+ * construction) and `ContextAssembler`'s extended-context re-resolution, which
+ * returns early on `MessageRole.Assistant`.
+ *
+ * Deliberately NOT unified with the forwarded path, because the suppression's
+ * reason does not transfer: on a forward the transcript is of the FORWARDED
+ * voice note, not of the bot's own text, so suppressing it there would delete
+ * real content rather than a duplicate. The divergence is the correct behaviour;
+ * only its unreachability needs stating.
+ */
+function renderedVoiceTranscripts(msg: RawHistoryEntry, normalizedRole: string): string[] {
+  if (normalizedRole === 'assistant') {
+    return [];
+  }
+  return msg.messageMetadata?.voiceTranscripts ?? [];
+}
+
 /** Format image descriptions section for XML output */
 export function formatImageSection(msg: RawHistoryEntry): string {
-  if (msg.messageMetadata?.imageDescriptions === undefined) {
-    return '';
-  }
-  if (msg.messageMetadata.imageDescriptions.length === 0) {
+  const images = renderedImageDescriptions(msg);
+  if (images.length === 0) {
     return '';
   }
 
-  const formattedImages = msg.messageMetadata.imageDescriptions
+  const formattedImages = images
     .map(
       img =>
         `<image filename="${escapeXml(img.filename)}">${escapeXmlContent(img.description)}</image>`
@@ -98,16 +199,21 @@ export function formatEmbedsSection(msg: RawHistoryEntry): string {
   return `\n<embeds>\n${msg.messageMetadata.embedsXml.join('\n')}\n</embeds>`;
 }
 
-/** Format voice transcripts section for XML output */
-export function formatVoiceSection(msg: RawHistoryEntry): string {
-  if (msg.messageMetadata?.voiceTranscripts === undefined) {
-    return '';
-  }
-  if (msg.messageMetadata.voiceTranscripts.length === 0) {
+/**
+ * Format voice transcripts section for XML output.
+ *
+ * Which transcripts an entry contributes — including the assistant own-TTS
+ * suppression — is `renderedVoiceTranscripts`, shared with the enrichment
+ * report. As a check at this function's call site it was one copy away from the
+ * two disagreeing, which is the class this whole change removes.
+ */
+export function formatVoiceSection(msg: RawHistoryEntry, normalizedRole: string): string {
+  const voiceTranscripts = renderedVoiceTranscripts(msg, normalizedRole);
+  if (voiceTranscripts.length === 0) {
     return '';
   }
 
-  const transcripts = msg.messageMetadata.voiceTranscripts
+  const transcripts = voiceTranscripts
     // voice_transcripts/transcript aren't in PROTECTED_TAGS — neutralize the
     // wrapper closings so </transcript> in the text can't break out.
     .map(t => `<transcript>${neutralizeWrapperClosingTags(escapeXmlContent(t))}</transcript>`)

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -363,6 +363,31 @@ export function attachmentEnrichment(att: RenderableAttachment): string | undefi
   return att.kind === 'file' ? undefined : att.description;
 }
 
+/**
+ * Identity of one piece of enrichment, for comparing across renderers: its text
+ * AND the modality it came from.
+ *
+ * Keyed rather than compared as a bare string because the two modalities arrive
+ * from different producers (vision and STT) and mean different things, so a
+ * transcript that happens to read the same as a description is not the same
+ * content — and the consequence of conflating them is an element silently
+ * dropped as a duplicate of something it has nothing to do with. The separator is
+ * NUL because neither producer can emit one, so no description can spoof another
+ * modality's key the way a printable delimiter would allow.
+ *
+ * Filename is deliberately NOT part of the key, though it would make two
+ * same-kind attachments with byte-identical descriptions distinguishable. It is
+ * optional on `AttachmentIdentity` and never synthesized, so keying on it would
+ * leave nameless attachments unkeyable — and it would make the match depend on
+ * two producers agreeing on a filename, which is the correspondence class the
+ * URL-keyed enrichment store was introduced to retire. The residual cost is that
+ * such a pair subtracts together; they are duplicates of each other, and the
+ * description they share is in the chat log either way.
+ */
+export function enrichmentKey(kind: RenderableAttachment['kind'], text: string): string {
+  return `${kind}\u0000${text}`;
+}
+
 /** Join defined attribute pairs into a leading-space attribute string. */
 function joinAttrs(defs: [string, string | undefined][]): string {
   const list = defs

--- a/services/ai-worker/src/services/prompt/RenderableReference.test.ts
+++ b/services/ai-worker/src/services/prompt/RenderableReference.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
+import { enrichmentKey } from './QuoteFormatter.js';
 import {
   dedupeReference,
   promptTime,
@@ -104,7 +105,7 @@ describe('promptTime', () => {
 });
 
 describe('dedupeReference', () => {
-  it('inherits EVERY field except the three it subtracts', () => {
+  it('inherits EVERY field except the three it always subtracts', () => {
     // The structural guard on the whole projection. A field-by-field rebuild —
     // the shape this replaced, and the source of three separate dropped-field
     // bugs — fails here the moment someone adds a field to the reference and
@@ -168,6 +169,81 @@ describe('dedupeReference', () => {
 
     expect(described.content).toContain('its media is described here');
     expect(undescribed.content).not.toContain('its media is described here');
+  });
+
+  describe('subtracting enrichment the chat log already renders', () => {
+    it('drops an attachment whose description the chat log carries', () => {
+      const stub = dedupeReference(reference(), new Set([enrichmentKey('image', 'a cat')]));
+
+      expect(stub.attachments).toEqual([]);
+      // And the prefix follows the subtraction rather than the input: promising
+      // "its media is described here" beside nothing is the same class of false
+      // claim this whole change exists to remove.
+      expect(stub.content).not.toContain('its media is described here');
+    });
+
+    it('keeps an attachment the chat log does NOT carry', () => {
+      const stub = dedupeReference(
+        reference(),
+        new Set([enrichmentKey('image', 'some other description')])
+      );
+
+      expect(renderReference(stub)).toContain('a cat');
+      expect(stub.content).toContain('its media is described here');
+    });
+
+    it('subtracts per attachment, not all-or-nothing', () => {
+      const stub = dedupeReference(
+        reference({
+          attachments: [
+            { kind: 'image', filename: 'carried.png', description: 'in the chat log' },
+            { kind: 'image', filename: 'orphan.png', description: 'nowhere else' },
+          ],
+        }),
+        new Set([enrichmentKey('image', 'in the chat log')])
+      );
+
+      expect(stub.attachments).toHaveLength(1);
+      expect(renderReference(stub)).toContain('nowhere else');
+      expect(renderReference(stub)).not.toContain('carried.png');
+    });
+
+    it('never subtracts an UNDESCRIBED attachment', () => {
+      // The chat log has nothing to render for it either, so the stub is its
+      // only mention — subtracting would erase the fact that it exists.
+      const stub = dedupeReference(
+        reference({
+          attachments: [{ kind: 'image', filename: 'broken.png', status: 'undescribed' }],
+        }),
+        new Set([enrichmentKey('image', 'a cat')])
+      );
+
+      expect(renderReference(stub)).toContain(
+        '<image filename="broken.png" status="undescribed"/>'
+      );
+    });
+
+    it('does not subtract across modalities on identical text', () => {
+      // The set is keyed by kind, so a TRANSCRIPT the chat log carries cannot
+      // cancel an image described with the same words. Improbable, but the two
+      // strings come from different producers and mean different things, and
+      // conflating them drops an element for a reason unrelated to it.
+      const stub = dedupeReference(
+        reference({
+          attachments: [{ kind: 'image', filename: 'sign.png', description: 'meet me at seven' }],
+        }),
+        new Set([enrichmentKey('voice', 'meet me at seven')])
+      );
+
+      expect(renderReference(stub)).toContain('meet me at seven');
+    });
+
+    it('subtracts nothing when the caller supplies no set', () => {
+      // The safe default, and it has a direction: a duplicated description costs
+      // tokens, a dropped one costs the answer.
+      expect(dedupeReference(reference()).attachments).toEqual(reference().attachments);
+      expect(dedupeReference(reference(), new Set()).attachments).toEqual(reference().attachments);
+    });
   });
 
   describe('the preview', () => {

--- a/services/ai-worker/src/services/prompt/RenderableReference.ts
+++ b/services/ai-worker/src/services/prompt/RenderableReference.ts
@@ -26,6 +26,7 @@ import { TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
 import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
 import {
   attachmentEnrichment,
+  enrichmentKey,
   formatQuoteElement,
   type RenderableAttachment,
 } from './QuoteFormatter.js';
@@ -134,14 +135,19 @@ function informativeUsername(ref: RenderableReference): string | undefined {
 const DEDUP_PREFIX = '[Referenced message — full text in the chat log]';
 
 /**
- * Variant used when the stub carries media enrichment. The extra clause is
- * load-bearing, not decoration: the chat-log copy of an embed or attachment
- * carries the raw URL, never a description, so media enrichment has no
- * counterpart there and "full text in the chat log" would send the model
- * somewhere the answer has never been.
+ * Variant used when the stub still carries media enrichment after subtraction.
+ * The extra clause is load-bearing, not decoration: where the chat-log copy of
+ * an attachment is only its raw URL, the enrichment has no counterpart there
+ * and a bare "full text in the chat log" would send the model somewhere the
+ * answer has never been.
  *
- * Conditional rather than unconditional so a text-only stub — the common case —
- * neither pays the tokens nor invites the model to hunt for media that isn't there.
+ * Whether that is so is NOT decided here. It is a fact about what the chat-log
+ * renderer emitted for that specific entry — true for a message nobody has
+ * triggered on, false for one whose own history entry renders
+ * <image_descriptions> — so `dedupeReference` subtracts against the renderer's
+ * actual output and this prefix is chosen from what survives. Conditional also
+ * keeps a text-only stub, the common case, from paying the tokens or inviting
+ * the model to hunt for media that isn't there.
  */
 const DEDUP_PREFIX_WITH_MEDIA =
   '[Referenced message — full text in the chat log; its media is described here]';
@@ -169,23 +175,48 @@ function capDedupText(text: string): string {
  * That is the whole point: its predecessor listed the fields it wanted and so
  * silently lost every field nobody remembered to list (the role, then the
  * attachments, then the forwarded flag). Here a field that does not appear
- * below is inherited, and adding a fourth exclusion is a conspicuous edit to
+ * below is inherited, and adding a fifth exclusion is a conspicuous edit to
  * this function rather than an omission nobody can see.
  *
- * The exclusion set has exactly three members, and each has the same
- * justification — <chat_log> reproduces it verbatim, so the stub would be
- * paying twice:
+ * Every member of the exclusion set has the same justification — <chat_log>
+ * reproduces it verbatim, so the stub would be paying twice:
  *
  * - `content` → the marker, plus a capped preview;
  * - `locationContext`;
- * - `embedsXml`.
+ * - `embedsXml`;
+ * - any attachment whose enrichment the chat log ALREADY renders.
  *
- * Media enrichment is deliberately NOT excluded. History renders an attachment
- * as its URL, so a description dropped here is enrichment that was computed,
- * paid for, and never reaches the model.
+ * That last member is CONDITIONAL, and it is the only one the stub cannot
+ * decide alone: whether history carries an attachment's description is a fact
+ * about the other renderer's output, so the caller passes what that renderer
+ * actually produced (`carriedByChatLog`) rather than this function assuming an
+ * answer. Both fixed answers are wrong in opposite halves of the input —
+ * dropping unconditionally discards vision spend for a message history renders
+ * as a bare URL, and carrying unconditionally prints the same description twice
+ * for a message whose own history entry already renders <image_descriptions>.
+ *
+ * With no set supplied, nothing is subtracted. That is the safe default: a
+ * duplicated description costs tokens, a dropped one costs the answer.
  */
-export function dedupeReference(ref: RenderableReference): RenderableReference {
-  const hasMedia = ref.attachments.some(att => {
+export function dedupeReference(
+  ref: RenderableReference,
+  carriedByChatLog?: ReadonlySet<string>
+): RenderableReference {
+  const attachments =
+    carriedByChatLog === undefined || carriedByChatLog.size === 0
+      ? ref.attachments
+      : ref.attachments.filter(att => {
+          const enrichment = attachmentEnrichment(att);
+          // Undescribed attachments are never subtracted — the chat log has
+          // nothing to render for them either, so the stub is their only mention.
+          return (
+            enrichment === undefined || !carriedByChatLog.has(enrichmentKey(att.kind, enrichment))
+          );
+        });
+
+  // Computed AFTER the subtraction: a stub whose media is entirely accounted
+  // for in the chat log must not promise "its media is described here".
+  const hasMedia = attachments.some(att => {
     const enrichment = attachmentEnrichment(att);
     return enrichment !== undefined && enrichment.length > 0;
   });
@@ -204,6 +235,7 @@ export function dedupeReference(ref: RenderableReference): RenderableReference {
     content: preview.length > 0 ? `${prefix}\n\n${preview}` : prefix,
     locationContext: undefined,
     embedsXml: undefined,
+    attachments,
   };
 }
 

--- a/services/ai-worker/src/services/prompt/storedReference.component.test.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.component.test.ts
@@ -27,6 +27,7 @@ import { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { type RawHistoryEntry } from '../../jobs/utils/conversationTypes.js';
 import { formatQuotedSection } from '../../jobs/utils/xmlMetadataFormatters.js';
 import { type BuiltAttachment } from './QuoteFormatter.js';
 import { toStoredReference } from './storedReference.js';
@@ -141,8 +142,18 @@ describe('built references survive the round trip (component, PGLite)', () => {
     });
   });
 
-  /** Read the trigger row back the way generation does, and render its quotes. */
-  async function replayQuotes(historyMessageIds?: Set<string>): Promise<string> {
+  /**
+   * Read the trigger row back the way generation does, and render its quotes.
+   *
+   * `dedupId` puts that message in the chat log, which is what makes the quote
+   * render as a stub. `chatLogCarries` is what the chat-log ENTRY for it renders
+   * on its own — the second question, and the one that decides whether the stub
+   * repeating its media would be a duplicate.
+   */
+  async function replayQuotes(
+    dedupId?: string,
+    chatLogCarries?: RawHistoryEntry['messageMetadata']
+  ): Promise<string> {
     const rows = await history.getChannelHistory(CHANNEL, 10);
     const trigger = rows.find(row => row.role === MessageRole.User);
     expect(trigger).toBeDefined();
@@ -152,7 +163,19 @@ describe('built references survive the round trip (component, PGLite)', () => {
       { role: 'user', content: trigger?.content ?? '', messageMetadata: trigger?.messageMetadata },
       'user',
       'Ref Bot',
-      historyMessageIds,
+      dedupId === undefined
+        ? undefined
+        : new Map([
+            [
+              dedupId,
+              {
+                role: 'user',
+                content: '',
+                discordMessageId: [dedupId],
+                messageMetadata: chatLogCarries,
+              },
+            ],
+          ]),
       undefined
     );
   }
@@ -184,16 +207,40 @@ describe('built references survive the round trip (component, PGLite)', () => {
 
   it('carries both across the DEDUPED replay arm too', async () => {
     // The stub subtracts the reference's TEXT because the chat log already has
-    // it; its media has no such second copy, so the media must ride along. This
-    // arm is where enrichment kept getting dropped, twice, under green coverage.
+    // it. Here the chat-log entry carries no enrichment of its own, so the media
+    // has no second copy and must ride along. This arm is where enrichment kept
+    // getting dropped, twice, under green coverage.
     const stored = toStoredReference(liveReference(), builtAttachments());
     await history.storeTriggerReferences(CHANNEL, PERSONALITY, PERSONA, [stored], TRIGGER_MESSAGE);
 
-    const rendered = await replayQuotes(new Set([stored.discordMessageId]));
+    const rendered = await replayQuotes(stored.discordMessageId);
 
     expect(rendered).toContain('full text in the chat log');
     expect(rendered).toContain(IMAGE_SENTINEL);
     expect(rendered).toContain(VOICE_SENTINEL);
+    expect(rendered).toContain('its media is described here');
+  });
+
+  it('does NOT repeat media the chat-log entry already renders', async () => {
+    // The inverse arm, and the reason the subtraction is derived rather than
+    // decided once: when the referenced message was ITSELF a trigger, its own
+    // history entry renders <image_descriptions>/<voice_transcripts>, so the
+    // stub repeating them prints the same paid text twice in one prompt.
+    const stored = toStoredReference(liveReference(), builtAttachments());
+    await history.storeTriggerReferences(CHANNEL, PERSONALITY, PERSONA, [stored], TRIGGER_MESSAGE);
+
+    const rendered = await replayQuotes(stored.discordMessageId, {
+      imageDescriptions: [{ filename: 'whiteboard.png', description: IMAGE_SENTINEL }],
+      voiceTranscripts: [VOICE_SENTINEL],
+    });
+
+    // Still a stub pointing at the chat log...
+    expect(rendered).toContain('full text in the chat log');
+    // ...but it no longer promises media it is not carrying, and does not
+    // reprint what the chat log renders one element away.
+    expect(rendered).not.toContain('its media is described here');
+    expect(rendered).not.toContain(IMAGE_SENTINEL);
+    expect(rendered).not.toContain(VOICE_SENTINEL);
   });
 
   it('renders an absence, not an invention, when nothing was ever computed', async () => {

--- a/services/ai-worker/src/services/prompt/storedReference.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.ts
@@ -44,8 +44,8 @@ const logger = createLogger('StoredReference');
  *
  * Two fields are deliberately NOT carried:
  * - `isDeduplicated` — a decision about THIS turn's prompt. Replay re-derives
- *   it from its own `historyMessageIds`, and a stored `true` would stub a
- *   quote whose full copy had since aged out of the window.
+ *   it from its own history index (`buildHistoryEntryIndex`), and a stored
+ *   `true` would stub a quote whose full copy had since aged out of the window.
  * - the derived `role` — `authorRole` is stored raw instead, because the
  *   sibling-persona demotion depends on which personalities are visible in the
  *   replaying turn's history, not this one's.


### PR DESCRIPTION
## The claim that was wrong

`dedupeReference` decided how much of a quote was redundant by asserting what the **other** renderer produces:

> the history entry the stub points at renders that image as a URL, not a description

True for a message nobody has triggered on. **False** for one that was a trigger itself — `injectImageDescriptions` populates `imageDescriptions` on exactly those entries, so `formatImageSection` renders `<image_descriptions>` and the stub printed the same paid vision text a second time in the same prompt.

This is TASK-368's named class: *a comment that describes a cross-module contract is a test that never runs.* And its recorded acceptance addition — "a deduped stub of a message whose own history entry already renders `<image_descriptions>` must NOT repeat them."

## Why it has to be derived, not decided

Both fixed answers are wrong in opposite halves of the input:

| | message never triggered on | message that was itself a trigger |
|---|---|---|
| drop unconditionally | ❌ discards vision spend (the #1877 bug) | ✅ |
| carry unconditionally | ✅ | ❌ prints the description twice |

So the caller passes what the chat-log renderer **actually produced** and the stub subtracts against it.

- `formatQuotedSection` takes the history **entries** rather than their ids. The id answers *"is this already in the chat log?"* (dedup); the entry answers *"and what does the chat log render for it?"* (how much is then redundant). Only the second can be derived.
- `chatLogEnrichmentFor` asks the section renderers whether they emit rather than restating their conditions, so it moves with them.
- The media clause on the stub prefix is computed **after** the subtraction — it can no longer promise media the stub isn't carrying.

That last one required moving the assistant own-TTS voice guard from the call site into `formatVoiceSection`. As a caller-side check it was one copy away from the two disagreeing — the same class, one level down.

## Model-visible change

Only for a **deduped** quote of a message whose own chat-log entry already renders that enrichment. That quote loses the duplicate `<image>`/`<voice>` element and the "its media is described here" clause; the description still reaches the model from the chat-log entry one element away. Every other quote renders byte-identically. Subtraction is per-attachment, never all-or-nothing, and an **undescribed** attachment is never subtracted — the chat log has nothing for it either, so the stub is its only mention.

## Scope: replay path only

The live path renders its stubs at Step 1 (`processInputs`, `ConversationalRAGService:324`) while `injectImageDescriptions` mutates the shared `context.rawConversationHistory` at Step 1.5 (`:354`). Asking there always answers "no" — and wrong for exactly the case this targets. A shared mutable object where the writer runs after the reader is the seam class from #1884/#1886, so fixing it means moving the ordering, which deserves its own evidence and PR. Filed as TASK-387 with this trace. Replay is also the more valuable half: it persists for the whole conversation window, while live is one turn.

## Verification

Verified failing pre-fix by disabling the subtraction: the component round trip plus two unit arms go red, while the opposite-direction regression guard ("carries both across the DEDUPED replay arm") stays green — which is what makes the pair meaningful rather than one assertion in two costumes.

- Component (PGLite, real `parseMessageMetadata` → render): new `does NOT repeat media the chat-log entry already renders`
- Unit: per-attachment subtraction, undescribed never subtracted, no-set-supplied is a no-op, prefix follows the subtraction
- `chatLogEnrichmentFor`: two arms only reachable by deriving — an assistant entry whose transcript the chat log **suppresses** is not carried, and an entry the chat log declines to render at all carries nothing
- `pnpm test` (26 packages) + `pnpm test:component` + `pnpm quality` green locally

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)