### PR TITLE
feat(ai-worker,bot-client): ship the three parked observability one-liners

### DIFF
--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -31,6 +31,14 @@ const entries = Object.entries(ROUTE_MANIFEST) as [string, AnyRouteDef][];
  * tier's name. Discord bounds the autocomplete side at 3s client-side regardless
  * of the gateway budget, so they correctly sit on DEFERRED (and are typically
  * dual-called from deferred browse anyway).
+ *
+ * The reason a long budget is not merely tolerable but USEFUL there: an
+ * autocomplete fetch that outlives its interaction still commits to
+ * `autocompleteCache` on success, so it warms the entry the user's next
+ * keystroke reads. Aborting it early would throw that work away and make the
+ * following keystroke miss too. Retiering an autocomplete-invoked route down
+ * therefore trades a wasted-but-harmless open request for a colder cache —
+ * which is why the escape hatch belongs per-CALL, not per-route.
  */
 const AUTOCOMPLETE_TIER = new Set<string>(['resolveUserLlmConfig']);
 

--- a/services/ai-worker/src/services/prompt/referenceRole.test.ts
+++ b/services/ai-worker/src/services/prompt/referenceRole.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UNKNOWN_USER_NAME } from '@tzurot/common-types/constants/message';
 import { deriveRefRole } from './referenceRole.js';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return { ...actual, createLogger: () => mockLogger };
+});
 
 describe('deriveRefRole name matching (fallback path)', () => {
   it('matches when the author name is prefixed by the active personality name', () => {
@@ -123,5 +134,67 @@ describe('deriveRefRole', () => {
     expect(deriveRefRole(undefined, UNKNOWN_USER_NAME, 'Lilith', new Set(['Lilith', 'Lila']))).toBe(
       'user'
     );
+  });
+});
+
+describe('name-match fallback tripwire', () => {
+  beforeEach(() => {
+    mockLogger.info.mockClear();
+  });
+
+  it('fires when the fallback promotes to assistant on a direct self-match', () => {
+    deriveRefRole(undefined, 'Lilith ▽', 'Lilith');
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { personalityName: 'Lilith', via: 'self' },
+      expect.stringContaining('name-match fallback')
+    );
+  });
+
+  it('distinguishes the self-variant arm, which matches under a different name vocabulary', () => {
+    // Stored rows carry `personality.name` while the live path passes displayName,
+    // so the two arms fire in different deployments — telling them apart is what
+    // makes the volume signal diagnosable rather than just a number.
+    // Same fixture as the self-variant behavioural pin above: the author matches
+    // the STORED name while the responder is identified by displayName, so the
+    // direct prefix check misses and only the self-variant guard resolves it.
+    deriveRefRole(
+      undefined,
+      'Yeshua ▽',
+      'Yeshua ben Yosef',
+      new Set(['Yeshua', 'Ha-Shem', 'Yeshua ben Yosef'])
+    );
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ via: 'self-variant' }),
+      expect.any(String)
+    );
+  });
+
+  it('never logs the author name — a Discord display name is username-class PII', () => {
+    // The collision this tripwire watches for is precisely a HUMAN whose name
+    // prefixes a personality's, so the tempting field to add is the one that must
+    // never be added. Pinned so a future "make it more diagnosable" edit fails here
+    // instead of in prod logs.
+    deriveRefRole(undefined, 'Lilith Smith', 'Lilith');
+
+    const [payload] = mockLogger.info.mock.calls[0];
+    expect(JSON.stringify(payload)).not.toContain('Lilith Smith');
+  });
+
+  it('stays silent when a stamp is present — this is the fallback path only', () => {
+    deriveRefRole('assistant', 'Lilith ▽', 'Lilith');
+    deriveRefRole('user', 'Some Human', 'Lilith');
+    deriveRefRole('bot', 'MEE6', 'Lilith');
+
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the fallback does NOT promote to assistant', () => {
+    deriveRefRole(undefined, 'Some Human', 'Lilith');
+    deriveRefRole(undefined, 'Lila ▽', 'Lilith', new Set(['Lila', 'Lilith']));
+
+    expect(mockLogger.info).not.toHaveBeenCalled();
   });
 });

--- a/services/ai-worker/src/services/prompt/referenceRole.ts
+++ b/services/ai-worker/src/services/prompt/referenceRole.ts
@@ -25,9 +25,20 @@
  * Without the fallback on the live path, a personality's own reply-target would
  * read as `role="user"` during that window — the exact self-reply confusion the
  * classifier exists to prevent.
+ *
+ * Both causes above are transitional. A THIRD is permanent and recurring:
+ * `classifyReferenceAuthorRole` deliberately omits the stamp when a message
+ * carries an `applicationId` but the client's own identity is not yet known
+ * (before `ClientReady`, and during every gateway reconnect) — our persona and
+ * a foreign bot are genuinely indistinguishable there, and a wrong `bot` stamp
+ * would be DURABLE. It defers to this fallback instead. So this path does not
+ * decay to zero; treat it as live code, not as scaffolding awaiting removal.
  */
 
+import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ReferenceAuthorRole } from '@tzurot/common-types/types/schemas/message';
+
+const logger = createLogger('referenceRole');
 
 /**
  * The role vocabulary RENDERED into `<quote role="...">` attributes. Extends
@@ -141,10 +152,20 @@ export function deriveRefRole(
   if (authorRole !== undefined) {
     return authorRole;
   }
-  if (
-    matchesPersonality(authorName, personalityName) ||
-    matchesSelfVariant(authorName, personalityName, allPersonalityNames)
-  ) {
+  const selfMatch = matchesPersonality(authorName, personalityName);
+  if (selfMatch || matchesSelfVariant(authorName, personalityName, allPersonalityNames)) {
+    // Tripwire for the collision edge documented below: this fallback is a pure
+    // name-match with no bot-authorship guard, so a human whose display name
+    // prefixes a personality's is promoted to `assistant` here — indistinguishable
+    // at this seam from the persona's own line. That risk is argued to be bounded;
+    // this log is what would falsify the argument. The author name is NOT logged
+    // (a Discord display name is username-class PII), so the signal is VOLUME:
+    // a low, reconnect-correlated rate matches the design, and a sustained or
+    // growing rate means an assumption here is wrong and deserves a targeted probe.
+    logger.info(
+      { personalityName, via: selfMatch ? 'self' : 'self-variant' },
+      'Reference role resolved by name-match fallback (no authorRole stamp)'
+    );
     return 'assistant';
   }
   if (matchesSiblingPersonality(authorName, personalityName, allPersonalityNames)) {

--- a/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
+++ b/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
@@ -19,19 +19,18 @@ import type { UserClient } from '@tzurot/clients';
 import type { PersonaSummary, ShapesSummary } from './autocompleteCache.js';
 import { makeOk, makeErr } from '../../test/gatewayClientStubs.js';
 
+// One shared logger instance rather than a fresh object per createLogger() call:
+// the miss-duration line is asserted below, and a per-call object would leave the
+// test holding a different mock than the module under test writes to.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
   );
-  return {
-    ...actual,
-    createLogger: () => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
-  };
+  return { ...actual, createLogger: () => mockLogger };
 });
 
 // One mock per typed-client method, shared across tests. `vi.clearAllMocks()`
@@ -537,5 +536,80 @@ describe('autocompleteCache', () => {
       expect(mockListPersonalities).not.toHaveBeenCalled();
       expect(mockListPersonas).not.toHaveBeenCalled();
     });
+  });
+
+  describe('cache-miss duration logging', () => {
+    // Fake timers here so the mocked fetch can advance the clock by a known
+    // amount, pinning that the logged value is the ELAPSED delta and not a raw
+    // timestamp — the mistake a "durationMs is a number" assertion would miss.
+    // Safe despite the TTLCache/performance.now caveat noted above: these tests
+    // never rely on TTL expiry, only on Date.now.
+    const FETCH_MS = 1250;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const cases = [
+      {
+        field: 'personalities',
+        fetchMock: mockListPersonalities,
+        call: getCachedPersonalities,
+        payload: { personalities: [{ id: 'p1' }, { id: 'p2' }] },
+      },
+      {
+        field: 'personas',
+        fetchMock: mockListPersonas,
+        call: getCachedPersonas,
+        payload: { personas: [{ id: 'x1' }] },
+      },
+      {
+        field: 'shapes',
+        fetchMock: mockListShapes,
+        call: getCachedShapes,
+        payload: { shapes: [] },
+      },
+    ] as const;
+
+    for (const { field, fetchMock, call, payload } of cases) {
+      it(`logs the ${field} miss round-trip at info with its elapsed duration`, async () => {
+        fetchMock.mockImplementation(async () => {
+          vi.advanceTimersByTime(FETCH_MS);
+          return makeOk(payload);
+        });
+
+        await call(stubUser(`user-${field}`));
+
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          {
+            userId: `user-${field}`,
+            field,
+            durationMs: FETCH_MS,
+            count: Object.values(payload)[0].length,
+          },
+          'Autocomplete cache miss fetched'
+        );
+      });
+
+      it(`carries the elapsed duration on a failed ${field} fetch`, async () => {
+        // The slow-failure case is the one that most needs measuring — a fetch
+        // that times out is exactly what blows Discord's interactivity window.
+        fetchMock.mockImplementation(async () => {
+          vi.advanceTimersByTime(FETCH_MS);
+          return makeErr(500);
+        });
+
+        await call(stubUser(`user-fail-${field}`));
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ durationMs: FETCH_MS }),
+          expect.stringContaining('Failed to fetch')
+        );
+      });
+    }
   });
 });

--- a/services/bot-client/src/utils/autocomplete/autocompleteCache.ts
+++ b/services/bot-client/src/utils/autocomplete/autocompleteCache.ts
@@ -160,6 +160,30 @@ function commitFetchedField<K extends keyof UserAutocompleteData>(
 }
 
 /**
+ * Log a completed cache-miss round-trip at INFO.
+ *
+ * A miss costs a full gateway round-trip against Discord's hard 3s autocomplete
+ * deadline, so miss LATENCY — not miss count — is what decides whether
+ * autocomplete is usable under load. Everything else on this path logs at
+ * debug, which production does not emit, so without this line the duration is
+ * unobservable in the only environment where it matters.
+ *
+ * Supersedes the per-field `Cached <thing>` debug lines it replaced: same
+ * `count`, plus the duration, at a level prod actually keeps.
+ */
+function logMissDuration(
+  userId: string,
+  field: keyof UserAutocompleteData,
+  startedAt: number,
+  count: number
+): void {
+  logger.info(
+    { userId, field, durationMs: Date.now() - startedAt, count },
+    'Autocomplete cache miss fetched'
+  );
+}
+
+/**
  * Handle the transient-error path: return stale data if present, else error.
  */
 function fallbackToStale<K extends keyof UserAutocompleteData>(
@@ -193,18 +217,24 @@ export async function getCachedPersonalities(
   }
 
   logger.debug({ userId }, 'Personality cache miss, fetching');
+  const startedAt = Date.now();
 
   try {
     const result = await userClient.listPersonalities();
 
     if (result.ok) {
       commitFetchedField(userId, 'personalities', result.data.personalities);
-      logger.debug({ userId, count: result.data.personalities.length }, 'Cached personalities');
+      logMissDuration(userId, 'personalities', startedAt, result.data.personalities.length);
       return { kind: 'ok', value: result.data.personalities };
     }
 
     logger.warn(
-      { userId, error: result.error, httpStatus: result.status },
+      {
+        userId,
+        error: result.error,
+        httpStatus: result.status,
+        durationMs: Date.now() - startedAt,
+      },
       'Failed to fetch personalities'
     );
     if (isTransientHttpStatus(result.status)) {
@@ -233,18 +263,24 @@ export async function getCachedPersonas(
   }
 
   logger.debug({ userId }, 'Persona cache miss, fetching');
+  const startedAt = Date.now();
 
   try {
     const result = await userClient.listPersonas();
 
     if (result.ok) {
       commitFetchedField(userId, 'personas', result.data.personas);
-      logger.debug({ userId, count: result.data.personas.length }, 'Cached personas');
+      logMissDuration(userId, 'personas', startedAt, result.data.personas.length);
       return { kind: 'ok', value: result.data.personas };
     }
 
     logger.warn(
-      { userId, error: result.error, httpStatus: result.status },
+      {
+        userId,
+        error: result.error,
+        httpStatus: result.status,
+        durationMs: Date.now() - startedAt,
+      },
       'Failed to fetch personas'
     );
     if (isTransientHttpStatus(result.status)) {
@@ -276,18 +312,24 @@ export async function getCachedShapes(userClient: UserClient): Promise<ApiCheck<
   }
 
   logger.debug({ userId }, 'Shapes cache miss, fetching');
+  const startedAt = Date.now();
 
   try {
     const result = await userClient.listShapes();
 
     if (result.ok) {
       commitFetchedField(userId, 'shapes', result.data.shapes);
-      logger.debug({ userId, count: result.data.shapes.length }, 'Cached shapes');
+      logMissDuration(userId, 'shapes', startedAt, result.data.shapes.length);
       return { kind: 'ok', value: result.data.shapes };
     }
 
     logger.warn(
-      { userId, error: result.error, httpStatus: result.status },
+      {
+        userId,
+        error: result.error,
+        httpStatus: result.status,
+        durationMs: Date.now() - startedAt,
+      },
       'Failed to fetch shapes'
     );
     if (isTransientHttpStatus(result.status)) {


### PR DESCRIPTION
Closes **TASK-395**. Three observability additions approved in a pre-beta.189 session that survived only as one italic line in `CURRENT.md` — a file reset at every release cut. Filed as one task because they are one small PR.

## 1. Name-match fallback tripwire — `referenceRole.ts`

`deriveRefRole`'s no-stamp path promotes a reference to `assistant` on a **pure name match with no bot-authorship guard**, so a human whose Discord display name prefixes a personality's is promoted too (**TASK-164**). That risk is argued to be bounded — and nothing observed it. This is the line that would falsify the argument.

### The author name is deliberately not logged

TASK-395 said to log "the matched name and the personality name (both are non-PII display names already in prompts)." **That parenthetical doesn't survive contact with the rules.** A Discord display name is username-class, and `00-critical.md` bans logging usernames outright. A repo-wide grep for `authorName`/`authorUsername` inside any `logger.*` call returns **zero hits** — the constraint is respected in practice, not just written down.

The irony is load-bearing: the collision this watches for is *precisely* a human's name, so the tempting field to add is exactly the one that must never be added. A test pins the omission so a future "make it more diagnosable" edit fails there instead of in prod logs.

The signal is **volume** instead: a low, reconnect-correlated rate matches the design; a sustained or growing rate means an assumption is wrong and earns a targeted probe. The `via: 'self' | 'self-variant'` discriminator makes it diagnosable — the two arms fire in different deployments (stored `personality.name` vs live `displayName`), so the split says *where*.

### Module-doc correction (found while working)

The doc framed this fallback as transitional — pre-classifier rows "age out over ~30 days," plus rolling-deploy windows. That is now **wrong**. Since `18b222f32` (5 days ago), `classifyReferenceAuthorRole` deliberately omits the stamp whenever an `applicationId` is present but client identity is not — **before `ClientReady` and during every gateway reconnect** — because our persona and a foreign bot are genuinely indistinguishable there and a wrong `bot` stamp would be *durable*. It defers to this fallback by design.

So the path is permanent and recurring, not scaffolding awaiting removal. A reader following the old doc would have concluded the opposite. Corrected here — and it is also what makes the tripwire worth having rather than a probe on a decaying path.

## 2. Autocomplete cache-miss duration — `autocompleteCache.ts`

A miss is a full gateway round-trip against Discord's hard 3s deadline, so miss **latency** decides whether autocomplete is usable. Every line on that path was `debug`, which prod does not emit — the deciding number was unobservable in the only environment that matters.

- Info-level `Autocomplete cache miss fetched` with `field`, `durationMs`, `count`, on all three fetchers (personalities / personas / shapes — same reasoning, same file; doing one of three would be arbitrary).
- **Replaces** the `Cached <thing>` debug lines rather than adding beside them: same `count`, plus the duration, at a level prod keeps.
- `durationMs` added to the failure warns too. A fetch that times out is exactly the case that blows the interactivity window; leaving the slowest path unmeasured would have been the real gap.

## 3. Route-tier cache-warming rationale — `manifest.test.ts`

TASK-395 recorded this site as **unidentified** (`rg routeTier` returns nothing) and instructed: confirm the site, or close the item as unrecoverable rather than invent a comment.

**Confirmed.** The `AUTOCOMPLETE_TIER` note asserts autocomplete-invoked routes "correctly sit on DEFERRED" but omits its strongest supporting reason. Traced the code: an autocomplete fetch that outlives its interaction still reaches `commitFetchedField` on success, warming the entry the user's *next* keystroke reads. Aborting early would discard that work and make the following keystroke miss too — so retiering down trades a wasted-but-harmless open request for a **colder cache**, which is why the escape hatch belongs per-**call** (TASK-132), not per-route. Verified by reading the commit path, not inferred from the docstring.

## Verification

Every assertion **RED-verified against unmodified code** — 3 fail without the tripwire, 6 without the duration logging.

The duration tests advance a fake clock *inside* the mocked fetch, so they pin the **elapsed delta**; a `durationMs is a number` assertion would pass just as happily on a raw timestamp. The existing per-call `createLogger: () => ({...})` mock in both test files was converted to a hoisted shared instance — a fresh object per call leaves the test holding a different mock than the module writes to.

`pnpm test` (26 packages) and `pnpm quality` green locally, sequentially.

No migration, no schema change, no behaviour change — three log lines and two comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
