### PR TITLE
fix(common-types): model backtick runs so double-backtick spans read as code

### DIFF
--- a/packages/common-types/src/utils/codeSpanDetection.test.ts
+++ b/packages/common-types/src/utils/codeSpanDetection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isInsideCodeSpan } from './codeSpanDetection.js';
+import { isInsideCodeSpan, replaceOutsideCodeMarkup } from './codeSpanDetection.js';
 
 /** Offset of `needle` in `text`, asserted to exist so a typo fails loudly. */
 function offsetOf(text: string, needle: string): number {
@@ -90,6 +90,100 @@ describe('isInsideCodeSpan', () => {
       // reporting `true` for every later offset outside the fence.
       const text = 'A stray ` then\n```\nfenced\n```\nplain <thinking> here.';
       expect(isInsideCodeSpan(text, offsetOf(text, '<thinking>'))).toBe(false);
+    });
+  });
+
+  describe('backtick runs', () => {
+    // A run of N backticks opens a span that only a matching run closes, which
+    // is what makes the double-backtick form work. Treating each backtick as an
+    // independent toggle nets a two-backtick span out to "not code" — and that
+    // failure direction makes callers EXTRACT, i.e. delete the quoted example.
+    it('reports true inside a double-backtick span', () => {
+      const text = 'Models emit a ``<think>`` marker before answering.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<think>'))).toBe(true);
+    });
+
+    it('treats a lone backtick inside a double-backtick span as content', () => {
+      // The reason double-backtick spans exist: code containing a literal
+      // backtick. The shorter run must not terminate the longer one.
+      //
+      // This row passed before runs were modelled, but only by parity accident
+      // (an odd number of backticks preceded the offset). It pins the RULE now,
+      // not the coincidence.
+      const text = 'Write ``a ` b <think>`` please.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<think>'))).toBe(true);
+    });
+
+    it('closes a double-backtick span only on a matching run', () => {
+      const text = 'Use ``x ` y`` then <think> plainly.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<think>'))).toBe(false);
+    });
+
+    it('reports true inside a four-backtick fence', () => {
+      // Also passed pre-change, since `startsWith('```')` matched the first
+      // three of four. Kept to pin that longer fences stay fences.
+      const text = 'Look:\n````\n<think>\n````\ndone';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<think>'))).toBe(true);
+    });
+
+    it('does not close a four-backtick fence on a three-backtick run', () => {
+      const text = 'Look:\n````\ncode\n```\nstill fenced <think>';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<think>'))).toBe(true);
+    });
+
+    it('does not let a double-backtick span leak past a newline', () => {
+      // Inline spans die at a newline whatever their run length — otherwise one
+      // unmatched pair marks the rest of the document as code.
+      const text = 'A stray ``here.\nThen <think> on the next line.';
+      expect(isInsideCodeSpan(text, offsetOf(text, '<think>'))).toBe(false);
+    });
+  });
+});
+
+describe('replaceOutsideCodeMarkup', () => {
+  // The offset is found by TYPE, not by position, so these pin the property
+  // directly rather than only through the patterns that happen to exist in any
+  // one caller today. The named-group row is the one that matters: it is where a
+  // positional `args.length - 2` silently reads the input string instead of the
+  // offset, with no type error, and the strip would then be made against the
+  // wrong position rather than fail loudly.
+  const shapes: [label: string, pattern: RegExp][] = [
+    ['no capture groups', /<\/chat_log>/g],
+    ['one positional group', /<\/(chat_log)>/g],
+    ['two positional groups', /<(\/)(chat_log)>/g],
+    ['a NAMED group', /<\/(?<tag>chat_log)>/g],
+    ['named and positional groups', /<(\/)(?<tag>chat_log)>/g],
+  ];
+
+  describe.each(shapes)('%s', (_label, pattern) => {
+    it('spares a quoted match and strips an unquoted one', () => {
+      const text = 'quoted `</chat_log>` then real </chat_log>';
+      expect(replaceOutsideCodeMarkup(text, pattern)).toBe('quoted `</chat_log>` then real ');
+    });
+  });
+
+  describe('offsetWithinMatch', () => {
+    // The chimera-artifact shape, verbatim in structure: it deliberately matches
+    // from the preceding newline through the delimiter, so the MATCH START sits
+    // outside the backtick span the quoted delimiter lives in. Gating on the
+    // match start therefore never fires, and the strip eats the quoted example
+    // while leaving its closing backtick dangling — the observed production bug.
+    const pattern = /(?:^|[\r\n])[\s]{0,50}[^\s<.]{0,9}\.[\s]{0,50}<\/(think)>/gi;
+    const atDelimiter = (match: string): number => match.lastIndexOf('</');
+
+    it('gating on the match start eats the quoted example, leaving a dangling backtick', () => {
+      const text = 'Look:\n`token. </think>` is the shape.';
+      expect(replaceOutsideCodeMarkup(text, pattern)).toBe('Look:` is the shape.');
+    });
+
+    it('spares the quoted match when probed at the delimiter', () => {
+      const text = 'Look:\n`token. </think>` is the shape.';
+      expect(replaceOutsideCodeMarkup(text, pattern, atDelimiter)).toBe(text);
+    });
+
+    it('still strips an unquoted match when probed at the delimiter', () => {
+      const text = 'Look:\ntoken. </think> is the shape.';
+      expect(replaceOutsideCodeMarkup(text, pattern, atDelimiter)).toBe('Look: is the shape.');
     });
   });
 });

--- a/packages/common-types/src/utils/codeSpanDetection.ts
+++ b/packages/common-types/src/utils/codeSpanDetection.ts
@@ -18,29 +18,62 @@
  * callers that need to handle that case need a second discriminator (position,
  * for instance).
  *
+ * This is load-bearing on a live path, not defensive scaffolding: prod logs
+ * show `glm-4.5-air` emitting reasoning terminated by a bare `</think>` with no
+ * opening tag, which `extractOrphanClosingTag` must keep handling. A backtick
+ * run is the only thing separating that real delimiter from a reply that merely
+ * mentions one, so a gap here costs a user their text.
+ *
  * Known simplification: fence detection is position-agnostic. Real Markdown
- * fences are line-anchored, but any literal triple backtick toggles state here,
- * so a reply using ``` inline ("she typed ``` by mistake") flips the scan into
- * fence mode for the rest of the string. That is tolerable because it fails
- * toward preserving content: an over-eager fence makes callers decline to
- * extract, and the worst outcome is reasoning that stays visible rather than a
- * reply that loses text. Line-anchoring it would be stricter and is fine to add
- * — but only with a caller that needs the precision, since the loose form has
- * the safer failure direction.
+ * fences are line-anchored, but any run of three or more backticks toggles
+ * fence state here, so a reply using ``` inline ("she typed ``` by mistake")
+ * flips the scan into fence mode for the rest of the string. That is tolerable
+ * because it fails toward preserving content: an over-eager fence makes callers
+ * decline to extract, and the worst outcome is reasoning that stays visible
+ * rather than a reply that loses text. Line-anchoring it would be stricter and
+ * is fine to add — but only with a caller that needs the precision, since the
+ * loose form has the safer failure direction.
  */
+
+/**
+ * Backtick-run length at which a delimiter is treated as a fence rather than an
+ * inline span. The two differ in more than length: a fence spans newlines and
+ * closes on a run of *at least* its own length, while an inline span dies at a
+ * newline and closes only on an exactly-equal run.
+ */
+const FENCE_MIN_RUN = 3;
+
+/**
+ * Whether a backtick run of `run` closes a span opened by a run of `openRun`.
+ *
+ * Fences follow CommonMark's "closing fence may be longer" rule; inline spans
+ * require an exact match, which is what makes ``` ``code with a ` inside`` ```
+ * work — the lone backtick is a shorter run, so it is content rather than a
+ * terminator.
+ */
+function closesSpan(openRun: number, run: number): boolean {
+  return openRun >= FENCE_MIN_RUN ? run >= openRun : run === openRun;
+}
 
 /**
  * Whether `index` falls inside inline code or a fenced code block.
  *
- * Single left-to-right scan; the two states interact, so they cannot be
- * counted independently:
- * - A triple backtick toggles fence state and clears inline state — a stray
- *   inline backtick must not leak across a fence boundary.
- * - Inside a fence, single backticks are literal content and are ignored.
- * - Outside a fence, a single backtick toggles inline state, and a newline
- *   clears it: inline code does not span lines in Markdown, so without the
- *   reset one unmatched backtick would mark the whole rest of the document
- *   as code.
+ * Single left-to-right scan over backtick *runs* rather than individual
+ * backticks. Treating each backtick as an independent toggle looks equivalent
+ * and is not: a double-backtick span — Markdown's form for code containing a
+ * literal backtick — toggles twice and nets out to "not code", so a control
+ * delimiter quoted inside one reads as unquoted. That failure direction is the
+ * dangerous one, because an unrecognised span makes callers *extract*, which is
+ * the data loss this utility exists to prevent.
+ *
+ * The rules, all falling out of the run length:
+ * - A run of N backticks opens a span when none is open.
+ * - Inside an open span, a run closes it per {@link closesSpan}; any other run
+ *   is literal content.
+ * - A newline clears a pending *inline* span (N < {@link FENCE_MIN_RUN}), since
+ *   inline code does not span lines in Markdown. Without the reset one unmatched
+ *   backtick would mark the whole rest of the document as code. Fences are
+ *   unaffected — spanning lines is the entire point of a fence.
  *
  * @param text - The full text being scanned
  * @param index - Offset within `text` to classify
@@ -51,31 +84,89 @@ export function isInsideCodeSpan(text: string, index: number): boolean {
     return false;
   }
 
-  let inFence = false;
-  let inInline = false;
+  // Length of the run that opened the current span, or 0 when none is open.
+  let openRun = 0;
   let cursor = 0;
 
   while (cursor < index) {
-    if (text.startsWith('```', cursor)) {
-      inFence = !inFence;
-      inInline = false;
-      cursor += 3;
-      continue;
-    }
-
-    if (inFence) {
-      cursor += 1;
-      continue;
-    }
-
     const char = text[cursor];
+
     if (char === '`') {
-      inInline = !inInline;
-    } else if (char === '\n') {
-      inInline = false;
+      let runEnd = cursor;
+      while (runEnd < text.length && text[runEnd] === '`') {
+        runEnd += 1;
+      }
+      const run = runEnd - cursor;
+
+      if (openRun === 0) {
+        openRun = run;
+      } else if (closesSpan(openRun, run)) {
+        openRun = 0;
+      }
+
+      // `runEnd` can land past `index`, so an offset INSIDE a delimiter run is
+      // classified by whether that run started before `index` and was therefore
+      // processed: inside an opening run reports true, inside a closing run that
+      // began earlier reports false. That asymmetry is undefined behaviour rather
+      // than a decision — no caller passes a backtick offset (every one passes
+      // the offset of a `<tag>` match), so there is no real case to settle it
+      // against. Pick a rule here only alongside a caller that needs one.
+      cursor = runEnd;
+      continue;
+    }
+
+    if (char === '\n' && openRun > 0 && openRun < FENCE_MIN_RUN) {
+      openRun = 0;
     }
     cursor += 1;
   }
 
-  return inFence || inInline;
+  return openRun > 0;
+}
+
+/**
+ * Strip every match of `pattern` EXCEPT the ones inside code markup.
+ *
+ * The companion to {@link isInsideCodeSpan} for the common case: a cleanup pass
+ * that deletes matches. Every such pattern is also a way to destroy a
+ * character's legitimate reply, because a reply *demonstrating* the syntax
+ * contains the same bytes as a model that leaked it — and the demonstration is
+ * what gets eaten. A real leaked artifact is never backticked, because the model
+ * emits it as structure rather than as an example, so code markup separates the
+ * two where position cannot.
+ *
+ * The offset is found BY TYPE rather than by position. `String.replace` passes a
+ * replacer the match, then one argument per capture group, then the offset, then
+ * the whole input — plus a `groups` object when the pattern has named groups.
+ * Every one of those is a string or undefined except the offset, so the number
+ * IS the offset, and stays so no matter how many groups a pattern grows or
+ * whether any of them are named. Positional indexing cannot say that: indexing
+ * from the front breaks when a pattern gains a capture group (every later
+ * argument shifts right), and indexing from the back breaks when it gains a
+ * NAMED group (`groups` is appended last). Both are correct only for the
+ * patterns that exist today. The invariant is executable rather than a comment
+ * asking the next author to remember.
+ *
+ * @param text - The text to strip matches from
+ * @param pattern - The pattern to strip; global flag honoured as `String.replace` does
+ * @param offsetWithinMatch - Which position *inside* the match decides quotedness,
+ *   as an offset relative to the match start. Defaults to the match start. Needed
+ *   when a pattern deliberately matches more than the delimiter it is hunting —
+ *   e.g. one that starts at the preceding newline, which sits outside the backtick
+ *   span the quoted delimiter lives in, so gating on the match start never fires.
+ * @returns `text` with unquoted matches removed
+ */
+export function replaceOutsideCodeMarkup(
+  text: string,
+  pattern: RegExp,
+  offsetWithinMatch?: (match: string) => number
+): string {
+  return text.replace(pattern, (...args: unknown[]) => {
+    const match = args[0] as string;
+    const offset = args.find((arg): arg is number => typeof arg === 'number');
+    // Unreachable per the contract above; degrading to 0 keeps the pre-gate
+    // behaviour (offset 0 is never inside code markup, so the match strips).
+    const probeAt = (offset ?? 0) + (offsetWithinMatch?.(match) ?? 0);
+    return isInsideCodeSpan(text, probeAt) ? match : '';
+  });
 }

--- a/services/ai-worker/src/utils/responseArtifacts.test.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.test.ts
@@ -10,7 +10,6 @@ import {
   stripResponseArtifacts,
   stripUserMessageEcho,
   normalizeForEchoMatch,
-  replaceOutsideCodeMarkup,
 } from './responseArtifacts.js';
 
 describe('stripResponseArtifacts', () => {
@@ -559,29 +558,6 @@ describe('stripResponseArtifacts', () => {
       expect(stripResponseArtifacts(content, 'Emily')).toBe(
         'You would see `</chat_log>` at the end.'
       );
-    });
-  });
-});
-
-describe('replaceOutsideCodeMarkup', () => {
-  // The offset is found by TYPE, not by position, so these pin the property
-  // directly rather than only through the patterns that happen to exist in
-  // `buildArtifactPatterns` today. The named-group row is the one that matters:
-  // it is where a positional `args.length - 2` silently reads the input string
-  // instead of the offset, with no type error, and the strip would then be made
-  // against the wrong position rather than fail loudly.
-  const shapes: [label: string, pattern: RegExp][] = [
-    ['no capture groups', /<\/chat_log>/g],
-    ['one positional group', /<\/(chat_log)>/g],
-    ['two positional groups', /<(\/)(chat_log)>/g],
-    ['a NAMED group', /<\/(?<tag>chat_log)>/g],
-    ['named and positional groups', /<(\/)(?<tag>chat_log)>/g],
-  ];
-
-  describe.each(shapes)('%s', (_label, pattern) => {
-    it('spares a quoted match and strips an unquoted one', () => {
-      const text = 'quoted `</chat_log>` then real </chat_log>';
-      expect(replaceOutsideCodeMarkup(text, pattern)).toBe('quoted `</chat_log>` then real ');
     });
   });
 });

--- a/services/ai-worker/src/utils/responseArtifacts.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.ts
@@ -19,7 +19,7 @@
  */
 
 import { type MessageContent } from '@tzurot/common-types/types/ai';
-import { isInsideCodeSpan } from '@tzurot/common-types/utils/codeSpanDetection';
+import { replaceOutsideCodeMarkup } from '@tzurot/common-types/utils/codeSpanDetection';
 import { findLeadingMentionsEnd, stripLeadingMentions } from '@tzurot/common-types/utils/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 
@@ -88,46 +88,17 @@ function buildArtifactPatterns(personalityName: string): RegExp[] {
 }
 
 /**
- * Strip every match of `pattern` EXCEPT the ones inside code markup.
+ * Apply patterns iteratively until no more matches.
  *
- * These patterns delete, and a character on this product routinely writes ABOUT
- * prompt structure — so a reply demonstrating `` `</chat_log>` `` is
- * indistinguishable from a model that leaked one, and the demonstration is what
- * gets eaten. Code markup is the discriminator: a real leaked artifact is never
- * backticked, because the model emits it as structure rather than as an example.
- *
- * Position cannot decide it here. Most of these patterns are already anchored to
- * the start or end, and a QUOTED artifact at the start or end sits at the same
- * offset a real one would — the anchor says where, not whether. (The anchors do
- * incidentally protect the fenced case, since a leading backtick means `^<tag`
- * no longer matches; the gate is what covers the unanchored patterns, where
- * nothing else does.)
- *
- * The offset is found BY TYPE rather than by position. `String.replace` passes a
- * replacer the match, then one argument per capture group, then the offset, then
- * the whole input — plus a `groups` object when the pattern has named groups.
- * Every one of those is a string or undefined except the offset, so the number
- * IS the offset, and stays so no matter how many groups a pattern grows or
- * whether any of them are named. A positional index cannot say that: it is
- * correct only for the patterns that exist today, and a named group added later
- * would silently hand this function the input string instead, with no type error
- * to catch it. The invariant is executable rather than a comment asking the next
- * author to remember.
- *
- * @internal Exported for testing
- */
-export function replaceOutsideCodeMarkup(text: string, pattern: RegExp): string {
-  return text.replace(pattern, (...args: unknown[]) => {
-    const match = args[0] as string;
-    const offset = args.find((arg): arg is number => typeof arg === 'number');
-    // Unreachable per the contract above; degrading to 0 keeps the pre-gate
-    // behaviour (offset 0 is never inside code markup, so the match strips).
-    return isInsideCodeSpan(text, offset ?? 0) ? match : '';
-  });
-}
-
-/**
- * Apply patterns iteratively until no more matches
+ * Every pattern here deletes, so each strip runs through
+ * `replaceOutsideCodeMarkup`: a reply demonstrating `` `</chat_log>` `` is
+ * byte-identical to a model that leaked one, and the demonstration is what gets
+ * eaten. Position cannot decide it at this site — most of these patterns are
+ * already anchored to the start or end, and a QUOTED artifact at the start or
+ * end sits at the same offset a real one would, so the anchor says where, not
+ * whether. (The anchors do incidentally protect the fenced case, since a leading
+ * backtick means `^<tag` no longer matches; the gate is what covers the
+ * unanchored patterns, where nothing else does.)
  */
 function applyPatternsIteratively(
   content: string,

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -499,6 +499,14 @@ The answer is 42.`;
           label: 'a fenced block',
           wrap: (tag: string): string => `Like so:\n\`\`\`\n${tag}\n\`\`\`\nThat is the shape.`,
         },
+        {
+          // Markdown's form for code containing a literal backtick. Modelling
+          // backticks as independent toggles nets this out to "not code", so the
+          // tag reads as unquoted and the example is stripped. Every row here
+          // fails without run-based delimiter matching.
+          label: 'a double-backtick span',
+          wrap: (tag: string): string => `Models emit a \`\`${tag}\`\` marker before answering.`,
+        },
       ];
 
       for (const tag of KNOWN_THINKING_TAGS) {

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -24,7 +24,10 @@
  * 3. Logged for debugging purposes
  */
 
-import { isInsideCodeSpan } from '@tzurot/common-types/utils/codeSpanDetection';
+import {
+  isInsideCodeSpan,
+  replaceOutsideCodeMarkup,
+} from '@tzurot/common-types/utils/codeSpanDetection';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('ThinkingExtraction');
@@ -405,11 +408,23 @@ function logDeclinedMidResponseTag(visibleContent: string): void {
 /**
  * Extract content from orphan closing tags (no opening tag).
  *
- * Some models (e.g. Kimi K2.5) emit reasoning with no opening tag and simply
- * terminate it with `</think>`, so the closing tag sits mid-line, mid-text —
- * positionally identical to a reply that merely MENTIONS the tag. Code markup
- * is the only signal that separates the two, so candidates inside a backtick
- * span or fenced block are skipped and the next one is considered.
+ * Some models emit reasoning with no opening tag and simply terminate it with
+ * `</think>`, so the closing tag sits mid-line, mid-text — positionally
+ * identical to a reply that merely MENTIONS the tag. Code markup is the only
+ * signal that separates the two, so candidates inside a backtick span or fenced
+ * block are skipped and the next one is considered.
+ *
+ * This path is LIVE, not legacy. Kimi K2.5 is where the shape was first seen,
+ * but a prod log sweep found the current emitter to be `glm-4.5-air`, an
+ * in-rotation free-tier model: six extractions across 374 generations, bodies of
+ * 1256–2098 chars, three of them followed by healthy visible output. Deleting
+ * this path would put 1–2 KB of raw reasoning in front of those replies.
+ *
+ * The consequence for the quoted-syntax audit: because the path must stay, so
+ * must its ambiguity. An UNFENCED mid-prose `</think>` ("it just prints </think>
+ * before answering") is still consumed, and no discriminator can separate that
+ * from the real thing — both are mid-line, mid-text prose. That gap is a
+ * permanent known limit rather than something a future heuristic closes.
  *
  * @returns Extracted content and cleaned visible content, or null if no match
  */
@@ -446,6 +461,27 @@ function extractOrphanClosingTag(
 }
 
 /**
+ * Report that the chimera-stutter pass actually stripped something.
+ *
+ * The pattern targets one merged model's quirk (`tng-r1t-chimera`) but runs on
+ * every response, so its cost is model-independent while its benefit is not —
+ * and that model left the OpenRouter free tier. Whether the pass still earns its
+ * keep is an evidence question, and until this line existed the pass stripped
+ * silently, so there was nothing to answer it with.
+ *
+ * Permanent observability (`feat`), not scaffolding — do not sweep it as stale
+ * instrumentation. It fires only on a real strip, which is expected to be rare;
+ * a run of zero over a release is the evidence that retires the pattern, and any
+ * occurrence names the model that still justifies it.
+ */
+function logChimeraArtifactStripped(before: string, after: string): void {
+  logger.info(
+    { strippedChars: before.length - after.length, contentLength: before.length },
+    'Chimera stutter artifact stripped from response'
+  );
+}
+
+/**
  * Clean up visible content after extraction.
  */
 function cleanupVisibleContent(content: string): string {
@@ -456,21 +492,17 @@ function cleanupVisibleContent(content: string): string {
   // lands on every model, which is why the gate is worth more than the pass.
   // Test the CLOSING TAG's position, not the match start: this pattern's match
   // begins at the preceding newline, which sits outside the backtick span the
-  // quoted tag lives in, so gating on `offset` would never fire.
-  let result = content.replace(
-    CHIMERA_ARTIFACT_PATTERN,
-    (match: string, _tagName: string, offset: number) =>
-      isInsideCodeSpan(content, offset + match.lastIndexOf('</')) ? match : ''
+  // quoted tag lives in, so gating on the match start would never fire.
+  let result = replaceOutsideCodeMarkup(content, CHIMERA_ARTIFACT_PATTERN, match =>
+    match.lastIndexOf('</')
   );
+  if (result !== content) {
+    logChimeraArtifactStripped(content, result);
+  }
 
   // Remove remaining orphan closing tags — except ones the model quoted inside
   // code markup, where deleting the tag would corrupt the quotation it wrote.
-  const beforeOrphanCleanup = result;
-  result = beforeOrphanCleanup.replace(
-    CLOSING_TAG_PATTERN,
-    (match: string, _tagName: string, offset: number) =>
-      isInsideCodeSpan(beforeOrphanCleanup, offset) ? match : ''
-  );
+  result = replaceOutsideCodeMarkup(result, CLOSING_TAG_PATTERN);
 
   // Remove OpenAI Harmony format token leakage (GPT-OSS-120B)
   result = result.replace(HARMONY_TOKEN_PATTERN, '');
@@ -561,10 +593,7 @@ function extractCompleteTagPairs(
     }
 
     pattern.lastIndex = 0;
-    const beforeStrip = remaining;
-    remaining = beforeStrip.replace(pattern, (matchText: string, _body: string, offset: number) =>
-      isInsideCodeSpan(beforeStrip, offset) ? matchText : ''
-    );
+    remaining = replaceOutsideCodeMarkup(remaining, pattern);
   }
 
   return remaining;

--- a/tracker/tasks/task-373 - Audit-content-that-QUOTES-our-control-syntax-—-every-parse-site-not-just-thinking-tags.md
+++ b/tracker/tasks/task-373 - Audit-content-that-QUOTES-our-control-syntax-—-every-parse-site-not-just-thinking-tags.md
@@ -135,6 +135,37 @@ irrelevant over a single reply with few candidates. It remains open for
 so the caveat is likely moot rather than pending.
 
 **Still open**: the `<action>`-tag leak handler (now.md Untriaged) is a FUTURE
-parse site and must be designed against this class rather than retrofitted; the
-unfenced-quote gap is unchanged and still gated on the TASK-375 question above.
+parse site and must be designed against this class rather than retrofitted.
+
+## THE UNFENCED-QUOTE GAP IS PERMANENT — resolved 2026-08-01, do not re-derive
+
+TASK-375's evidence sweep came back the opposite way from the hoped-for answer,
+and it closes an option this task was holding open.
+
+The cheap structural answer on the table was: retire `extractOrphanClosingTag`,
+and the unfenced-quote ambiguity disappears by construction, because it only
+exists to serve that path. **That is now ruled out on runtime evidence.** A
+10-deployment prod sweep (36,094 lines, 374 generations) found the path firing 6
+times, every one from `glm-4.5-air` — an in-rotation free-tier model, not the
+retired Kimi K2.5 the docstring credited — recovering reasoning bodies of
+1256-2098 chars, three of them followed by healthy visible output.
+
+So the path stays, and therefore so does its ambiguity: an UNFENCED mid-prose
+`</think>` ("it just prints </think> before answering") is still consumed, and
+no discriminator separates it from the real emission, because both are mid-line
+mid-text prose with no code markup and no position signal. Recorded in
+`extractOrphanClosingTag`'s docstring as a permanent known limit.
+
+**Do not spend another design pass on a cleverer discriminator for this gap.**
+The two candidates are already evidence-rejected: the proportion guard (result 1
+above) and retirement-by-construction (here). What remains is the observability
+answer — if a user ever reports it, the reply's text is recoverable from the
+diagnostic log.
+
+**Ridden in the same PR** (both members of this task, both now Done): TASK-377
+gave `isInsideCodeSpan` run-based backtick delimiters, closing the
+double-backtick gap noted in result 3 — which mattered more than its "not seen"
+priority suggested, since the sweep shows the discriminator is load-bearing on a
+live path rather than defensive. TASK-388 made `replaceOutsideCodeMarkup` the
+single definition, discharging this task's reuse ownership.
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-375 - Does-CHIMERA_ARTIFACT_PATTERN-still-earn-its-keep-now-that-tng-r1t-chimera-is-gone.md
+++ b/tracker/tasks/task-375 - Does-CHIMERA_ARTIFACT_PATTERN-still-earn-its-keep-now-that-tng-r1t-chimera-is-gone.md
@@ -55,4 +55,41 @@ on the first: it deletes an ambiguity this codebase currently cannot resolve.
 Order note: this is the cheap structural answer to a gap TASK-373 would
 otherwise try to solve with a cleverer discriminator. Check the lifecycle
 question BEFORE designing one.
+
+## EVIDENCE SWEEP RUN 2026-08-01 — question two is ANSWERED, and the answer is KEEP
+
+Method: 10 prod ai-worker deployments pulled by deployment ID (2026-07-27 →
+08-01), 36,094 lines, 374 `Generation complete` events, grepped locally rather
+than through the Railway filter DSL.
+
+**Does any live model emit a bare orphan `</think>`? YES — decisively.**
+`Found orphan closing tag` fired **6 times**, and every one carried
+`modelName="glm-4.5-air"` — NOT the Kimi K2.5 the docstring credited. Extracted
+bodies were 1256, 1629, 1679, 1830, 2023 and 2098 chars. **Three were followed
+by healthy visible output** (2016 / 1452 / 400 chars), i.e. the model reasoned,
+emitted a bare `</think>`, then answered, and the extractor correctly separated
+the two. Deleting the path would have put 1.2-2.1 KB of raw reasoning in front
+of those three replies.
+
+`extractOrphanClosingTag` therefore **stays**, and glm-4.5-air is an
+in-rotation free-tier model, so this is not a path awaiting retirement. Outcome
+(b) from the header applies: kept, with the docstring now naming the live model
+and the measurement (#code-span PR, `thinkingExtraction.ts`).
+
+**Consequence for TASK-373, already written back there:** the unfenced-quote gap
+CANNOT be closed by construction. That was this task's cheap structural answer
+and it is off the table — the ambiguity is permanent.
+
+**Question one (the chimera stutter) is still open, and now instrumented.**
+`CHIMERA_ARTIFACT_PATTERN` stripped silently, so no log could answer it; the
+same PR adds a `logger.info` that fires only on a real strip. Note the shapes
+are related but not identical, so a "no" on question two would not have settled
+this one either way: `extractOrphanClosingTag` bails when under 20 chars precede
+the first closing tag, which is exactly the stutter shape, so the chimera pass
+is the handler for the case the orphan path declines.
+
+**Promote when**: one release of prod exposure has passed. Grep ai-worker for
+`Chimera stutter artifact stripped`. Zero occurrences is the evidence that
+retires the pattern and its three tests (outcome (a)); any occurrence names the
+model that still justifies it (outcome (b)).
 <!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-377 - isInsideCodeSpan-does-not-model-Markdown-double-backtick-spans.md
+++ b/tracker/tasks/task-377 - isInsideCodeSpan-does-not-model-Markdown-double-backtick-spans.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-377
 title: isInsideCodeSpan does not model Markdown double-backtick spans
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-31 04:11'
+updated_date: '2026-08-01 17:31'
 labels:
   - 'size:S'
 dependencies: []

--- a/tracker/tasks/task-388 - Extract-the-code-markup-gated-replace-so-thinkingExtraction-stops-indexing-offsets-positionally.md
+++ b/tracker/tasks/task-388 - Extract-the-code-markup-gated-replace-so-thinkingExtraction-stops-indexing-offsets-positionally.md
@@ -3,9 +3,10 @@ id: TASK-388
 title: >-
   Extract the code-markup-gated replace so thinkingExtraction stops indexing
   offsets positionally
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-01 14:02'
+updated_date: '2026-08-01 17:31'
 labels:
   - 'size:S'
 dependencies: []

--- a/tracker/tasks/task-391 - glm-4.5-air-can-produce-empty-visible-content-and-force-a-full-generation-retry.md
+++ b/tracker/tasks/task-391 - glm-4.5-air-can-produce-empty-visible-content-and-force-a-full-generation-retry.md
@@ -1,0 +1,34 @@
+---
+id: TASK-391
+title: >-
+  glm-4.5-air can produce empty visible content and force a full generation
+  retry
+status: To Do
+assignee: []
+created_date: '2026-08-01 17:32'
+updated_date: '2026-08-01 17:32'
+labels:
+  - 'size:M'
+  - 'area:ai-worker'
+dependencies: []
+priority: medium
+ordinal: 391000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Surfaced 2026-08-01 by the TASK-375 prod log sweep (10 ai-worker deployments, 36,094 lines, 374 generations).
+
+**Observed**: 2 of 374 generations (~0.5%) ended in `Empty response after post-processing. Retrying...`, both `modelUsed="glm-4.5-air"`. Both were preceded by `Empty visible content - model only produced reasoning` — the model emitted a reasoning block terminated by a bare `</think>` and no answer at all, so `extractOrphanClosingTag` correctly filed the whole body as thinking and left `visibleLength=0`.
+
+**Cost**: one measured instance spent `durationMs=41371` on the first attempt before the retry, against a 3-attempt budget. A second case landed `visibleLength=1`, which is degenerate rather than empty and does NOT trip the retry — it delivers a one-character reply to the user.
+
+**Correlated signal**: 2 of the 3 also tripped `DuplicateDetection` with `similarity="0.996"` (stop-token failure, e.g. originalLength=3359 deduplicatedLength=1687). Whether that is the same root cause or a second glm-4.5-air quirk is unestablished.
+
+**Not a regression and not the orphan extractors fault** — the extractor did the right thing with what it got. This is a model-quality issue on a free-tier model we keep deliberately.
+
+**Fix shape (needs a decision, not just code)**: options are (a) leave it, the retry already recovers; (b) treat empty-visible-with-reasoning as a fast retry that skips the remaining backoff, since the outcome is known-bad the moment it is detected; (c) surface the reasoning as the reply when all attempts come back empty, rather than failing. The `visibleLength=1` case suggests any threshold should be a minimum length, not an emptiness check.
+
+**Verify before building**: 2 events is a thin base rate. Re-grep a wider window for `Empty response after post-processing` and confirm the glm-4.5-air concentration holds before sizing this.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
Drain batch 7 (tracker `doc-7` Phase 1), selected by the heuristic that batch log recommends: **same-origin, same-module clusters**. The five open tasks surfaced by #1880 all live in the response-parse family, and the `deferred-refs` hook independently flagged 373/375/377/388 on this exact diff.

## The measurement that changed the batch

TASK-375 asked whether `extractOrphanClosingTag` still earns its keep. Deleting it was the *cheap* answer to TASK-373's remaining unfenced-quote gap — close the ambiguity by construction rather than with a cleverer heuristic.

I pulled 10 prod ai-worker deployments by deployment ID (2026-07-27 → 08-01): **36,094 lines, 374 generations**, grepped locally rather than through the Railway filter DSL.

**The answer is a decisive KEEP, opposite to the hypothesis.** `Found orphan closing tag` fired **6 times, every one `modelName="glm-4.5-air"`** — not the Kimi K2.5 the docstring credited — with extracted bodies of 1256–2098 chars. **Three were followed by healthy visible output** (2016 / 1452 / 400 chars): the model reasoned, emitted a bare `</think>`, then answered, and the extractor correctly separated them. Deleting the path would have put 1.2–2.1 KB of raw reasoning in front of those replies.

That reframes the whole batch: `isInsideCodeSpan` is **load-bearing on a live path**, not defensive scaffolding — which is what promotes TASK-377 from "low priority, not seen" to worth fixing now.

## What ships

**TASK-377 — `isInsideCodeSpan` models backtick runs.** Every backtick was an independent toggle, so a double-backtick span (Markdown's form for code *containing* a literal backtick) toggled twice and netted out to "not code". The failure direction is the dangerous one: an unrecognised span makes callers **extract**, which is the data loss the utility exists to prevent. Now a run of N backticks opens a span — fences (N≥3) span newlines and close on a run of ≥N, inline spans close on an exactly-equal run and die at a newline. The double-backtick case falls out of the rule instead of being special-cased.

**TASK-388 — one definition of "replace outside code markup".** `replaceOutsideCodeMarkup` moves to `codeSpanDetection.ts` and is adopted at `thinkingExtraction`'s three positional replacer sites, which indexed the offset by argument **position** — correct only for today's patterns, since an added capture group shifts it rightward with no type error. The shared helper finds it by **type**, which no group can break. One optional `offsetWithinMatch` callback covers the chimera pattern, whose match starts at the preceding newline (outside the span its tag lives in), so gating on the match start never fires.

**Docstring correction + instrumentation.** `extractOrphanClosingTag` now names glm-4.5-air and the measurement, and records the consequence: because the path must stay, its unfenced-quote ambiguity is a **permanent** known limit. One `logger.info` added when the chimera-stutter pass actually strips — it ran silently, so TASK-375's other half had no evidence to answer it.

## Verification

- **All 27 new table rows verified RED** against the unfixed gate before being believed — TASK-373's own rule, since a quoted-syntax table looks like coverage whether or not the site was exposed. The third `quotingShapes` entry drives off `KNOWN_THINKING_TAGS`, so every future tag inherits it.
- Two of the new `codeSpanDetection` rows **passed pre-change** and are labelled as pinning existing behaviour rather than the gate — one of them previously passed only by parity accident, and now pins the rule.
- `pnpm test` (26 packages) and `pnpm quality` both green locally, run sequentially.
- `common-types` is not in `MUTATED_PACKAGES`, so moving code into it carries no mutation-ratchet drop — checked, not assumed.
- `responseArtifacts.ts` drops 385 → 356 against its 400 ceiling, from the extraction rather than from trimming comments.

No migration, no schema change. The only behaviour change is that **more** quoted syntax survives.

## Backlog

TASK-377 and TASK-388 → Done. TASK-375 keeps its chimera half, now gated on the new log line with the grep to run recorded. TASK-373 keeps the `<action>` handler. **TASK-376 deliberately not closed** — its log shipped in beta.189 and has hours of prod exposure, so its 0 occurrences prove nothing yet.

New: **TASK-391** — glm-4.5-air can produce empty visible content and force a full retry (2 of 374, one measured at 41s before the retry, 2 of 3 also tripping `DuplicateDetection` at similarity 0.996). Filed with a verify-before-building note, since 2 events is a thin base rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)