### PR TITLE
fix(tooling): colorize the [LEVEL] tags railway logs actually renders

### DIFF
--- a/packages/tooling/src/deployment/logs.test.ts
+++ b/packages/tooling/src/deployment/logs.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 
-// Mock chalk
+// Mock chalk. The colour-carrying helpers wrap rather than pass through, so a
+// colorization assertion can distinguish red from yellow from untouched — an
+// identity mock makes every such expectation trivially true.
 vi.mock('chalk', () => ({
   default: {
     cyan: Object.assign((s: string) => s, { bold: (s: string) => s }),
     green: (s: string) => s,
-    yellow: (s: string) => s,
-    red: (s: string) => s,
-    dim: (s: string) => s,
+    yellow: (s: string) => `<yellow>${s}</yellow>`,
+    red: (s: string) => `<red>${s}</red>`,
+    dim: (s: string) => `<dim>${s}</dim>`,
   },
 }));
 
@@ -24,7 +26,7 @@ vi.mock('../utils/env-runner.js', () => ({
 }));
 
 import { execFileSync } from 'node:child_process';
-import { fetchLogs, parseSinceMs } from './logs.js';
+import { fetchLogs, parseSinceMs, colorizeLogs } from './logs.js';
 
 describe('fetchLogs', () => {
   let consoleLogSpy: MockInstance;
@@ -473,5 +475,55 @@ describe('parseSinceMs', () => {
 
   it('throws on garbage', () => {
     expect(() => parseSinceMs('soonish', NOW)).toThrow('Cannot parse --since');
+  });
+});
+
+describe('colorizeLogs', () => {
+  /**
+   * The shape `railway logs` actually renders: RFC3339 ingest prefix, a
+   * BRACKETED level tag, the message, then pino's logfmt pairs. The JSON /
+   * `level=` forms the function also matches never appear in this position —
+   * they only show up inside a payload (`--json`, or raw pino output).
+   */
+  const railwayTagged = (tag: string, msg: string): string =>
+    `2026-07-03T02:00:02.898914Z [${tag}] ${msg} time=1751500000000 pid=1 ` +
+    `hostname="859ec3aad942" name="ai-worker"`;
+
+  it('reds a Railway-rendered [ERROR] line', () => {
+    const line = railwayTagged('ERROR', 'Error: connect ECONNREFUSED');
+    expect(colorizeLogs(line)).toBe(`<red>${line}</red>`);
+  });
+
+  it('yellows a Railway-rendered [WARN] line', () => {
+    const line = railwayTagged('WARN', 'Redis reconnect scheduled');
+    expect(colorizeLogs(line)).toBe(`<yellow>${line}</yellow>`);
+  });
+
+  it('dims a Railway-rendered [DEBUG] line', () => {
+    const line = railwayTagged('DEBUG', 'Cache hit for personality');
+    expect(colorizeLogs(line)).toBe(`<dim>${line}</dim>`);
+  });
+
+  it('passes a Railway-rendered [INFO] line through untouched', () => {
+    // Railway tags EVERY pino stdout line [INFO] regardless of the pino level,
+    // so this is the common case and must stay uncoloured.
+    const line = railwayTagged('INFO', 'Generated response');
+    expect(colorizeLogs(line)).toBe(line);
+  });
+
+  it('still reds the JSON payload form', () => {
+    const line = '{"level":"error","msg":"vision fallback exhausted"}';
+    expect(colorizeLogs(line)).toBe(`<red>${line}</red>`);
+  });
+
+  it('still reds the logfmt payload form', () => {
+    const line = 'vision fallback exhausted level=error pid=1';
+    expect(colorizeLogs(line)).toBe(`<red>${line}</red>`);
+  });
+
+  it('colorizes each line of a multi-line block independently', () => {
+    const err = railwayTagged('ERROR', 'boom');
+    const info = railwayTagged('INFO', 'fine');
+    expect(colorizeLogs(`${err}\n${info}`)).toBe(`<red>${err}</red>\n${info}`);
   });
 });

--- a/packages/tooling/src/deployment/logs.ts
+++ b/packages/tooling/src/deployment/logs.ts
@@ -75,20 +75,44 @@ function validateService(service: string | undefined): string | undefined {
 }
 
 /**
- * Colorize log output based on log level
+ * Colorize log output based on log level.
+ *
+ * The Railway CLI renders its own level as a bracketed tag (`[ERROR]`,
+ * `[WARN]`, `[INFO]`, `[DEBUG]`) ahead of the message; the JSON/logfmt forms
+ * only appear inside the payload itself (`railway logs --json`, or an app that
+ * prints raw pino). Both are matched, because both reach this function.
+ *
+ * Known limitation: Railway tags every line a pino service writes to stdout as
+ * `[INFO]` regardless of the pino level, so an app-level error is colorized
+ * only when its payload carries the JSON/logfmt level. The tag matches cover
+ * Railway-tagged lines — stderr, crash output, deploy events.
+ *
+ * Exported for direct unit testing.
  */
-function colorizeLogs(logs: string): string {
+export function colorizeLogs(logs: string): string {
   return logs
     .split('\n')
     .map(line => {
       const lineLower = line.toLowerCase();
-      if (lineLower.includes('"level":"error"') || lineLower.includes('level=error')) {
+      if (
+        lineLower.includes('[error]') ||
+        lineLower.includes('"level":"error"') ||
+        lineLower.includes('level=error')
+      ) {
         return chalk.red(line);
       }
-      if (lineLower.includes('"level":"warn"') || lineLower.includes('level=warn')) {
+      if (
+        lineLower.includes('[warn]') ||
+        lineLower.includes('"level":"warn"') ||
+        lineLower.includes('level=warn')
+      ) {
         return chalk.yellow(line);
       }
-      if (lineLower.includes('"level":"debug"') || lineLower.includes('level=debug')) {
+      if (
+        lineLower.includes('[debug]') ||
+        lineLower.includes('"level":"debug"') ||
+        lineLower.includes('level=debug')
+      ) {
         return chalk.dim(line);
       }
       return line;


### PR DESCRIPTION
## Why

TASK-409, same wrong-format-assumption class as the `--since` fix (#1918), found by the same diagnosis probe: `colorizeLogs` greps for `"level":"error"` (pino JSON) and `level=error` (logfmt), but the Railway CLI renders level as a bracketed tag (`[ERROR]`/`[WARN]`/`[INFO]`/`[DEBUG]`) — so no real CLI line was ever colorized. Purely cosmetic (nothing dropped), but the dig output was uniformly uncolored.

## What

- `colorizeLogs` now matches the bracketed tag forms first (`[ERROR]` → red, `[WARN]` → yellow, `[DEBUG]` → dim), keeping the JSON/logfmt payload matches for `--json`/raw pino output. Exported for direct unit testing (the `parseSinceMs` pattern).
- JSDoc documents the known limitation: Railway tags every pino stdout line `[INFO]` regardless of pino level, so app-level errors colorize only via the payload forms — the tag matches cover Railway-tagged lines (stderr, crash output, deploy events). This mirrors the "never grep prod logs by level" doctrine.
- 7 new tests pin the behavior against the captured Railway line shape (RFC3339 ingest prefix + tag + logfmt pairs, from the #1918 verbatim captures). The chalk mock's color helpers now wrap (`<red>…</red>`) instead of identity — an identity mock makes every colorization assertion trivially true.

Note: the repo's captured fixtures carry only `[INFO]` lines; the `[ERROR]`/`[WARN]`/`[DEBUG]` spellings come from the live-capture probe recorded in TASK-409, reproduced in the fixtures' exact shape.

## Verification

- `pnpm --filter @tzurot/tooling test`: 136 files / 1865 tests green; the 7 new cases listed individually via verbose run.
- Full `pnpm test`: 26 tasks green. `pnpm quality`: exit 0, gate-parity in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)