### PR TITLE
docs: rewrite BYOK manual testing guide against the current command surface

### DIFF
--- a/docs/reference/testing/BYOK_MANUAL_TESTING.md
+++ b/docs/reference/testing/BYOK_MANUAL_TESTING.md
@@ -1,387 +1,383 @@
 # BYOK Manual Testing Guide
 
-> **Last Updated**: 2025-11-27
-> **PR**: Sprint 2-3 BYOK Implementation
-> **Purpose**: Comprehensive manual testing checklist for BYOK features
+A manual test pass for **BYOK** (Bring Your Own Key): storing your own provider
+API keys, what changes once a key is present, and what happens when it is
+removed. Every step is executable from a phone — a slash command plus the exact
+thing you should see.
 
-## Prerequisites
+**How to report**: one line per step — `B.3 pass` / `B.3 fail: <what you saw>`.
+A screenshot is only needed where a step says so. Steps are grouped into passes;
+each pass states what it uniquely proves, so you can skip a pass whose property
+you already trust.
 
-### Environment Variables Required
+---
 
-On **both** `api-gateway` and `ai-worker` services:
+## 0. Before you start
+
+### 0.1 What has to be configured
+
+| Variable                          | Services                                 | Why                                                                   |
+| --------------------------------- | ---------------------------------------- | --------------------------------------------------------------------- |
+| `API_KEY_ENCRYPTION_KEY`          | `api-gateway`, `ai-worker`               | AES-256-GCM key for encrypting stored keys. Unset ⇒ BYOK is disabled. |
+| `API_KEY_ENCRYPTION_KEY_PREVIOUS` | `api-gateway`, `ai-worker`               | Only set during a staged key rotation (dual-key window).              |
+| `OPENROUTER_API_KEY`              | `ai-worker`                              | The system fallback key. Unset ⇒ users with no key get no response.   |
+| `INTERNAL_SERVICE_SECRET`         | `api-gateway`, `bot-client`, `ai-worker` | Service-to-service auth for owner/admin routes.                       |
+
+Verify they are present (values are never printed):
 
 ```bash
-# Generate encryption key (run once, use same key for both services)
-openssl rand -hex 32
-
-# Set on Railway
-railway variables --set "API_KEY_ENCRYPTION_KEY=<your-64-hex-chars>" --service api-gateway
-railway variables --set "API_KEY_ENCRYPTION_KEY=<your-64-hex-chars>" --service ai-worker
+railway variables --service api-gateway | grep -E 'API_KEY_ENCRYPTION|INTERNAL_SERVICE_SECRET'
+railway variables --service ai-worker   | grep -E 'API_KEY_ENCRYPTION|OPENROUTER_API_KEY|INTERNAL_SERVICE_SECRET'
+railway variables --service bot-client  | grep INTERNAL_SERVICE_SECRET
 ```
 
-On **all three** of `api-gateway`, `bot-client`, and `ai-worker` services:
+`ApiKeyResolver` logs `API_KEY_ENCRYPTION_KEY not set - BYOK disabled, using system keys only`
+at ai-worker startup when the encryption key is missing — grep for that line if
+every key you store appears to be ignored.
 
-- api-gateway validates incoming `X-Service-Auth` headers
-- bot-client sends it on admin command → gateway calls
-- ai-worker sends it on `/voice-references/:slug` fetches (service-auth-protected)
+> **Never rotate `API_KEY_ENCRYPTION_KEY` by hand-editing the variable.** Rows
+> encrypted under the old key become unreadable. Use the staged rotation:
+> `pnpm ops secrets:rotate-byok --env <env> --stage 1|2|3` (stage → re-encrypt →
+> finalize).
+
+### 0.2 State that can make a test falsely pass
+
+Read this once; the passes below refer back to it.
+
+| Masking state                 | Effect                                                                                                    | Reset                                                          |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| **Wallet write rate limit**   | `set` / `test` / `remove` share **10 operations per 15 minutes** per user. Exhausting it returns a 429.   | Wait. There is no bypass — budget your steps.                  |
+| **ai-worker key cache**       | Resolved keys are cached **10 seconds** per (user, provider), with Redis pub/sub invalidation on change.  | Wait ~10s, or rely on the invalidation (Pass F tests it).      |
+| **`/models browse` cache**    | Your key providers and the global-preset model set are cached **30 seconds** in bot-client.               | Wait 30s before re-checking a usability badge.                 |
+| **`showModelFooter`**         | Defaults to `true`. If you turned it off in `/settings defaults edit`, the `Model:` footer never renders. | Re-enable it — several steps read that footer.                 |
+| **Existing keys**             | Guest-mode observables only appear when you have **no active key for any provider**.                      | `/settings apikey browse` first; Pass A assumes an empty list. |
+| **Existing presets/defaults** | A leftover default preset or per-character override changes which model answers.                          | `/preset default clear` and `/preset override browse`.         |
+
+### 0.3 Providers
+
+`/settings apikey` accepts four providers (the `provider` option is a fixed choice list):
+
+| Choice label              | Value        | Key format check at submit | Validated against the provider before storage |
+| ------------------------- | ------------ | -------------------------- | --------------------------------------------- |
+| OpenRouter                | `openrouter` | must start with `sk-or-`   | yes                                           |
+| ElevenLabs (Voice)        | `elevenlabs` | none (any non-empty key)   | yes                                           |
+| Z.AI Coding Plan          | `zai-coding` | none                       | yes                                           |
+| Mistral (Voxtral TTS/STT) | `mistral`    | none                       | yes                                           |
+
+Only OpenRouter and ElevenLabs report a remaining balance; the other two show no
+credit field.
+
+**OpenRouter is the primary LLM provider.** The voice providers (ElevenLabs,
+Mistral) do not make chat responses stop being guest-mode at generation time.
+The one exception is **Z.AI Coding Plan**: when the resolved preset's model is a
+`z-ai/<model>` on the coding-plan catalog AND you hold a zai-coding key, the
+request auto-promotes to direct z.ai routing and is **not** guest mode — no
+OpenRouter key required. See the known-asymmetry note at the end of Pass E.
+
+### 0.4 The command surface under test
+
+| Area                    | Commands                                                              |
+| ----------------------- | --------------------------------------------------------------------- |
+| API keys (BYOK)         | `/settings apikey set` `browse` `remove` `test`                       |
+| Model presets           | `/preset browse` `create` `edit` `export` `import` `template`         |
+| Your default preset     | `/preset default set` `/preset default clear`                         |
+| Per-character overrides | `/preset override browse` `set` `clear`                               |
+| Model catalog           | `/models browse` `/models view`                                       |
+| Owner-only              | `/preset global default` `/preset global free-default` `/admin usage` |
+
+### 0.5 How a preset is chosen for a response
+
+First match wins:
+
+1. Your per-character override — `/preset override set`
+2. Your default preset — `/preset default set`
+3. The character's own preset
+4. The system default preset — `/preset global default` (owner)
+
+**Guest mode cuts across all four.** With no OpenRouter key of your own, the
+ai-worker substitutes a free model whenever the resolved preset is not free —
+resolution continues down the guest ladder (your free selection → the free-tier
+default set by `/preset global free-default` → the `openrouter/free` router as a
+last resort). You do not get an error; you get a different model.
+
+Presets are scoped: **global** presets (owner-created, visible to everyone) and
+**your own** presets (`/preset create`, visible only to you).
+
+Each preset assignment targets a **slot** — `Chat` (default) or `Vision`. Every
+`default set` / `default clear` / `override set` / `override clear` /
+`global default` command takes an optional `slot` option. A `clear` with **no**
+slot clears **both** slots.
+
+---
+
+## Pass A — Guest baseline (no key stored)
+
+**Proves**: what the bot looks like before BYOK, so every later change is
+attributable to the key.
+
+**Setup**: `/settings apikey browse` must be empty. If it is not, run Pass F
+first and come back.
+
+| Step | Action                                                            | Expected                                                                                                                                                                                             |
+| ---- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A.1  | `/settings apikey browse`                                         | Ephemeral embed titled **API Keys**, body: “You have no API keys configured yet (BYOK = Bring Your Own Key). Add one with `/settings apikey set` …”. No 💡 Management Commands field.                |
+| A.2  | `/preset browse`                                                  | Preamble line: “⚠️ **Guest Mode** - Limited to free models (🆓). Use `/settings apikey set` for full access.” Paid presets render ~~struck through~~; free ones carry 🆓.                            |
+| A.3  | `/models browse`                                                  | Free models carry 🆓; paid models carry 🔑 (needs a key). If you instead see ❔ on everything plus “Couldn't verify your API keys right now”, the wallet read failed — retry, don't record a result. |
+| A.4  | `/models view` on a paid model (e.g. an Anthropic one)            | Card status line: “🔑 **Needs an OpenRouter key** — add one with `/settings apikey set`”, and the **Access** field reads `OpenRouter key`.                                                           |
+| A.5  | Message a character (`@character hi`, any channel)                | It responds. Footer carries **two** lines: `Model: …` and `🆓 Using free model (no API key required)`.                                                                                               |
+| A.6  | `/preset override set` → focus the `preset` option                | The autocomplete list ends with an entry **✨ Unlock All Models…** (`/preset default set` shares this autocomplete — either command proves it).                                                      |
+| A.7  | Pick **✨ Unlock All Models…** and submit                         | Embed **✨ Unlock All Models** explaining Guest Mode and the three-step key setup. Nothing is written.                                                                                               |
+| A.8  | `/preset override set` character:`<any>` preset:`<a paid preset>` | Embed **❌ Premium Model Not Available** naming the preset, telling you to use `/settings apikey set`. The override is **not** set.                                                                  |
+
+_Screenshot A.5 — the two footer lines are the guest-mode signature and the
+cheapest evidence for the rest of the pass._
+
+---
+
+## Pass B — Storing a key
+
+**Proves**: the modal path, provider-side validation before storage, and that
+the key itself is never echoed back.
+
+**Rate-limit budget**: B.2 + B.5 = 2 of your 10 writes per 15 minutes.
+
+| Step | Action                                                                               | Expected                                                                                                                                                                                                                                                             |
+| ---- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B.1  | `/settings apikey set` provider:**OpenRouter**                                       | A modal titled **Set OpenRouter API Key** with one short (single-line) field, placeholder `sk-or-v1-xxxx...`, and the hint “Get a key: https://openrouter.ai/keys”.                                                                                                  |
+| B.2  | Submit a **valid** OpenRouter key                                                    | Ephemeral embed **✅ API Key Configured** with a 🔐 Security field (“encrypted at rest and never visible in logs”), a 💡 Next Steps field (“Your API key will now be used for AI responses.”), footer “Use /settings apikey browse to see all configured providers”. |
+| B.3  | `/settings apikey browse`                                                            | One row: ✅ badge, name **OpenRouter**, the slug `openrouter`, and `Active · Last used … · Added …`. Plus a **💡 Management Commands** field listing set/test/remove. **The key itself is never shown, masked or otherwise.**                                        |
+| B.4  | `/settings apikey test` provider:**OpenRouter**                                      | Embed **✅ API Key Valid**, a **💰 Credit Balance** field (`$` + 4 decimals) if OpenRouter reports one, and a **🚀 Ready to Use** field.                                                                                                                             |
+| B.5  | `/settings apikey set` provider:**OpenRouter** again, with a **different** valid key | Same ✅ API Key Configured embed. `/settings apikey browse` still shows exactly **one** OpenRouter row — set overwrites, it never duplicates.                                                                                                                        |
+
+---
+
+## Pass C — What the key changes
+
+**Proves**: the stored key actually widens access, at every surface that reads it.
+No writes, so no rate-limit cost.
+
+**Masking state**: `/models browse` caches your key providers for 30 s. If you
+run C.1 within seconds of B.2, wait and re-run before recording a failure.
+
+| Step | Action                                         | Expected                                                                                                                                                                           |
+| ---- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C.1  | `/models browse`                               | Previously-🔑 paid models now carry ✅. Free models keep 🆓.                                                                                                                       |
+| C.2  | `/models view` on the same paid model as A.4   | Status line is now “✅ **You can use this**” and **Access** reads `Ready`.                                                                                                         |
+| C.3  | `/preset browse`                               | The ⚠️ Guest Mode preamble is **gone**; no preset is struck through.                                                                                                               |
+| C.4  | `/preset override set` → focus `preset`        | **✨ Unlock All Models…** is no longer offered.                                                                                                                                    |
+| C.5  | Message a character again                      | Footer has the `Model: …` line **only** — the `🆓 Using free model (no API key required)` line is gone.                                                                            |
+| C.6  | Check ai-worker logs (see “Watching the logs”) | `API key resolved from user wallet` with `source: "user"`. Before Pass B the same field read `source: "system"` alongside “Using system API key in Guest Mode (free models only)”. |
+
+_C.5 is the load-bearing one: it is the only step that proves the key reached
+the generation path rather than just the UI._
+
+---
+
+## Pass D — Presets, defaults, and overrides
+
+**Proves**: the four-tier resolution order, and that the slot axis is honoured.
+Requires the key from Pass B (a guest cannot select a paid preset).
+
+**Setup**: you need at least **two** distinguishable presets. Create one:
+
+| Step | Action                                                                       | Expected                                                                                                                                                                                                                                                                               |
+| ---- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D.1  | `/preset create`                                                             | A modal **Create New Preset**. Fill in a name and a model id.                                                                                                                                                                                                                          |
+| D.2  | Submit                                                                       | The preset dashboard embed opens with edit buttons. (A duplicate name returns ❌ “A preset with name … already exists.” plus a retry button that reopens the modal prefilled.)                                                                                                         |
+| D.3  | `/preset browse` filter:**My Presets**                                       | Your new preset appears with the 🔒 owned badge. Global presets carry 🌐.                                                                                                                                                                                                              |
+| D.4  | `/preset default set` preset:`<your preset>`                                 | Embed **✅ Default Preset Set** — “Your default chat preset is now **\<name\>**. This will be used for all characters unless you have a specific override.” Footer: “Use /preset default clear to remove this setting”.                                                                |
+| D.5  | Message **two different** characters, neither with an override               | Both footers name the model from your default preset.                                                                                                                                                                                                                                  |
+| D.6  | `/preset override set` character:`<character A>` preset:`<the other preset>` | Embed **✅ Preset Override Set** — “**\<Character A\>** will now use the **\<preset\>** preset for chat messages.” Footer: “Use /preset override clear to remove this override”.                                                                                                       |
+| D.7  | Message character A                                                          | Footer names the **override's** model (tier 1 beats tier 2).                                                                                                                                                                                                                           |
+| D.8  | Message character B                                                          | Footer still names the **default's** model (tier 2 applies where there is no override).                                                                                                                                                                                                |
+| D.9  | `/preset override browse`                                                    | A list of your overrides with a select menu (“Select an override to clear…”). Character A is listed.                                                                                                                                                                                   |
+| D.10 | Select character A's row, confirm the clear                                  | The override is removed. Re-running `/preset override browse` with none left shows “You haven't set any preset overrides — use `/preset override set` …”.                                                                                                                              |
+| D.11 | `/preset override clear` character:`<character A>` (already clear)           | Embed **ℹ️ No Override Set** — “This character was already using its default preset.”                                                                                                                                                                                                  |
+| D.12 | `/preset default set` preset:`<a vision-capable preset>` slot:**Vision**     | **✅ Default Preset Set** — “Your default **vision (image)** preset is now …”. Your chat default is unchanged (D.13 checks this).                                                                                                                                                      |
+| D.13 | `/preset default clear` slot:**Chat**                                        | **✅ Default Preset Cleared** with **one** fallback line beginning `**Chat** →`. The vision default from D.12 survives.                                                                                                                                                                |
+| D.14 | `/preset default clear` with **no** slot                                     | **✅ Default Preset Cleared** with fallback lines for **both** `**Chat**` and `**Vision**`, each naming the system default it falls back to (or saying no system default is configured). Closing line: “Characters with their own per-character overrides will continue to use those.” |
+| D.15 | Message a character                                                          | Footer names the character's own preset or the system default — not the preset you just cleared.                                                                                                                                                                                       |
+
+_D.13 vs D.14 is the whole point of the slot axis: a slot-less clear must clear
+both, a slot-scoped clear must clear exactly one._
+
+---
+
+## Pass E — Multiple providers
+
+**Proves**: keys are per-provider, and that the LLM guest-mode decision is
+driven by the OpenRouter key specifically.
+
+**Rate-limit budget**: 2 writes. Skip this pass if you have no second provider key.
+
+**Setup**: start from Pass B's state (an OpenRouter key stored).
+
+| Step | Action                                                    | Expected                                                                                                                                                     |
+| ---- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| E.1  | `/settings apikey set` provider:**ElevenLabs (Voice)**    | Modal titled **Set ElevenLabs API Key**, placeholder `sk_xxxx...`. Submit a valid key ⇒ **✅ API Key Configured**.                                           |
+| E.2  | `/settings apikey browse`                                 | **Two** rows — OpenRouter and ElevenLabs — each with its own status and slug. Neither key value is displayed.                                                |
+| E.3  | `/settings apikey test` provider:**ElevenLabs (Voice)**   | **✅ API Key Valid**. A Credit Balance field may appear (ElevenLabs reports remaining quota); the other providers show none.                                 |
+| E.4  | `/settings apikey remove` provider:**ElevenLabs (Voice)** | Embed **🗑️ API Key Removed** — “Your **ElevenLabs** API key has been deleted. The bot will now use the default system key (if available) for this provider.” |
+| E.5  | `/settings apikey browse`                                 | Only the OpenRouter row remains — removing one provider does not touch another.                                                                              |
+
+**Known asymmetry — report what you see, don't assume it's a bug.** The
+bot-client UI treats you as a key-holder when you have an active key for **any**
+provider, while the ai-worker decides chat guest-mode from your **OpenRouter**
+key (with the z.ai auto-promotion exception in §0.3 — a zai-coding key exits
+guest mode only for presets targeting a `z-ai/<model>` on the coding-plan
+catalog). So with only an ElevenLabs key stored: `/preset browse` would show no
+Guest Mode preamble, but a chat response would still carry the
+`🆓 Using free model` footer. If you want to check that combination, remove the
+OpenRouter key first (Pass F), store only an ElevenLabs key, and record both
+observables.
+
+---
+
+## Pass F — Removing the key
+
+**Proves**: removal takes effect on the generation path promptly (Redis pub/sub
+invalidation, not just the 10-second cache expiry).
+
+**Rate-limit budget**: 1–2 writes.
+
+| Step | Action                                            | Expected                                                                                                                                                                                                  |
+| ---- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F.1  | Message a character; note the footer              | `Model: …` only, no guest line (you still hold the key).                                                                                                                                                  |
+| F.2  | `/settings apikey remove` provider:**OpenRouter** | Embed **🗑️ API Key Removed**, footer “Use /settings apikey set to configure a new key”.                                                                                                                   |
+| F.3  | **Immediately** message a character again         | The footer gains the `🆓 Using free model (no API key required)` line and the model is a free one. A stale paid model here means invalidation did not propagate — record it as a fail with the timestamp. |
+| F.4  | `/settings apikey browse`                         | Back to the empty-state text from A.1.                                                                                                                                                                    |
+| F.5  | `/models browse` (wait ~30 s first, per §0.2)     | Paid models are 🔑 again.                                                                                                                                                                                 |
+
+---
+
+## Pass G — Error paths
+
+**Proves**: each failure has its own message, and an unusable key never reaches
+storage.
+
+**Rate-limit budget**: G.2, G.3 and G.4 each consume one of the ten writes — the
+limiter counts the request, not its success. G.1 does not (it fails client-side,
+before any request). G.5 deliberately exhausts the budget, so run it last.
+
+| Step | Action                                                                       | Expected                                                                                                                                                                                                                                                                           |
+| ---- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| G.1  | `/settings apikey set` provider:**OpenRouter**, submit `not-a-real-key`      | ❌ **Invalid OpenRouter Key Format** — “OpenRouter API keys should start with `sk-or-`.” Nothing is stored. (A value under 10 characters is rejected by Discord before submit.)                                                                                                    |
+| G.2  | `/settings apikey set` provider:**OpenRouter**, submit `sk-or-v1-` + garbage | ❌ **Invalid API Key** with the three-bullet checklist. **The key is NOT stored** — `/settings apikey browse` still shows no OpenRouter row. Correct-format-but-wrong-key is rejected at the gateway, which validates against the provider before writing.                         |
+| G.3  | `/settings apikey remove` provider:**Mistral (Voxtral TTS/STT)** (never set) | `❌ You don't have an API key configured for **Mistral (Voxtral TTS/STT)**.`                                                                                                                                                                                                       |
+| G.4  | `/settings apikey test` provider:**Mistral (Voxtral TTS/STT)** (never set)   | `❌ You don't have an API key configured for **Mistral (Voxtral TTS/STT)**.` followed by “Use `/settings apikey set` to add your API key first.”                                                                                                                                   |
+| G.5  | Repeat `/settings apikey test` until you exceed **10 writes in 15 minutes**  | `⏳ Too many key operations in a short window. Your **\<provider\>** key wasn't tested — please wait a moment and try again.` — a throttle message, never an “invalid key” message. (The `set` modal's throttle reads **⚠️ Too Many Requests** instead; both are ⏳/⚠️, never ❌.) |
+
+Two failure shapes worth recognising if you hit them incidentally:
+
+- **⏳ Request Timed Out** — “Your key may already have been saved — check `/settings apikey browse` before trying again.” Do exactly that; do not blind-retry.
+- **⚠️ Couldn't verify your \<provider\> key — the provider didn't respond normally** — the provider was unreachable. Your key was **not** judged invalid.
+
+---
+
+## Pass H — Owner-only
+
+**Proves**: the global default tiers and the usage rollup. Skip unless you are
+the bot owner; every command here refuses other users.
+
+| Step | Action                                                              | Expected                                                                                                                                                            |
+| ---- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| H.1  | `/preset global default` preset:`<a global preset>`                 | Embed **System Default Preset Updated** — “**\<name\>** is now the system default preset. Characters without a specific config will use this default.”              |
+| H.2  | With no personal default and no override, message a character       | The footer names H.1's model (tier 4 applies).                                                                                                                      |
+| H.3  | `/preset global free-default` preset:`<a free-model global preset>` | Embed **Free Tier Default Preset Updated** — “**\<name\>** is now the free tier default preset. Guest users without API keys will use this model for AI responses.” |
+| H.4  | As a user with **no** key, message a character                      | The footer names H.3's model, plus the `🆓 Using free model` line.                                                                                                  |
+| H.5  | `/preset global default` slot:**Vision** preset:`<a vision preset>` | Same **System Default Preset Updated** embed; the chat default is untouched.                                                                                        |
+| H.6  | `/admin usage`                                                      | The global usage embed (all users). Optional `timeframe`: Last 24 hours / 7 days / 30 days; default 7d.                                                             |
+| H.7  | Run `/preset global default` as a **non-owner**                     | `❌ Owner-only command. This command is restricted to the bot owner.` — nothing is changed.                                                                         |
+
+There is **no per-user usage command**; `/admin usage` is the only usage surface
+and it is owner-scoped and global. Per-user totals come from the SQL in Pass I.
+
+---
+
+## Pass I — Data at rest (requires a terminal, not a phone)
+
+**Proves**: keys are stored encrypted and usage is recorded even under BYOK.
 
 ```bash
-# Generate admin API key (shared secret for service-to-service auth)
-openssl rand -hex 32
-
-# Set on Railway (same key for all three services)
-railway variables --set "INTERNAL_SERVICE_SECRET=<your-64-hex-chars>" --service api-gateway
-railway variables --set "INTERNAL_SERVICE_SECRET=<your-64-hex-chars>" --service bot-client
-railway variables --set "INTERNAL_SERVICE_SECRET=<your-64-hex-chars>" --service ai-worker
+# Keys are encrypted: iv / content / tag are opaque, and no column holds `sk-or-…`.
+# The single quotes matter: `ops run` injects DATABASE_URL into the child env
+# with shell interpretation off, so the variable must be expanded by the
+# wrapped bash — a double-quoted "$DATABASE_URL" would expand (empty) in YOUR
+# shell before pnpm even runs, and psql would silently hit the wrong database.
+pnpm ops run --env dev -- bash -c \
+  'psql "$DATABASE_URL" -c "SELECT provider, is_active, left(iv, 8) AS iv_head, left(content, 16) AS content_head, left(tag, 8) AS tag_head, last_used_at FROM user_api_keys LIMIT 5"'
 ```
 
-### Verify Setup
+Expected: `iv_head` / `content_head` / `tag_head` are hex-ish noise. **Fail the
+step immediately if any of them starts with `sk-`.**
 
 ```bash
-# Check BYOK encryption key is set
-railway variables --service api-gateway | grep API_KEY_ENCRYPTION
-railway variables --service ai-worker | grep API_KEY_ENCRYPTION
-
-# Check admin API key is set on all three services
-railway variables --service api-gateway | grep INTERNAL_SERVICE_SECRET
-railway variables --service bot-client | grep INTERNAL_SERVICE_SECRET
-railway variables --service ai-worker | grep INTERNAL_SERVICE_SECRET
-
-# Check services are healthy
-curl https://api-gateway-<your-deployment>.railway.app/health
+# Usage is logged even for BYOK requests (same quoting rule as above).
+pnpm ops run --env dev -- bash -c \
+  'psql "$DATABASE_URL" -c "SELECT provider, model, tokens_in, tokens_out, request_type, created_at FROM usage_logs ORDER BY created_at DESC LIMIT 5"'
 ```
 
----
-
-## Feature Overview
-
-### What Was Implemented
-
-| Category               | Slash Commands                                    | Description                                             |
-| ---------------------- | ------------------------------------------------- | ------------------------------------------------------- |
-| **API Keys (BYOK)**    | `/settings apikey set/browse/remove/test`         | Store and manage your own API keys                      |
-| **Model Override**     | `/model set/list/reset/set-default/clear-default` | Override which LLM config a personality uses (per-user) |
-| **LLM Configs**        | `/llm-config create/list/delete`                  | Create personal model configurations                    |
-| **Settings**           | `/settings timezone/usage`                        | User preferences and usage stats                        |
-| **Admin (Owner Only)** | `/admin llm-config-create/edit/set-default`       | Manage global LLM configs                               |
-
-### Important Architecture Notes
-
-#### LLM Config Ownership Model
-
-| Config Type    | Created By                 | Visible To | Usable By  |
-| -------------- | -------------------------- | ---------- | ---------- |
-| **Global**     | `/admin llm-config-create` | Everyone   | Everyone   |
-| **User-owned** | `/llm-config create`       | Owner only | Owner only |
-
-**Config Resolution Hierarchy** (first match wins):
-
-1. User per-personality override (`/model set <personality> <config>`)
-2. User global default (`/model set-default <config>`)
-3. Personality default (assigned by bot owner)
-4. System default config (`/admin llm-config-set-default`)
-
-#### Model Override Scope
-
-- `/model set` creates a **per-user** override
-- Each user can have different model configs for the same personality
-- Overrides are stored in `UserPersonalityConfig` table
-- Users can choose from global configs OR their own personal configs
+Expected: a row per recent request, naming the model the footer showed you.
 
 ---
 
-## Test Scenarios
-
-### 1. API Key Commands (Core BYOK)
-
-**Commands:**
-
-- `/settings apikey set <provider>` - Opens secure modal for API key entry
-- `/settings apikey browse` - Shows stored keys (masked: `sk-or-...xxx`)
-- `/settings apikey test <provider>` - Validates key with the provider
-- `/settings apikey remove <provider>` - Deletes stored key
-
-**Providers:** `openrouter`, `openai`
-
-#### Test Flow
-
-| Step | Action                               | Expected Result                           |
-| ---- | ------------------------------------ | ----------------------------------------- |
-| 1.1  | `/settings apikey browse`            | Empty list or "No API keys configured"    |
-| 1.2  | `/settings apikey set openrouter`    | Modal opens for key entry                 |
-| 1.3  | Enter valid OpenRouter key           | Success message                           |
-| 1.4  | `/settings apikey browse`            | Shows `openrouter: sk-or-...xxx` (masked) |
-| 1.5  | `/settings apikey test openrouter`   | "Key is valid" message                    |
-| 1.6  | Send `@lilith hello`                 | Bot responds                              |
-| 1.7  | Check logs                           | Should show `source: 'user'`              |
-| 1.8  | `/settings apikey remove openrouter` | Success message                           |
-| 1.9  | `/settings apikey browse`            | Empty again                               |
-| 1.10 | Send `@lilith hello again`           | Bot responds (using system key)           |
-| 1.11 | Check logs                           | Should show `source: 'system'`            |
-
-#### Edge Cases
-
-| Test                | Action                                           | Expected                                      |
-| ------------------- | ------------------------------------------------ | --------------------------------------------- |
-| Invalid key format  | `/settings apikey set openrouter` with "invalid" | Error: invalid key format                     |
-| Invalid key         | `/settings apikey set openrouter` with wrong key | Key stored, but `/settings apikey test` fails |
-| Remove non-existent | `/settings apikey remove openai` (never set)     | Error: no key found                           |
-| Duplicate set       | `/settings apikey set openrouter` twice          | Second overwrites first                       |
-
----
-
-### 2. Model Override Commands
-
-**Commands:**
-
-- `/model set <personality> <config>` - Set override for a specific personality
-- `/model list` - Show all your model overrides
-- `/model reset <personality>` - Remove personality-specific override
-- `/model set-default <config>` - Set your global default config (applies to ALL personalities)
-- `/model clear-default` - Remove your global default config
-
-#### Test Flow - Per-Personality Override
-
-| Step | Action                            | Expected Result                          |
-| ---- | --------------------------------- | ---------------------------------------- |
-| 2.1  | `/model list`                     | Empty or "No overrides"                  |
-| 2.2  | `/llm-config create` first        | Create a personal config (see section 3) |
-| 2.3  | `/model set lilith <your-config>` | Success: "Lilith will now use..."        |
-| 2.4  | `/model list`                     | Shows lilith → your-config               |
-| 2.5  | Send `@lilith hello`              | Response uses your config's model        |
-| 2.6  | `/model reset lilith`             | Success: "Override removed"              |
-| 2.7  | `/model list`                     | Empty again                              |
-
-#### Test Flow - User Global Default
-
-| Step | Action                             | Expected Result                      |
-| ---- | ---------------------------------- | ------------------------------------ |
-| 2.8  | `/model set-default <config>`      | Success: "Default config set"        |
-| 2.9  | `/model list`                      | Shows global default in header       |
-| 2.10 | Send `@lilith hello`               | Uses your default config             |
-| 2.11 | Send `@sarcastic hi`               | Also uses your default config        |
-| 2.12 | `/model set lilith <other-config>` | Set personality-specific override    |
-| 2.13 | Send `@lilith hello`               | Uses personality override (priority) |
-| 2.14 | Send `@sarcastic hi`               | Uses global default (no override)    |
-| 2.15 | `/model clear-default`             | Success: "Default config cleared"    |
-
-#### Notes
-
-- Personality selection should show available personalities (autocomplete)
-- Config selection shows global configs + your personal configs (autocomplete)
-- Override is per-user: other users see default config
-- Hierarchy: per-personality > user-global > personality default > system default
-
----
-
-### 3. LLM Config Commands
-
-**Commands:**
-
-- `/llm-config create <name> <model>` - Create personal config
-- `/llm-config list` - Show global + your configs
-- `/llm-config delete <config>` - Delete your config (not global)
-
-#### Test Flow
-
-| Step | Action                                                             | Expected Result                             |
-| ---- | ------------------------------------------------------------------ | ------------------------------------------- |
-| 3.1  | `/llm-config list`                                                 | Shows global configs only                   |
-| 3.2  | `/llm-config create name:creative model:anthropic/claude-sonnet-4` | Success                                     |
-| 3.3  | `/llm-config list`                                                 | Shows global + "creative" (marked as yours) |
-| 3.4  | `/llm-config delete creative`                                      | Success                                     |
-| 3.5  | `/llm-config list`                                                 | Only global configs again                   |
-
-#### Edge Cases
-
-| Test           | Action                               | Expected                        |
-| -------------- | ------------------------------------ | ------------------------------- |
-| Duplicate name | Create "creative" twice              | Error: already exists           |
-| Delete global  | Try to delete a global config        | Error: can only delete your own |
-| Delete in use  | Delete config that's set as override | Error: in use by X overrides    |
-| Long name      | Name > 100 chars                     | Error: too long                 |
-
----
-
-### 4. Settings Commands
-
-**Commands:**
-
-- `/settings timezone <timezone>` - Set your timezone
-- `/settings usage [period]` - View API usage stats
-
-#### Test Flow
-
-| Step | Action                                | Expected Result            |
-| ---- | ------------------------------------- | -------------------------- |
-| 4.1  | `/settings timezone America/New_York` | Success                    |
-| 4.2  | `/settings usage`                     | Shows usage (may be empty) |
-| 4.3  | Send several messages with BYOK key   | Messages processed         |
-| 4.4  | `/settings usage`                     | Shows token counts         |
-| 4.5  | `/settings usage week`                | Shows weekly breakdown     |
-
-#### Valid Timezones
-
-Common examples: `America/New_York`, `America/Los_Angeles`, `Europe/London`, `Asia/Tokyo`, `UTC`
-
----
-
-### 5. Admin Commands (Owner Only)
-
-**Commands:**
-
-- `/admin llm-config-create <name> <model>` - Create a global LLM config
-- `/admin llm-config-edit <config> [name] [model] [...]` - Edit an existing global config
-- `/admin llm-config-set-default <config>` - Set a config as the system default
-
-#### Test Flow
-
-| Step | Action                                                                  | Expected Result                   |
-| ---- | ----------------------------------------------------------------------- | --------------------------------- |
-| 5.1  | `/llm-config list` (as any user)                                        | Shows existing global configs     |
-| 5.2  | `/admin llm-config-create name:Claude4 model:anthropic/claude-sonnet-4` | Success: shows new config ID      |
-| 5.3  | `/llm-config list` (as any user)                                        | Shows new "Claude4" config        |
-| 5.4  | `/admin llm-config-edit config:Claude4 model:anthropic/claude-haiku-4`  | Success: shows updated config     |
-| 5.5  | `/admin llm-config-set-default config:Claude4`                          | Success: "Claude4 is now default" |
-| 5.6  | Send message without any overrides                                      | Uses Claude4 model                |
-
-#### Notes
-
-- Only the bot owner can run these commands
-- Global configs are visible to all users for selection
-- Setting a default affects all users who don't have overrides
-- Can't delete a config that's set as default or in use
-- Config selection uses autocomplete (type to filter)
-
----
-
-### 6. Infrastructure & Integration Tests
-
-#### 6.1 Encryption Verification
+## Watching the logs
 
 ```bash
-# After storing a key, verify it's encrypted in DB (not plaintext)
-railway run psql -c "SELECT iv, LEFT(content, 20) as content_preview, tag FROM user_api_keys LIMIT 1"
+# Which key served a request — 'user' (BYOK) vs 'system' (guest mode)
+railway logs --service ai-worker | grep -E "API key resolved|Guest Mode|source"
+
+# Key writes, validation, and cache-invalidation publishes
+railway logs --service api-gateway | grep -iE "api key|wallet|invalidat"
+
+# Command dispatch
+railway logs --service bot-client | grep -iE "apikey|preset|command"
+
+# Errors
+railway logs --service ai-worker | grep -iE "error|failed|exception"
 ```
 
-Expected: `iv`, `content`, and `tag` columns contain hex/base64 data, NOT your actual API key.
+The exact lines to look for:
 
-#### 6.2 Cache Invalidation
-
-| Step | Action                    | Expected                                   |
-| ---- | ------------------------- | ------------------------------------------ |
-| 1    | Store BYOK key            | Key stored                                 |
-| 2    | Send message              | Uses user key (check logs)                 |
-| 3    | Remove key immediately    | Key removed                                |
-| 4    | Send message within 5 min | Should use system key, NOT cached user key |
-
-This tests that cache invalidation via Redis pub/sub is working.
-
-#### 6.3 Usage Logging
-
-```bash
-# After sending messages, verify usage is logged
-railway run psql -c "SELECT * FROM usage_logs ORDER BY created_at DESC LIMIT 5"
-```
-
-Expected: Entries with `user_id`, `provider`, `model`, `tokens_in`, `tokens_out`.
-
-#### 6.4 Fallback Behavior
-
-| Scenario                          | Expected Behavior                    |
-| --------------------------------- | ------------------------------------ |
-| No BYOK key, system key exists    | Uses system key                      |
-| BYOK key exists                   | Uses BYOK key (priority)             |
-| No BYOK key, no system key        | Error: "No API key available"        |
-| BYOK disabled (no encryption key) | Warning logged, uses system key only |
-
----
-
-## Log Monitoring Commands
-
-```bash
-# Watch ai-worker for key resolution
-railway logs --service ai-worker | grep -E "(API key resolved|source)"
-
-# Watch api-gateway for wallet/auth operations
-railway logs --service api-gateway | grep -E "(wallet|cache|Auth)"
-
-# Watch bot-client for command execution
-railway logs --service bot-client | grep -E "(command|wallet|model|settings)"
-
-# Watch for errors
-railway logs --service ai-worker | grep -iE "(error|failed|exception)"
-```
-
----
-
-## Quick Smoke Test (5 minutes)
-
-Run these in order to verify basic functionality:
-
-```
-1. /settings apikey browse                          → Empty
-2. /settings apikey set openrouter                → Enter your key
-3. /settings apikey test openrouter               → Valid
-4. @lilith hello                         → Responds
-5. /settings usage                       → Shows usage
-6. /llm-config create name:test model:anthropic/claude-sonnet-4
-7. /llm-config list                      → Shows "test" config
-8. /model set lilith test                → Override set
-9. @lilith hi again                      → Works with new config
-10. /model set-default test              → Global default set
-11. @sarcastic hello                     → Also uses test config
-12. /model clear-default                 → Global default cleared
-13. /model reset lilith                  → Override removed
-14. /llm-config delete test              → Config deleted
-15. /settings apikey remove openrouter            → Key removed
-```
-
-### Admin-Only Smoke Test (Bot Owner)
-
-```
-1. /admin llm-config-create name:GlobalTest model:google/gemini-2.0-flash-exp
-2. /llm-config list                                → Shows "GlobalTest" as global
-3. /admin llm-config-edit config:GlobalTest model:anthropic/claude-sonnet-4
-4. /llm-config list                                → Shows updated model
-5. /admin llm-config-set-default config:GlobalTest → Set as system default
-6. @lilith hello (as normal user)                  → Uses GlobalTest model
-```
-
----
-
-## Known Limitations
-
-1. **No admin commands for BYOK** - Bot owner cannot view/manage other users' keys (by design - security)
-
-2. **Config deletion blocked if in use** - Must remove all overrides using a config before deleting it
-
-3. **No global config deletion via Discord** - Can create, edit, and set default, but deletion requires database access (prevents accidental deletion of configs in use)
+| Line                                                    | Means                                          |
+| ------------------------------------------------------- | ---------------------------------------------- |
+| `API key resolved from user wallet` (`source: "user"`)  | Your BYOK key served the request.              |
+| `Using system API key in Guest Mode (free models only)` | No user key — free models only.                |
+| `API key resolved from cache` (`source: "cache"`)       | Within the 10-second resolution cache window.  |
+| `API_KEY_ENCRYPTION_KEY not set - BYOK disabled`        | BYOK is off entirely; every key is ignored.    |
+| `Published API key cache invalidation event`            | A set/remove propagated to the ai-worker pool. |
 
 ---
 
 ## Troubleshooting
 
-### "No API key available" Error
+**“My key is stored but responses still say 🆓 Using free model.”**
+The guest-mode decision reads your **OpenRouter** key. A key for ElevenLabs or
+Mistral does not change it, and a Z.AI Coding Plan key changes it only when the
+resolved preset targets a `z-ai/<model>` on the coding-plan catalog (§0.3).
+Confirm with `/settings apikey browse` that the OpenRouter row exists and is
+Active, then check ai-worker logs for `source: "user"`.
 
-- Check `API_KEY_ENCRYPTION_KEY` is set on ai-worker
-- Check `OPENROUTER_API_KEY` is set as fallback
-- Verify user has stored a key via `/settings apikey browse`
+**“The bot says my key is invalid, but it works on the provider's site.”**
+The gateway validates against the provider before storing, so this is the
+provider's own answer. Check for a scoped key missing permissions (that returns a
+descriptive **Validation Error**, not the generic invalid message) and for a zero
+credit balance (**Insufficient Credits**).
 
-### Key Not Being Used
+**“Nothing happens / I keep getting a throttle message.”**
+Ten wallet writes per 15 minutes, shared across set/test/remove. Wait it out —
+`/settings apikey browse` reads are on a separate, far more generous budget.
 
-- Check logs for `source: 'user'` vs `source: 'system'`
-- Verify key is active: `/settings apikey browse` should show it
-- Test key validity: `/settings apikey test openrouter`
+**“A key change didn't take effect.”**
+Resolution is cached 10 seconds and invalidated over Redis pub/sub on change.
+Longer than that is a real failure — capture the api-gateway log around the write
+(`Published API key cache invalidation event`) and report it.
 
-### Cache Issues
+**“The command doesn't exist.”**
+Commands register on bot-client deploy. Confirm the deploy finished, then check
+`/help commands`.
 
-- Cache TTL is 5 minutes
-- Invalidation should be instant via Redis pub/sub
-- Check api-gateway logs for cache invalidation events
-
-### Command Not Found
-
-- Redeploy bot-client to register new commands
-- Check `AUTO_DEPLOY_COMMANDS=true` is set
-- Try `/help` to see available commands
+**“A model I expected is not being used.”**
+Walk §0.5 top-down: per-character override → your default → the character's own
+preset → the system default — and remember guest mode substitutes a free model
+at the end of that chain regardless of which tier won.


### PR DESCRIPTION
## Summary

TASK-408. The old guide scripted `/model set-default`, `/llm-config`, and `/settings usage` flows that no longer exist, listed two providers (one of which, `openai`, was never real), and carried several factually wrong claims. This is a full rewrite verified step-by-step against the command sources and `command-manifest.json` — not a string swap.

**Structure**: Pass A–I (guest baseline → key storage → key effects → presets/defaults/overrides incl. the slot axis → multi-provider isolation → removal + cache invalidation → error paths → owner-only → data at rest). Each pass states what it uniquely proves, its masking-state resets, its wallet rate-limit budget, and exact expected strings quoted from the code (embed titles, footers, error copy).

**Corrections to factually wrong content** (each verified at source):
- Keys are never rendered in `/settings apikey browse` — not "masked" (`browse.ts`)
- Invalid keys are rejected **before** storage — the gateway validates against the provider first (`setKey.ts`)
- The ai-worker key cache TTL is **10 seconds**, not 5 minutes (`constants/timing.ts`)
- Providers are `openrouter` / `elevenlabs` / `zai-coding` / `mistral` — there is no `openai` provider
- No-key is **silent free-model substitution** with the `🆓` footer, not an error

**New coverage the old doc predated**: the Chat/Vision slot axis (a slot-less `/preset default clear` clears both FKs — `preset/default/clear.ts`), guest-mode UI surfaces (browse preamble, strikethrough, unlock-models upsell), the 10-writes/15-min wallet rate limit, `/models browse|view` usability badges.

**Deleted**: `/settings usage` steps (no per-user usage surface exists — `/admin usage` is owner-scoped and global), timezone steps (not BYOK behavior), the retired smoke blocks, and stale Known Limitations (preset deletion exists in the dashboard now).

**Known asymmetry documented, not resolved**: bot-client derives guest-mode from ANY active key while ai-worker keys chat guest-mode on the OpenRouter key alone — the doc carries a report-what-you-see note in Pass E; the underlying inconsistency is filed as TASK-416.

## Verification

- Every slash-command invocation in the doc mechanically checked against `command-manifest.json` (22 distinct invocations, all present)
- Survivor greps for every retired command name (`/model *`, `/llm-config*`, `set-default`, `clear-default`, `/settings usage|wallet`): zero hits
- Expected outputs quoted from source with file:line verification (re-verified after a rename-PR rebase mid-rewrite)
- Prettier clean; temporal-marker grep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)