### PR TITLE
fix(ai-worker): spare quoted artifacts in response cleanup

### DIFF
--- a/services/ai-worker/src/utils/responseArtifacts.test.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.test.ts
@@ -10,6 +10,7 @@ import {
   stripResponseArtifacts,
   stripUserMessageEcho,
   normalizeForEchoMatch,
+  replaceOutsideCodeMarkup,
 } from './responseArtifacts.js';
 
 describe('stripResponseArtifacts', () => {
@@ -467,6 +468,120 @@ describe('stripResponseArtifacts', () => {
     it('should strip multiple prompt template tags', () => {
       const content = 'Response</chat_log></participants>';
       expect(stripResponseArtifacts(content, 'Emily')).toBe('Response');
+    });
+  });
+
+  describe('content that QUOTES an artifact is not an artifact', () => {
+    // Every pattern in this module deletes, and a character on this product is
+    // routinely asked about the structures these patterns hunt for. The
+    // discriminator is code markup: a real leaked artifact is never backticked,
+    // because the model emits it as structure rather than as an example.
+    //
+    // WHAT EACH ROW ACTUALLY PROVES — measured for EVERY family by disabling
+    // the gate and re-running, not generalized from the ones written first:
+    //
+    //   - `prompt-template closing tag` is the ONLY family that goes red without
+    //     the gate. It is the one unanchored, global pattern, so nothing else
+    //     was stopping it from eating a quoted tag mid-prose.
+    //   - All nine others pass with the gate disabled, because their patterns
+    //     are anchored to `^` or `$` and a leading/trailing backtick already
+    //     means no match. They are NOT gate coverage. They pin the ANCHOR as the
+    //     thing protecting those families — so de-anchoring one later (a
+    //     plausible "make this catch mid-response too" edit) turns them red,
+    //     which is exactly when someone needs to be told the gate is now
+    //     load-bearing for that family.
+    //
+    // The gate is applied uniformly anyway: a per-pattern exemption list would
+    // be one more thing to keep in sync with the anchors it mirrors.
+    // COVERS EVERY TAG-SHAPED PATTERN in `buildArtifactPatterns`, not a
+    // selection of them — the anchor argument is exactly the kind of reasoning
+    // this file exists to distrust, so it is measured per family rather than
+    // generalized from the families that happened to get written first. The two
+    // patterns left out are the `Name:` prefix and the `[timestamp]` prefix,
+    // which are not control syntax: there is no "quoted" form of them to confuse
+    // with a real one.
+    const artifacts: [family: string, artifact: string][] = [
+      ['prompt-template closing tag (global, unanchored)', '</chat_log>'],
+      ['generic trailing closing tag', '</message>'],
+      ['tool-use wrapper', '<function_calls>'],
+      ['tool-use orphan closing tag', '</function_results>'],
+      ['speaker identification', '<from id="abc">Emily</from>'],
+      ['reactions block', '<reactions>👍</reactions>'],
+      ['last_message echo block', '<last_message>User: hi</last_message>'],
+      ['self-contained metadata tag', '<result>Emily</result>'],
+      ['received-message receipt', '<received message>hi</received>'],
+      ['message speaker prefix', '<message speaker="Emily">'],
+    ];
+
+    describe.each(artifacts)('%s', (_family, artifact) => {
+      it('survives inside an inline code span', () => {
+        const content = `The prompt wraps history in \`${artifact}\` — that is the marker.`;
+        expect(stripResponseArtifacts(content, 'Emily')).toBe(content);
+      });
+
+      it('survives inside a fenced block', () => {
+        const content = `Here is the shape:\n\`\`\`xml\n${artifact}\n\`\`\`\nThat is what you would see.`;
+        expect(stripResponseArtifacts(content, 'Emily')).toBe(content);
+      });
+    });
+
+    it('still strips the same artifact when it is NOT quoted', () => {
+      // The other half of the pair: the gate must not have simply disabled the
+      // stripping. Same tag, same position, no backticks.
+      expect(stripResponseArtifacts('Hello</chat_log> there', 'Emily')).toBe('Hello there');
+    });
+
+    it('an UNBALANCED fence makes a real artifact survive, never eats content', () => {
+      // `isInsideCodeSpan` toggles on every ``` without line-anchoring, so an
+      // odd number of them before a real artifact classifies it as "inside code"
+      // and the artifact is left alone. Measured, not assumed — the same input
+      // with a balanced fence strips normally, below.
+      //
+      // Pinned rather than fixed because the direction is the safe one: the
+      // failure is a stray `</chat_log>` reaching the reader, never a sentence
+      // of the character's reply being deleted. If the shared detector is ever
+      // made line-anchored, this test goes red and is the place to notice that
+      // the trade was re-decided.
+      const unbalanced = 'Try ```npm install and then it works.</chat_log>';
+      expect(stripResponseArtifacts(unbalanced, 'Emily')).toBe(unbalanced);
+
+      const balanced = 'Try ```npm install``` and then it works.</chat_log>';
+      expect(stripResponseArtifacts(balanced, 'Emily')).toBe(
+        'Try ```npm install``` and then it works.'
+      );
+    });
+
+    it('strips a real trailing artifact while sparing a quoted one earlier', () => {
+      // The case the gate exists for — both forms in one reply, which is exactly
+      // what a character explaining its own prompt while the model leaks a tag
+      // would produce.
+      const content = 'You would see `</chat_log>` at the end.</chat_log>';
+      expect(stripResponseArtifacts(content, 'Emily')).toBe(
+        'You would see `</chat_log>` at the end.'
+      );
+    });
+  });
+});
+
+describe('replaceOutsideCodeMarkup', () => {
+  // The offset is found by TYPE, not by position, so these pin the property
+  // directly rather than only through the patterns that happen to exist in
+  // `buildArtifactPatterns` today. The named-group row is the one that matters:
+  // it is where a positional `args.length - 2` silently reads the input string
+  // instead of the offset, with no type error, and the strip would then be made
+  // against the wrong position rather than fail loudly.
+  const shapes: [label: string, pattern: RegExp][] = [
+    ['no capture groups', /<\/chat_log>/g],
+    ['one positional group', /<\/(chat_log)>/g],
+    ['two positional groups', /<(\/)(chat_log)>/g],
+    ['a NAMED group', /<\/(?<tag>chat_log)>/g],
+    ['named and positional groups', /<(\/)(?<tag>chat_log)>/g],
+  ];
+
+  describe.each(shapes)('%s', (_label, pattern) => {
+    it('spares a quoted match and strips an unquoted one', () => {
+      const text = 'quoted `</chat_log>` then real </chat_log>';
+      expect(replaceOutsideCodeMarkup(text, pattern)).toBe('quoted `</chat_log>` then real ');
     });
   });
 });

--- a/services/ai-worker/src/utils/responseArtifacts.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.ts
@@ -10,9 +10,16 @@
  * - Add <message speaker="Name"> prefixes
  * - Append <reactions>...</reactions> blocks (mimicking conversation history metadata)
  * - Still occasionally add "Name:" prefixes
+ *
+ * Every pattern here DELETES, so each one is also a way to destroy a character's
+ * legitimate reply — this product hosts AI characters and they are routinely
+ * asked about the very structures these patterns hunt for. Matches inside code
+ * markup are therefore left alone (`replaceOutsideCodeMarkup`), which is the
+ * same discriminator the reasoning-tag extractor settled on for the same reason.
  */
 
 import { type MessageContent } from '@tzurot/common-types/types/ai';
+import { isInsideCodeSpan } from '@tzurot/common-types/utils/codeSpanDetection';
 import { findLeadingMentionsEnd, stripLeadingMentions } from '@tzurot/common-types/utils/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 
@@ -81,6 +88,45 @@ function buildArtifactPatterns(personalityName: string): RegExp[] {
 }
 
 /**
+ * Strip every match of `pattern` EXCEPT the ones inside code markup.
+ *
+ * These patterns delete, and a character on this product routinely writes ABOUT
+ * prompt structure — so a reply demonstrating `` `</chat_log>` `` is
+ * indistinguishable from a model that leaked one, and the demonstration is what
+ * gets eaten. Code markup is the discriminator: a real leaked artifact is never
+ * backticked, because the model emits it as structure rather than as an example.
+ *
+ * Position cannot decide it here. Most of these patterns are already anchored to
+ * the start or end, and a QUOTED artifact at the start or end sits at the same
+ * offset a real one would — the anchor says where, not whether. (The anchors do
+ * incidentally protect the fenced case, since a leading backtick means `^<tag`
+ * no longer matches; the gate is what covers the unanchored patterns, where
+ * nothing else does.)
+ *
+ * The offset is found BY TYPE rather than by position. `String.replace` passes a
+ * replacer the match, then one argument per capture group, then the offset, then
+ * the whole input — plus a `groups` object when the pattern has named groups.
+ * Every one of those is a string or undefined except the offset, so the number
+ * IS the offset, and stays so no matter how many groups a pattern grows or
+ * whether any of them are named. A positional index cannot say that: it is
+ * correct only for the patterns that exist today, and a named group added later
+ * would silently hand this function the input string instead, with no type error
+ * to catch it. The invariant is executable rather than a comment asking the next
+ * author to remember.
+ *
+ * @internal Exported for testing
+ */
+export function replaceOutsideCodeMarkup(text: string, pattern: RegExp): string {
+  return text.replace(pattern, (...args: unknown[]) => {
+    const match = args[0] as string;
+    const offset = args.find((arg): arg is number => typeof arg === 'number');
+    // Unreachable per the contract above; degrading to 0 keeps the pre-gate
+    // behaviour (offset 0 is never inside code markup, so the match strips).
+    return isInsideCodeSpan(text, offset ?? 0) ? match : '';
+  });
+}
+
+/**
  * Apply patterns iteratively until no more matches
  */
 function applyPatternsIteratively(
@@ -96,7 +142,7 @@ function applyPatternsIteratively(
     let matched = false;
 
     for (const pattern of patterns) {
-      cleaned = cleaned.replace(pattern, '').trim();
+      cleaned = replaceOutsideCodeMarkup(cleaned, pattern).trim();
       if (cleaned !== beforeStrip) {
         strippedCount++;
         matched = true;


### PR DESCRIPTION
TASK-373's sweep — the second destructive parse site, after #1880 closed `thinkingExtraction.ts`.

## The class, at this site

Every pattern in `responseArtifacts.ts` **deletes**. A character on this product is routinely asked about the very structures they hunt for, so a reply demonstrating `` `</chat_log>` `` was indistinguishable from a model that leaked one — and the demonstration is what got eaten. Same shape as #1880, same discriminator: **a real leaked artifact is never backticked**, because the model emits it as structure rather than as an example.

Matches inside code markup are now left alone, via the shared `isInsideCodeSpan` rather than a second detector. Perf is fine here — one reply, few candidates — which is the measurement the task asks for before reuse; the whole-prompt caveat it records applies to `promptSanitizer`, not this site.

## Exactly one pattern is exposed — measured across ALL ten tag-shaped patterns

The table covers every tag-shaped pattern in `buildArtifactPatterns`, and each family was measured by **disabling the gate and re-running**, not generalized from the anchor argument:

| Family | Red without the gate? |
|---|---|
| prompt-template closing tags | **yes** — the only unanchored, global pattern |
| generic trailing closing tag | no — `$`-anchored |
| tool-use wrapper | no — `^`-anchored |
| tool-use orphan closing tag | no — `^`-anchored |
| speaker identification | no — `^`-anchored |
| reactions block | no — `$`-anchored |
| last_message echo block | no — `^`-anchored |
| self-contained metadata tag | no — `^`-anchored |
| received-message receipt | no — `^`-anchored |
| message speaker prefix | no — `^`-anchored |

A leading or trailing backtick already breaks the anchor, so those nine rows are **not gate coverage** and the test file says so. They're kept because they pin the *anchor* as the protection — a later "make this catch mid-response too" edit turns them red exactly when the gate becomes load-bearing there.

Excluded deliberately: the `Name:` and `[timestamp]` prefixes are not control syntax, so there is no quoted form of them to confuse with a real one.

The gate is still applied uniformly. A per-pattern exemption list would be one more thing to keep in sync with the anchors it mirrors.

## Unbalanced fences: pinned, not fixed

`isInsideCodeSpan` toggles on every ``` without line-anchoring, so an odd count before a real artifact classifies it as quoted and the artifact survives. Measured both directions:

- odd fence count → real `</chat_log>` **survives** (leaks to the reader)
- balanced → stripped normally

That's the safe direction — a stray tag reaches the reader; a sentence of the character's reply never gets deleted. Both halves are in one test so it can't pass by the strip being broken generally. If the shared detector is ever made line-anchored, that test goes red and is the place to notice the trade was re-decided.

## Where the sweep stops, and why

- **`promptSanitizer` / `xmlBuilder`** — these ESCAPE rather than delete. A quoted `</character>` becomes `&lt;/character&gt;`, which the model reads as the literal text: the example survives, rendered inert. A false positive costs nothing. **That's the rule the whole audit reduces to — only destructive sites need this discriminator**, which is what bounds the remaining surface.
- **`extractJsonPayload`** — unwraps a fence we explicitly asked for, on a JSON response, not prose. Different direction, not this class.

Both recorded on TASK-373 so the reasoning outlives this branch.

## Still open on TASK-373

The `<action>`-tag leak handler (now.md Untriaged) is a *future* parse site and must be designed against this class rather than retrofitted. The unfenced-quote gap is unchanged — an unfenced `</chat_log>` mid-prose is still consumed — and per the task, TASK-375 should be checked before anyone designs a cleverer heuristic for it.

Full `pnpm test` (26 packages) + `pnpm quality` green. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)