### PR TITLE
refactor(ai-worker): delete anti-cache measures and dead o-series transform

### DIFF
--- a/packages/tooling/src/dev/check-prompt-tags.ts
+++ b/packages/tooling/src/dev/check-prompt-tags.ts
@@ -72,7 +72,6 @@ export const KNOWN_UNPROTECTED_TAGS: Record<string, string> = {
   context:
     'Wrapper over <datetime> (system time) + <location> (escapeXml); no escaped-content descendant.',
   datetime: 'System-generated current time (formatFullDateTime).',
-  request_id: 'System-generated correlation id.',
   think: 'Literal example text inside a hardcoded <constraint>, not a content wrapper.',
   user: 'Literal example text inside a hardcoded <constraint>, not a content wrapper.',
   // Values fully entity-escaped via escapeXml (< > & " ' → entities) — a closing

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.test.ts
@@ -263,7 +263,6 @@ describe('logRetryEscalation', () => {
       logRetryEscalation('job-1', 2, {
         temperatureOverride: 0.9,
         frequencyPenaltyOverride: 0.3,
-        historyReductionPercent: 50,
       })
     ).not.toThrow();
   });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
@@ -92,7 +92,6 @@ export function logFallbackUsed(fallback: FallbackResponse, jobId: string | unde
 interface RetryConfigForLog {
   temperatureOverride?: number;
   frequencyPenaltyOverride?: number;
-  historyReductionPercent?: number;
 }
 
 /** Log escalating retry parameters when attempt > 1 */
@@ -110,7 +109,6 @@ export function logRetryEscalation(
       attempt,
       temperatureOverride: retryConfig.temperatureOverride,
       frequencyPenaltyOverride: retryConfig.frequencyPenaltyOverride,
-      historyReductionPercent: retryConfig.historyReductionPercent,
     },
     'Escalating retry parameters'
   );

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/duplicateRetry.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/duplicateRetry.ts
@@ -103,8 +103,7 @@ export async function generateWithDuplicateRetry(
     // so we need a fresh copy for each attempt.
     const attemptContext = cloneContextForRetry(conversationContext);
 
-    // Generate response - each call gets new request_id via entropy injection
-    // Pass retry config for escalating parameters on duplicate retries
+    // Generate response with escalating sampling parameters on duplicate retries
     // IMPORTANT: skipMemoryStorage=true prevents storing memory on every retry attempt.
     // Memory is stored ONCE after the retry loop completes (see process method).
     // diagnosticCollector captures data from each attempt - overwrites with final attempt's data

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -83,7 +83,7 @@ export class ContentBudgetManager {
   preselectHistory(
     opts: Omit<BudgetAllocationOptions, 'retrievedMemories' | 'facts'>
   ): PreselectedHistory {
-    const { personality, context, historyReductionPercent } = opts;
+    const { personality, context } = opts;
     const contextWindowTokens = opts.effectiveContextWindowTokens;
 
     // Cast is safe: buildBaseComponents reads only prompt/message inputs,
@@ -109,25 +109,10 @@ export class ContentBudgetManager {
       historyTokens
     );
 
-    let historyBudget = Math.max(
+    const historyBudget = Math.max(
       0,
       contextWindowTokens - systemPromptBaseTokens - currentMessageTokens - memoryReserve
     );
-    // History reduction for duplicate-detection retries (changes the context
-    // window to break API-level caching on free models) — history absorbs it;
-    // the memory reserve is untouched, same as the old order.
-    if (historyReductionPercent !== undefined && historyReductionPercent > 0) {
-      const reducedBudget = Math.floor(historyBudget * (1 - historyReductionPercent));
-      logger.info(
-        {
-          reductionPercent: Math.round(historyReductionPercent * 100),
-          originalBudget: historyBudget,
-          reducedBudget,
-        },
-        'Reducing history budget for duplicate retry'
-      );
-      historyBudget = reducedBudget;
-    }
 
     const {
       serializedHistory,

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -385,7 +385,6 @@ export class ConversationalRAGService {
         userMessage: inputs.userMessage,
         processedAttachments: inputs.processedAttachments,
         referencedMessagesDescriptions: inputs.referencedMessagesDescriptions,
-        historyReductionPercent: retryConfig?.historyReductionPercent,
         effectiveContextWindowTokens,
       };
       const preselected = this.contentBudgetManager.preselectHistory(budgetOptionsBase);

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -312,12 +312,6 @@ export interface BudgetAllocationOptions {
   // Note: extendedContextDescriptions removed - image descriptions are now
   // injected inline into conversation history entries for better context colocation
   /**
-   * Optional percentage (0-1) to reduce history budget by.
-   * Used during duplicate detection retries (attempt 3) to break API-level caching
-   * by changing the context window.
-   */
-  historyReductionPercent?: number;
-  /**
    * The input-token budget for this generation: the configured
    * contextWindowTokens clamped to the model's real limit when known
    * (see contextWindowResolver.ts).
@@ -364,11 +358,9 @@ export interface ModelInvocationOptions {
 /**
  * Configuration for escalating retry strategy when duplicate responses are detected.
  *
- * The "Ladder of Desperation" progressively increases randomness and changes
- * context to break API-level caching on free models:
+ * Escalation is sampling-only (the prompt bytes stay stable across attempts):
  * - Attempt 1: Normal generation
- * - Attempt 2: Increase temperature and frequency_penalty
- * - Attempt 3: Reduce context by removing oldest messages
+ * - Attempt 2+: Increase temperature (jittered) and frequency_penalty
  */
 export interface DuplicateRetryConfig {
   /** Current attempt number (1-based) */
@@ -377,8 +369,6 @@ export interface DuplicateRetryConfig {
   temperatureOverride?: number;
   /** Frequency penalty override for this attempt */
   frequencyPenaltyOverride?: number;
-  /** Percent of oldest history to remove (0-1) */
-  historyReductionPercent?: number;
 }
 
 /**

--- a/services/ai-worker/src/services/LLMInvoker.test.ts
+++ b/services/ai-worker/src/services/LLMInvoker.test.ts
@@ -849,12 +849,18 @@ describe('LLMInvoker', () => {
     });
 
     describe('reasoning model support', () => {
-      it('should detect and log reasoning model type for o1 models', async () => {
+      it('should pass messages through unchanged for the deprecated o-series (transform deleted)', async () => {
         const mockModel = {
           invoke: vi.fn().mockResolvedValue({ content: 'Reasoning response' }),
         } as any as BaseChatModel;
 
-        const messages: BaseMessage[] = [new HumanMessage('Hello')];
+        // 'openai/o1-preview' is the exact name that used to trigger the
+        // system→user rewrite. The o-series is deprecated and the transform is
+        // gone — the system message must reach the model intact.
+        const messages: BaseMessage[] = [
+          new SystemMessage('System rules'),
+          new HumanMessage('Hello'),
+        ];
 
         const result = await invoker.invokeWithRetry({
           model: mockModel,
@@ -864,6 +870,11 @@ describe('LLMInvoker', () => {
 
         expect(result.content).toBe('Reasoning response');
         expect(mockModel.invoke).toHaveBeenCalledTimes(1);
+        const sentMessages = (mockModel.invoke as ReturnType<typeof vi.fn>).mock
+          .calls[0][0] as BaseMessage[];
+        expect(sentMessages).toHaveLength(2);
+        expect(sentMessages[0]).toBeInstanceOf(SystemMessage);
+        expect(sentMessages[0].content).toBe('System rules');
       });
 
       it('should detect and log reasoning model type for Claude thinking models', async () => {

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -44,11 +44,7 @@ import {
 import { type RateLimitCache, assertValidCacheKeyId } from './RateLimitCache.js';
 import type { CreditExhaustionCache } from './CreditExhaustionCache.js';
 import { rateLimitCache, creditExhaustionCache } from '../redis.js';
-import {
-  getReasoningModelConfig,
-  transformMessagesForReasoningModel,
-  ReasoningModelType,
-} from '../utils/reasoningModelUtils.js';
+import { isReasoningModel } from '../utils/reasoningModelUtils.js';
 
 const logger = createLogger('LLMInvoker');
 
@@ -208,24 +204,6 @@ export class LLMInvoker {
     // LLM always gets full independent timeout budget (480s = 8 minutes)
     const globalTimeoutMs = TIMEOUTS.LLM_INVOCATION;
 
-    // Get reasoning model config for special handling
-    const reasoningConfig = getReasoningModelConfig(modelName);
-    const isReasoningModel = reasoningConfig.type !== ReasoningModelType.Standard;
-
-    if (isReasoningModel) {
-      logger.info(
-        {
-          modelName,
-          reasoningType: reasoningConfig.type,
-          allowsSystemMessage: reasoningConfig.allowsSystemMessage,
-        },
-        'Detected reasoning model, applying special handling'
-      );
-    }
-
-    // Transform messages for reasoning models (e.g., convert system to user for o1)
-    const transformedMessages = transformMessagesForReasoningModel(messages, reasoningConfig);
-
     logger.info(
       {
         modelName,
@@ -233,9 +211,8 @@ export class LLMInvoker {
         audioCount,
         jobTimeout,
         globalTimeoutMs,
-        isReasoningModel,
-        originalMessageCount: messages.length,
-        transformedMessageCount: transformedMessages.length,
+        isReasoningModel: isReasoningModel(modelName),
+        messageCount: messages.length,
       },
       `Dynamic timeout calculated: ${globalTimeoutMs}ms (job: ${jobTimeout}ms)`
     );
@@ -244,24 +221,21 @@ export class LLMInvoker {
     // Fast-fail on permanent errors (auth, quota, content policy, etc.)
     let result;
     try {
-      result = await withRetry(
-        () => this.invokeSingleAttempt(model, transformedMessages, modelName),
-        {
-          maxAttempts,
-          globalTimeoutMs,
-          logger,
-          operationName: `LLM invocation (${modelName})`,
-          shouldRetry: shouldRetryError,
-          getErrorContext: getErrorLogContext,
-          // A cause-class attempt error (429/quota/credit/404-model) must
-          // survive as the terminal `lastError` even when a LATER attempt dies
-          // of the per-attempt abort (TIMEOUT) — during a 429 storm the abort
-          // is the symptom, the rate limit is the cause. NOT the wide
-          // retargetable set: withRetry keeps the LAST preferred error, so a
-          // wide predicate would let the trailing symptom overwrite the cause.
-          preferTerminalError: isCausePrecedenceFailure,
-        }
-      );
+      result = await withRetry(() => this.invokeSingleAttempt(model, messages, modelName), {
+        maxAttempts,
+        globalTimeoutMs,
+        logger,
+        operationName: `LLM invocation (${modelName})`,
+        shouldRetry: shouldRetryError,
+        getErrorContext: getErrorLogContext,
+        // A cause-class attempt error (429/quota/credit/404-model) must
+        // survive as the terminal `lastError` even when a LATER attempt dies
+        // of the per-attempt abort (TIMEOUT) — during a 429 storm the abort
+        // is the symptom, the rate limit is the cause. NOT the wide
+        // retargetable set: withRetry keeps the LAST preferred error, so a
+        // wide predicate would let the trailing symptom overwrite the cause.
+        preferTerminalError: isCausePrecedenceFailure,
+      });
     } catch (err) {
       // Cache rate-limit state on 429 with a usable reset header so the next
       // call in the same window short-circuits at the top of this function.

--- a/services/ai-worker/src/services/PromptBuilder.test.ts
+++ b/services/ai-worker/src/services/PromptBuilder.test.ts
@@ -772,7 +772,9 @@ describe('PromptBuilder', () => {
       // Context now in <context> section
       expect(content).toContain('<context>');
       expect(content).toContain('<datetime>');
-      expect(content).toContain('<request_id>'); // Entropy injection to break API caching
+      // No <request_id>: per-request entropy in the prompt was a deliberate
+      // cache-buster and is gone — the prefix must stay byte-stable.
+      expect(content).not.toContain('<request_id>');
       // Protocol section
       expect(content).toContain('<protocol>');
       expect(content).toContain('You are a helpful assistant');
@@ -1444,13 +1446,7 @@ describe('PromptBuilder', () => {
           context: baseContext,
         });
 
-        // Normalize request_id which contains random entropy
-        const content = (result.content as string).replace(
-          /<request_id>[^<]+<\/request_id>/g,
-          '<request_id>NORMALIZED</request_id>'
-        );
-
-        expect(content).toMatchSnapshot();
+        expect(result.content as string).toMatchSnapshot();
       });
 
       it('should match snapshot with multiple participants (stop sequence scenario)', () => {
@@ -1517,12 +1513,7 @@ describe('PromptBuilder', () => {
           context: baseContext,
         });
 
-        const content = (result.content as string).replace(
-          /<request_id>[^<]+<\/request_id>/g,
-          '<request_id>NORMALIZED</request_id>'
-        );
-
-        expect(content).toMatchSnapshot();
+        expect(result.content as string).toMatchSnapshot();
       });
 
       it('should match snapshot with memories and guild environment', () => {
@@ -1559,12 +1550,7 @@ describe('PromptBuilder', () => {
           context: contextWithGuild,
         });
 
-        const content = (result.content as string).replace(
-          /<request_id>[^<]+<\/request_id>/g,
-          '<request_id>NORMALIZED</request_id>'
-        );
-
-        expect(content).toMatchSnapshot();
+        expect(result.content as string).toMatchSnapshot();
       });
 
       it('should match snapshot with referenced messages', () => {
@@ -1580,12 +1566,7 @@ I was wondering about the performance implications of using pgvector
 </contextual_references>`,
         });
 
-        const content = (result.content as string).replace(
-          /<request_id>[^<]+<\/request_id>/g,
-          '<request_id>NORMALIZED</request_id>'
-        );
-
-        expect(content).toMatchSnapshot();
+        expect(result.content as string).toMatchSnapshot();
       });
     });
 

--- a/services/ai-worker/src/services/PromptBuilder.ts
+++ b/services/ai-worker/src/services/PromptBuilder.ts
@@ -252,13 +252,9 @@ ${escapeXmlContent(persona)}
         ? formatEnvironmentContext(context.environment)
         : '<location type="dm">Direct Message (private one-on-one chat)</location>';
 
-    // Unique request ID to break API-level prompt caching
-    const requestId = `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
-
     const contextSection = `\n\n<context>
 <datetime>${datetime}</datetime>
 ${locationXml}
-<request_id>${requestId}</request_id>
 </context>`;
 
     // Conversation participants

--- a/services/ai-worker/src/services/__snapshots__/PromptBuilder.test.ts.snap
+++ b/services/ai-worker/src/services/__snapshots__/PromptBuilder.test.ts.snap
@@ -26,7 +26,6 @@ exports[`PromptBuilder > Prompt Snapshots > buildFullSystemPrompt snapshots > sh
 <context>
 <datetime>Saturday, June 15, 2024 at 10:30 AM EDT</datetime>
 <location type="dm">Direct Message (private one-on-one chat)</location>
-<request_id>NORMALIZED</request_id>
 </context>
 
 <protocol>
@@ -72,7 +71,6 @@ exports[`PromptBuilder > Prompt Snapshots > buildFullSystemPrompt snapshots > sh
 <category name="Development"/>
 <channel name="bot-testing" type="text"/>
 </location>
-<request_id>NORMALIZED</request_id>
 </context>
 
 <participants>
@@ -128,7 +126,6 @@ exports[`PromptBuilder > Prompt Snapshots > buildFullSystemPrompt snapshots > sh
 <context>
 <datetime>Saturday, June 15, 2024 at 10:30 AM EDT</datetime>
 <location type="dm">Direct Message (private one-on-one chat)</location>
-<request_id>NORMALIZED</request_id>
 </context>
 
 <participants>
@@ -207,7 +204,6 @@ exports[`PromptBuilder > Prompt Snapshots > buildFullSystemPrompt snapshots > sh
 <context>
 <datetime>Saturday, June 15, 2024 at 10:30 AM EDT</datetime>
 <location type="dm">Direct Message (private one-on-one chat)</location>
-<request_id>NORMALIZED</request_id>
 </context>
 
 <contextual_references>

--- a/services/ai-worker/src/utils/duplicateDetection.test.ts
+++ b/services/ai-worker/src/utils/duplicateDetection.test.ts
@@ -20,7 +20,6 @@ import {
   RETRY_TEMPERATURE_MIN,
   RETRY_TEMPERATURE_MAX,
   RETRY_ATTEMPT_2_FREQUENCY_PENALTY,
-  RETRY_ATTEMPT_3_HISTORY_REDUCTION,
 } from './duplicateDetection.js';
 import { isCrossTurnDuplicate, isRecentDuplicate } from './crossTurnDetection.js';
 import { getRecentAssistantMessages } from './conversationHistoryUtils.js';
@@ -694,11 +693,10 @@ describe('buildRetryConfig', () => {
       const config = buildRetryConfig(1);
       expect(config.temperatureOverride).toBeUndefined();
       expect(config.frequencyPenaltyOverride).toBeUndefined();
-      expect(config.historyReductionPercent).toBeUndefined();
     });
   });
 
-  describe('attempt 2 (increased randomness)', () => {
+  describe('attempt 2+ (increased randomness, sampling-only)', () => {
     it('should return temperature and frequency penalty overrides', () => {
       const config = buildRetryConfig(2);
       expect(config.temperatureOverride).toBeGreaterThanOrEqual(RETRY_TEMPERATURE_MIN);
@@ -706,12 +704,7 @@ describe('buildRetryConfig', () => {
       expect(config.frequencyPenaltyOverride).toBe(RETRY_ATTEMPT_2_FREQUENCY_PENALTY);
     });
 
-    it('should NOT include history reduction on attempt 2', () => {
-      const config = buildRetryConfig(2);
-      expect(config.historyReductionPercent).toBeUndefined();
-    });
-
-    it('should use temperature in range 0.95-1.0 to break cache', () => {
+    it('should use temperature in range 0.95-1.0', () => {
       expect(RETRY_TEMPERATURE_MIN).toBe(0.95);
       expect(RETRY_TEMPERATURE_MAX).toBe(1.0);
     });
@@ -719,58 +712,37 @@ describe('buildRetryConfig', () => {
     it('should use frequency penalty 0.5 for variety', () => {
       expect(RETRY_ATTEMPT_2_FREQUENCY_PENALTY).toBe(0.5);
     });
-  });
 
-  describe('attempt 3+ (aggressive cache breaking)', () => {
-    it('should include all overrides including history reduction', () => {
-      const config = buildRetryConfig(3);
-      expect(config.temperatureOverride).toBeGreaterThanOrEqual(RETRY_TEMPERATURE_MIN);
-      expect(config.temperatureOverride).toBeLessThanOrEqual(RETRY_TEMPERATURE_MAX);
-      expect(config.frequencyPenaltyOverride).toBe(RETRY_ATTEMPT_2_FREQUENCY_PENALTY);
-      expect(config.historyReductionPercent).toBe(RETRY_ATTEMPT_3_HISTORY_REDUCTION);
-    });
-
-    it('should use 30% history reduction on attempt 3', () => {
-      expect(RETRY_ATTEMPT_3_HISTORY_REDUCTION).toBe(0.3);
-    });
-
-    it('should return configs with same structure for attempt 4+ (temperature varies)', () => {
+    it('should return the same sampling-only structure for attempts 3+ (no input mutation)', () => {
+      // Escalation is deliberately sampling-only: the prompt bytes stay stable
+      // across attempts. A history shrink existed once as a cache-breaker and
+      // was removed — an attempt must never mutate the input again.
+      const config2 = buildRetryConfig(2);
       const config3 = buildRetryConfig(3);
       const config4 = buildRetryConfig(4);
-      const config5 = buildRetryConfig(5);
 
-      // All should have the same keys/structure
-      expect(Object.keys(config4)).toEqual(Object.keys(config3));
-      expect(Object.keys(config5)).toEqual(Object.keys(config3));
-
-      // Frequency penalty and history reduction should be identical
-      expect(config4.frequencyPenaltyOverride).toBe(config3.frequencyPenaltyOverride);
-      expect(config5.frequencyPenaltyOverride).toBe(config3.frequencyPenaltyOverride);
-      expect(config4.historyReductionPercent).toBe(config3.historyReductionPercent);
-      expect(config5.historyReductionPercent).toBe(config3.historyReductionPercent);
-
-      // Temperature values should be within valid range (but may vary due to jitter)
-      expect(config4.temperatureOverride).toBeGreaterThanOrEqual(RETRY_TEMPERATURE_MIN);
-      expect(config4.temperatureOverride).toBeLessThanOrEqual(RETRY_TEMPERATURE_MAX);
-      expect(config5.temperatureOverride).toBeGreaterThanOrEqual(RETRY_TEMPERATURE_MIN);
-      expect(config5.temperatureOverride).toBeLessThanOrEqual(RETRY_TEMPERATURE_MAX);
+      for (const config of [config2, config3, config4]) {
+        expect(Object.keys(config).sort()).toEqual([
+          'frequencyPenaltyOverride',
+          'temperatureOverride',
+        ]);
+        expect(config.temperatureOverride).toBeGreaterThanOrEqual(RETRY_TEMPERATURE_MIN);
+        expect(config.temperatureOverride).toBeLessThanOrEqual(RETRY_TEMPERATURE_MAX);
+        expect(config.frequencyPenaltyOverride).toBe(RETRY_ATTEMPT_2_FREQUENCY_PENALTY);
+      }
     });
   });
 
   describe('escalation strategy', () => {
-    it('should escalate progressively', () => {
+    it('should escalate from no overrides to sampling overrides', () => {
       const attempt1 = buildRetryConfig(1);
       const attempt2 = buildRetryConfig(2);
-      const attempt3 = buildRetryConfig(3);
 
       // Attempt 1: No overrides
       expect(Object.keys(attempt1).length).toBe(0);
 
-      // Attempt 2: Temperature + frequency penalty
+      // Attempt 2+: Temperature + frequency penalty
       expect(Object.keys(attempt2).length).toBe(2);
-
-      // Attempt 3: All three overrides
-      expect(Object.keys(attempt3).length).toBe(3);
     });
   });
 });

--- a/services/ai-worker/src/utils/duplicateDetection.ts
+++ b/services/ai-worker/src/utils/duplicateDetection.ts
@@ -104,7 +104,8 @@ export const RETRY_TEMPERATURE_MAX = 1.0;
  * Generate a random temperature for retry attempts.
  * Returns a value between RETRY_TEMPERATURE_MIN and RETRY_TEMPERATURE_MAX (inclusive).
  *
- * The random jitter helps bust API-level caches more effectively than a fixed value.
+ * The jitter varies sampling between attempts so a retry doesn't fall into the
+ * same output attractor; it does not touch the input (prompt bytes stay stable).
  */
 export function getRetryTemperature(): number {
   const range = RETRY_TEMPERATURE_MAX - RETRY_TEMPERATURE_MIN;
@@ -118,13 +119,14 @@ export function getRetryTemperature(): number {
 export const RETRY_ATTEMPT_2_FREQUENCY_PENALTY = 0.5;
 
 /**
- * Percent of oldest conversation history to remove on Attempt 3.
- * This changes the input significantly, breaking cache keys.
- */
-export const RETRY_ATTEMPT_3_HISTORY_REDUCTION = 0.3;
-
-/**
  * Build retry configuration for escalating duplicate detection.
+ *
+ * Escalation is sampling-only: temperature jitter + frequency penalty from
+ * attempt 2 on. There is deliberately NO input mutation (a history shrink on
+ * attempt 3 existed once as a cache-breaker — provider prefix caching affects
+ * billing, not sampling, so mutating the input bought nothing and cost prompt
+ * stability). If duplicate retries regress, tune sampling params; never
+ * reintroduce input entropy.
  *
  * @param attempt Current attempt number (1-based)
  * @returns Retry configuration with appropriate overrides for the attempt
@@ -132,26 +134,16 @@ export const RETRY_ATTEMPT_3_HISTORY_REDUCTION = 0.3;
 export function buildRetryConfig(attempt: number): {
   temperatureOverride?: number;
   frequencyPenaltyOverride?: number;
-  historyReductionPercent?: number;
 } {
   if (attempt === 1) {
     // Attempt 1: Normal generation, no overrides
     return {};
   }
 
-  if (attempt === 2) {
-    // Attempt 2: Increase temperature (with jitter) and frequency penalty
-    return {
-      temperatureOverride: getRetryTemperature(),
-      frequencyPenaltyOverride: RETRY_ATTEMPT_2_FREQUENCY_PENALTY,
-    };
-  }
-
-  // Attempt 3+: Also reduce history to break cache
+  // Attempt 2+: Increase temperature (with jitter) and frequency penalty
   return {
     temperatureOverride: getRetryTemperature(),
     frequencyPenaltyOverride: RETRY_ATTEMPT_2_FREQUENCY_PENALTY,
-    historyReductionPercent: RETRY_ATTEMPT_3_HISTORY_REDUCTION,
   };
 }
 

--- a/services/ai-worker/src/utils/reasoningModelUtils.test.ts
+++ b/services/ai-worker/src/utils/reasoningModelUtils.test.ts
@@ -2,68 +2,15 @@
  * Tests for Reasoning Model Utilities
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { SystemMessage, HumanMessage, AIMessage } from '@langchain/core/messages';
+import { describe, it, expect } from 'vitest';
 import {
   detectReasoningModelType,
-  getReasoningModelConfig,
   isReasoningModel,
-  transformMessagesForReasoningModel,
-  stripThinkingTags,
-  processReasoningModelOutput,
   ReasoningModelType,
 } from './reasoningModelUtils.js';
 
-// Mock logger
-vi.mock('@tzurot/common-types/utils/logger', async () => {
-  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
-    '@tzurot/common-types/utils/logger'
-  );
-  return {
-    ...actual,
-    createLogger: () => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
-  };
-});
-
 describe('ReasoningModelUtils', () => {
   describe('detectReasoningModelType', () => {
-    describe('OpenAI o-series detection', () => {
-      it('should detect o1 as OpenAI reasoning model', () => {
-        expect(detectReasoningModelType('o1')).toBe(ReasoningModelType.OpenAIReasoning);
-        expect(detectReasoningModelType('openai/o1')).toBe(ReasoningModelType.OpenAIReasoning);
-      });
-
-      it('should detect o1-preview as OpenAI reasoning model', () => {
-        expect(detectReasoningModelType('o1-preview')).toBe(ReasoningModelType.OpenAIReasoning);
-        expect(detectReasoningModelType('openai/o1-preview')).toBe(
-          ReasoningModelType.OpenAIReasoning
-        );
-      });
-
-      it('should detect o1-mini as OpenAI reasoning model', () => {
-        expect(detectReasoningModelType('o1-mini')).toBe(ReasoningModelType.OpenAIReasoning);
-        expect(detectReasoningModelType('openai/o1-mini')).toBe(ReasoningModelType.OpenAIReasoning);
-      });
-
-      it('should detect o3 as OpenAI reasoning model', () => {
-        expect(detectReasoningModelType('o3')).toBe(ReasoningModelType.OpenAIReasoning);
-        expect(detectReasoningModelType('openai/o3')).toBe(ReasoningModelType.OpenAIReasoning);
-      });
-
-      it('should detect o3-mini as OpenAI reasoning model', () => {
-        expect(detectReasoningModelType('o3-mini')).toBe(ReasoningModelType.OpenAIReasoning);
-      });
-
-      it('should handle date suffixes', () => {
-        expect(detectReasoningModelType('o1-2024')).toBe(ReasoningModelType.OpenAIReasoning);
-      });
-    });
-
     describe('Claude extended thinking detection', () => {
       it('should detect Claude 3.7 as extended thinking model', () => {
         expect(detectReasoningModelType('claude-3-7-sonnet')).toBe(
@@ -269,75 +216,8 @@ describe('ReasoningModelUtils', () => {
     });
   });
 
-  describe('getReasoningModelConfig', () => {
-    it('should return correct config for OpenAI o-series', () => {
-      const config = getReasoningModelConfig('openai/o1');
-
-      expect(config.type).toBe(ReasoningModelType.OpenAIReasoning);
-      expect(config.allowsSystemMessage).toBe(false);
-      expect(config.requiredTemperature).toBeNull();
-      expect(config.useMaxCompletionTokens).toBe(true);
-      expect(config.mayContainThinkingTags).toBe(true);
-    });
-
-    it('should return correct config for Claude extended thinking', () => {
-      const config = getReasoningModelConfig('anthropic/claude-3-7-sonnet');
-
-      expect(config.type).toBe(ReasoningModelType.ClaudeExtendedThinking);
-      expect(config.allowsSystemMessage).toBe(true);
-      expect(config.requiredTemperature).toBe(1.0);
-      expect(config.useMaxCompletionTokens).toBe(false);
-      expect(config.mayContainThinkingTags).toBe(true);
-    });
-
-    it('should return correct config for Gemini thinking', () => {
-      const config = getReasoningModelConfig('gemini-2.0-flash-thinking');
-
-      expect(config.type).toBe(ReasoningModelType.GeminiThinking);
-      expect(config.allowsSystemMessage).toBe(true);
-      expect(config.requiredTemperature).toBeNull();
-      expect(config.mayContainThinkingTags).toBe(true);
-    });
-
-    it('should return standard config for regular models', () => {
-      const config = getReasoningModelConfig('gpt-4-turbo');
-
-      expect(config.type).toBe(ReasoningModelType.Standard);
-      expect(config.allowsSystemMessage).toBe(true);
-      expect(config.requiredTemperature).toBeNull();
-      expect(config.useMaxCompletionTokens).toBe(false);
-      expect(config.mayContainThinkingTags).toBe(false);
-    });
-
-    it('should return correct config for DeepSeek R1', () => {
-      const config = getReasoningModelConfig('deepseek/deepseek-r1');
-
-      expect(config.type).toBe(ReasoningModelType.DeepSeekR1);
-      expect(config.allowsSystemMessage).toBe(true);
-      expect(config.requiredTemperature).toBeNull();
-      expect(config.mayContainThinkingTags).toBe(true);
-    });
-
-    it('should return correct config for Qwen QwQ', () => {
-      const config = getReasoningModelConfig('qwen/qwq-32b');
-
-      expect(config.type).toBe(ReasoningModelType.QwenReasoning);
-      expect(config.allowsSystemMessage).toBe(true);
-      expect(config.mayContainThinkingTags).toBe(true);
-    });
-
-    it('should return correct config for GLM thinking', () => {
-      const config = getReasoningModelConfig('glm-4.7');
-
-      expect(config.type).toBe(ReasoningModelType.GlmThinking);
-      expect(config.allowsSystemMessage).toBe(true);
-      expect(config.mayContainThinkingTags).toBe(true);
-    });
-  });
-
   describe('isReasoningModel', () => {
     it('should return true for reasoning models', () => {
-      expect(isReasoningModel('o1')).toBe(true);
       expect(isReasoningModel('claude-3-7-sonnet')).toBe(true);
       expect(isReasoningModel('gemini-2.0-flash-thinking')).toBe(true);
     });
@@ -359,148 +239,14 @@ describe('ReasoningModelUtils', () => {
       expect(isReasoningModel('gemini-2.0-flash')).toBe(false);
       expect(isReasoningModel('deepseek/deepseek-chat')).toBe(false);
     });
-  });
 
-  describe('transformMessagesForReasoningModel', () => {
-    it('should not transform messages for standard models', () => {
-      const messages = [
-        new SystemMessage('You are a helpful assistant'),
-        new HumanMessage('Hello'),
-      ];
-
-      const config = getReasoningModelConfig('gpt-4');
-      const transformed = transformMessagesForReasoningModel(messages, config);
-
-      expect(transformed).toHaveLength(2);
-      expect(transformed[0]).toBeInstanceOf(SystemMessage);
-    });
-
-    it('should convert system message to human message prefix for o-series', () => {
-      const messages = [
-        new SystemMessage('You are a helpful assistant'),
-        new HumanMessage('Hello'),
-      ];
-
-      const config = getReasoningModelConfig('o1');
-      const transformed = transformMessagesForReasoningModel(messages, config);
-
-      expect(transformed).toHaveLength(1);
-      expect(transformed[0]).toBeInstanceOf(HumanMessage);
-      expect(transformed[0].content).toContain('[System Instructions]');
-      expect(transformed[0].content).toContain('You are a helpful assistant');
-      expect(transformed[0].content).toContain('Hello');
-    });
-
-    it('should handle messages without system message', () => {
-      const messages = [new HumanMessage('Hello'), new AIMessage('Hi there!')];
-
-      const config = getReasoningModelConfig('o1');
-      const transformed = transformMessagesForReasoningModel(messages, config);
-
-      expect(transformed).toHaveLength(2);
-      expect(transformed[0].content).toBe('Hello');
-    });
-
-    it('should preserve conversation history order', () => {
-      const messages = [
-        new SystemMessage('System'),
-        new HumanMessage('User 1'),
-        new AIMessage('AI 1'),
-        new HumanMessage('User 2'),
-      ];
-
-      const config = getReasoningModelConfig('o1');
-      const transformed = transformMessagesForReasoningModel(messages, config);
-
-      // System merged into first human, then rest preserved
-      expect(transformed).toHaveLength(3);
-      expect(transformed[0]).toBeInstanceOf(HumanMessage);
-      expect(transformed[0].content).toContain('[System Instructions]');
-      expect(transformed[1]).toBeInstanceOf(AIMessage);
-      expect(transformed[2]).toBeInstanceOf(HumanMessage);
-      expect(transformed[2].content).toBe('User 2');
-    });
-  });
-
-  describe('stripThinkingTags', () => {
-    it('should remove <thinking> tags and their content', () => {
-      const content = '<thinking>Let me think...</thinking>Here is my answer.';
-      expect(stripThinkingTags(content)).toBe('Here is my answer.');
-    });
-
-    it('should handle multiline thinking content', () => {
-      const content = `<thinking>
-Step 1: Consider the problem
-Step 2: Analyze options
-Step 3: Form conclusion
-</thinking>
-The answer is 42.`;
-
-      expect(stripThinkingTags(content)).toBe('The answer is 42.');
-    });
-
-    it('should handle multiple thinking blocks', () => {
-      const content =
-        '<thinking>First thought</thinking>Answer 1. <thinking>Second thought</thinking>Answer 2.';
-      // Note: The space between Answer 1. and the second thinking block is preserved
-      expect(stripThinkingTags(content)).toBe('Answer 1. Answer 2.');
-    });
-
-    it('should handle <think> variant', () => {
-      const content = '<think>Some thinking</think>The answer.';
-      expect(stripThinkingTags(content)).toBe('The answer.');
-    });
-
-    it('should be case insensitive', () => {
-      const content = '<THINKING>Thoughts</THINKING>Answer';
-      expect(stripThinkingTags(content)).toBe('Answer');
-    });
-
-    it('should handle nested content correctly', () => {
-      const content =
-        '<thinking>Outer <b>bold</b> text with newlines\nand more</thinking>Final answer.';
-      expect(stripThinkingTags(content)).toBe('Final answer.');
-    });
-
-    it('should return original content when no thinking tags', () => {
-      const content = 'Just a normal response without thinking.';
-      expect(stripThinkingTags(content)).toBe('Just a normal response without thinking.');
-    });
-
-    it('should trim whitespace after stripping', () => {
-      const content = '  <thinking>thoughts</thinking>  Answer  ';
-      expect(stripThinkingTags(content)).toBe('Answer');
-    });
-  });
-
-  describe('processReasoningModelOutput', () => {
-    it('should strip thinking tags for reasoning models', () => {
-      const content = '<thinking>Internal reasoning</thinking>User-facing response';
-      const config = getReasoningModelConfig('o1');
-
-      expect(processReasoningModelOutput(content, config)).toBe('User-facing response');
-    });
-
-    it('should not modify output for standard models', () => {
-      const content = '<thinking>This should stay</thinking>Response';
-      const config = getReasoningModelConfig('gpt-4');
-
-      expect(processReasoningModelOutput(content, config)).toBe(content);
-    });
-
-    it('should handle Claude extended thinking output', () => {
-      const content = `<thinking>
-Let me consider this carefully:
-1. First, I'll analyze the question
-2. Then form a response
-</thinking>
-
-Based on my analysis, the answer is clear.`;
-
-      const config = getReasoningModelConfig('claude-3-7-sonnet');
-      const result = processReasoningModelOutput(content, config);
-
-      expect(result).toBe('Based on my analysis, the answer is clear.');
+    it('should return false for the deprecated OpenAI o-series (pattern deleted)', () => {
+      // The o-series is fully deprecated upstream; its detection pattern and the
+      // system-message transform it gated were removed. Names like these now
+      // detect as Standard, which is correct for models that no longer exist.
+      expect(isReasoningModel('o1')).toBe(false);
+      expect(isReasoningModel('openai/o1-preview')).toBe(false);
+      expect(isReasoningModel('o3-mini')).toBe(false);
     });
   });
 });

--- a/services/ai-worker/src/utils/reasoningModelUtils.ts
+++ b/services/ai-worker/src/utils/reasoningModelUtils.ts
@@ -1,29 +1,22 @@
 /**
- * Reasoning Model Utilities
+ * Reasoning Model Detection
  *
- * Handles special requirements for AI models with reasoning/thinking capabilities:
- * - OpenAI o1/o3 series: No system messages, use max_completion_tokens
- * - Claude 3.7+: Extended thinking requires temperature=1
- * - Gemini 2.0 Flash Thinking: Uses thinkingConfig.thinkingBudget
+ * Identifies models with reasoning/thinking capabilities by name. Consumers:
+ * reasoning-effort plumbing (ModelFactory) and invocation logging (LLMInvoker).
  *
- * All reasoning models may emit `<thinking>` tags that should be stripped from output.
+ * Detection is the whole job. Thinking-tag stripping lives in
+ * ResponsePostProcessor's extraction chain, which handles the per-family tag
+ * vocabularies; reasoning-model request-shape rewrites no longer exist (the
+ * o-series system-message transform was deleted when OpenAI deprecated the
+ * o-series — no current model rejects the `system` role).
  */
-
-import { createLogger } from '@tzurot/common-types/utils/logger';
-import { SystemMessage, HumanMessage, type BaseMessage } from '@langchain/core/messages';
-
-const logger = createLogger('ReasoningModelUtils');
 
 /**
  * Patterns to identify reasoning/thinking models
  *
  * These models may emit thinking tags that need to be stripped from output.
- * Detection enables early stripping in LLMInvoker as a first line of defense.
  */
 const REASONING_MODEL_PATTERNS = {
-  // OpenAI o1/o3 models - require no system messages
-  OPENAI_O_SERIES: /^(openai\/)?o[13](-mini|-preview)?(-\d+)?$/i,
-
   // Claude models with extended thinking capability
   // Claude 3.7+ supports extended thinking (e.g., claude-3-7-sonnet-20250219)
   CLAUDE_EXTENDED_THINKING: /claude-3-[789]|claude-4/i,
@@ -66,9 +59,7 @@ const REASONING_MODEL_PATTERNS = {
 export enum ReasoningModelType {
   /** Standard model - no special handling needed */
   Standard = 'standard',
-  /** OpenAI o1/o3 - no system messages allowed */
-  OpenAIReasoning = 'openai-reasoning',
-  /** Claude with extended thinking - temperature must be 1.0 */
+  /** Claude with extended thinking */
   ClaudeExtendedThinking = 'claude-extended-thinking',
   /** Gemini thinking model */
   GeminiThinking = 'gemini-thinking',
@@ -93,28 +84,11 @@ export enum ReasoningModelType {
 }
 
 /**
- * Configuration adjustments needed for reasoning models
- */
-interface ReasoningModelConfig {
-  /** Type of reasoning model */
-  type: ReasoningModelType;
-  /** Whether system messages are allowed */
-  allowsSystemMessage: boolean;
-  /** Required temperature (null = use default) */
-  requiredTemperature: number | null;
-  /** Whether to use max_completion_tokens instead of max_tokens */
-  useMaxCompletionTokens: boolean;
-  /** Whether output may contain <thinking> tags to strip */
-  mayContainThinkingTags: boolean;
-}
-
-/**
  * Pattern-to-type mapping for data-driven detection.
  * Order matters: more specific patterns should be checked first.
  * Generic thinking is last to avoid false positives.
  */
 const DETECTION_ORDER: readonly { pattern: RegExp; type: ReasoningModelType }[] = [
-  { pattern: REASONING_MODEL_PATTERNS.OPENAI_O_SERIES, type: ReasoningModelType.OpenAIReasoning },
   {
     pattern: REASONING_MODEL_PATTERNS.CLAUDE_EXTENDED_THINKING,
     type: ReasoningModelType.ClaudeExtendedThinking,
@@ -135,7 +109,7 @@ const DETECTION_ORDER: readonly { pattern: RegExp; type: ReasoningModelType }[] 
 /**
  * Detect the type of reasoning model from its name
  *
- * @param modelName - The model identifier (e.g., "openai/o1-preview", "deepseek/deepseek-r1")
+ * @param modelName - The model identifier (e.g., "deepseek/deepseek-r1")
  * @returns The type of reasoning model
  */
 export function detectReasoningModelType(modelName: string): ReasoningModelType {
@@ -148,73 +122,6 @@ export function detectReasoningModelType(modelName: string): ReasoningModelType 
 }
 
 /**
- * Get configuration requirements for a reasoning model
- *
- * @param modelName - The model identifier
- * @returns Configuration requirements
- */
-export function getReasoningModelConfig(modelName: string): ReasoningModelConfig {
-  const type = detectReasoningModelType(modelName);
-
-  switch (type) {
-    case ReasoningModelType.OpenAIReasoning:
-      return {
-        type,
-        allowsSystemMessage: false,
-        requiredTemperature: null, // o1/o3 doesn't support temperature parameter
-        useMaxCompletionTokens: true,
-        mayContainThinkingTags: true,
-      };
-
-    case ReasoningModelType.ClaudeExtendedThinking:
-      return {
-        type,
-        allowsSystemMessage: true,
-        requiredTemperature: 1.0, // Extended thinking requires temperature=1
-        useMaxCompletionTokens: false,
-        mayContainThinkingTags: true,
-      };
-
-    case ReasoningModelType.GeminiThinking:
-      return {
-        type,
-        allowsSystemMessage: true,
-        requiredTemperature: null,
-        useMaxCompletionTokens: false,
-        mayContainThinkingTags: true,
-      };
-
-    // DeepSeek, Qwen, GLM, Kimi, GPT-OSS, StepFun, Hermes 4, MiMo
-    // All emit <think> tags in text output
-    case ReasoningModelType.DeepSeekR1:
-    case ReasoningModelType.QwenReasoning:
-    case ReasoningModelType.GlmThinking:
-    case ReasoningModelType.KimiThinking:
-    case ReasoningModelType.GptOss:
-    case ReasoningModelType.StepFun:
-    case ReasoningModelType.Hermes4:
-    case ReasoningModelType.MiMo:
-    case ReasoningModelType.GenericThinking:
-      return {
-        type,
-        allowsSystemMessage: true,
-        requiredTemperature: null,
-        useMaxCompletionTokens: false,
-        mayContainThinkingTags: true,
-      };
-
-    default:
-      return {
-        type: ReasoningModelType.Standard,
-        allowsSystemMessage: true,
-        requiredTemperature: null,
-        useMaxCompletionTokens: false,
-        mayContainThinkingTags: false,
-      };
-  }
-}
-
-/**
  * Check if a model is a reasoning/thinking model
  *
  * @param modelName - The model identifier
@@ -222,118 +129,4 @@ export function getReasoningModelConfig(modelName: string): ReasoningModelConfig
  */
 export function isReasoningModel(modelName: string): boolean {
   return detectReasoningModelType(modelName) !== ReasoningModelType.Standard;
-}
-
-/**
- * Transform messages for reasoning models that don't support system messages.
- * Converts SystemMessage to a HumanMessage with the system content prefixed.
- *
- * @param messages - Original messages array
- * @param modelConfig - Reasoning model configuration
- * @returns Transformed messages array
- */
-// eslint-disable-next-line sonarjs/cognitive-complexity -- Transforms system→user messages for models without system message support, with content merging and role deduplication
-export function transformMessagesForReasoningModel(
-  messages: BaseMessage[],
-  modelConfig: ReasoningModelConfig
-): BaseMessage[] {
-  if (modelConfig.allowsSystemMessage) {
-    return messages;
-  }
-
-  // For models that don't support system messages (OpenAI o1/o3),
-  // convert system message to user message with a prefix
-  const transformedMessages: BaseMessage[] = [];
-  let systemContent = '';
-
-  for (const message of messages) {
-    if (message instanceof SystemMessage || message._getType() === 'system') {
-      // Collect system message content to prepend to first user message
-      const content =
-        typeof message.content === 'string'
-          ? message.content
-          : Array.isArray(message.content)
-            ? message.content
-                .map(c => (typeof c === 'object' && 'text' in c ? c.text : ''))
-                .join('')
-            : '';
-      systemContent += content + '\n\n';
-      logger.debug(
-        { contentLength: content.length },
-        'Converting system message to context prefix'
-      );
-    } else {
-      transformedMessages.push(message);
-    }
-  }
-
-  // If we collected system content, prepend it to the first user message
-  if (systemContent && transformedMessages.length > 0) {
-    const firstMessage = transformedMessages[0];
-    if (firstMessage instanceof HumanMessage || firstMessage._getType() === 'human') {
-      const originalContent =
-        typeof firstMessage.content === 'string'
-          ? firstMessage.content
-          : Array.isArray(firstMessage.content)
-            ? firstMessage.content
-                .map(c => (typeof c === 'object' && 'text' in c ? c.text : ''))
-                .join('')
-            : '';
-
-      // Create new message with system context prepended
-      transformedMessages[0] = new HumanMessage({
-        content: `[System Instructions]\n${systemContent}[End System Instructions]\n\n${originalContent}`,
-      });
-
-      logger.info('Prepended system message content to first user message for o-series model');
-    }
-  }
-
-  return transformedMessages;
-}
-
-/**
- * Strip thinking tags from model output.
- * Removes content between <thinking> and </thinking> tags (including the tags).
- *
- * @param content - The model output content
- * @returns Content with thinking tags removed
- */
-export function stripThinkingTags(content: string): string {
-  // Match <thinking>...</thinking> including newlines (non-greedy)
-  const thinkingPattern = /<thinking>[\s\S]*?<\/thinking>/gi;
-
-  const stripped = content.replace(thinkingPattern, '').trim();
-
-  // Also handle lowercase and variations
-  const thinkPattern2 = /<think>[\s\S]*?<\/think>/gi;
-  const finalResult = stripped.replace(thinkPattern2, '').trim();
-
-  if (finalResult !== content) {
-    const removedLength = content.length - finalResult.length;
-    logger.debug(
-      { originalLength: content.length, strippedLength: finalResult.length, removedLength },
-      'Stripped thinking tags from response'
-    );
-  }
-
-  return finalResult;
-}
-
-/**
- * Process model output to strip thinking tags if needed
- *
- * @param content - The raw model output
- * @param modelConfig - Reasoning model configuration
- * @returns Processed content
- */
-export function processReasoningModelOutput(
-  content: string,
-  modelConfig: ReasoningModelConfig
-): string {
-  if (!modelConfig.mayContainThinkingTags) {
-    return content;
-  }
-
-  return stripThinkingTags(content);
 }


### PR DESCRIPTION
## Summary

Phase 0 (PR 1 of 6) of the **Provider Prompt Caching epic** (doc-17, promoted to the active-epic slot). Three verify-and-remove deletions — all confirmed dead or actively counterproductive for the epic's goal. Net **−660 lines**.

### 1. The o-series system→user message transform (dead code)

`transformMessagesForReasoningModel` rewrote system messages into a `[System Instructions]` human-message prefix — but only for models matching `/^(openai\/)?o[13].../`, and the o-series is fully deprecated upstream (no current OpenAI model rejects the `system` role; design doc §2.6, fact-checked 2026-07-05 against first-party docs). Its only remaining effects were destructive: lossy content-part flattening and silent system-content drops.

Also removed as part of the same family: `getReasoningModelConfig` + `ReasoningModelConfig` (the transform was their only consumer), and `stripThinkingTags`/`processReasoningModelOutput` (zero production consumers — thinking-tag extraction lives in ResponsePostProcessor's chain). `reasoningModelUtils.ts` reduces to pure name-based detection; **`isReasoningModel` is kept** (live consumer: the reasoning-effort gate in `ModelFactory.ts`).

### 2. `historyReductionPercent` (disproven cache-buster)

Duplicate-retry attempt 3 shrank the history budget 30% to "break API-level caching." Provider prefix caching affects **billing, not sampling** — mutating the input bought nothing and destabilized the prompt bytes. Duplicate retries are now sampling-only (temperature jitter + frequency penalty), pinned by a test that asserts attempts 2+ share the same sampling-only structure. The rationale is recorded at `buildRetryConfig` so the entropy idea isn't re-derived.

### 3. The `<request_id>` prompt buster (same disproven hypothesis)

`Date.now()+random` rendered at section 4 of 11 in the system prompt — every byte after it was downstream of per-request entropy, which is the single biggest structural block to prefix caching. Deleted along with its snapshot normalizer and its `check-prompt-tags` registry entry (stale entries fail that guard).

## What this does NOT yet buy

Deleting the buster alone moves the cache breakpoint from the volatile `<datetime>` line to… the volatile `<datetime>` line (+72 tokens, measured). The caching win arrives with the V-tier hoist (PR 5); these deletions are the prerequisite, not the payoff.

## Verified

- Full unit suite green (4,238 ai-worker tests + tooling 1,781); `pnpm quality` green.
- Snapshot diff is exactly the 4 deleted `<request_id>NORMALIZED</request_id>` lines.
- New regression pin: `openai/o1-preview` (the exact name that used to trigger the rewrite) now reaches the model with its SystemMessage intact.
- Deletion sweep: `grep -rn 'request_id|historyReduction|RETRY_ATTEMPT_3'` over `src/` returns only the intentional negative-assertion comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)