### PR TITLE
refactor(bot-client): retire legacy execute arm and dead slash dispatch

### DIFF
--- a/services/bot-client/src/handlers/CommandHandler.test.ts
+++ b/services/bot-client/src/handlers/CommandHandler.test.ts
@@ -5,12 +5,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { CommandHandler, topLevelErrorSpec } from './CommandHandler.js';
-import { CATALOG } from '../ux/catalog/catalog.js';
+import { CommandHandler } from './CommandHandler.js';
 import { InfraError } from '@tzurot/clients';
-import { Collection, MessageFlags, type SlashCommandBuilder } from 'discord.js';
+import { Collection, type SlashCommandBuilder } from 'discord.js';
 import type {
-  ChatInputCommandInteraction,
   ModalSubmitInteraction,
   AutocompleteInteraction,
   ButtonInteraction,
@@ -41,25 +39,6 @@ vi.mock('node:fs', () => ({
 }));
 
 import { readdirSync, statSync } from 'node:fs';
-
-describe('topLevelErrorSpec', () => {
-  const fallback = CATALOG.error.commandFailed();
-
-  it('returns the transient shape for an InfraError (transient gateway failure)', () => {
-    const err = new InfraError({ ok: false, kind: 'timeout', error: 'timed out', status: 0 });
-    const spec = topLevelErrorSpec(err, fallback);
-    expect(spec.text).toContain('try again later');
-    expect(spec).not.toBe(fallback);
-  });
-
-  it('returns the surface-specific fallback for a non-infra Error', () => {
-    expect(topLevelErrorSpec(new Error('boom'), fallback)).toBe(fallback);
-  });
-
-  it('returns the fallback for a non-Error throwable', () => {
-    expect(topLevelErrorSpec('string error', fallback)).toBe(fallback);
-  });
-});
 
 describe('CommandHandler', () => {
   let handler: CommandHandler;
@@ -235,7 +214,7 @@ describe('CommandHandler', () => {
     });
   });
 
-  describe('handleInteraction', () => {
+  describe('handleModalInteraction / handleComponentInteraction', () => {
     beforeEach(() => {
       // Add a mock command to the handler
       const mockCommand: Command = {
@@ -252,28 +231,9 @@ describe('CommandHandler', () => {
       (handler as any).prefixToCommand.set('test', mockCommand);
     });
 
-    it('should execute chat input command', async () => {
-      const mockInteraction = {
-        isChatInputCommand: () => true,
-        isModalSubmit: () => false,
-        commandName: 'test',
-        reply: vi.fn().mockResolvedValue(undefined),
-        followUp: vi.fn(),
-        replied: false,
-        deferred: false,
-      } as unknown as ChatInputCommandInteraction;
-
-      await handler.handleInteraction(mockInteraction);
-
-      const command = handler.getCommands().get('test');
-      expect(command?.execute).toHaveBeenCalledWith(mockInteraction);
-    });
-
     it('should ignore modal submit when command has no handleModal', async () => {
       // Commands without handleModal export do not handle modals (no fallback to execute)
       const mockInteraction = {
-        isChatInputCommand: () => false,
-        isModalSubmit: () => true,
         customId: 'test::create',
         reply: vi.fn().mockResolvedValue(undefined),
         followUp: vi.fn(),
@@ -281,7 +241,7 @@ describe('CommandHandler', () => {
         deferred: false,
       } as unknown as ModalSubmitInteraction;
 
-      await handler.handleInteraction(mockInteraction);
+      await handler.handleModalInteraction(mockInteraction);
 
       const command = handler.getCommands().get('test');
       // execute should NOT be called - modals require handleModal
@@ -303,8 +263,6 @@ describe('CommandHandler', () => {
       (handler as any).prefixToCommand.set('modal-test', mockCommand);
 
       const mockInteraction = {
-        isChatInputCommand: () => false,
-        isModalSubmit: () => true,
         customId: 'modal-test::create',
         reply: vi.fn().mockResolvedValue(undefined),
         followUp: vi.fn(),
@@ -312,7 +270,7 @@ describe('CommandHandler', () => {
         deferred: false,
       } as unknown as ModalSubmitInteraction;
 
-      await handler.handleInteraction(mockInteraction);
+      await handler.handleModalInteraction(mockInteraction);
 
       expect(mockHandleModal).toHaveBeenCalledWith(mockInteraction);
       expect(mockCommand.execute).not.toHaveBeenCalled();
@@ -334,8 +292,6 @@ describe('CommandHandler', () => {
       (handler as any).prefixToCommand.set('test', mockCommand);
 
       const mockInteraction = {
-        isChatInputCommand: () => false,
-        isModalSubmit: () => true,
         customId: 'test::edit::entity-123',
         reply: vi.fn().mockResolvedValue(undefined),
         followUp: vi.fn(),
@@ -343,7 +299,7 @@ describe('CommandHandler', () => {
         deferred: false,
       } as unknown as ModalSubmitInteraction;
 
-      await handler.handleInteraction(mockInteraction);
+      await handler.handleModalInteraction(mockInteraction);
 
       // Should extract 'test' from 'test::edit::entity-123' and call handleModal
       expect(mockHandleModal).toHaveBeenCalledWith(mockInteraction);
@@ -368,8 +324,6 @@ describe('CommandHandler', () => {
       (handler as any).prefixToCommand.set('admin-settings', mockCommand);
 
       const mockInteraction = {
-        isChatInputCommand: () => false,
-        isModalSubmit: () => true,
         customId: 'admin-settings::modal::global::maxAge',
         reply: vi.fn().mockResolvedValue(undefined),
         followUp: vi.fn(),
@@ -377,176 +331,9 @@ describe('CommandHandler', () => {
         deferred: false,
       } as unknown as ModalSubmitInteraction;
 
-      await handler.handleInteraction(mockInteraction);
+      await handler.handleModalInteraction(mockInteraction);
 
       expect(mockHandleModal).toHaveBeenCalledWith(mockInteraction);
-    });
-
-    it('should reply with error for unknown command', async () => {
-      const mockInteraction = {
-        isChatInputCommand: () => true,
-        isModalSubmit: () => false,
-        commandName: 'unknown',
-        reply: vi.fn().mockResolvedValue(undefined),
-        followUp: vi.fn(),
-        replied: false,
-        deferred: false,
-      } as unknown as ChatInputCommandInteraction;
-
-      await handler.handleInteraction(mockInteraction);
-
-      expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: 'Unknown command!',
-        flags: MessageFlags.Ephemeral,
-      });
-    });
-
-    it('should execute help command like any other command', async () => {
-      // Note: Help command accesses commands via interaction.client.commands,
-      // not as a second argument. This is handled by the help command itself.
-      const mockHelpCommand: Command = {
-        data: {
-          name: 'help',
-          description: 'Show all available commands',
-        } as unknown as SlashCommandBuilder,
-        execute: vi.fn().mockResolvedValue(undefined),
-      };
-
-      handler.getCommands().set('help', mockHelpCommand);
-
-      const mockInteraction = {
-        isChatInputCommand: () => true,
-        isModalSubmit: () => false,
-        commandName: 'help',
-        reply: vi.fn().mockResolvedValue(undefined),
-        followUp: vi.fn(),
-        replied: false,
-        deferred: false,
-      } as unknown as ChatInputCommandInteraction;
-
-      await handler.handleInteraction(mockInteraction);
-
-      // Help is executed like any other command (no special handling)
-      expect(mockHelpCommand.execute).toHaveBeenCalledWith(mockInteraction);
-    });
-
-    it('should handle command execution error with reply', async () => {
-      const mockCommand: Command = {
-        data: {
-          name: 'failing',
-          description: 'Failing command',
-        } as unknown as SlashCommandBuilder,
-        execute: vi.fn().mockRejectedValue(new Error('Command failed')),
-      };
-
-      handler.getCommands().set('failing', mockCommand);
-
-      const mockInteraction = {
-        isChatInputCommand: () => true,
-        isModalSubmit: () => false,
-        commandName: 'failing',
-        reply: vi.fn().mockResolvedValue(undefined),
-        followUp: vi.fn(),
-        replied: false,
-        deferred: false,
-      } as unknown as ChatInputCommandInteraction;
-
-      await handler.handleInteraction(mockInteraction);
-
-      expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: '❌ There was an error executing this command!',
-        flags: MessageFlags.Ephemeral,
-      });
-    });
-
-    it('should handle command execution error with followUp when already replied', async () => {
-      const mockCommand: Command = {
-        data: {
-          name: 'failing',
-          description: 'Failing command',
-        } as unknown as SlashCommandBuilder,
-        execute: vi.fn().mockRejectedValue(new Error('Command failed')),
-      };
-
-      handler.getCommands().set('failing', mockCommand);
-
-      const mockInteraction = {
-        isChatInputCommand: () => true,
-        isModalSubmit: () => false,
-        commandName: 'failing',
-        reply: vi.fn().mockResolvedValue(undefined),
-        followUp: vi.fn().mockResolvedValue(undefined),
-        replied: true, // Already replied
-        deferred: false,
-      } as unknown as ChatInputCommandInteraction;
-
-      await handler.handleInteraction(mockInteraction);
-
-      expect(mockInteraction.followUp).toHaveBeenCalledWith({
-        content: '❌ There was an error executing this command!',
-        flags: MessageFlags.Ephemeral,
-      });
-      expect(mockInteraction.reply).not.toHaveBeenCalled();
-    });
-
-    it('fills the deferral placeholder via editReply when deferred (fixed: was followUp)', async () => {
-      // Deliberate behavior change: the old sendErrorReply followUp'd a
-      // deferred-but-unreplied interaction, stranding the "Thinking…"
-      // placeholder forever. The unified replySpec path edits it instead.
-      const mockCommand: Command = {
-        data: {
-          name: 'failing',
-          description: 'Failing command',
-        } as unknown as SlashCommandBuilder,
-        execute: vi.fn().mockRejectedValue(new Error('Command failed')),
-      };
-
-      handler.getCommands().set('failing', mockCommand);
-
-      const mockInteraction = {
-        isChatInputCommand: () => true,
-        isModalSubmit: () => false,
-        commandName: 'failing',
-        reply: vi.fn().mockResolvedValue(undefined),
-        followUp: vi.fn().mockResolvedValue(undefined),
-        editReply: vi.fn().mockResolvedValue(undefined),
-        replied: false,
-        deferred: true, // Deferred
-      } as unknown as ChatInputCommandInteraction;
-
-      await handler.handleInteraction(mockInteraction);
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: '❌ There was an error executing this command!',
-      });
-      expect(mockInteraction.followUp).not.toHaveBeenCalled();
-      expect(mockInteraction.reply).not.toHaveBeenCalled();
-    });
-
-    it('should not throw when error reply itself fails (interaction already acknowledged)', async () => {
-      const mockCommand: Command = {
-        data: {
-          name: 'failing',
-          description: 'Failing command',
-        } as unknown as SlashCommandBuilder,
-        execute: vi.fn().mockRejectedValue(new Error('Command failed')),
-      };
-
-      handler.getCommands().set('failing', mockCommand);
-
-      const mockInteraction = {
-        isChatInputCommand: () => true,
-        isModalSubmit: () => false,
-        commandName: 'failing',
-        // reply throws because Discord already acknowledged the interaction
-        reply: vi.fn().mockRejectedValue(new Error('Interaction has already been acknowledged.')),
-        followUp: vi.fn(),
-        replied: false,
-        deferred: false,
-      } as unknown as ChatInputCommandInteraction;
-
-      // Should not throw — the failed error reply is caught internally
-      await expect(handler.handleInteraction(mockInteraction)).resolves.toBeUndefined();
     });
 
     it('should not throw when modal error reply itself fails', async () => {
@@ -563,8 +350,6 @@ describe('CommandHandler', () => {
       (handler as any).prefixToCommand.set('modal-fail', mockCommand);
 
       const mockInteraction = {
-        isChatInputCommand: () => false,
-        isModalSubmit: () => true,
         customId: 'modal-fail::edit::entity-123',
         reply: vi.fn().mockRejectedValue(new Error('Interaction has already been acknowledged.')),
         followUp: vi.fn(),
@@ -572,7 +357,7 @@ describe('CommandHandler', () => {
         deferred: false,
       } as unknown as ModalSubmitInteraction;
 
-      await expect(handler.handleInteraction(mockInteraction)).resolves.toBeUndefined();
+      await expect(handler.handleModalInteraction(mockInteraction)).resolves.toBeUndefined();
     });
 
     it('should early-return when command has no handleSelectMenu handler', async () => {

--- a/services/bot-client/src/handlers/CommandHandler.ts
+++ b/services/bot-client/src/handlers/CommandHandler.ts
@@ -1,16 +1,20 @@
 /**
  * Command Handler
  *
- * Loads slash commands from the commands directory and routes interactions
- * Simple, modular approach - just scan files and build a Map
+ * Loads slash commands from the commands directory and routes the
+ * non-chat-input interaction surfaces: modal submits, autocomplete,
+ * components, and context-menu commands. Simple, modular approach - just
+ * scan files and build a Map.
+ *
+ * Chat-input (slash) dispatch is NOT here: it lives in
+ * `handlers/commandDispatch.ts`, which owns deferral-mode resolution and
+ * context creation and calls the loaded command's `execute`.
  */
 
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { InfraError } from '@tzurot/clients';
 import {
   Collection,
   ContextMenuCommandBuilder,
-  type ChatInputCommandInteraction,
   type MessageContextMenuCommandInteraction,
   type ModalSubmitInteraction,
   type AutocompleteInteraction,
@@ -19,8 +23,7 @@ import {
   MessageFlags,
 } from 'discord.js';
 import { CATALOG } from '../ux/catalog/catalog.js';
-import type { MessageSpec } from '../ux/catalog/types.js';
-import { replySpecSafe } from '../ux/render/reply.js';
+import { replySpecSafe, topLevelErrorSpec } from '../ux/render/reply.js';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
 import type { Command, ContextMenuCommand } from '../types.js';
@@ -34,19 +37,6 @@ import { getCommandFromCustomId } from '../utils/customIds.js';
 import { getCommandFiles } from '../utils/commandFileUtils.js';
 
 const logger = createLogger('CommandHandler');
-
-/**
- * Spec for a top-level command/interaction error. An `InfraError` (a gateway
- * call failed for an infrastructure reason — timeout/network/5xx, surfaced
- * via the Pattern-B result helpers in `@tzurot/clients`) gets the transient
- * shape, so a blip never reads to the user as a definitive failure of the
- * command. Everything else keeps the surface-specific fallback spec.
- */
-export function topLevelErrorSpec(error: unknown, fallback: MessageSpec): MessageSpec {
-  return error instanceof InfraError
-    ? CATALOG.error.transient("Couldn't reach the server right now.")
-    : fallback;
-}
 
 // Get directory name for ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -62,7 +52,7 @@ function deriveCategory(filePath: string, commandsPath: string): string | undefi
 }
 
 /**
- * Command Handler - manages slash command registration and execution
+ * Command Handler - manages command registration and non-chat-input routing
  *
  * Uses a prefix-to-command map for component routing:
  * - Command name is automatically registered as a prefix
@@ -251,50 +241,10 @@ export class CommandHandler {
   }
 
   /**
-   * Handle a slash command or modal submit interaction
-   */
-  async handleInteraction(
-    interaction: ChatInputCommandInteraction | ModalSubmitInteraction
-  ): Promise<void> {
-    // Handle modal submits via prefix routing
-    if (interaction.isModalSubmit()) {
-      await this.handleModalInteraction(interaction);
-      return;
-    }
-
-    // Handle slash commands
-    const commandName = interaction.commandName;
-    const command = this.commands.get(commandName);
-
-    if (!command) {
-      logger.warn({ commandName }, 'Unknown command');
-      await interaction.reply({
-        content: 'Unknown command!',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    try {
-      logger.info({ commandName }, 'Executing command');
-      // Type assertion for legacy commands that receive raw interaction
-      // New commands with deferralMode are handled by index.ts directly
-      type LegacyExecute = (interaction: ChatInputCommandInteraction) => Promise<void>;
-      const execute = command.execute as LegacyExecute;
-      await execute(interaction);
-    } catch (error) {
-      logger.error({ err: error, commandName }, 'Error executing command');
-      await replySpecSafe(interaction, topLevelErrorSpec(error, CATALOG.error.commandFailed()), {
-        logContext: { commandName },
-      });
-    }
-  }
-
-  /**
    * Handle a modal submit interaction
    * Routes via prefix map and uses handleModal if available
    */
-  private async handleModalInteraction(interaction: ModalSubmitInteraction): Promise<void> {
+  async handleModalInteraction(interaction: ModalSubmitInteraction): Promise<void> {
     const customId = interaction.customId;
     const prefix = getCommandFromCustomId(customId) ?? customId;
 

--- a/services/bot-client/src/handlers/commandDispatch.test.ts
+++ b/services/bot-client/src/handlers/commandDispatch.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for chat-input command dispatch.
+ *
+ * Covers the three things this module owns: deferral-mode resolution
+ * (including per-subcommand overrides), the ack + context-creation seam
+ * (what the command receives must forward to the real interaction), and the
+ * top-level error UX when execute() throws. The error-UX assertions run the
+ * REAL replySpecSafe/topLevelErrorSpec/CATALOG — that seam IS the thing under
+ * test, so mocking it would prove nothing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  MessageFlags,
+  type ChatInputCommandInteraction,
+  type SlashCommandBuilder,
+} from 'discord.js';
+import { InfraError } from '@tzurot/clients';
+import { handleCommandWithContext, resolveEffectiveDeferralMode } from './commandDispatch.js';
+import type { Command } from '../types.js';
+import type { DeferralMode, SafeCommandContext } from '../utils/commandContext/index.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+interface MockInteraction {
+  commandName: string;
+  deferred: boolean;
+  replied: boolean;
+  ephemeral: boolean | null;
+  options: {
+    getSubcommand: (required?: boolean) => string | null;
+    getSubcommandGroup: (required?: boolean) => string | null;
+    get: (name: string, required?: boolean) => { value: unknown } | null;
+  };
+  user: { id: string };
+  guild: null;
+  member: null;
+  channel: null;
+  channelId: string;
+  guildId: null;
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
+  reply: ReturnType<typeof vi.fn>;
+  followUp: ReturnType<typeof vi.fn>;
+  deleteReply: ReturnType<typeof vi.fn>;
+  showModal: ReturnType<typeof vi.fn>;
+}
+
+function makeInteraction(
+  opts: { commandName?: string; subcommand?: string | null; group?: string | null } = {}
+): MockInteraction {
+  const interaction: MockInteraction = {
+    commandName: opts.commandName ?? 'test',
+    deferred: false,
+    replied: false,
+    ephemeral: null,
+    options: {
+      getSubcommand: () => opts.subcommand ?? null,
+      getSubcommandGroup: () => opts.group ?? null,
+      get: () => null,
+    },
+    user: { id: 'user-1' },
+    guild: null,
+    member: null,
+    channel: null,
+    channelId: 'channel-1',
+    guildId: null,
+    deferReply: vi.fn().mockImplementation(() => {
+      interaction.deferred = true;
+      return Promise.resolve(undefined);
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
+    deleteReply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  };
+  return interaction;
+}
+
+function asInteraction(mock: MockInteraction): ChatInputCommandInteraction {
+  return mock as unknown as ChatInputCommandInteraction;
+}
+
+function makeCommand(overrides: Partial<Command> = {}): Command {
+  return {
+    data: { name: 'test', description: 'Test command' } as unknown as SlashCommandBuilder,
+    execute: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('resolveEffectiveDeferralMode', () => {
+  it("defaults to 'ephemeral' when the command declares no deferralMode", () => {
+    expect(resolveEffectiveDeferralMode(makeCommand(), asInteraction(makeInteraction()))).toBe(
+      'ephemeral'
+    );
+  });
+
+  it('uses the declared deferralMode when there is no override', () => {
+    const command = makeCommand({ deferralMode: 'public' });
+    expect(resolveEffectiveDeferralMode(command, asInteraction(makeInteraction()))).toBe('public');
+  });
+
+  it('applies a plain-subcommand override', () => {
+    const command = makeCommand({
+      deferralMode: 'ephemeral',
+      subcommandDeferralModes: { set: 'modal' },
+    });
+    const interaction = makeInteraction({ subcommand: 'set' });
+    expect(resolveEffectiveDeferralMode(command, asInteraction(interaction))).toBe('modal');
+  });
+
+  it("applies a 'group subcommand' path override", () => {
+    const command = makeCommand({
+      deferralMode: 'ephemeral',
+      subcommandDeferralModes: { 'profile create': 'modal' },
+    });
+    const interaction = makeInteraction({ group: 'profile', subcommand: 'create' });
+    expect(resolveEffectiveDeferralMode(command, asInteraction(interaction))).toBe('modal');
+  });
+
+  it('falls back to the command default when the interaction has no subcommand', () => {
+    const command = makeCommand({
+      deferralMode: 'public',
+      subcommandDeferralModes: { set: 'modal' },
+    });
+    const interaction = makeInteraction({ subcommand: null, group: null });
+    expect(resolveEffectiveDeferralMode(command, asInteraction(interaction))).toBe('public');
+  });
+
+  it('falls back to the command default when subcommand introspection throws', () => {
+    // discord.js option getters throw on malformed/absent option payloads;
+    // getSubcommandPath treats that as "no subcommand path".
+    const command = makeCommand({
+      deferralMode: 'public',
+      subcommandDeferralModes: { set: 'modal' },
+    });
+    const interaction = makeInteraction();
+    interaction.options.getSubcommand = () => {
+      throw new Error('CommandInteractionOptionNotFound');
+    };
+    expect(resolveEffectiveDeferralMode(command, asInteraction(interaction))).toBe('public');
+  });
+
+  it('falls back to the command default when the subcommand has no override entry', () => {
+    const command = makeCommand({
+      deferralMode: 'none',
+      subcommandDeferralModes: { set: 'modal' },
+    });
+    const interaction = makeInteraction({ subcommand: 'view' });
+    expect(resolveEffectiveDeferralMode(command, asInteraction(interaction))).toBe('none');
+  });
+});
+
+describe('handleCommandWithContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replies ephemerally and skips dispatch when the command lookup came back empty', async () => {
+    // Reachable only via a stale registration (Discord offering a command the
+    // bot no longer loads) — the reply prevents "This interaction failed".
+    const interaction = makeInteraction({ commandName: 'ghost' });
+
+    await handleCommandWithContext(asInteraction(interaction), undefined);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'Unknown command!',
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+  });
+
+  it('defers EPHEMERAL by default and hands execute a context wired to the interaction', async () => {
+    const interaction = makeInteraction();
+    let seen: SafeCommandContext | undefined;
+    const execute = vi.fn().mockImplementation(async (context: SafeCommandContext) => {
+      seen = context;
+      // Seam assertion: what the command calls must reach the interaction.
+      await (context as { editReply: (o: unknown) => Promise<unknown> }).editReply({
+        content: 'from-command',
+      });
+    });
+    const command = makeCommand({ execute });
+
+    await handleCommandWithContext(asInteraction(interaction), command);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(seen).toBeDefined();
+    expect((seen as { isEphemeral: boolean }).isEphemeral).toBe(true);
+    expect(interaction.editReply).toHaveBeenCalledWith({ content: 'from-command' });
+  });
+
+  it("defers WITHOUT the ephemeral flag in 'public' mode", async () => {
+    const interaction = makeInteraction();
+    const execute = vi.fn().mockResolvedValue(undefined);
+    const command = makeCommand({ deferralMode: 'public', execute });
+
+    await handleCommandWithContext(asInteraction(interaction), command);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: undefined });
+    const context = execute.mock.calls[0][0] as { isEphemeral: boolean };
+    expect(context.isEphemeral).toBe(false);
+  });
+
+  it("does NOT defer in 'modal' mode and passes a modal context", async () => {
+    const interaction = makeInteraction();
+    const execute = vi.fn().mockImplementation(async (context: SafeCommandContext) => {
+      await (context as { showModal: (m: unknown) => Promise<unknown> }).showModal('modal-builder');
+    });
+    const command = makeCommand({ deferralMode: 'modal', execute });
+
+    await handleCommandWithContext(asInteraction(interaction), command);
+
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledTimes(1);
+    // Seam: the modal context's showModal forwards to the interaction
+    expect(interaction.showModal).toHaveBeenCalledWith('modal-builder');
+  });
+
+  it("does NOT defer in 'none' mode and passes a manual context", async () => {
+    const interaction = makeInteraction();
+    const execute = vi.fn().mockImplementation(async (context: SafeCommandContext) => {
+      await (context as { reply: (o: unknown) => Promise<unknown> }).reply({ content: 'manual' });
+    });
+    const command = makeCommand({ deferralMode: 'none', execute });
+
+    await handleCommandWithContext(asInteraction(interaction), command);
+
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).toHaveBeenCalledWith({ content: 'manual' });
+  });
+
+  it('routes a subcommand override through dispatch (modal subcommand of a deferred command)', async () => {
+    const interaction = makeInteraction({ subcommand: 'set' });
+    const execute = vi.fn().mockResolvedValue(undefined);
+    const command = makeCommand({
+      deferralMode: 'ephemeral',
+      subcommandDeferralModes: { set: 'modal' },
+      execute,
+    });
+
+    await handleCommandWithContext(asInteraction(interaction), command);
+
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips execute (and the error UX) when the defer itself fails', async () => {
+    const interaction = makeInteraction();
+    interaction.deferReply = vi.fn().mockRejectedValue(new Error('Unknown interaction'));
+    const execute = vi.fn().mockResolvedValue(undefined);
+    const command = makeCommand({ execute });
+
+    await expect(
+      handleCommandWithContext(asInteraction(interaction), command)
+    ).resolves.toBeUndefined();
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(interaction.editReply).not.toHaveBeenCalled();
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it('fills the deferral placeholder via editReply when execute throws', async () => {
+    const interaction = makeInteraction();
+    const command = makeCommand({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
+
+    await expect(
+      handleCommandWithContext(asInteraction(interaction), command)
+    ).resolves.toBeUndefined();
+
+    // deferred && !replied → editReply (fills "Thinking…"), not followUp
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ There was an error executing this command!',
+    });
+    expect(interaction.followUp).not.toHaveBeenCalled();
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it('routes an InfraError from execute to the transient copy', async () => {
+    const interaction = makeInteraction();
+    const command = makeCommand({
+      execute: vi
+        .fn()
+        .mockRejectedValue(new InfraError({ ok: false, kind: 'timeout', error: 't/o', status: 0 })),
+    });
+
+    await handleCommandWithContext(asInteraction(interaction), command);
+
+    const { content } = interaction.editReply.mock.calls[0][0] as { content: string };
+    expect(content).toContain("Couldn't reach the server");
+  });
+
+  it("replies ephemerally when execute throws in an unacked mode ('none')", async () => {
+    const interaction = makeInteraction();
+    const command = makeCommand({
+      deferralMode: 'none',
+      execute: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+
+    await handleCommandWithContext(asInteraction(interaction), command);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: '❌ There was an error executing this command!',
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('does not throw when the error reply itself fails', async () => {
+    const interaction = makeInteraction();
+    interaction.editReply = vi.fn().mockRejectedValue(new Error('already acknowledged'));
+    const command = makeCommand({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
+
+    await expect(
+      handleCommandWithContext(asInteraction(interaction), command)
+    ).resolves.toBeUndefined();
+  });
+
+  it('exercises every deferral mode without throwing', async () => {
+    const modes: DeferralMode[] = ['ephemeral', 'public', 'modal', 'none'];
+    for (const mode of modes) {
+      const interaction = makeInteraction();
+      const execute = vi.fn().mockResolvedValue(undefined);
+      await handleCommandWithContext(
+        asInteraction(interaction),
+        makeCommand({ deferralMode: mode, execute })
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/services/bot-client/src/handlers/commandDispatch.ts
+++ b/services/bot-client/src/handlers/commandDispatch.ts
@@ -1,0 +1,142 @@
+/**
+ * Chat-input (slash) command dispatch.
+ *
+ * Owns the whole path between "Discord delivered a chat-input interaction"
+ * and "the command's execute() ran":
+ *   1. resolve the effective deferral mode (command default, possibly
+ *      overridden per-subcommand; unset means 'ephemeral'),
+ *   2. ack accordingly (deferReply for the deferred modes, nothing for
+ *      'modal'/'none') and build the matching SafeCommandContext,
+ *   3. call execute(), and
+ *   4. deliver the top-level error UX when execute() throws — `replySpecSafe`
+ *      fills the deferral placeholder via editReply when the interaction is
+ *      deferred-but-unreplied, and replies ephemerally when it is unacked.
+ *
+ * Step 4 is the reason this is a module and not inline wiring: without it a
+ * throwing command strands the "Thinking…" placeholder forever.
+ */
+
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { CATALOG } from '../ux/catalog/catalog.js';
+import { replySpecSafe, topLevelErrorSpec } from '../ux/render/reply.js';
+import type { Command } from '../types.js';
+import {
+  createDeferredContext,
+  createModalContext,
+  createManualContext,
+  type DeferralMode,
+} from '../utils/commandContext/index.js';
+
+const logger = createLogger('CommandDispatch');
+
+/**
+ * Get the subcommand path for looking up deferral mode overrides.
+ * Returns 'group subcommand' for subcommand groups, or just 'subcommand' for simple subcommands.
+ */
+function getSubcommandPath(interaction: ChatInputCommandInteraction): string | null {
+  try {
+    const group = interaction.options.getSubcommandGroup(false);
+    const subcommand = interaction.options.getSubcommand(false);
+
+    if (group !== null && subcommand !== null) {
+      return `${group} ${subcommand}`;
+    }
+    return subcommand;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the effective deferral mode for a command/subcommand.
+ *
+ * Checks subcommandDeferralModes for overrides, falls back to deferralMode,
+ * and finally to 'ephemeral' when the command declares none.
+ */
+export function resolveEffectiveDeferralMode(
+  command: Command,
+  interaction: ChatInputCommandInteraction
+): DeferralMode {
+  const defaultMode = command.deferralMode ?? 'ephemeral';
+
+  // Check for subcommand-level override
+  if (command.subcommandDeferralModes !== undefined) {
+    const subcommandPath = getSubcommandPath(interaction);
+    if (subcommandPath !== null && subcommandPath in command.subcommandDeferralModes) {
+      return command.subcommandDeferralModes[subcommandPath];
+    }
+  }
+
+  return defaultMode;
+}
+
+/**
+ * Handle a command using the typed context pattern.
+ *
+ * Commands declare their deferralMode via defineCommand(), and receive a
+ * SafeCommandContext that doesn't expose deferReply() (for deferred modes),
+ * preventing InteractionAlreadyReplied errors at compile time.
+ *
+ * For commands with mixed subcommand requirements, subcommandDeferralModes
+ * allows per-subcommand overrides of the default deferral behavior.
+ */
+export async function handleCommandWithContext(
+  interaction: ChatInputCommandInteraction,
+  command: Command | undefined
+): Promise<void> {
+  // Reachable only via a stale registration (Discord offering a command the
+  // bot no longer loads) — ack it anyway so the user sees a reply instead of
+  // Discord's "This interaction failed".
+  if (command === undefined) {
+    logger.warn({ commandName: interaction.commandName }, 'Unknown command');
+    await interaction.reply({ content: 'Unknown command!', flags: MessageFlags.Ephemeral });
+    return;
+  }
+
+  // Resolve effective deferral mode (may be overridden per-subcommand)
+  const effectiveMode = resolveEffectiveDeferralMode(command, interaction);
+
+  try {
+    switch (effectiveMode) {
+      case 'ephemeral':
+      case 'public': {
+        // Defer appropriately
+        const isEphemeral = effectiveMode === 'ephemeral';
+        try {
+          await interaction.deferReply({
+            flags: isEphemeral ? MessageFlags.Ephemeral : undefined,
+          });
+        } catch (deferError) {
+          // A failed defer leaves nothing to reply to — log and bail out
+          // WITHOUT attempting the error UX below.
+          logger.error(
+            { err: deferError, command: interaction.commandName },
+            'Failed to defer interaction'
+          );
+          return;
+        }
+        // Create typed context (no deferReply method!)
+        await command.execute(createDeferredContext(interaction, isEphemeral));
+        break;
+      }
+
+      case 'modal': {
+        // Don't defer - command will show modal
+        await command.execute(createModalContext(interaction));
+        break;
+      }
+
+      case 'none': {
+        // Don't defer - command handles timing itself
+        await command.execute(createManualContext(interaction));
+        break;
+      }
+    }
+  } catch (error) {
+    logger.error({ err: error, commandName: interaction.commandName }, 'Error executing command');
+    await replySpecSafe(interaction, topLevelErrorSpec(error, CATALOG.error.commandFailed()), {
+      logContext: { commandName: interaction.commandName },
+    });
+  }
+}

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -1,11 +1,4 @@
-import {
-  Client,
-  GatewayIntentBits,
-  Events,
-  MessageFlags,
-  Partials,
-  type ChatInputCommandInteraction,
-} from 'discord.js';
+import { Client, GatewayIntentBits, Events, Partials } from 'discord.js';
 import { Queue, type Worker } from 'bullmq';
 import { Redis } from 'ioredis';
 import { getConfig } from '@tzurot/common-types/config/config';
@@ -30,6 +23,7 @@ import { WebhookManager } from './utils/WebhookManager.js';
 import { getServiceClient } from './utils/gatewayClients.js';
 import type { MessageHandler } from './handlers/MessageHandler.js';
 import { CommandHandler } from './handlers/CommandHandler.js';
+import { handleCommandWithContext } from './handlers/commandDispatch.js';
 import { redis as botRedis, closeRedis } from './redis.js';
 import { deployCommands } from './utils/deployCommands.js';
 import { respondToInteractionDuringMaintenance } from './utils/maintenanceResponses.js';
@@ -85,11 +79,6 @@ import {
   logGatewayHealthStatus,
 } from './startup.js';
 import { restoreBotPresence } from './commands/admin/presence.js';
-import {
-  createDeferredContext,
-  createModalContext,
-  createManualContext,
-} from './utils/commandContext/index.js';
 
 // Initialize logger
 const logger = createLogger('bot-client');
@@ -427,13 +416,6 @@ client.on(Events.InteractionCreate, interaction => {
       }
 
       if (interaction.isChatInputCommand()) {
-        // Get the command to determine its deferral mode
-        const command = commandHandler.getCommand(interaction.commandName);
-        if (command === undefined) {
-          logger.warn({ commandName: interaction.commandName }, 'Unknown command');
-          return;
-        }
-
         // Retention: pure-client commands (e.g. /help) render bot-side and never
         // reach the gateway, so stamp activity here for every chat-input command.
         // Fire-and-forget — the wrapper logs on failure and never throws; the
@@ -444,12 +426,16 @@ client.on(Events.InteractionCreate, interaction => {
           /* wrapper already logs; swallow so a rejection can't become unhandled */
         });
 
-        // All commands use the typed context pattern with deferralMode metadata
-        await handleCommandWithContext(interaction, command);
+        // The dispatcher owns the whole chat-input path, including the
+        // unknown-command reply when the lookup comes back empty.
+        await handleCommandWithContext(
+          interaction,
+          commandHandler.getCommand(interaction.commandName)
+        );
       } else if (interaction.isMessageContextMenuCommand()) {
         await commandHandler.handleContextMenuCommand(interaction);
       } else if (interaction.isModalSubmit()) {
-        await commandHandler.handleInteraction(interaction);
+        await commandHandler.handleModalInteraction(interaction);
       } else if (interaction.isAutocomplete()) {
         await commandHandler.handleAutocomplete(interaction);
       } else if (interaction.isStringSelectMenu() || interaction.isButton()) {
@@ -461,109 +447,6 @@ client.on(Events.InteractionCreate, interaction => {
     }
   })();
 });
-
-/**
- * Get the subcommand path for looking up deferral mode overrides.
- * Returns 'group subcommand' for subcommand groups, or just 'subcommand' for simple subcommands.
- */
-function getSubcommandPath(interaction: ChatInputCommandInteraction): string | null {
-  try {
-    const group = interaction.options.getSubcommandGroup(false);
-    const subcommand = interaction.options.getSubcommand(false);
-
-    if (group !== null && subcommand !== null) {
-      return `${group} ${subcommand}`;
-    }
-    return subcommand;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Resolve the effective deferral mode for a command/subcommand.
- *
- * Checks subcommandDeferralModes for overrides, falls back to deferralMode.
- */
-function resolveEffectiveDeferralMode(
-  command: import('./types.js').Command,
-  interaction: ChatInputCommandInteraction
-): import('./utils/commandContext/index.js').DeferralMode {
-  const defaultMode = command.deferralMode ?? 'ephemeral';
-
-  // Check for subcommand-level override
-  if (command.subcommandDeferralModes !== undefined) {
-    const subcommandPath = getSubcommandPath(interaction);
-    if (subcommandPath !== null && subcommandPath in command.subcommandDeferralModes) {
-      return command.subcommandDeferralModes[subcommandPath];
-    }
-  }
-
-  return defaultMode;
-}
-
-/**
- * Handle a command using the typed context pattern.
- *
- * Commands declare their deferralMode via defineCommand(), and receive a
- * SafeCommandContext that doesn't expose deferReply() (for deferred modes),
- * preventing InteractionAlreadyReplied errors at compile time.
- *
- * For commands with mixed subcommand requirements, subcommandDeferralModes
- * allows per-subcommand overrides of the default deferral behavior.
- */
-async function handleCommandWithContext(
-  interaction: ChatInputCommandInteraction,
-  command: import('./types.js').Command
-): Promise<void> {
-  // Resolve effective deferral mode (may be overridden per-subcommand)
-  const effectiveMode = resolveEffectiveDeferralMode(command, interaction);
-
-  // Type assertion: We dispatch the correct context type based on deferralMode,
-  // but TypeScript can't narrow the execute function signature at compile time.
-  // This is safe because we control both the context creation and the dispatch.
-  type ContextExecute = (
-    context: import('./utils/commandContext/index.js').SafeCommandContext
-  ) => Promise<void>;
-  const execute = command.execute as ContextExecute;
-
-  switch (effectiveMode) {
-    case 'ephemeral':
-    case 'public': {
-      // Defer appropriately
-      const isEphemeral = effectiveMode === 'ephemeral';
-      try {
-        await interaction.deferReply({
-          flags: isEphemeral ? MessageFlags.Ephemeral : undefined,
-        });
-      } catch (deferError) {
-        logger.error(
-          { err: deferError, command: interaction.commandName },
-          'Failed to defer interaction'
-        );
-        return;
-      }
-      // Create typed context (no deferReply method!)
-      const context = createDeferredContext(interaction, isEphemeral);
-      await execute(context);
-      break;
-    }
-
-    case 'modal': {
-      // Don't defer - command will show modal
-      const context = createModalContext(interaction);
-      await execute(context);
-      break;
-    }
-
-    case 'none': {
-      // Don't defer - command handles timing itself
-      const context = createManualContext(interaction);
-      await execute(context);
-      break;
-    }
-  }
-}
 
 // Ready event
 client.once(Events.ClientReady, () => {

--- a/services/bot-client/src/types.ts
+++ b/services/bot-client/src/types.ts
@@ -5,7 +5,6 @@
  */
 
 import type {
-  ChatInputCommandInteraction,
   ModalSubmitInteraction,
   AutocompleteInteraction,
   StringSelectMenuInteraction,
@@ -58,8 +57,8 @@ export interface Command {
    * - 'modal': Not deferred - command shows a modal first
    * - 'none': Not deferred - command handles response timing itself
    *
-   * When set, execute() receives a typed SafeCommandContext.
-   * When not set (legacy mode), execute() receives raw ChatInputCommandInteraction.
+   * Optional: when unset, the dispatcher defaults to 'ephemeral'. The mode
+   * determines which SafeCommandContext variant execute() receives.
    */
   deferralMode?: DeferralMode;
 
@@ -74,12 +73,10 @@ export interface Command {
   /**
    * Main command execution handler.
    *
-   * If deferralMode is set, receives a typed SafeCommandContext.
-   * Otherwise, receives raw ChatInputCommandInteraction (legacy mode).
+   * Always receives a typed SafeCommandContext — the dispatcher creates the
+   * variant matching the effective deferral mode before calling this.
    */
-  execute:
-    | ((interaction: ChatInputCommandInteraction) => Promise<void>)
-    | ((context: SafeCommandContext) => Promise<void>);
+  execute: (context: SafeCommandContext) => Promise<void>;
 
   /** Optional autocomplete handler for commands with autocomplete options */
   autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;

--- a/services/bot-client/src/utils/defineCommand.ts
+++ b/services/bot-client/src/utils/defineCommand.ts
@@ -9,17 +9,7 @@
  * CommandHandler looked for `handleModal`. The typo was silently ignored,
  * causing cryptic runtime errors. This pattern prevents that class of bug.
  *
- * Usage (legacy - receives raw interaction):
- * ```typescript
- * export default defineCommand({
- *   data: new SlashCommandBuilder().setName('ping').setDescription('Pong'),
- *   execute: async (interaction) => {
- *     await interaction.editReply('Pong!');
- *   },
- * });
- * ```
- *
- * Usage (new - receives typed context, compile-time safe):
+ * Usage:
  * ```typescript
  * export default defineCommand({
  *   data: new SlashCommandBuilder().setName('ping').setDescription('Pong'),
@@ -33,7 +23,6 @@
  */
 
 import type {
-  ChatInputCommandInteraction,
   ContextMenuCommandBuilder,
   MessageContextMenuCommandInteraction,
   ModalSubmitInteraction,
@@ -72,9 +61,9 @@ export interface CommandDefinition {
    * - 'modal': Not deferred - command shows a modal first
    * - 'none': Not deferred - command handles response timing itself
    *
-   * When set, the command's execute() receives a typed SafeCommandContext
-   * instead of raw ChatInputCommandInteraction. This enables compile-time
-   * prevention of InteractionAlreadyReplied errors.
+   * Optional: when unset, the dispatcher defaults to 'ephemeral'. The mode
+   * determines which SafeCommandContext variant execute() receives, which is
+   * what makes InteractionAlreadyReplied errors a compile-time failure.
    *
    * For commands with mixed subcommand modes, use `subcommandDeferralModes`
    * to override specific subcommands.
@@ -108,12 +97,10 @@ export interface CommandDefinition {
    * Main command execution handler.
    * Called when the slash command is invoked.
    *
-   * If deferralMode is set, receives a typed SafeCommandContext.
-   * Otherwise, receives raw ChatInputCommandInteraction (legacy mode).
+   * Always receives a typed SafeCommandContext — the dispatcher creates the
+   * variant matching the effective deferral mode before calling this.
    */
-  execute:
-    | ((interaction: ChatInputCommandInteraction) => Promise<void>)
-    | ((context: SafeCommandContext) => Promise<void>);
+  execute: (context: SafeCommandContext) => Promise<void>;
 
   /**
    * Autocomplete handler for commands with autocomplete options.

--- a/services/bot-client/src/ux/render/reply.test.ts
+++ b/services/bot-client/src/ux/render/reply.test.ts
@@ -8,10 +8,12 @@ import {
   followUpSpec,
   replySpec,
   replySpecSafe,
+  topLevelErrorSpec,
   type RepliableInteraction,
   type DeferUpdatableInteraction,
 } from './reply.js';
 import { CATALOG } from '../catalog/catalog.js';
+import { InfraError } from '@tzurot/clients';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -181,5 +183,24 @@ describe('replySpecSafe', () => {
     interaction.reply.mockRejectedValue(new Error('Unknown interaction'));
 
     await expect(replySpecSafe(interaction, CATALOG.error.commandFailed())).resolves.not.toThrow();
+  });
+});
+
+describe('topLevelErrorSpec', () => {
+  const fallback = CATALOG.error.commandFailed();
+
+  it('returns the transient shape for an InfraError (transient gateway failure)', () => {
+    const err = new InfraError({ ok: false, kind: 'timeout', error: 'timed out', status: 0 });
+    const spec = topLevelErrorSpec(err, fallback);
+    expect(spec.text).toContain('try again later');
+    expect(spec).not.toBe(fallback);
+  });
+
+  it('returns the surface-specific fallback for a non-infra Error', () => {
+    expect(topLevelErrorSpec(new Error('boom'), fallback)).toBe(fallback);
+  });
+
+  it('returns the fallback for a non-Error throwable', () => {
+    expect(topLevelErrorSpec('string error', fallback)).toBe(fallback);
   });
 });

--- a/services/bot-client/src/ux/render/reply.ts
+++ b/services/bot-client/src/ux/render/reply.ts
@@ -20,10 +20,25 @@ import {
   type StringSelectMenuInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { InfraError } from '@tzurot/clients';
+import { CATALOG } from '../catalog/catalog.js';
 import type { MessageSpec } from '../catalog/types.js';
 import { renderSpec, type RenderOptions } from './render.js';
 
 const logger = createLogger('ux-reply');
+
+/**
+ * Spec for a top-level command/interaction error. An `InfraError` (a gateway
+ * call failed for an infrastructure reason — timeout/network/5xx, surfaced
+ * via the Pattern-B result helpers in `@tzurot/clients`) gets the transient
+ * shape, so a blip never reads to the user as a definitive failure of the
+ * command. Everything else keeps the surface-specific fallback spec.
+ */
+export function topLevelErrorSpec(error: unknown, fallback: MessageSpec): MessageSpec {
+  return error instanceof InfraError
+    ? CATALOG.error.transient("Couldn't reach the server right now.")
+    : fallback;
+}
 
 /** Every repliable interaction shape the bot handles. */
 export type RepliableInteraction =


### PR DESCRIPTION
## Summary

TASK-413 (2026-08-03 drift audit). Every chat-input interaction is routed by `index.ts` through the typed-context dispatcher, which always passes a `SafeCommandContext` (`deferralMode` defaults to `'ephemeral'`). The `execute()` union's raw-interaction arm was therefore dead — and `defineCommand.ts`'s documented "legacy usage" example was a trap: a dev following it would receive a context object where the example promises an interaction.

- **Union collapse**: `Command.execute` / `CommandDefinition.execute` are now single-arm `(context: SafeCommandContext) => Promise<void>`; the legacy docblock example is gone and the `deferralMode` docs state the `'ephemeral'` default.
- **Dead dispatch removed**: `CommandHandler.handleInteraction`'s slash branch was unreachable (its only production caller was the modal-submit line in `index.ts`). The method is deleted; `handleModalInteraction` is now public and called directly.
- **Dispatch gets a home + tests**: `getSubcommandPath` / `resolveEffectiveDeferralMode` / `handleCommandWithContext` move from `index.ts` (where they were untestable) into `handlers/commandDispatch.ts`, dropping the now-unneeded `ContextExecute` assertion. New colocated suite: 17 tests.
- **Behavior change (deliberate, user-visible)**: the dead branch carried the top-level error UX the live path lacked — previously a throwing `execute()` fell through to a log-only catch, stranding the "Thinking…" placeholder forever. The dispatcher now delivers `replySpecSafe` + `topLevelErrorSpec` on throw: editReply fills the placeholder when deferred, ephemeral reply when unacked, `InfraError` routes to the transient copy. A failed defer still logs and bails without attempting an error reply.

## Review riders (rounds 1–3)

- **Coverage**: codecov's one uncovered line (`getSubcommandPath`'s catch) closed with a throwing-option-getter test.
- **`topLevelErrorSpec` relocated** to `ux/render/reply.ts` (reviewer observation: `CommandHandler.ts` is no longer the dispatch owner) — its tests moved to `reply.test.ts`; both callers import from the new home.
- **Unknown-command guard moved into the dispatcher**: previously `index.ts` logged and returned without acking, so a stale-registered command surfaced as Discord's "This interaction failed". The dispatcher now replies `Unknown command!` ephemerally (tested), mirroring the context-menu path.
- **Second behavioral delta (deliberate)**: `stampUserActivity` now fires for every chat-input interaction, including unknown-command ones — previously the early return skipped it. The user did interact, so stamping is the more correct behavior; the stamp is an idempotent NOW-write.

## Verification

- `pnpm test` green repo-wide (bot-client 389 files / 6009 tests); `pnpm quality` green; pre-push gate green.
- `typecheck` + `typecheck:spec` clean — the collapse surfaced zero raw-interaction executes, confirming the audit's claim that all command modules already use the context pattern.
- `CommandHandler.component.test.ts` 23/23 with **no snapshot changes** — command structure untouched.
- New `commandDispatch.test.ts` asserts across the seams with real collaborators: context methods forward to the interaction (editReply/showModal/reply per mode), and the error-UX cases run the real `replySpecSafe`/`CATALOG` (deferred→editReply, unacked→ephemeral reply, InfraError→transient copy, error-reply-failure swallowed, defer-failure skips execute).
- Sweep: no `LegacyExecute` / legacy-mode references survive in src (one true-contrast sentence in `subcommandContextRouter.ts` retained deliberately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
