### PR TITLE
docs(ai-worker): stop three load-bearing claims reading as guarantees

### DIFF
--- a/services/ai-worker/src/services/context/fromApiMessage.ts
+++ b/services/ai-worker/src/services/context/fromApiMessage.ts
@@ -4,8 +4,15 @@ import { type RawAssemblyInputs } from '@tzurot/common-types/types/schemas/rawEn
 /**
  * Normalizes a raw extended-context message (as fetched bot-side) into the
  * internal `ConversationMessage` shape used during assembly. The wire schema
- * leaves several fields optional that the fetcher always populates; this fills
- * the defensive defaults so downstream assembly never has to guard them.
+ * leaves several fields optional that the fetcher populates in practice; this
+ * fills defensive defaults so the shape is total.
+ *
+ * The defaults make the fields PRESENT, not meaningful — `''` and `[]` are
+ * "absent, spelled in a non-optional type". Downstream still guards them, and
+ * should: `findDescriptionsForEntry` checks `id.length > 0` and
+ * `buildHistoryEntryIndex` skips empty ids, because an entry defaulted here
+ * must not match another entry defaulted the same way. Read this as widening a
+ * type, never as a guarantee that the values are real.
  */
 export function fromApiMessage(
   msg: NonNullable<RawAssemblyInputs['rawExtendedContextMessages']>[number],

--- a/services/ai-worker/src/services/prompt/RenderableReference.ts
+++ b/services/ai-worker/src/services/prompt/RenderableReference.ts
@@ -129,6 +129,16 @@ function informativeUsername(ref: RenderableReference): string | undefined {
  * Prefix for deduplicated reference stubs. Order-agnostic (points to <chat_log>
  * rather than "above" — references are assembled BEFORE <chat_log>) and drops
  * the "reply target" Discord-UI jargon, which read as a task to the model.
+ *
+ * It tells the model where to look, so it is a claim about the OTHER renderer's
+ * output and true only while one invariant holds: every entry in the dedup
+ * index also survives into the rendered chat log. `formatConversationHistoryAsXml`
+ * drops any entry whose render comes back empty — which `resolveSpeakerInfo`
+ * returns for a role that is neither user nor assistant — while the index keeps
+ * it, and a stub built against such an entry would point at nothing. Unreachable
+ * today: nothing writes a system-role conversation row. Written down because
+ * the day something does, this marker starts lying silently, and the failure
+ * looks like the model ignoring a quote rather than like a renderer disagreeing.
  */
 // Prose marker — avoids literal tag syntax so it isn't escaped when it rides
 // through escapeXmlContent inside <content>.

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -206,8 +206,15 @@ export function buildSystemPromptView(
 // ---------------------------------------------------------------------------
 
 /**
- * Reasoning content, always inline — chunked across ephemeral messages when
- * long (owner decision: reading text must never require a file download).
+ * Reasoning content, chunked across ephemeral messages.
+ *
+ * The standing owner decision is that reading text must never require a file
+ * download. The `maxChunks` cap below does NOT currently honour it: past the
+ * cap `sendChunkedReply` sends the overflow as a text-file attachment, so a
+ * long reasoning dump still lands as a download. Stated rather than implied
+ * because the previous wording ("always inline") read as a guarantee the code
+ * thirty lines down contradicts. Raising the cap is the open decision; until
+ * then this is the honest description of what happens.
  *
  * Reasoning content is shown to non-owners by design (per project decision —
  * model thinking is genuinely interesting and the user already saw the


### PR DESCRIPTION
TASK-368's sweep. Comment-only, no behavior change.

Kimi K3's framing for the task: *"Every invariant currently living in a docstring or code comment is an unfiled bug report."* Two of these were false; one was true by an invariant nobody had written down.

## The three

**1. `fromApiMessage` — false.** Claimed its defaults exist "so downstream assembly never has to guard them." Downstream does guard them, and should: `findDescriptionsForEntry` checks `id.length > 0`, `buildHistoryEntryIndex` skips empty ids. `''` and `[]` here are *absence spelled in a non-optional type*, not values — two entries defaulted the same way must not match each other. Now says it widens a type rather than that it guarantees content.

**2. `buildReasoningView` — false, and the instance that widened the task.** The docstring records the owner decision *"reading text must never require a file download"* and calls the view "always inline" — thirty lines above a `maxChunks: 3` that does the opposite. Verified in `chunkedReply.ts`: past the cap, the overflow ships as *"a final follow-up carrying the COMPLETE content as a text-file attachment."*

Raising the cap is an open owner decision (TASK-371), so this PR changes **only the wording** — it now describes what happens instead of promising what doesn't. This is the instance that motivated widening TASK-368 past cross-module claims: there's no module boundary here to make anyone suspicious, just a docstring and a constant in the same function.

**3. `DEDUP_PREFIX` — true, by an unstated invariant.** The marker tells the model the full text is in the chat log, which is a claim about the *other* renderer's output. It holds only while every entry in the dedup index survives into the rendered chat log — and `formatConversationHistoryAsXml` drops entries whose render is empty (a role `resolveSpeakerInfo` has no speaker for) while the index keeps them. A stub built against such an entry would point at nothing.

Unreachable: `MessageRole.System` exists in the enum but nothing writes a system-role conversation row. So the invariant is **recorded, not coded around** — writing unreachable code to satisfy it would be speculation, and the same call was made on the forwarded-voice case in #1887.

## Audit method — the negative result is the useful part

The task suggested grepping `owner decision` / `always` / `never` / `must`. Measured against its own three known instances, that vocabulary finds **one**. Instance 1 described a symptom in plain prose; instance 2 said "carries the raw URL, never a description" — no carriage-claim pattern matches either. A codebase-wide grep would have returned a tidy list with ~33% recall over 76k comment lines.

So the greps were scoped to what they can actually decide, and the prompt-assembly surface (32 files, where all three originated) was read instead:

- **All 24 recorded-decision sites** checked against their surrounding code — `buildReasoningView` is the only contradiction. The class is in better shape than the task's three-in-one-day filing suggested.
- **Files pairing an absolute claim with a cap** (instance 3's self-contradiction shape): 5 candidates, 4 hold.
- **String literals asserting another layer's output**: only the two `DEDUP_PREFIX` variants; #1887 made the media half derived, this covers the base claim.

## Still open on TASK-368

The instance the task names first was deleted by #1883 before this sweep ran. What remains is `maxChunks` itself (TASK-371, owner-gated) and the live-path variant (TASK-387). GLM 5.2's "derive the exclusion set from what the other renderer actually produced" proposal shipped in #1887.

`pnpm test` (26 packages) + `pnpm quality` green locally. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)