### PR TITLE
docs(docs): durability-tier inventory, and fix three wrong cache rows

### DIFF
--- a/.claude/rules/03-database.md
+++ b/.claude/rules/03-database.md
@@ -163,20 +163,24 @@ const cache = new TTLCache<ValueType>({
 
 ### Existing Cache Implementations
 
-| Cache              | Location                     | TTL   | Type                   |
-| ------------------ | ---------------------------- | ----- | ---------------------- |
-| Channel Activation | `gatewayServiceCalls.ts`     | 30s   | TTLCache + pub/sub     |
-| Admin Settings     | `gatewayServiceCalls.ts`     | 60s   | TTLCache (in-memory)   |
-| Personality        | `PersonalityService.ts`      | 5 min | TTLCache + pub/sub     |
-| Personality (bot)  | `HttpPersonalityLoader.ts`   | 5 min | TTLCache (+ negative)  |
-| Denylist           | `DenylistCache.ts`           | -     | In-memory + pub/sub    |
-| User               | `UserService.ts`             | 5 min | TTLCache (in-memory)   |
-| Autocomplete       | `autocompleteCache.ts`       | 60s   | TTLCache (in-memory)   |
-| OpenRouter Models  | `OpenRouterModelCache.ts`    | 24h   | Redis-backed           |
-| Vision Description | `VisionDescriptionCache.ts`  | 1h    | Redis-backed (L1 only) |
-| Voice Transcript   | `VoiceTranscriptCache.ts`    | -     | Custom (in-memory)     |
-| Redis Dedup        | `RedisDeduplicationCache.ts` | TTL   | Redis-backed           |
+`Tier` is the durability tier — see [durability-tiers.md](../../docs/reference/architecture/durability-tiers.md) for what each means and how to sort a new cache into one. **1** = recomputable for free, loss is correctness-neutral. **2** = costs money to regenerate and is conversation-scoped (the history row is the system of record; Redis is L1 only). **3** = costs money and the asset outlives the conversation (needs a home that is not a TTL).
+
+| Cache              | Location                     | TTL           | Tier | Type                                 |
+| ------------------ | ---------------------------- | ------------- | ---- | ------------------------------------ |
+| Channel Activation | `gatewayServiceCalls.ts`     | 30s           | 1    | TTLCache + pub/sub                   |
+| Admin Settings     | `gatewayServiceCalls.ts`     | 60s           | 1    | TTLCache (in-memory)                 |
+| Personality        | `PersonalityService.ts`      | 5 min         | 1    | TTLCache + pub/sub                   |
+| Personality (bot)  | `HttpPersonalityLoader.ts`   | 5 min         | 1    | TTLCache (+ 60s negative)            |
+| Denylist           | `DenylistCache.ts`           | -             | 1    | In-memory + pub/sub                  |
+| User               | `UserService.ts`             | **1h**        | 1    | TTLCache (in-memory)                 |
+| Autocomplete       | `autocompleteCache.ts`       | 60s           | 1    | TTLCache (+ LRU-bounded stale, 500)  |
+| OpenRouter Models  | `OpenRouterModelCache.ts`    | **5 min/24h** | 1    | **Two-tier**: memory L1 → Redis      |
+| Vision Description | `VisionDescriptionCache.ts`  | 1h            | 2    | Redis L1 over `attachmentEnrichment` |
+| Voice Transcript   | `VoiceTranscriptCache.ts`    | **1h**        | 2    | **Redis-backed**, L1 over the row    |
+| Redis Dedup        | `RedisDeduplicationCache.ts` | configurable  | 1    | Redis-backed                         |
+
+Three rows were wrong before the durability audit and are corrected in bold: `User` said 5 min (it is 1h — `USER_CACHE_TTL_MS`), `OpenRouter Models` hid its 5-minute in-memory L1 in front of the 24h Redis entry, and `Voice Transcript` said "Custom (in-memory)" with no TTL when it is Redis `setex` at `INTERVALS.VOICE_TRANSCRIPT_TTL`. **Verify a row against the constant before relying on it** — every value here was re-read from source, and a stale TTL in an always-loaded table is a wrong premise in every session that reads it.
 
 **Cache invalidation services** (Redis pub/sub): `CacheInvalidationService`, `LlmConfigCacheInvalidationService`, `ChannelActivationCacheInvalidationService`, `ApiKeyCacheInvalidationService`, `PersonaCacheInvalidationService`
 
-**Full cache audit:** `docs/reference/architecture/CACHING_AUDIT.md`
+**Durability tiers + full inventory:** [`docs/reference/architecture/durability-tiers.md`](../../docs/reference/architecture/durability-tiers.md). The older [`CACHING_AUDIT.md`](../../docs/reference/architecture/CACHING_AUDIT.md) covers a different axis (horizontal-scaling safety) and its inventory is historical.

--- a/.claude/rules/06-backlog.md
+++ b/.claude/rules/06-backlog.md
@@ -43,6 +43,16 @@ pnpm tracker doc create 'Idea: Title'                                       # fi
 pnpm ops backlog:digest                                                     # the briefing
 ```
 
+**Apostrophes silently break the `$'...'` description.** `$'…'` is what makes
+`\n` a real newline, and the usual way to get an apostrophe inside it —
+`'"'"'` — CLOSES the ANSI-C string and reopens a plain one, so every `\n` after
+the first apostrophe stays a literal backslash-n and the whole body files as one
+unreadable line. Three tasks were filed that way before review caught one.
+Avoid the apostrophe (`doc-56's` → `the doc-56`), or write the body by editing
+the task file directly. Either way **read the file back after creating a task
+with a multi-paragraph description** — `pnpm ops backlog` gates on frontmatter
+parsing and cannot see a mangled body.
+
 - **A task description carries why, what, and acceptance** — same bar as any backlog entry. `Promote when: <event>` is an optional annotation (see the admission bar).
 - **Labels**: `area:<package-or-domain>` (db, redis, voice, bot-client, …). Label at filing; the digest's per-area counts are the jump-around index.
 - **Size + priority** (set at filing; every existing task carries them): `size:S` (<~1hr, one file) / `size:M` (a PR) / `size:L` (multi-PR or needs design) labels, plus the CLI priority field — `high` (prod-correctness / data-rights adjacent) · `medium` (real improvement, no urgency) · `low` (gated, speculative, or watch items). The drain query: `pnpm tracker task list -l size:S --priority high --plain`.

--- a/docs/reference/architecture/CACHING_AUDIT.md
+++ b/docs/reference/architecture/CACHING_AUDIT.md
@@ -1,6 +1,21 @@
 # Caching Architecture Audit
 
 > Last updated: 2025-12-20
+>
+> **Scope: horizontal-scaling safety only.** This document asks "what breaks
+> when there is more than one replica" — in-memory vs Redis, per-replica
+> staleness, pub/sub invalidation. It has nothing to say about **durability**,
+> because a Redis entry and a DB row look identical on this axis. For "what
+> happens when this is lost", see
+> [durability-tiers.md](./durability-tiers.md).
+>
+> **The cache inventory below is historical.** It was written before several
+> caches were added, removed, or re-tiered, and the durability audit found three
+> of its descendants in `.claude/rules/03-database.md` factually wrong. Treat the
+> inventory as a record of what existed in 2025-12; the current one lives in
+> `durability-tiers.md`. The scaling ANALYSIS — the invalidation strategies, the
+> pub/sub map, the resolved channel-activation case — is still accurate and is
+> why this file is kept rather than deleted.
 
 ## Executive Summary
 

--- a/docs/reference/architecture/durability-tiers.md
+++ b/docs/reference/architecture/durability-tiers.md
@@ -1,0 +1,161 @@
+# Durability Tiers
+
+What is truly Redis-ephemeral, what is conversation-scoped, and what has to
+outlive both. The axis is **cost of loss × natural lifetime** — not storage
+mechanism.
+
+[`CACHING_AUDIT.md`](./CACHING_AUDIT.md) inventories the same caches on a
+different axis (what breaks under horizontal scaling). That question cannot see
+this one: a Redis entry and a DB row look identical to a scaling audit and are
+completely different when the question is "what happens when this is lost."
+
+## The sorting question
+
+> If this is lost, does someone **pay again** — and does the thing it describes
+> **outlive the conversation**?
+
+Two yeses → tier 3. Pay-again but conversation-bound → tier 2. Neither → tier 1.
+
+| Tier                        | Test                                                                                                           | Home                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **1 — ephemeral**           | recomputable for free; losing it is correctness-neutral                                                        | in-memory or Redis, short TTL                                        |
+| **2 — conversation-scoped** | costs money or real latency to regenerate, and is meaningful exactly as long as the conversation it belongs to | the conversation-history row; dies with it at `DAYS_TO_KEEP_HISTORY` |
+| **3 — globally durable**    | costs money to regenerate, and the underlying asset is immutable and shared across users                       | its own table (or an external system of record), no TTL              |
+
+Redis then has exactly one honest job at tiers 2 and 3: an **L1 accelerator**,
+never the system of record.
+
+### Ask the prior question first: is it ever read twice?
+
+The tier-1 test — "recomputable for free, loss is correctness-neutral" — is too
+strict as written, and TTS audio is the counterexample. `storeTTSAudio` holds
+generated speech between synthesis and delivery. It cost money, and losing it is
+NOT correctness-neutral (the reply ships without voice). By the letter of the
+test it is tier 2 or 3. It is neither, and short-TTL Redis is exactly right for
+it.
+
+The reason is that it is **never read twice**. It has one consumer, once, and
+its only requirement is to outlive the slowest delivery path — which is what its
+TTL is derived from. Tiering is about _re-reads_; a single-use buffer has no
+durability question to answer, only a lifetime one.
+
+So the real first question is **"will anything ever ask for this again?"** If
+no, it is a transit buffer: size the TTL to the consumer and stop. Only if yes
+does the cost-of-loss axis apply.
+
+## Inventory
+
+Every value below was re-read from source rather than copied from the previous
+table — three of the eleven rows in `03-database.md` were wrong, so the table
+itself could not be trusted as input.
+
+That rule has one recorded exception, because the audit broke it and review
+caught it: the first draft listed sticker descriptions as tier 3 with "own
+table", read off a backlog note rather than the schema. The table does not
+exist — it is a designed-but-unbuilt piece of doc-55 — so the audit had
+converted its one genuine open violation into an example of the tier done
+right. **A board entry describing a plan reads exactly like a board entry
+describing a shipped thing.** Grep the schema.
+
+### Tier 1 — ephemeral (correct as-is)
+
+| What                                                                                                                                                                                                                   | Where                                                | Why tier 1                                            |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------- |
+| Config/identity resolution (`BaseConfigResolver`, `LlmConfigResolver`, `VisionConfigResolver`, `SttResolver`, `ConfigCascadeResolver`, `ApiKeyResolver`, `PersonalityService`, `UserService`, `HttpPersonalityLoader`) | in-memory `TTLCache`, most with pub/sub invalidation | a DB query rebuilds them; loss costs one query        |
+| Channel/admin settings, autocomplete, preset + browse pickers, voice list, model capabilities, maintenance flag                                                                                                        | in-memory `TTLCache`                                 | same — read models over rows we own                   |
+| OpenRouter model catalogue                                                                                                                                                                                             | 5-min memory L1 → 24h Redis                          | an unpriced API call rebuilds it                      |
+| Rate limit, quotas, credit exhaustion, dedup, fetch gates (`RateLimitCache`, `FreeTierRequestQuota`, `VisionFallbackQuota`, `CreditExhaustionCache`, `RedisDeduplicationCache`, `shapesFetchGate`)                     | Redis, TTL                                           | counters whose loss fails **open** by design          |
+| UI/session state (dashboard `SessionManager`, `MemoryActionTokenService`, `MemoryModeSessionManager`, verification messages, db-sync report stash, nag cooldowns)                                                      | Redis, TTL                                           | losing it ends a UI session; nothing is unrecoverable |
+| TTS audio (`storeTTSAudio`)                                                                                                                                                                                            | Redis, TTL sized to the delivery window              | paid, but single-use — see the prior question above   |
+
+### Tier 2 — conversation-scoped
+
+| What                | System of record                                                                                     | L1                                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Vision descriptions | `attachmentEnrichment` on the history row's `messageMetadata`                                        | `VisionDescriptionCache`, 1h Redis |
+| Voice transcripts   | the same field; a voice message with its own row also carries the transcript as that row's `content` | `VoiceTranscriptCache`, 1h Redis   |
+
+Both were tier-2 **violations** when this idea was filed — Redis with no durable
+tier behind them. Both were closed by persisting the built reference, so the
+formatter now writes the same enrichment it renders.
+
+One asymmetry survives: the replay hydrator heals a row's missing enrichment
+from the vision cache but has no equivalent voice path, so a row written before
+persistence shipped can still replay a transcript-less voice note. Bounded and
+self-closing — the heal only helps within the 1h cache TTL, and rows predating
+persistence age out of the 30-day history window on their own. Tracked
+separately; not a tier violation, an incomplete backfill.
+
+### Tier 3 — globally durable
+
+| What                 | System of record          | Notes                                                                                                            |
+| -------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Sticker descriptions | **none — OPEN VIOLATION** | tier 3 by the test, stored at tier 1: 1h Redis via the ordinary vision cache. See below                          |
+| Cloned voice IDs     | **the TTS provider**      | `CloneCacheKernel` is a 30-min in-memory L1 with no local durable copy — which LOOKS like a violation and is not |
+
+**Sticker descriptions are the one open violation this audit found.** A sticker
+is the cleanest tier-3 asset in the system: describing it costs a vision call,
+and the asset is immutable and shared across _every user who ever sends that
+sticker_ — so one description could serve all of them forever. Instead, stickers
+ride the ordinary attachment → download → vision → describe chain (deliberately,
+to inherit the CDN allowlist, size caps, model cascade and failure fallbacks),
+which means the description lands in `VisionDescriptionCache` — 1h Redis, L1
+only, no durable tier. There is no sticker table or column in the schema.
+
+The fix is already designed and unbuilt: the snowflake-keyed asset table is
+doc-55's PR-2, the only outstanding piece of that idea. Tracked as TASK-389 so
+the gap is a tracked violation and not only a feature idea — a feature can be
+deprioritised on product grounds; a violation should be closed or consciously
+accepted.
+
+Worth noting why the reasoning that removed the vision L2 does not extend here:
+that Postgres tier was dropped because Discord attachment URLs are ephemeral, so
+persisting descriptions keyed to them bought little. A sticker snowflake is
+stable and re-describable at any time, so the premise that justified dropping
+the L2 is simply false for stickers.
+
+**Cloned voices, in detail**, because the shape is instructive: cloning costs
+money and the clone outlives any conversation, so it is unambiguously tier 3 —
+and there is no `voiceId` column anywhere in the schema. The tier still holds,
+because the resolution path lists voices at the provider before cloning. The
+provider IS the system of record; our cache is a legitimate L1 over a remote
+one.
+
+The consequence to keep in view is that this makes our correctness depend on
+someone else's list endpoint. A provider list that under-reports produces a
+duplicate clone and a second charge, which is why the Mistral client's
+pagination handling has its own guards. Tier 3 satisfied externally is a real
+answer, not a loophole — but it is worth writing down that the durable store is
+outside the blast radius of our own backups.
+
+## Decisions this pass settles
+
+**1. Does a tier-2 item ever get its own table, or is inline-on-the-row always
+right?** Inline, so far, and the reason generalizes: a tier-2 item by definition
+has no key dimension the conversation row does not already have, and inlining
+gives it the row's retention for free — no second cleanup job, no orphan class,
+no way for the enrichment to outlive the thing it describes. A table would be
+justified only by a key that is genuinely not the row (a shared asset), and that
+is the definition of tier 3. **The tier boundary and the storage decision are
+the same question**, which is why "should this get a table?" is answered by
+sorting it, not by estimating its size.
+
+**2. Does `CACHING_AUDIT.md` gain a durability column, or is it superseded?**
+Neither cleanly — it is **narrowed**. Its scaling analysis is still correct and
+still useful; its headline finding is resolved and its inventory is stale.
+Bolting a durability column onto it would produce one document answering two
+questions and re-staling the inventory it already got wrong. So durability lives
+here, the always-loaded table in `03-database.md` points here for tiers, and
+`CACHING_AUDIT.md` keeps the scaling axis with its inventory marked historical.
+
+## Adding a cache
+
+1. **Will anything read it twice?** No → transit buffer; size the TTL to the
+   consumer, stop here.
+2. **Does losing it make someone pay again?** No → tier 1, any TTL store.
+3. **Does the thing it describes outlive the conversation?** No → tier 2: the
+   history row is the system of record, Redis is L1. Yes → tier 3: it needs a
+   home that is not a TTL, which may be a table of ours or an external system of
+   record you can actually re-read.
+4. Add the row to `03-database.md`'s table **with its tier**, and put the real
+   TTL constant in it.

--- a/tracker/tasks/task-387 - Live-reference-path-cannot-subtract-chat-log-enrichment-it-renders-before-injection.md
+++ b/tracker/tasks/task-387 - Live-reference-path-cannot-subtract-chat-log-enrichment-it-renders-before-injection.md
@@ -16,7 +16,22 @@ ordinal: 387000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-**Surfaced by TASK-368's replay-path fix (#1887).**\n\nA deduped quote should not repeat media the chat-log entry already renders. #1887 derives that for the REPLAY path (`formatQuotedSection` holds the history entries). The LIVE path cannot answer the question at all, for an ordering reason:\n\n- Step 1 `ConversationalRAGService:324` `processInputs` -> `formatReferencedMessages` renders the live deduped stub.\n- Step 1.5 `ConversationalRAGService:354` `enrichRagHistory` -> `injectImageDescriptions` MUTATES `context.rawConversationHistory`, populating `imageDescriptions`.\n\nSo at render time the entries carry no descriptions yet; asking "does the chat log already carry this?" always answers no, and answers wrong for exactly the case worth subtracting. `enrichRawReferences` has `history` too but runs even earlier (context assembly), so it is no better.\n\nThis is the shared-mutable-context seam class (#1884 / rule 7 clause from #1886) in a THIRD place: two steps communicating through a field on a shared object, correctness decided by which runs first.\n\n**Fix shape (needs design):** either (a) move the reference render after Step 1.5 — but processInputs also produces things 1.5 does not depend on, so the reorder needs its own evidence; or (b) hoist "each description appears once in the prompt" to a prompt-assembly-level invariant instead of a per-renderer decision. (b) is the better framing and the bigger change.\n\n**Impact:** token redundancy only, one turn per live reply, not a correctness regression. Replay (the long tail) is fixed.\n\n**Acceptance:** a live deduped reference to a message whose history entry renders <image_descriptions> does not also render them in the quote; a sequencing test runs Step 1 and Step 1.5 in order (rule 7's shared-context clause).
+**Surfaced by TASK-368's replay-path fix (#1887).**
+
+A deduped quote should not repeat media the chat-log entry already renders. #1887 derives that for the REPLAY path (`formatQuotedSection` holds the history entries). The LIVE path cannot answer the question at all, for an ordering reason:
+
+- Step 1 `ConversationalRAGService:324` `processInputs` -> `formatReferencedMessages` renders the live deduped stub.
+- Step 1.5 `ConversationalRAGService:354` `enrichRagHistory` -> `injectImageDescriptions` MUTATES `context.rawConversationHistory`, populating `imageDescriptions`.
+
+So at render time the entries carry no descriptions yet; asking "does the chat log already carry this?" always answers no, and answers wrong for exactly the case worth subtracting. `enrichRawReferences` has `history` too but runs even earlier (context assembly), so it is no better.
+
+This is the shared-mutable-context seam class (#1884 / rule 7 clause from #1886) in a THIRD place: two steps communicating through a field on a shared object, correctness decided by which runs first.
+
+**Fix shape (needs design):** either (a) move the reference render after Step 1.5 — but processInputs also produces things 1.5 does not depend on, so the reorder needs its own evidence; or (b) hoist "each description appears once in the prompt" to a prompt-assembly-level invariant instead of a per-renderer decision. (b) is the better framing and the bigger change.
+
+**Impact:** token redundancy only, one turn per live reply, not a correctness regression. Replay (the long tail) is fixed.
+
+**Acceptance:** a live deduped reference to a message whose history entry renders <image_descriptions> does not also render them in the quote; a sequencing test runs Step 1 and Step 1.5 in order (rule 7's shared-context clause).
 ## RUNTIME-CONFIRMED 2026-08-01 (req `1ab06c8d`)
 
 Owner replied directly to an image and asked the character to confirm it was not

--- a/tracker/tasks/task-388 - Extract-the-code-markup-gated-replace-so-thinkingExtraction-stops-indexing-offsets-positionally.md
+++ b/tracker/tasks/task-388 - Extract-the-code-markup-gated-replace-so-thinkingExtraction-stops-indexing-offsets-positionally.md
@@ -16,5 +16,25 @@ ordinal: 388000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-**Surfaced by #1889's review.** TASK-373 owns the isInsideCodeSpan reuse, so this is a member of it.\n\n`responseArtifacts.replaceOutsideCodeMarkup` finds the replace offset BY TYPE — `args.find(a => typeof a === "number")` — because `String.replace` passes exactly one number to a replacer and everything else is string/undefined/object. That is immune to any future capture group, named or not.\n\n`thinkingExtraction.ts` has ~4 inline instances of the same "skip matches inside code markup" shape written positionally, e.g. `(match: string, _tagName: string, offset: number)`.\n\n**Correction to the review's framing, which called it "the exact fragility":** the two are different fragilities and only one is what my docstring described.\n- BACK-indexed (`args[args.length - 2]`, what #1889 removed) breaks when a pattern gains a NAMED group, because `groups` is appended last.\n- FRONT-indexed (thinkingExtraction today) is unaffected by a named group — those append at the end — but breaks when a pattern gains an EXTRA CAPTURE GROUP, which shifts `offset` rightward.\n\nBoth are "correct only for the patterns that exist today". Find-by-type is immune to both. So the suggestion stands; the reason needed restating.\n\n**Not currently broken.** thinkingExtraction's signatures are typed and correct for its present patterns. This is hardening, not a bug fix — which is why it was not ridden into #1889.\n\n**Why not done in #1889:** it touches the highest-consequence parse file in the system (the one that ate user text in prod, #1880) on a PR about a different file. That change deserves its own review surface.\n\n**Fix shape:** extract to a shared helper — `codeSpanDetection.ts` in common-types is the natural home since it already owns `isInsideCodeSpan` — then adopt it at thinkingExtraction's call sites. Keep the existing table-driven KNOWN_THINKING_TAGS guard green; it is the regression net.\n\n**Acceptance:** one definition of "replace outside code markup" in the codebase; no positional offset indexing at any isInsideCodeSpan call site; thinkingExtraction's tag-x-quoting-shape table still passes unchanged.\n\n**Also noted in the same review:** `responseArtifacts.ts` is at 385/400 max-lines. The next pattern or helper added there forces a split — and moving this helper out buys some of that back.
+**Surfaced by #1889's review.** TASK-373 owns the isInsideCodeSpan reuse, so this is a member of it.
+
+`responseArtifacts.replaceOutsideCodeMarkup` finds the replace offset BY TYPE — `args.find(a => typeof a === "number")` — because `String.replace` passes exactly one number to a replacer and everything else is string/undefined/object. That is immune to any future capture group, named or not.
+
+`thinkingExtraction.ts` has ~4 inline instances of the same "skip matches inside code markup" shape written positionally, e.g. `(match: string, _tagName: string, offset: number)`.
+
+**Correction to the review's framing, which called it "the exact fragility":** the two are different fragilities and only one is what my docstring described.
+- BACK-indexed (`args[args.length - 2]`, what #1889 removed) breaks when a pattern gains a NAMED group, because `groups` is appended last.
+- FRONT-indexed (thinkingExtraction today) is unaffected by a named group — those append at the end — but breaks when a pattern gains an EXTRA CAPTURE GROUP, which shifts `offset` rightward.
+
+Both are "correct only for the patterns that exist today". Find-by-type is immune to both. So the suggestion stands; the reason needed restating.
+
+**Not currently broken.** thinkingExtraction's signatures are typed and correct for its present patterns. This is hardening, not a bug fix — which is why it was not ridden into #1889.
+
+**Why not done in #1889:** it touches the highest-consequence parse file in the system (the one that ate user text in prod, #1880) on a PR about a different file. That change deserves its own review surface.
+
+**Fix shape:** extract to a shared helper — `codeSpanDetection.ts` in common-types is the natural home since it already owns `isInsideCodeSpan` — then adopt it at thinkingExtraction's call sites. Keep the existing table-driven KNOWN_THINKING_TAGS guard green; it is the regression net.
+
+**Acceptance:** one definition of "replace outside code markup" in the codebase; no positional offset indexing at any isInsideCodeSpan call site; thinkingExtraction's tag-x-quoting-shape table still passes unchanged.
+
+**Also noted in the same review:** `responseArtifacts.ts` is at 385/400 max-lines. The next pattern or helper added there forces a split — and moving this helper out buys some of that back.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-389 - Sticker-descriptions-are-a-tier-3-asset-stored-at-tier-1-1h-Redis-no-durable-home.md
+++ b/tracker/tasks/task-389 - Sticker-descriptions-are-a-tier-3-asset-stored-at-tier-1-1h-Redis-no-durable-home.md
@@ -1,0 +1,34 @@
+---
+id: TASK-389
+title: >-
+  Sticker descriptions are a tier-3 asset stored at tier 1 (1h Redis, no durable
+  home)
+status: To Do
+assignee: []
+created_date: '2026-08-01 14:59'
+labels:
+  - 'size:M'
+dependencies: []
+priority: medium
+ordinal: 389000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Found by doc-56's durability audit (#1890) — the one open tier violation it surfaced.**
+
+A sticker is the cleanest tier-3 asset in the system: describing it costs a vision call, and the asset is IMMUTABLE and SHARED across every user who ever sends that sticker. One description could serve all of them forever.
+
+Instead it lands in `VisionDescriptionCache` — 1h Redis, L1 only, explicitly no durable tier (`services/ai-worker/src/redis.ts` says "L1 Redis only (no L2 PostgreSQL)"). There is no sticker table or column in `prisma/schema.prisma`.
+
+**Not a design mistake — a deliberate trade with an unbuilt second half.** #1872 routed stickers through the ordinary attachment -> download -> vision -> describe chain on purpose, to inherit the CDN allowlist, size caps, model cascade and failure fallbacks rather than reimplement them. That was right. The durable store was always meant to be a separate piece.
+
+**The fix is designed and unbuilt: doc-55 PR-2**, the snowflake-keyed asset table, described there as "the only outstanding piece of this doc". This task exists so the gap is tracked as a TIER VIOLATION and not only as a feature idea — a feature can be deprioritised on product grounds; a violation should be closed or consciously accepted.
+
+**Cost of leaving it:** every 1h TTL expiry re-describes a sticker the system has already paid to describe, across all users, forever. Unlike an ordinary Discord attachment (ephemeral URL, genuinely not worth persisting — which is WHY the Postgres L2 was removed before beta.110), a sticker snowflake is stable and re-describable at any time, so the reason that justified dropping the L2 does not apply to stickers.
+
+**Acceptance:** a sticker description survives a Redis flush and a 1h+ gap; key is the sticker snowflake, not an attachment URL; `durability-tiers.md`'s tier-3 table stops saying OPEN VIOLATION.
+
+**Promote when:** doc-55 PR-2 is picked up, or vision spend on repeat stickers becomes visible in usage data.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
doc-56's inventory pass. Needs a PR because it edits `.claude/rules/03-database.md`, which is review-gated.

## Three rows in the always-loaded cache table were wrong

Verified against source, not against the table — the table was the thing under audit:

| Row | Said | Actually |
|---|---|---|
| **User** | 5 min | **1 hour** (`USER_CACHE_TTL_MS`) — a 12× understatement |
| **OpenRouter Models** | 24h, Redis-backed | **two-tier**: 5-min in-memory L1 in front of the 24h Redis entry |
| **Voice Transcript** | `-`, "Custom (in-memory)" | **1h, Redis** `setex` at `INTERVALS.VOICE_TRANSCRIPT_TTL` |

The other eight check out. A wrong TTL on an always-loaded surface is a wrong premise in every session that reads it, so the table now also carries a **Tier** column and a note to verify a row against its constant.

*(The Voice Transcript error was already noted inside TASK-384 as a ride-along. It's fixed here because this is the pass that owns the table.)*

## Two findings the filing didn't anticipate

**The proposed tier-1 test is too strict.** It reads "recomputable for free; losing it is correctness-neutral." TTS audio fails *both* halves — it costs money, and losing it ships a reply without voice — yet short-TTL Redis is exactly right for it.

The reason is that it's **never read twice**: one consumer, once, and its only requirement is to outlive the slowest delivery path (which is where its TTL comes from). Tiering is about *re-reads*. So the sort now starts with **"will anything ever ask for this again?"** — if no, it's a transit buffer with a lifetime question and no durability question, and the cost axis never applies.

**Cloned voice IDs look like a tier-3 violation and aren't.** Cloning costs money and the clone outlives any conversation, so it's unambiguously tier 3 — and there is no `voiceId` anywhere in the schema. But the resolution path lists voices at the provider before cloning, so **the provider is the system of record** and `CloneCacheKernel`'s 30-min in-memory cache is a legitimate L1 over a remote one.

Recorded with its consequence rather than as a clean pass: this makes our correctness depend on someone else's list endpoint, outside the blast radius of our own backups. A list that under-reports produces a duplicate clone and a second charge — which is why the Mistral client's pagination handling has its own guards.

## Status of the violations doc-56 named

Both — vision descriptions and voice transcripts — were closed by persisting the built reference (#1883). What survives is **an incomplete backfill, not a tier violation**: the replay hydrator heals vision but has no voice equivalent. Bounded and self-closing (the heal only helps inside the 1h TTL, and pre-persistence rows age out of the 30-day window on their own). Already tracked as TASK-384.

## The two design questions, settled

**Does a tier-2 item ever get its own table?** No — inline-on-the-row, and the reason generalizes: a tier-2 item by definition has no key dimension the row doesn't already have, and inlining gives it the row's retention for free (no second cleanup job, no orphan class, no way for enrichment to outlive what it describes). A table is justified only by a key that genuinely isn't the row — and that *is* the definition of tier 3. **The tier boundary and the storage decision are the same question.**

**Does `CACHING_AUDIT.md` gain a durability column or get superseded?** Neither — it's **narrowed**. Its scaling analysis is still correct and still useful; its headline finding is resolved and its inventory is stale. Bolting a durability column on would make one document answer two questions and re-stale the inventory it already got wrong. So durability lives in the new doc, the rules table points there for tiers, and `CACHING_AUDIT.md` keeps the scaling axis with a scope header and its inventory marked historical.

## Scope

Inventory pass only, per the filing — no cache was moved or re-homed. `pnpm quality` green; docs-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)