### PR TITLE
feat(tooling): mine attachment-bearing goldens for the search-query allocation A/B

### DIFF
--- a/packages/tooling/src/commands/memory.ts
+++ b/packages/tooling/src/commands/memory.ts
@@ -12,6 +12,15 @@ const ENV_OPTION_DESC = 'Environment: local, dev, or prod';
 const ENV_OPTION_DEFAULT = { default: 'dev' } as const;
 const FORCE_OPTION_DESC = 'Skip production confirmation prompt';
 
+// Shared by the three goldens miners (sonarjs/no-duplicate-string at 3 uses).
+const PERSONA_OPTION = '--persona-id <uuid>';
+const PERSONA_OPTION_DESC = 'Persona UUID to mine (required)';
+const SAMPLE_OPTION = '--sample <n>';
+const HISTORY_WINDOW_OPTION = '--history-window <n>';
+const HISTORY_WINDOW_OPTION_DESC = 'Prior turns to capture per golden (default 50)';
+const OUT_OPTION = '--out <dir>';
+const OUT_OPTION_DESC = 'Output dir (default reports/goldens-mining — gitignored)';
+
 /**
  * Parse an optional positive-integer CLI flag. Returns the number, `undefined`
  * if the flag is absent, or `null` if it's present-but-invalid (having already
@@ -119,10 +128,10 @@ function registerGoldensCommands(cli: CAC): void {
       "Mine a stratified sample of a persona's memories for retrieval-eval goldens"
     )
     .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
-    .option('--persona-id <uuid>', 'Persona UUID to mine (required)')
+    .option(PERSONA_OPTION, PERSONA_OPTION_DESC)
     .option('--personality-ids <csv>', 'Personality UUIDs to include (default: top 2 by count)')
-    .option('--sample <n>', 'Target sample size (default 800)')
-    .option('--out <dir>', 'Output dir (default reports/goldens-mining — gitignored)')
+    .option(SAMPLE_OPTION, 'Target sample size (default 800)')
+    .option(OUT_OPTION, OUT_OPTION_DESC)
     .action(
       async (options: {
         env?: Environment;
@@ -176,6 +185,50 @@ function registerGoldensCommands(cli: CAC): void {
     });
 }
 
+/** The attachment-goldens miner — additive to the conversation set (see mine-attachment-goldens.ts). */
+function registerAttachmentGoldensCommand(cli: CAC): void {
+  cli
+    .command(
+      'memory:mine-attachment-goldens',
+      'Mine attachment-bearing user turns (image descriptions, voice transcripts) for the search-query allocation A/B'
+    )
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
+    .option(PERSONA_OPTION, PERSONA_OPTION_DESC)
+    .option(SAMPLE_OPTION, 'Target golden count across kinds (default 24)')
+    .option(HISTORY_WINDOW_OPTION, HISTORY_WINDOW_OPTION_DESC)
+    .option(OUT_OPTION, OUT_OPTION_DESC)
+    .action(
+      async (options: {
+        env?: Environment;
+        personaId?: string;
+        sample?: string;
+        historyWindow?: string;
+        out?: string;
+      }) => {
+        const personaId = requirePersonaId(options.personaId);
+        if (personaId === null) {
+          return;
+        }
+        const sampleSize = parsePositiveIntOption(options.sample, '--sample');
+        if (sampleSize === null) {
+          return;
+        }
+        const historyWindow = parsePositiveIntOption(options.historyWindow, '--history-window');
+        if (historyWindow === null) {
+          return;
+        }
+        const { mineAttachmentGoldens } = await import('../memory/mine-attachment-goldens.js');
+        await mineAttachmentGoldens({
+          env: options.env ?? 'dev',
+          personaId,
+          sampleSize,
+          historyWindow,
+          outDir: options.out,
+        });
+      }
+    );
+}
+
 /** The conversation-goldens miner — its own registrar so registerGoldensCommands stays under the line cap. */
 function registerConversationGoldensCommand(cli: CAC): void {
   cli
@@ -184,10 +237,10 @@ function registerConversationGoldensCommand(cli: CAC): void {
       'Mine real user turns + their preceding conversation window (the fold input) for the retrieval re-baseline'
     )
     .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
-    .option('--persona-id <uuid>', 'Persona UUID to mine (required)')
-    .option('--sample <n>', 'Target golden count across all styles (default 40)')
-    .option('--history-window <n>', 'Prior turns to capture per golden (default 50)')
-    .option('--out <dir>', 'Output dir (default reports/goldens-mining — gitignored)')
+    .option(PERSONA_OPTION, PERSONA_OPTION_DESC)
+    .option(SAMPLE_OPTION, 'Target golden count across all styles (default 40)')
+    .option(HISTORY_WINDOW_OPTION, HISTORY_WINDOW_OPTION_DESC)
+    .option(OUT_OPTION, OUT_OPTION_DESC)
     .action(
       async (options: {
         env?: Environment;
@@ -272,6 +325,7 @@ export function registerMemoryCommands(cli: CAC): void {
   registerRepairFactTimestampsCommand(cli);
   registerGoldensCommands(cli);
   registerConversationGoldensCommand(cli);
+  registerAttachmentGoldensCommand(cli);
 
   // Cleanup duplicate memories
   cli

--- a/packages/tooling/src/memory/mine-attachment-goldens.test.ts
+++ b/packages/tooling/src/memory/mine-attachment-goldens.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQueryRaw = vi.fn();
+const mockDisconnect = vi.fn();
+vi.mock('./prisma-env.js', () => ({
+  getPrismaForEnv: vi.fn(async () => ({
+    prisma: { $queryRaw: (...args: unknown[]) => mockQueryRaw(...args) },
+    disconnect: mockDisconnect,
+  })),
+}));
+
+const mockWriteFileSync = vi.fn();
+const mockMkdirSync = vi.fn();
+vi.mock('node:fs', () => ({
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  readFileSync: vi.fn(),
+}));
+
+import {
+  splitEnrichedContent,
+  classifyAttachmentKind,
+  sampleByKind,
+  mineAttachmentGoldens,
+  type AttachmentKind,
+} from './mine-attachment-goldens.js';
+
+describe('splitEnrichedContent', () => {
+  it('splits message + image description at the header boundary', () => {
+    const content = 'look at this gym\n\n[Image: gym.png]\nA large room with rubber flooring.';
+    const split = splitEnrichedContent(content);
+    expect(split).toEqual({
+      messageBare: 'look at this gym',
+      attachmentText: '[Image: gym.png]\nA large room with rubber flooring.',
+    });
+  });
+
+  it('handles description-only content (no user text)', () => {
+    const content = '[Image: cat.jpg]\nA tabby cat on a windowsill.';
+    const split = splitEnrichedContent(content);
+    expect(split).toEqual({
+      messageBare: '',
+      attachmentText: '[Image: cat.jpg]\nA tabby cat on a windowsill.',
+    });
+  });
+
+  it('splits voice-transcript content at the voice header', () => {
+    const content =
+      'hey\n\n[Voice message: 5.2s]\n<voice_transcripts><transcript>hello there</transcript></voice_transcripts>';
+    const split = splitEnrichedContent(content);
+    expect(split?.messageBare).toBe('hey');
+    expect(split?.attachmentText).toContain('<voice_transcripts>');
+    expect(split?.attachmentText.startsWith('[Voice message: 5.2s]')).toBe(true);
+  });
+
+  it('splits at the FIRST header when several attachments follow', () => {
+    const content =
+      'two things\n\n[Image: a.png]\nFirst description.\n\n[Image: b.png]\nSecond description.';
+    const split = splitEnrichedContent(content);
+    expect(split?.messageBare).toBe('two things');
+    expect(split?.attachmentText).toContain('[Image: a.png]');
+    expect(split?.attachmentText).toContain('[Image: b.png]');
+  });
+
+  it('returns null for content with no attachment header', () => {
+    expect(splitEnrichedContent('just a plain message')).toBeNull();
+  });
+
+  it('does not split on a bracket header that is not at a paragraph boundary', () => {
+    // Inline mention mid-line is not the enrichment shape (writer joins with \n\n).
+    expect(splitEnrichedContent('I typed [Image: fake] inline here')).toBeNull();
+  });
+
+  it('treats a sticker header as an attachment boundary', () => {
+    const split = splitEnrichedContent('nice\n\n[Sticker: wave]\nA cartoon hand waving.');
+    expect(split?.messageBare).toBe('nice');
+    expect(split?.attachmentText.startsWith('[Sticker: wave]')).toBe(true);
+  });
+});
+
+describe('classifyAttachmentKind', () => {
+  it('classifies image blocks', () => {
+    expect(classifyAttachmentKind('[Image: a.png]\nA description.')).toBe('image');
+  });
+
+  it('classifies sticker blocks as image', () => {
+    expect(classifyAttachmentKind('[Sticker: wave]\nA hand.')).toBe('image');
+  });
+
+  it('classifies voice blocks', () => {
+    expect(
+      classifyAttachmentKind(
+        '[Voice message: 3.0s]\n<voice_transcripts><transcript>hi</transcript></voice_transcripts>'
+      )
+    ).toBe('voice');
+  });
+
+  it('classifies blocks with both as mixed', () => {
+    expect(
+      classifyAttachmentKind(
+        '[Image: a.png]\nA description.\n\n[Voice message: 3.0s]\n<voice_transcripts><transcript>hi</transcript></voice_transcripts>'
+      )
+    ).toBe('mixed');
+  });
+});
+
+describe('sampleByKind', () => {
+  const candidate = (id: string, kind: AttachmentKind, minute: number) =>
+    ({
+      id,
+      channelId: 'c',
+      personalityId: 'p',
+      content: '',
+      messageMetadata: null,
+      createdAt: new Date(2026, 0, 1, 0, minute),
+      kind,
+      messageBare: '',
+      attachmentText: '',
+    }) as Parameters<typeof sampleByKind>[0][number];
+
+  it('fills the 2/3 image and 1/3 voice quotas when both pools are deep', () => {
+    const pool = [
+      ...Array.from({ length: 30 }, (_, i) => candidate(`img-${i}`, 'image', i)),
+      ...Array.from({ length: 30 }, (_, i) => candidate(`vox-${i}`, 'voice', i)),
+    ];
+    const picked = sampleByKind(pool, 12);
+    expect(picked.filter(c => c.kind === 'image')).toHaveLength(8);
+    expect(picked.filter(c => c.kind === 'voice')).toHaveLength(4);
+  });
+
+  it('counts mixed candidates under the image quota', () => {
+    const pool = [
+      ...Array.from({ length: 10 }, (_, i) => candidate(`mix-${i}`, 'mixed', i)),
+      ...Array.from({ length: 10 }, (_, i) => candidate(`vox-${i}`, 'voice', i)),
+    ];
+    const picked = sampleByKind(pool, 6);
+    expect(picked.filter(c => c.kind === 'mixed')).toHaveLength(4);
+    expect(picked.filter(c => c.kind === 'voice')).toHaveLength(2);
+  });
+
+  it('is deterministic: the same pool yields the same sample', () => {
+    const pool = Array.from({ length: 20 }, (_, i) =>
+      candidate(`img-${i}`, i % 3 === 0 ? 'voice' : 'image', i)
+    );
+    const first = sampleByKind(pool, 8).map(c => c.id);
+    const second = sampleByKind(pool.slice().reverse(), 8).map(c => c.id);
+    expect(second).toEqual(first);
+  });
+
+  it('does not overdraw a shallow pool', () => {
+    const pool = [candidate('img-0', 'image', 0), candidate('vox-0', 'voice', 1)];
+    const picked = sampleByKind(pool, 12);
+    expect(picked).toHaveLength(2);
+  });
+});
+
+describe('mineAttachmentGoldens (the Prisma + fs seams)', () => {
+  const imageRow = (id: string, minute: number) => ({
+    id,
+    channel_id: 'chan-1',
+    personality_id: 'char-1',
+    content: `about this one\n\n[Image: ${id}.png]\nA long description of ${id}.`,
+    message_metadata: { note: id },
+    created_at: new Date(2026, 0, 10, 0, minute),
+  });
+  const voiceRow = (id: string, minute: number) => ({
+    id,
+    channel_id: 'chan-1',
+    personality_id: 'char-1',
+    content: `hey\n\n[Voice message: 3.0s]\n<voice_transcripts><transcript>spoken ${id}</transcript></voice_transcripts>`,
+    message_metadata: { note: id },
+    created_at: new Date(2026, 0, 10, 0, minute),
+  });
+  // 3 turns ≥ the miner's minimum, so a finalist with this history becomes a golden.
+  const priorTurns = [
+    { role: 'user', content: 'earlier one', created_at: new Date('2026-01-09T00:00:00Z') },
+    { role: 'assistant', content: 'earlier reply', created_at: new Date('2026-01-09T00:01:00Z') },
+    { role: 'user', content: 'earlier two', created_at: new Date('2026-01-09T00:02:00Z') },
+  ];
+
+  const writtenGoldens = () => {
+    const write = mockWriteFileSync.mock.calls.find(call =>
+      String(call[0]).endsWith('attachment-goldens.json')
+    );
+    expect(write).toBeDefined();
+    return (
+      JSON.parse(String(write![1])) as {
+        goldens: {
+          id: string;
+          attachmentKind: AttachmentKind;
+          messageBare: string;
+          attachmentText: string;
+          message: string;
+          priorHistory: unknown[];
+        }[];
+      }
+    ).goldens;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDisconnect.mockResolvedValue(undefined);
+  });
+
+  it('keeps per-kind quotas when history-drops force image backfills (the first-live-run bug)', async () => {
+    // sampleSize 6 → caps 4 image / 2 voice. Pools sized to the 2x over-sample
+    // quotas (8 image, 4 voice) so finalist order is img-0..7 then vox-0..3.
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        ...Array.from({ length: 8 }, (_, i) => imageRow(`img-${i}`, i)),
+        ...Array.from({ length: 4 }, (_, i) => voiceRow(`vox-${i}`, 30 + i)),
+      ])
+      // img-0 and img-1: too little prior history → dropped, backfilled by img-2..5.
+      .mockResolvedValueOnce([priorTurns[0]])
+      .mockResolvedValueOnce([priorTurns[0]])
+      .mockResolvedValue(priorTurns);
+    await mineAttachmentGoldens({ env: 'dev', personaId: 'persona-xyz', sampleSize: 6 });
+
+    const goldens = writtenGoldens();
+    // The regression this PR fixed: image backfills must consume IMAGE's share
+    // only — voice keeps its 1/3 despite 6 more image finalists in the queue.
+    expect(goldens.filter(g => g.attachmentKind === 'image').map(g => g.id)).toEqual([
+      'img-2',
+      'img-3',
+      'img-4',
+      'img-5',
+    ]);
+    expect(goldens.filter(g => g.attachmentKind === 'voice').map(g => g.id)).toEqual([
+      'vox-0',
+      'vox-1',
+    ]);
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips over-cap candidates BEFORE fetching their history (no wasted round-trips)', async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        ...Array.from({ length: 8 }, (_, i) => imageRow(`img-${i}`, i)),
+        ...Array.from({ length: 4 }, (_, i) => voiceRow(`vox-${i}`, 30 + i)),
+      ])
+      .mockResolvedValue(priorTurns);
+    await mineAttachmentGoldens({ env: 'dev', personaId: 'persona-xyz', sampleSize: 6 });
+    // Call 0 = candidates; history calls = 4 images that fit the cap + 2 voice.
+    // img-4..7 hit the image cap and must not cost a query each.
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1 + 4 + 2);
+  });
+
+  it('writes goldens carrying the split fields alongside the full enriched message', async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([imageRow('img-0', 0), voiceRow('vox-0', 1)])
+      .mockResolvedValue(priorTurns);
+    await mineAttachmentGoldens({ env: 'dev', personaId: 'persona-xyz', sampleSize: 3 });
+    expect(mockMkdirSync).toHaveBeenCalledWith('reports/goldens-mining', { recursive: true });
+    const goldens = writtenGoldens();
+    expect(goldens).toHaveLength(2);
+    const image = goldens.find(g => g.attachmentKind === 'image');
+    expect(image?.messageBare).toBe('about this one');
+    expect(image?.attachmentText).toContain('[Image: img-0.png]');
+    // `message` deliberately holds the FULL enriched content (see the type's doc).
+    expect(image?.message).toBe(`${image?.messageBare}\n\n${image?.attachmentText}`);
+    expect(image?.priorHistory).toHaveLength(3);
+  });
+});

--- a/packages/tooling/src/memory/mine-attachment-goldens.ts
+++ b/packages/tooling/src/memory/mine-attachment-goldens.ts
@@ -1,0 +1,299 @@
+/**
+ * Attachment-goldens mining: pull REAL attachment-bearing user turns (image
+ * descriptions, voice transcripts) so the search-query allocation A/B can be
+ * scored on the query shape it is actually about.
+ *
+ * Why a SEPARATE miner and output file: the conversation-goldens set is
+ * already judged (fold qrels), and re-mining it against a moved DB state would
+ * invalidate those judgments. Attachment goldens are ADDITIVE —
+ * `attachment-goldens.json` beside `conversation-goldens.json` — and the
+ * allocation arms only diverge on attachment-bearing queries anyway.
+ *
+ * Attachment text lives appended in `content` (VisionDescriptionWriter
+ * upgrades the placeholder row post-vision: `message + '\n\n' + descriptions`).
+ * `messageMetadata.attachmentDescriptions` has NO producer — the JSONB field
+ * is schema-only — so candidates are found by content marker and split back
+ * into (bare message, attachment block) at mine time.
+ *
+ * The mined output is LOCAL-ONLY (gitignored `reports/goldens-mining/`) — it
+ * holds raw conversation content. What gets committed is THIS miner
+ * (deterministic: same DB state → same sample), never the goldens.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { Environment } from '../utils/env-runner.js';
+import { pickEvenlySpaced } from './sampling.js';
+import {
+  classifyQueryStyle,
+  fetchPriorHistory,
+  type ConversationGolden,
+} from './mine-conversation-goldens.js';
+
+/** Which enrichment the turn carries — drives per-kind sampling quotas. */
+export type AttachmentKind = 'image' | 'voice' | 'mixed';
+
+/**
+ * A conversation golden whose turn carries attachment enrichment, pre-split.
+ *
+ * NOTE: unlike the base type's doc says, `message` here holds the FULL
+ * enriched row content (bare message + attachment block) — what production's
+ * history actually stores. The split parts live in `messageBare` /
+ * `attachmentText` so the allocation eval can rebuild each arm's query;
+ * `messageBare` is the naive-query baseline, not `message`.
+ */
+export interface AttachmentGolden extends ConversationGolden {
+  attachmentKind: AttachmentKind;
+  /** The user's own text, split from the enriched row (may be empty for image/voice-only turns). */
+  messageBare: string;
+  /** The appended attachment block: `[Image: …]` headers + descriptions / voice transcript wrappers. */
+  attachmentText: string;
+}
+
+/**
+ * First attachment header in enriched content. VisionDescriptionWriter joins
+ * `message + '\n\n' + descriptions` (or descriptions alone), and each entry
+ * opens with a bracketed type header — so the first header at a `\n\n`
+ * boundary (or at position 0) is where the user's text ends. A user message
+ * that itself contains such a line would split early; acceptable for an
+ * eval-only miner, and the bare-message part is still inspectable in the JSON.
+ */
+const ATTACHMENT_HEADER_RE = /(?:^|\n\n)\[(?:Image|Sticker|Voice message|Audio|File):[^\]\n]*\]/;
+
+/** Split enriched row content into the bare user message and the attachment block. */
+export function splitEnrichedContent(
+  content: string
+): { messageBare: string; attachmentText: string } | null {
+  const match = ATTACHMENT_HEADER_RE.exec(content);
+  if (match === null) {
+    return null;
+  }
+  const headerStart = match[0].startsWith('\n\n') ? match.index + 2 : match.index;
+  return {
+    messageBare: content.slice(0, match.index).trim(),
+    attachmentText: content.slice(headerStart).trim(),
+  };
+}
+
+/**
+ * Classify the attachment block. Voice transcripts are wrapped in
+ * `<voice_transcripts>`; images/stickers carry bracket headers with a
+ * following description line. A block with both is 'mixed' (sampled under the
+ * image quota — the image description is the long dominant part).
+ */
+export function classifyAttachmentKind(attachmentText: string): AttachmentKind {
+  const hasVoice = attachmentText.includes('<voice_transcripts>');
+  const hasImage = /\[(?:Image|Sticker): /.test(attachmentText);
+  if (hasVoice && hasImage) {
+    return 'mixed';
+  }
+  return hasVoice ? 'voice' : 'image';
+}
+
+export interface MineAttachmentGoldensOptions {
+  env: Environment;
+  personaId: string;
+  /** Target golden count across kinds (default 24: 2/3 image+mixed, 1/3 voice). */
+  sampleSize?: number;
+  /** Raw prior-turn pool per golden (same bound as the conversation miner). */
+  historyWindow?: number;
+  outDir?: string;
+}
+
+const DEFAULT_SAMPLE_SIZE = 24;
+const DEFAULT_HISTORY_WINDOW = 50;
+const DEFAULT_OUT_DIR = 'reports/goldens-mining';
+/** Time buckets for even spread across the retention window. */
+const STRATA_BUCKETS = 8;
+/** Image (+mixed) share of the sample — the long-description shape the allocation A/B targets. */
+const IMAGE_QUOTA_SHARE = 2 / 3;
+
+interface RawCandidateRow {
+  id: string;
+  channel_id: string;
+  personality_id: string;
+  content: string;
+  message_metadata: unknown;
+  created_at: Date;
+}
+
+interface AttachmentCandidate {
+  id: string;
+  channelId: string;
+  personalityId: string;
+  content: string;
+  messageMetadata: unknown;
+  createdAt: Date;
+  kind: AttachmentKind;
+  messageBare: string;
+  attachmentText: string;
+}
+
+/** Deterministic per-kind even-time sample: image+mixed under one quota, voice under the other. */
+export function sampleByKind(
+  candidates: AttachmentCandidate[],
+  sampleSize: number
+): AttachmentCandidate[] {
+  const imagePool = candidates.filter(c => c.kind !== 'voice');
+  const voicePool = candidates.filter(c => c.kind === 'voice');
+  const sortByTime = (pool: AttachmentCandidate[]): AttachmentCandidate[] =>
+    pool
+      .slice()
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id));
+  const imageQuota = Math.round(sampleSize * IMAGE_QUOTA_SHARE);
+  const voiceQuota = sampleSize - imageQuota;
+  return [
+    ...pickEvenlySpaced(sortByTime(imagePool), imageQuota, STRATA_BUCKETS),
+    ...pickEvenlySpaced(sortByTime(voicePool), voiceQuota, STRATA_BUCKETS),
+  ];
+}
+
+/**
+ * Mine attachment goldens from `conversation_history`. Candidates are
+ * enriched-content user turns (image-description or voice-transcript markers);
+ * each finalist gets the same prior-history window the conversation miner
+ * captures, and finalists without enough prior history are dropped (2×
+ * over-sampling backfills the loss).
+ */
+export async function mineAttachmentGoldens(options: MineAttachmentGoldensOptions): Promise<void> {
+  const sampleSize = options.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+  const historyWindow = options.historyWindow ?? DEFAULT_HISTORY_WINDOW;
+  const outDir = options.outDir ?? DEFAULT_OUT_DIR;
+
+  const { getPrismaForEnv } = await import('./prisma-env.js');
+  const { prisma, disconnect } = await getPrismaForEnv(options.env);
+
+  try {
+    const candidates = await fetchAttachmentCandidates(prisma, options.personaId);
+    logKindDistribution('Candidate kind distribution', candidates);
+
+    const finalists = sampleByKind(candidates, sampleSize * 2);
+    // Per-kind caps mirror the sampling quotas: without them, the 2× image
+    // over-sample (ordered first in `finalists`) backfills history-drops out
+    // of VOICE's share and the sample collapses to one kind.
+    const imageCap = Math.round(sampleSize * IMAGE_QUOTA_SHARE);
+    const kindCap = (kind: AttachmentKind): number =>
+      kind === 'voice' ? sampleSize - imageCap : imageCap;
+    const perKindCount = new Map<AttachmentKind, number>();
+    const countForCap = (kind: AttachmentKind): number =>
+      kind === 'voice'
+        ? (perKindCount.get('voice') ?? 0)
+        : (perKindCount.get('image') ?? 0) + (perKindCount.get('mixed') ?? 0);
+    const goldens: AttachmentGolden[] = [];
+    let droppedNoHistory = 0;
+    for (const candidate of finalists) {
+      if (goldens.length >= sampleSize) {
+        break;
+      }
+      if (countForCap(candidate.kind) >= kindCap(candidate.kind)) {
+        continue;
+      }
+      const priorHistory = await fetchPriorHistory(prisma, candidate, historyWindow);
+      if (priorHistory === null) {
+        droppedNoHistory += 1;
+        continue;
+      }
+      perKindCount.set(candidate.kind, (perKindCount.get(candidate.kind) ?? 0) + 1);
+      goldens.push({
+        id: candidate.id,
+        channelId: candidate.channelId,
+        personaId: options.personaId,
+        personalityId: candidate.personalityId,
+        message: candidate.content,
+        messageMetadata: candidate.messageMetadata,
+        createdAt: candidate.createdAt.toISOString(),
+        style: classifyQueryStyle(candidate.messageBare),
+        priorHistory,
+        attachmentKind: candidate.kind,
+        messageBare: candidate.messageBare,
+        attachmentText: candidate.attachmentText,
+      });
+    }
+
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(
+      join(outDir, 'attachment-goldens.json'),
+      `${JSON.stringify({ goldens }, null, 2)}\n`
+    );
+
+    console.log(
+      `\nWrote ${goldens.length} attachment goldens to ${outDir}/attachment-goldens.json` +
+        ' (LOCAL-ONLY, gitignored)'
+    );
+    console.log(`Dropped ${droppedNoHistory} candidates with too little prior history.`);
+    logKindDistribution('Golden kind distribution', goldens);
+    logAttachmentLengths(goldens);
+  } finally {
+    await disconnect();
+  }
+}
+
+/** Fetch + split every enriched-content user turn for the persona. */
+async function fetchAttachmentCandidates(
+  prisma: PrismaClient,
+  personaId: string
+): Promise<AttachmentCandidate[]> {
+  // Enriched image rows have a description line after the bracket header
+  // (placeholder-only rows join headers inline with no newline); voice rows
+  // carry the transcript wrapper. Bounded by the persona scope + retention
+  // window, same as the conversation miner's sanctioned-unbounded query.
+  const rows = await prisma.$queryRaw<RawCandidateRow[]>`
+    SELECT id, channel_id, personality_id, content, message_metadata, created_at
+    FROM conversation_history
+    WHERE persona_id = ${personaId}::uuid
+      AND role = 'user'
+      AND deleted_at IS NULL
+      AND (
+        content ~ ${'\\[(Image|Sticker): [^\\]]*\\]\n'}
+        OR content LIKE '%<voice_transcripts>%'
+      )
+  `;
+  const candidates: AttachmentCandidate[] = [];
+  for (const row of rows) {
+    const split = splitEnrichedContent(row.content);
+    if (split === null) {
+      continue;
+    }
+    candidates.push({
+      id: row.id,
+      channelId: row.channel_id,
+      personalityId: row.personality_id,
+      content: row.content,
+      messageMetadata: row.message_metadata,
+      createdAt: new Date(row.created_at),
+      kind: classifyAttachmentKind(split.attachmentText),
+      messageBare: split.messageBare,
+      attachmentText: split.attachmentText,
+    });
+  }
+  return candidates;
+}
+
+/** Console-only kind histogram (no content — safe to print). */
+function logKindDistribution(
+  label: string,
+  items: ({ kind: AttachmentKind } | { attachmentKind: AttachmentKind })[]
+): void {
+  const counts = new Map<AttachmentKind, number>();
+  for (const item of items) {
+    const kind = 'kind' in item ? item.kind : item.attachmentKind;
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  }
+  const summary = (['image', 'mixed', 'voice'] as const)
+    .map(kind => `${kind}=${counts.get(kind) ?? 0}`)
+    .join(', ');
+  console.log(`${label}: ${summary}`);
+}
+
+/** Console-only length summary for the attachment blocks (counts, not content). */
+function logAttachmentLengths(goldens: AttachmentGolden[]): void {
+  if (goldens.length === 0) {
+    return;
+  }
+  const lengths = goldens.map(g => g.attachmentText.length).sort((a, b) => a - b);
+  const p50 = lengths[Math.floor(lengths.length / 2)];
+  console.log(
+    `Attachment block chars: min=${lengths[0]}, p50=${p50}, max=${lengths[lengths.length - 1]}`
+  );
+}

--- a/packages/tooling/src/memory/mine-conversation-goldens.ts
+++ b/packages/tooling/src/memory/mine-conversation-goldens.ts
@@ -190,6 +190,13 @@ interface Candidate {
   style: QueryStyle;
 }
 
+/** The row-identity fields prior-history fetching needs (shared with the attachment miner). */
+export interface PriorHistoryTarget {
+  id: string;
+  channelId: string;
+  createdAt: Date;
+}
+
 /**
  * Fetch the turns preceding a target in the same CHANNEL — the exact substrate
  * production folds. Production's history source (`ConversationHistoryService.
@@ -200,9 +207,9 @@ interface Candidate {
  * helps. `extractRecentHistoryWindow` slices the tail of this window. Returns null
  * when there is too little history to fold.
  */
-async function fetchPriorHistory(
+export async function fetchPriorHistory(
   prisma: PrismaClient,
-  candidate: Candidate,
+  candidate: PriorHistoryTarget,
   historyWindow: number
 ): Promise<ConversationTurn[] | null> {
   const priorRows = await prisma.$queryRaw<RawTurnRow[]>`


### PR DESCRIPTION
## Summary

TASK-393's open half — which text wins the embedder's 512-token window — is blocked on a goldens gap: the 40 conversation goldens contain **zero attachment-bearing turns**, so no query of the shape the task is about has ever been scored. This PR adds `pnpm ops memory:mine-attachment-goldens`, an **additive** miner that writes `attachment-goldens.json` beside the already-judged conversation set.

## Why additive, not a re-mine

The conversation goldens carry judged fold qrels; the miner is deterministic only against a fixed DB state, so re-mining against today's data would produce a different sample and invalidate those judgments. The allocation arms also only diverge on attachment-bearing queries — non-attachment goldens score identically under every option.

## What I verified (not just read)

- **`messageMetadata.attachmentDescriptions` has no producer.** Probed the synced history (dev): 0 of 4,020 retained user turns carry it; the 9 `referencedMessages` rows exactly match the existing goldens' census. Attachment text lives appended in `content` — `VisionDescriptionWriter` upgrades the placeholder row post-vision (`message + '\n\n' + descriptions`).
- **The shape exists at scale**: 69 image-enriched + 44 voice turns for the mining persona; enriched-image turns run p50 3,654 chars / p90 12,550 / max 30,648 — the *median* such turn overflows the ~2,000-char model window nearly 2×.
- **Ran the miner end-to-end against dev**: 24 goldens (16 image / 8 voice, per-kind caps enforced), all with ≥2 prior turns for the fold, output confirmed gitignored.
- `pnpm --filter @tzurot/tooling test` (1,778 passing, 15 new) and `pnpm quality` both green.

## Design notes

- Content is split back into (bare message, attachment block) at mine time via the `\n\n[Image: …]` / voice-wrapper markers, so the eval can rebuild production's query parts per allocation option.
- Per-kind collection caps mirror the sampling quotas — without them the 2× image over-sample backfills history-drops out of voice's share (observed on the first live run: 21/3 instead of 16/8).
- `fetchPriorHistory` is now exported from the conversation miner with a narrowed `PriorHistoryTarget` param, shared by both miners.

Next (separate PR): allocation A/B arms in the fold-aware eval harness, scored on these goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)