### PR TITLE
feat(ai-worker): attachment-allocation A/B eval harness (TASK-393 Phase B)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "eval:extraction": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts",
     "eval:fact-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/factPooling.eval.test.ts",
     "eval:fact-score": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/factScoring.eval.test.ts",
+    "eval:allocation-goldens": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/attachmentAllocationPooling.eval.test.ts",
+    "eval:allocation-score": "vitest run --config vitest.eval.config.ts services/ai-worker/src/services/eval/attachmentAllocationScoring.eval.test.ts",
     "tracker": "backlog"
   },
   "devDependencies": {

--- a/services/ai-worker/src/services/eval/allocationArms.test.ts
+++ b/services/ai-worker/src/services/eval/allocationArms.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseAttachmentSegments,
+  leadSentence,
+  truncateAtWordBoundary,
+  buildAllocationQueries,
+  ATTACHMENT_BUDGET_CHARS,
+} from './allocationArms.js';
+
+const IMAGE_BLOCK = '[Image: gym.png]\nA large room with rubber flooring. Mirrors line the wall.';
+const VOICE_BLOCK =
+  '[Voice message: 5.2s]\n<voice_transcripts><transcript>hey are you around later</transcript></voice_transcripts>';
+
+describe('parseAttachmentSegments', () => {
+  it('strips the header from an image block and keeps the description', () => {
+    expect(parseAttachmentSegments(IMAGE_BLOCK)).toEqual([
+      { isTranscript: false, text: 'A large room with rubber flooring. Mirrors line the wall.' },
+    ]);
+  });
+
+  it('unwraps a voice block down to the spoken text', () => {
+    expect(parseAttachmentSegments(VOICE_BLOCK)).toEqual([
+      { isTranscript: true, text: 'hey are you around later' },
+    ]);
+  });
+
+  it('splits a mixed block into one segment per attachment, in order', () => {
+    const segments = parseAttachmentSegments(`${IMAGE_BLOCK}\n\n${VOICE_BLOCK}`);
+    expect(segments).toHaveLength(2);
+    expect(segments[0].isTranscript).toBe(false);
+    expect(segments[1]).toEqual({ isTranscript: true, text: 'hey are you around later' });
+  });
+
+  it('joins multiple transcripts inside one wrapper', () => {
+    const block =
+      '[Voice message: 9.0s]\n<voice_transcripts><transcript>first part</transcript><transcript>second part</transcript></voice_transcripts>';
+    expect(parseAttachmentSegments(block)).toEqual([
+      { isTranscript: true, text: 'first part\nsecond part' },
+    ]);
+  });
+
+  it('drops a header-only entry (bare placeholder, no description)', () => {
+    expect(parseAttachmentSegments(`[Sticker: wave]\n\n${IMAGE_BLOCK}`)).toEqual([
+      { isTranscript: false, text: 'A large room with rubber flooring. Mirrors line the wall.' },
+    ]);
+  });
+
+  it('handles Audio and File headers', () => {
+    expect(parseAttachmentSegments('[Audio: song.mp3]\nA slow piano piece.')).toEqual([
+      { isTranscript: false, text: 'A slow piano piece.' },
+    ]);
+    expect(parseAttachmentSegments('[File: notes.txt]\nMeeting notes about the launch.')).toEqual([
+      { isTranscript: false, text: 'Meeting notes about the launch.' },
+    ]);
+  });
+
+  it('returns nothing for text without an attachment header', () => {
+    expect(parseAttachmentSegments('just a plain message')).toEqual([]);
+  });
+
+  it('keeps a multi-paragraph description as one segment', () => {
+    const block = '[Image: a.png]\nFirst paragraph.\n\nSecond paragraph continues.';
+    expect(parseAttachmentSegments(block)).toEqual([
+      { isTranscript: false, text: 'First paragraph.\n\nSecond paragraph continues.' },
+    ]);
+  });
+});
+
+describe('leadSentence', () => {
+  it('takes the first sentence up to a terminator', () => {
+    expect(leadSentence('A tabby cat sleeps. The window is open behind it.')).toBe(
+      'A tabby cat sleeps.'
+    );
+  });
+
+  it('spans a wrapped line to reach the first terminator', () => {
+    expect(leadSentence('A tabby cat\nsleeps on a sill. More detail.')).toBe(
+      'A tabby cat\nsleeps on a sill.'
+    );
+  });
+
+  it('falls back to the first line when no terminator exists', () => {
+    expect(leadSentence('no punctuation here\nsecond line')).toBe('no punctuation here');
+  });
+
+  it('returns the whole text for a single unterminated line', () => {
+    expect(leadSentence('just words')).toBe('just words');
+  });
+});
+
+describe('truncateAtWordBoundary', () => {
+  it('returns short text unchanged', () => {
+    expect(truncateAtWordBoundary('short', 100)).toBe('short');
+  });
+
+  it('cuts at the last word boundary inside the budget', () => {
+    expect(truncateAtWordBoundary('alpha beta gamma delta', 17)).toBe('alpha beta gamma');
+  });
+
+  it('cuts hard when the only boundary sacrifices over half the budget', () => {
+    const text = `ab ${'x'.repeat(50)}`;
+    expect(truncateAtWordBoundary(text, 20)).toBe(text.slice(0, 20));
+  });
+
+  it('treats newlines as boundaries', () => {
+    expect(truncateAtWordBoundary('alpha beta\ngamma delta', 17)).toBe('alpha beta\ngamma');
+  });
+});
+
+describe('buildAllocationQueries', () => {
+  const golden = {
+    messageBare: 'look at this gym',
+    attachmentText: `${IMAGE_BLOCK}\n\n${VOICE_BLOCK}`,
+  };
+
+  it('builds current as bare + full stripped descriptions (no headers, no wrappers)', () => {
+    const queries = buildAllocationQueries(golden);
+    expect(queries['current-dense']).toBe(
+      'look at this gym\n\nA large room with rubber flooring. Mirrors line the wall.\n\nhey are you around later'
+    );
+    expect(queries['current-dense']).not.toContain('[Image:');
+    expect(queries['current-dense']).not.toContain('<voice_transcripts>');
+  });
+
+  it('builds bare as the user text only', () => {
+    expect(buildAllocationQueries(golden)['bare-dense']).toBe('look at this gym');
+  });
+
+  it('lead-truncates image descriptions but keeps transcripts whole', () => {
+    expect(buildAllocationQueries(golden)['lead-dense']).toBe(
+      'look at this gym\n\nA large room with rubber flooring.\n\nhey are you around later'
+    );
+  });
+
+  it('caps the budget arm attachment part at ATTACHMENT_BUDGET_CHARS', () => {
+    const longDescription = `${'word '.repeat(400)}end.`;
+    const queries = buildAllocationQueries({
+      messageBare: 'context',
+      attachmentText: `[Image: big.png]\n${longDescription}`,
+    });
+    const attachmentPart = queries['budget-dense'].slice('context\n\n'.length);
+    expect(attachmentPart.length).toBeLessThanOrEqual(ATTACHMENT_BUDGET_CHARS);
+    expect(attachmentPart.length).toBeGreaterThan(ATTACHMENT_BUDGET_CHARS - 20);
+    expect(queries['current-dense'].length).toBeGreaterThan(queries['budget-dense'].length);
+  });
+
+  it('leaves a within-budget attachment untouched in the budget arm', () => {
+    const queries = buildAllocationQueries(golden);
+    expect(queries['budget-dense']).toBe(queries['current-dense']);
+  });
+
+  it('yields an empty bare arm for an image-only turn (the arm earns its miss)', () => {
+    const queries = buildAllocationQueries({ messageBare: '', attachmentText: IMAGE_BLOCK });
+    expect(queries['bare-dense']).toBe('');
+    expect(queries['current-dense']).toBe(
+      'A large room with rubber flooring. Mirrors line the wall.'
+    );
+  });
+});

--- a/services/ai-worker/src/services/eval/allocationArms.ts
+++ b/services/ai-worker/src/services/eval/allocationArms.ts
@@ -1,0 +1,160 @@
+/**
+ * Attachment-allocation arm queries (TASK-393's A/B).
+ *
+ * The search-query builder is unbounded while the embedder reads only 512
+ * tokens — on attachment-bearing turns the description overflows the window at
+ * the MEDIAN (mined p50 3,654 chars against a ~2,000-char window). These arms
+ * sweep HOW MUCH attachment text the query carries, dose-response style, so the
+ * judged pools can locate the optimum instead of reasoning to it:
+ *
+ * - `bare-dense`    — the user's own text only (0 attachment chars; control).
+ * - `lead-dense`    — bare + the lead sentence of each image description
+ *                     (voice transcripts ride whole: they ARE the user's words,
+ *                     not a model's description of them).
+ * - `budget-dense`  — bare + descriptions truncated to half the window
+ *                     ({@link ATTACHMENT_BUDGET_CHARS}), the per-part-allocation
+ *                     policy shape.
+ * - `current-dense` — bare + full descriptions; the embedder truncates at 512
+ *                     tokens keeping the head. This is production behavior.
+ *
+ * ## Stored format vs. the live query
+ *
+ * The goldens carry the STORED enrichment (`[Image: name]` headers, transcripts
+ * in `<voice_transcripts>` wrappers — `buildAttachmentDescriptions`'s display
+ * format). The live search query embeds `extractContentDescriptions` output:
+ * raw descriptions/transcripts joined by blank lines, no headers, no wrappers.
+ * {@link parseAttachmentSegments} strips the storage dressing so every arm —
+ * including `current` — is built from the text production actually embeds.
+ *
+ * ## Why a char budget, not a token budget
+ *
+ * The window is 512 model tokens (`EMBEDDING_MAX_INPUT_TOKENS`, deliberately
+ * un-exported from `@tzurot/embeddings` until a production caller sizes against
+ * it). Real prod prose measures ~4 chars/token (the overflow warn reports the
+ * observed ratio per request), so the half-window budget is 1024 chars. The
+ * eval only needs "roughly half the window"; a production budget policy would
+ * count real tokens via the worker's tokenizer.
+ */
+
+/** Half the 512-token window at the ~4 chars/token measured on prod prose. */
+export const ATTACHMENT_BUDGET_CHARS = 1024;
+
+/** Dense arms in report order: production first, then ascending attachment text. */
+export const ALLOCATION_DENSE_ARMS = [
+  'current-dense',
+  'bare-dense',
+  'lead-dense',
+  'budget-dense',
+] as const;
+
+export type AllocationDenseArm = (typeof ALLOCATION_DENSE_ARMS)[number];
+
+/**
+ * The FTS diversity arm's name — shared by the pooling producer and the scoring
+ * consumer so a rename can't leave the scorer silently reading an arm no
+ * candidate carries.
+ */
+export const ALLOCATION_FTS_ARM = 'current-fts';
+
+/** One attachment's query-relevant text, stripped of storage formatting. */
+export interface AttachmentSegment {
+  /** True for voice/audio transcripts — user speech, never lead-truncated. */
+  isTranscript: boolean;
+  /** Header-stripped, wrapper-unwrapped text, as the live search query carries it. */
+  text: string;
+}
+
+/** Storage-format attachment headers, at the start or after a blank line. */
+const HEADER_RE = /(?:^|\n\n)\[(?:Image|Sticker|Voice message|Audio|File):[^\]\n]*\]/g;
+
+const TRANSCRIPT_RE = /<transcript>([\s\S]*?)<\/transcript>/g;
+
+/**
+ * Split a stored attachment block into per-attachment segments, dropping the
+ * bracket headers and unwrapping `<voice_transcripts>` down to the spoken text.
+ * Header-only entries (bare placeholders with no description) yield nothing.
+ */
+export function parseAttachmentSegments(attachmentText: string): AttachmentSegment[] {
+  const starts: number[] = [];
+  for (const match of attachmentText.matchAll(HEADER_RE)) {
+    starts.push(match.index + (match[0].startsWith('\n\n') ? 2 : 0));
+  }
+  const segments: AttachmentSegment[] = [];
+  starts.forEach((start, index) => {
+    const block = attachmentText.slice(start, starts[index + 1]).trim();
+    const headerEnd = block.indexOf('\n');
+    const body = headerEnd === -1 ? '' : block.slice(headerEnd + 1).trim();
+    if (body.length === 0) {
+      return;
+    }
+    if (body.includes('<voice_transcripts>')) {
+      const spoken = [...body.matchAll(TRANSCRIPT_RE)]
+        .map(match => match[1].trim())
+        .filter(text => text.length > 0)
+        .join('\n');
+      if (spoken.length > 0) {
+        segments.push({ isTranscript: true, text: spoken });
+      }
+      return;
+    }
+    segments.push({ isTranscript: false, text: body });
+  });
+  return segments;
+}
+
+/**
+ * First sentence of a description (up to `.` / `!` / `?` before whitespace or
+ * end), falling back to the first line, then the whole text. Abbreviation
+ * false-positives ("approx. 3m") cut early — tolerable for an eval arm whose
+ * question is "does a SHORT lead beat the full description", not the exact cut.
+ */
+export function leadSentence(text: string): string {
+  const match = /^[\s\S]*?[.!?](?=\s|$)/.exec(text);
+  if (match !== null) {
+    return match[0].trim();
+  }
+  const firstLine = text.split('\n', 1)[0].trim();
+  return firstLine.length > 0 ? firstLine : text.trim();
+}
+
+/**
+ * Truncate to at most `maxChars`, backing up to the last whitespace so the cut
+ * lands between words — unless that would sacrifice more than half the budget
+ * (one unbroken run), in which case cut hard.
+ */
+export function truncateAtWordBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  const slice = text.slice(0, maxChars);
+  const lastBreak = Math.max(slice.lastIndexOf(' '), slice.lastIndexOf('\n'));
+  return (lastBreak > maxChars / 2 ? slice.slice(0, lastBreak) : slice).trimEnd();
+}
+
+/**
+ * Build every dense arm's query for one golden. An empty string means the arm
+ * has nothing to search with (an image-only turn under the bare policy) — the
+ * pooling runner skips the retrieval and the arm scores the miss it earned.
+ */
+export function buildAllocationQueries(golden: {
+  messageBare: string;
+  attachmentText: string;
+}): Record<AllocationDenseArm, string> {
+  const segments = parseAttachmentSegments(golden.attachmentText);
+  const full = joinParts(...segments.map(segment => segment.text));
+  const lead = joinParts(
+    ...segments.map(segment => (segment.isTranscript ? segment.text : leadSentence(segment.text)))
+  );
+  const bare = golden.messageBare.trim();
+  return {
+    'current-dense': joinParts(bare, full),
+    'bare-dense': bare,
+    'lead-dense': joinParts(bare, lead),
+    'budget-dense': joinParts(bare, truncateAtWordBoundary(full, ATTACHMENT_BUDGET_CHARS)),
+  };
+}
+
+/** Join non-empty parts with the builder's separator (blank line). */
+function joinParts(...parts: string[]): string {
+  return parts.filter(part => part.length > 0).join('\n\n');
+}

--- a/services/ai-worker/src/services/eval/attachmentAllocationPooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/attachmentAllocationPooling.eval.test.ts
@@ -30,7 +30,14 @@ import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
 import { PgvectorMemoryAdapter } from '../PgvectorMemoryAdapter.js';
 import { extractRecentHistoryWindow } from '../RAGUtils.js';
 import { classifyCandidate } from './nonCircularityGuard.js';
-import { denseArm, ftsArm, armSortKey, rankBadge, type RetrievedRow } from './poolingArms.js';
+import {
+  denseArm,
+  ftsArm,
+  armSortKey,
+  rankBadge,
+  oldestHistoryMs,
+  type RetrievedRow,
+} from './poolingArms.js';
 import {
   buildAllocationQueries,
   ALLOCATION_DENSE_ARMS,
@@ -131,10 +138,7 @@ describe.skipIf(!ready)('attachment-allocation pooling (live dev memory store)',
       // Same guard inputs as the fold runner (see its inline comments): the
       // window is what production's PROMPT already carries, so an in-window or
       // echoed memory can't count as a retrieval win for ANY allocation arm.
-      const oldestHistoryMs =
-        golden.priorHistory.length === 0
-          ? Number.MAX_SAFE_INTEGER
-          : Math.min(...golden.priorHistory.map(turn => new Date(turn.createdAt).getTime()));
+      const historyFloorMs = oldestHistoryMs(golden.priorHistory);
       const foldWindowText = extractRecentHistoryWindow(turns, PROD_FOLD_TURNS) ?? '';
 
       const queries = buildAllocationQueries(golden);
@@ -171,7 +175,7 @@ describe.skipIf(!ready)('attachment-allocation pooling (live dev memory store)',
         ranks: candidate.ranks,
         verdict: classifyCandidate(
           { createdAtMs: candidate.createdAtMs, content: candidate.content },
-          { oldestHistoryMs, foldWindowText }
+          { oldestHistoryMs: historyFloorMs, foldWindowText }
         ),
       }));
 
@@ -180,7 +184,7 @@ describe.skipIf(!ready)('attachment-allocation pooling (live dev memory store)',
         message: golden.message,
         style: golden.style,
         kind: golden.attachmentKind,
-        oldestHistoryMs,
+        oldestHistoryMs: historyFloorMs,
         arms: [...ALLOCATION_DENSE_ARMS, FTS_ARM],
         candidates,
       });

--- a/services/ai-worker/src/services/eval/attachmentAllocationPooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/attachmentAllocationPooling.eval.test.ts
@@ -1,21 +1,23 @@
 /**
- * Fold-aware pooling runner (the honest re-baseline).
+ * Attachment-allocation pooling runner (TASK-393's A/B).
  *
- * Runs the retrieval A/B the way production actually retrieves: with the fold.
- * For each REAL conversation golden (mined via `memory:mine-conversation-goldens`)
- * it runs bare-vs-folded arms — dense (pgvector) and FTS — pools the top-K of
+ * For each REAL attachment-bearing golden (mined via
+ * `memory:mine-attachment-goldens`) it runs the allocation arms from
+ * `allocationArms.ts` — a dose-response sweep of how much attachment text the
+ * search query carries (bare → lead → budget → current) — pools the top-K of
  * each into a judgment sheet, and flags every pooled candidate against the
- * non-circularity guard so a memory the fold window already contains can't count
- * as a "win".
+ * non-circularity guard, exactly like the fold-aware re-baseline.
+ *
+ * The prior this tests against: the fold A/B measured dilution on content-rich
+ * queries as monotonically harmful (recall@10 0.436 → 0.390 → 0.256 → 0.195 as
+ * the fold widened). If `bare` wins here too, the fix is a gate like
+ * `shouldFoldSearchQuery`, not a budget.
  *
  * NOT a CI test and NOT hermetic: it queries a LIVE, prod-synced memory store
- * directly (dev), because the faithful corpus is the persona's FULL ~19k memory
- * pool with real embeddings — infeasible to re-embed into PGLite. Persona-wide
- * (no personality filter) matches the owner's shareLtmAcrossPersonalities=ON.
- *
- * Run: `EVAL_MEMORY_DATABASE_URL=<dev-url> pnpm eval:fold-goldens`. Skips itself
- * cleanly when the env var or the local goldens file is absent. Output (pool +
- * judgment sheet) is LOCAL-ONLY (gitignored `reports/goldens-mining/`).
+ * directly (dev), same as `foldAwarePooling.eval.test.ts` (see its header for
+ * why). Run: `EVAL_MEMORY_DATABASE_URL=<dev-url> pnpm eval:allocation-goldens`.
+ * Skips itself cleanly when the env var or the local goldens file is absent.
+ * Output is LOCAL-ONLY (gitignored `reports/goldens-mining/`).
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -26,21 +28,25 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
 import { PgvectorMemoryAdapter } from '../PgvectorMemoryAdapter.js';
-import { buildSearchQuery } from '../prompt/SearchQueryBuilder.js';
 import { extractRecentHistoryWindow } from '../RAGUtils.js';
 import { classifyCandidate } from './nonCircularityGuard.js';
 import { denseArm, ftsArm, armSortKey, rankBadge, type RetrievedRow } from './poolingArms.js';
+import {
+  buildAllocationQueries,
+  ALLOCATION_DENSE_ARMS,
+  ALLOCATION_FTS_ARM,
+} from './allocationArms.js';
 import type { PooledCandidate, GoldenPool } from './qrelsReconciliation.js';
 
 const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
-const GOLDENS_PATH = join(WORK_DIR, 'conversation-goldens.json');
+const GOLDENS_PATH = join(WORK_DIR, 'attachment-goldens.json');
 const DB_URL = process.env.EVAL_MEMORY_DATABASE_URL;
 
-/** Fold depths swept: production is 3; 5/8 probe whether more context helps. */
-const FOLD_TURN_COUNTS = [3, 5, 8] as const;
-/** The production fold depth — its window text is what the guard checks against.
- * Sourced from the same constant production uses so it can't drift from a stale literal. */
+/** The production fold depth — its window text is what the guard checks against. */
 const PROD_FOLD_TURNS = AI_DEFAULTS.LTM_SEARCH_HISTORY_TURNS;
+
+/** The FTS diversity arm pools lexical candidates the dense arms can't see. */
+const FTS_ARM = ALLOCATION_FTS_ARM;
 
 interface ConversationTurn {
   role: string;
@@ -48,24 +54,23 @@ interface ConversationTurn {
   createdAt: string;
 }
 
-interface ConversationGolden {
+interface AttachmentGolden {
   id: string;
   channelId: string;
   personaId: string;
   personalityId: string;
+  /** FULL enriched row content (bare message + stored attachment block). */
   message: string;
+  messageBare: string;
+  attachmentText: string;
+  attachmentKind: string;
   messageMetadata: unknown;
   createdAt: string;
   style: string;
   priorHistory: ConversationTurn[];
 }
 
-/**
- * Transient during pooling — carries the FULL memory content the guard must see.
- * A truncated preview would let a verbatim fold-window overlap past the cutoff
- * slip through as `eligible`, flattering the folded arm; only the preview is
- * persisted (as `PooledCandidate.contentPreview`), never the full content.
- */
+/** Transient during pooling — full content for the guard; only a preview persists. */
 interface PoolingCandidate {
   corpusId: string;
   createdAtMs: number;
@@ -75,16 +80,20 @@ interface PoolingCandidate {
 
 const ready = DB_URL !== undefined && DB_URL.length > 0 && existsSync(GOLDENS_PATH);
 
-describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
+describe.skipIf(!ready)('attachment-allocation pooling (live dev memory store)', () => {
   let prisma: PrismaClient;
   let embeddings: LocalEmbeddingService;
   let adapter: PgvectorMemoryAdapter;
-  let goldens: ConversationGolden[];
+  let goldens: AttachmentGolden[];
   const pools: GoldenPool[] = [];
+  const goldensById = new Map<string, AttachmentGolden>();
 
   beforeAll(async () => {
-    goldens = (JSON.parse(readFileSync(GOLDENS_PATH, 'utf8')) as { goldens: ConversationGolden[] })
+    goldens = (JSON.parse(readFileSync(GOLDENS_PATH, 'utf8')) as { goldens: AttachmentGolden[] })
       .goldens;
+    for (const golden of goldens) {
+      goldensById.set(golden.id, golden);
+    }
 
     prisma = new PrismaClient({
       adapter: new PrismaPg({ connectionString: DB_URL }),
@@ -100,42 +109,35 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
 
   afterAll(async () => {
     if (pools.length > 0) {
-      writeFileSync(join(WORK_DIR, 'fold-pool.json'), `${JSON.stringify({ pools }, null, 2)}\n`);
-      writeFileSync(join(WORK_DIR, 'fold-judgment-sheets.md'), buildJudgmentSheets(pools));
+      writeFileSync(
+        join(WORK_DIR, 'allocation-pool.json'),
+        `${JSON.stringify({ pools }, null, 2)}\n`
+      );
+      writeFileSync(
+        join(WORK_DIR, 'allocation-judgment-sheets.md'),
+        buildJudgmentSheets(pools, goldensById)
+      );
       console.log(
-        `\n=== fold-aware pooling: ${pools.length} goldens → ${WORK_DIR}/fold-judgment-sheets.md ===`
+        `\n=== allocation pooling: ${pools.length} goldens → ${WORK_DIR}/allocation-judgment-sheets.md ===`
       );
     }
     await prisma?.$disconnect();
     await embeddings?.shutdown();
   });
 
-  it('pools bare-vs-folded arms for every golden', { timeout: 1_800_000 }, async () => {
+  it('pools the allocation arms for every golden', { timeout: 1_800_000 }, async () => {
     for (const golden of goldens) {
       const turns = golden.priorHistory.map(turn => ({ role: turn.role, content: turn.content }));
-      // Approximation of production's oldestHistoryTimestamp: computed from the mined
-      // channel-scoped priorHistory (capped at historyWindow). Production can also fold
-      // cross-channel timestamps in, which would push this slightly older — acceptable
-      // for the temporal guard (a looser cutoff only makes the folded arm's bar HIGHER).
-      // Empty history → MAX_SAFE_INTEGER: no fold window exists, so nothing should
-      // classify as in-window (no real timestamp exceeds it), and unlike Math.min()'s
-      // Infinity it survives JSON persistence (Infinity stringifies to null).
+      // Same guard inputs as the fold runner (see its inline comments): the
+      // window is what production's PROMPT already carries, so an in-window or
+      // echoed memory can't count as a retrieval win for ANY allocation arm.
       const oldestHistoryMs =
         golden.priorHistory.length === 0
           ? Number.MAX_SAFE_INTEGER
           : Math.min(...golden.priorHistory.map(turn => new Date(turn.createdAt).getTime()));
       const foldWindowText = extractRecentHistoryWindow(turns, PROD_FOLD_TURNS) ?? '';
 
-      // Build the arm → query map. Dense arms embed + pgvector; FTS arms lexical.
-      const denseQueries: Record<string, string> = { 'bare-dense': golden.message };
-      for (const n of FOLD_TURN_COUNTS) {
-        denseQueries[`fold${n}-dense`] = buildSearchQuery(
-          golden.message,
-          [],
-          undefined,
-          extractRecentHistoryWindow(turns, n)
-        );
-      }
+      const queries = buildAllocationQueries(golden);
 
       const pooled = new Map<string, PoolingCandidate>();
       const record = (armName: string, rows: RetrievedRow[]): void => {
@@ -143,9 +145,6 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
           const existing = pooled.get(row.corpusId) ?? {
             corpusId: row.corpusId,
             createdAtMs: row.createdAtMs,
-            // The first arm to surface a candidate sets its content. Dense hits are
-            // placeholder-resolved ({user}→name) while FTS hits are raw SQL content;
-            // the tiny token delta doesn't move the lexical-echo verdict in practice.
             content: row.content,
             ranks: {} as Record<string, number>,
           };
@@ -154,16 +153,17 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
         });
       };
 
-      for (const [armName, query] of Object.entries(denseQueries)) {
-        record(armName, await denseArm(adapter, golden.personaId, query));
+      for (const armName of ALLOCATION_DENSE_ARMS) {
+        const query = queries[armName];
+        // An empty query means the arm has nothing to search with (image-only
+        // turn under the bare policy) — it contributes no candidates and scores
+        // the miss it earned.
+        if (query.length > 0) {
+          record(armName, await denseArm(adapter, golden.personaId, query));
+        }
       }
-      record('bare-fts', await ftsArm(prisma, golden.personaId, golden.message));
-      record(
-        `fold${PROD_FOLD_TURNS}-fts`,
-        await ftsArm(prisma, golden.personaId, denseQueries[`fold${PROD_FOLD_TURNS}-dense`])
-      );
+      record(FTS_ARM, await ftsArm(prisma, golden.personaId, queries['current-dense']));
 
-      // The guard classifies against FULL content; only the preview is persisted.
       const candidates: PooledCandidate[] = [...pooled.values()].map(candidate => ({
         corpusId: candidate.corpusId,
         createdAtMs: candidate.createdAtMs,
@@ -179,8 +179,9 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
         goldenId: golden.id,
         message: golden.message,
         style: golden.style,
+        kind: golden.attachmentKind,
         oldestHistoryMs,
-        arms: [...Object.keys(denseQueries), 'bare-fts', `fold${PROD_FOLD_TURNS}-fts`],
+        arms: [...ALLOCATION_DENSE_ARMS, FTS_ARM],
         candidates,
       });
     }
@@ -188,36 +189,52 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
   });
 });
 
-/** Build the owner/judge relevance sheet — one section per golden. */
-function buildJudgmentSheets(pools: GoldenPool[]): string {
+/** Sheet header quote budget — enough attachment context to judge relevance by. */
+const ATTACHMENT_QUOTE_CHARS = 600;
+
+/**
+ * Build the judge relevance sheet — one section per golden. Quotes the bare
+ * message in full plus the head of the attachment block (a 29k-char description
+ * pasted whole would drown the sheet; relevance is judgeable from the lead).
+ */
+function buildJudgmentSheets(
+  pools: GoldenPool[],
+  goldensById: Map<string, AttachmentGolden>
+): string {
   const lines = [
-    '# Fold-aware pooled-judgment sheets',
+    '# Attachment-allocation pooled-judgment sheets',
     '',
     'For each golden: mark every candidate `[R]` relevant, `[S]` sort-of, or leave `[ ]`.',
     'You judge ONLY what is listed. Rank badges show where each arm placed the candidate',
-    '(`B`=bare-dense, `F3/F5/F8`=folded-dense at 3/5/8 turns, `Bf/F3f`=bare/folded FTS).',
+    '(`C`=current [prod: bare+full attachment], `B`=bare message only, `L`=bare+lead',
+    'sentences, `G`=bare+budgeted attachment, `Cf`=FTS over the current query).',
     '`⊘in-window` / `⊘echo` mark candidates the non-circularity guard disqualifies — the',
-    'fold window already contains them, so they DO NOT count even if you mark them relevant.',
+    'prompt window already contains them, so they DO NOT count even if you mark them relevant.',
     '',
   ];
   for (const pool of pools) {
+    const golden = goldensById.get(pool.goldenId);
+    const attachmentHead = (golden?.attachmentText ?? '')
+      .slice(0, ATTACHMENT_QUOTE_CHARS)
+      .replace(/\n/g, '\n> ');
     lines.push(
       '---',
       '',
-      `## ${pool.goldenId.slice(0, 8)} (${pool.style})`,
+      `## ${pool.goldenId.slice(0, 8)} (${pool.kind ?? '?'}, ${pool.style})`,
       '',
-      `> ${pool.message}`,
+      `> ${golden?.messageBare ?? pool.message}`,
+      '>',
+      `> ${attachmentHead}${(golden?.attachmentText.length ?? 0) > ATTACHMENT_QUOTE_CHARS ? '…' : ''}`,
       ''
     );
     const sorted = [...pool.candidates].sort((a, b) => armSortKey(a) - armSortKey(b));
     for (const candidate of sorted) {
       const badges = [
+        rankBadge(candidate, 'current-dense', 'C'),
         rankBadge(candidate, 'bare-dense', 'B'),
-        rankBadge(candidate, 'fold3-dense', 'F3'),
-        rankBadge(candidate, 'fold5-dense', 'F5'),
-        rankBadge(candidate, 'fold8-dense', 'F8'),
-        rankBadge(candidate, 'bare-fts', 'Bf'),
-        rankBadge(candidate, 'fold3-fts', 'F3f'),
+        rankBadge(candidate, 'lead-dense', 'L'),
+        rankBadge(candidate, 'budget-dense', 'G'),
+        rankBadge(candidate, FTS_ARM, 'Cf'),
         candidate.verdict !== 'eligible' ? `⊘${candidate.verdict}` : null,
       ]
         .filter(Boolean)

--- a/services/ai-worker/src/services/eval/attachmentAllocationScoring.eval.test.ts
+++ b/services/ai-worker/src/services/eval/attachmentAllocationScoring.eval.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Attachment-allocation scoring glue (TASK-393's A/B number).
+ *
+ * Reads the local pool (`allocation-pool.json`, produced by
+ * `attachmentAllocationPooling.eval.test.ts`) and the judged relevance labels
+ * (`allocation-qrels.json`, produced by hand-judging the sheet), and emits the
+ * allocation A/B table via the committed `poolScoring` instrument — same
+ * prefix-reconciliation integrity as the fold re-baseline.
+ *
+ * The decision this feeds: which allocation policy replaces "the embedder
+ * truncates whatever the builder concatenated" — keep current, gate the
+ * attachment part out (bare), lead-sentence it, or budget it.
+ *
+ * NOT a CI test: it reads LOCAL-ONLY gitignored artifacts. Skips itself
+ * cleanly when either file is absent. Run: `pnpm eval:allocation-score`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { scoreArm, pairedFlips, combinedMissRate, type ScoredQuery } from './poolScoring.js';
+import { reconcile, type GoldenPool, type PrefixQrels, type Qrels } from './qrelsReconciliation.js';
+import { ALLOCATION_DENSE_ARMS, ALLOCATION_FTS_ARM } from './allocationArms.js';
+
+const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
+const POOL_PATH = join(WORK_DIR, 'allocation-pool.json');
+const QRELS_PATH = join(WORK_DIR, 'allocation-qrels.json');
+const REPORT_PATH = join(WORK_DIR, 'allocation-ab-result.md');
+
+/** Arms in report order; production behavior is current-dense. */
+const ARMS = [...ALLOCATION_DENSE_ARMS, ALLOCATION_FTS_ARM];
+/** Ascending attachment-text dose, for the dose-response read. */
+const DOSE_ORDER = ['bare-dense', 'lead-dense', 'budget-dense', 'current-dense'];
+const K_VALUES = [5, 10] as const;
+
+const ready = existsSync(POOL_PATH) && existsSync(QRELS_PATH);
+
+describe.skipIf(!ready)('attachment-allocation scoring (local pool + qrels)', () => {
+  it('emits the allocation A/B table', () => {
+    const pools = (JSON.parse(readFileSync(POOL_PATH, 'utf8')) as { pools: GoldenPool[] }).pools;
+    const prefixQrels = JSON.parse(readFileSync(QRELS_PATH, 'utf8')) as PrefixQrels;
+
+    const { queries, qrels } = reconcile(pools, prefixQrels);
+    const report = buildReport(pools, queries, qrels);
+    writeFileSync(REPORT_PATH, report);
+    console.log(`\n=== attachment-allocation A/B → ${REPORT_PATH} ===\n`);
+    console.log(report);
+
+    // At least one query must have scored, or reconciliation silently produced
+    // nothing (the failure mode this glue exists to prevent).
+    const scored = scoreArm(queries, qrels, 'current-dense', 10).scoredQueries;
+    expect(scored).toBeGreaterThan(0);
+  });
+});
+
+function buildReport(pools: GoldenPool[], queries: ScoredQuery[], qrels: Qrels): string {
+  const lines: string[] = [
+    '# Attachment-allocation A/B result',
+    '',
+    'How much attachment text should the memory-search query carry? Arms sweep the dose:',
+    'bare (none) → lead (first sentence per description) → budget (≤1024 chars) → current',
+    '(full text; the embedder truncates at 512 tokens). Every metric masks the relevant set',
+    'to the non-circularity guard, as in the fold re-baseline.',
+    '',
+    `Goldens: ${pools.length}. Production behavior is **current-dense**.`,
+    '',
+  ];
+
+  for (const k of K_VALUES) {
+    lines.push(`## Per-arm metrics @ K=${k}`, '');
+    lines.push('| Arm | recall@K | MRR | miss-rate | scored |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const arm of ARMS) {
+      const m = scoreArm(queries, qrels, arm, k);
+      lines.push(
+        `| ${arm} | ${fmt(m.recallAtK)} | ${fmt(m.mrr)} | ${fmt(m.missRate)} | ${m.scoredQueries} |`
+      );
+    }
+    lines.push('');
+  }
+
+  // The decisive question: does any alternative beat production's full-text head?
+  lines.push('## Paired comparisons — current-dense vs each alternative', '');
+  lines.push('| Treatment | K | both-hit | both-miss | fixes | breaks | net |');
+  lines.push('| --- | --- | --- | --- | --- | --- | --- |');
+  for (const arm of DOSE_ORDER.filter(a => a !== 'current-dense')) {
+    for (const k of K_VALUES) {
+      const f = pairedFlips(queries, qrels, 'current-dense', arm, k);
+      lines.push(
+        `| ${arm} | ${k} | ${f.bothHit} | ${f.bothMiss} | ${f.treatmentFixes} | ${f.treatmentBreaks} | ${signed(f.net)} |`
+      );
+    }
+  }
+  lines.push('');
+
+  // Dose-response: is more attachment text monotonically better, worse, or peaked?
+  lines.push('## Dose-response (dense) @ K=10', '');
+  lines.push('| Arm (ascending attachment text) | recall@10 | miss-rate |');
+  lines.push('| --- | --- | --- |');
+  for (const arm of DOSE_ORDER) {
+    const m = scoreArm(queries, qrels, arm, 10);
+    lines.push(`| ${arm} | ${fmt(m.recallAtK)} | ${fmt(m.missRate)} |`);
+  }
+  lines.push('');
+
+  lines.push(perKindSection(pools, queries, qrels));
+  return `${lines.join('\n')}\n`;
+}
+
+/** Per-kind dense miss @10 — voice transcripts and image descriptions may want different policies. */
+function perKindSection(pools: GoldenPool[], queries: ScoredQuery[], qrels: Qrels): string {
+  const kindById = new Map(pools.map(pool => [pool.goldenId, pool.kind ?? 'unknown']));
+  const kinds = [...new Set(pools.map(pool => pool.kind ?? 'unknown'))].sort();
+  const lines = [
+    '## Per-kind miss @ K=10 (dense arms)',
+    '',
+    `| Kind | ${DOSE_ORDER.join(' | ')} |`,
+    `| --- | ${DOSE_ORDER.map(() => '---').join(' | ')} |`,
+  ];
+  for (const kind of kinds) {
+    const subset = queries.filter(query => kindById.get(query.queryId) === kind);
+    const cells = DOSE_ORDER.map(arm => {
+      const miss = combinedMissRate(subset, qrels, [arm], 10);
+      return `${miss.missedTurns}/${miss.scoredQueries}`;
+    });
+    lines.push(`| ${kind} | ${cells.join(' | ')} |`);
+  }
+  return lines.join('\n');
+}
+
+function fmt(value: number): string {
+  return value.toFixed(3);
+}
+
+function signed(value: number): string {
+  return value > 0 ? `+${value}` : `${value}`;
+}

--- a/services/ai-worker/src/services/eval/factPooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/factPooling.eval.test.ts
@@ -34,6 +34,7 @@ import { buildSearchQuery } from '../prompt/SearchQueryBuilder.js';
 import { shouldFoldSearchQuery } from '../prompt/queryFoldGate.js';
 import { extractRecentHistoryWindow } from '../RAGUtils.js';
 import { isLexicalEcho } from './nonCircularityGuard.js';
+import { oldestHistoryMs } from './poolingArms.js';
 import {
   FACT_WEIGHT_GRID,
   compositePolicy,
@@ -151,12 +152,8 @@ describe.skipIf(!ready)('fact pooling (live dev fact store)', () => {
         message: golden.message,
         style: golden.style,
         // Metadata-only for facts (validFrom doesn't map onto the conversation
-        // window). Empty history → MAX_SAFE_INTEGER, not Math.min()'s Infinity,
-        // which JSON.stringify silently corrupts to null in the persisted pool.
-        oldestHistoryMs:
-          golden.priorHistory.length === 0
-            ? Number.MAX_SAFE_INTEGER
-            : Math.min(...golden.priorHistory.map(turn => new Date(turn.createdAt).getTime())),
+        // window).
+        oldestHistoryMs: oldestHistoryMs(golden.priorHistory),
         arms: ['prod'],
         channelId: golden.channelId,
         searchQuery,

--- a/services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/foldAwarePooling.eval.test.ts
@@ -29,7 +29,14 @@ import { PgvectorMemoryAdapter } from '../PgvectorMemoryAdapter.js';
 import { buildSearchQuery } from '../prompt/SearchQueryBuilder.js';
 import { extractRecentHistoryWindow } from '../RAGUtils.js';
 import { classifyCandidate } from './nonCircularityGuard.js';
-import { denseArm, ftsArm, armSortKey, rankBadge, type RetrievedRow } from './poolingArms.js';
+import {
+  denseArm,
+  ftsArm,
+  armSortKey,
+  rankBadge,
+  oldestHistoryMs,
+  type RetrievedRow,
+} from './poolingArms.js';
 import type { PooledCandidate, GoldenPool } from './qrelsReconciliation.js';
 
 const WORK_DIR = join(process.cwd(), 'reports/goldens-mining');
@@ -117,13 +124,7 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
       // channel-scoped priorHistory (capped at historyWindow). Production can also fold
       // cross-channel timestamps in, which would push this slightly older — acceptable
       // for the temporal guard (a looser cutoff only makes the folded arm's bar HIGHER).
-      // Empty history → MAX_SAFE_INTEGER: no fold window exists, so nothing should
-      // classify as in-window (no real timestamp exceeds it), and unlike Math.min()'s
-      // Infinity it survives JSON persistence (Infinity stringifies to null).
-      const oldestHistoryMs =
-        golden.priorHistory.length === 0
-          ? Number.MAX_SAFE_INTEGER
-          : Math.min(...golden.priorHistory.map(turn => new Date(turn.createdAt).getTime()));
+      const historyFloorMs = oldestHistoryMs(golden.priorHistory);
       const foldWindowText = extractRecentHistoryWindow(turns, PROD_FOLD_TURNS) ?? '';
 
       // Build the arm → query map. Dense arms embed + pgvector; FTS arms lexical.
@@ -171,7 +172,7 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
         ranks: candidate.ranks,
         verdict: classifyCandidate(
           { createdAtMs: candidate.createdAtMs, content: candidate.content },
-          { oldestHistoryMs, foldWindowText }
+          { oldestHistoryMs: historyFloorMs, foldWindowText }
         ),
       }));
 
@@ -179,7 +180,7 @@ describe.skipIf(!ready)('fold-aware pooling (live dev memory store)', () => {
         goldenId: golden.id,
         message: golden.message,
         style: golden.style,
-        oldestHistoryMs,
+        oldestHistoryMs: historyFloorMs,
         arms: [...Object.keys(denseQueries), 'bare-fts', `fold${PROD_FOLD_TURNS}-fts`],
         candidates,
       });

--- a/services/ai-worker/src/services/eval/poolingArms.test.ts
+++ b/services/ai-worker/src/services/eval/poolingArms.test.ts
@@ -5,6 +5,7 @@ import {
   ftsArm,
   armSortKey,
   rankBadge,
+  oldestHistoryMs,
   POOL_K,
   OVERFETCH,
   SCORE_FLOOR,
@@ -86,6 +87,24 @@ describe('ftsArm', () => {
       content: 'content of m1',
     });
     expect(out.filter(row => row.corpusId === 'group-a')).toHaveLength(1);
+  });
+});
+
+describe('oldestHistoryMs', () => {
+  it('returns the earliest turn timestamp', () => {
+    const history = [
+      { createdAt: '2026-01-02T00:00:00Z' },
+      { createdAt: '2026-01-01T00:00:00Z' },
+      { createdAt: '2026-01-03T00:00:00Z' },
+    ];
+    expect(oldestHistoryMs(history)).toBe(new Date('2026-01-01T00:00:00Z').getTime());
+  });
+
+  it('returns MAX_SAFE_INTEGER (not Infinity) for empty history so JSON survives', () => {
+    expect(oldestHistoryMs([])).toBe(Number.MAX_SAFE_INTEGER);
+    expect(JSON.parse(JSON.stringify({ ms: oldestHistoryMs([]) })).ms).toBe(
+      Number.MAX_SAFE_INTEGER
+    );
   });
 });
 

--- a/services/ai-worker/src/services/eval/poolingArms.test.ts
+++ b/services/ai-worker/src/services/eval/poolingArms.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import {
+  denseArm,
+  ftsArm,
+  armSortKey,
+  rankBadge,
+  POOL_K,
+  OVERFETCH,
+  SCORE_FLOOR,
+} from './poolingArms.js';
+import type { PooledCandidate } from './qrelsReconciliation.js';
+
+const hit = (id: string, chunkGroupId: string | null, createdAt = 1000) => ({
+  pageContent: `content of ${id}`,
+  metadata: { id, chunkGroupId, createdAt },
+});
+
+describe('denseArm', () => {
+  it('passes the query and pooling options across the adapter seam', async () => {
+    const queryMemories = vi.fn().mockResolvedValue([]);
+    await denseArm({ queryMemories }, 'persona-1', 'the query');
+    expect(queryMemories).toHaveBeenCalledWith('the query', {
+      personaId: 'persona-1',
+      limit: OVERFETCH,
+      scoreThreshold: SCORE_FLOOR,
+    });
+  });
+
+  it('collapses chunk siblings to one candidate keyed by chunk group', async () => {
+    const queryMemories = vi
+      .fn()
+      .mockResolvedValue([hit('m1', 'group-a'), hit('m2', 'group-a'), hit('m3', null)]);
+    const rows = await denseArm({ queryMemories }, 'p', 'q');
+    expect(rows.map(row => row.corpusId)).toEqual(['group-a', 'm3']);
+    expect(rows[0].content).toBe('content of m1');
+  });
+
+  it('skips hits carrying neither chunk group nor id, and caps at POOL_K', async () => {
+    const hits = [
+      { pageContent: 'orphan', metadata: {} },
+      ...Array.from({ length: OVERFETCH }, (_, i) => hit(`m${i}`, null)),
+    ];
+    const queryMemories = vi.fn().mockResolvedValue(hits);
+    const rows = await denseArm({ queryMemories }, 'p', 'q');
+    expect(rows).toHaveLength(POOL_K);
+    expect(rows[0].corpusId).toBe('m0');
+  });
+});
+
+describe('ftsArm', () => {
+  const ftsRow = (id: string, chunkGroupId: string | null = null) => ({
+    id,
+    content: `content of ${id}`,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    chunk_group_id: chunkGroupId,
+  });
+
+  const prismaWith = (rows: unknown[]): Pick<PrismaClient, '$queryRaw'> =>
+    ({ $queryRaw: vi.fn().mockResolvedValue(rows) }) as unknown as Pick<PrismaClient, '$queryRaw'>;
+
+  it('builds an OR-of-lexemes query from words of 2+ characters', async () => {
+    const prisma = prismaWith([]);
+    await ftsArm(prisma, 'persona-1', 'Look, at THIS gym! a x');
+    const values = (prisma.$queryRaw as ReturnType<typeof vi.fn>).mock.calls[0].slice(1);
+    expect(values).toContain('look | at | this | gym');
+  });
+
+  it('short-circuits without querying when no lexemes survive', async () => {
+    const prisma = prismaWith([]);
+    expect(await ftsArm(prisma, 'persona-1', '!!! ?')).toEqual([]);
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('dedups by chunk group and caps at POOL_K', async () => {
+    const rows = [
+      ftsRow('m1', 'group-a'),
+      ftsRow('m2', 'group-a'),
+      ...Array.from({ length: OVERFETCH }, (_, i) => ftsRow(`f${i}`)),
+    ];
+    const out = await ftsArm(prismaWith(rows), 'persona-1', 'some words');
+    expect(out).toHaveLength(POOL_K);
+    expect(out[0]).toEqual({
+      corpusId: 'group-a',
+      createdAtMs: new Date('2026-01-01T00:00:00Z').getTime(),
+      content: 'content of m1',
+    });
+    expect(out.filter(row => row.corpusId === 'group-a')).toHaveLength(1);
+  });
+});
+
+describe('sheet helpers', () => {
+  const candidate = (ranks: Record<string, number>): PooledCandidate => ({
+    corpusId: 'c1',
+    createdAtMs: 0,
+    contentPreview: '',
+    ranks,
+    verdict: 'eligible',
+  });
+
+  it('armSortKey uses the best rank across arms, 99 when unranked', () => {
+    expect(armSortKey(candidate({ a: 5, b: 2 }))).toBe(2);
+    expect(armSortKey(candidate({}))).toBe(99);
+  });
+
+  it('rankBadge renders label#rank or null when the arm missed it', () => {
+    expect(rankBadge(candidate({ a: 3 }), 'a', 'A')).toBe('A#3');
+    expect(rankBadge(candidate({ a: 3 }), 'b', 'B')).toBeNull();
+  });
+});

--- a/services/ai-worker/src/services/eval/poolingArms.ts
+++ b/services/ai-worker/src/services/eval/poolingArms.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared pooling arm runners for the eval harnesses.
+ *
+ * `denseArm` (embed → pgvector, the production retrieval path) and `ftsArm`
+ * (OR-of-lexemes lexical retrieval) were born inside the fold-aware pooling
+ * runner; the attachment-allocation A/B pools with the same runners, so they
+ * live here — one implementation both harnesses share, with the chunk-dedup
+ * and pool-depth behavior pinned by unit test instead of duplicated per eval.
+ *
+ * The constants are harness tuning, shared so every A/B pools at the same
+ * depth: cross-experiment numbers stay comparable only while POOL_K matches.
+ */
+
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { PgvectorMemoryAdapter } from '../PgvectorMemoryAdapter.js';
+import type { PooledCandidate } from './qrelsReconciliation.js';
+
+/** Pool depth per arm — TREC-style shallow pools judge fine at 10. */
+export const POOL_K = 10;
+/** Over-fetch before chunk-dedup so a deduped arm still fills K distinct candidates. */
+export const OVERFETCH = POOL_K * 2;
+/** Floor threshold: let ranking (not the production cutoff) decide the pool. */
+export const SCORE_FLOOR = 0.01;
+
+export interface RetrievedRow {
+  corpusId: string;
+  createdAtMs: number;
+  content: string;
+}
+
+/** The one adapter capability the dense arm needs — structural, so tests can fake it. */
+export type DenseRetriever = Pick<PgvectorMemoryAdapter, 'queryMemories'>;
+
+/**
+ * Dense arm: the production retrieval path (embed → pgvector), persona-wide.
+ * Over-fetches then dedups by chunk group (falling back to id) so chunk siblings
+ * collapse to one candidate and the arm still yields K distinct rows — without the
+ * over-fetch, a top-K crowded with same-source chunks would under-fill the pool.
+ */
+export async function denseArm(
+  adapter: DenseRetriever,
+  personaId: string,
+  query: string
+): Promise<RetrievedRow[]> {
+  const hits = await adapter.queryMemories(query, {
+    personaId,
+    limit: OVERFETCH,
+    scoreThreshold: SCORE_FLOOR,
+  });
+  const seen = new Set<string>();
+  const rows: RetrievedRow[] = [];
+  for (const hit of hits) {
+    const meta = hit.metadata as {
+      id?: string;
+      chunkGroupId?: string | null;
+      createdAt?: number;
+    };
+    const corpusId = meta.chunkGroupId ?? meta.id;
+    if (corpusId === undefined || corpusId === null || seen.has(corpusId)) {
+      continue;
+    }
+    seen.add(corpusId);
+    rows.push({ corpusId, createdAtMs: meta.createdAt ?? 0, content: hit.pageContent });
+    if (rows.length >= POOL_K) {
+      break;
+    }
+  }
+  return rows;
+}
+
+interface FtsRow {
+  id: string;
+  content: string;
+  created_at: Date;
+  chunk_group_id: string | null;
+}
+
+/**
+ * FTS arm: OR-of-lexemes over the query text (plainto_tsquery ANDs every word,
+ * which a conversational message never satisfies). Scoped by persona_id +
+ * visibility ONLY — matching the dense arm's `buildWhereConditions` exactly
+ * (which has no `type` filter), so both arms see the same candidate universe
+ * (incl. any knowledge-type rows). Long queries balloon the term set, so FTS on
+ * a rich query is near-degenerate — pooled for candidate diversity; the
+ * decisive arms are dense.
+ */
+export async function ftsArm(
+  prisma: Pick<PrismaClient, '$queryRaw'>,
+  personaId: string,
+  text: string
+): Promise<RetrievedRow[]> {
+  const orQuery = text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(word => word.length > 1)
+    .join(' | ');
+  if (orQuery.length === 0) {
+    return [];
+  }
+  const rows = await prisma.$queryRaw<FtsRow[]>`
+    SELECT id, content, created_at, chunk_group_id
+    FROM memories
+    WHERE persona_id = ${personaId}::uuid
+      AND visibility = 'normal'
+      AND to_tsvector('english', content) @@ to_tsquery('english', ${orQuery})
+    ORDER BY ts_rank(to_tsvector('english', content), to_tsquery('english', ${orQuery})) DESC
+    LIMIT ${OVERFETCH * 2}
+  `;
+  const seen = new Set<string>();
+  const out: RetrievedRow[] = [];
+  for (const row of rows) {
+    const corpusId = row.chunk_group_id ?? row.id;
+    if (seen.has(corpusId)) {
+      continue;
+    }
+    seen.add(corpusId);
+    out.push({ corpusId, createdAtMs: new Date(row.created_at).getTime(), content: row.content });
+    if (out.length >= POOL_K) {
+      break;
+    }
+  }
+  return out;
+}
+
+/** Sort candidates by best (lowest) rank across all arms for sheet readability. */
+export function armSortKey(candidate: PooledCandidate): number {
+  const ranks = Object.values(candidate.ranks);
+  return ranks.length === 0 ? 99 : Math.min(...ranks);
+}
+
+/** `label#rank` badge for the judgment sheet, or null when the arm missed the candidate. */
+export function rankBadge(candidate: PooledCandidate, arm: string, label: string): string | null {
+  const rank = candidate.ranks[arm];
+  return rank === undefined ? null : `${label}#${rank}`;
+}

--- a/services/ai-worker/src/services/eval/poolingArms.ts
+++ b/services/ai-worker/src/services/eval/poolingArms.ts
@@ -123,6 +123,19 @@ export async function ftsArm(
   return out;
 }
 
+/**
+ * Oldest prior-history timestamp, for the non-circularity guard's temporal
+ * cutoff. Empty history → MAX_SAFE_INTEGER: no window exists, so nothing should
+ * classify as in-window (no real timestamp exceeds it) — and unlike
+ * Math.min()'s Infinity it survives JSON persistence (Infinity stringifies to
+ * null in the pool file).
+ */
+export function oldestHistoryMs(priorHistory: { createdAt: string }[]): number {
+  return priorHistory.length === 0
+    ? Number.MAX_SAFE_INTEGER
+    : Math.min(...priorHistory.map(turn => new Date(turn.createdAt).getTime()));
+}
+
 /** Sort candidates by best (lowest) rank across all arms for sheet readability. */
 export function armSortKey(candidate: PooledCandidate): number {
   const ranks = Object.values(candidate.ranks);

--- a/services/ai-worker/src/services/eval/qrelsReconciliation.ts
+++ b/services/ai-worker/src/services/eval/qrelsReconciliation.ts
@@ -31,6 +31,8 @@ export interface GoldenPool {
   goldenId: string;
   message: string;
   style: string;
+  /** Attachment kind (image/voice/mixed) — set by the allocation pools only. */
+  kind?: string;
   oldestHistoryMs: number;
   arms: string[];
   candidates: PooledCandidate[];


### PR DESCRIPTION
## What

The eval harness for TASK-393's allocation decision. The search-query builder is unbounded while the embedder reads 512 tokens; on attachment-bearing turns the description overflows the window at the **median** (mined p50 3,654 chars vs the ~2,000-char window). Before changing which text wins the window, the options get scored the same way the fold gate was: pooled arms on real mined goldens, non-circularity guard, hand-judged qrels.

- **`allocationArms.ts`** (CI-tested, pure): builds the four dense arm queries as a dose-response sweep of attachment text — `bare` (none, control) → `lead` (first sentence per image description; voice transcripts ride whole — they're user speech, not model output) → `budget` (≤1024 chars, the per-part-allocation shape) → `current` (full text, embedder truncates; prod behavior). Arm queries are built in the **live** query format: storage headers stripped, `<voice_transcripts>` wrappers unwrapped, matching `extractContentDescriptions` output rather than the stored row.
- **`poolingArms.ts`** (CI-tested, shared): the dense/FTS pooling runners lifted out of `foldAwarePooling.eval.test.ts` (verbatim), plus the `oldestHistoryMs` guard helper that was duplicated across factPooling/foldAwarePooling and would have gained a third copy here (TASK-263's promote condition — done in this PR, second commit).
- **`attachmentAllocationPooling.eval.test.ts`** / **`attachmentAllocationScoring.eval.test.ts`**: local-only eval glue, same skip-when-absent + prefix-reconciled-qrels flow as the fold re-baseline. `GoldenPool` gains an optional `kind` field so scoring stratifies image vs voice.

## Verified

- 30 new unit tests (arm construction: header stripping, transcript unwrapping, lead-sentence + word-boundary truncation, per-arm composition; pooling runners: chunk dedup, K-fill, seam args, lexeme building; guard helper: JSON-safe empty-history sentinel). `pnpm test` 4,259 green; `pnpm quality` green.
- **Live pooling run completed against the dev memory store**: 24/24 goldens pooled, every arm filled its top-10, 748 distinct candidates (633 guard-eligible). Image goldens share ~0 of their top-10 between `current` and `bare` — the description text completely redirects retrieval, so the A/B measures a real fork. (Pool/sheets are local-only gitignored artifacts, per the goldens privacy boundary.)

## Not in this PR

Judging the 633 eligible candidates + the scored result + any production policy change — the policy PR follows the evidence, same sequencing as the fold gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)