### PR TITLE
fix: ops logs --since matched a time format Railway never emits

### DIFF
--- a/packages/tooling/src/deployment/logs.test.ts
+++ b/packages/tooling/src/deployment/logs.test.ts
@@ -325,6 +325,79 @@ describe('fetchLogs', () => {
       const errors = consoleErrorSpy.mock.calls.flat().join(' ');
       expect(errors).toContain('Cannot parse --since');
     });
+
+    describe('against the shape the Railway CLI actually emits', () => {
+      /**
+       * `railway logs` renders structured logs as an RFC3339 ingest prefix +
+       * level tag + message + logfmt key=value pairs — pino's `time` arrives as
+       * `time=<epoch ms>`, NOT as JSON `"time":<epoch ms>`. Captured verbatim
+       * from `railway logs --environment production --service ai-worker -n 5`.
+       */
+      const railwayLine = (pinoTimeMs: number, msg: string): string => {
+        // Railway's own prefix is nanosecond-precision and lands slightly after
+        // the pino stamp (it is the ingest time, not the emit time).
+        const prefix = `${new Date(pinoTimeMs + 2_000).toISOString().replace('Z', '')}898914Z`;
+        return `${prefix} [INFO] ${msg} time=${pinoTimeMs} pid=1 hostname="859ec3aad942" name="ai-worker"`;
+      };
+
+      it('keeps a logfmt pino line stamped inside the window', async () => {
+        vi.mocked(execFileSync).mockReturnValue(
+          `${railwayLine(FROZEN_NOW - 60_000, 'Generated response')}\n` +
+            `${railwayLine(FROZEN_NOW - 7_200_000, 'stale response')}\n`
+        );
+
+        await fetchLogs({ env: 'prod', service: 'ai-worker', since: '45m' });
+
+        const output = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(output).toContain('Generated response');
+        expect(output).not.toContain('stale response');
+      });
+
+      it('accepts an ISO-8601 --since floor against the same shape', async () => {
+        vi.mocked(execFileSync).mockReturnValue(
+          `${railwayLine(FROZEN_NOW - 30_000, 'after the floor')}\n` +
+            `${railwayLine(FROZEN_NOW - 3_600_000, 'before the floor')}\n`
+        );
+
+        await fetchLogs({
+          env: 'prod',
+          service: 'ai-worker',
+          since: new Date(FROZEN_NOW - 600_000).toISOString(),
+        });
+
+        const output = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(output).toContain('after the floor');
+        expect(output).not.toContain('before the floor');
+      });
+
+      it('falls back to the Railway ingest prefix for lines with no pino time', async () => {
+        // Non-pino services (redis, pgvector) still carry Railway's prefix; without
+        // the fallback they vanish from every --since dig.
+        const bare = (epochMs: number, msg: string): string =>
+          `${new Date(epochMs).toISOString().replace('Z', '')}898914Z ${msg}`;
+        vi.mocked(execFileSync).mockReturnValue(
+          `${bare(FROZEN_NOW - 60_000, 'redis ready to accept connections')}\n` +
+            `${bare(FROZEN_NOW - 7_200_000, 'redis old startup banner')}\n`
+        );
+
+        await fetchLogs({ env: 'prod', service: 'redis', since: '45m' });
+
+        const output = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(output).toContain('ready to accept connections');
+        expect(output).not.toContain('old startup banner');
+      });
+
+      it('reports how many lines were dropped for having no parseable timestamp', async () => {
+        // The silent-empty failure mode this bug produced: a zero-row result must
+        // say WHY it was zero when the cause was unparseable timestamps.
+        vi.mocked(execFileSync).mockReturnValue('no-timestamp boot noise\nanother bare line\n');
+
+        await fetchLogs({ env: 'prod', service: 'ai-worker', since: '45m' });
+
+        const output = consoleLogSpy.mock.calls.flat().join('\n');
+        expect(output).toContain('2 line(s) had no parseable timestamp');
+      });
+    });
   });
 
   describe('dig-mode composition and failure paths', () => {

--- a/packages/tooling/src/deployment/logs.ts
+++ b/packages/tooling/src/deployment/logs.ts
@@ -32,7 +32,10 @@ interface LogsOptions {
   requestId?: string;
   /** Correlation term: match lines containing this job ID (local substring). */
   jobId?: string;
-  /** Time floor: ISO-8601 timestamp or relative (`30m`, `2h`, `1d`). Local filter on pino `time`. */
+  /**
+   * Time floor: ISO-8601 timestamp or relative (`30m`, `2h`, `1d`). Local filter
+   * on the line's pino `time`, falling back to Railway's ingest prefix.
+   */
   since?: string;
 }
 
@@ -153,34 +156,73 @@ export function parseSinceMs(since: string, nowMs: number): number {
   return parsed;
 }
 
-/** Extract the pino epoch-ms `time` field from a JSON log line, if present. */
+/**
+ * Pino's epoch-ms `time` as the Railway CLI RENDERS it: structured logs come
+ * back as `<msg> time=1785776400257 pid=1 …` logfmt pairs, not as raw JSON —
+ * so a `"time":` matcher finds nothing on real output and silently drops every
+ * line. The JSON form is kept because `railway logs --json` still emits it.
+ */
+const PINO_TIME_LOGFMT = /(?:^|\s)time=(\d{10,})/;
+const PINO_TIME_JSON = /"time":\s*(\d{10,})/;
+
+/**
+ * Railway stamps every line it returns with an RFC3339 ingest prefix
+ * (nanosecond precision, a beat later than the emit time). It's the only clock
+ * on lines from non-pino services (redis, pgvector), so it backs the filter up.
+ */
+const RAILWAY_PREFIX_TIME = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/;
+
+/** Extract a line's epoch-ms timestamp: pino `time` first, Railway prefix as fallback. */
 function lineTimeMs(line: string): number | undefined {
-  const match = /"time":\s*(\d{10,})/.exec(line);
-  return match === null ? undefined : Number(match[1]);
+  const pino = PINO_TIME_LOGFMT.exec(line) ?? PINO_TIME_JSON.exec(line);
+  if (pino !== null) {
+    return Number(pino[1]);
+  }
+  const prefix = RAILWAY_PREFIX_TIME.exec(line);
+  if (prefix === null) {
+    return undefined;
+  }
+  const parsed = Date.parse(prefix[1]);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 /**
  * Local line filtering: every correlation term must appear (case-insensitive
  * substring — predictable, unlike the server DSL), and when a time floor is
- * set, only lines whose pino `time` is at/after it survive (lines without a
- * parseable time are dropped in since-mode; they're boot noise, not events).
+ * set, only lines whose timestamp is at/after it survive. Lines carrying no
+ * parseable timestamp are still dropped in since-mode, but they're COUNTED —
+ * a zero-row dig has to be able to say whether the window was empty or the
+ * timestamps were unreadable.
  */
-export function applyLocalFilters(logs: string, terms: string[], sinceMs?: number): string[] {
+export function applyLocalFilters(
+  logs: string,
+  terms: string[],
+  sinceMs?: number
+): { matched: string[]; undated: number } {
   const lowered = terms.map(t => t.toLowerCase());
-  return logs.split('\n').filter(line => {
+  const matched: string[] = [];
+  let undated = 0;
+  for (const line of logs.split('\n')) {
     if (line.trim().length === 0) {
-      return false;
+      continue;
     }
     const lineLower = line.toLowerCase();
     if (!lowered.every(term => lineLower.includes(term))) {
-      return false;
+      continue;
     }
     if (sinceMs !== undefined) {
       const time = lineTimeMs(line);
-      return time !== undefined && time >= sinceMs;
+      if (time === undefined) {
+        undated += 1;
+        continue;
+      }
+      if (time < sinceMs) {
+        continue;
+      }
     }
-    return true;
-  });
+    matched.push(line);
+  }
+  return { matched, undated };
 }
 
 /**
@@ -293,6 +335,7 @@ function runLocalFilterDig(opts: {
   const services: string[] = opts.service !== undefined ? [opts.service] : [...APP_SERVICES];
 
   let totalMatched = 0;
+  let totalUndated = 0;
   for (const svc of services) {
     const args = buildRailwayArgs({
       railwayEnv: opts.railwayEnv,
@@ -312,8 +355,9 @@ function runLocalFilterDig(opts: {
       continue;
     }
 
-    const matched = applyLocalFilters(raw, opts.terms, opts.sinceMs);
+    const { matched, undated } = applyLocalFilters(raw, opts.terms, opts.sinceMs);
     totalMatched += matched.length;
+    totalUndated += undated;
     if (services.length > 1) {
       console.log(chalk.cyan.bold(`\n── ${svc} ──`));
     }
@@ -330,6 +374,15 @@ function runLocalFilterDig(opts: {
       `${totalMatched} matching line(s) across ${services.length} service window(s) of ${opts.lines} lines each.`
     )
   );
+  if (totalUndated > 0) {
+    // Without this, an all-unparseable window is indistinguishable from a
+    // genuinely empty one — the exact way --since read as "no data".
+    console.log(
+      chalk.yellow(
+        `⚠️  ${totalUndated} line(s) had no parseable timestamp and were excluded by --since.`
+      )
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

TASK-404 — the bug that nearly misdirected the beta.190 post-release cache check: `pnpm ops logs --env prod --since 45m` reported "0 matching lines" while the unfiltered pull showed in-window lines.

**Confirmed mechanism (live-probed, not assumed)**: neither of the task's filed hypotheses held. `parseSinceMs` anchors correctly and pino `time` was already treated as epoch-ms — but `lineTimeMs` grepped for the JSON form (`"time":`) while the Railway CLI actually renders structured logs as logfmt (`… time=1785776400257 pid=1 …`), captured verbatim from a read-only prod `railway logs` probe. Every line therefore parsed as dateless, and since-mode drops dateless lines → the whole window vanished. The pre-existing tests passed because their fixtures were hand-written JSON — a shape the CLI never emits.

## Fix

- `lineTimeMs` matches logfmt `time=<epoch ms>` first, keeps the JSON form (`railway logs --json` still emits it), and falls back to Railway's RFC3339 ingest prefix — without the fallback, non-pino services (redis, pgvector) would still lose every line under `--since`.
- The silent-empty failure mode gets a voice: `applyLocalFilters` now counts unparseable-timestamp exclusions and the dig summary appends `⚠️ N line(s) had no parseable timestamp…` when nonzero — a zero-row result must be distinguishable from an unreadable window.
- No epoch-seconds tolerance added: every producer is pino with default ms timestamps and the probe shows 13-digit values; seconds handling would be speculative.

## Verified

- The reproducing test **failed on the old code with the exact field symptom** ("0 matching line(s) across 1 service window(s)" over an in-window line) before the fix; passes after. Fixtures are copied from the real probe output, nanosecond ingest prefix included.
- New cases: in-window inclusion, out-of-window exclusion, ISO-8601 `--since`, ingest-prefix fallback, unparseable counter. 37/37 in the module; full `pnpm test` + `pnpm quality` green sequentially.

## Adjacent finding (not fixed here)

`colorizeLogs` matches `"level":"error"` / `level=error` but Railway renders `[ERROR]`/`[WARN]` — same wrong-format-assumption class, purely cosmetic (nothing dropped). Filing as a tracker task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)