### PR TITLE
chore(ci): dependabot-ignore bullmq majors pending the v6 migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,13 @@ updates:
       # remove this ignore. Tracked as TASK-258.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
+      # BullMQ 6 is a breaking major: `repeat` is gone from JobsOptions (v6
+      # replaces repeatable jobs with the Job Schedulers API), and our
+      # lock/stall tuning was verified against 5.x internals — the upgrade is
+      # a deliberate migration, not a bump. Tracked as TASK-410; remove this
+      # ignore in the migration PR.
+      - dependency-name: 'bullmq'
+        update-types: ['version-update:semver-major']
 
   # GitHub Actions workflow file dependencies — separate ecosystem.
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
Dependabot's production group (#1913) is red because bullmq 6.0.2 is a breaking major: `repeat` no longer exists in `JobsOptions` (v6 replaces repeatable jobs with the Job Schedulers API — confirmed via the run's CI annotations), and #1647's lock/stall tuning was verified against 5.x internals, so the upgrade needs deliberate re-grounding. TASK-410 tracks the migration and removes this ignore; same pin pattern as the existing jscpd/TS7 entries. After merge, `@dependabot recreate` on #1913 regenerates the group without the bullmq major so the langchain/astro patches land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)