### PR TITLE
refactor(ai-worker): typed prompt sections (behavior-preserving)

### DIFF
--- a/packages/common-types/src/types/diagnostic.ts
+++ b/packages/common-types/src/types/diagnostic.ts
@@ -196,6 +196,26 @@ export interface DiagnosticAssembledPrompt {
   messages: DiagnosticMessage[];
   /** Estimated total tokens */
   totalTokenEstimate: number;
+  /**
+   * Per-section map of the system prompt (id, stability tier, char size,
+   * offset into the system message). Written from the prompt builder's
+   * section model; the prefix-diff tool reads it to annotate cache-miss
+   * divergence offsets with the section they landed in. Absent on payloads
+   * recorded before the section model shipped.
+   */
+  systemPromptSections?: DiagnosticPromptSection[];
+}
+
+/** One system-prompt section's placement (mirrors ai-worker's SectionDescription). */
+export interface DiagnosticPromptSection {
+  /** Stable section id (e.g. 'system_identity', 'chat_log') */
+  id: string;
+  /** Stability tier: S0 cross-persona static · S1 per-persona · H history · V volatile */
+  tier: 'S0' | 'S1' | 'H' | 'V';
+  /** Rendered length in chars (separators excluded) */
+  chars: number;
+  /** Offset of the section's first char in the system message */
+  offset: number;
 }
 
 /**

--- a/services/ai-worker/src/services/ContentBudgetManager.test.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.test.ts
@@ -42,6 +42,9 @@ describe('ContentBudgetManager', () => {
         contentForStorage: 'User message for storage',
       }),
       buildFullSystemPrompt: vi.fn().mockReturnValue(mockSystemPrompt),
+      buildFullSystemPromptWithSections: vi
+        .fn()
+        .mockReturnValue({ message: mockSystemPrompt, sections: [] }),
       countTokens: vi.fn().mockReturnValue(100),
       countMemoryTokens: vi.fn().mockReturnValue(50),
     } as unknown as PromptBuilder;
@@ -190,14 +193,16 @@ describe('ContentBudgetManager', () => {
 
       budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
-      // buildFullSystemPrompt is called exactly twice:
-      // 1. Base system prompt (pre-pass, for token counting)
-      // 2. Final with memories AND history
+      // The system prompt is built exactly twice:
+      // 1. Base system prompt (pre-pass, for token counting) — plain variant
+      // 2. Final with memories AND history — sections variant, whose section
+      //    descriptions ride into the diagnostic payload
       // The old middle build (prompt-with-memories to size the history
       // budget) is gone by design: the history budget uses the memory
       // RESERVE so it is computable BEFORE retrieval — that ordering is what
       // closes the STM/LTM coverage hole.
-      expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledTimes(2);
+      expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledTimes(1);
+      expect(mockPromptBuilder.buildFullSystemPromptWithSections).toHaveBeenCalledTimes(1);
     });
 
     it('should pass participant personas to system prompt builder', () => {
@@ -208,7 +213,7 @@ describe('ContentBudgetManager', () => {
 
       budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
-      expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledWith(
+      expect(mockPromptBuilder.buildFullSystemPromptWithSections).toHaveBeenCalledWith(
         expect.objectContaining({
           participantPersonas: options.participantPersonas,
         })
@@ -221,7 +226,7 @@ describe('ContentBudgetManager', () => {
 
       budgetManager.allocate(options, budgetManager.preselectHistory(options));
 
-      expect(mockPromptBuilder.buildFullSystemPrompt).toHaveBeenCalledWith(
+      expect(mockPromptBuilder.buildFullSystemPromptWithSections).toHaveBeenCalledWith(
         expect.objectContaining({
           referencedMessagesFormatted: 'Referenced: Some quoted message',
         })
@@ -395,7 +400,7 @@ describe('ContentBudgetManager', () => {
       expect(episodeBudget).toBe(700);
       // The selected facts cross the seam into the prompt build.
       const promptFacts = vi
-        .mocked(mockPromptBuilder.buildFullSystemPrompt)
+        .mocked(mockPromptBuilder.buildFullSystemPromptWithSections)
         .mock.calls.at(-1)?.[0].facts;
       expect(promptFacts).toHaveLength(2);
     });
@@ -431,7 +436,7 @@ describe('ContentBudgetManager', () => {
       expect(episodeBudget).toBe(300);
       // Nothing crosses the seam into the prompt build.
       const promptFacts = vi
-        .mocked(mockPromptBuilder.buildFullSystemPrompt)
+        .mocked(mockPromptBuilder.buildFullSystemPromptWithSections)
         .mock.calls.at(-1)?.[0].facts;
       expect(promptFacts).toEqual([]);
     });
@@ -639,7 +644,7 @@ describe('ContentBudgetManager', () => {
         { ...options, retrievedMemories: [droppedMemory, shippedMemory], facts: [] },
         preselected
       );
-      const calls = vi.mocked(mockPromptBuilder.buildFullSystemPrompt).mock.calls;
+      const calls = vi.mocked(mockPromptBuilder.buildFullSystemPromptWithSections).mock.calls;
       const finalPromptArgs = calls[calls.length - 1][0] as {
         relevantMemories: MemoryDocument[];
       };

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -260,15 +260,16 @@ export class ContentBudgetManager {
 
     // Build final system prompt
     // Note: Image descriptions are now inline in serializedHistory (via injectImageDescriptions)
-    const systemPrompt = this.promptBuilder.buildFullSystemPrompt({
-      personality: processedPersonality,
-      participantPersonas,
-      relevantMemories,
-      facts: selectedFacts,
-      context,
-      referencedMessagesFormatted: opts.referencedMessagesDescriptions,
-      serializedHistory,
-    });
+    const { message: systemPrompt, sections: systemPromptSections } =
+      this.promptBuilder.buildFullSystemPromptWithSections({
+        personality: processedPersonality,
+        participantPersonas,
+        relevantMemories,
+        facts: selectedFacts,
+        context,
+        referencedMessagesFormatted: opts.referencedMessagesDescriptions,
+        serializedHistory,
+      });
 
     this.logAllocation({
       contextWindowTokens,
@@ -288,6 +289,7 @@ export class ContentBudgetManager {
       selectedFacts,
       serializedHistory,
       systemPrompt,
+      systemPromptSections,
       memoryTokensUsed,
       factTokensUsed,
       historyTokensUsed,

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -449,7 +449,7 @@ describe('ConversationalRAGService', () => {
 
       const result = await service.generateResponse(personality, 'Recall something', context);
 
-      expect(getPromptBuilderMock().buildFullSystemPrompt).toHaveBeenCalledWith({
+      expect(getPromptBuilderMock().buildFullSystemPromptWithSections).toHaveBeenCalledWith({
         personality,
         participantPersonas: expect.any(Map),
         relevantMemories: memories,
@@ -488,7 +488,7 @@ describe('ConversationalRAGService', () => {
       );
       // The non-empty facts flow through the REAL ContentBudgetManager into the
       // prompt's <facts> block (default budget mocks let one fact fit).
-      expect(getPromptBuilderMock().buildFullSystemPrompt).toHaveBeenCalledWith(
+      expect(getPromptBuilderMock().buildFullSystemPromptWithSections).toHaveBeenCalledWith(
         expect.objectContaining({ facts })
       );
     });
@@ -504,7 +504,7 @@ describe('ConversationalRAGService', () => {
 
       await service.generateResponse(personality, 'Hello', context);
 
-      expect(getPromptBuilderMock().buildFullSystemPrompt).toHaveBeenCalledWith({
+      expect(getPromptBuilderMock().buildFullSystemPromptWithSections).toHaveBeenCalledWith({
         personality,
         participantPersonas: participantMap,
         relevantMemories: expect.any(Array),
@@ -547,7 +547,7 @@ describe('ConversationalRAGService', () => {
 
       await service.generateResponse(personality, 'Hello', context);
 
-      const call = getPromptBuilderMock().buildFullSystemPrompt.mock.calls[0]?.[0] as
+      const call = getPromptBuilderMock().buildFullSystemPromptWithSections.mock.calls[0]?.[0] as
         { participantPersonas: Map<string, { personaId: string; content?: string }> } | undefined;
       expect(call).toBeDefined();
       const participants = call!.participantPersonas;
@@ -885,7 +885,7 @@ describe('ConversationalRAGService', () => {
 
       await service.generateResponse(personality, 'Respond to Dave', context);
 
-      expect(getPromptBuilderMock().buildFullSystemPrompt).toHaveBeenCalledWith({
+      expect(getPromptBuilderMock().buildFullSystemPromptWithSections).toHaveBeenCalledWith({
         personality,
         participantPersonas: expect.any(Map),
         relevantMemories: expect.any(Array),

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -47,7 +47,7 @@ import { resolveRagVisionAuth, enrichRagHistory } from './multimodal/ragVisionAu
 import type { ApiKeyResolver } from './ApiKeyResolver.js';
 import {
   parseResponseMetadata,
-  recordLlmConfigDiagnostic,
+  recordPreInvocationDiagnostics,
   recordLlmResponseDiagnostic,
   recordBudgetDiagnostics,
 } from './diagnostics/DiagnosticRecorders.js';
@@ -121,6 +121,7 @@ export class ConversationalRAGService {
     const {
       personality,
       systemPrompt,
+      systemPromptSections,
       userMessage,
       processedAttachments,
       context,
@@ -163,22 +164,19 @@ export class ConversationalRAGService {
     // Calculate attachment counts for timeout
     const { imageCount, audioCount } = countMediaAttachments(context.attachments);
 
-    // Record assembled prompt and LLM config for diagnostics
+    // Record assembled prompt (with section map) + LLM config for diagnostics
     if (diagnosticCollector) {
-      const totalTokenEstimate =
-        this.promptBuilder.countTokens(contentToText(systemPrompt.content)) +
-        this.promptBuilder.countTokens(contentToText(currentMessage.content));
-
-      diagnosticCollector.recordAssembledPrompt(messages, totalTokenEstimate);
-      recordLlmConfigDiagnostic({
+      recordPreInvocationDiagnostics({
         collector: diagnosticCollector,
+        messages,
+        systemPromptSections,
+        countTokens: text => this.promptBuilder.countTokens(text),
         modelName,
         personality,
         effectiveTemperature: retryConfig?.temperatureOverride ?? personality.temperature,
         effectiveFrequencyPenalty:
           retryConfig?.frequencyPenaltyOverride ?? personality.frequencyPenalty,
       });
-      diagnosticCollector.markLlmInvocationStart();
     }
 
     // cacheKeyId scopes doom caches by BILLING identity: guest/system-key
@@ -438,6 +436,7 @@ export class ConversationalRAGService {
       const modelResult = await this.invokeModelAndClean({
         personality,
         systemPrompt: budgetResult.systemPrompt,
+        systemPromptSections: budgetResult.systemPromptSections,
         userMessage: inputs.userMessage,
         processedAttachments: inputs.processedAttachments,
         context,

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -18,6 +18,7 @@ import type { LoadedPersonality } from '@tzurot/common-types/types/schemas/perso
 import type { SttDispatch } from '@tzurot/common-types/types/sttProvider';
 import type { SummonAnonymity } from '@tzurot/common-types/types/summon-anonymity';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
+import type { SectionDescription } from './prompt/sections.js';
 
 /**
  * Cross-provider vision auth, resolved ONCE per request and threaded to every
@@ -271,6 +272,10 @@ export interface BudgetAllocationResult {
   selectedFacts: FactForPrompt[];
   serializedHistory: string;
   systemPrompt: BaseMessage;
+  /** Per-section tier/size/offset map of the FINAL system prompt — stored in
+   *  the diagnostic payload so the prefix-diff tool can name the section a
+   *  cache-miss divergence landed in. */
+  systemPromptSections: SectionDescription[];
   memoryTokensUsed: number;
   /** Tokens consumed by the `<facts>` block (wrapper + statements). */
   factTokensUsed: number;
@@ -333,6 +338,8 @@ export interface DiagnosticCollectorRef {}
 export interface ModelInvocationOptions {
   personality: LoadedPersonality;
   systemPrompt: BaseMessage;
+  /** Section map of systemPrompt, recorded into the diagnostic payload. */
+  systemPromptSections?: SectionDescription[];
   userMessage: string;
   processedAttachments: ProcessedAttachment[];
   context: ConversationContext;

--- a/services/ai-worker/src/services/DiagnosticCollector.test.ts
+++ b/services/ai-worker/src/services/DiagnosticCollector.test.ts
@@ -378,6 +378,27 @@ describe('DiagnosticCollector', () => {
       const payload = collector.finalize();
       expect(payload.assembledPrompt.messages[0].content).toBe('First partSecond part');
     });
+
+    it('should carry system-prompt section descriptions into the finalized payload', () => {
+      // The prefix-diff tool reads these off the stored payload — a dropped
+      // forward here silently removes its annotation source.
+      const sections = [
+        { id: 'system_identity', tier: 'S1' as const, chars: 120, offset: 0 },
+        { id: 'chat_log', tier: 'H' as const, chars: 4000, offset: 122 },
+      ];
+
+      collector.recordAssembledPrompt([new SystemMessage('sys')], 100, sections);
+
+      const payload = collector.finalize();
+      expect(payload.assembledPrompt.systemPromptSections).toEqual(sections);
+    });
+
+    it('should omit systemPromptSections when none are provided', () => {
+      collector.recordAssembledPrompt([new SystemMessage('sys')], 100);
+
+      const payload = collector.finalize();
+      expect(payload.assembledPrompt.systemPromptSections).toBeUndefined();
+    });
   });
 
   describe('recordLlmConfig', () => {

--- a/services/ai-worker/src/services/DiagnosticCollector.ts
+++ b/services/ai-worker/src/services/DiagnosticCollector.ts
@@ -27,6 +27,7 @@ import {
   type DiagnosticMemoryEntry,
   type DiagnosticTokenBudget,
   type DiagnosticAssembledPrompt,
+  type DiagnosticPromptSection,
   type DiagnosticMessage,
   type DiagnosticLlmConfig,
   type DiagnosticLlmResponse,
@@ -231,12 +232,19 @@ export class DiagnosticCollector {
   }
 
   /**
-   * Record Stage 4: Assembled prompt (the exact messages sent to the LLM)
+   * Record Stage 4: Assembled prompt (the exact messages sent to the LLM).
+   * `systemPromptSections` maps each system-prompt section's tier/size/offset —
+   * the prefix-diff tool reads it to name the section a divergence landed in.
    */
-  recordAssembledPrompt(messages: BaseMessage[], tokenEstimate: number): void {
+  recordAssembledPrompt(
+    messages: BaseMessage[],
+    tokenEstimate: number,
+    systemPromptSections?: DiagnosticPromptSection[]
+  ): void {
     this.assembledPrompt = {
       messages: messages.map(msg => this.convertMessage(msg)),
       totalTokenEstimate: tokenEstimate,
+      ...(systemPromptSections !== undefined ? { systemPromptSections } : {}),
     };
   }
 

--- a/services/ai-worker/src/services/PromptBuilder.test.ts
+++ b/services/ai-worker/src/services/PromptBuilder.test.ts
@@ -1402,6 +1402,66 @@ describe('PromptBuilder', () => {
    * - Extended context with image descriptions
    * - Voice transcripts
    */
+  describe('buildFullSystemPromptWithSections — production section list', () => {
+    // Pins the REAL section array in PromptBuilder (ids, tiers, order) against
+    // a build where every section renders. The synthetic sections.test.ts pins
+    // the assembler contract; this pins the production wiring — the list the
+    // prefix-diff tool annotates against. A wrong id/tier or a section missing
+    // from the array fails here instead of surfacing as a mis-annotated diff.
+    it('describes every rendered section with its id and tier, in assembly order', () => {
+      const { message, sections } = promptBuilder.buildFullSystemPromptWithSections({
+        personality: {
+          id: 'p-1',
+          slug: 'sect-bot',
+          ownerId: 'owner-1',
+          name: 'SectBot',
+          systemPrompt: 'Be helpful.',
+          characterInfo: 'A section-model test character',
+          personalityTraits: 'Precise',
+          voiceEnabled: false,
+          displayName: 'Sect Bot',
+          model: 'gpt-4',
+          provider: 'openrouter',
+          temperature: 0.7,
+          maxTokens: 2000,
+          contextWindowTokens: 8000,
+        },
+        participantPersonas: new Map([
+          ['User', { content: 'A tester', isActive: true, personaId: 'persona-1' }],
+        ]),
+        relevantMemories: [
+          { pageContent: 'Test memory', metadata: { createdAt: new Date('2024-01-15').getTime() } },
+        ],
+        facts: [{ statement: 'Likes tests.' }],
+        context: { userId: 'user-1', activePersonaName: 'User' } as ConversationContext,
+        referencedMessagesFormatted: '<contextual_references>ref</contextual_references>',
+        serializedHistory: '<message>hi</message>',
+      });
+
+      expect(sections.map(section => `${section.tier}:${section.id}`)).toEqual([
+        'S1:system_identity',
+        'S1:identity_constraints',
+        'S0:platform_constraints',
+        'V:context',
+        'V:participants',
+        'V:facts',
+        'V:memory_archive',
+        'V:contextual_references',
+        'H:chat_log',
+        'S1:protocol',
+        'S0:output_constraints',
+      ]);
+
+      // Offsets index back into the actual assembled message.
+      const content = message.content as string;
+      for (const section of sections) {
+        const slice = content.slice(section.offset, section.offset + section.chars);
+        expect(slice.length).toBe(section.chars);
+      }
+      expect(content.slice(sections[0].offset, 17)).toBe('<system_identity>');
+    });
+  });
+
   describe('Prompt Snapshots', () => {
     // Fixed date for deterministic snapshots
     const FIXED_DATE = new Date('2024-06-15T14:30:00Z');

--- a/services/ai-worker/src/services/PromptBuilder.ts
+++ b/services/ai-worker/src/services/PromptBuilder.ts
@@ -17,6 +17,12 @@ import type {
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 import { formatParticipantsContext } from './prompt/ParticipantFormatter.js';
 import { formatMemoriesContext, formatFactsContext } from './prompt/MemoryFormatter.js';
+import {
+  assembleSections,
+  describeSections,
+  type PromptSection,
+  type SectionDescription,
+} from './prompt/sections.js';
 import { formatPersonalityFields } from './prompt/PersonalityFieldsFormatter.js';
 import { formatEnvironmentContext } from './prompt/EnvironmentFormatter.js';
 import { extractContentDescriptions } from './RAGUtils.js';
@@ -64,7 +70,7 @@ function buildChatLogSection(
   if (serializedHistory === undefined || serializedHistory.length === 0) {
     return '';
   }
-  return `\n\n<chat_log>
+  return `<chat_log>
 <instruction>The conversation so far. Each message's role says who wrote it: role="assistant" marks your own earlier lines (${escapeXmlContent(personalityName)}); role="user" marks humans (match from_id to <participants>); role="character" marks a different AI character — a conversation peer, never you.</instruction>
 ${serializedHistory}
 </chat_log>`;
@@ -186,20 +192,30 @@ export class PromptBuilder {
   }
 
   /**
-   * Build full system prompt with personas, memories, and date context
-   *
-   * NEW ARCHITECTURE (2025-12): Full XML structure to prevent identity bleeding
-   *
-   * Section ordering follows Gemini's "XML Containment & Sandwich Method":
-   * 1. <system_identity> - Identity, character, AND constraints (who am I, what I must NOT do)
-   * 2. <context> - Date/time and location (when and where)
-   * 3. <participants> - Who else is involved (NOT including self)
-   * 4. <memory_archive> - Historical memories (middle = less attention = good for archives)
-   * 5. <contextual_references> - Referenced messages from replies/links
-   * 6. <chat_log> - Serialized conversation history with XML tags per message
-   * 7. <protocol> - Behavior rules (END for recency bias)
+   * Convenience wrapper over {@link buildFullSystemPromptWithSections} for
+   * callers that only need the message (the base/measurement build, tests).
    */
   buildFullSystemPrompt(options: BuildFullSystemPromptOptions): SystemMessage {
+    return this.buildFullSystemPromptWithSections(options).message;
+  }
+
+  /**
+   * Build full system prompt with personas, memories, and date context.
+   *
+   * Assembly runs over typed {@link PromptSection}s (see prompt/sections.ts);
+   * the returned descriptions map each rendered section's tier and offset —
+   * the diagnostic payload stores them so the prefix-diff tool can annotate
+   * a cache-miss divergence with the section it landed in.
+   *
+   * Section ordering follows Gemini's "XML Containment & Sandwich Method":
+   * identity + constraints first (who am I, what I must NOT do), volatile
+   * context/participants/retrieval in the middle, chat_log, then protocol +
+   * output constraints at the END for recency bias.
+   */
+  buildFullSystemPromptWithSections(options: BuildFullSystemPromptOptions): {
+    message: SystemMessage;
+    sections: SectionDescription[];
+  } {
     const {
       personality,
       participantPersonas,
@@ -252,7 +268,7 @@ ${escapeXmlContent(persona)}
         ? formatEnvironmentContext(context.environment)
         : '<location type="dm">Direct Message (private one-on-one chat)</location>';
 
-    const contextSection = `\n\n<context>
+    const contextSection = `<context>
 <datetime>${datetime}</datetime>
 ${locationXml}
 </context>`;
@@ -278,10 +294,7 @@ ${locationXml}
     const memoryContext = formatMemoriesContext(relevantMemories, context.userTimezone);
 
     // Referenced messages (from replies and message links)
-    const referencesContext =
-      referencedMessagesFormatted !== undefined && referencedMessagesFormatted.length > 0
-        ? `\n\n${referencedMessagesFormatted}`
-        : '';
+    const referencesContext = referencedMessagesFormatted ?? '';
 
     if (referencesContext.length > 0) {
       logger.info(
@@ -297,32 +310,37 @@ ${locationXml}
     // escape kept: it also covers the LEGACY raw-systemPrompt path (author XML),
     // and the <protocol> boundary protection stops sub-section values escaping.
     const protocolSection =
-      protocol.length > 0 ? `\n\n<protocol>\n${escapeXmlContent(protocol)}\n</protocol>` : '';
+      protocol.length > 0 ? `<protocol>\n${escapeXmlContent(protocol)}\n</protocol>` : '';
 
-    // Output constraints at the VERY END (recency bias for format compliance)
-    const outputConstraintsSection = `\n\n${OUTPUT_CONSTRAINTS}`;
+    // The Sandwich Method order (identity first, protocol + output constraints
+    // last for recency). Tiers are descriptive until the Phase-1 restructure
+    // keys placement on them; identity_constraints is tagged S1 although its
+    // collision constraint is request-dependent today — that constraint moves
+    // to the V-tier participants block when tiers become load-bearing.
+    const sections: PromptSection[] = [
+      { id: 'system_identity', tier: 'S1', render: () => identitySection },
+      { id: 'identity_constraints', tier: 'S1', render: () => identityConstraintsSection },
+      { id: 'platform_constraints', tier: 'S0', render: () => PLATFORM_CONSTRAINTS },
+      { id: 'context', tier: 'V', render: () => contextSection },
+      { id: 'participants', tier: 'V', render: () => participantsContext },
+      { id: 'facts', tier: 'V', render: () => factsContext },
+      { id: 'memory_archive', tier: 'V', render: () => memoryContext },
+      { id: 'contextual_references', tier: 'V', render: () => referencesContext },
+      { id: 'chat_log', tier: 'H', render: () => chatLogSection },
+      { id: 'protocol', tier: 'S1', render: () => protocolSection },
+      { id: 'output_constraints', tier: 'S0', render: () => OUTPUT_CONSTRAINTS },
+    ];
 
-    // Assemble in correct order using Sandwich Method
-    const fullSystemPrompt = `${identitySection}\n\n${identityConstraintsSection}\n\n${PLATFORM_CONSTRAINTS}${contextSection}${participantsContext}${factsContext}${memoryContext}${referencesContext}${chatLogSection}${protocolSection}${outputConstraintsSection}`;
+    const fullSystemPrompt = assembleSections(sections);
+    const sectionDescriptions = describeSections(sections);
 
-    // Basic prompt composition logging
-    const historyLength = serializedHistory?.length ?? 0;
-    const promptLengths = {
-      identity: identitySection.length,
-      identityConstraints: identityConstraintsSection.length,
-      platformConstraints: PLATFORM_CONSTRAINTS.length,
-      context: contextSection.length,
-      participants: participantsContext.length,
-      memories: memoryContext.length,
-      references: referencesContext.length,
-      history: historyLength,
-      protocol: protocolSection.length,
-      outputConstraints: outputConstraintsSection.length,
-      total: fullSystemPrompt.length,
-    };
-    logger.info(promptLengths, 'Prompt composition');
+    logger.info(
+      { sections: sectionDescriptions, total: fullSystemPrompt.length },
+      'Prompt composition'
+    );
 
     // Detailed prompt assembly logging (development only)
+    const historyLength = serializedHistory?.length ?? 0;
     logDetailedPromptAssembly({
       personality,
       persona,
@@ -336,7 +354,7 @@ ${locationXml}
       fullSystemPrompt,
     });
 
-    return new SystemMessage(fullSystemPrompt);
+    return { message: new SystemMessage(fullSystemPrompt), sections: sectionDescriptions };
   }
 
   /**

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
@@ -27,10 +27,11 @@ import {
   parseResponseMetadata,
   recordLlmConfigDiagnostic,
   recordLlmResponseDiagnostic,
+  recordPreInvocationDiagnostics,
   recordBudgetDiagnostics,
   type ParsedResponseMetadata,
 } from './DiagnosticRecorders.js';
-import { SystemMessage } from '@langchain/core/messages';
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
 import type { DiagnosticCollector } from '../DiagnosticCollector.js';
 import type { BudgetAllocationResult, MemoryDocument } from '../ConversationalRAGTypes.js';
 
@@ -162,6 +163,7 @@ describe('DiagnosticRecorders', () => {
         selectedFacts: [],
         serializedHistory: '',
         systemPrompt: new SystemMessage('system prompt text'),
+        systemPromptSections: [],
         memoryTokensUsed: 50,
         factTokensUsed: 0,
         historyTokensUsed: 200,
@@ -213,6 +215,7 @@ describe('DiagnosticRecorders', () => {
         selectedFacts: [{ statement: 'fact a' }, { statement: 'fact b' }],
         serializedHistory: '',
         systemPrompt: new SystemMessage('sys'),
+        systemPromptSections: [],
         memoryTokensUsed: 10,
         factTokensUsed: 42,
         historyTokensUsed: 20,
@@ -238,6 +241,36 @@ describe('DiagnosticRecorders', () => {
           factsDropped: 3,
         })
       );
+    });
+  });
+
+  describe('recordPreInvocationDiagnostics', () => {
+    it('records prompt (with sections), config, and start mark in one call', () => {
+      const mockCollector = {
+        recordAssembledPrompt: vi.fn(),
+        recordLlmConfig: vi.fn(),
+        markLlmInvocationStart: vi.fn(),
+      };
+      const sections = [{ id: 'system_identity', tier: 'S1' as const, chars: 10, offset: 0 }];
+      const messages = [new SystemMessage('0123456789'), new HumanMessage('01234')];
+
+      recordPreInvocationDiagnostics({
+        collector: mockCollector as never,
+        messages,
+        systemPromptSections: sections,
+        countTokens: text => text.length,
+        modelName: 'z-ai/glm-4.7',
+        personality: { topP: 0.9 } as never,
+        effectiveTemperature: 0.8,
+        effectiveFrequencyPenalty: undefined,
+      });
+
+      // Token estimate sums every message through the provided counter.
+      expect(mockCollector.recordAssembledPrompt).toHaveBeenCalledWith(messages, 15, sections);
+      expect(mockCollector.recordLlmConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'z-ai/glm-4.7', temperature: 0.8, topP: 0.9 })
+      );
+      expect(mockCollector.markLlmInvocationStart).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
@@ -5,6 +5,8 @@
  * extracting verbose inline construction from the main orchestration methods.
  */
 
+import type { BaseMessage } from '@langchain/core/messages';
+import type { DiagnosticPromptSection } from '@tzurot/common-types/types/diagnostic';
 import type { DiagnosticCollector } from '../DiagnosticCollector.js';
 import { resolveFinishReason } from '@tzurot/common-types/constants/finishReasons';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
@@ -113,6 +115,33 @@ export function recordLlmConfigDiagnostic(opts: LlmConfigDiagnosticOptions): voi
     route: personality.route,
     verbosity: personality.verbosity,
   });
+}
+
+/** Options for recording everything the collector needs before model.invoke() */
+interface PreInvocationDiagnosticOptions extends LlmConfigDiagnosticOptions {
+  /** The exact messages array about to be sent to the model */
+  messages: BaseMessage[];
+  /** Section map of the system prompt (tier/size/offset), for the prefix-diff tool */
+  systemPromptSections?: DiagnosticPromptSection[];
+  countTokens: (text: string) => number;
+}
+
+/**
+ * Record the assembled prompt (with its section map), the LLM config, and the
+ * invocation start mark — the full pre-invoke diagnostic set — in one call.
+ */
+export function recordPreInvocationDiagnostics(opts: PreInvocationDiagnosticOptions): void {
+  const totalTokenEstimate = opts.messages.reduce(
+    (sum, message) => sum + opts.countTokens(contentToText(message.content)),
+    0
+  );
+  opts.collector.recordAssembledPrompt(
+    opts.messages,
+    totalTokenEstimate,
+    opts.systemPromptSections
+  );
+  recordLlmConfigDiagnostic(opts);
+  opts.collector.markLlmInvocationStart();
 }
 
 /** Build reasoning debug info for diagnostics */

--- a/services/ai-worker/src/services/prompt/MemoryFormatter.ts
+++ b/services/ai-worker/src/services/prompt/MemoryFormatter.ts
@@ -133,7 +133,8 @@ export function formatMemoriesContext(
     .map(doc => formatSingleMemory(doc, timezone))
     .join('\n');
 
-  return '\n\n' + buildMemoryArchiveXml(formattedMemories);
+  // Bare block — the section assembler owns inter-section separators.
+  return buildMemoryArchiveXml(formattedMemories);
 }
 
 /**
@@ -235,5 +236,6 @@ export function formatFactsContext(facts: FactForPrompt[], names?: FactRenderNam
     return '';
   }
   const formatted = facts.map(f => formatSingleFact(f, names)).join('\n');
-  return '\n\n' + buildFactsXml(formatted, names?.subjectName);
+  // Bare block — the section assembler owns inter-section separators.
+  return buildFactsXml(formatted, names?.subjectName);
 }

--- a/services/ai-worker/src/services/prompt/ParticipantFormatter.ts
+++ b/services/ai-worker/src/services/prompt/ParticipantFormatter.ts
@@ -129,6 +129,6 @@ export function formatParticipantsContext(
 
   parts.push('</participants>');
 
-  // Return with leading newlines for proper prompt spacing
-  return '\n\n' + parts.join('\n');
+  // Bare block — the section assembler owns inter-section separators.
+  return parts.join('\n');
 }

--- a/services/ai-worker/src/services/prompt/sections.test.ts
+++ b/services/ai-worker/src/services/prompt/sections.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assembleSections,
+  describeSections,
+  SECTION_SEPARATOR,
+  type PromptSection,
+} from './sections.js';
+
+function section(id: string, text: string, tier: PromptSection['tier'] = 'V'): PromptSection {
+  return { id, tier, render: () => text };
+}
+
+describe('assembleSections', () => {
+  it('joins non-empty sections with the separator, in order', () => {
+    const result = assembleSections([section('a', 'first'), section('b', 'second')]);
+    expect(result).toBe(`first${SECTION_SEPARATOR}second`);
+  });
+
+  it('omits empty sections without emitting their separator', () => {
+    const result = assembleSections([
+      section('a', 'first'),
+      section('gone', ''),
+      section('b', 'second'),
+    ]);
+    expect(result).toBe(`first${SECTION_SEPARATOR}second`);
+  });
+
+  it('returns an empty string when every section is empty', () => {
+    expect(assembleSections([section('a', ''), section('b', '')])).toBe('');
+  });
+
+  it('returns a lone section bare (no separators)', () => {
+    expect(assembleSections([section('only', 'content')])).toBe('content');
+  });
+});
+
+describe('describeSections', () => {
+  // The offsets exist for the prefix-diff tool and the composition log: a
+  // divergence offset maps back to "which section changed". An off-by-one here
+  // misattributes divergence, so offsets are checked against the assembled
+  // string itself rather than against hand-computed numbers.
+  it('reports offsets that index back into the assembled string', () => {
+    const sections = [
+      section('identity', '<system_identity>x</system_identity>', 'S1'),
+      section('context', '<context>now</context>', 'V'),
+      section('protocol', '<protocol>rules</protocol>', 'S1'),
+    ];
+    const assembled = assembleSections(sections);
+
+    for (const described of describeSections(sections)) {
+      const slice = assembled.slice(described.offset, described.offset + described.chars);
+      expect(slice).toBe(sections.find(s => s.id === described.id)?.render());
+    }
+  });
+
+  it('skips omitted sections and keeps later offsets correct', () => {
+    const sections = [section('a', 'xxxx'), section('empty', ''), section('b', 'yy')];
+
+    expect(describeSections(sections)).toEqual([
+      { id: 'a', tier: 'V', chars: 4, offset: 0 },
+      // 4 chars + the 2-char separator; the empty section contributes nothing
+      { id: 'b', tier: 'V', chars: 2, offset: 6 },
+    ]);
+  });
+
+  it('carries the tier through for placement-aware consumers', () => {
+    const described = describeSections([section('platform_constraints', 'text', 'S0')]);
+    expect(described[0].tier).toBe('S0');
+  });
+
+  it('returns an empty description list when nothing renders', () => {
+    expect(describeSections([section('a', '')])).toEqual([]);
+  });
+});

--- a/services/ai-worker/src/services/prompt/sections.ts
+++ b/services/ai-worker/src/services/prompt/sections.ts
@@ -1,0 +1,86 @@
+/**
+ * Typed prompt sections — the assembly model for the system/human containers.
+ *
+ * Replaces the single template-literal concatenation in `buildFullSystemPrompt`
+ * with named, tier-tagged parts, mirroring the `QueryPart` pattern in
+ * `SearchQueryBuilder.ts` (name + text + offset diagnostics). The tier tags the
+ * stability class from the prompt-assembly architecture
+ * (`docs/proposals/backlog/prompt-assembly-architecture.md` §2.1); placement
+ * decisions keyed on tier arrive with the Phase-1 restructure — until then the
+ * tier is descriptive metadata carried by the composition log and the
+ * diagnostic payload (which the prefix-diff tool annotates against).
+ *
+ * `render()` returns a BARE block — no leading/trailing separator; the
+ * assembler owns the joining. An empty string means "omit this section
+ * entirely" (no separator is emitted for it). Phase 3 (provider cache markers)
+ * is expected to widen `render()` to content-parts arrays; string is the
+ * deliberate simpler shape while both containers are single strings.
+ */
+
+/**
+ * Stability tier per the accepted architecture:
+ * - S0: static across ALL personas (platform/output constraints)
+ * - S1: static per persona (identity, identity constraints, protocol)
+ * - H: frozen conversation history (grows per turn)
+ * - V: per-request volatile (datetime, participants, retrieval output, references)
+ *
+ * Keep in lockstep with common-types' DiagnosticPromptSection.tier — the two
+ * are structurally compatible mirrors with no compiler tie (the diagnostic
+ * payload is untyped Json at the wire).
+ */
+export type SectionTier = 'S0' | 'S1' | 'H' | 'V';
+
+/** One named contributor to an assembled prompt container, in append order. */
+export interface PromptSection {
+  /** Stable id, used in logs, diagnostics, and prefix-diff annotation. */
+  id: string;
+  tier: SectionTier;
+  /** Bare block without separators; '' = omit the section. */
+  render(): string;
+}
+
+/** The separator between rendered sections (matches the historical assembly). */
+export const SECTION_SEPARATOR = '\n\n';
+
+/** One rendered section's placement inside the assembled container. */
+export interface SectionDescription {
+  id: string;
+  tier: SectionTier;
+  /** Rendered length in chars (bare block, separators excluded). */
+  chars: number;
+  /** Offset of the block's first char in the assembled string. */
+  offset: number;
+}
+
+/**
+ * Join the non-empty sections with the separator, in order.
+ */
+export function assembleSections(sections: PromptSection[]): string {
+  return sections
+    .map(section => section.render())
+    .filter(text => text.length > 0)
+    .join(SECTION_SEPARATOR);
+}
+
+/**
+ * Describe each RENDERED section's size and offset in the assembled string.
+ * Omitted (empty) sections produce no entry — an absent id in the description
+ * is itself signal. The offsets index into `assembleSections`' output exactly;
+ * the composition log and the prefix-diff tool both key on that property.
+ */
+export function describeSections(sections: PromptSection[]): SectionDescription[] {
+  const descriptions: SectionDescription[] = [];
+  let offset = 0;
+  for (const section of sections) {
+    const text = section.render();
+    if (text.length === 0) {
+      continue;
+    }
+    if (descriptions.length > 0) {
+      offset += SECTION_SEPARATOR.length;
+    }
+    descriptions.push({ id: section.id, tier: section.tier, chars: text.length, offset });
+    offset += text.length;
+  }
+  return descriptions;
+}

--- a/services/ai-worker/src/test/mocks/PromptBuilder.mock.ts
+++ b/services/ai-worker/src/test/mocks/PromptBuilder.mock.ts
@@ -14,6 +14,7 @@ interface MockPromptBuilderInstance {
   formatUserMessage: ReturnType<typeof vi.fn>;
   buildSearchQuery: ReturnType<typeof vi.fn>;
   buildFullSystemPrompt: ReturnType<typeof vi.fn>;
+  buildFullSystemPromptWithSections: ReturnType<typeof vi.fn>;
   buildHumanMessage: ReturnType<typeof vi.fn>;
   countTokens: ReturnType<typeof vi.fn>;
   countMemoryTokens: ReturnType<typeof vi.fn>;
@@ -28,6 +29,7 @@ let mockInstance: MockPromptBuilderInstance | null = null;
  * - `formatUserMessage()` → Returns `'formatted user message'`
  * - `buildSearchQuery()` → Returns `'search query'`
  * - `buildFullSystemPrompt()` → Returns `SystemMessage('system prompt')`
+ * - `buildFullSystemPromptWithSections()` → Returns `{ message, sections: [] }`
  * - `buildHumanMessage()` → Returns `{ message: HumanMessage, contentForStorage: string }`
  * - `countTokens()` → Returns `100` tokens
  * - `countMemoryTokens()` → Returns `50` tokens
@@ -39,6 +41,10 @@ function createMockFunctions(): MockPromptBuilderInstance {
     formatUserMessage: vi.fn().mockReturnValue('formatted user message'),
     buildSearchQuery: vi.fn().mockReturnValue('search query'),
     buildFullSystemPrompt: vi.fn().mockReturnValue(new SystemMessage('system prompt')),
+    buildFullSystemPromptWithSections: vi.fn().mockReturnValue({
+      message: new SystemMessage('system prompt'),
+      sections: [],
+    }),
     buildHumanMessage: vi.fn().mockReturnValue({
       message: new HumanMessage('human message'),
       contentForStorage: 'content for storage',
@@ -56,6 +62,7 @@ export const mockPromptBuilder = {
     formatUserMessage: ReturnType<typeof vi.fn>;
     buildSearchQuery: ReturnType<typeof vi.fn>;
     buildFullSystemPrompt: ReturnType<typeof vi.fn>;
+    buildFullSystemPromptWithSections: ReturnType<typeof vi.fn>;
     buildHumanMessage: ReturnType<typeof vi.fn>;
     countTokens: ReturnType<typeof vi.fn>;
     countMemoryTokens: ReturnType<typeof vi.fn>;
@@ -65,6 +72,7 @@ export const mockPromptBuilder = {
       this.formatUserMessage = fns.formatUserMessage;
       this.buildSearchQuery = fns.buildSearchQuery;
       this.buildFullSystemPrompt = fns.buildFullSystemPrompt;
+      this.buildFullSystemPromptWithSections = fns.buildFullSystemPromptWithSections;
       this.buildHumanMessage = fns.buildHumanMessage;
       this.countTokens = fns.countTokens;
       this.countMemoryTokens = fns.countMemoryTokens;


### PR DESCRIPTION
## Summary

Phase 1 groundwork for the **Provider Prompt Caching epic** (doc-17, PR 3 of 6). The system prompt's single template-literal concatenation becomes an ordered list of typed sections — `{ id, tier, render() }` — modeled on the existing `QueryPart` pattern in `SearchQueryBuilder`. **Placement stays exactly as today**; the tier (`S0` cross-persona / `S1` per-persona / `H` history / `V` volatile) is descriptive metadata until the restructure PR keys placement on it.

## The byte-identity proof

**Zero-line diff on all 10 PromptBuilder snapshots** — the whole PromptBuilder test file passed without a single snapshot regeneration. The four self-separating formatters (participants, memories, facts, chat_log) and the inline-separator sections were converted to bare blocks; `assembleSections` reproduces the exact historical bytes (`join('\n\n')` over non-empty blocks — identical to the old per-section leading-separator convention, including the empty-section-omits-its-separator behavior).

## What the section model buys immediately

- **`describeSections`** emits `{id, tier, chars, offset}` per rendered section, offsets indexing into the assembled string (pinned by a test that slices the assembled string back out). This replaces the hand-maintained `promptLengths` log, which had drifted — it was missing the `facts` section entirely.
- **The final build's section map rides into the diagnostic payload**: `buildFullSystemPromptWithSections` → `BudgetAllocationResult.systemPromptSections` → `recordAssembledPrompt` (untyped Json column, no migration). This is PR 4's annotation source — the prefix-diff tool maps a cache-miss divergence offset to the section it landed in ("divergence at S1 → persona edit, expected").
- `buildFullSystemPrompt` survives as a thin wrapper for callers that only need the message (the base/measurement build, tests), consolidated when PR 5 reshapes the API anyway.

## Also in here

- **Pre-invocation diagnostics extracted** to `DiagnosticRecorders.recordPreInvocationDiagnostics` (assembled prompt + LLM config + start mark in one call) — that file exists precisely for orchestration-glue extraction, and `ConversationalRAGService` had tipped over the 400-line `max-lines` cap by two lines. Extraction over comment-trimming, per the standards.
- `identity_constraints` is tagged S1 with an explicit comment that its collision constraint is request-dependent today — that constraint moves to the V-tier participants block in PR 5 (per the approved plan), not silently here.

## Verified

- Zero snapshot diff (the review artifact for behavior preservation).
- New unit coverage: `sections.test.ts` (assembly/omission/offset-slicing invariants), collector pass-through pins for `systemPromptSections` (present + omitted), `recordPreInvocationDiagnostics` seam test.
- Full `pnpm test` (26 tasks) green → `pnpm quality` green (typecheck:spec caught and fixed the two `BudgetAllocationResult` fixture updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)