### PR TITLE
fix(embeddings): make silent input-window truncation observable

### DIFF
--- a/packages/embeddings/src/LocalEmbeddingService.test.ts
+++ b/packages/embeddings/src/LocalEmbeddingService.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Worker } from 'node:worker_threads';
 import {
   LocalEmbeddingService,
   LOCAL_EMBEDDING_DIMENSIONS,
@@ -18,6 +19,22 @@ import {
 vi.mock('node:worker_threads', () => ({
   Worker: vi.fn(),
 }));
+
+const warnSpy = vi.fn();
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: (...args: unknown[]) => warnSpy(...args),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('LocalEmbeddingService', () => {
   describe('constants', () => {
@@ -208,6 +225,95 @@ describe('LocalEmbeddingService', () => {
     it('should return 384 dimensions', () => {
       const service = new LocalEmbeddingService();
       expect(service.getDimensions()).toBe(384);
+    });
+  });
+
+  describe('overflow warn wiring', () => {
+    // A WIRING test, per 02-code-standards rule 7: it runs the real chain
+    // (getEmbedding -> sendMessage -> describeInputOverflow -> logger.warn) and
+    // mocks only the external boundary, the worker thread. The pieces are each
+    // unit-tested elsewhere, which is exactly why this is needed — every one of
+    // those suites mocks the seam it would have to cross, so a slip like
+    // `warnOnTruncatedInput(text, undefined)` would leave them all green while
+    // silently killing every overflow warning this PR exists to produce.
+
+    /**
+     * A fake worker thread that replies to health and embed with a fixed count.
+     *
+     * Must be a `function` expression, not an arrow: the service calls
+     * `new Worker(path)`, and an arrow function is not a constructor — vitest
+     * reports it as "did not use 'function' or 'class' in its implementation"
+     * and `initialize()` fails with a TypeError swallowed by its catch.
+     */
+    function installFakeWorker(inputTokens: number | undefined): void {
+      vi.mocked(Worker).mockImplementation(function () {
+        const handlers: ((msg: unknown) => void)[] = [];
+        const emit = (msg: unknown): void => {
+          for (const handler of handlers) {
+            handler(msg);
+          }
+        };
+
+        // The 'ready' signal must land after initialize() has awaited into
+        // waitForReady and registered its handler; a macrotask guarantees that.
+        setTimeout(() => emit({ id: 0, status: 'ready', modelSource: 'local' }), 0);
+
+        return {
+          on: (event: string, handler: (msg: unknown) => void) => {
+            if (event === 'message') {
+              handlers.push(handler);
+            }
+          },
+          off: () => undefined,
+          postMessage: (msg: { id: number; type: string }) => {
+            const reply =
+              msg.type === 'health'
+                ? { id: msg.id, status: 'success', modelLoaded: true }
+                : {
+                    id: msg.id,
+                    status: 'success',
+                    vector: new Array(LOCAL_EMBEDDING_DIMENSIONS).fill(0.1),
+                    inputTokens,
+                  };
+            setTimeout(() => emit(reply), 0);
+          },
+          terminate: () => Promise.resolve(0),
+        } as unknown as Worker;
+      });
+    }
+
+    async function embedWithReportedTokens(
+      inputTokens: number | undefined
+    ): Promise<Float32Array | undefined> {
+      installFakeWorker(inputTokens);
+      const service = new LocalEmbeddingService();
+      expect(await service.initialize()).toBe(true);
+      warnSpy.mockClear();
+      return service.getEmbedding('some text the model only partly read');
+    }
+
+    it('warns with the discarded count when the worker reports overflow', async () => {
+      const vector = await embedWithReportedTokens(2093);
+
+      expect(vector).toHaveLength(LOCAL_EMBEDDING_DIMENSIONS);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatchObject({
+        inputTokens: 2093,
+        maxInputTokens: 512,
+        discardedTokens: 1581,
+      });
+    });
+
+    it('stays silent when the input fits the window', async () => {
+      await embedWithReportedTokens(120);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when the worker could not count', async () => {
+      await embedWithReportedTokens(undefined);
+
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/embeddings/src/LocalEmbeddingService.ts
+++ b/packages/embeddings/src/LocalEmbeddingService.ts
@@ -35,6 +35,7 @@ import {
   WORKER_TIMEOUT_MS,
   WORKER_INIT_TIMEOUT_MS,
 } from './constants.js';
+import { describeInputOverflow } from './inputWindow.js';
 
 const logger = createLogger('LocalEmbeddingService');
 
@@ -207,6 +208,7 @@ export class LocalEmbeddingService implements IEmbeddingService {
       const response = await this.sendMessage({ type: 'embed', text });
 
       if (response.status === 'success' && response.vector) {
+        this.warnOnTruncatedInput(text, response.inputTokens);
         return new Float32Array(response.vector);
       }
 
@@ -216,6 +218,24 @@ export class LocalEmbeddingService implements IEmbeddingService {
       logger.error({ err: error }, '[LocalEmbeddingService] Failed to get embedding');
       return undefined;
     }
+  }
+
+  /**
+   * Report an input the model could only read part of.
+   *
+   * Logged at `warn` because the caller asked for work that did not happen: the
+   * discarded text contributed nothing to the vector, so any downstream claim
+   * that "X was included in the query" is false past this point.
+   */
+  private warnOnTruncatedInput(text: string, inputTokens: number | undefined): void {
+    const overflow = describeInputOverflow(text, inputTokens);
+    if (overflow === undefined) {
+      return;
+    }
+    logger.warn(
+      overflow,
+      '[LocalEmbeddingService] Input exceeded the model window — the tail was discarded before embedding'
+    );
   }
 
   /**

--- a/packages/embeddings/src/constants.ts
+++ b/packages/embeddings/src/constants.ts
@@ -28,6 +28,27 @@ export const SEMANTIC_SIMILARITY_THRESHOLD = 0.88;
 export const EMBEDDING_SLIDING_WINDOW_SIZE = 10;
 
 /**
+ * Maximum input length the model can actually read, in ITS tokens.
+ *
+ * From the vendored model's own config: `tokenizer_config.json` declares
+ * `model_max_length: 512` and `config.json` declares
+ * `max_position_embeddings: 512`.
+ *
+ * **Anything past this is discarded, silently.** transformers.js hardcodes
+ * `truncation: true` in `FeatureExtractionPipeline._call`, so an over-long
+ * input does not error, does not warn, and does not return a partial result —
+ * it returns a perfectly valid-looking vector computed from the first 512
+ * tokens only. A caller that concatenates its way past the limit therefore
+ * embeds a prefix while believing it embedded the whole thing.
+ *
+ * Counted with the model's own WordPiece tokenizer, which is not tiktoken:
+ * do not budget against a GPT tokenizer's count and expect it to line up.
+ * `LocalEmbeddingService` reports the real count per call so callers can see
+ * overflow rather than infer it.
+ */
+export const EMBEDDING_MAX_INPUT_TOKENS = 512;
+
+/**
  * Timeout for embedding requests to the worker (ms).
  */
 export const WORKER_TIMEOUT_MS = 30_000;

--- a/packages/embeddings/src/embeddingWorker.test.ts
+++ b/packages/embeddings/src/embeddingWorker.test.ts
@@ -106,6 +106,80 @@ describe('embeddingWorker', () => {
       expect(postedMessages[0].vector).toHaveLength(384);
     });
 
+    describe('inputTokens (pre-truncation count)', () => {
+      // These assert ACROSS the mocked pipeline seam. The whole point of
+      // `inputTokens` is to make silent truncation visible, and it reads a real
+      // transformers.js Tensor shape — so if that shape ever moves, every
+      // overflow warning degrades to "unknown" with no other symptom. Mocking
+      // the extractor without a `.tokenizer` (as the other tests here do) takes
+      // the early-return path and proves nothing about the parsing.
+
+      /** Drive one embed through the worker and return the posted response. */
+      async function embedWith(
+        tokenizer: unknown
+      ): Promise<WorkerResponse & { inputTokens?: number }> {
+        const mockExtractor = Object.assign(
+          vi.fn().mockResolvedValue({ data: new Float32Array(384).fill(0.1) }),
+          tokenizer === undefined ? {} : { tokenizer }
+        );
+        mockPipeline.mockResolvedValue(mockExtractor);
+
+        await loadWorker();
+        const handler = getMessageHandler();
+
+        postedMessages.length = 0;
+        await handler({ type: 'health', id: 1 });
+        await vi.waitFor(() => expect(postedMessages.length).toBe(1));
+
+        postedMessages.length = 0;
+        await handler({ type: 'embed', text: 'Hello world', id: 2 });
+        await vi.waitFor(() => expect(postedMessages.length).toBe(1));
+
+        return postedMessages[0];
+      }
+
+      it('reports the sequence length from the tensor dims', async () => {
+        // The real shape, confirmed against the vendored model: an over-long
+        // input tokenizes to [1, 602] here while only 512 get embedded.
+        const response = await embedWith(() => ({ input_ids: { dims: [1, 602] } }));
+
+        expect(response.status).toBe('success');
+        expect(response.inputTokens).toBe(602);
+      });
+
+      it('falls back to size when dims is absent', async () => {
+        const response = await embedWith(() => ({ input_ids: { size: 47 } }));
+
+        expect(response.inputTokens).toBe(47);
+      });
+
+      it('degrades to undefined when the tokenizer throws, without failing the embed', async () => {
+        const response = await embedWith(() => {
+          throw new Error('tokenizer exploded');
+        });
+
+        // The invariant that matters: a broken diagnostic must never cost an
+        // embedding. Losing the count is acceptable; losing the vector is not.
+        expect(response.status).toBe('success');
+        expect(response.vector).toHaveLength(384);
+        expect(response.inputTokens).toBeUndefined();
+      });
+
+      it('degrades to undefined when the shape is unrecognised', async () => {
+        const response = await embedWith(() => ({ input_ids: { somethingElse: 1 } }));
+
+        expect(response.status).toBe('success');
+        expect(response.inputTokens).toBeUndefined();
+      });
+
+      it('degrades to undefined when the pipeline exposes no tokenizer', async () => {
+        const response = await embedWith(undefined);
+
+        expect(response.status).toBe('success');
+        expect(response.inputTokens).toBeUndefined();
+      });
+    });
+
     it('should return error when no text provided', async () => {
       await loadWorker();
       const handler = getMessageHandler();

--- a/packages/embeddings/src/embeddingWorker.ts
+++ b/packages/embeddings/src/embeddingWorker.ts
@@ -108,11 +108,70 @@ async function getExtractor(): Promise<FeatureExtractionPipeline> {
 }
 
 /**
+ * Count the input in the model's own tokens, BEFORE truncation.
+ *
+ * Calling the tokenizer bare (no `truncation` option) is what makes this the
+ * pre-truncation length: the pipeline passes `truncation: true` internally and
+ * so can only ever report the clamped value. Verified against the vendored
+ * model — a deliberately over-long input returns dims `[1, 602]` here while the
+ * pipeline embeds 512 of them.
+ *
+ * Returns `undefined` rather than throwing on any unexpected shape. This number
+ * exists to make a silent problem visible; it must never become a way for
+ * embedding itself to fail, so every access is guarded and a surprise degrades
+ * to "unknown" instead of taking the call down with it.
+ *
+ * ## Cost of the second tokenization, measured
+ *
+ * This does tokenize the input twice — once here, once inside the pipeline's
+ * own truncated call — on EVERY embed, not only overflowing ones. Benchmarked
+ * against the vendored q8 model rather than assumed:
+ *
+ * | input            | tokenize | full embed | overhead |
+ * | ---------------- | -------- | ---------- | -------- |
+ * | short (~10 tok)  | 0.114 ms | 6.90 ms    | 1.65%    |
+ * | long (>512 tok)  | 1.565 ms | 171.80 ms  | 0.91%    |
+ *
+ * The share FALLS as input grows, because the transformer forward pass scales
+ * worse than a linear tokenizer scan — so the longer-content call sites
+ * (FactStore, PgvectorMemoryAdapter) are the ones where it matters least. No
+ * reason to optimise this away; re-measure only if the model or dtype changes.
+ */
+function countInputTokens(embeddingPipeline: unknown, text: string): number | undefined {
+  try {
+    const tokenizer = (embeddingPipeline as { tokenizer?: (input: string) => unknown }).tokenizer;
+    if (typeof tokenizer !== 'function') {
+      return undefined;
+    }
+    const encoded = tokenizer(text) as { input_ids?: { dims?: number[]; size?: number } };
+    const dims = encoded.input_ids?.dims;
+    // Shape is [batch, sequence]; the sequence length is the last dimension.
+    const sequenceLength = Array.isArray(dims) ? dims[dims.length - 1] : undefined;
+    if (typeof sequenceLength === 'number') {
+      return sequenceLength;
+    }
+    return typeof encoded.input_ids?.size === 'number' ? encoded.input_ids.size : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Generate embedding for text
  * Returns normalized vector suitable for cosine similarity
  */
-async function generateEmbedding(text: string): Promise<number[]> {
+async function generateEmbedding(text: string): Promise<{
+  vector: number[];
+  inputTokens: number | undefined;
+}> {
   const embeddingPipeline = await getExtractor();
+
+  // Count with the model's OWN tokenizer before the pipeline runs. The pipeline
+  // tokenizes again internally with `truncation: true` and keeps no record of
+  // what it dropped, so this is the only place the pre-truncation length can be
+  // observed. It is the same tokenizer instance, so the count is exact rather
+  // than an estimate — and cheap next to the forward pass.
+  const inputTokens = countInputTokens(embeddingPipeline, text);
 
   // Generate embedding with mean pooling and normalization
   // pooling: 'mean' averages all token embeddings
@@ -133,7 +192,7 @@ async function generateEmbedding(text: string): Promise<number[]> {
     );
   }
 
-  return vector;
+  return { vector, inputTokens };
 }
 
 // ============================================================================
@@ -154,9 +213,10 @@ async function handleMessage(message: WorkerMessage): Promise<void> {
           break;
         }
 
-        const vector = await generateEmbedding(message.text);
+        const { vector, inputTokens } = await generateEmbedding(message.text);
         response.status = 'success';
         response.vector = vector;
+        response.inputTokens = inputTokens;
         break;
       }
 

--- a/packages/embeddings/src/index.ts
+++ b/packages/embeddings/src/index.ts
@@ -23,6 +23,10 @@
 export type { IEmbeddingService } from './types.js';
 
 // Constants
+// EMBEDDING_MAX_INPUT_TOKENS is deliberately NOT re-exported: it is the
+// package's own constraint, and consumers learn about overflow from the warn
+// LocalEmbeddingService emits rather than by budgeting against it themselves.
+// Export it when a caller actually needs to size an input against the window.
 export {
   LOCAL_EMBEDDING_DIMENSIONS,
   SEMANTIC_SIMILARITY_THRESHOLD,

--- a/packages/embeddings/src/inputWindow.test.ts
+++ b/packages/embeddings/src/inputWindow.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { EMBEDDING_MAX_INPUT_TOKENS } from './constants.js';
+import { describeInputOverflow } from './inputWindow.js';
+
+describe('EMBEDDING_MAX_INPUT_TOKENS', () => {
+  // The constant is a claim ABOUT the vendored model, so it is pinned to the
+  // model's own config rather than to a literal. Swapping in a model with a
+  // different window breaks this test instead of silently making every
+  // overflow warn wrong — which is the failure mode that hides a truncation
+  // bug rather than surfacing it.
+  const modelDir = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'models',
+    'Xenova',
+    'bge-small-en-v1.5'
+  );
+
+  it('matches the vendored tokenizer_config model_max_length', () => {
+    const config = JSON.parse(readFileSync(join(modelDir, 'tokenizer_config.json'), 'utf8')) as {
+      model_max_length: number;
+    };
+    expect(EMBEDDING_MAX_INPUT_TOKENS).toBe(config.model_max_length);
+  });
+
+  it('matches the vendored model max_position_embeddings', () => {
+    const config = JSON.parse(readFileSync(join(modelDir, 'config.json'), 'utf8')) as {
+      max_position_embeddings: number;
+    };
+    expect(EMBEDDING_MAX_INPUT_TOKENS).toBe(config.max_position_embeddings);
+  });
+});
+
+describe('describeInputOverflow', () => {
+  it('returns undefined when the input fits', () => {
+    expect(describeInputOverflow('short', 10)).toBeUndefined();
+  });
+
+  it('returns undefined exactly at the window', () => {
+    // Boundary matters: the model reads all 512, so nothing was discarded.
+    expect(describeInputOverflow('x'.repeat(2048), EMBEDDING_MAX_INPUT_TOKENS)).toBeUndefined();
+  });
+
+  it('reports one discarded token at one over the window', () => {
+    const overflow = describeInputOverflow('x'.repeat(2052), EMBEDDING_MAX_INPUT_TOKENS + 1);
+    expect(overflow?.discardedTokens).toBe(1);
+  });
+
+  it('returns undefined when the token count is unavailable', () => {
+    // Counting is a diagnostic and degrades to undefined; treating unknown as
+    // overflow would warn on every call the moment counting broke.
+    expect(describeInputOverflow('x'.repeat(100_000), undefined)).toBeUndefined();
+  });
+
+  it('describes a real over-long query the way prod would see it', () => {
+    // The measured prod case that motivated this: 8,462 chars / 2,093 tokens.
+    const overflow = describeInputOverflow('x'.repeat(8462), 2093);
+
+    expect(overflow).toEqual({
+      inputTokens: 2093,
+      maxInputTokens: 512,
+      discardedTokens: 1581,
+      discardedFraction: 0.755,
+      inputChars: 8462,
+      charsPerToken: 4.04,
+    });
+  });
+});

--- a/packages/embeddings/src/inputWindow.ts
+++ b/packages/embeddings/src/inputWindow.ts
@@ -1,0 +1,67 @@
+/**
+ * Input-window overflow reporting.
+ *
+ * The embedding pipeline truncates at {@link EMBEDDING_MAX_INPUT_TOKENS}
+ * without erroring or warning, so an over-long input produces a perfectly
+ * ordinary vector computed from a prefix. Nothing at the call site distinguishes
+ * that from a full embedding — which is how a memory-search query grew to four
+ * times the window and lost its referenced-message tail unnoticed.
+ *
+ * This module owns the decision "was anything discarded, and how much", kept
+ * separate from the service so it can be exercised directly rather than through
+ * a mocked worker exchange.
+ */
+
+import { EMBEDDING_MAX_INPUT_TOKENS } from './constants.js';
+
+/** Everything worth logging about an input the model could only partly read. */
+export interface InputOverflow {
+  /** Real model tokens in the input, counted before truncation. */
+  inputTokens: number;
+  /** The window the input was measured against. */
+  maxInputTokens: number;
+  /** Tokens the model never saw. */
+  discardedTokens: number;
+  /** Discarded share of the input, 0-1, rounded to 3dp. */
+  discardedFraction: number;
+  /** Input length in characters, for callers that budget in characters. */
+  inputChars: number;
+  /**
+   * Observed characters-per-token for THIS input, rounded to 2dp.
+   *
+   * Included because callers can only measure characters, and the ratio needed
+   * to convert is content-dependent — ordinary prose runs near 4, dense markup
+   * or unusual vocabulary lower. A caller sizing a budget should use a measured
+   * ratio from its own traffic rather than a guessed constant.
+   */
+  charsPerToken: number;
+}
+
+/**
+ * Describe how much of `text` the model discarded, or `undefined` when nothing
+ * was lost.
+ *
+ * `undefined` for `inputTokens` means the count was unavailable, not that the
+ * input fit — the worker degrades to `undefined` rather than failing an
+ * embedding over a diagnostic. Treating unknown as "no overflow" is the correct
+ * bias here: silence about a possible problem beats a warn that fires on every
+ * call because counting broke.
+ */
+export function describeInputOverflow(
+  text: string,
+  inputTokens: number | undefined
+): InputOverflow | undefined {
+  if (inputTokens === undefined || inputTokens <= EMBEDDING_MAX_INPUT_TOKENS) {
+    return undefined;
+  }
+
+  const discardedTokens = inputTokens - EMBEDDING_MAX_INPUT_TOKENS;
+  return {
+    inputTokens,
+    maxInputTokens: EMBEDDING_MAX_INPUT_TOKENS,
+    discardedTokens,
+    discardedFraction: Math.round((discardedTokens / inputTokens) * 1000) / 1000,
+    inputChars: text.length,
+    charsPerToken: Math.round((text.length / inputTokens) * 100) / 100,
+  };
+}

--- a/packages/embeddings/src/types.ts
+++ b/packages/embeddings/src/types.ts
@@ -69,6 +69,16 @@ export interface WorkerResponse {
   modelLoaded?: boolean;
   /** Set on the 'ready' message only — surfaced in the main thread's init log. */
   modelSource?: ModelSource;
+  /**
+   * Set on a successful 'embed' only: how many tokens the model's OWN tokenizer
+   * produced for the input, counted before truncation.
+   *
+   * Present so overflow is observable. The pipeline truncates silently at
+   * `EMBEDDING_MAX_INPUT_TOKENS` (constants.ts), so without this number a
+   * caller cannot distinguish "embedded all of it" from "embedded the first
+   * quarter of it" — both return an equally valid vector.
+   */
+  inputTokens?: number;
 }
 
 /**

--- a/services/ai-worker/src/services/prompt/SearchQueryBuilder.test.ts
+++ b/services/ai-worker/src/services/prompt/SearchQueryBuilder.test.ts
@@ -21,7 +21,7 @@ vi.mock('../RAGUtils.js', () => ({
   ),
 }));
 
-import { buildSearchQuery } from './SearchQueryBuilder.js';
+import { buildSearchQuery, describeParts, type QueryPart } from './SearchQueryBuilder.js';
 import type { ProcessedAttachment } from '../MultimodalProcessor.js';
 import { AttachmentType } from '@tzurot/common-types/constants/media';
 
@@ -87,6 +87,53 @@ describe('SearchQueryBuilder', () => {
       );
       const parts = result.split('\n\n');
       expect(parts.length).toBe(4);
+    });
+  });
+
+  describe('describeParts', () => {
+    // The offsets exist to make STARVATION legible — a part whose offset already
+    // exceeds the embedder window contributed nothing to the vector. An off-by-one
+    // here would misreport which part got starved, so the offsets are checked
+    // against the joined string itself rather than against expected numbers.
+    it('reports offsets that index back into the joined query', () => {
+      const parts: QueryPart[] = [
+        { name: 'userMessage', text: 'sapphic yearning' },
+        { name: 'attachmentDescriptions', text: 'This image depicts a gym.' },
+        { name: 'referencedMessages', text: 'Ref: the earlier thing' },
+      ];
+      const query = parts.map(p => p.text).join('\n\n');
+
+      for (const described of describeParts(parts)) {
+        const slice = query.slice(described.offset, described.offset + described.chars);
+        expect(slice).toBe(parts.find(p => p.name === described.name)?.text);
+      }
+    });
+
+    it('starts the first part at zero and counts the separator between parts', () => {
+      const described = describeParts([
+        { name: 'a', text: 'xxxx' },
+        { name: 'b', text: 'yy' },
+      ]);
+
+      expect(described).toEqual([
+        { name: 'a', chars: 4, offset: 0 },
+        // 4 chars + the 2-char '\n\n' separator
+        { name: 'b', chars: 2, offset: 6 },
+      ]);
+    });
+
+    it('places a starved part past the embedder window when an earlier part is long', () => {
+      // The prod shape: a long image description ahead of the references. The
+      // reference part's offset alone shows it never reached the model.
+      const described = describeParts([
+        { name: 'userMessage', text: 'short question' },
+        { name: 'attachmentDescriptions', text: 'x'.repeat(8000) },
+        { name: 'referencedMessages', text: 'the reference that never lands' },
+      ]);
+
+      const references = described[2];
+      // ~4 chars/token measured on real traffic, so 512 tokens is ~2k chars.
+      expect(references.offset).toBeGreaterThan(512 * 4);
     });
   });
 });

--- a/services/ai-worker/src/services/prompt/SearchQueryBuilder.ts
+++ b/services/ai-worker/src/services/prompt/SearchQueryBuilder.ts
@@ -11,6 +11,43 @@ import { extractContentDescriptions } from '../RAGUtils.js';
 
 const logger = createLogger('SearchQueryBuilder');
 
+/** Separator between assembled query parts. */
+const PART_SEPARATOR = '\n\n';
+
+/** One named contributor to the assembled query, in append order. */
+export interface QueryPart {
+  name: string;
+  text: string;
+}
+
+/**
+ * Per-part `{ name, chars, offset }` for the assembly log.
+ *
+ * `offset` is the part's start position in the joined query, and it is the
+ * field that matters: a part whose offset is already past the embedder's window
+ * contributed nothing, however many characters it has. Reported in characters
+ * because that is what this module can count — the model-token truth comes from
+ * `LocalEmbeddingService`'s overflow warn on the same request.
+ *
+ * **These offsets are CHARACTERS, not tokens — do not compare them directly to
+ * the 512-token window.** Converting needs a chars-per-token ratio that varies
+ * with content (measured near 4 on real prod prose, lower for dense markup), so
+ * a character offset only ever indicates that a part is *probably* starved. The
+ * overflow warn reports the observed ratio per request for exactly this reason.
+ *
+ * @internal Exported for testing
+ */
+export function describeParts(
+  parts: QueryPart[]
+): { name: string; chars: number; offset: number }[] {
+  let offset = 0;
+  return parts.map(part => {
+    const described = { name: part.name, chars: part.text.length, offset };
+    offset += part.text.length + PART_SEPARATOR.length;
+    return described;
+  });
+}
+
 /**
  * Build search query for memory retrieval.
  *
@@ -20,6 +57,30 @@ const logger = createLogger('SearchQueryBuilder');
  *
  * The recentHistoryWindow solves the "pronoun problem" where users say things like
  * "what do you think about that?" - without context, LTM search can't find relevant memories.
+ *
+ * ## This builder is UNBOUNDED, and the embedder is not
+ *
+ * The parts are concatenated with no cap, but the embedding model reads only
+ * `EMBEDDING_MAX_INPUT_TOKENS` (512) and discards the rest silently. Parts are
+ * appended in the order below, so **a long earlier part starves every later
+ * one**: measured on a real prod turn, a 1,700-char image description pushed the
+ * query to 2,093 tokens and the referenced-message text — appended last —
+ * contributed nothing at all.
+ *
+ * Two consequences worth knowing before changing anything here:
+ *
+ * - **Order is allocation.** Whatever comes first wins the window. That is not a
+ *   considered ranking; it is the order the parts happened to be written in.
+ * - **More text is not more signal.** The fold-aware A/B on mined goldens found
+ *   dilution actively harmful for content-rich queries — recall@10 fell 0.436 →
+ *   0.390 → 0.256 → 0.195 as the fold widened. That is why the recent-history
+ *   part is gated by `shouldFoldSearchQuery` (queryFoldGate.ts) and the others
+ *   are not (yet).
+ *
+ * Fixing the allocation therefore needs evidence, not just a budget: the
+ * goldens are text-only today, so no attachment-bearing turn has ever been
+ * scored. `LocalEmbeddingService` now warns on overflow, which is how the real
+ * rate becomes measurable.
  */
 export function buildSearchQuery(
   userMessage: string,
@@ -27,18 +88,17 @@ export function buildSearchQuery(
   referencedMessagesText?: string,
   recentHistoryWindow?: string
 ): string {
-  const parts: string[] = [];
+  const parts: QueryPart[] = [];
 
   // Add recent conversation history FIRST (provides context for ambiguous queries)
   // This helps resolve pronouns like "that", "it", "he" by embedding the recent topic
   if (recentHistoryWindow !== undefined && recentHistoryWindow.length > 0) {
-    parts.push(recentHistoryWindow);
-    logger.info({ chars: recentHistoryWindow.length }, 'Including recent history in memory search');
+    parts.push({ name: 'recentHistory', text: recentHistoryWindow });
   }
 
   // Add user message (if not just the "Hello" fallback)
   if (userMessage.trim().length > 0 && userMessage.trim() !== 'Hello') {
-    parts.push(userMessage);
+    parts.push({ name: 'userMessage', text: userMessage });
   }
 
   // Add attachment descriptions (voice transcriptions, image descriptions)
@@ -46,7 +106,7 @@ export function buildSearchQuery(
     const descriptions = extractContentDescriptions(processedAttachments);
 
     if (descriptions.length > 0) {
-      parts.push(descriptions);
+      parts.push({ name: 'attachmentDescriptions', text: descriptions });
 
       // Log when using voice transcription instead of "Hello"
       if (userMessage.trim() === 'Hello') {
@@ -57,8 +117,7 @@ export function buildSearchQuery(
 
   // Add referenced message content for semantic search
   if (referencedMessagesText !== undefined && referencedMessagesText.length > 0) {
-    parts.push(referencedMessagesText);
-    logger.info('Including referenced message content in memory search query');
+    parts.push({ name: 'referencedMessages', text: referencedMessagesText });
   }
 
   // If we have nothing, fall back to "Hello"
@@ -66,5 +125,20 @@ export function buildSearchQuery(
     return userMessage.trim().length > 0 ? userMessage : 'Hello';
   }
 
-  return parts.join('\n\n');
+  const query = parts.map(part => part.text).join(PART_SEPARATOR);
+
+  // Report what was ASSEMBLED and where each part starts, not what was
+  // "included" — a part appended past the embedder's window contributes
+  // nothing, and the previous per-part "Including referenced message content in
+  // memory search query" line asserted an inclusion it could not know had
+  // happened. Offsets make starvation legible: a part whose offset already
+  // exceeds the window never reached the model. The authoritative overflow
+  // signal is LocalEmbeddingService's warn, which counts real model tokens;
+  // this is the composition that produced it.
+  logger.info(
+    { totalChars: query.length, parts: describeParts(parts) },
+    'Assembled memory search query'
+  );
+
+  return query;
 }

--- a/tracker/tasks/task-394 - A-future-transformers.js-upgrade-could-silently-stop-the-embedding-overflow-warn.md
+++ b/tracker/tasks/task-394 - A-future-transformers.js-upgrade-could-silently-stop-the-embedding-overflow-warn.md
@@ -1,0 +1,35 @@
+---
+id: TASK-394
+title: >-
+  A future transformers.js upgrade could silently stop the embedding overflow
+  warn
+status: To Do
+assignee: []
+created_date: '2026-08-01 19:11'
+labels:
+  - 'size:S'
+  - 'area:embeddings'
+dependencies: []
+priority: low
+ordinal: 394000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Surfaced by #1893 review round 3 (non-blocking, explicitly not a change request).
+
+`countInputTokens` in `packages/embeddings/src/embeddingWorker.ts` calls `tokenizer(text)` synchronously and reads `encoded.input_ids.dims`. Verified correct against the vendored model today: an over-long input returns dims `[1, 602]`.
+
+**The risk**: if `@huggingface/transformers` ever makes the tokenizer async, `tokenizer(text)` returns a Promise, `input_ids` is `undefined`, and the function degrades to `undefined` — which is the SAFE direction (no crash, embedding unaffected) but means the overflow warn silently stops firing with nothing surfaced.
+
+**Why no test was added instead.** A test that mocks an async tokenizer would assert it degrades to `undefined` — which is the current behaviour AND the broken behaviour. It would pass either way, so it is vacuous coverage rather than a regression net. Adding one would look like protection while providing none, which is the exact trap two other findings on this same PR were about.
+
+**Why no defensive code either.** Detecting a thenable and reporting it distinctly is speculative hardening for a library change that has not happened, and the whole counting path is deliberately fail-soft.
+
+**Fix shape when the trigger fires**: at the next `@huggingface/transformers` MAJOR upgrade, re-run the tokenizer shape probe (call `p.tokenizer(text)` on a deliberately over-long input and confirm `input_ids.dims` is still `[1, N]` with N past 512). If it went async, await it. The probe takes about a minute.
+
+**Promote when**: a `@huggingface/transformers` major version bump lands (Dependabot will PR it), OR prod stops emitting `Input exceeded the model window` entirely despite long queries still being assembled.
+
+**Cost of missing it**: the warn goes quiet, which reads as "no overflow" — the same silence this PR existed to remove. Low severity while nothing upgrades; the whole point is that the trigger is external and dated.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
Partial fix for **TASK-393**. Ships the measurement; deliberately does not change the allocation policy (reasoning below).

## The problem

`bge-small-en-v1.5` reads **512 tokens**, and transformers.js hardcodes `truncation: true` in `FeatureExtractionPipeline._call`. So an over-long input doesn't error, doesn't warn, and doesn't return a partial result — it returns a perfectly ordinary vector computed from a prefix. Nothing at any call site can tell the difference.

Measured on a prod turn (req `456ec221`): the memory-search query was **2,093 tokens**, so **1,581 — 75.5% — were discarded before embedding**. What survived was the user's ~40 chars of text and then a 1,700-char image description. `referencedMessagesText`, appended last, reached the model *not at all* — while `SearchQueryBuilder` logged `Including referenced message content in memory search query` on every one of those requests.

Corroborating symptom in the same capture: all 20 retrieved memories scored inside a **0.028 band** (0.635–0.663), which is what a diluted query vector looks like.

## What ships

- **`EMBEDDING_MAX_INPUT_TOKENS` names the constraint** — which existed nowhere in our code. It's pinned by test to the vendored model's own `tokenizer_config.json` / `config.json` rather than to a literal, so swapping models breaks the test instead of silently invalidating every warn.
- **The worker counts with the model's own tokenizer, before the pipeline runs.** Calling the tokenizer *bare* is what makes it the pre-truncation length — the pipeline passes `truncation: true` internally and can only ever report the clamped value. Verified against the vendored model: an over-long input returns dims `[1, 602]` there while 512 get embedded. Counting is guarded end-to-end and degrades to `undefined`; a diagnostic must never take an embedding down with it.
- **`LocalEmbeddingService` warns on overflow** with the discarded count and the *observed* chars-per-token, because callers can only budget in characters and the ratio is content-dependent.
- **`SearchQueryBuilder` stops claiming inclusion it can't verify.** It now reports the assembled composition with each part's offset — which is what makes starvation legible: a part whose offset already exceeds the window never reached the model.

## What deliberately does NOT ship

Changing *which* text wins the window. The fold-aware A/B on mined goldens (`reports/goldens-mining/fold-ab-result.md`) found dilution actively harmful for content-rich queries — recall@10 fell **0.436 → 0.390 → 0.256 → 0.195** as the fold widened. So "give every part a share of 512" is not obviously an improvement; it could easily make retrieval worse.

And it can't be settled here: **the goldens are text-only** — zero attachment-bearing turns, so no query of this shape has ever been scored. Guessing on exactly the axis where the project already has hard data that guessing loses would be the wrong call. The allocation policy needs mined attachment goldens first; this PR is what makes the real overflow rate measurable in the meantime.

## Verification

`pnpm test` (26 packages) and `pnpm quality` both green locally, sequentially. Knip caught a speculative export of the new constant from the package entry point (no external consumer) — removed rather than kept, with a comment saying when to add it back.

New tests: 7 in `inputWindow.test.ts` (including the two model-config parity pins and the real prod 8,462-char/2,093-token case), 3 in `SearchQueryBuilder.test.ts` for the offset arithmetic — one of which asserts the offsets index back into the joined string rather than matching hardcoded numbers.

No migration, no schema change, no behaviour change to what gets embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)