### PR TITLE
fix(ai-worker): stop doubling the voice transcript in the persisted trigger row

### DIFF
--- a/packages/common-types/src/types/schemas/rawEnvelope.ts
+++ b/packages/common-types/src/types/schemas/rawEnvelope.ts
@@ -65,18 +65,17 @@ export const rawAssemblyInputsSchema = z.object({
    * references, never a forward's inline snapshot). EMPTY for voice triggers,
    * where the worker re-transcribes the shipped attachment itself (the bot-side
    * STT transcript rides rawRoutingTranscript, telemetry-only) — keeping the
-   * voice transcript out of this field is what lets the shadow diff STT.
+   * voice transcript out of this field is what keeps the worker transcription
+   * the prompt's single source for the spoken words.
    */
   rawMessageContent: z.string(),
   /**
    * The bot-side STT transcript produced for routing (mention detection in
    * spoken text). TELEMETRY-ONLY: assembly ignores it — the prompt's
    * transcript comes from the worker's own transcription via the
-   * attachment-description path — and the shadow diffs it against the
-   * worker transcript to measure STT divergence. Consuming it for assembly
-   * (skipping the worker STT) is a deliberate post-burn-in change gated on
-   * that divergence data. ABSENT for non-voice triggers and when bot-side
-   * STT produced nothing.
+   * attachment-description path. Consuming it for assembly (skipping the
+   * worker STT) would be a deliberate design change, never a drop-in swap.
+   * ABSENT for non-voice triggers and when bot-side STT produced nothing.
    */
   rawRoutingTranscript: z.string().optional(),
   /**
@@ -111,8 +110,8 @@ export const rawAssemblyInputsSchema = z.object({
    * Discord-fetched extended-context messages BEFORE the merge with DB
    * history. Array-field semantics (also for the two user lists below):
    * ABSENT = the extended-context fetch didn't run for this message;
-   * EMPTY = the fetch ran and observed nothing. The shadow assembler treats
-   * the two differently, so producers must not collapse [] to undefined.
+   * EMPTY = the fetch ran and observed nothing. The assembler treats the two
+   * differently, so producers must not collapse [] to undefined.
    */
   rawExtendedContextMessages: z.array(apiConversationMessageSchema).optional(),
   /** Authors observed in extended context — inputs to the batch user upsert. */

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
@@ -419,6 +419,92 @@ describe('DependencyStep', () => {
       );
     });
 
+    it('forwards an empty rawMessageContent for a voice trigger (writer stores descriptions only)', async () => {
+      // This step runs before ContextStep re-derives the message, so
+      // `job.data.message` still carries the bot-side STT transcript here. The
+      // writer needs the raw typed content to know not to prefix it.
+      const audioResult: AudioTranscriptionResult = {
+        requestId: 'test-req',
+        success: true,
+        content: 'can you hear me okay',
+        attachmentUrl: 'https://example.com/voice-message.ogg',
+        attachmentName: 'voice-message.ogg',
+      };
+      mockGetJobResult.mockResolvedValueOnce(audioResult);
+      const writer = makeWriter();
+      const stepWithWriter = new DependencyStep(undefined, writer as never);
+
+      await stepWithWriter.process({
+        job: createMockJob({
+          message: 'can you hear me okay',
+          context: {
+            kind: 'envelope',
+            userId: 'user-456',
+            userName: 'TestUser',
+            channelId: 'channel-789',
+            rawAssemblyInputs: { rawMessageContent: '' },
+          },
+          dependencies: [
+            {
+              jobId: 'audio-job-1',
+              type: JobType.AudioTranscription,
+              status: JobStatus.Completed,
+              resultKey: `${REDIS_KEY_PREFIXES.JOB_RESULT}audio-key`,
+            },
+          ],
+        }),
+        startTime: Date.now(),
+      });
+
+      expect(writer.persistTriggerDescriptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'can you hear me okay',
+          rawMessageContent: '',
+          processedAttachments: [expect.objectContaining({ description: 'can you hear me okay' })],
+        })
+      );
+    });
+
+    it('forwards the typed content for a text trigger (writer keeps the message prefix)', async () => {
+      const imageResult: ImageDescriptionResult = {
+        requestId: 'test-req',
+        success: true,
+        descriptions: [{ url: 'https://example.com/image.png', description: 'A beautiful sunset' }],
+      };
+      mockGetJobResult.mockResolvedValueOnce(imageResult);
+      const writer = makeWriter();
+      const stepWithWriter = new DependencyStep(undefined, writer as never);
+
+      await stepWithWriter.process({
+        job: createMockJob({
+          message: 'look at this sunset',
+          context: {
+            kind: 'envelope',
+            userId: 'user-456',
+            userName: 'TestUser',
+            channelId: 'channel-789',
+            rawAssemblyInputs: { rawMessageContent: 'look at this sunset' },
+          },
+          dependencies: [
+            {
+              jobId: 'image-job-1',
+              type: JobType.ImageDescription,
+              status: JobStatus.Completed,
+              resultKey: `${REDIS_KEY_PREFIXES.JOB_RESULT}image-key`,
+            },
+          ],
+        }),
+        startTime: Date.now(),
+      });
+
+      expect(writer.persistTriggerDescriptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'look at this sunset',
+          rawMessageContent: 'look at this sunset',
+        })
+      );
+    });
+
     it('does not invoke the writer when no trigger attachments were processed', async () => {
       const writer = makeWriter();
       const stepWithWriter = new DependencyStep(undefined, writer as never);

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
@@ -153,6 +153,12 @@ export class DependencyStep implements IPipelineStep {
    * Uses the RAW job personality (NOT config.effectivePersonality): the update
    * must match the key the row was saved under, and routing-time personality
    * substitution doesn't change the saved row's key.
+   *
+   * `rawMessageContent` crosses to the writer as the typed-vs-voice
+   * discriminator. `job.data.message` is NOT that discriminator: this step runs
+   * before ContextStep re-derives the message from the envelope, so for a voice
+   * trigger the field still holds the bot-side STT transcript, which the writer
+   * must not prefix onto descriptions that already carry the transcript.
    */
   private async persistVisionDescriptions(
     context: GenerationContext,
@@ -168,6 +174,7 @@ export class DependencyStep implements IPipelineStep {
       await this.visionDescriptionWriter.persistTriggerDescriptions({
         jobId: job.id,
         message: job.data.message,
+        rawMessageContent: jobContext.rawAssemblyInputs?.rawMessageContent,
         jobContext,
         personalityId: job.data.personality.id,
         processedAttachments: preprocessing.processedAttachments,

--- a/services/ai-worker/src/services/context/contentRewriter.ts
+++ b/services/ai-worker/src/services/context/contentRewriter.ts
@@ -18,15 +18,15 @@
  *    kernel scan bot-side, so within-cap resolvable ids are present and
  *    everything else placeholders/passes through identically.
  *
- * Known accepted divergences (burn-in): the bot rewrites the REFETCHED
- * trigger content while the envelope captured the pre-submission `content`
- * param — these differ for voice triggers (raw carries the transcript, the
- * refetched content is empty) and forwarded triggers (raw carries snapshot
- * content), plus the rare mid-flight edit inside the embed-processing delay.
- * The shadow skips the messageContent comparison for voice jobs and counts
- * the rest as real divergence signal. The voice content story must be
- * settled before this output replaces the payload — using the transcript
- * as the message would double it with the attachment-description path.
+ * This output REPLACES `job.data.message` unconditionally (ContextStep
+ * applies it; there is no legacy fallback to the payload's own copy).
+ *
+ * Voice triggers: `rawMessageContent` is `''` by producer contract — the
+ * spoken words are not in this input and never enter the rewritten message.
+ * The transcript reaches the current turn solely via the worker's own
+ * transcription on the attachment-description path, which is what keeps it
+ * from appearing twice. (`rawRoutingTranscript`, the bot-side STT copy, is
+ * telemetry-only and is not read here.)
  */
 
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
@@ -124,7 +124,7 @@ export async function rewriteRawContent(
 
   // 4. Role mentions — names rewritten into content; the resolved list is
   // NOT surfaced (payload parity: JobContext carries no mentioned-roles
-  // field, so the shadow has nothing to compare it against either).
+  // field).
   const roleById = new Map((raw.rawMentionedRoles ?? []).map(r => [r.roleId, r]));
   const roleResult = rewriteRoleMentions(content, id => roleById.get(id) ?? null);
   content = roleResult.processedContent;

--- a/services/ai-worker/src/services/context/visionDescriptionWriter.test.ts
+++ b/services/ai-worker/src/services/context/visionDescriptionWriter.test.ts
@@ -38,6 +38,31 @@ const imageAttachment: ProcessedAttachment = {
   metadata: { url: 'https://cdn/img.png', name: 'img.png', contentType: 'image/png', size: 10 },
 };
 
+const SPOKEN_WORDS = 'can you hear me okay';
+
+/**
+ * Shaped exactly as DependencyStep builds a trigger audio attachment from a
+ * transcription dependency result: no isVoiceMessage/duration metadata, so the
+ * description carries an `[Audio: name]` header (not `[Voice message: Ns]`).
+ */
+const voiceAttachment: ProcessedAttachment = {
+  type: AttachmentType.Audio,
+  description: SPOKEN_WORDS,
+  originalUrl: 'https://cdn/voice-message.ogg',
+  metadata: {
+    url: 'https://cdn/voice-message.ogg',
+    name: 'voice-message.ogg',
+    contentType: 'audio/unknown',
+    size: 0,
+  },
+};
+
+const VOICE_DESCRIPTIONS = `[Audio: voice-message.ogg]\n<voice_transcripts><transcript>${SPOKEN_WORDS}</transcript></voice_transcripts>`;
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
 describe('VisionDescriptionWriter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,6 +75,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: 'look at this',
+      rawMessageContent: 'look at this',
       jobContext: makeContext(),
       personalityId: 'pers-1',
       processedAttachments: [imageAttachment],
@@ -71,6 +97,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: '',
+      rawMessageContent: '',
       jobContext: makeContext(),
       personalityId: 'pers-1',
       processedAttachments: [imageAttachment],
@@ -85,6 +112,77 @@ describe('VisionDescriptionWriter', () => {
     );
   });
 
+  it('stores descriptions alone for a voice trigger (the transcript appears once)', async () => {
+    // The user typed nothing (rawMessageContent === ''), so `message` here is
+    // the bot-side STT transcript — prefixing it would store the spoken words
+    // both bare and inside <voice_transcripts>.
+    const history = makeHistory();
+    const writer = new VisionDescriptionWriter(history as never);
+
+    await writer.persistTriggerDescriptions({
+      jobId: 'j1',
+      message: SPOKEN_WORDS,
+      rawMessageContent: '',
+      jobContext: makeContext(),
+      personalityId: 'pers-1',
+      processedAttachments: [voiceAttachment],
+    });
+
+    expect(history.updateLastUserMessage).toHaveBeenCalledWith(
+      'chan-1',
+      'pers-1',
+      'persona-1',
+      VOICE_DESCRIPTIONS,
+      { triggerMessageId: undefined }
+    );
+    const stored = history.updateLastUserMessage.mock.calls[0][3] as string;
+    expect(occurrences(stored, SPOKEN_WORDS)).toBe(1);
+  });
+
+  it('keeps the message prefix when the user typed text alongside an audio attachment', async () => {
+    const history = makeHistory();
+    const writer = new VisionDescriptionWriter(history as never);
+
+    await writer.persistTriggerDescriptions({
+      jobId: 'j1',
+      message: 'listen to this clip',
+      rawMessageContent: 'listen to this clip',
+      jobContext: makeContext(),
+      personalityId: 'pers-1',
+      processedAttachments: [voiceAttachment],
+    });
+
+    expect(history.updateLastUserMessage).toHaveBeenCalledWith(
+      'chan-1',
+      'pers-1',
+      'persona-1',
+      `listen to this clip\n\n${VOICE_DESCRIPTIONS}`,
+      { triggerMessageId: undefined }
+    );
+  });
+
+  it('keeps the message prefix when the payload carries no raw inputs to discriminate on', async () => {
+    const history = makeHistory();
+    const writer = new VisionDescriptionWriter(history as never);
+
+    await writer.persistTriggerDescriptions({
+      jobId: 'j1',
+      message: 'look at this',
+      rawMessageContent: undefined,
+      jobContext: makeContext(),
+      personalityId: 'pers-1',
+      processedAttachments: [imageAttachment],
+    });
+
+    expect(history.updateLastUserMessage).toHaveBeenCalledWith(
+      'chan-1',
+      'pers-1',
+      'persona-1',
+      'look at this\n\n[Image: img.png]\na red bicycle leaning on a wall',
+      { triggerMessageId: undefined }
+    );
+  });
+
   it('targets the row the job was queued for, not just the latest one', async () => {
     // The other write this job makes uses the same id. A second message landing
     // mid-generation must not collect this one's descriptions.
@@ -94,6 +192,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: 'look at this',
+      rawMessageContent: 'look at this',
       jobContext: makeContext({ triggerMessageId: 'discord-42' }),
       personalityId: 'pers-1',
       processedAttachments: [imageAttachment],
@@ -115,6 +214,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: 'plain text',
+      rawMessageContent: 'plain text',
       jobContext: makeContext(),
       personalityId: 'pers-1',
       processedAttachments: [],
@@ -130,6 +230,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: 'text',
+      rawMessageContent: 'text',
       jobContext: makeContext(),
       personalityId: 'pers-1',
       processedAttachments: [
@@ -147,6 +248,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: { structured: true },
+      rawMessageContent: 'text',
       jobContext: makeContext(),
       personalityId: 'pers-1',
       processedAttachments: [imageAttachment],
@@ -162,6 +264,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: 'text',
+      rawMessageContent: 'text',
       jobContext: makeContext({ activePersonaId: undefined }),
       personalityId: 'pers-1',
       processedAttachments: [imageAttachment],
@@ -177,6 +280,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: 'text',
+      rawMessageContent: 'text',
       jobContext: makeContext({ channelId: undefined }),
       personalityId: 'pers-1',
       processedAttachments: [imageAttachment],
@@ -184,6 +288,7 @@ describe('VisionDescriptionWriter', () => {
     await writer.persistTriggerDescriptions({
       jobId: 'j1',
       message: 'text',
+      rawMessageContent: 'text',
       jobContext: makeContext({ channelId: '' }),
       personalityId: 'pers-1',
       processedAttachments: [imageAttachment],
@@ -202,6 +307,7 @@ describe('VisionDescriptionWriter', () => {
       writer.persistTriggerDescriptions({
         jobId: 'j1',
         message: 'text',
+        rawMessageContent: 'text',
         jobContext: makeContext(),
         personalityId: 'pers-1',
         processedAttachments: [imageAttachment],

--- a/services/ai-worker/src/services/context/visionDescriptionWriter.ts
+++ b/services/ai-worker/src/services/context/visionDescriptionWriter.ts
@@ -31,13 +31,24 @@ export class VisionDescriptionWriter {
   /**
    * Upgrade the trigger user message's placeholders to rich descriptions.
    *
-   * The enriched content mirrors the retired bot-side composition exactly:
+   * The enriched content mirrors the retired bot-side composition:
    * `message + '\n\n' + descriptions`, or descriptions alone when the
-   * message has no text (voice-only / image-only triggers).
+   * message contributes no user-typed text (image-only or voice triggers).
    */
   async persistTriggerDescriptions(opts: {
     jobId: string | number | undefined;
     message: string | object;
+    /**
+     * The user's ACTUAL typed content for this turn
+     * (`context.rawAssemblyInputs.rawMessageContent`), which discriminates a
+     * voice trigger from a typed one. `''` means the user typed nothing — a
+     * Discord voice message by producer contract — and `opts.message` at this
+     * point in the pipeline still holds the bot-side STT transcript, so
+     * prefixing it would store the spoken words twice: once bare and once
+     * inside the attachment descriptions' `<voice_transcripts>` block.
+     * `undefined` (no raw inputs on the payload) keeps the message prefix.
+     */
+    rawMessageContent: string | undefined;
     jobContext: JobContext;
     personalityId: string;
     processedAttachments: ProcessedAttachment[];
@@ -63,8 +74,15 @@ export class VisionDescriptionWriter {
         return;
       }
 
+      // A typed-nothing turn contributes no prefix: the descriptions carry the
+      // whole of what the user said. Only an explicit `''` suppresses it —
+      // `undefined` means the payload carried no raw inputs to discriminate on,
+      // so the prefix is kept defensively.
+      const keepMessagePrefix = opts.rawMessageContent !== '';
       const enrichedContent =
-        opts.message.length > 0 ? `${opts.message}\n\n${descriptions}` : descriptions;
+        keepMessagePrefix && opts.message.length > 0
+          ? `${opts.message}\n\n${descriptions}`
+          : descriptions;
 
       const updated = await this.history.updateLastUserMessage(
         jobContext.channelId,

--- a/tracker/tasks/task-415 - Verify-voice-transcript-is-not-double-rendered-post-context-cutover.md
+++ b/tracker/tasks/task-415 - Verify-voice-transcript-is-not-double-rendered-post-context-cutover.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-415
-title: Verify voice transcript is not double-rendered post context-cutover
+title: Fix doubled voice transcript in the persisted trigger row
 status: To Do
 assignee: []
 created_date: '2026-08-03 18:27'
+updated_date: '2026-08-03 19:23'
 labels:
   - 'size:S'
 dependencies: []
@@ -14,7 +15,9 @@ ordinal: 415000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Why: contentRewriter.ts docblock gated payload replacement on settling the voice content story ("using the transcript as the message would double it with the attachment-description path"), but ContextStep.ts:84-89 now overwrites job.data.message unconditionally - the cutover shipped through the documented precondition without discharging it. Code-read suggests voice jobs MAY render the transcript twice (message body + attachment description); NOT runtime-confirmed. Surfaced by the 2026-08-03 drift audit.
-Fix shape: trace a voice job through ContextStep/assembleCore - does messageContent embed the transcript AND does the attachment path inject it again? Confirm with a dev voice-turn diagnostic (/inspect or ai-worker logs). If doubled, pick the single source and fix; either way rewrite the contentRewriter docblock to state the live contract (left stale deliberately until this investigation lands).
-Acceptance: runtime evidence of single-render (close + docblock fix) or a fix PR; docblock states the live contract.
+CONFIRMED (2026-08-03, code-read + prod-data probe). Current-turn prompt is clean - the context cutover accidentally fixed the old double (contract test RawEnvelopeContract.consumer.contract.test.ts:194-212 pins messageContent="" for voice). But the PERSISTED trigger row doubles: DependencyStep runs before ContextStep, so visionDescriptionWriter.persistTriggerDescriptions receives the PRE-overwrite job.data.message (= bot STT transcript) and stores botTranscript + newlines + <voice_transcripts>workerTranscript</voice_transcripts>. That row renders in every SUBSEQUENT turn chat_log - spoken words twice.
+Prod probe (counts-only, no content read): 55 voice rows in retention (Jul 4 - Aug 3), 55/55 have a non-empty prefix before the block, avg prefix 866 chars vs avg inner transcript 837, 50/55 within 20 percent length match. Newest row is same-day - current behavior.
+Fix shape (chosen): discriminate on jobContext.rawAssemblyInputs.rawMessageContent - empty (Discord voice message) means persist descriptions only, no prefix; non-empty typed text keeps the current prefix+descriptions shape so text+image turns are unchanged. Do NOT switch the prefix source to rawMessageContent for text turns (would diverge from the bot-written baseline row).
+Existing 55 doubled rows: owner call - recommend leaving them; 30-day retention evicts by ~Sep 2.
+Acceptance: writer test covers audio empty-raw (descriptions only) and typed-text+attachment (prefix kept); DependencyStep forwards the discriminator; contentRewriter docblock rewritten to the live contract in the same PR.
 <!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## Why (TASK-415 — found by today's drift audit, runtime-confirmed)

For Discord voice-message turns, the persisted trigger-message history row carried the spoken words **twice**: `DependencyStep.persistVisionDescriptions` runs before `ContextStep` overwrites `job.data.message`, so it prefixed the row with the bot-side STT transcript and then appended the worker transcript inside `<voice_transcripts>`. The row is excluded from the current turn (triggerMessageId filter) but renders in **every subsequent turn's** chat_log.

**Runtime evidence** (counts-only prod probe, no message content read): 55 voice rows in retention (Jul 4 → Aug 3), 55/55 with a non-empty prefix before the transcript block, avg prefix 866 chars vs avg inner transcript 837, 50/55 within a 20% length match. Newest row same-day — live behavior.

The current-turn prompt was already clean: the context cutover made voice `messageContent` empty by producer contract (pinned by `RawEnvelopeContract.consumer.contract.test.ts`), so the transcript reaches the current turn only via attachment descriptions.

## What

- `visionDescriptionWriter.persistTriggerDescriptions` gains a **required** `rawMessageContent: string | undefined` option — the user's actual typed content (`context.rawAssemblyInputs.rawMessageContent`). Exactly `''` (the Discord voice-message signature) suppresses the message prefix and stores descriptions only; typed text keeps today's `message\n\ndescriptions` shape unchanged; `undefined` (no raw inputs) defensively keeps the prefix. Required-key-nullable-type so the compiler forces every future call site to state the discriminator.
- `DependencyStep` forwards the raw value and documents why `job.data.message` is not the discriminator (this step precedes ContextStep's re-derivation).
- `contentRewriter.ts` docblock rewritten to the live contract (the stale pre-cutover shadow-gate paragraph was the finding that started this task); the last dead shadow-machinery comment references in `rawEnvelope.ts` swept in the same pass.

## Tests

- Writer: voice trigger → descriptions only, transcript appears **exactly once** (counted, not just contained); typed text + audio → prefix kept; `undefined` raw → prefix kept; all 10 existing cases updated and passing. Fixtures mirror the real audio description shape (`[Audio: name]` header — verified against `buildPreprocessingResults`, and matching the prod rows, which carry no `[Voice message:` header).
- DependencyStep: two seam tests asserting the discriminator crossing the mocked writer boundary (voice-shaped job forwards `''` while `message` still holds the transcript; text job forwards the typed content).

## Notes

- The 55 already-doubled prod rows are left as-is — 30-day retention evicts the last by ~Sep 2 (owner-visible call, recorded in TASK-415).
- Voice-consistency gate unaffected: no prompt-assembly code touched; the harness probes are frozen pre-beta.190 bundles.

## Verification

- `pnpm --filter @tzurot/ai-worker test`: 206 files / 4317 tests green; the 5 new cases confirmed executed via verbose run.
- Full `pnpm test`: 26 tasks green. `pnpm quality`: green through gate-parity.
- Survivor grep: no shadow-machinery references remain outside the alias-shadowing domain concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)