### PR TITLE
chore(ci): ignore ioredis majors with bullmq; document dependabot config gotcha

### DIFF
--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-08-02'
+lastUpdated: '2026-08-03'
 ---
 
 # Git Workflow Procedures
@@ -142,6 +142,8 @@ Dependabot PRs have three distinct cleanup paths — using the wrong one wastes 
 **Key constraint**: `@dependabot rebase` **refuses to run** if any commit on the branch is authored by someone other than dependabot. GitHub's "Update branch" UI button appears to rebase, but it actually adds a merge commit authored by `github-actions[bot]` — which poisons the branch for `rebase`. Once that happens, `recreate` is the only in-band recovery.
 
 **Rule of thumb**: don't hit "Update branch" on dependabot PRs. Use the chat command. If you do hit it by accident, don't waste time on `rebase` — go straight to `recreate`.
+
+**`dependabot.yml` is read from the DEFAULT branch (`main`)** — same trap as the claude workflow files below. An `ignore:` entry merged to `develop` does nothing until the next release lands it on `main`; dependabot will keep opening PRs with the "ignored" dep in the meantime (observed: the bullmq ignore merged to develop, and the very next recreate still carried bullmq 6). For immediate effect, comment `@dependabot ignore <dep-name> major version` on the open PR — a server-side ignore, persistent until `@dependabot unignore <dep-name> major version`, and it works per-dependency inside grouped PRs. Config entry = durable documentation; chat command = the thing that actually stops the PRs. Removing an ignore later requires BOTH the config-entry removal and the unignore comment.
 
 ## Claude workflow changes target `main`, not `develop`
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,12 @@ updates:
         patterns:
           - '*'
     ignore:
+      # NOTE: dependabot reads this file from the DEFAULT branch (main), so an
+      # entry added here on develop is inert until the next release. For
+      # immediate effect, pair the entry with the chat command on the open PR
+      # (`@dependabot ignore <dep> major version`) — that ignore is stored
+      # server-side and persists until `@dependabot unignore`. Removing an
+      # entry below therefore ALSO requires the matching unignore comment.
       # jscpd 5.x is a fresh Rust rewrite (5.0.4 shipped 2026-06-08, v4 still
       # maintained in parallel) that drops the `.jscpd.json` `ignore` key — only
       # the CLI `--ignore-pattern` works — and shifts detection counts vs the JS
@@ -60,6 +66,12 @@ updates:
       # a deliberate migration, not a bump. Tracked as TASK-410; remove this
       # ignore in the migration PR.
       - dependency-name: 'bullmq'
+        update-types: ['version-update:semver-major']
+      # ioredis 6 rides the same migration: bullmq 5.x hard-pins ioredis 5.11.1
+      # (dual-install + type clashes at the shared-connection seam), while
+      # bullmq 6 takes ioredis as a peer (>=5). Upgrade both in TASK-410's PR;
+      # remove this ignore there too.
+      - dependency-name: 'ioredis'
         update-types: ['version-update:semver-major']
 
   # GitHub Actions workflow file dependencies — separate ecosystem.

--- a/tracker/tasks/task-410 - Migrate-to-BullMQ-6-repeat-opts-removed-re-verify-lock-stall-tuning.md
+++ b/tracker/tasks/task-410 - Migrate-to-BullMQ-6-repeat-opts-removed-re-verify-lock-stall-tuning.md
@@ -17,6 +17,7 @@ ordinal: 410000
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Why: dependabot PR #1913 showed bullmq 6.0.2 is a breaking major - JobsOptions no longer has repeat (v6 replaces repeatable jobs with the Job Schedulers API, queue.upsertJobScheduler); ai-worker build/typecheck fail on it. Also #1647 tuned WORKER_LOCK_DURATION/maxStalledCount against bullmq 5.80.2 SOURCE (lock auto-renew cadence, stall semantics) - those invariants must be re-verified against v6 internals before upgrading. bullmq majors are dependabot-ignored until this executes.
-Fix shape: read the v6 migration guide; convert repeat-option call sites to job schedulers; re-verify the #1647 lock/stall invariant tests against installed v6 source; remove the dependabot ignore in the same PR.
-Acceptance: bullmq 6 in the lockfile, all repeatable jobs registered via schedulers, #1647 invariant tests re-grounded, dependabot ignore removed.
+Scope addition (2026-08-03): ioredis 6 rides this migration. bullmq 5.x hard-pins ioredis 5.11.1 (a direct ioredis 6 bump dual-installs and type-clashes at the shared-connection seam), while bullmq 6 takes ioredis as a peer (>=5.0.0) - so both majors upgrade in the same PR. Both are ignored twice: dependabot.yml entries AND server-side chat-command ignores on PR #1919 (config alone was inert - dependabot reads dependabot.yml from main, not develop).
+Fix shape: read the v6 migration guide; convert repeat-option call sites to job schedulers; bump ioredis to 6.x alongside; re-verify the #1647 lock/stall invariant tests against installed v6 source; remove BOTH dependabot.yml ignore entries AND comment "@dependabot unignore bullmq major version" + "@dependabot unignore ioredis major version" on any open dependabot PR in the same cycle.
+Acceptance: bullmq 6 + ioredis 6 in the lockfile, all repeatable jobs registered via schedulers, #1647 invariant tests re-grounded, all four ignores (2 config + 2 server-side) removed.
 <!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## Why

The recreated dependabot group PR (#1919) came back red, still carrying bullmq 6 **plus** the brand-new ioredis 6 major (released 2026-07-31). Two findings:

1. **`dependabot.yml` is read from the default branch (`main`)** — the bullmq ignore merged to develop in #1921 was inert. Immediate mitigation applied: server-side chat-command ignores (`@dependabot ignore <dep> major version`) commented on #1919 for both bullmq and ioredis.
2. **ioredis 6 is coupled to the bullmq 6 migration**: bullmq 5.81.2 hard-pins ioredis 5.11.1 (a direct ioredis 6 bump dual-installs and type-clashes at the shared-connection seam), while bullmq 6 takes ioredis as a peer (`>=5.0.0`). Both majors upgrade together in TASK-410.

## Changes

- `dependabot.yml`: ioredis semver-major ignore entry + a comment block documenting the default-branch read and the paired chat-command requirement.
- `tzurot-git-workflow` skill § Dependabot PR Recovery: the default-branch gotcha and the chat-command ignore/unignore procedure (observed live today).
- TASK-410: scope now includes ioredis 6 and the four-ignore removal checklist (2 config entries + 2 server-side unignores).

## Verification

- `pnpm ops backlog` green (tracker frontmatter parses).
- Config/docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)