### PR TITLE
feat(ai-worker): surface provider cache telemetry in diagnostics + /inspect

### DIFF
--- a/packages/common-types/src/types/diagnostic.ts
+++ b/packages/common-types/src/types/diagnostic.ts
@@ -246,6 +246,14 @@ export interface DiagnosticLlmResponse {
   promptTokens: number;
   /** Tokens in the completion */
   completionTokens: number;
+  /**
+   * Prompt tokens served from the provider's prefix cache
+   * (`usage.prompt_tokens_details.cached_tokens`). Undefined = provider
+   * reported no cache activity; 0 = a real report of a cold prefix.
+   */
+  cachedPromptTokens?: number;
+  /** OpenRouter's `usage.cache_discount` billing adjustment (negative = savings) */
+  cacheDiscount?: number;
   /** Model actually used (may differ from requested) */
   modelUsed: string;
   /** Debug info for reasoning extraction troubleshooting */

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -259,7 +259,15 @@ export class ConversationalRAGService {
     );
 
     logger.info(
-      { charCount: cleanedContent.length, personalityName: personality.name, modelName },
+      {
+        charCount: cleanedContent.length,
+        personalityName: personality.name,
+        modelName,
+        promptTokens: usageMetadata?.input_tokens,
+        // Prefix-cache hit size (provider-reported). The prod cache-hit-rate
+        // measurement greps this field — cachedPromptTokens/promptTokens.
+        cachedPromptTokens: usageMetadata?.input_token_details?.cache_read,
+      },
       'Generated response'
     );
 

--- a/services/ai-worker/src/services/DiagnosticCollector.test.ts
+++ b/services/ai-worker/src/services/DiagnosticCollector.test.ts
@@ -504,6 +504,26 @@ describe('DiagnosticCollector', () => {
       });
     });
 
+    it('should carry cache telemetry through to the finalized payload', () => {
+      // The collector copies llmResponse field-by-field — a hand-maintained
+      // list, which is exactly where a new field silently drops. Sentinels pin
+      // the copy-through end to end (recordLlmResponse → finalize).
+      collector.recordLlmResponse({
+        rawContent: 'cached response',
+        finishReason: 'stop',
+        promptTokens: 6426,
+        completionTokens: 1,
+        cachedPromptTokens: 6272,
+        cacheDiscount: -0.0123,
+        modelUsed: 'glm-4.7',
+      });
+
+      const payload = collector.finalize();
+
+      expect(payload.llmResponse.cachedPromptTokens).toBe(6272);
+      expect(payload.llmResponse.cacheDiscount).toBe(-0.0123);
+    });
+
     it('should record reasoning debug info when provided', () => {
       collector.recordLlmResponse({
         rawContent: 'Response with reasoning',

--- a/services/ai-worker/src/services/DiagnosticCollector.ts
+++ b/services/ai-worker/src/services/DiagnosticCollector.ts
@@ -357,6 +357,8 @@ export class DiagnosticCollector {
       finishReason: data.finishReason,
       promptTokens: data.promptTokens,
       completionTokens: data.completionTokens,
+      cachedPromptTokens: data.cachedPromptTokens,
+      cacheDiscount: data.cacheDiscount,
       modelUsed: data.modelUsed,
       reasoningDebug: data.reasoningDebug,
     };
@@ -379,6 +381,8 @@ export class DiagnosticCollector {
       finishReason: data.finishReason ?? FINISH_REASONS.UNKNOWN,
       promptTokens: data.promptTokens ?? 0,
       completionTokens: data.completionTokens ?? 0,
+      cachedPromptTokens: data.cachedPromptTokens,
+      cacheDiscount: data.cacheDiscount,
       modelUsed: data.modelUsed ?? 'unknown',
       reasoningDebug: data.reasoningDebug,
     };

--- a/services/ai-worker/src/services/LLMInvoker.test.ts
+++ b/services/ai-worker/src/services/LLMInvoker.test.ts
@@ -15,6 +15,26 @@ import {
 } from '@tzurot/common-types/constants/error';
 import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
 
+// Capture the module logger so tests can assert log payloads (the finish-reason
+// and response-diagnostics paths are log-only — the logger IS their output seam).
+const mockLoggerInfo = vi.fn();
+const mockLoggerDebug = vi.fn();
+const mockLoggerWarn = vi.fn();
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: (...args: unknown[]) => mockLoggerInfo(...args),
+      debug: (...args: unknown[]) => mockLoggerDebug(...args),
+      warn: (...args: unknown[]) => mockLoggerWarn(...args),
+      error: vi.fn(),
+    }),
+  };
+});
+
 // Mock ModelFactory
 vi.mock('./ModelFactory.js', () => ({
   createChatModel: vi.fn(({ modelName }) => ({
@@ -846,6 +866,90 @@ describe('LLMInvoker', () => {
 
       expect(result.content).toBe('The file has a .ext extension');
       expect(mockModel.invoke).toHaveBeenCalledTimes(1); // No retry needed
+    });
+
+    describe('usage logging reads usage_metadata (not response_metadata.usage)', () => {
+      // response_metadata.usage is only populated when the provider returns a
+      // truthy system_fingerprint — OpenRouter generally does not, so reading
+      // it logged undefined token counts on the dominant route. These tests pin
+      // the switch to LangChain's normalized usage_metadata, including the
+      // cache-read field the caching epic measures.
+      it('logs promptTokens/cachedPromptTokens from usage_metadata on the length-finish warn', async () => {
+        const mockModel = {
+          invoke: vi.fn().mockResolvedValue({
+            content: 'Truncated response',
+            response_metadata: { finish_reason: 'length' },
+            usage_metadata: {
+              input_tokens: 100,
+              output_tokens: 5,
+              total_tokens: 105,
+              input_token_details: { cache_read: 80 },
+            },
+          }),
+        } as any as BaseChatModel;
+
+        await invoker.invokeWithRetry({
+          model: mockModel,
+          messages: [new HumanMessage('Hello')],
+          modelName: 'test-model',
+        });
+
+        const lengthLog = mockLoggerInfo.mock.calls.find(call =>
+          (call[1] as string)?.includes('token limit')
+        );
+        expect(lengthLog?.[0]).toMatchObject({
+          promptTokens: 100,
+          completionTokens: 5,
+          totalTokens: 105,
+          cachedPromptTokens: 80,
+        });
+      });
+
+      it('ignores response_metadata.usage (the system_fingerprint-gated dead path)', async () => {
+        const mockModel = {
+          invoke: vi.fn().mockResolvedValue({
+            content: 'Truncated response',
+            response_metadata: { finish_reason: 'length', usage: { prompt_tokens: 999 } },
+            usage_metadata: { input_tokens: 100, output_tokens: 5 },
+          }),
+        } as any as BaseChatModel;
+
+        await invoker.invokeWithRetry({
+          model: mockModel,
+          messages: [new HumanMessage('Hello')],
+          modelName: 'test-model',
+        });
+
+        const lengthLog = mockLoggerInfo.mock.calls.find(call =>
+          (call[1] as string)?.includes('token limit')
+        );
+        expect(lengthLog?.[0]).toMatchObject({ promptTokens: 100 });
+        expect(lengthLog?.[0]).not.toMatchObject({ promptTokens: 999 });
+      });
+
+      it('extractResponseDiagnostics reports usage_metadata tokens on the empty-response warn', async () => {
+        const mockModel = {
+          invoke: vi.fn().mockResolvedValue({
+            content: '',
+            response_metadata: { finish_reason: 'stop' },
+            usage_metadata: { input_tokens: 250, output_tokens: 0 },
+          }),
+        } as any as BaseChatModel;
+
+        await expect(
+          invoker.invokeWithRetry({
+            model: mockModel,
+            messages: [new HumanMessage('Hello')],
+            modelName: 'test-model',
+            maxAttempts: 1,
+          })
+        ).rejects.toThrow();
+
+        const emptyLog = mockLoggerWarn.mock.calls.find(call =>
+          (call[1] as string)?.includes('Empty response')
+        );
+        expect(emptyLog?.[0]).toMatchObject({ promptTokens: 250, completionTokens: 0 });
+      });
     });
 
     describe('reasoning model support', () => {

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -4,10 +4,9 @@
  * Handles language model invocation with retry logic, timeout handling, and model caching.
  * Extracted from ConversationalRAGService for better modularity and testability.
  *
- * Reasoning Model Support:
- * - Detects and handles reasoning/thinking models (o1, Claude 3.7+, Gemini Thinking)
- * - Transforms messages for models that don't support system messages
- * - Thinking tag extraction delegated to ResponsePostProcessor
+ * Messages pass through unmodified — no request-shape rewrites exist (the
+ * o-series system→user transform died with the o-series deprecation), and
+ * thinking-tag extraction is delegated to ResponsePostProcessor.
  */
 
 import { type BaseMessage } from '@langchain/core/messages';
@@ -152,7 +151,6 @@ export class LLMInvoker {
    * - Exponential backoff between retries (1s, 2s, 4s, ...)
    * - Dynamic global timeout based on attachment count
    * - Per-attempt timeout using LLM_PER_ATTEMPT constant
-   * - Reasoning model support (o1, Claude 3.7+, Gemini Thinking)
    */
   async invokeWithRetry(options: InvokeWithRetryOptions): Promise<BaseMessage> {
     const {
@@ -570,14 +568,27 @@ export class LLMInvoker {
     }
 
     const finishReason = resolveFinishReason(metadata);
-    const usage = metadata.usage as
-      { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number } | undefined;
+    // Read LangChain's normalized usage_metadata, not response_metadata.usage —
+    // the latter is only populated when the provider returns a truthy
+    // system_fingerprint, which OpenRouter generally does not, so it logged
+    // undefined on the dominant route.
+    const usage = (
+      response as {
+        usage_metadata?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          total_tokens?: number;
+          input_token_details?: { cache_read?: number };
+        };
+      }
+    ).usage_metadata;
 
     const logContext: Record<string, unknown> = { modelName, finishReason };
     if (usage !== undefined) {
-      logContext.promptTokens = usage.prompt_tokens;
-      logContext.completionTokens = usage.completion_tokens;
+      logContext.promptTokens = usage.input_tokens;
+      logContext.completionTokens = usage.output_tokens;
       logContext.totalTokens = usage.total_tokens;
+      logContext.cachedPromptTokens = usage.input_token_details?.cache_read;
     }
 
     if (finishReason === FINISH_REASONS.LENGTH) {
@@ -620,8 +631,8 @@ export class LLMInvoker {
 
   /**
    * Extract diagnostic metadata from a response for enriched error logging.
-   * Pulls finish_reason, token usage, refusal, and key inventories from
-   * LangChain's response_metadata and additional_kwargs.
+   * Pulls finish_reason and key inventories from LangChain's response_metadata
+   * and additional_kwargs, and token usage from the normalized usage_metadata.
    */
   private extractResponseDiagnostics(response: BaseMessage): Record<string, unknown> {
     const metadata = (response as { response_metadata?: Record<string, unknown> })
@@ -629,15 +640,17 @@ export class LLMInvoker {
     const additionalKwargs = (response as { additional_kwargs?: Record<string, unknown> })
       .additional_kwargs;
     const finishReason = resolveFinishReason(metadata);
-    const usage = metadata?.usage as
-      { prompt_tokens?: number; completion_tokens?: number } | undefined;
+    // usage_metadata, not response_metadata.usage — see logFinishReason.
+    const usage = (
+      response as { usage_metadata?: { input_tokens?: number; output_tokens?: number } }
+    ).usage_metadata;
 
     return {
       responseType: Array.isArray(response.content) ? 'array' : typeof response.content,
       contentLength: Array.isArray(response.content) ? response.content.length : 0,
       finishReason,
-      promptTokens: usage?.prompt_tokens,
-      completionTokens: usage?.completion_tokens,
+      promptTokens: usage?.input_tokens,
+      completionTokens: usage?.output_tokens,
       refusal:
         (response as unknown as Record<string, unknown>).refusal ??
         additionalKwargs?.refusal ??

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
@@ -275,6 +275,44 @@ describe('DiagnosticRecorders', () => {
       expect(call.completionTokens).toBe(0);
     });
 
+    it('should thread cache telemetry through from both sources (sentinel values)', () => {
+      // The cached-token count comes from LangChain's normalized usage path;
+      // the discount only exists on the OpenRouter raw capture. Sentinels
+      // assert each field reaches the collector from its OWN source — a
+      // dropped forward here silently kills the epic's measurement.
+      const mockCollector = { recordLlmResponse: vi.fn() };
+      const metadata: ParsedResponseMetadata = {
+        usageMetadata: {
+          input_tokens: 6426,
+          output_tokens: 1,
+          input_token_details: { cache_read: 6272 },
+        },
+        responseMetadata: {
+          finish_reason: 'stop',
+          openrouter: { apiMessageKeys: [], apiReasoningLength: 0, cacheDiscount: -0.0123 },
+        },
+      };
+
+      recordLlmResponseDiagnostic(mockCollector as never, 'response', 'model', metadata);
+
+      const call = mockCollector.recordLlmResponse.mock.calls[0][0] as Record<string, unknown>;
+      expect(call.cachedPromptTokens).toBe(6272);
+      expect(call.cacheDiscount).toBe(-0.0123);
+    });
+
+    it('should leave cache telemetry undefined when the provider reported none', () => {
+      const mockCollector = { recordLlmResponse: vi.fn() };
+      const metadata: ParsedResponseMetadata = {
+        usageMetadata: { input_tokens: 500, output_tokens: 200 },
+      };
+
+      recordLlmResponseDiagnostic(mockCollector as never, 'response', 'model', metadata);
+
+      const call = mockCollector.recordLlmResponse.mock.calls[0][0] as Record<string, unknown>;
+      expect(call.cachedPromptTokens).toBeUndefined();
+      expect(call.cacheDiscount).toBeUndefined();
+    });
+
     it('should resolve finish_reason from various field names', () => {
       const mockCollector = { recordLlmResponse: vi.fn() };
 

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
@@ -19,6 +19,15 @@ export interface ParsedResponseMetadata {
     input_tokens?: number;
     output_tokens?: number;
     total_tokens?: number;
+    /**
+     * LangChain's normalization of the provider's `prompt_tokens_details`.
+     * `cache_read` carries `cached_tokens` — prompt tokens served from the
+     * provider's prefix cache. Populated on both OpenRouter and z.ai-direct
+     * responses whenever the provider reports cache activity.
+     */
+    input_token_details?: {
+      cache_read?: number;
+    };
   };
   responseMetadata?: {
     finish_reason?: string;
@@ -33,6 +42,7 @@ export interface ParsedResponseMetadata {
       provider?: string;
       apiMessageKeys?: string[];
       apiReasoningLength?: number;
+      cacheDiscount?: number;
     };
   };
   additionalKwargs?: {
@@ -186,6 +196,8 @@ export function recordLlmResponseDiagnostic(
     finishReason,
     promptTokens: metadata.usageMetadata?.input_tokens ?? 0,
     completionTokens: metadata.usageMetadata?.output_tokens ?? 0,
+    cachedPromptTokens: metadata.usageMetadata?.input_token_details?.cache_read,
+    cacheDiscount: metadata.responseMetadata?.openrouter?.cacheDiscount,
     modelUsed: modelName,
     reasoningDebug: buildReasoningDebug(rawContent, metadata),
   });

--- a/services/ai-worker/src/services/diagnostics/DiagnosticTypes.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticTypes.ts
@@ -115,6 +115,20 @@ export interface LlmResponseData {
   finishReason: string;
   promptTokens: number;
   completionTokens: number;
+  /**
+   * Prompt tokens served from the provider's prefix cache
+   * (`usage.prompt_tokens_details.cached_tokens`, via LangChain's
+   * `usage_metadata.input_token_details.cache_read`). Undefined when the
+   * provider reported no cache activity; 0 is a real report of a cold prefix.
+   * This is the epic's primary caching measurement.
+   */
+  cachedPromptTokens?: number;
+  /**
+   * OpenRouter's `usage.cache_discount` billing adjustment (negative =
+   * cache-read savings). OpenRouter-only; z.ai reports cache activity via
+   * cachedPromptTokens alone.
+   */
+  cacheDiscount?: number;
   modelUsed: string;
   /** Debug info for reasoning extraction troubleshooting */
   reasoningDebug?: {

--- a/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.test.ts
+++ b/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.test.ts
@@ -126,6 +126,45 @@ describe('extractAndPopulateOpenRouterReasoning', () => {
       expect(openrouter.provider).toBe('Chutes');
     });
 
+    it('captures usage.cache_discount before __raw_response is deleted (only recoverable here)', () => {
+      const message = buildMessage({
+        content: 'response',
+        finishReason: 'stop',
+        rawResponse: {
+          provider: 'Anthropic',
+          usage: { prompt_tokens: 1000, cache_discount: -0.0042 },
+          choices: [{ message: { content: 'response' } }],
+        },
+      });
+
+      extractAndPopulateOpenRouterReasoning(message);
+
+      const openrouter = (message.response_metadata as Record<string, unknown>).openrouter as {
+        cacheDiscount?: number;
+      };
+      expect(openrouter.cacheDiscount).toBe(-0.0042);
+      // The source is gone — the capture above was the only chance.
+      expect(message.additional_kwargs.__raw_response).toBeUndefined();
+    });
+
+    it('omits cacheDiscount when usage carries none (or usage is absent)', () => {
+      const message = buildMessage({
+        content: 'response',
+        finishReason: 'stop',
+        rawResponse: {
+          usage: { prompt_tokens: 1000 },
+          choices: [{ message: { content: 'response' } }],
+        },
+      });
+
+      extractAndPopulateOpenRouterReasoning(message);
+
+      const openrouter = (message.response_metadata as Record<string, unknown>).openrouter as {
+        cacheDiscount?: number;
+      };
+      expect(openrouter.cacheDiscount).toBeUndefined();
+    });
+
     it('captures apiMessageKeys (distinguishes structured-reasoning vs content-only responses)', () => {
       const message = buildMessage({
         content: 'response',

--- a/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.ts
+++ b/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.ts
@@ -56,6 +56,15 @@ export interface OpenRouterMessageMetadata {
    * diagnostics can surface what the provider actually said.
    */
   providerError?: { message?: string; code?: number | string };
+  /**
+   * OpenRouter's `usage.cache_discount` — the billing adjustment applied for
+   * prompt-cache reads (negative = savings) or writes (positive = premium on
+   * write-priced providers like Anthropic). Only OpenRouter emits it, and only
+   * here is it recoverable: LangChain's usage normalization doesn't carry it,
+   * and `__raw_response` is deleted below. Absent when the provider reported
+   * no cache activity.
+   */
+  cacheDiscount?: number;
 }
 
 /**
@@ -155,6 +164,10 @@ function buildOpenrouterMetadata(
   const providerError = extractProviderErrorObject(raw);
   if (providerError !== undefined) {
     result.providerError = providerError;
+  }
+  const usage = raw.usage as Record<string, unknown> | undefined;
+  if (usage !== undefined && typeof usage.cache_discount === 'number') {
+    result.cacheDiscount = usage.cache_discount;
   }
   return result;
 }

--- a/services/bot-client/src/commands/inspect/embed.test.ts
+++ b/services/bot-client/src/commands/inspect/embed.test.ts
@@ -355,6 +355,38 @@ describe('buildDiagnosticEmbed', () => {
     expect(embed.toJSON().footer?.text).toContain('buttons and menu');
   });
 
+  it('shows Cached Tokens with hit percent when the provider reported cache activity', () => {
+    const payload = createMockPayload();
+    payload.llmResponse.promptTokens = 1000;
+    payload.llmResponse.cachedPromptTokens = 750;
+
+    const embed = buildDiagnosticEmbed(payload);
+    const fields = embed.toJSON().fields ?? [];
+    const responseField = fields.find(f => f.name.includes('Response'));
+    expect(responseField?.value).toContain('**Cached Tokens:** 750 (75%)');
+  });
+
+  it('renders Cached Tokens without a percent when promptTokens is 0 (no divide-by-zero)', () => {
+    const payload = createMockPayload();
+    payload.llmResponse.promptTokens = 0;
+    payload.llmResponse.cachedPromptTokens = 0;
+
+    const embed = buildDiagnosticEmbed(payload);
+    const fields = embed.toJSON().fields ?? [];
+    const responseField = fields.find(f => f.name.includes('Response'));
+    expect(responseField?.value).toContain('**Cached Tokens:** 0');
+    expect(responseField?.value).not.toContain('%');
+  });
+
+  it('omits Cached Tokens when the provider reported no cache activity (old logs included)', () => {
+    const payload = createMockPayload();
+
+    const embed = buildDiagnosticEmbed(payload);
+    const fields = embed.toJSON().fields ?? [];
+    const responseField = fields.find(f => f.name.includes('Response'));
+    expect(responseField?.value).not.toContain('Cached Tokens');
+  });
+
   it('should include reasoning field when reasoning config present', () => {
     const payload = createMockPayload();
     payload.llmConfig.allParams = { reasoning: { effort: 'high', enabled: true } };

--- a/services/bot-client/src/commands/inspect/embed.ts
+++ b/services/bot-client/src/commands/inspect/embed.ts
@@ -202,13 +202,23 @@ function buildResponseField(llmResponse: DiagnosticPayload['llmResponse']): {
 } {
   const lowTokenWarning =
     llmResponse.completionTokens < 100 && llmResponse.completionTokens > 0 ? ' ⚠️ LOW' : '';
+  const lines = [
+    `**Finish Reason:** ${formatFinishReason(llmResponse.finishReason)}`,
+    `**Prompt Tokens:** ${llmResponse.promptTokens}`,
+    `**Completion Tokens:** ${llmResponse.completionTokens}${lowTokenWarning}`,
+  ];
+  // Provider-reported prefix-cache hit. Absent = provider reported no cache
+  // activity (old logs predate the field); 0 = a real cold-prefix report.
+  if (llmResponse.cachedPromptTokens !== undefined) {
+    const hitPercent =
+      llmResponse.promptTokens > 0
+        ? ` (${Math.round((llmResponse.cachedPromptTokens / llmResponse.promptTokens) * 100)}%)`
+        : '';
+    lines.push(`**Cached Tokens:** ${llmResponse.cachedPromptTokens}${hitPercent}`);
+  }
   return {
     name: '📤 Response',
-    value: [
-      `**Finish Reason:** ${formatFinishReason(llmResponse.finishReason)}`,
-      `**Prompt Tokens:** ${llmResponse.promptTokens}`,
-      `**Completion Tokens:** ${llmResponse.completionTokens}${lowTokenWarning}`,
-    ].join('\n'),
+    value: lines.join('\n'),
     inline: true,
   };
 }


### PR DESCRIPTION
## Summary

Phase 0 (PR 2 of 6) of the **Provider Prompt Caching epic** (doc-17). The measurement layer: every later phase of the epic is adjudicated by these fields, and before this PR nothing in the codebase read the provider's cache-usage reporting (`rg cached_tokens` → zero source hits).

### What's captured, from where

- **`cachedPromptTokens`** — LangChain already normalizes the provider's `usage.prompt_tokens_details.cached_tokens` onto `AIMessage.usage_metadata.input_token_details.cache_read`; our `ParsedResponseMetadata` type narrowing silently dropped it. Now threaded: recorder → collector → diagnostic payload → `/inspect` Response field (rendered with a hit percent, omitted for old logs that predate the field — `0` is a real cold-prefix report and renders). This path covers **both** the OpenRouter and z.ai-direct routes (the z.ai coding endpoint's field shape was empirically confirmed in the doc-17 Phase-0 spike: 97.6% cached on a shared prefix).
- **`cacheDiscount`** — OpenRouter-only billing adjustment, exists ONLY on `__raw_response.usage`, which is deleted for memory hygiene; `buildOpenrouterMetadata` now captures it before the delete (the only recoverable point in the process).
- **Prod greppability** — the per-completion `'Generated response'` info log gains `promptTokens` + `cachedPromptTokens`, so hit rates are measurable from Railway logs without `/inspect`.

### Do-it-now rider

`LLMInvoker.logFinishReason` and `extractResponseDiagnostics` read token usage from `response_metadata.usage` — which LangChain only populates when the provider returns a truthy `system_fingerprint`, i.e. essentially never via OpenRouter, so those log fields were `undefined` on the dominant route. Both now read the normalized `usage_metadata`. Also corrected LLMInvoker's stale header (it still claimed the message transform deleted in #1903).

## Scope notes

- **No migration, no Zod change** — the diagnostic payload is deliberately an untyped Json column; `DiagnosticLlmResponse` (common-types) and `LlmResponseData` (ai-worker) are hand-mirrored twins, both edited.
- **UsageLog deliberately untouched** — cost columns would need a migration; Phase 3's measurement decides whether that's wanted.
- **Expected values until PR 5 lands**: ~0 cached tokens (the system prompt still leads with volatile content). The before/after delta across the Phase-1 restructure IS the epic's measurement.

## Verified

- Sentinel thread-through tests at every hand-copied seam: recorder (6272/-0.0123 from their two distinct sources), collector field-copy → finalized payload, extractor capture-before-delete (asserts `__raw_response` is gone after capture), embed render (75% hit percent + omitted-when-absent).
- Full `pnpm test` (26 tasks) green → `pnpm quality` green → `pnpm test:component` green (inspect is a command surface; 613 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)