### PR TITLE
feat(ai-worker): absolute-only timestamps in chat_log entries

### DIFF
--- a/packages/common-types/src/utils/dateFormatting.test.ts
+++ b/packages/common-types/src/utils/dateFormatting.test.ts
@@ -6,6 +6,7 @@ import {
   formatMemoryTimestamp,
   formatRelativeTimeDelta,
   formatPromptTimestamp,
+  formatAbsoluteTimestamp,
   formatDateShort,
   formatDateTimeCompact,
   formatDiscordTimestamp,
@@ -200,6 +201,25 @@ describe('dateFormatting', () => {
 
     it('should return empty string for invalid date', () => {
       expect(formatRelativeTimeDelta('not-a-date')).toBe('');
+    });
+  });
+
+  describe('formatAbsoluteTimestamp', () => {
+    it('formats YYYY-MM-DD (Day) HH:MM with no relative suffix', () => {
+      const result = formatAbsoluteTimestamp(new Date('2025-01-25T14:30:00Z'), 'UTC');
+      expect(result).toBe('2025-01-25 (Sat) 14:30');
+      expect(result).not.toContain('•');
+    });
+
+    it('keeps the SAME format regardless of age (no 7-day branch)', () => {
+      // The age branch is itself cache-poison: a chat-log entry crossing the
+      // boundary would re-serialize differently. Absolute means absolute.
+      const old = formatAbsoluteTimestamp(new Date('2020-06-15T09:05:00Z'), 'UTC');
+      expect(old).toBe('2020-06-15 (Mon) 09:05');
+    });
+
+    it('returns empty string for an invalid date', () => {
+      expect(formatAbsoluteTimestamp('not a date')).toBe('');
     });
   });
 

--- a/packages/common-types/src/utils/dateFormatting.ts
+++ b/packages/common-types/src/utils/dateFormatting.ts
@@ -295,6 +295,44 @@ export function formatRelativeTimeDelta(timestamp: Date | string | number): stri
 }
 
 /**
+ * Format a timestamp ABSOLUTELY for frozen prompt content (chat_log).
+ *
+ * Format: "YYYY-MM-DD (Day) HH:MM" — always, with no relative suffix and no
+ * age-dependent branching. Both of {@link formatPromptTimestamp}'s dynamic
+ * parts re-render differently as time passes ("2h ago" → "3h ago"; the time
+ * component drops at the 7-day boundary), which mutates FROZEN history bytes
+ * between requests and silently breaks the provider prompt-cache prefix at
+ * the oldest drifted message. Chat-log entries must serialize identically on
+ * every render; volatile-tier content (memory archive, references) keeps the
+ * relative form — it re-renders per request anyway and recency phrasing is
+ * genuinely useful there.
+ *
+ * @param timestamp - Timestamp to format
+ * @param timezone - Optional IANA timezone. Defaults to APP_SETTINGS.TIMEZONE
+ * @returns Absolute timestamp string, or empty string for invalid date
+ */
+export function formatAbsoluteTimestamp(
+  timestamp: Date | string | number,
+  timezone?: string
+): string {
+  const date = parseTimestamp(timestamp);
+  if (!date) {
+    return '';
+  }
+
+  const tz = resolveTimezone(timezone);
+  const dayOfWeek = date.toLocaleDateString(LOCALE, { weekday: 'short', timeZone: tz });
+  const datePart = formatDateOnly(date, tz);
+  const time = date.toLocaleTimeString(LOCALE, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: tz,
+  });
+  return `${datePart} (${dayOfWeek}) ${time}`;
+}
+
+/**
  * Format a timestamp for prompt display with unified format
  *
  * Format: "YYYY-MM-DD (Day) HH:MM • relative"
@@ -303,10 +341,11 @@ export function formatRelativeTimeDelta(timestamp: Date | string | number): stri
  * For older timestamps (>7 days), omits time:
  * Example: "2025-11-15 (Fri) • 2 months ago"
  *
- * Used for:
- * - Message timestamps in chat_log
+ * Used for VOLATILE-tier prompt content that re-renders per request:
  * - Referenced message timestamps
  * - Memory timestamps in memory_archive
+ * (chat_log uses {@link formatAbsoluteTimestamp} — frozen history must not
+ * carry time-drifting text.)
  *
  * @param timestamp - Timestamp to format
  * @param timezone - Optional IANA timezone. Defaults to APP_SETTINGS.TIMEZONE

--- a/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
@@ -33,9 +33,10 @@ vi.mock('@tzurot/common-types/utils/dateFormatting', async () => {
       // Simple mock that returns a formatted string
       return 'just now';
     }),
-    formatPromptTimestamp: vi.fn((_timestamp: string | Date | number) => {
-      // Simple mock that returns a unified timestamp string
-      return '2025-01-25 (Sat) 14:30 • just now';
+    formatAbsoluteTimestamp: vi.fn((_timestamp: string | Date | number) => {
+      // Simple mock returning the absolute-only chat_log form (no relative
+      // suffix — frozen history must serialize identically on every render)
+      return '2025-01-25 (Sat) 14:30';
     }),
   };
 });
@@ -507,7 +508,7 @@ describe('Conversation Utilities', () => {
 
       const result = formatConversationHistoryAsXml(history, 'TestBot');
 
-      expect(result).toContain('t="2025-01-25 (Sat) 14:30 • just now"'); // Mocked formatPromptTimestamp
+      expect(result).toContain('t="2025-01-25 (Sat) 14:30"'); // Mocked formatAbsoluteTimestamp
     });
 
     it('should skip system messages', () => {
@@ -1689,7 +1690,7 @@ describe('Conversation Utilities', () => {
       // Format should be: <message from="..." from_id="..." role="..." t="...">
       // Uses unified timestamp format
       expect(result).toMatch(
-        /<message from="Alice" from_id="persona-uuid-123" role="user" t="2025-01-25 \(Sat\) 14:30 • just now">/
+        /<message from="Alice" from_id="persona-uuid-123" role="user" t="2025-01-25 \(Sat\) 14:30">/
       );
     });
 
@@ -2136,7 +2137,7 @@ describe('Conversation Utilities', () => {
       // Both messages should have unified t attribute (mocked to consistent value)
       expect(result).toMatch(/t="[^"]+"/);
       // Should appear twice (once per message)
-      const tAttrCount = (result.match(/t="2025-01-25 \(Sat\) 14:30 • just now"/g) || []).length;
+      const tAttrCount = (result.match(/t="2025-01-25 \(Sat\) 14:30"/g) || []).length;
       expect(tAttrCount).toBe(2);
     });
   });

--- a/services/ai-worker/src/jobs/utils/conversationUtils.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.ts
@@ -12,7 +12,7 @@
  */
 
 import { type CrossChannelHistoryGroupEntry } from '@tzurot/common-types/types/schemas/message';
-import { formatPromptTimestamp } from '@tzurot/common-types/utils/dateFormatting';
+import { formatAbsoluteTimestamp } from '@tzurot/common-types/utils/dateFormatting';
 import { formatLocationAsXml } from '@tzurot/common-types/utils/environmentFormatter';
 import { escapeXmlContent } from '@tzurot/common-types/utils/promptSanitizer';
 import {
@@ -106,11 +106,14 @@ export function formatSingleHistoryEntryAsXml(
 
   const { speakerName, role, normalizedRole } = speakerInfo;
 
-  // Format the timestamp with unified format (escape for use in attribute)
-  // Format: "YYYY-MM-DD (Day) HH:MM • relative" - combines date, time, and relative in one token-efficient attribute
+  // Absolute-only timestamp: "YYYY-MM-DD (Day) HH:MM". Chat-log entries are
+  // frozen content — a relative suffix (or the old 7-day format switch) would
+  // re-render differently as time passes and silently break the provider
+  // prompt-cache prefix at the oldest drifted message. Elapsed-time cues live
+  // in the <time_gap> markers, which are inter-message deltas and stable.
   const timeAttr =
     msg.createdAt !== undefined && msg.createdAt.length > 0
-      ? ` t="${escapeXml(formatPromptTimestamp(msg.createdAt))}"`
+      ? ` t="${escapeXml(formatAbsoluteTimestamp(msg.createdAt))}"`
       : '';
 
   // Escape content to prevent XML injection

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -217,7 +217,8 @@ export interface QuoteElementOptions {
   role?: RenderedQuoteRole;
   /**
    * Pre-formatted timestamp for the `t=""` attribute — always via
-   * `formatPromptTimestamp`, the same helper `<message>` uses in `<chat_log>`.
+   * `formatPromptTimestamp` (quotes are volatile-tier content and keep the
+   * relative form; `<chat_log>` messages use `formatAbsoluteTimestamp`).
    *
    * There used to be a second slot here (a `{absolute, relative}` pair rendered
    * as a `<time/>` child) that only the live paths filled, so the same quote


### PR DESCRIPTION
## Summary

**Phase 1 of the Provider Prompt Caching epic — PR 6 of 6, the last slice.**

The `chat_log` `<message t=…>` attribute carried `YYYY-MM-DD (Day) HH:MM • relative`, and **both** dynamic parts mutate frozen history bytes as time passes: the relative suffix re-renders ("2h ago" → "3h ago"), and the format itself switches at the 7-day boundary (drops HH:MM). Either change silently breaks the provider prompt-cache prefix at the oldest drifted message — with #1907's restructure live, chat_log is the tail of the cacheable container, so this drift was the last self-inflicted cache poison.

## Changes

- **`formatAbsoluteTimestamp`** (common-types): `YYYY-MM-DD (Day) HH:MM` always — no relative suffix, no age branch (the branch is itself drift; pinned by an old-date test asserting the same format at any age).
- `conversationUtils`' chat_log serializer switches to it. Elapsed-time cues stay covered by the `<time_gap>` markers — inter-message **deltas**, stable once both messages exist.
- Volatile-tier consumers (memory archive, references, quote formatter) deliberately keep `formatPromptTimestamp`: they re-render per request anyway, and relative phrasing is genuinely useful there.

## Verified

- common-types (2,676) + ai-worker (4,258) suites green; `pnpm quality` green.
- Sequenced after #1907 per the plan so quality effects stay attributable per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)