### PR TITLE
docs: sweep stale comments and reference docs (drift audit)

### DIFF
--- a/docs/reference/STATIC_ANALYSIS.md
+++ b/docs/reference/STATIC_ANALYSIS.md
@@ -22,7 +22,7 @@ pnpm cpd:report       # Generate HTML report in reports/jscpd/
 | Setting     | Value | Purpose                                     |
 | ----------- | ----- | ------------------------------------------- |
 | `threshold` | 5     | Allow up to 5% total duplication            |
-| `minLines`  | 5     | Ignore duplicates shorter than 5 lines      |
+| `minLines`  | 10    | Ignore duplicates shorter than 10 lines     |
 | `minTokens` | 50    | Ignore duplicates with fewer than 50 tokens |
 
 Tests are excluded because test boilerplate is often intentionally similar (setup patterns, mock configurations).
@@ -122,29 +122,20 @@ Validates dependency rules at the import graph level. Encodes the architectural 
 **Commands:**
 
 ```bash
-pnpm depcruise            # Check for violations (exits non-zero on NEW violations)
-pnpm depcruise:baseline   # Update baseline after fixing violations
+pnpm depcruise            # Check for violations (exits non-zero on any violation)
 pnpm depcruise:graph      # Generate SVG dependency graph (requires graphviz)
 ```
 
 **Configuration:** `.dependency-cruiser.cjs`
 
-**Baseline:** `.dependency-cruiser-baseline.json` — known violations that existed before adoption. CI passes as long as no NEW violations are introduced. Same pattern as `test-coverage-baseline.json`.
+There is no baseline: depcruise is hard-blocking in `pnpm quality` and in the pre-push hook, and every violation must be fixed rather than recorded.
 
-**Rules enforced:**
-
-| Rule                       | Severity | Description                                         |
-| -------------------------- | -------- | --------------------------------------------------- |
-| `bot-client-no-prisma`     | error    | bot-client must never import @prisma/client         |
-| `no-cross-service-imports` | error    | Services cannot import from each other              |
-| `no-circular-dependencies` | error    | No circular dependency chains                       |
-| `ai-worker-no-discord`     | warn     | ai-worker should use common-types for Discord types |
+**Rules enforced:** the `forbidden` array in `.dependency-cruiser.cjs` is the authoritative list (bot-client isolation from Prisma / config-resolver / identity / conversation-history, no cross-service imports, no circular dependencies, and several import-direction rules). Read it there rather than duplicating it here — a copy in this document drifts silently.
 
 **Fixing violations:**
 
 1. Run `pnpm depcruise` to see current violations
 2. Fix the import (move shared code to common-types, use API calls instead of direct imports)
-3. If fixing a legacy violation, run `pnpm depcruise:baseline` to update the baseline
 
 **Adding new rules:**
 
@@ -213,18 +204,12 @@ Each package has `tsconfig.spec.json` that extends the main `tsconfig.json` but:
 
 ## CI Integration
 
-- **Pre-push hook**: `typecheck:spec` (blocking), `cpd` (warning), `depcruise` (warning)
-- **CI pipeline**: `typecheck:spec` is blocking; `cpd`, `depcruise`, `knip` have `continue-on-error: true`
+- **Pre-push hook**: `typecheck:spec`, `knip:dead`, and `depcruise` are blocking; `cpd` prints a summary only (warning)
+- **CI pipeline**: only the raw `cpd` step carries `continue-on-error: true` — everything else in the lint job, including the CPD ratchet (`pnpm ops cpd:check`), `depcruise`, and `knip`, is blocking
 
 ## Quality Command
 
-`pnpm quality` runs the full quality suite:
-
-1. `pnpm lint` - ESLint with sonarjs rules
-2. `pnpm cpd` - Copy-paste detection
-3. `pnpm depcruise` - Architecture boundary validation
-4. `pnpm typecheck` - Type-check source files
-5. `pnpm typecheck:spec` - Type-check test files
+`pnpm quality` runs the full static gate. Its composition lives in the root `package.json` under `scripts.quality` — read it there; it is deliberately not enumerated in docs (a second list drifts, and `pnpm ops guard:gate-parity` already keeps the script in sync with the CI lint job).
 
 Run this before submitting PRs to catch issues early.
 
@@ -265,38 +250,3 @@ This is expected on first run if tests were never type-checked. Prioritize:
 3. Assertion type issues
 
 Use `// @ts-expect-error` sparingly and only with comments explaining why.
-
-## Making Static Analysis Blocking
-
-Currently, static analysis checks run as **warnings** to allow time to fix baseline violations. Once violations are resolved:
-
-### Steps to Make Checks Blocking
-
-1. **CPD (CI)**: Remove `continue-on-error: true` from `.github/workflows/ci.yml` (line ~47)
-
-2. **typecheck:spec (Pre-push)**: Already blocking in both CI and pre-push.
-
-3. **CPD (Pre-push)**: Change from warning to blocking by adding `exit 1`:
-
-   ```bash
-   if ! pnpm cpd 2>/dev/null; then
-       echo "${RED}Copy-paste detection found violations${NC}"
-       exit 1
-   fi
-   ```
-
-4. **depcruise (Pre-push)**: Same pattern as CPD — change from warning to blocking.
-
-### Target State
-
-| Check          | Target                         | When to Make Blocking           |
-| -------------- | ------------------------------ | ------------------------------- |
-| CPD            | Under 3% duplication           | After extracting shared utils   |
-| typecheck:spec | Zero test type errors          | After fixing all test types     |
-| sonarjs        | Zero cognitive violations      | After refactoring complex funcs |
-| depcruise      | Zero baseline violations       | After fixing all circular deps  |
-| knip           | Triaged, false positives clean | After first clean advisory run  |
-
-### Tracking Progress
-
-Run `pnpm quality` to see current violation counts. Track progress in BACKLOG.md under "Fix Static Analysis Baseline Violations".

--- a/docs/reference/architecture/ARCHITECTURE_DECISIONS.md
+++ b/docs/reference/architecture/ARCHITECTURE_DECISIONS.md
@@ -4,7 +4,7 @@
 
 **Date:** 2025-10-02
 **Source:** Initial Gemini planning conversation
-**Status:** Foundational decisions implemented in v3
+**Status:** Historical planning artifact. Several decisions here were superseded during implementation (the shipped stack is simpler — pgvector rather than a managed vector DB, no graph-orchestration or user-runtime-profile layer). For what actually runs today, see [`system-model.md`](./system-model.md).
 
 ---
 

--- a/docs/reference/architecture/CASCADING_CONFIG_PATTERN.md
+++ b/docs/reference/architecture/CASCADING_CONFIG_PATTERN.md
@@ -241,8 +241,8 @@ Resolver tests mock the Prisma client to verify:
 
 See:
 
-- `services/ai-worker/src/services/resolvers/PersonaResolver.test.ts`
-- `services/ai-worker/src/services/resolvers/LlmConfigResolver.test.ts`
+- `packages/identity/src/resolvers/PersonaResolver.test.ts`
+- `packages/config-resolver/src/LlmConfigResolver.test.ts`
 
 ## Usage Guidelines
 

--- a/docs/reference/architecture/system-model.md
+++ b/docs/reference/architecture/system-model.md
@@ -26,7 +26,7 @@
 
 ## 2. The flows (routes only mean something inside one)
 
-~190 HTTP handlers, 5 queues, 16 job types collapse into eight flows:
+~190 HTTP handlers, 5 queues, 18 job types collapse into eight flows:
 
 1. **A message becomes a character reply** (the spine). MessageCreate → filter gates
    (bot/denylist/empty) → trigger match (reply-to-webhook · activated channel · @tags ·
@@ -125,23 +125,24 @@
 - Voice config depth (per-character voice overrides, ElevenLabs) is underused and
   therefore latent-bug-prone — one voice command sat broken for a while because
   nobody used it. The used voice paths, by contrast, run flawlessly.
+- The api-gateway "legacy aggregator" router-factory layer is dead code (test-only imports). Production routing is _generated/mounts.ts + sortRoutesForExpress — in-factory ordering comments and factory-attached middleware are inert. Known casualty: the denylist rate limiter exists only in the dead factory, so denylist mutations currently run unlimited (tracked for fix-or-drop).
 - <!-- OWNER: where does this page disagree with the system you actually experience? -->
 
 ## 5. Concept → location (bridging words to code; the generated index has the rest)
 
-| You say…                  | It lives…                                                                                              |
-| ------------------------- | ------------------------------------------------------------------------------------------------------ |
-| character                 | `personalities` table · `bot-client/commands/character` · `/api/user/personality/*`                    |
-| persona (speaker)         | `personas` table · `bot-client/commands/persona` · `/api/user/persona/*`                               |
-| the reply pipeline        | `bot-client/handlers` + `composition.ts` → `api-gateway/queue.ts` → `ai-worker/jobs/handlers/pipeline` |
-| memory / episode          | `memories` (pgvector) · `ai-worker/services/context` · `/api/user/memory/*`                            |
-| fact                      | `memory_facts` · `ai-worker/services/extraction` · fact routes                                         |
-| preset / cascade          | `llm_configs`/`tts_configs` · `packages/config-resolver` · `/api/user/config-overrides/*`              |
-| voice                     | `voice-engine/server.py` · `ai-worker/services/voice` · `bot-client/commands/voice`                    |
-| dashboard                 | `bot-client/utils/dashboard` (sessions in Redis, modals, truncation gate)                              |
-| inspect / flight recorder | `diagnostic_logs` · `bot-client/commands/inspect` · `/api/user/diagnostic/*`                           |
-| retention / purge         | `api-gateway/services/retention` (single-predicate `eligibility.ts`) · `retention:*` CLIs              |
-| release DMs               | `api-gateway/routes/webhooks` + `releaseBroadcast` · `bot-client/services/releaseDm`                   |
-| dev↔prod sync             | `api-gateway/services/sync` (`syncTables.ts` = the manifest)                                           |
-| the ops CLI               | `packages/tooling` (`pnpm ops …`)                                                                      |
-| the website               | `services/website` (renders `docs/commands.md`, `/privacy`, `/terms` live)                             |
+| You say…                  | It lives…                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| character                 | `personalities` table · `bot-client/commands/character` · `/api/user/personality/*`                                 |
+| persona (speaker)         | `personas` table · `bot-client/commands/persona` · `/api/user/persona/*`                                            |
+| the reply pipeline        | `bot-client/handlers` + `composition.ts` → `api-gateway/queue.ts` → `ai-worker/jobs/handlers/pipeline`              |
+| memory / episode          | `memories` (pgvector) · `ai-worker/services/context` · `/api/user/memory/*`                                         |
+| fact                      | `memory_facts` · `ai-worker/services/extraction` · fact routes                                                      |
+| preset / cascade          | `llm_configs`/`tts_configs` · `packages/config-resolver` · `/api/user/config-overrides/*`                           |
+| voice                     | `voice-engine/server.py` · `ai-worker/services/voice` · `bot-client/commands/voice`                                 |
+| dashboard                 | `bot-client/utils/dashboard` (sessions in Redis, modals, truncation gate)                                           |
+| inspect / flight recorder | `llm_diagnostic_logs` · `bot-client/commands/inspect` · `/api/user/diagnostic/*`                                    |
+| retention / purge         | `api-gateway/services/retention` (single-predicate `eligibility.ts`) · `retention:*` CLIs                           |
+| release DMs               | `api-gateway/routes/public/githubWebhook.ts` + `routes/internal/releaseBroadcast` · `bot-client/services/releaseDm` |
+| dev↔prod sync             | `api-gateway/services/sync` (`syncTables.ts` = the manifest)                                                        |
+| the ops CLI               | `packages/tooling` (`pnpm ops …`)                                                                                   |
+| the website               | `services/website` (renders `docs/commands.md`, `/privacy`, `/terms` live)                                          |

--- a/docs/reference/operations/REDIS_TIMEOUT_ANALYSIS.md
+++ b/docs/reference/operations/REDIS_TIMEOUT_ANALYSIS.md
@@ -132,7 +132,7 @@ Note: bot-client has some of these handlers (`services/bot-client/src/redis.ts:4
 
 ### Priority 1: Add Explicit Timeouts (Critical)
 
-**File**: `packages/common-types/src/redis-utils.ts`
+**File**: `packages/common-types/src/utils/redis.ts`
 
 Add a new function to create standardized Redis connection options:
 

--- a/docs/reference/standards/CONTEXT_AWARE_FIELDS.md
+++ b/docs/reference/standards/CONTEXT_AWARE_FIELDS.md
@@ -165,7 +165,9 @@ interface CharacterSessionData extends CharacterData {
 }
 ```
 
-## Current Implementations
+## Example Implementation
+
+One implementation, shown as a worked example — not an exhaustive inventory:
 
 | Entity    | Field  | Context Property | Security Gate             |
 | --------- | ------ | ---------------- | ------------------------- |

--- a/docs/reference/standards/TRI_STATE_PATTERN.md
+++ b/docs/reference/standards/TRI_STATE_PATTERN.md
@@ -100,5 +100,5 @@ Effective: **{enabled|disabled}** (from {entity|channel|global})
 
 ## Related Files
 
-- `services/bot-client/src/commands/channel/context.ts` - Channel command example
+- `services/bot-client/src/commands/channel/settings.ts` - Channel command example
 - `services/bot-client/src/commands/character/settings.ts` - Entity command example

--- a/docs/reference/testing/COVERAGE_AUDIT_SYSTEM.md
+++ b/docs/reference/testing/COVERAGE_AUDIT_SYSTEM.md
@@ -114,7 +114,7 @@ pnpm ops test:audit --update
 
 1. `services/ai-worker/src/services/LongTermMemoryService.ts` - core memory ops
 2. `services/ai-worker/src/services/ConversationalRAGService.ts` - AI generation flow
-3. `packages/common-types/src/services/ConversationRetentionService.ts` - retention logic
+3. `packages/conversation-history/src/ConversationRetentionService.ts` - retention logic
 
 ## Coverage Requirements (Codecov Enforced)
 

--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -364,5 +364,3 @@ Root `package.json` provides shortcuts for common ops CLI commands:
 | `pnpm generate:pglite`        | `pnpm ops test:generate-schema`  | Regenerate PGLite schema   |
 | `pnpm generate:command-types` | `pnpm ops codegen:command-types` | Generate command type defs |
 | `pnpm update-deps`            | `pnpm ops dev:update-deps`       | Update dependencies        |
-| `pnpm import-personality`     | `pnpm ops data:import`           | Import a personality       |
-| `pnpm bulk-import`            | `pnpm ops data:bulk-import`      | Bulk import personalities  |

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -270,8 +270,9 @@ async function readValidatedBody(args: {
  * Make a single gateway request. Returns a `GatewayResult` envelope; the
  * caller decides whether to throw or branch.
  *
- * Generated clients are the primary caller. Legacy code paths can continue
- * to call this directly during the migration to typed clients.
+ * The generated clients are the only callers — this is not part of the
+ * package's public surface, so new call sites go through a generated client
+ * method (or a new route manifest entry) rather than here.
  */
 export async function callGateway<T>(options: TransportOptions): Promise<GatewayResult<T>> {
   const {

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -98,7 +98,9 @@ export const internalRoutes = {
 
   /**
    * POST /api/internal/ai/transcribe
-   * Submits an audio transcription job (sync via `?wait=true` or async otherwise).
+   * Submits an audio transcription job. The generated client posts to the bare
+   * path (no `?wait=true`), so it returns as soon as the job is enqueued; the
+   * synchronous long-poll form is a raw-fetch caller in bot-client.
    */
   aiTranscribe: {
     audience: 'internal',

--- a/packages/common-types/src/utils/dateFormatting.ts
+++ b/packages/common-types/src/utils/dateFormatting.ts
@@ -63,7 +63,7 @@ function formatTimeUnit(value: number, unit: string): string {
  * Example: "Monday, January 27, 2025, 02:45 AM EST"
  *
  * Used for:
- * - Current date in system prompt
+ * - Current date in the prompt
  * - Displaying when context was generated
  *
  * @param date - Date to format
@@ -177,7 +177,7 @@ export function formatRelativeTime(timestamp: Date | string | number, timezone?:
  * Example: "Mon, Jan 27, 2025"
  *
  * Used for:
- * - LTM memory timestamps in system prompt
+ * - LTM memory timestamps in the prompt
  * - More compact than full format but still includes day of week
  *
  * @param timestamp - Timestamp to format

--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
@@ -104,7 +104,7 @@ const logger = createLogger('LLMGenerationHandler');
  * - These propagate as exceptions and fail the BullMQ job directly
  * - No error result is returned; the job goes to the failed queue
  *
- * **Steps 2-6** run inside try/catch:
+ * **Steps 2-10** run inside try/catch:
  * - Errors are caught and converted to error results with `success: false`
  * - Error results include `failedStep` and `lastSuccessfulStep` for debugging
  * - These are "soft failures" - the job completes but reports an error to the client
@@ -316,9 +316,9 @@ export class LLMGenerationHandler {
   }
 
   /**
-   * Construct the ContextStep with its shadow instrumentation: the hydration
-   * data source plus the context assembler (user/persona re-derivation +
-   * shared history merge against the raw envelope).
+   * Construct the ContextStep — the sole context-hydration path: the
+   * hydration data source plus the context assembler (user/persona
+   * re-derivation + shared history merge against the raw envelope).
    */
   private buildContextStep(prisma: PrismaClient): ContextStep {
     const dataSource = new PrismaContextDataSource(prisma);

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -223,7 +223,9 @@ export class ContentBudgetManager {
    * 3. Select memories within budget
    * 4. Calculate and allocate history budget
    * 5. Select and serialize history
-   * 6. Build final system prompt with all content
+   * 6. Rebuild the final human message (volatile prefix carrying the selected
+   *    memories/facts) alongside a system message carrying the serialized
+   *    history
    */
   allocate(opts: BudgetAllocationOptions, preselected: PreselectedHistory): BudgetAllocationResult {
     const { processedPersonality, participantPersonas, context } = opts;

--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -427,7 +427,7 @@ export class MemoryRetriever {
       // is still valuable to the LLM even without a bio. Dropping an active
       // participant for empty content was the root of an incident where new
       // users whose persona had no bio text were entirely missing from the
-      // <participants> section of the system prompt.
+      // <participants> section of the human message's volatile prefix.
       if (personaData.content.length === 0) {
         logger.warn(
           {

--- a/services/ai-worker/src/services/PromptBuilder.ts
+++ b/services/ai-worker/src/services/PromptBuilder.ts
@@ -1,5 +1,8 @@
 /**
- * Prompt Builder - Builds system prompts with personality info, memories, and context.
+ * Prompt Builder - Builds the cacheable system message (constraints, personality
+ * identity, protocol, chat log) and the human message, whose volatile prefix
+ * carries the per-request content (environment, participants, facts, memories,
+ * referenced messages).
  */
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
@@ -115,9 +118,10 @@ export class PromptBuilder {
    * - Provides consistent behavior between current turn and history
    *
    * The message includes speaker identification via a <from> tag to help the LLM
-   * know who is speaking. This is critical because while the system prompt has
-   * a participants section with active="true", and chat_log has from= attributes,
-   * the raw HumanMessage content also needs explicit speaker identification.
+   * know who is speaking. This is critical because while the volatile prefix of
+   * this same message has a participants section with active="true", and the
+   * system message's chat_log has from= attributes, the raw HumanMessage content
+   * also needs explicit speaker identification.
    */
   buildHumanMessage(
     userMessage: string,

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -153,9 +153,9 @@ export class ContextAssembler {
   constructor(private readonly deps: ContextAssemblerDeps) {}
 
   /**
-   * Assemble the core surfaces. Throws on unexpected failures — the SHADOW
-   * caller owns the never-throws contract, not the assembler (at cutover the
-   * assembler's errors must surface as real job failures).
+   * Assemble the core surfaces. Throws on unexpected failures — deliberately:
+   * this is the live context path, so an assembly error must surface as a real
+   * job failure via the pipeline's try/catch rather than being swallowed here.
    */
   async assembleCore(
     jobContext: JobContext,
@@ -199,7 +199,7 @@ export class ContextAssembler {
     const userTimezone = await this.deps.dataSource.getUserTimezone(user.userId);
 
     // Step 3: hydrate channel history — same limit derivation as the
-    // bot-side dbLimit (and as the hydration shadow).
+    // bot-side dbLimit.
     const limit = Math.min(
       configOverrides?.maxMessages ?? MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES,
       MESSAGE_LIMITS.MAX_EXTENDED_CONTEXT

--- a/services/ai-worker/src/services/context/PrismaContextDataSource.ts
+++ b/services/ai-worker/src/services/context/PrismaContextDataSource.ts
@@ -2,10 +2,10 @@
  * Prisma-backed ContextDataSource.
  *
  * Deliberately thin: every read delegates to the SAME shared services the
- * bot-client pipeline uses today (`ConversationHistoryService`,
- * `UserService`) so hydrated results are comparable row-for-row with the
- * bot-client-assembled payload during the shadow-verification window. The
- * context-epoch lookup replicates bot-client's raw
+ * bot-client pipeline used (`ConversationHistoryService`, `UserService`), so
+ * hydration stays row-for-row equivalent to the payload bot-client used to
+ * assemble — keep new reads on those services rather than hand-rolling
+ * queries here. The context-epoch lookup replicates bot-client's raw
  * `userPersonaHistoryConfig` query (the one read that never had a service
  * wrapper).
  */

--- a/services/ai-worker/src/services/context/fromApiMessage.ts
+++ b/services/ai-worker/src/services/context/fromApiMessage.ts
@@ -24,8 +24,9 @@ export function fromApiMessage(
     channelId,
     guildId,
     // id/personaId are schema-optional on the wire but always populated by
-    // the bot-side fetcher; '' mirrors the shadow diff's own normalization
-    // ('' ids are excluded from id-keyed diffs, personaIds compare via ?? '').
+    // the bot-side fetcher. '' is the normalization contract for both: an ''
+    // id is excluded from every id-keyed lookup, and personaId compares as
+    // '' when absent — never treat either as a real identifier.
     id: msg.id ?? '',
     personaId: msg.personaId ?? '',
     // Discord messages always carry timestamps; epoch-0 is a defensive

--- a/services/ai-worker/src/services/context/referenceEnricher.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.ts
@@ -22,10 +22,10 @@
  * applies (isDeduplicated is checked before the forwarded branch).
  *
  * Known accepted divergence: dedup DISAGREEMENT. The worker dedups against
- * its own assembled history, which can differ from the bot's by fetch-timing
- * drift — a reference one side stubs and the other keeps full surfaces as a
- * per-number dedup mismatch in the shadow diff. Counts always align by
- * construction: a bot-deduped forward ships ONE raw container ref (the raw
+ * its own assembled history, which can differ from the history the bot saw by
+ * fetch-timing drift — so a given reference number may be stubbed here and
+ * kept full on the bot side. Only the per-number decision can diverge; counts
+ * always align by construction: a bot-deduped forward ships ONE raw container ref (the raw
  * side never expanded it), a kept forward ships its per-snapshot refs, and
  * the worker enriches exactly the list it received.
  */

--- a/services/ai-worker/src/services/extraction/ExtractionBudget.ts
+++ b/services/ai-worker/src/services/extraction/ExtractionBudget.ts
@@ -4,7 +4,8 @@
  * Per-(personality, UTC-day) cap on extraction model calls. Extraction runs on
  * a fixed cheap SYSTEM model (never the personality's model), so the direct
  * dollar cost per call is small — but it is unbounded without a ceiling, and
- * shadow mode already spends money. Over-budget batches are skipped with a
+ * extraction spends on every batch regardless of whether the extracted facts
+ * are being read into prompts. Over-budget batches are skipped with a
  * structured log (the episodes stay in Postgres; nothing is lost — extraction
  * simply doesn't run for that personality until the UTC day rolls over).
  *

--- a/services/ai-worker/src/services/extraction/ExtractionTrigger.ts
+++ b/services/ai-worker/src/services/extraction/ExtractionTrigger.ts
@@ -16,8 +16,8 @@
  * extraction is delayed (the next N episodes rebuild the batch), never lost
  * data (episodes are safe in Postgres). A channel going quiet mid-batch
  * leaves a partial list until its TTL; those episodes are simply never
- * extracted (bounded, acceptable for shadow mode — a periodic flusher is a
- * tracked follow-up if observation shows it matters).
+ * extracted (bounded and accepted — a periodic flusher is a tracked follow-up
+ * if observation shows it matters).
  */
 
 import type { Redis } from 'ioredis';

--- a/services/ai-worker/src/services/extraction/FactExtractionService.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.ts
@@ -262,7 +262,8 @@ export class FactExtractionService {
   private async processGroup(job: FactExtractionJobData, group: EpisodeGroup): Promise<number> {
     const scope = { personalityId: job.personalityId, personaId: group.personaId };
 
-    // Cost tripwire FIRST — shadow mode already spends money. Owner-initiated
+    // Cost tripwire FIRST — every extracted group costs a model call whether
+    // or not the facts are read back into prompts. Owner-initiated
     // backfill jobs are exempt (finite job set, deliberate consumption); the
     // busy-path refund below mirrors this gate so the counter stays balanced.
     if (job.budgetExempt !== true) {

--- a/services/ai-worker/src/services/prompt/EnvironmentFormatter.ts
+++ b/services/ai-worker/src/services/prompt/EnvironmentFormatter.ts
@@ -1,7 +1,8 @@
 /**
  * Environment Formatter
  *
- * Formats Discord environment context (DM vs guild) for inclusion in system prompts.
+ * Formats Discord environment context (DM vs guild) for the volatile prefix of
+ * the human message.
  * Uses pure XML structure for clear LLM context separation.
  *
  * This is a thin wrapper around the shared formatLocationAsXml() function,
@@ -15,7 +16,8 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 const logger = createLogger('EnvironmentFormatter');
 
 /**
- * Format Discord environment context for inclusion in system prompt.
+ * Format Discord environment context for inclusion in the human message's
+ * volatile prefix.
  * Returns a `<location>` XML element for embedding in the `<context>` section.
  *
  * Uses the shared formatLocationAsXml() from common-types (DRY with referenced messages).

--- a/services/ai-worker/src/services/prompt/HardcodedConstraints.ts
+++ b/services/ai-worker/src/services/prompt/HardcodedConstraints.ts
@@ -4,11 +4,17 @@
  * Platform-level constraints that are hardcoded in code rather than stored in
  * the database. These cannot be overridden by personality configurations.
  *
- * Architecture follows the "Sandwich Method":
- * - PLATFORM_CONSTRAINTS: Near the start (primacy effect for safety)
- * - Identity constraints: Right after platform constraints
- * - Database content (permissions, directives): Middle section
- * - OUTPUT_CONSTRAINTS: At the very end (recency bias for format compliance)
+ * Placement is by cacheability tier, not by recency. Both blocks here are
+ * S0 (cross-persona static) and lead the system message:
+ * - PLATFORM_CONSTRAINTS: first (primacy effect for safety)
+ * - OUTPUT_CONSTRAINTS: second, still ahead of any per-persona content
+ * - Then S1 (system_identity, identity_constraints, protocol), then the
+ *   H-tier chat_log; per-request volatile content renders in the human
+ *   message prefix instead.
+ *
+ * Putting OUTPUT_CONSTRAINTS at the start rather than the recency tail is a
+ * deliberate trade: an all-static prefix is what automatic-prefix caching can
+ * share across personas and turns.
  */
 
 import { escapeXmlContent } from '@tzurot/common-types/utils/promptSanitizer';
@@ -51,7 +57,8 @@ export function buildIdentityConstraints(personalityName: string): string {
 
 /**
  * Output constraints - technical requirements for clean output.
- * Placed at the END of the prompt for recency bias (highest impact on actual output).
+ * Rendered as the second S0 block, at the start of the system message, so the
+ * whole constraint prefix stays byte-stable and cacheable.
  */
 export const OUTPUT_CONSTRAINTS = `<output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>

--- a/services/ai-worker/src/services/prompt/MemoryFormatter.ts
+++ b/services/ai-worker/src/services/prompt/MemoryFormatter.ts
@@ -1,7 +1,8 @@
 /**
  * Memory Formatter
  *
- * Formats relevant memories from past interactions for inclusion in system prompts.
+ * Formats relevant memories from past interactions for the volatile prefix of
+ * the human message.
  * Uses pure XML structure with <memory_archive>, <instruction>, and <historical_note> tags.
  *
  * The XML format helps LLMs clearly distinguish historical context from current

--- a/services/ai-worker/src/services/prompt/ParticipantFormatter.ts
+++ b/services/ai-worker/src/services/prompt/ParticipantFormatter.ts
@@ -1,7 +1,8 @@
 /**
  * Participant Formatter
  *
- * Formats conversation participant personas for inclusion in system prompts.
+ * Formats conversation participant personas for the volatile prefix of the
+ * human message.
  * Uses pure XML structure with ID binding for clear identity association.
  *
  * Key features:

--- a/services/api-gateway/src/routes/admin/diagnostic.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.ts
@@ -1,13 +1,16 @@
 /**
- * Admin Diagnostic Routes
- * Owner-only endpoints for accessing LLM diagnostic logs (flight recorder)
+ * Diagnostic Routes
+ * Endpoints for accessing LLM diagnostic logs (flight recorder). The GETs are
+ * open to any authenticated user but filtered server-side to that user's own
+ * logs; only the bot owner sees every row unfiltered. The PATCH is a
+ * service-to-service call (shared secret, no human user).
  *
- * Endpoints:
- * - GET /admin/diagnostic/recent - List recent diagnostic logs (last 100)
- * - GET /admin/diagnostic/by-message/:messageId - Get logs by Discord trigger message ID
- * - GET /admin/diagnostic/by-response/:messageId - Get logs by AI response message ID
- * - GET /admin/diagnostic/:requestId - Get diagnostic log by request ID
- * - PATCH /admin/diagnostic/:requestId/response-ids - Update response message IDs
+ * Endpoints (as mounted in routes/_generated/mounts.ts):
+ * - GET /api/user/diagnostic/recent - List recent diagnostic logs (last 100)
+ * - GET /api/user/diagnostic/by-message/:messageId - Get logs by Discord trigger message ID
+ * - GET /api/user/diagnostic/by-response/:messageId - Get logs by AI response message ID
+ * - GET /api/user/diagnostic/:requestId - Get diagnostic log by request ID
+ * - PATCH /api/internal/diagnostic/:requestId/response-ids - Update response message IDs
  *
  * Note: Diagnostic logs are ephemeral (24h retention) and stored for debugging
  * prompt construction issues.
@@ -160,7 +163,7 @@ function formatRecentLogResponse(row: RecentLogRow): RecentLogResponse {
 }
 
 /**
- * Handler: GET /admin/diagnostic/recent
+ * Handler: GET /api/user/diagnostic/recent
  * List recent diagnostic logs (last 100) with personality name extracted from JSONB
  */
 export const handleGetRecentDiagnostics = (deps: DiagnosticDeps): RequestHandler => {
@@ -233,7 +236,7 @@ export const handleGetRecentDiagnostics = (deps: DiagnosticDeps): RequestHandler
 };
 
 /**
- * Handler: GET /admin/diagnostic/by-message/:messageId
+ * Handler: GET /api/user/diagnostic/by-message/:messageId
  * Get all diagnostic logs for a Discord message ID
  */
 export const handleGetDiagnosticByMessage = (deps: DiagnosticDeps): RequestHandler => {
@@ -286,7 +289,7 @@ export const handleGetDiagnosticByMessage = (deps: DiagnosticDeps): RequestHandl
 };
 
 /**
- * Handler: GET /admin/diagnostic/:requestId
+ * Handler: GET /api/user/diagnostic/:requestId
  * Get full diagnostic log by request ID
  */
 export const handleGetDiagnosticByRequestId = (deps: DiagnosticDeps): RequestHandler => {
@@ -335,7 +338,7 @@ export const handleGetDiagnosticByRequestId = (deps: DiagnosticDeps): RequestHan
 };
 
 /**
- * Handler: GET /admin/diagnostic/by-response/:messageId
+ * Handler: GET /api/user/diagnostic/by-response/:messageId
  * Get diagnostic log by AI response message ID (array containment query)
  */
 export const handleGetDiagnosticByResponse = (deps: DiagnosticDeps): RequestHandler => {
@@ -387,7 +390,7 @@ export const handleGetDiagnosticByResponse = (deps: DiagnosticDeps): RequestHand
 };
 
 /**
- * Handler: PATCH /admin/diagnostic/:requestId/response-ids
+ * Handler: PATCH /api/internal/diagnostic/:requestId/response-ids
  * Update the response message IDs for a diagnostic log
  * Called by bot-client after sending response to Discord
  */

--- a/services/api-gateway/src/routes/conformance/fixtures/harness.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/harness.ts
@@ -128,7 +128,9 @@ export async function buildConformanceHarness(): Promise<ConformanceHarness> {
     releaseBroadcastQueue: fakeQueue,
     queueEvents: fakeQueueEvents,
     // Real resolvers over PGLite — required deps since the detached-resolver
-    // cleanup; enableCleanup off (no timers in tests).
+    // cleanup. `enableCleanup: false` is inert (BaseConfigResolver keeps the
+    // option only for shape compatibility; the TTLCache expires on access and
+    // starts no timer either way) — it stays for explicitness.
     cascadeResolver: new ConfigCascadeResolver(prisma, { enableCleanup: false }),
     llmConfigResolver: new LlmConfigResolver(prisma, { enableCleanup: false }),
     // Real invalidation/retention services over the mock Redis/PGLite — the

--- a/services/api-gateway/src/routes/user/conversationLookup.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.ts
@@ -2,7 +2,7 @@
  * Conversation Lookup Routes
  * Internal endpoints for conversation data lookups (service-to-service)
  *
- * GET /user/conversation/message-personality - Get personality from Discord message ID
+ * GET /api/internal/conversation/message-personality - Get personality from Discord message ID
  */
 
 import { Router, type Request, type Response, type RequestHandler } from 'express';
@@ -23,7 +23,7 @@ interface MessagePersonalityResponse {
 }
 
 /**
- * GET /api/user/conversation/message-personality — lookup personality by Discord message ID
+ * GET /api/internal/conversation/message-personality — lookup personality by Discord message ID
  * Internal service-to-service endpoint (no user auth required).
  */
 export const handleLookupPersonalityFromMessage = (deps: RouteDeps): RequestHandler => {

--- a/services/api-gateway/src/test/shared-route-test-utils.ts
+++ b/services/api-gateway/src/test/shared-route-test-utils.ts
@@ -32,21 +32,19 @@ export const createMockUpdatedAt = (): Date => new Date('2024-01-02T00:00:00.000
  * Create a mock request with `provisionedUserId` + `provisionedDefaultPersonaId`
  * already attached — the post-middleware state of a user-scoped route.
  *
- * This is the migration target for the route test files that currently
- * mock `requireProvisionedUser` as a no-op `vi.fn((_req, _res, next) => next())`
- * and therefore exercise the shadow-mode fallback branch of
- * `resolveProvisionedUserId` / `getOrCreateInternalUser` rather than the
- * common provisioned path. When the middleware is tightened from shadow-
- * mode-fallthrough to strict-400 (tracked in BACKLOG.md work
- * items), those no-op mocks will produce 400s at the middleware layer and
- * every unmigrated test file will break en masse.
+ * `requireProvisionedUser` is strict: every failure mode (missing headers,
+ * malformed URI encoding, a thrown `getOrCreateUser`) returns 400, and the
+ * old shadow-mode fallthrough — along with the shell-user path it fell back
+ * to — is gone. A test file that mocks the middleware as a no-op
+ * `vi.fn((_req, _res, next) => next())` therefore hands the handler a request
+ * with no provisioned fields, which is a shape production can no longer
+ * produce.
  *
- * To migrate a test: replace `createMockReqRes(body, params, query)` with
+ * To migrate such a test: replace `createMockReqRes(body, params, query)` with
  * `createProvisionedMockReqRes(body, params, query)`, and the route handler
  * will see the same shape it would in prod post-middleware. Handlers that
- * call `resolveProvisionedUserId(req, userService)` will hit the
- * common-path short-circuit and return the `provisionedUserId` directly,
- * without exercising `UserService.getOrCreateUserShell`.
+ * call `resolveProvisionedUserId(req, userService)` hit the common-path
+ * short-circuit and return the `provisionedUserId` directly.
  *
  * See `routes/user/shapes/auth.test.ts` for a reference caller using this
  * helper and the "migrate-this-file" TODO pattern.

--- a/services/bot-client/src/commands/character/api.ts
+++ b/services/bot-client/src/commands/character/api.ts
@@ -153,8 +153,8 @@ export async function fetchAllCharacters(
 
   const data = result.data;
 
-  // The list endpoint returns summaries, but we need full data for the dashboard
-  // For now, just return the summaries cast to CharacterData (we'll fetch full data when editing)
+  // The list endpoint returns summaries, so each row is widened into the
+  // CharacterData shape below; the fields the summary omits are placeholders.
   const owned: CharacterData[] = [];
   const publicOthers: CharacterData[] = [];
 

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -6,6 +6,7 @@
  * - /settings timezone view|set - Manage timezone
  * - /settings apikey set|browse|remove|test - Manage API keys (BYOK)
  * - /settings defaults edit - Manage global default settings (config cascade)
+ * - /settings data export|delete - Export all account data, or delete the account
  *
  * HISTORY:
  * - Consolidated from former /me timezone, /wallet, and /me preset commands

--- a/services/bot-client/src/services/ResponseOrderingService.ts
+++ b/services/bot-client/src/services/ResponseOrderingService.ts
@@ -90,7 +90,7 @@ export class ResponseOrderingService {
   /**
    * Start periodic cleanup of stale pending jobs.
    *
-   * NOTE: This setInterval is a known horizontal scaling blocker (see TECH_DEBT.md).
+   * NOTE: This setInterval is a known horizontal scaling blocker.
    * TODO: Migrate to BullMQ repeatable jobs for multi-instance deployments.
    */
   private startCleanupInterval(): void {

--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
@@ -231,9 +231,10 @@ export async function handleSettingsButton(
       await handleBackButton(interaction, config, session);
       break;
     case 'close':
-      // The Close button no longer renders on paged dashboards (D18), but the
-      // action stays routable — stale messages predating the change still
-      // carry it, and flat dashboards keep the button.
+      // No settings dashboard renders a Close row anymore — ephemeral
+      // dashboards rely on native dismiss plus the session TTL for teardown.
+      // The action stays routable because stale messages predating the
+      // removal still carry the button.
       await handleCloseButton(interaction, config, session);
       break;
     case 'page':

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -905,7 +905,7 @@ async def register_voice(
             _cache_voice(voice_id, voice_state)
         except Exception:
             # Inline containment check for cleanup (CodeQL py/path-injection #63/#64).
-            # voice_path was already validated by _safe_voice_path at line 580, but
+            # voice_path was already validated by _safe_voice_path earlier in this handler, but
             # CodeQL can't trace custom sanitizer functions — it only recognizes the
             # realpath + startswith pattern when inlined in the same scope.
             real_dir = os.path.realpath(voices_dir)


### PR DESCRIPTION
## Why

A four-scout drift audit (2026-08-03, the "known lies" hunt from the system-map accuracy review) verified ~50 places where written claims contradict the code. This PR is the **zero-behavior** tranche: every fix-now-trivial comment/docblock/reference-doc finding. The behavioral findings went to tracker tasks (TASK-411–415) and the big doc rewrites to doc-58.

## What

**Code comments (~30 sites, comments ONLY — verified zero non-comment lines in the diff):**
- ai-worker: the pre-caching "Sandwich Method" architecture block in `HardcodedConstraints.ts` (OUTPUT_CONSTRAINTS is now the second S0 block, not the recency tail — rewritten with the cacheability-trade rationale); six missed references to the deleted shadow machinery (`ContextStep` "shadow instrumentation", `ContextAssembler` never-throws contract, `PrismaContextDataSource`/`referenceEnricher`/`fromApiMessage` shadow-diff framing); "system prompt" → human-message volatile prefix in `PromptBuilder`, three formatters, `ContentBudgetManager`, `MemoryRetriever`; "shadow mode" cost justifications in the three extraction files; "Steps 2-6" → "2-10".
- api-gateway/clients: wrong route paths in `conversationLookup.ts` and `diagnostic.ts` headers (real mounts per `_generated/mounts.ts`, auth framing corrected); shipped strict-400 middleware described as future work in `shared-route-test-utils.ts`; `callGateway` "legacy callers" claim; transcribe sync/async claim; inert `enableCleanup` rationale.
- bot-client: Close-button contract, deleted `TECH_DEBT.md` pointer, missing `/settings data` group, stale "cast" comment.
- voice-engine: rot-prone line-number reference.

**Reference docs (~12 fixes):** STATIC_ANALYSIS.md (retired depcruise baseline, wrong continue-on-error claims, already-done "Making Blocking" section deleted, `minLines` 5→10, rules table and quality-chain enumeration replaced with pointers at their sources so they can't drift again); OPS_CLI_REFERENCE phantom `data:*` rows; ARCHITECTURE_DECISIONS.md restatused as a historical planning artifact; path repoints in CASCADING_CONFIG_PATTERN / TRI_STATE_PATTERN / COVERAGE_AUDIT_SYSTEM / REDIS_TIMEOUT_ANALYSIS; CONTEXT_AWARE_FIELDS table retitled non-exhaustive.

**system-model.md:** job types 16→18, two §5 location fixes (`llm_diagnostic_logs`, `routes/public/githubWebhook.ts`), and a new §4 known-lie entry for the dead api-gateway router-factory layer (incl. the orphaned denylist rate limiter, tracked as TASK-411).

**Deliberately untouched:** `contentRewriter.ts` (owned by TASK-415's investigation), `legacyPromptAssembly.ts` (its old-order description is its purpose), all dead-code deletions (TASK-412/413/414).

## Verification

- `pnpm test`: 26 tasks green (bot-client 386 files / 6000 tests among them).
- `pnpm quality`: exit 0, gate-parity in sync.
- Non-comment audit: `git diff -U0` filtered to non-comment lines is **empty** — prompt-assembly output is byte-identical (the voice-consistency gate's arm B is unaffected).
- Survivor greps for `TECH_DEBT`, `Sandwich Method`, shadow references, and depcruise-baseline mentions all clean (sole remaining "Sandwich Method" hit is the deliberately-vendored eval module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)