### PR TITLE
feat(bot-client): show usernames in the retention nag embed and preview CLI

### DIFF
--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -661,6 +661,7 @@ describe('SecretRotationEntrySchema', () => {
 describe('RetentionPreviewUserSchema', () => {
   const user = {
     discordId: '900000000000000071',
+    username: 'inactiveuser',
     inactiveSince: '2025-01-01T00:00:00.000Z',
     reason: 'unreachable' as const,
     ownedCharacters: { toDelete: 2, toReHome: 1 },
@@ -686,6 +687,30 @@ describe('RetentionPreviewUserSchema', () => {
     expect(RetentionPreviewUserSchema.safeParse({ ...user, discordId: 'unknown' }).success).toBe(
       true
     );
+  });
+
+  it('ACCEPTS an empty username — nag delivery outranks field validity', () => {
+    // Same fail-open doctrine as the discordId above: the username is a
+    // display-only identity token, and a malformed or blank stored value must
+    // never crash the CLI or silence the daily nag. The rendering surfaces
+    // omit the token instead.
+    expect(RetentionPreviewUserSchema.safeParse({ ...user, username: '' }).success).toBe(true);
+    expect(RetentionPreviewUserSchema.safeParse({ ...user, username: '*weird*' }).success).toBe(
+      true
+    );
+  });
+
+  it('REQUIRES the username field — a missing one must not silently strip', () => {
+    // The client transport Zod-parses in strip mode, so an undeclared field
+    // vanishes before any consumer sees it; the producer always supplies this
+    // one (the column is NOT NULL).
+    const withoutUsername = {
+      discordId: user.discordId,
+      inactiveSince: user.inactiveSince,
+      reason: user.reason,
+      ownedCharacters: user.ownedCharacters,
+    };
+    expect(RetentionPreviewUserSchema.safeParse(withoutUsername).success).toBe(false);
   });
 
   it('still rejects empty/oversized ids and negative character counts', () => {

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -317,6 +317,15 @@ export const RetentionPreviewUserSchema = z.object({
    * pipeline's recipient schemas stay strict; such rows never qualify there.
    */
   discordId: z.string().min(1).max(32),
+  /**
+   * Display-only identity token, rendered beside the id because `<@id>`
+   * mentions often fail to resolve on mobile. Deliberately NOT `.min(1)`:
+   * the same fail-open doctrine `discordId` above documents — nag delivery
+   * outranks field validity, so a malformed or empty stored username must
+   * never crash the CLI or silence the daily nag. The rendering surfaces
+   * omit the token rather than reject the payload.
+   */
+  username: z.string().max(255),
   /** Inactivity anchor as ISO — last_active_at, or created_at when never stamped. */
   inactiveSince: z.string().datetime(),
   /**

--- a/packages/tooling/src/retention/preview.test.ts
+++ b/packages/tooling/src/retention/preview.test.ts
@@ -30,12 +30,14 @@ const COHORT = {
   users: [
     {
       discordId: '900000000000000001',
+      username: 'unreachableuser',
       inactiveSince: '2025-01-01T00:00:00.000Z',
       reason: 'unreachable' as const,
       ownedCharacters: { toDelete: 1, toReHome: 2 },
     },
     {
       discordId: '900000000000000002',
+      username: 'goneaccount',
       inactiveSince: '2025-02-01T00:00:00.000Z',
       reason: 'account_gone' as const,
       ownedCharacters: { toDelete: 0, toReHome: 0 },
@@ -147,6 +149,33 @@ describe('renderPreview', () => {
     expect(output).toContain('Discord account deleted');
     expect(output).toContain('2 would be re-homed');
     expect(output).toContain('Read-only');
+    logSpy.mockRestore();
+  });
+
+  it('prints the username beside each id (the readable identity token)', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    renderPreview(COHORT);
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('@unreachableuser');
+    expect(output).toContain('@goneaccount');
+    logSpy.mockRestore();
+  });
+
+  it('omits the username column for a row whose stored username is empty', () => {
+    // The schema keeps the field fail-open on content, so the report must
+    // render a blank username as an absent column, never a dangling `@`.
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    renderPreview({
+      ...COHORT,
+      users: [{ ...COHORT.users[0], username: '   ' }],
+    });
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('900000000000000001  inactive since');
+    expect(output).not.toContain('@ ');
     logSpy.mockRestore();
   });
 

--- a/packages/tooling/src/retention/preview.ts
+++ b/packages/tooling/src/retention/preview.ts
@@ -69,8 +69,11 @@ export function renderPreview(preview: RetentionPreviewResponse): void {
       user.ownedCharacters.toDelete + user.ownedCharacters.toReHome === 0
         ? 'no characters'
         : `${user.ownedCharacters.toDelete} to delete, ${user.ownedCharacters.toReHome} to re-home`;
+    // An empty stored username drops its column rather than printing a
+    // dangling `@` — the schema keeps the field fail-open on content.
+    const usernameColumn = user.username.trim() === '' ? '' : `@${user.username}  `;
     console.log(
-      `  ${user.discordId}  inactive since ${inactiveSince}  ` +
+      `  ${user.discordId}  ${usernameColumn}inactive since ${inactiveSince}  ` +
         `${chalk.dim(REASON_LABEL[user.reason])}  ${chalk.dim(`(${characters})`)}`
     );
   }

--- a/packages/tooling/src/retention/purge.test.ts
+++ b/packages/tooling/src/retention/purge.test.ts
@@ -21,6 +21,7 @@ function cohort(...discordIds: string[]) {
   return {
     users: discordIds.map(discordId => ({
       discordId,
+      username: `user${discordId.slice(-2)}`,
       inactiveSince: '2025-01-01T00:00:00.000Z',
       reason: 'unreachable' as const,
       ownedCharacters: { toDelete: 1, toReHome: 0 },

--- a/services/api-gateway/src/routes/internal/retentionPreview.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionPreview.test.ts
@@ -19,6 +19,7 @@ const PREVIEW = {
   users: [
     {
       discordId: '900000000000000001',
+      username: 'inactiveuser',
       inactiveSince: '2025-01-01T00:00:00.000Z',
       reason: 'unreachable' as const,
       ownedCharacters: { toDelete: 1, toReHome: 2 },

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.component.test.ts
@@ -250,6 +250,18 @@ describe('RetentionPurgeService (component, PGLite)', () => {
     expect(byId.get(BYSTANDER)).toBe('bystander');
   });
 
+  it('threads each seeded username through to the preview rows', async () => {
+    // End-to-end pin of the identity token the operator surfaces render beside
+    // the id: real column → the cohort SELECT → toCohortRow → buildPreview.
+    // Keyed on the two reasons exactly one seeded user holds.
+    const preview = await service.buildPreview();
+
+    expect(preview.users.find(user => user.reason === 'account_gone')?.username).toBe(
+      'goneaccount'
+    );
+    expect(preview.users.find(user => user.reason === 'bystander')?.username).toBe('bystanderrow');
+  });
+
   it('reports the character split and userbase share in the preview', async () => {
     const preview = await service.buildPreview();
 

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.test.ts
@@ -46,6 +46,7 @@ describe('RetentionPurgeService.buildPreview', () => {
     {
       userId: 'u1',
       discordId: '900000000000000001',
+      username: 'inactiveuser',
       inactiveSince: new Date('2025-01-01T00:00:00Z'),
       accountGone: false,
       unreachable: true,
@@ -97,6 +98,7 @@ describe('RetentionPurgeService.buildPreview', () => {
     const cohort = ['u1', 'u2', 'u3'].map((userId, i) => ({
       userId,
       discordId: `90000000000000000${i}`,
+      username: `inactive${String(i)}`,
       inactiveSince: new Date('2025-01-01T00:00:00Z'),
       accountGone: false,
       unreachable: true,
@@ -128,6 +130,7 @@ describe('RetentionPurgeService.buildPreview', () => {
       {
         userId: 'u2',
         discordId: '900000000000000002',
+        username: 'gracelapsed',
         inactiveSince: new Date('2025-02-01T00:00:00Z'),
         accountGone: false,
         unreachable: false,

--- a/services/api-gateway/src/services/retention/RetentionPurgeService.ts
+++ b/services/api-gateway/src/services/retention/RetentionPurgeService.ts
@@ -61,6 +61,8 @@ export const BREAKER_HARD_FRACTION = 0.25;
 
 export interface RetentionPreviewUser {
   discordId: string;
+  /** Display-only identity token: the operator surfaces render it beside the id. */
+  username: string;
   inactiveSince: string;
   reason: PurgeReason;
   ownedCharacters: {
@@ -150,6 +152,7 @@ export class RetentionPurgeService {
     const users: RetentionPreviewUser[] = await Promise.all(
       cohort.map(async row => ({
         discordId: row.discordId,
+        username: row.username,
         inactiveSince: row.inactiveSince.toISOString(),
         reason: row.reason,
         ownedCharacters: await this.splitOwnedCharacters(row.userId),

--- a/services/api-gateway/src/services/retention/eligibility.test.ts
+++ b/services/api-gateway/src/services/retention/eligibility.test.ts
@@ -112,6 +112,7 @@ describe('the eligibility predicate', () => {
       {
         userId: 'u1',
         discordId: '900000000000000001',
+        username: 'goneaccount',
         inactiveSince: new Date('2025-01-01'),
         accountGone: true,
         unreachable: true,
@@ -120,6 +121,7 @@ describe('the eligibility predicate', () => {
       {
         userId: 'u2',
         discordId: '900000000000000002',
+        username: 'unreachableuser',
         inactiveSince: new Date('2025-02-01'),
         accountGone: false,
         unreachable: true,
@@ -128,6 +130,7 @@ describe('the eligibility predicate', () => {
       {
         userId: 'u3',
         discordId: '900000000000000003',
+        username: 'graceexpired',
         inactiveSince: new Date('2025-03-01'),
         accountGone: false,
         unreachable: false,
@@ -136,6 +139,7 @@ describe('the eligibility predicate', () => {
       {
         userId: 'u4',
         discordId: '900000000000000004',
+        username: 'bystanderrow',
         inactiveSince: new Date('2025-04-01'),
         accountGone: false,
         unreachable: false,
@@ -151,6 +155,28 @@ describe('the eligibility predicate', () => {
       'grace_expired',
       'bystander',
     ]);
+  });
+
+  it('selects the username and maps it through to the cohort row', async () => {
+    // The operator surfaces (nag embed, preview CLI) render it beside the id;
+    // it rides the SAME cohort query — a separate lookup would fork the
+    // predicate's one round-trip.
+    const { db, queryRaw } = makeDb([
+      {
+        userId: 'u1',
+        discordId: '900000000000000001',
+        username: 'inactiveuser',
+        inactiveSince: new Date('2025-01-01'),
+        accountGone: false,
+        unreachable: true,
+        wasNotified: false,
+      },
+    ]);
+
+    const cohort = await selectEligibleUsers(db);
+
+    expect(flattenSql(queryRaw.mock.calls[0])).toContain('u.username AS "username"');
+    expect(cohort[0].username).toBe('inactiveuser');
   });
 });
 

--- a/services/api-gateway/src/services/retention/eligibility.ts
+++ b/services/api-gateway/src/services/retention/eligibility.ts
@@ -40,6 +40,8 @@ export type PurgeReason = 'unreachable' | 'account_gone' | 'grace_expired' | 'by
 export interface PurgeCohortRow {
   userId: string;
   discordId: string;
+  /** Display-only identity token for the operator surfaces (nag embed, CLI). */
+  username: string;
   /** Effective inactivity anchor: last_active_at ?? created_at. */
   inactiveSince: Date;
   reason: PurgeReason;
@@ -48,6 +50,7 @@ export interface PurgeCohortRow {
 interface CohortSqlRow {
   userId: string;
   discordId: string;
+  username: string;
   inactiveSince: Date;
   accountGone: boolean;
   unreachable: boolean;
@@ -142,6 +145,7 @@ function toCohortRow(row: CohortSqlRow): PurgeCohortRow {
   return {
     userId: row.userId,
     discordId: row.discordId,
+    username: row.username,
     inactiveSince: row.inactiveSince,
     // Label precedence mirrors signal strength: a gone account beats
     // unreachable, either unreachable stamp beats the two reachable reasons (a
@@ -177,6 +181,7 @@ export async function selectEligibleUsers(db: Prisma.TransactionClient): Promise
   const rows = await db.$queryRaw<CohortSqlRow[]>`
     SELECT u.id AS "userId",
            u.discord_id AS "discordId",
+           u.username AS "username",
            COALESCE(u.last_active_at, u.created_at) AS "inactiveSince",
            (u.discord_account_gone_at IS NOT NULL) AS "accountGone",
            (u.dm_undeliverable_since IS NOT NULL) AS "unreachable",

--- a/services/bot-client/src/services/RetentionNagScheduler.test.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.test.ts
@@ -37,6 +37,7 @@ function makePreview(overrides: {
   return {
     users: Array.from({ length: listedUsers }, (_, i) => ({
       discordId: `99000000000000${String(i).padStart(4, '0')}`,
+      username: `inactive${String(i)}`,
       inactiveSince: '2025-09-01T00:00:00.000Z',
       reason: i === 0 ? ('unreachable' as const) : ('account_gone' as const),
       ownedCharacters: { toDelete: 1, toReHome: 0 },
@@ -206,6 +207,39 @@ describe('buildRetentionNagEmbed', () => {
 
     expect(expiredOnly.description).toContain('Reachable branch');
     expect(expiredOnly.description).toContain('**2** grace-expired');
+  });
+
+  it('renders all three identity tokens per user line', () => {
+    // The owner reads this embed on mobile, where `<@id>` mentions frequently
+    // fail to resolve — the plain-text username is the readable identity, and
+    // the backticked id stays the copy-paste handle for the CLI commands.
+    const embed = buildRetentionNagEmbed(makePreview({ eligibleCount: 1 })).toJSON();
+
+    expect(embed.description).toContain('<@990000000000000000>');
+    expect(embed.description).toContain('@inactive0');
+    expect(embed.description).toContain('`990000000000000000`');
+  });
+
+  it('escapes markdown in the username (user-controlled text in an owner embed)', () => {
+    const preview = makePreview({ eligibleCount: 1 });
+    preview.users[0] = { ...preview.users[0], username: '*bold*`tick`' };
+
+    const embed = buildRetentionNagEmbed(preview).toJSON();
+
+    expect(embed.description).toContain('\\*bold\\*\\`tick\\`');
+    expect(embed.description).not.toContain('@*bold*');
+  });
+
+  it('omits the username token entirely when the stored username is empty', () => {
+    // Fail-open: the schema deliberately allows an empty username, so the line
+    // must render without a dangling `@` rather than crash the nag.
+    const preview = makePreview({ eligibleCount: 1 });
+    preview.users[0] = { ...preview.users[0], username: '   ' };
+
+    const embed = buildRetentionNagEmbed(preview).toJSON();
+
+    expect(embed.description).toContain('<@990000000000000000> — `990000000000000000`');
+    expect(embed.description).not.toContain('@ —');
   });
 
   it('caps the listed users and reports the overflow', () => {

--- a/services/bot-client/src/services/RetentionNagScheduler.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.ts
@@ -13,7 +13,7 @@
  * week, surviving deploys precisely because in-process state does not.
  */
 
-import { EmbedBuilder, type Client } from 'discord.js';
+import { EmbedBuilder, escapeMarkdown, type Client } from 'discord.js';
 import type { Redis } from 'ioredis';
 import { getConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -66,13 +66,21 @@ export function buildRetentionNagEmbed(preview: RetentionPreviewResponse): Embed
     bystander: 'never used directly',
   } as const;
 
-  const lines = users
-    .slice(0, MAX_LISTED_USERS)
-    .map(
-      user =>
-        `\`${user.discordId}\` — inactive since ${user.inactiveSince.slice(0, 10)} ` +
-        `(${reasonLabel[user.reason]})`
+  // Three identity tokens per line, deliberately redundant: the `<@id>` mention
+  // frequently fails to resolve on mobile, the plain-text username is the
+  // readable fallback, and the backticked id is the copy-paste handle the CLI
+  // commands take. The username is user-controlled text entering an
+  // owner-facing embed, so it is escaped; an empty one drops its token rather
+  // than rendering a dangling `@`.
+  const lines = users.slice(0, MAX_LISTED_USERS).map(user => {
+    const escapedUsername = escapeMarkdown(user.username);
+    const usernameToken = user.username.trim() === '' ? '' : `@${escapedUsername} `;
+    return (
+      `<@${user.discordId}> ${usernameToken}— \`${user.discordId}\` — ` +
+      `inactive since ${user.inactiveSince.slice(0, 10)} ` +
+      `(${reasonLabel[user.reason]})`
     );
+  });
   if (users.length > MAX_LISTED_USERS) {
     lines.push(`…and ${String(users.length - MAX_LISTED_USERS)} more (see the preview CLI)`);
   }


### PR DESCRIPTION
## Summary

TASK-402 (owner ask from the beta.190 smoke round): the daily retention-nag embed rendered only raw snowflakes, which are unreadable on a phone. Each user line now carries **three identity tokens** (owner-refined design):

- `<@id>` mention — clickable profile on desktop (renders without pinging: `ownerChannel`'s `allowedMentions: { parse: [] }` is load-bearing and untouched)
- plain-text `@username` — the readable identity on mobile, where embed mentions frequently fail to resolve; **markdown-escaped** (user-controlled text in an owner-facing embed)
- the backticked `id` — unchanged, the copy-paste handle for `retention:purge`

`pnpm ops retention:preview` gains the same username column (`retention:purge`'s preview render inherits it; its own per-user progress lines deliberately stay id-keyed).

## Design calls

- **The Zod declaration is the load-bearing edit**: the client transport parses responses in strip mode, so `username` had to be added to `RetentionPreviewUserSchema` or the wire field would be silently deleted before either background consumer saw it. The payload shape is declared four times (raw SQL row → cohort row → service interface → schema); all four widened, and the field rides the existing cohort SELECT (no second query — the service tests mock `$queryRaw` by call order).
- **Required but fail-open on content** (`z.string().max(255)`, no `.min(1)`): nag delivery outranks field validity, per the doctrine already documented on this schema's `discordId` (strict validation once silenced the nag). Empty/whitespace usernames drop their token instead of rendering a dangling `@`. The schema test pins BOTH halves: empty/markdown usernames accepted, missing field rejected.
- The notify-path schema (`RetentionNotifyCohortUserSchema`) deliberately stays narrow.
- No username ever reaches a logger (PII rule); the file's logging still emits counts and errors only.

## Verified

- Full `pnpm test` (all 26 tasks) + `pnpm test:component` (46 files, the PGLite end-to-end username-threading pin) + `pnpm quality` — sequential, all green.
- New tests: three-token line render, markdown-escape, empty-username token omission (embed + CLI), SQL-seam pin (`u.username AS "username"` present in the SELECT and mapped through `toCohortRow`), schema fail-open/required pair, component-tier seeded-username round-trip.
- The pre-existing embed format pins (10-line cap regex, overflow line, reason labels) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)