### PR TITLE
feat(ai-worker): cap attachment text in memory-search query (TASK-393 Phase C)

### DIFF
--- a/services/ai-worker/src/services/eval/allocationArms.test.ts
+++ b/services/ai-worker/src/services/eval/allocationArms.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  parseAttachmentSegments,
-  leadSentence,
-  truncateAtWordBoundary,
-  buildAllocationQueries,
-  ATTACHMENT_BUDGET_CHARS,
-} from './allocationArms.js';
+import { parseAttachmentSegments, leadSentence, buildAllocationQueries } from './allocationArms.js';
+import { ATTACHMENT_SEARCH_BUDGET_CHARS } from '../prompt/searchQueryBudget.js';
 
 const IMAGE_BLOCK = '[Image: gym.png]\nA large room with rubber flooring. Mirrors line the wall.';
 const VOICE_BLOCK =
@@ -88,25 +83,6 @@ describe('leadSentence', () => {
   });
 });
 
-describe('truncateAtWordBoundary', () => {
-  it('returns short text unchanged', () => {
-    expect(truncateAtWordBoundary('short', 100)).toBe('short');
-  });
-
-  it('cuts at the last word boundary inside the budget', () => {
-    expect(truncateAtWordBoundary('alpha beta gamma delta', 17)).toBe('alpha beta gamma');
-  });
-
-  it('cuts hard when the only boundary sacrifices over half the budget', () => {
-    const text = `ab ${'x'.repeat(50)}`;
-    expect(truncateAtWordBoundary(text, 20)).toBe(text.slice(0, 20));
-  });
-
-  it('treats newlines as boundaries', () => {
-    expect(truncateAtWordBoundary('alpha beta\ngamma delta', 17)).toBe('alpha beta\ngamma');
-  });
-});
-
 describe('buildAllocationQueries', () => {
   const golden = {
     messageBare: 'look at this gym',
@@ -132,15 +108,15 @@ describe('buildAllocationQueries', () => {
     );
   });
 
-  it('caps the budget arm attachment part at ATTACHMENT_BUDGET_CHARS', () => {
+  it('caps the budget arm attachment part at the production budget', () => {
     const longDescription = `${'word '.repeat(400)}end.`;
     const queries = buildAllocationQueries({
       messageBare: 'context',
       attachmentText: `[Image: big.png]\n${longDescription}`,
     });
     const attachmentPart = queries['budget-dense'].slice('context\n\n'.length);
-    expect(attachmentPart.length).toBeLessThanOrEqual(ATTACHMENT_BUDGET_CHARS);
-    expect(attachmentPart.length).toBeGreaterThan(ATTACHMENT_BUDGET_CHARS - 20);
+    expect(attachmentPart.length).toBeLessThanOrEqual(ATTACHMENT_SEARCH_BUDGET_CHARS);
+    expect(attachmentPart.length).toBeGreaterThan(ATTACHMENT_SEARCH_BUDGET_CHARS - 20);
     expect(queries['current-dense'].length).toBeGreaterThan(queries['budget-dense'].length);
   });
 

--- a/services/ai-worker/src/services/eval/allocationArms.ts
+++ b/services/ai-worker/src/services/eval/allocationArms.ts
@@ -12,7 +12,7 @@
  *                     (voice transcripts ride whole: they ARE the user's words,
  *                     not a model's description of them).
  * - `budget-dense`  — bare + descriptions truncated to half the window
- *                     ({@link ATTACHMENT_BUDGET_CHARS}), the per-part-allocation
+ *                     (`ATTACHMENT_SEARCH_BUDGET_CHARS`), the per-part-allocation
  *                     policy shape.
  * - `current-dense` — bare + full descriptions; the embedder truncates at 512
  *                     tokens keeping the head. This is production behavior.
@@ -26,18 +26,15 @@
  * {@link parseAttachmentSegments} strips the storage dressing so every arm —
  * including `current` — is built from the text production actually embeds.
  *
- * ## Why a char budget, not a token budget
- *
- * The window is 512 model tokens (`EMBEDDING_MAX_INPUT_TOKENS`, deliberately
- * un-exported from `@tzurot/embeddings` until a production caller sizes against
- * it). Real prod prose measures ~4 chars/token (the overflow warn reports the
- * observed ratio per request), so the half-window budget is 1024 chars. The
- * eval only needs "roughly half the window"; a production budget policy would
- * count real tokens via the worker's tokenizer.
+ * The budget constant and truncation come from the PRODUCTION policy module
+ * (`../prompt/searchQueryBudget.ts`) — the arm measures literally the code
+ * that ships, so measurement and policy cannot drift apart.
  */
 
-/** Half the 512-token window at the ~4 chars/token measured on prod prose. */
-export const ATTACHMENT_BUDGET_CHARS = 1024;
+import {
+  ATTACHMENT_SEARCH_BUDGET_CHARS,
+  truncateAtWordBoundary,
+} from '../prompt/searchQueryBudget.js';
 
 /** Dense arms in report order: production first, then ascending attachment text. */
 export const ALLOCATION_DENSE_ARMS = [
@@ -118,20 +115,6 @@ export function leadSentence(text: string): string {
 }
 
 /**
- * Truncate to at most `maxChars`, backing up to the last whitespace so the cut
- * lands between words — unless that would sacrifice more than half the budget
- * (one unbroken run), in which case cut hard.
- */
-export function truncateAtWordBoundary(text: string, maxChars: number): string {
-  if (text.length <= maxChars) {
-    return text;
-  }
-  const slice = text.slice(0, maxChars);
-  const lastBreak = Math.max(slice.lastIndexOf(' '), slice.lastIndexOf('\n'));
-  return (lastBreak > maxChars / 2 ? slice.slice(0, lastBreak) : slice).trimEnd();
-}
-
-/**
  * Build every dense arm's query for one golden. An empty string means the arm
  * has nothing to search with (an image-only turn under the bare policy) — the
  * pooling runner skips the retrieval and the arm scores the miss it earned.
@@ -150,7 +133,7 @@ export function buildAllocationQueries(golden: {
     'current-dense': joinParts(bare, full),
     'bare-dense': bare,
     'lead-dense': joinParts(bare, lead),
-    'budget-dense': joinParts(bare, truncateAtWordBoundary(full, ATTACHMENT_BUDGET_CHARS)),
+    'budget-dense': joinParts(bare, truncateAtWordBoundary(full, ATTACHMENT_SEARCH_BUDGET_CHARS)),
   };
 }
 

--- a/services/ai-worker/src/services/prompt/SearchQueryBuilder.test.ts
+++ b/services/ai-worker/src/services/prompt/SearchQueryBuilder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
+const mockLoggerInfo = vi.fn();
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
@@ -7,7 +8,7 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   return {
     ...actual,
     createLogger: () => ({
-      info: vi.fn(),
+      info: (...args: unknown[]) => mockLoggerInfo(...args),
       debug: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
@@ -17,11 +18,12 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
 
 vi.mock('../RAGUtils.js', () => ({
   extractContentDescriptions: vi.fn((attachments: unknown[]) =>
-    attachments.map(() => 'attachment description').join('\n')
+    attachments.map((a: unknown) => (a as { description: string }).description).join('\n\n')
   ),
 }));
 
 import { buildSearchQuery, describeParts, type QueryPart } from './SearchQueryBuilder.js';
+import { ATTACHMENT_SEARCH_BUDGET_CHARS } from './searchQueryBudget.js';
 import type { ProcessedAttachment } from '../MultimodalProcessor.js';
 import { AttachmentType } from '@tzurot/common-types/constants/media';
 
@@ -53,7 +55,7 @@ describe('SearchQueryBuilder', () => {
 
     it('should include attachment descriptions', () => {
       const result = buildSearchQuery('Look at this', [makeAttachment()]);
-      expect(result).toContain('attachment description');
+      expect(result).toContain('An image of a cat');
       expect(result).toContain('Look at this');
     });
 
@@ -65,7 +67,7 @@ describe('SearchQueryBuilder', () => {
     it('should skip "Hello" fallback user message', () => {
       const result = buildSearchQuery('Hello', [makeAttachment()]);
       expect(result).not.toContain('Hello');
-      expect(result).toContain('attachment description');
+      expect(result).toContain('An image of a cat');
     });
 
     it('should return "Hello" if nothing else is available', () => {
@@ -87,6 +89,59 @@ describe('SearchQueryBuilder', () => {
       );
       const parts = result.split('\n\n');
       expect(parts.length).toBe(4);
+    });
+
+    // The attachment budget (searchQueryBudget.ts): descriptions are capped at
+    // half the embedder window so the parts AFTER them — the referenced-message
+    // text especially — actually reach the model. Before the cap, a
+    // median-length image description starved the references out entirely.
+    describe('attachment budget', () => {
+      const longAttachment = () =>
+        makeAttachment({ description: `${'word '.repeat(800)}end of description.` });
+
+      it('caps the attachment part at the budget, cut between words', () => {
+        const result = buildSearchQuery('Look at this', [longAttachment()]);
+        const attachmentPart = result.split('\n\n')[1];
+        expect(attachmentPart.length).toBeLessThanOrEqual(ATTACHMENT_SEARCH_BUDGET_CHARS);
+        expect(attachmentPart.length).toBeGreaterThan(ATTACHMENT_SEARCH_BUDGET_CHARS - 20);
+        expect(attachmentPart.endsWith('word')).toBe(true);
+      });
+
+      it('keeps the referenced-message text within reach of the embedder window', () => {
+        const result = buildSearchQuery(
+          'short question',
+          [longAttachment()],
+          'Ref: the message being replied to'
+        );
+        expect(result).toContain('Ref: the message being replied to');
+        // ~4 chars/token measured on real traffic → 512 tokens ≈ 2048 chars.
+        // With the attachment capped at half that, the reference's offset must
+        // land inside the window instead of thousands of chars past it.
+        expect(result.indexOf('Ref: the message being replied to')).toBeLessThan(512 * 4);
+      });
+
+      it('leaves a within-budget attachment untouched', () => {
+        const result = buildSearchQuery('Look at this', [makeAttachment()]);
+        expect(result.split('\n\n')[1]).toBe('An image of a cat');
+      });
+
+      it('reports the pre-cap length in the composition log only when the cap bit', () => {
+        mockLoggerInfo.mockClear();
+        buildSearchQuery('Look at this', [longAttachment()]);
+        const capped = mockLoggerInfo.mock.calls.find(
+          call => (call[1] as string) === 'Assembled memory search query'
+        );
+        expect(capped?.[0]).toMatchObject({
+          attachmentCharsBeforeBudget: 'word '.repeat(800).length + 'end of description.'.length,
+        });
+
+        mockLoggerInfo.mockClear();
+        buildSearchQuery('Look at this', [makeAttachment()]);
+        const uncapped = mockLoggerInfo.mock.calls.find(
+          call => (call[1] as string) === 'Assembled memory search query'
+        );
+        expect(uncapped?.[0]).not.toHaveProperty('attachmentCharsBeforeBudget');
+      });
     });
   });
 

--- a/services/ai-worker/src/services/prompt/SearchQueryBuilder.ts
+++ b/services/ai-worker/src/services/prompt/SearchQueryBuilder.ts
@@ -8,6 +8,7 @@
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ProcessedAttachment } from '../MultimodalProcessor.js';
 import { extractContentDescriptions } from '../RAGUtils.js';
+import { ATTACHMENT_SEARCH_BUDGET_CHARS, truncateAtWordBoundary } from './searchQueryBudget.js';
 
 const logger = createLogger('SearchQueryBuilder');
 
@@ -58,29 +59,29 @@ export function describeParts(
  * The recentHistoryWindow solves the "pronoun problem" where users say things like
  * "what do you think about that?" - without context, LTM search can't find relevant memories.
  *
- * ## This builder is UNBOUNDED, and the embedder is not
+ * ## Allocation: order + the attachment budget
  *
- * The parts are concatenated with no cap, but the embedding model reads only
- * `EMBEDDING_MAX_INPUT_TOKENS` (512) and discards the rest silently. Parts are
- * appended in the order below, so **a long earlier part starves every later
- * one**: measured on a real prod turn, a 1,700-char image description pushed the
- * query to 2,093 tokens and the referenced-message text — appended last —
- * contributed nothing at all.
+ * The embedding model reads only `EMBEDDING_MAX_INPUT_TOKENS` (512) and
+ * discards the rest silently, so **a long earlier part starves every later
+ * one** — order is allocation. Two measured results govern how the parts are
+ * bounded, and they point in OPPOSITE directions:
  *
- * Two consequences worth knowing before changing anything here:
+ * - **Folded history dilutes.** The fold-aware A/B on mined goldens found
+ *   recall@10 falling 0.436 → 0.390 → 0.256 → 0.195 as the fold widened,
+ *   which is why the recent-history part is gated by `shouldFoldSearchQuery`
+ *   (queryFoldGate.ts).
+ * - **Attachment text is signal, not dilution.** The attachment-allocation A/B
+ *   on mined attachment goldens found the opposite dose-response — recall@10
+ *   RISES with attachment text (bare 0.379 → lead-sentence 0.482 → half-window
+ *   0.528-equivalent) — so the attachment part must NOT be gated out or
+ *   trimmed to a lead sentence. It is instead capped at
+ *   `ATTACHMENT_SEARCH_BUDGET_CHARS` (half the window), which scored
+ *   indistinguishably from the full text while guaranteeing the parts after
+ *   it (`referencedMessagesText`) actually reach the embedder — before the
+ *   cap, a median-length image description starved them out entirely.
  *
- * - **Order is allocation.** Whatever comes first wins the window. That is not a
- *   considered ranking; it is the order the parts happened to be written in.
- * - **More text is not more signal.** The fold-aware A/B on mined goldens found
- *   dilution actively harmful for content-rich queries — recall@10 fell 0.436 →
- *   0.390 → 0.256 → 0.195 as the fold widened. That is why the recent-history
- *   part is gated by `shouldFoldSearchQuery` (queryFoldGate.ts) and the others
- *   are not (yet).
- *
- * Fixing the allocation therefore needs evidence, not just a budget: the
- * goldens are text-only today, so no attachment-bearing turn has ever been
- * scored. `LocalEmbeddingService` now warns on overflow, which is how the real
- * rate becomes measurable.
+ * The eval arms (`../eval/allocationArms.ts`) import the same budget code, so
+ * a change here is automatically what the next A/B measures.
  */
 export function buildSearchQuery(
   userMessage: string,
@@ -101,18 +102,9 @@ export function buildSearchQuery(
     parts.push({ name: 'userMessage', text: userMessage });
   }
 
-  // Add attachment descriptions (voice transcriptions, image descriptions)
-  if (processedAttachments.length > 0) {
-    const descriptions = extractContentDescriptions(processedAttachments);
-
-    if (descriptions.length > 0) {
-      parts.push({ name: 'attachmentDescriptions', text: descriptions });
-
-      // Log when using voice transcription instead of "Hello"
-      if (userMessage.trim() === 'Hello') {
-        logger.info('Using voice transcription for memory search instead of "Hello" fallback');
-      }
-    }
+  const attachmentPart = buildAttachmentPart(processedAttachments, userMessage);
+  if (attachmentPart !== null) {
+    parts.push({ name: 'attachmentDescriptions', text: attachmentPart.text });
   }
 
   // Add referenced message content for semantic search
@@ -134,11 +126,49 @@ export function buildSearchQuery(
   // happened. Offsets make starvation legible: a part whose offset already
   // exceeds the window never reached the model. The authoritative overflow
   // signal is LocalEmbeddingService's warn, which counts real model tokens;
-  // this is the composition that produced it.
+  // this is the composition that produced it. `attachmentCharsBeforeBudget`
+  // (only present when the cap actually removed text) is how the budget's
+  // real-world bite becomes measurable.
+  const attachmentCharsBeforeBudget =
+    attachmentPart !== null && attachmentPart.beforeBudgetChars > ATTACHMENT_SEARCH_BUDGET_CHARS
+      ? attachmentPart.beforeBudgetChars
+      : undefined;
   logger.info(
-    { totalChars: query.length, parts: describeParts(parts) },
+    {
+      totalChars: query.length,
+      parts: describeParts(parts),
+      ...(attachmentCharsBeforeBudget !== undefined ? { attachmentCharsBeforeBudget } : {}),
+    },
     'Assembled memory search query'
   );
 
   return query;
+}
+
+/**
+ * Budget-capped attachment part, or null when there is nothing to add.
+ * `beforeBudgetChars` carries the pre-cap length for the composition log.
+ */
+function buildAttachmentPart(
+  processedAttachments: ProcessedAttachment[],
+  userMessage: string
+): { text: string; beforeBudgetChars: number } | null {
+  if (processedAttachments.length === 0) {
+    return null;
+  }
+  const descriptions = extractContentDescriptions(processedAttachments);
+  if (descriptions.length === 0) {
+    return null;
+  }
+
+  // The turn has no real user text — the attachment content (a transcript or
+  // an image description) is what the search runs on.
+  if (userMessage.trim() === 'Hello') {
+    logger.info('Using attachment content for memory search instead of "Hello" fallback');
+  }
+
+  return {
+    text: truncateAtWordBoundary(descriptions, ATTACHMENT_SEARCH_BUDGET_CHARS),
+    beforeBudgetChars: descriptions.length,
+  };
 }

--- a/services/ai-worker/src/services/prompt/searchQueryBudget.test.ts
+++ b/services/ai-worker/src/services/prompt/searchQueryBudget.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { truncateAtWordBoundary, ATTACHMENT_SEARCH_BUDGET_CHARS } from './searchQueryBudget.js';
+
+describe('truncateAtWordBoundary', () => {
+  it('returns short text unchanged', () => {
+    expect(truncateAtWordBoundary('short', 100)).toBe('short');
+  });
+
+  it('cuts at the last word boundary inside the budget', () => {
+    expect(truncateAtWordBoundary('alpha beta gamma delta', 17)).toBe('alpha beta gamma');
+  });
+
+  it('cuts hard when the only boundary sacrifices over half the budget', () => {
+    const text = `ab ${'x'.repeat(50)}`;
+    expect(truncateAtWordBoundary(text, 20)).toBe(text.slice(0, 20));
+  });
+
+  it('treats newlines as boundaries', () => {
+    expect(truncateAtWordBoundary('alpha beta\ngamma delta', 17)).toBe('alpha beta\ngamma');
+  });
+
+  it('does not leave a lone surrogate when the hard cut lands mid-emoji', () => {
+    // 40 chars of unbroken emoji (2 UTF-16 units each); an odd cap forces the
+    // hard-cut path to land between a surrogate pair's halves.
+    const text = '😀'.repeat(20);
+    const cut = truncateAtWordBoundary(text, 21);
+    expect(cut).toBe('😀'.repeat(10));
+    expect(/[\uD800-\uDBFF]$/.test(cut)).toBe(false);
+  });
+
+  it('never exceeds the budget', () => {
+    const text = 'word '.repeat(500);
+    expect(truncateAtWordBoundary(text, ATTACHMENT_SEARCH_BUDGET_CHARS).length).toBeLessThanOrEqual(
+      ATTACHMENT_SEARCH_BUDGET_CHARS
+    );
+  });
+});
+
+describe('ATTACHMENT_SEARCH_BUDGET_CHARS', () => {
+  it('is half the 512-token window at ~4 chars/token', () => {
+    // The policy the A/B validated: attachment text gets at most half the
+    // embedder window, leaving the other half for the user message and the
+    // referenced-message text that used to be starved out entirely.
+    expect(ATTACHMENT_SEARCH_BUDGET_CHARS).toBe((512 / 2) * 4);
+  });
+});

--- a/services/ai-worker/src/services/prompt/searchQueryBudget.ts
+++ b/services/ai-worker/src/services/prompt/searchQueryBudget.ts
@@ -1,0 +1,54 @@
+/**
+ * Search-query part budgets.
+ *
+ * The embedder reads only 512 model tokens (`EMBEDDING_MAX_INPUT_TOKENS`) and
+ * silently discards the rest, so the ORDER parts are appended in is an
+ * allocation policy: a long early part starves every later one. On
+ * attachment-bearing turns the image description overflows the window at the
+ * MEDIAN (mined p50 3,654 chars against a ~2,000-char window), which starved
+ * `referencedMessagesText` — appended last — on every such turn.
+ *
+ * The cap below is the arm that WON the judged attachment-allocation A/B
+ * (24 real mined goldens, TREC-pooled, non-circularity-guarded — harness in
+ * `../eval/attachmentAllocationPooling.eval.test.ts`):
+ *
+ * - Dropping the attachment part entirely ("gate it like the fold") lost
+ *   6 of 16 image turns (net −5 paired flips) — descriptions are SIGNAL on
+ *   attachment turns, the opposite of what folded history is.
+ * - Trimming to a lead sentence lost recall too (net −1).
+ * - Capping at half the window scored indistinguishably from the full text
+ *   (net 0, recall@10 0.511 vs 0.528) while freeing the tail of the window
+ *   for the parts after it.
+ *
+ * So the cap costs nothing measurable and makes the builder's existing intent
+ * real: references actually reach the embedder instead of being a silent
+ * no-op. The eval arm imports THIS function and THIS constant, so the
+ * measured policy and the shipped policy cannot drift apart.
+ *
+ * Chars, not tokens: the builder runs outside the embedding worker, so it
+ * cannot count model tokens. Real prod prose measures ~4 chars/token (the
+ * overflow warn reports the observed ratio per request), making half the
+ * 512-token window ≈ 1024 chars.
+ */
+
+/** Half the 512-token window at the ~4 chars/token measured on prod prose. */
+export const ATTACHMENT_SEARCH_BUDGET_CHARS = 1024;
+
+/**
+ * Truncate to at most `maxChars`, backing up to the last whitespace so the cut
+ * lands between words — unless that would sacrifice more than half the budget
+ * (one unbroken run), in which case cut hard.
+ */
+export function truncateAtWordBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  const slice = text.slice(0, maxChars);
+  const lastBreak = Math.max(slice.lastIndexOf(' '), slice.lastIndexOf('\n'));
+  const bounded = lastBreak > maxChars / 2 ? slice.slice(0, lastBreak) : slice;
+  // Only the hard cut can land mid-character (the word-boundary cut ends at
+  // whitespace): drop a dangling high surrogate so an emoji at the cap can't
+  // leave a lone half-pair in the query.
+  const clean = /[\uD800-\uDBFF]$/.test(bounded) ? bounded.slice(0, -1) : bounded;
+  return clean.trimEnd();
+}


### PR DESCRIPTION
## What

The evidence-chosen fix for TASK-393's truncation defect. `buildSearchQuery` is unbounded while the embedder reads 512 tokens keeping the head — and enriched-image descriptions overflow that window at the **median** (mined p50 3,654 chars vs the ~2,000-char window), so `referencedMessagesText` (appended last, included explicitly "for better memory recall") never reached the embedder on any sizable-attachment turn.

**The change**: the `attachmentDescriptions` part is capped at `ATTACHMENT_SEARCH_BUDGET_CHARS` (1024 chars ≈ half the window at the measured ~4 chars/token), cut at a word boundary. Everything else — part order, the fold gate, the reference text — is untouched; references simply fit now.

## Why this option (the judged A/B, PR #1901's harness)

Scored on 24 real mined attachment goldens (TREC-pooled, non-circularity-guarded, hand-judged qrels), paired flips vs production's full-text behavior @K=10:

| Alternative | net | verdict |
|---|---|---|
| gate the attachment out (bare) | **−5** (1 fix / 6 breaks) | dead — descriptions are SIGNAL, the inverse of folded history |
| lead sentence per description | −1 | not free |
| **half-window cap (this PR)** | **0** (0 fixes / 0 breaks, 23/24 both-hit) | indistinguishable from full text |

Dose-response recall@10: bare 0.379 → lead 0.482 → budget 0.511 → current 0.528. The cap costs nothing measurable and un-starves the references by construction.

**Anti-drift property**: the budget constant and truncation function live in `searchQueryBudget.ts` and the eval arms (`allocationArms.ts`) import the SAME code — the next A/B automatically measures whatever ships.

**Observability**: the `Assembled memory search query` composition log gains `attachmentCharsBeforeBudget` (present only when the cap removed text), so the budget's real-world bite rate is greppable in prod alongside the existing `Input exceeded the model window` warn.

## Verified

- 12 new/updated unit tests: cap applied at word boundary, within-budget text untouched, reference offset lands inside the embedder window behind a long attachment (the defect's exact repro shape), log field present only when the cap bit, budget-constant derivation pinned.
- `buildSearchQuery` extraction (`buildAttachmentPart`) keeps cognitive complexity under the lint cap; behavior pinned by the existing 8 builder tests (all green unmodified except the mock now passing real descriptions through).
- `pnpm test` 4,271 green; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)