### PR TITLE
feat(bot-client): describe stickers on referenced and forwarded messages

### DIFF
--- a/packages/common-types/src/services/stickerVisionGate.test.ts
+++ b/packages/common-types/src/services/stickerVisionGate.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetSystemSetting = vi.fn();
+vi.mock('./SystemSettingsService.js', () => ({
+  getSystemSetting: (key: string) => mockGetSystemSetting(key) as unknown,
+}));
+
+const { keepStickersIf, filterStickersBySetting } = await import('./stickerVisionGate.js');
+
+/**
+ * `isSticker` is declared but left ABSENT on `image` — the state ordinary
+ * attachments actually arrive in, and the one the gate must not read as true.
+ * Declaring it is required rather than cosmetic: `StickerFlagged` has only
+ * optional members, so TypeScript's weak-type check rejects an object literal
+ * sharing no properties with it.
+ */
+type Attachmentish = { url: string; isSticker?: boolean };
+
+const sticker: Attachmentish = { url: 'https://cdn/s.png', isSticker: true };
+const image: Attachmentish = { url: 'https://cdn/i.png' };
+
+describe('keepStickersIf', () => {
+  it('keeps everything when enabled', () => {
+    expect(keepStickersIf(true, [sticker, image])).toEqual([sticker, image]);
+  });
+
+  it('drops only stickers when disabled', () => {
+    expect(keepStickersIf(false, [sticker, image])).toEqual([image]);
+  });
+
+  it('leaves a non-sticker list untouched when disabled', () => {
+    // `isSticker` is absent on ordinary attachments, and absent must not read
+    // as true — the switch governs stickers, not attachments in general.
+    expect(keepStickersIf(false, [image])).toEqual([image]);
+  });
+
+  it('takes `enabled` rather than reading the setting, so one request reads it once', () => {
+    // Two lists, one decision. Reading a live setting per list could in
+    // principle disagree mid-request and produce a message whose trigger
+    // stickers were dropped while its reference stickers were not.
+    mockGetSystemSetting.mockClear();
+    keepStickersIf(false, [sticker]);
+    keepStickersIf(false, [sticker]);
+    expect(mockGetSystemSetting).not.toHaveBeenCalled();
+  });
+});
+
+describe('filterStickersBySetting', () => {
+  it('drops stickers when the switch is off', () => {
+    mockGetSystemSetting.mockReturnValue(false);
+    expect(filterStickersBySetting([sticker, image])).toEqual([image]);
+    expect(mockGetSystemSetting).toHaveBeenCalledWith('stickerVisionEnabled');
+  });
+
+  it('keeps stickers when the switch is on', () => {
+    mockGetSystemSetting.mockReturnValue(true);
+    expect(filterStickersBySetting([sticker, image])).toEqual([sticker, image]);
+  });
+});

--- a/packages/common-types/src/services/stickerVisionGate.ts
+++ b/packages/common-types/src/services/stickerVisionGate.ts
@@ -1,0 +1,83 @@
+/**
+ * The `stickerVisionEnabled` kill switch, in one place.
+ *
+ * Sticker vision is admin-switchable because it is unconditional spend: every
+ * sticker that reaches the vision chain costs a call. bot-client cannot make
+ * that decision — it has no reader for system settings and always sends
+ * stickers — so the switch has to bite server-side.
+ *
+ * ## Where the spend actually happens (the thing that is easy to get wrong)
+ *
+ * It is NOT in ai-worker's generation pipeline. **api-gateway queues the vision
+ * work first**: `createJobChain` -> `categorizeAttachments` buckets anything
+ * `image/*` — including sticker-derived synthetic attachments — into
+ * `ImageDescription` CHILD jobs, and BullMQ runs those to completion before the
+ * parent generation job starts.
+ *
+ * So a filter placed anywhere in the generation pipeline is not a kill switch:
+ * the call has already been billed, and filtering merely discards the paid-for
+ * description. That is the exact failure this module exists to prevent — a
+ * switch that covers some of the spend is worse than none, because it reads as
+ * off while still billing.
+ *
+ * ## The gates
+ *
+ * 1. **`jobChainOrchestrator` (api-gateway)** — THE one that stops spend, for
+ *    both the trigger message and every referenced/quoted/forwarded one, by
+ *    filtering before the dependency jobs are built.
+ * 2. `DownloadAttachmentsStep` (ai-worker) — trigger + extended context.
+ * 3. `AttachmentProcessor.processAttachmentsParallel` (ai-worker) — references.
+ *
+ * 2 and 3 are NOT redundant with 1: they keep a sticker out of the rendered
+ * prompt on paths that do not go through the job chain at all (a job replayed
+ * from a payload built before the switch flipped, a description already cached
+ * from an earlier turn). They govern what the model SEES; gate 1 governs what
+ * gets BOUGHT.
+ *
+ * **Gates, not callers.** Several places hand attachments to vision —
+ * `ConversationInputProcessor`, `DependencyStep`, `extendedContextVisionProcessor`
+ * — but each reads a list an earlier gate already filtered. Before adding a
+ * gate, check whether the list is already filtered upstream; before adding a
+ * vision CALLER, check whether its list is.
+ *
+ * **Known ungated path**: `ragVisionAuth.enrichRagHistory` re-describes
+ * attachments already stored in conversation history (heal-on-read). Whether it
+ * should be gated is a genuinely separate question — that spend re-derives a
+ * description already paid for once rather than describing a newly-arrived
+ * sticker — so it is tracked rather than silently included here.
+ *
+ * This list is the current state, not a proof of exhaustiveness. Re-derive it
+ * when a render path is added, and derive it from where JOBS are created, not
+ * from where descriptions are consumed.
+ *
+ * Dropping a sticker costs the message nothing. The `[Stickers: …]` line
+ * bot-client renders into the content names every sticker regardless, so the
+ * character still knows one arrived and what it was called — it just does not
+ * get told what the image depicts.
+ */
+
+import { getSystemSetting } from './SystemSettingsService.js';
+
+/** The slice of an attachment this gate reads. */
+interface StickerFlagged {
+  isSticker?: boolean;
+}
+
+/**
+ * Drop sticker attachments when the kill switch is off.
+ *
+ * Takes `enabled` rather than reading the setting itself so a caller that
+ * filters several lists reads the switch ONCE — two reads of a live setting
+ * could in principle disagree mid-request, and a message whose trigger stickers
+ * were dropped but whose reference stickers were not would be incoherent.
+ */
+export function keepStickersIf<T extends StickerFlagged>(enabled: boolean, attachments: T[]): T[] {
+  return enabled ? attachments : attachments.filter(a => a.isSticker !== true);
+}
+
+/**
+ * Read the switch and apply it in one step, for callers with a single list.
+ */
+export function filterStickersBySetting<T extends StickerFlagged>(attachments: T[]): T[] {
+  return keepStickersIf(getSystemSetting('stickerVisionEnabled'), attachments);
+}

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DownloadAttachmentsStep.ts
@@ -34,6 +34,7 @@
  */
 
 import { getSystemSetting } from '@tzurot/common-types/services/SystemSettingsService';
+import { keepStickersIf } from '@tzurot/common-types/services/stickerVisionGate';
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { IPipelineStep, GenerationContext } from '../types.js';
@@ -84,17 +85,6 @@ function hasMessageText(message: string | object | undefined): boolean {
   //   - anything else                → reaches this `return false` and is
   //                                    treated as text-empty (fail closed).
   return false;
-}
-
-/**
- * Drop sticker-sourced attachments when sticker vision is switched off.
- *
- * Filtering here rather than at the describe call is what makes "off" actually
- * free: a dropped sticker is never downloaded, never resized, and never counted
- * against the job's aggregate payload cap.
- */
-function keepStickersIf(enabled: boolean, attachments: AttachmentMetadata[]): AttachmentMetadata[] {
-  return enabled ? attachments : attachments.filter(a => a.isSticker !== true);
 }
 
 export class DownloadAttachmentsStep implements IPipelineStep {

--- a/services/ai-worker/src/services/AttachmentProcessor.test.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.test.ts
@@ -12,9 +12,16 @@ import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/perso
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
-const { mockDescribeImage, mockTranscribeAudio } = vi.hoisted(() => ({
+const { mockDescribeImage, mockTranscribeAudio, mockGetSystemSetting } = vi.hoisted(() => ({
   mockDescribeImage: vi.fn(),
   mockTranscribeAudio: vi.fn(),
+  // Defaults to the registry default (sticker vision ON) so every pre-existing
+  // case behaves exactly as before; only the kill-switch case flips it.
+  mockGetSystemSetting: vi.fn(() => true),
+}));
+
+vi.mock('@tzurot/common-types/services/SystemSettingsService', () => ({
+  getSystemSetting: mockGetSystemSetting,
 }));
 
 // Mock the MultimodalProcessor module
@@ -52,6 +59,69 @@ describe('AttachmentProcessor', () => {
   });
 
   describe('processAttachmentsParallel', () => {
+    it('does not spend a vision call on a sticker when the kill switch is off', async () => {
+      // The reference/quoted/forwarded path reaches vision through here, NOT
+      // through DownloadAttachmentsStep — so the switch has to bite here too.
+      // Without this, turning sticker vision OFF still bills for every sticker
+      // in a reply's quoted message: a switch that reads as off while spending.
+      // `Once`, not a persistent return: `vi.clearAllMocks()` in beforeEach
+      // clears call history but NOT a configured mockReturnValue, so the plain
+      // form leaks "switch off" into every later test in the file. Harmless
+      // today (nothing below uses a sticker) and a trap tomorrow — the next
+      // sticker test added anywhere after this would silently inherit it and
+      // fail for a reason unrelated to its own change.
+      // One call per processAttachmentsParallel, so Once is exactly the scope.
+      mockGetSystemSetting.mockReturnValueOnce(false);
+
+      const result = await processAttachmentsParallel({
+        attachments: [
+          { url: 'https://cdn/sticker.png', contentType: 'image/png', isSticker: true },
+        ],
+        referenceNumber: 1,
+        personality: mockPersonality,
+        isGuestMode: false,
+      } as never);
+
+      expect(mockDescribeImage).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('still describes a NON-sticker image when the sticker switch is off', async () => {
+      // The switch governs stickers only; an ordinary quoted image is untouched.
+      // `Once`, not a persistent return: `vi.clearAllMocks()` in beforeEach
+      // clears call history but NOT a configured mockReturnValue, so the plain
+      // form leaks "switch off" into every later test in the file. Harmless
+      // today (nothing below uses a sticker) and a trap tomorrow — the next
+      // sticker test added anywhere after this would silently inherit it and
+      // fail for a reason unrelated to its own change.
+      // One call per processAttachmentsParallel, so Once is exactly the scope.
+      mockGetSystemSetting.mockReturnValueOnce(false);
+      mockDescribeImage.mockResolvedValue('a photo of a dog');
+
+      await processAttachmentsParallel({
+        attachments: [{ url: 'https://cdn/photo.png', contentType: 'image/png' }],
+        referenceNumber: 1,
+        personality: mockPersonality,
+        isGuestMode: false,
+      } as never);
+
+      expect(mockDescribeImage).toHaveBeenCalled();
+    });
+
+    it('CANARY: a later test still sees sticker vision ON (leak check)', async () => {
+      // Placed AFTER the two kill-switch cases in file order. If either leaked
+      // its `false` return, this sticker would be filtered and describeImage
+      // would never fire.
+      mockDescribeImage.mockResolvedValue('a sticker of a cat');
+      await processAttachmentsParallel({
+        attachments: [{ url: 'https://cdn/s.png', contentType: 'image/png', isSticker: true }],
+        referenceNumber: 1,
+        personality: mockPersonality,
+        isGuestMode: false,
+      } as never);
+      expect(mockDescribeImage).toHaveBeenCalled();
+    });
+
     it('should return empty array for empty attachments', async () => {
       const result = await processAttachmentsParallel({
         attachments: [],

--- a/services/ai-worker/src/services/AttachmentProcessor.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.ts
@@ -20,6 +20,7 @@ import {
   type RenderableAttachment,
 } from './prompt/QuoteFormatter.js';
 import { withRetry } from '../utils/retry.js';
+import { filterStickersBySetting } from '@tzurot/common-types/services/stickerVisionGate';
 
 const logger = createLogger('AttachmentProcessor');
 
@@ -92,9 +93,13 @@ export interface ProcessAttachmentsOptions {
 /**
  * Process all attachments in parallel.
  *
- * Uses Promise.allSettled to process images and voice messages concurrently,
- * significantly reducing latency when multiple attachments are present.
+ * Images and voice messages are processed concurrently, which materially cuts
+ * latency when a reference carries several. Each is caught individually so one
+ * failure degrades to an unprocessed placeholder rather than losing the batch.
  * If preprocessed attachments are provided, uses them instead of making API calls.
+ *
+ * Stickers are subject to the `stickerVisionEnabled` kill switch here — this is
+ * the reference/quoted/forwarded path, distinct from `DownloadAttachmentsStep`.
  */
 export async function processAttachmentsParallel(
   options: ProcessAttachmentsOptions
@@ -115,38 +120,68 @@ export async function processAttachmentsParallel(
     return [];
   }
 
-  const processingPromises = attachments.map(attachment =>
-    processSingleAttachment({
-      attachment,
-      referenceNumber,
-      personality,
-      isGuestMode,
-      preprocessedAttachments,
-      userApiKey,
-      sttDispatch,
-      loggingContext,
-      visionProvider,
-      model,
+  // Referenced, quoted and forwarded messages reach vision through here — a
+  // separate path from DownloadAttachmentsStep, so the sticker kill switch has
+  // to bite here too. Without it, switching sticker vision OFF still bills for
+  // every sticker in a reply's quoted message: a switch that reads as off while
+  // spending. Applied before the fan-out so a dropped sticker costs no call at
+  // all, not a call whose result is discarded.
+  const visionable = filterStickersBySetting(attachments);
+  if (visionable.length === 0) {
+    return [];
+  }
+
+  // Each outcome CARRIES its attachment rather than being matched back by
+  // index. Two arrays walked in parallel is the shape that just broke: adding
+  // the sticker gate made `results` 1:1 with the FILTERED list while the
+  // failure path still indexed the unfiltered one, so a dropped sticker ahead
+  // of a failure misidentified it — and could resurface the very sticker the
+  // kill switch removed. The branch is near-unreachable (both modality helpers
+  // catch internally; only the pre-dispatch classify is unguarded), which is
+  // precisely why it went unnoticed and why the fix is structural rather than a
+  // corrected subscript.
+  type Attachment = ProcessSingleAttachmentOptions['attachment'];
+  type Outcome =
+    { ok: true; built: BuiltAttachment } | { ok: false; attachment: Attachment; error: unknown };
+
+  const outcomes: Outcome[] = await Promise.all(
+    visionable.map(async (attachment): Promise<Outcome> => {
+      try {
+        return {
+          ok: true,
+          built: await processSingleAttachment({
+            attachment,
+            referenceNumber,
+            personality,
+            isGuestMode,
+            preprocessedAttachments,
+            userApiKey,
+            sttDispatch,
+            loggingContext,
+            visionProvider,
+            model,
+          }),
+        };
+      } catch (error) {
+        return { ok: false, attachment, error };
+      }
     })
   );
 
-  const results = await Promise.allSettled(processingPromises);
-
   const rendered: BuiltAttachment[] = [];
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i];
-    if (result.status === 'fulfilled') {
-      rendered.push(result.value);
-    } else {
-      logger.error(
-        { err: result.reason, index: i, referenceNumber },
-        'Unexpected error in attachment processing'
-      );
-      const attachment = attachments[i];
-      if (attachment !== undefined) {
-        rendered.push({ url: attachment.url, attachment: unprocessedAttachment(attachment) });
-      }
+  for (const outcome of outcomes) {
+    if (outcome.ok) {
+      rendered.push(outcome.built);
+      continue;
     }
+    logger.error(
+      { err: outcome.error, url: outcome.attachment.url, referenceNumber },
+      'Unexpected error in attachment processing'
+    );
+    rendered.push({
+      url: outcome.attachment.url,
+      attachment: unprocessedAttachment(outcome.attachment),
+    });
   }
 
   return rendered;

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -36,7 +36,10 @@ import {
   ConfigCascadeCacheInvalidationService,
   SystemSettingsCacheInvalidationService,
 } from '@tzurot/cache-invalidation';
-import { SystemSettingsService } from '@tzurot/common-types/services/SystemSettingsService';
+import {
+  SystemSettingsService,
+  registerSystemSettings,
+} from '@tzurot/common-types/services/SystemSettingsService';
 import { PersonalityService } from '@tzurot/identity';
 import {
   ConfigCascadeResolver,
@@ -247,7 +250,14 @@ async function initializeServices(prisma: PrismaClient): Promise<ServicesContext
     systemSettings.invalidate();
   });
   await systemSettings.prime();
-  logger.info('SystemSettingsService seeded, primed, and subscribed to invalidation');
+  // Register the ambient instance, per registerSystemSettings' contract ("each
+  // service registers its wired instance at boot"). api-gateway was building
+  // and priming the service but never registering it, so every free-function
+  // `getSystemSetting` read in this process silently served the registry
+  // FALLBACK instead of the admin's value — which would have made the sticker
+  // gate below a no-op.
+  registerSystemSettings(systemSettings);
+  logger.info('SystemSettingsService seeded, primed, registered, and subscribed to invalidation');
 
   // Orphaned-Characters sentinel (retention D11): the holder a purge re-homes a
   // departed user's still-used characters to. The purge creates it lazily too,

--- a/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
@@ -12,6 +12,19 @@ import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/perso
 import type { LlmConfigResolver, VisionConfigResolver } from '@tzurot/config-resolver';
 
 // Mock the queue (flowProducer for job dependencies)
+const mockGetSystemSetting = vi.hoisted(() => vi.fn(() => true));
+vi.mock('@tzurot/common-types/services/stickerVisionGate', async () => {
+  const actual = await vi.importActual<
+    typeof import('@tzurot/common-types/services/stickerVisionGate')
+  >('@tzurot/common-types/services/stickerVisionGate');
+  return {
+    ...actual,
+    // Exercise the REAL filter, only the setting read is controlled.
+    filterStickersBySetting: <T extends { isSticker?: boolean }>(a: T[]): T[] =>
+      actual.keepStickersIf(mockGetSystemSetting(), a),
+  };
+});
+
 vi.mock('../queue.js', () => ({
   flowProducer: {
     add: vi.fn(),
@@ -131,6 +144,72 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
   });
 
   describe('with attachments', () => {
+    it('does NOT queue an ImageDescription job for a sticker when the switch is off', async () => {
+      // The spend is committed HERE, not in ai-worker: this child job runs to
+      // completion before the generation job starts, so a filter downstream
+      // would only discard a description already paid for. If this regresses,
+      // `stickerVisionEnabled` silently becomes a display toggle that still bills.
+      mockGetSystemSetting.mockReturnValueOnce(false);
+
+      const context: JobContext = {
+        kind: 'envelope',
+        rawAssemblyInputs: { rawMessageContent: 'hello' },
+        userId: 'user-123',
+        channelId: 'channel-123',
+        attachments: [
+          {
+            url: 'https://example.com/sticker.png',
+            name: 'partyblob',
+            contentType: CONTENT_TYPES.IMAGE_PNG,
+            size: 2048,
+            isSticker: true,
+          },
+        ],
+      };
+
+      await createJobChain({
+        requestId: 'req-sticker-off',
+        personality: mockPersonality,
+        message: 'what is that',
+        context,
+        responseDestination: mockResponseDestination,
+      });
+
+      const flowCall = (flowProducer.add as any).mock.calls[0][0];
+      expect(flowCall.children ?? []).toHaveLength(0);
+      expect(flowCall.data.dependencies ?? []).toHaveLength(0);
+    });
+
+    it('DOES queue an ImageDescription job for a sticker when the switch is on', async () => {
+      const context: JobContext = {
+        kind: 'envelope',
+        rawAssemblyInputs: { rawMessageContent: 'hello' },
+        userId: 'user-123',
+        channelId: 'channel-123',
+        attachments: [
+          {
+            url: 'https://example.com/sticker.png',
+            name: 'partyblob',
+            contentType: CONTENT_TYPES.IMAGE_PNG,
+            size: 2048,
+            isSticker: true,
+          },
+        ],
+      };
+
+      await createJobChain({
+        requestId: 'req-sticker-on',
+        personality: mockPersonality,
+        message: 'what is that',
+        context,
+        responseDestination: mockResponseDestination,
+      });
+
+      const flowCall = (flowProducer.add as any).mock.calls[0][0];
+      expect(flowCall.children).toHaveLength(1);
+      expect(flowCall.children[0].name).toBe(JobType.ImageDescription);
+    });
+
     it('should create flow with preprocessing children and LLM parent', async () => {
       const context: JobContext = {
         kind: 'envelope',

--- a/services/api-gateway/src/utils/jobChainOrchestrator.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.ts
@@ -6,6 +6,7 @@
  */
 
 import { CONTENT_TYPES } from '@tzurot/common-types/constants/media';
+import { filterStickersBySetting } from '@tzurot/common-types/services/stickerVisionGate';
 import {
   JobType,
   JOB_PREFIXES,
@@ -244,7 +245,20 @@ function processAttachmentsForJobs(
     referenceNumber?: number;
   }
 ): PreprocessingJobsResult {
-  const { audio, images } = categorizeAttachments(attachments);
+  // THE sticker kill switch. This is where the spend is committed: every
+  // `image/*` attachment below becomes an ImageDescription child job that
+  // BullMQ runs to completion before the generation job starts. A sticker
+  // filtered anywhere downstream has already been billed — the filter would
+  // only discard a description we paid for.
+  //
+  // Both call sites funnel through here (trigger attachments and each
+  // referenced message's), so one gate covers every sticker in the request.
+  //
+  // Read per call rather than threaded: this whole collection path is
+  // synchronous, so every read lands in one tick and they cannot observe a
+  // mid-request flip — the hazard `keepStickersIf`'s explicit-boolean form
+  // exists to prevent elsewhere.
+  const { audio, images } = categorizeAttachments(filterStickersBySetting(attachments));
   const children: FlowJob[] = [];
   const dependencies: JobDependency[] = [];
 

--- a/services/bot-client/src/handlers/references/MessageFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.test.ts
@@ -133,6 +133,39 @@ describe('MessageFormatter', () => {
       expect(result.content).toBe('[Stickers: partyblob]');
     });
 
+    it('should attach a referenced sticker so vision can describe it, not just name it', async () => {
+      // The name line above is only half. Without the sticker reaching
+      // `attachments`, a character replying to a sticker saw what it was CALLED
+      // and never what it depicted — while the same sticker sent directly was
+      // described. This is the wiring, not the conversion (that is unit-tested
+      // in stickerAttachments.test.ts); it fails if the call site is dropped.
+      const stickers = new Map([
+        [
+          '99',
+          {
+            id: '99',
+            name: 'partyblob',
+            description: null,
+            format: 1, // StickerFormatType.PNG
+            url: 'https://cdn.discordapp.com/stickers/99.png',
+          },
+        ],
+      ]);
+      const message = createMockMessage({
+        content: '',
+        author: createMockUser(),
+        attachments: new Map() as any,
+        embeds: [],
+        stickers: stickers as any,
+      });
+
+      const result = await formatter.formatMessage(message, 1);
+
+      expect(result.attachments).toEqual([
+        expect.objectContaining({ id: '99', isSticker: true, contentType: 'image/png' }),
+      ]);
+    });
+
     it('should mark message as forwarded when flag is set', async () => {
       const message = createMockMessage({
         content: 'Forwarded message',

--- a/services/bot-client/src/handlers/references/MessageFormatter.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.ts
@@ -15,6 +15,7 @@ const logger = createLogger('MessageFormatter');
 import { extractDiscordEnvironment } from '../../utils/discordContext.js';
 import { extractAttachments } from '../../utils/attachmentExtractor.js';
 import { extractEmbedImages } from '../../utils/embedImageExtractor.js';
+import { extractStickerImages } from '../../utils/stickerAttachments.js';
 import { EmbedParser } from '../../utils/EmbedParser.js';
 import { withStickerAndPollDescriptions } from '../../utils/stickerPollDescriptions.js';
 import { type TranscriptRetriever } from './TranscriptRetriever.js';
@@ -51,11 +52,21 @@ export class MessageFormatter {
 
     const regularAttachments = extractAttachments(message.attachments);
     const embedImages = extractEmbedImages(message.embeds);
+    // Stickers ride the same synthetic-attachment path as embed images so the
+    // reference gets a vision DESCRIPTION, not just the name that
+    // `withStickerAndPollDescriptions` renders below. Both together is the
+    // established shape — it is what `MessageContentBuilder` does for the
+    // triggering message; this path was simply missing the image half.
+    const stickerImages = extractStickerImages(message);
     return {
       // Without the descriptions, replying to a sticker-only or poll-only
       // message renders an empty [Reference N] block.
       content: withStickerAndPollDescriptions(message, message.content),
-      attachments: [...(regularAttachments ?? []), ...(embedImages ?? [])],
+      attachments: [
+        ...(regularAttachments ?? []),
+        ...(embedImages ?? []),
+        ...(stickerImages ?? []),
+      ],
     };
   }
 

--- a/services/bot-client/src/handlers/references/SnapshotFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/SnapshotFormatter.test.ts
@@ -64,6 +64,36 @@ describe('SnapshotFormatter', () => {
     } as unknown as MessageSnapshot;
   }
 
+  describe('forwarded stickers', () => {
+    it('attaches a forwarded snapshot sticker so vision can describe it', () => {
+      // A forward carries its stickers on the SNAPSHOT, not on the forwarding
+      // message, and this path formats the snapshot directly — so it needs its
+      // own extractor. Before this, a forwarded sticker reached the model as a
+      // name with no image behind it.
+      const snapshot = createMockSnapshot({
+        stickers: new Map([
+          [
+            '77',
+            {
+              id: '77',
+              name: 'shipit',
+              format: 1, // StickerFormatType.PNG
+              url: 'https://cdn.discordapp.com/stickers/77.png',
+            },
+          ],
+        ]),
+      });
+
+      const forwardedFrom = createMockMessage();
+
+      const result = formatter.formatSnapshot(snapshot, 1, forwardedFrom);
+
+      expect(result.attachments).toEqual([
+        expect.objectContaining({ id: '77', isSticker: true, contentType: 'image/png' }),
+      ]);
+    });
+  });
+
   describe('Basic Formatting', () => {
     it('should format a simple snapshot', () => {
       const snapshot = createMockSnapshot({

--- a/services/bot-client/src/handlers/references/SnapshotFormatter.ts
+++ b/services/bot-client/src/handlers/references/SnapshotFormatter.ts
@@ -11,6 +11,7 @@ import { formatLocationAsXml } from '@tzurot/common-types/utils/environmentForma
 import { extractDiscordEnvironment } from '../../utils/discordContext.js';
 import { extractAttachments } from '../../utils/attachmentExtractor.js';
 import { extractEmbedImages } from '../../utils/embedImageExtractor.js';
+import { extractSnapshotStickerImages } from '../../utils/stickerAttachments.js';
 import { EmbedParser } from '../../utils/EmbedParser.js';
 
 /**
@@ -72,8 +73,16 @@ export class SnapshotFormatter {
     // Extract images from snapshot embeds (for vision model processing)
     const embedImages = extractEmbedImages(snapshot.embeds);
 
-    // Combine both types of attachments
-    const allAttachments = [...(regularAttachments ?? []), ...(embedImages ?? [])];
+    // Forwarded stickers get the same treatment — without this a forwarded
+    // sticker reached the model as a name with no image behind it.
+    const stickerImages = extractSnapshotStickerImages(snapshot);
+
+    // Combine all attachment kinds
+    const allAttachments = [
+      ...(regularAttachments ?? []),
+      ...(embedImages ?? []),
+      ...(stickerImages ?? []),
+    ];
 
     // Process embeds from snapshot (XML format)
     const embedString =

--- a/services/bot-client/src/utils/forwardedMessageUtils.test.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.test.ts
@@ -40,6 +40,7 @@ function createMockMessage(options: {
       isVoiceMessage?: boolean;
     }>;
     embeds?: Array<{ title?: string; description?: string }>;
+    stickers?: Array<{ id: string; name: string; format: number; url: string }>;
   }>;
   attachments?: Array<{
     url: string;
@@ -94,6 +95,10 @@ function createMockMessage(options: {
         content: snap.content ?? '',
         attachments: snapAttachments,
         embeds: snap.embeds ?? [],
+        // Discord keeps a forward's stickers on the SNAPSHOT, not on the
+        // forwarding message — the shape the sticker extractor reads.
+        stickers:
+          snap.stickers === undefined ? undefined : new Map(snap.stickers.map(st => [st.id, st])),
       });
     });
 
@@ -286,6 +291,34 @@ describe('forwardedMessageUtils', () => {
   });
 
   describe('extractForwardedAttachments', () => {
+    it('extracts a snapshot sticker as a synthetic image attachment', () => {
+      // This walk collected regular attachments and embed images but skipped
+      // stickers, so a forwarded sticker arrived name-only and vision never saw
+      // it. The other media kinds beside it are the reason the omission was easy
+      // to miss.
+      const message = createMockMessage({
+        referenceType: MessageReferenceType.Forward,
+        snapshots: [
+          {
+            stickers: [
+              {
+                id: '55',
+                name: 'thumbsup',
+                format: 1, // StickerFormatType.PNG
+                url: 'https://cdn.discordapp.com/stickers/55.png',
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = extractForwardedAttachments(message);
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: '55', isSticker: true, contentType: 'image/png' }),
+      ]);
+    });
+
     it('should extract attachments from snapshot', () => {
       const message = createMockMessage({
         referenceType: MessageReferenceType.Forward,

--- a/services/bot-client/src/utils/forwardedMessageUtils.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.ts
@@ -28,6 +28,7 @@ import {
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
+import { extractSnapshotStickerImages } from './stickerAttachments.js';
 import { isVoiceAttachment } from './voiceAttachment.js';
 
 /**
@@ -202,6 +203,13 @@ export function extractForwardedAttachments(message: Message): AttachmentMetadat
     const embedImages = extractEmbedImages(snapshot.embeds);
     if (embedImages !== undefined) {
       attachments.push(...embedImages);
+    }
+
+    // ...and the snapshot's stickers, which were the one media kind this walk
+    // skipped — a forwarded sticker arrived name-only, never described.
+    const stickerImages = extractSnapshotStickerImages(snapshot);
+    if (stickerImages !== undefined) {
+      attachments.push(...stickerImages);
     }
   }
 

--- a/services/bot-client/src/utils/stickerAttachments.test.ts
+++ b/services/bot-client/src/utils/stickerAttachments.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { StickerFormatType, type Message, type Sticker } from 'discord.js';
-import { extractStickerImages, isRasterizableSticker } from './stickerAttachments.js';
+import {
+  extractSnapshotStickerImages,
+  extractStickerImages,
+  isRasterizableSticker,
+  stickersToAttachments,
+} from './stickerAttachments.js';
 
 interface StickerFixture {
   id: string;
@@ -136,5 +141,66 @@ describe('extractStickerImages', () => {
     const ids = extractStickerImages(message)?.map(a => a.id);
 
     expect(ids).toEqual(['own', 'forwarded']);
+  });
+});
+
+describe('extractSnapshotStickerImages', () => {
+  // The reference-rendering paths format a forwarded SNAPSHOT directly, without
+  // the parent Message that extractStickerImages needs — so this is the shape
+  // those call sites actually hold.
+  const snapshotWith = (list: StickerFixture[]): { stickers: Map<string, StickerFixture> } => ({
+    stickers: new Map(list.map(s => [s.id, s])),
+  });
+
+  it('converts a snapshot’s rasterizable stickers', () => {
+    const result = extractSnapshotStickerImages(snapshotWith([sticker({ id: '1' })]) as never);
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: '1', isSticker: true, contentType: 'image/png' }),
+    ]);
+  });
+
+  it('returns undefined when the snapshot carries no stickers', () => {
+    // undefined, not [] — matches extractEmbedImages so both spread the same way.
+    expect(extractSnapshotStickerImages(snapshotWith([]) as never)).toBeUndefined();
+  });
+
+  it('returns undefined when the stickers collection is absent entirely', () => {
+    expect(extractSnapshotStickerImages({} as never)).toBeUndefined();
+    expect(extractSnapshotStickerImages({ stickers: null } as never)).toBeUndefined();
+  });
+
+  it('drops Lottie stickers, which have no raster form to describe', () => {
+    const result = extractSnapshotStickerImages(
+      snapshotWith([
+        sticker({ id: 'lottie', format: StickerFormatType.Lottie }),
+        sticker({ id: 'png' }),
+      ]) as never
+    );
+
+    expect(result?.map(a => a.id)).toEqual(['png']);
+  });
+});
+
+describe('stickersToAttachments', () => {
+  it('is the single conversion both extractors share', () => {
+    // Pinned directly because the whole point of the kernel is that a live
+    // message and a forwarded snapshot cannot drift in how a sticker becomes an
+    // attachment — only in how the stickers are collected.
+    const one = sticker({ id: 'shared', format: StickerFormatType.GIF });
+
+    expect(stickersToAttachments([one] as never)).toEqual(
+      extractSnapshotStickerImages({ stickers: new Map([['shared', one]]) } as never)
+    );
+  });
+
+  it('uses image/gif only for GIF, image/png for PNG and APNG', () => {
+    const result = stickersToAttachments([
+      sticker({ id: 'g', format: StickerFormatType.GIF }),
+      sticker({ id: 'a', format: StickerFormatType.APNG }),
+      sticker({ id: 'p', format: StickerFormatType.PNG }),
+    ] as never);
+
+    expect(result?.map(a => a.contentType)).toEqual(['image/gif', 'image/png', 'image/png']);
   });
 });

--- a/services/bot-client/src/utils/stickerAttachments.ts
+++ b/services/bot-client/src/utils/stickerAttachments.ts
@@ -58,13 +58,18 @@ function stickerContentType(sticker: Sticker): string {
 }
 
 /**
- * Convert a message's rasterizable stickers into synthetic image attachments.
+ * Convert a sticker list into synthetic image attachments.
+ *
+ * The shared kernel behind every extractor below. It exists because stickers
+ * reach the vision chain from several shapes — a live `Message`, a forwarded
+ * `MessageSnapshot` — and the CONVERSION must not be re-derived per shape. Only
+ * the collection differs; the mapping is one definition.
  *
  * Returns `undefined` (not `[]`) when there is nothing to convert, matching
  * `extractEmbedImages`'s contract so both can be spread the same way.
  */
-export function extractStickerImages(message: Message): AttachmentMetadata[] | undefined {
-  const rasterizable = collectAllStickers(message).filter(isRasterizableSticker);
+export function stickersToAttachments(stickers: Sticker[]): AttachmentMetadata[] | undefined {
+  const rasterizable = stickers.filter(isRasterizableSticker);
   if (rasterizable.length === 0) {
     return undefined;
   }
@@ -77,4 +82,38 @@ export function extractStickerImages(message: Message): AttachmentMetadata[] | u
     name: sticker.name,
     isSticker: true,
   }));
+}
+
+/**
+ * Convert a message's rasterizable stickers into synthetic image attachments.
+ *
+ * Covers the message's own stickers AND any its forwarded snapshots carry —
+ * `collectAllStickers` walks both, so a live message never needs the snapshot
+ * extractor below as well.
+ */
+export function extractStickerImages(message: Message): AttachmentMetadata[] | undefined {
+  return stickersToAttachments(collectAllStickers(message));
+}
+
+/**
+ * Convert ONE forwarded snapshot's stickers into synthetic image attachments.
+ *
+ * Needed because the reference-rendering paths format a snapshot directly,
+ * without the parent `Message` that {@link extractStickerImages} requires —
+ * `ReferenceFormatter` dispatches a forward to `SnapshotFormatter.formatSnapshot`
+ * per snapshot, and `extractForwardedAttachments` walks snapshots itself.
+ *
+ * Mirrors `extractEmbedImages(snapshot.embeds)`, which already sits beside every
+ * call site of this: a forwarded sticker was the one media kind those paths
+ * still rendered name-only, so a character replying to a forwarded sticker saw
+ * its name and never its content.
+ */
+export function extractSnapshotStickerImages(snapshot: {
+  stickers?: { values(): Iterable<Sticker> } | null;
+}): AttachmentMetadata[] | undefined {
+  const stickers = snapshot.stickers;
+  if (stickers === undefined || stickers === null) {
+    return undefined;
+  }
+  return stickersToAttachments([...stickers.values()]);
 }

--- a/tracker/tasks/task-359 - Stickers-in-referenced-quoted-messages-are-not-vision-described.md
+++ b/tracker/tasks/task-359 - Stickers-in-referenced-quoted-messages-are-not-vision-described.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-359
 title: Stickers in referenced/quoted messages are not vision-described
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-30 15:50'
-updated_date: '2026-07-30 17:08'
+updated_date: '2026-08-02 00:04'
 labels:
   - 'size:M'
 dependencies: []

--- a/tracker/tasks/task-364 - Deduped-references-drop-image-descriptions-—-vision-spend-is-computed-then-discarded.md
+++ b/tracker/tasks/task-364 - Deduped-references-drop-image-descriptions-—-vision-spend-is-computed-then-discarded.md
@@ -3,9 +3,10 @@ id: TASK-364
 title: >-
   Deduped references drop image descriptions — vision spend is computed then
   discarded
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-30 22:35'
+updated_date: '2026-08-01 23:43'
 labels:
   - 'area:ai-worker'
 dependencies: []
@@ -38,6 +39,28 @@ The stub's premise — "full text in the chat log" — is FALSE for embed images
 **Same class as TASK-162** (role dropped on the deduped path, since fixed) — the deduped path keeps losing fields.
 
 **Fix shape is a DESIGN CALL, owner-gated:** (a) thread descriptions into the deduped stub (costs tokens, but they are NOT duplicated since history lacks them); (b) make history carry embed-image descriptions so the stub premise becomes true; (c) do not dedup messages whose images are undescribed in history.
+
+## SHIPPED — closed 2026-08-01 on runtime evidence
+
+Fixed by `88adc17d6` (on develop AND main), taking option **(a)**: thread the
+descriptions into the deduped stub, in all three render sites, plus the stub
+wording — the old "full text in the chat log" premise was the trap, true for
+text and false for media.
+
+**This task sat at To Do / HIGH priority after its fix shipped**, i.e. at the top
+of the drain queue while already done. Caught by the freshness-check that
+`doc-7`'s batch log requires before every batch; it is the session-end
+removal-gate miss that gate exists for.
+
+**Runtime-confirmed 2026-08-01** from a prod `/inspect` capture (req
+`456ec221`), independently of the code read: a deduped quote rendered as
+`[Referenced message — full text in the chat log; its media is described here]`
+and carried its `<voice>` transcript inline. The paid enrichment now reaches the
+model instead of being computed and discarded.
+
+Later work refined the same path rather than reverting it: #1883 gave quoted
+enrichment a durable home and #1887 stopped the REPLAY path repeating what the
+chat log already carries.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## COMPLETE DIAGNOSIS 2026-07-30 (owner supplied a working capture — regression CONFIRMED)

--- a/tracker/tasks/task-397 - Forwarded-non-rasterizable-stickers-are-invisible-SnapshotFormatter-never-renders-the-name-line.md
+++ b/tracker/tasks/task-397 - Forwarded-non-rasterizable-stickers-are-invisible-SnapshotFormatter-never-renders-the-name-line.md
@@ -1,0 +1,35 @@
+---
+id: TASK-397
+title: >-
+  Forwarded non-rasterizable stickers are invisible: SnapshotFormatter never
+  renders the name line
+status: To Do
+assignee: []
+created_date: '2026-08-02 00:39'
+labels:
+  - 'size:S'
+  - 'area:bot-client'
+dependencies: []
+priority: medium
+ordinal: 397000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Raised by #1895 review (round 1), and it corrects a claim in that PR body.**
+
+I wrote that `SnapshotFormatter` "was missing the image half only." That is wrong. It never calls `withStickerAndPollDescriptions` at all — before or after #1895 — so it renders no sticker NAME either.
+
+**Consequence, for the non-rasterizable subset only.** A Lottie sticker has no raster form, so `stickersToAttachments` correctly filters it out and #1895 gives it no description. In `MessageFormatter` that is fine: both its branches call `withStickerAndPollDescriptions`, so the sticker still gets a `[Stickers: name]` label. In `SnapshotFormatter` — the path `ReferenceFormatter.appendForwardedSnapshots` uses for every NON-deduplicated forwarded message, i.e. the common case — there is no such call. So a forwarded Lottie sticker produces neither name nor description: `content` stays whatever `snapshot.content` was (typically empty for a sticker-only message) and `attachments` stays undefined. **The sticker is entirely invisible to the model.**
+
+Pre-existing, not introduced by #1895 — but #1895 is what makes the asymmetry sharp, because now every OTHER sticker shape in that path is described.
+
+**Second site, same family (same review, minor):** `forwardedMessageUtils.extractAllForwardedContent` no-snapshot fallback (used by `hasForwardedContent` / `hasForwardedVoiceAttachment`) also ignores stickers. That one only feeds a boolean has-meaningful-content gate on the rare path where Discord did not populate snapshots — no vision spend, but the same blind spot.
+
+**Fix shape**: call `withStickerAndPollDescriptions` (or the sticker half of it) in `SnapshotFormatter.formatSnapshot` so the name line is present regardless of rasterizability, matching what `MessageFormatter` already does. Check the forwarded-dedup path does not then render the names twice.
+
+**Why not ridden into #1895**: that PR is about vision descriptions on three attachment paths; this is text rendering on a fourth, and it touches the deduped-vs-not interaction that TASK-365 is actively consolidating. Worth its own review surface.
+
+**Promote when**: picked up alongside TASK-365 render-path consolidation, or if a forwarded Lottie sticker is observed reaching a character as nothing at all.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tracker/tasks/task-398 - Heal-on-read-re-describes-history-stickers-with-no-stickerVisionEnabled-gate.md
+++ b/tracker/tasks/task-398 - Heal-on-read-re-describes-history-stickers-with-no-stickerVisionEnabled-gate.md
@@ -1,0 +1,31 @@
+---
+id: TASK-398
+title: Heal-on-read re-describes history stickers with no stickerVisionEnabled gate
+status: To Do
+assignee: []
+created_date: '2026-08-02 00:52'
+labels:
+  - 'size:S'
+  - 'area:ai-worker'
+dependencies: []
+priority: low
+ordinal: 398000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Found while verifying an exhaustiveness claim during #1895 review (round 3).** The reviewer flagged that the new `stickerVisionGate` module doc read as a claim that only two points need the gate; checking it properly turned up a third path that genuinely has none.
+
+**The path**: `ragVisionAuth.enrichRagHistory` -> `enrichConversationHistory(context.rawConversationHistory, ...)` -> `processAttachments`. This is heal-on-read over attachments already stored in CONVERSATION HISTORY, and no `stickerVisionEnabled` check applies anywhere along it.
+
+**Why the other vision callers are fine and this one is not.** `ConversationInputProcessor`, `DependencyStep` and `extendedContextVisionProcessor` all read lists that `DownloadAttachmentsStep` already filtered, so they inherit that gate. `processAttachmentsParallel` got its own gate in #1895. The history path reads persisted rows instead, which were written when the switch may have been ON, and re-describes them when a description is missing.
+
+**Why it was NOT just gated in #1895, and why this needs a decision rather than a patch.** The spend here is not the same shape as the others. Gates 1 and 2 stop us paying to describe a sticker that has just arrived. This path re-derives a description the system already paid for once and then lost (cache expiry, an older row, a failed write). Gating it means an admin flipping the switch off also degrades EXISTING history — stickers that were described and rendered fine yesterday start coming back bare. That may be exactly what an operator wants from a kill switch, or it may be a surprising retroactive change to conversations already had. It is a product call.
+
+**Options**: (a) gate it, so off means off everywhere and history degrades; (b) leave it ungated on the grounds that heal-on-read completes work already authorised, and say so in the module doc; (c) gate it separately from the arrival switch, so the two can differ.
+
+**Acceptance**: whichever is chosen, the `stickerVisionGate` module doc stops listing this as a known ungated path and states the decision instead.
+
+**Promote when**: sticker vision is actually switched off in prod and the spend does not drop as expected — that is the observation that turns this from tidy-up into a real gap. Until then the switch has never been flipped, so the path has never mattered.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
Drain batch 8 — the `#1872` cluster. Closes **TASK-359**, and closes **TASK-364** which was already done but still sitting at the top of the queue.

> **Scope grew during review, twice.** It started as "wire stickers into the reference paths." Review then found (a) the `stickerVisionEnabled` kill switch didn't cover the new surface, and (b) the gate I added for that ran *after* the money was spent. Both are fixed here. The description below reflects what actually ships, not what was originally intended.

## Part 1 — the feature (TASK-359)

`extractStickerImages` was wired only into `MessageContentBuilder` — the **triggering** message. So a sticker sent directly got a vision description, while the same sticker *replied to* or *forwarded* reached the model as a name with no image behind it. A conscious scope cut when stickers shipped (#1872, PR-1 of doc-55).

Tracing the dispatch found **three** sites, not the two the task named — `extractForwardedAttachments` also skipped stickers while collecting regular attachments *and* embed images, which is why it was easy to miss.

| site | shape it holds |
|---|---|
| `MessageFormatter.resolveMessageContent` (regular branch) | a `Message` — `extractStickerImages` drops in |
| `SnapshotFormatter.formatSnapshot` | a forwarded **snapshot**, no parent Message |
| `forwardedMessageUtils.extractForwardedAttachments` | walks snapshots itself |

The conversion is extracted into `stickersToAttachments(stickers)`; only the **collection** differs per shape. This mirrors `extractEmbedImages`, already one function called at these same sites — so it adds a call, not a fifth thing to hand-sync while TASK-365 consolidates these paths.

## Part 2 — making the kill switch actually kill (found in review)

`stickerVisionEnabled` existed but covered only `DownloadAttachmentsStep`. This PR's new surface — stickers in referenced messages — had no gate at all. Adding one exposed the deeper problem: **the spend isn't committed in ai-worker.**

`api-gateway`'s `createJobChain` → `categorizeAttachments` buckets anything `image/*` (including sticker-derived synthetic attachments) into `ImageDescription` **child** jobs, which BullMQ runs to completion *before* the generation job starts. So a filter anywhere in the generation pipeline only discards a description already paid for — precisely the failure mode that makes a partial kill switch worse than none.

Ships as three gates, with distinct jobs:

1. **`jobChainOrchestrator` (api-gateway)** — the one that stops **spend**, for trigger *and* reference attachments, before dependency jobs are built.
2. `DownloadAttachmentsStep` (ai-worker) — trigger + extended context.
3. `AttachmentProcessor.processAttachmentsParallel` (ai-worker) — references.

2 and 3 aren't redundant: they govern what the model **sees** on paths that skip the job chain (a replayed job, a cached description). Gate 1 governs what gets **bought**.

`stickerVisionGate` moved to **common-types** because two services now need it (api-gateway can't import from ai-worker).

**This also closes a pre-existing leak**: trigger-message stickers had the same gap since #1872, so the switch has arguably never stopped billing until now.

### `registerSystemSettings` in api-gateway

api-gateway constructed, primed and subscribed `SystemSettingsService` but **never registered the ambient instance**, so every free-function `getSystemSetting` read there silently served the *registry fallback* rather than the admin's value. Without this one line the new gate would have read a constant and no-oped forever — green tests and all. `registerSystemSettings`' own doc states each service registers at boot, so this was a gap, not a design choice.

## Verification

Each of the three feature sites gets a wiring assertion; each gate gets one too. Every one verified RED by disabling the thing it covers — the three call sites individually, the reference gate, and the gateway spend gate (removing it makes the "switch off queues zero children" test fail alone).

`AttachmentProcessor` also gained a real fix: filtering before the fan-out desynced `results[i]` from `attachments[i]` on the error path, which could have resurfaced the very sticker the switch dropped. Restructured so each outcome **carries** its attachment — no index to mis-subscript. (`findPreprocessedByUrl` matches by URL, not index, so the filter doesn't desync preprocessed results.)

A mock-leak canary was added after `mockReturnValue` was found to survive `vi.clearAllMocks()`, silently leaving later tests with the switch off.

`pnpm test` (26 packages) and `pnpm quality` green locally, sequentially, including depcruise for the new cross-service import.

## Corrections to earlier claims in this PR

- **"This path was missing the image half only" was wrong for `SnapshotFormatter`.** It never calls `withStickerAndPollDescriptions` at all, so a forwarded **Lottie** sticker gets neither name nor description — invisible to the model. Pre-existing, non-rasterizable only. Filed as **TASK-397**.
- **TASK-364** was `To Do` at HIGH priority with its fix already shipped (`88adc17d6`) — caught by the pre-batch freshness check, confirmed against a prod `/inspect` capture where a deduped quote carried its enrichment.

## Deferred, deliberately

- **TASK-397** — forwarded Lottie stickers render as nothing (text path, interacts with TASK-365).
- **TASK-398** — heal-on-read re-describes stored history stickers ungated. A product call: gating it means flipping the switch retroactively degrades existing conversations.
- **TASK-360** (animated stickers described from one frame) and **TASK-389** (sticker descriptions are tier-3 stored at tier-1) — both genuinely event-gated, left filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
