### PR TITLE
refactor(api-gateway): retire the dead pre-cutover router-factory tier

### DIFF
--- a/services/api-gateway/src/routes/_generated/mounts.component.test.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.component.test.ts
@@ -115,6 +115,89 @@ describe('mounts.ts — audience-prefix routing', () => {
     });
   });
 
+  // The two blocks below pin per-route invariants that used to be asserted by
+  // structural router-stack tests in the route files themselves. Those tests
+  // inspected a pre-cutover route factory; the manifest + these mounts own the
+  // wiring now, so the assertions belong here, at the level that decides it.
+
+  describe('diagnostic routes — split across two audiences', () => {
+    // The diagnostic reads are user-audience (any authenticated user, filtered
+    // server-side to their own rows; the owner sees everything), while the
+    // response-ids write is a service-to-service call from bot-client with no
+    // human actor. Swapping those two audiences would silently either lock
+    // bot-client out of the write or expose the write to any Discord user, and
+    // neither shows up as a 404, so each route is probed by identity of gate.
+    it.each([
+      '/api/user/diagnostic/recent',
+      '/api/user/diagnostic/by-message/1234567890123456789',
+      '/api/user/diagnostic/by-response/1234567890123456789',
+      '/api/user/diagnostic/some-request-id',
+    ])('rejects unauthenticated GET %s with 401', async path => {
+      const res = await request(app).get(path);
+      // 401 proves requireUserAuth() is wired on the route: without it the
+      // request would reach the handler and fail some other way.
+      expect(res.status).toBe(401);
+    });
+
+    it('does not gate PATCH /api/internal/diagnostic/:requestId/response-ids on user auth', async () => {
+      const res = await request(app)
+        .patch('/api/internal/diagnostic/req-123/response-ids')
+        .send({});
+      // Mounted (≠ 404) and NOT behind user auth (≠ 401) — the internal
+      // audience carries no user middleware; the shared service secret is
+      // enforced globally in index.ts. The empty body then trips the handler's
+      // own Zod parse and answers 400, which is what makes these negative
+      // assertions load-bearing rather than vacuous; the 400 itself is
+      // behavior covered by admin/diagnostic.test.ts, so it isn't pinned here.
+      // ≠ 403 closes the remaining gate shape: an auth layer rejecting the
+      // no-user call outright would break bot-client's delivery write.
+      expect(res.status).not.toBe(404);
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  describe('admin-settings — one handler, two mounts with different gates', () => {
+    // handleGetAdminSettings is mounted twice on purpose: bot-client hydrates
+    // its admin-settings cache at startup with no Discord actor, so the read
+    // needs an ungated internal alias; the same read under /api/admin is
+    // owner-only. Collapsing either mount into the other breaks one of the two
+    // callers, so both halves are pinned.
+    it('serves the internal read without user auth', async () => {
+      const res = await request(app).get('/api/internal/admin-settings');
+      // The handler is reached and dies on the inert stub prisma (500), which
+      // is the proof there is no user gate in front of it — a gated route
+      // would have short-circuited to 401 or 403 before touching prisma. The
+      // ≠ 403 arm matters most: isAuthorizedForRead rejecting the no-userId
+      // call is exactly the regression that locks bot-client out of its
+      // startup cache hydration.
+      expect(res.status).not.toBe(404);
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(403);
+    });
+
+    it('rejects the unauthenticated admin read with 401', async () => {
+      const res = await request(app).get('/api/admin/settings');
+      expect(res.status).toBe(401);
+    });
+
+    // A caller that presents an identity clears requireUserAuth and lands on
+    // requireOwnerAuth, which answers 403 for a non-owner. Asserting both codes
+    // per route is what distinguishes "user auth only" from "user + owner auth"
+    // — a route missing the owner gate would answer something other than 403.
+    it.each([
+      { method: 'get' as const, path: '/api/admin/settings' },
+      { method: 'patch' as const, path: '/api/admin/settings/config-defaults' },
+      { method: 'delete' as const, path: '/api/admin/settings/config-defaults' },
+    ])('gates $method $path behind user auth then owner auth', async ({ method, path }) => {
+      const unauthenticated = await request(app)[method](path).send({});
+      expect(unauthenticated.status).toBe(401);
+
+      const nonOwner = await request(app)[method](path).set('X-User-Id', 'not-the-owner').send({});
+      expect(nonOwner.status).toBe(403);
+    });
+  });
+
   describe('unmounted prefixes', () => {
     it('returns 404 for unmounted paths', async () => {
       const res = await request(app).get('/some/random/path');

--- a/services/api-gateway/src/routes/admin/broadcast.ts
+++ b/services/api-gateway/src/routes/admin/broadcast.ts
@@ -1,5 +1,5 @@
 /**
- * POST /admin/broadcast
+ * POST /api/admin/broadcast
  * Owner-only DM blast through the release-broadcast pipeline.
  * Dry-run resolves eligible recipients without writing or enqueueing anything.
  */

--- a/services/api-gateway/src/routes/admin/cleanup.test.ts
+++ b/services/api-gateway/src/routes/admin/cleanup.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createCleanupRoute } from './cleanup.js';
+import { handleCleanup } from './cleanup.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { ConversationRetentionService } from '@tzurot/conversation-history';
 import type { RouteDeps } from '../routeDeps.js';
@@ -27,15 +27,7 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-// Mock requireOwnerAuth to allow requests through in tests
-vi.mock('../../services/AuthMiddleware.js', () => ({
-  requireOwnerAuth:
-    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => {
-      next();
-    },
-}));
-
-describe('Admin Cleanup Routes', () => {
+describe('Admin Cleanup Route', () => {
   let mockService: {
     cleanupOldHistory: ReturnType<typeof vi.fn>;
     cleanupSoftDeletedMessages: ReturnType<typeof vi.fn>;
@@ -57,7 +49,7 @@ describe('Admin Cleanup Routes', () => {
     };
     app = express();
     app.use(express.json());
-    app.use('/admin/cleanup', createCleanupRoute(deps));
+    app.post('/admin/cleanup', handleCleanup(deps));
     // Add error handler for debugging
     app.use(
       (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/services/api-gateway/src/routes/admin/cleanup.ts
+++ b/services/api-gateway/src/routes/admin/cleanup.ts
@@ -1,12 +1,11 @@
 /**
- * POST /admin/cleanup
+ * POST /api/admin/cleanup
  * Manually trigger cleanup of old conversation history.
  */
 
-import { Router, type Request, type RequestHandler, type Response } from 'express';
+import { type Request, type RequestHandler, type Response } from 'express';
 import { CLEANUP_DEFAULTS } from '@tzurot/common-types/constants/timing';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -28,9 +27,8 @@ function buildCleanupMessage(historyDeleted: number, daysToKeep: number): string
 
 /**
  * POST /api/admin/cleanup — named handler export. Returns 503 if the
- * retention service wasn't wired. The legacy aggregator gates
- * conditionally so this branch is only reachable when the route is
- * mounted unconditionally.
+ * retention service wasn't wired: the route is mounted unconditionally,
+ * so a missing dep has to degrade at request time rather than at mount.
  */
 export const handleCleanup = (deps: RouteDeps): RequestHandler => {
   const { retentionService } = deps;
@@ -78,14 +76,3 @@ export const handleCleanup = (deps: RouteDeps): RequestHandler => {
     });
   });
 };
-
-/**
- * Legacy factory for the `/admin/cleanup` mount. Wraps the named
- * handler with per-route middleware for callers that haven't yet
- * migrated to the bare handler export.
- */
-export function createCleanupRoute(deps: RouteDeps): Router {
-  const router = Router();
-  router.post('/', requireOwnerAuth(), handleCleanup(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/configResponseContract.test.ts
+++ b/services/api-gateway/src/routes/admin/configResponseContract.test.ts
@@ -14,8 +14,8 @@
  * and the TTS-global flows — but every unit test mocked above the validation
  * boundary, so nothing failed.
  *
- * Strategy: mount the REAL route aggregators with a mocked Prisma (so the real
- * service + formatter run), drive each endpoint through supertest, and assert
+ * Strategy: mount the REAL handlers with a mocked Prisma (so the real service +
+ * formatter run), drive each endpoint through supertest, and assert
  * the emitted body parses against `ROUTE_MANIFEST[id].output` — the same schema
  * the generated client validates with. LIST / GET / CREATE / UPDATE — every
  * config-emitting admin verb — is covered for both resources.
@@ -41,8 +41,19 @@ vi.mock('../../utils/llmConfigValidation.js', () => ({
   validateLlmConfigModelFields: vi.fn().mockResolvedValue(true),
 }));
 
-import { createAdminLlmConfigRoutes } from './llm-config.js';
-import { createAdminTtsConfigRoutes } from './tts-config.js';
+import {
+  handleCreateGlobalLlmConfig,
+  handleGetGlobalLlmConfig,
+  handleListGlobalLlmConfigs,
+  handleUpdateGlobalLlmConfig,
+} from './llm-config.js';
+import {
+  handleCreateGlobalTtsConfig,
+  handleGetGlobalTtsConfig,
+  handleListGlobalTtsConfigs,
+  handleUpdateGlobalTtsConfig,
+} from './tts-config.js';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 // A valid RFC-4122 UUID — `LlmConfigSummarySchema.id` / `TtsConfigSummarySchema.id`
@@ -108,7 +119,11 @@ describe('Admin LLM config response contract', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/admin/llm-config', createAdminLlmConfigRoutes({ ...stubRouteResolvers(), prisma }));
+    const deps = { ...stubRouteResolvers(), prisma };
+    app.get('/admin/llm-config', requireOwnerAuth(), handleListGlobalLlmConfigs(deps));
+    app.post('/admin/llm-config', requireOwnerAuth(), handleCreateGlobalLlmConfig(deps));
+    app.get('/admin/llm-config/:id', requireOwnerAuth(), handleGetGlobalLlmConfig(deps));
+    app.put('/admin/llm-config/:id', requireOwnerAuth(), handleUpdateGlobalLlmConfig(deps));
   });
 
   it('GET /admin/llm-config satisfies listGlobalLlmConfigs output schema', async () => {
@@ -178,7 +193,11 @@ describe('Admin TTS config response contract', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/admin/tts-config', createAdminTtsConfigRoutes({ ...stubRouteResolvers(), prisma }));
+    const deps = { ...stubRouteResolvers(), prisma };
+    app.get('/admin/tts-config', requireOwnerAuth(), handleListGlobalTtsConfigs(deps));
+    app.post('/admin/tts-config', requireOwnerAuth(), handleCreateGlobalTtsConfig(deps));
+    app.get('/admin/tts-config/:id', requireOwnerAuth(), handleGetGlobalTtsConfig(deps));
+    app.put('/admin/tts-config/:id', requireOwnerAuth(), handleUpdateGlobalTtsConfig(deps));
   });
 
   it('GET /admin/tts-config satisfies listGlobalTtsConfigs output schema', async () => {

--- a/services/api-gateway/src/routes/admin/createPersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.test.ts
@@ -5,18 +5,22 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
-import { createCreatePersonalityRoute } from './createPersonality.js';
+import { handleCreateGlobalPersonality } from './createPersonality.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { CacheInvalidationService } from '@tzurot/cache-invalidation';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
-// Mock AuthMiddleware
-vi.mock('../../services/AuthMiddleware.js', () => ({
-  requireOwnerAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
-    req.userId = 'admin-discord-id'; // Set admin user ID
+/**
+ * Stand-in for the owner-auth middleware applied at the mount site in
+ * routes/_generated/mounts.ts: the handler reads `req.userId` to resolve the
+ * owning admin user, so the tests have to populate it.
+ */
+function stubOwnerIdentity(app: Express): void {
+  app.use((req, _res, next) => {
+    (req as express.Request & { userId: string }).userId = 'admin-discord-id';
     next();
-  },
-}));
+  });
+}
 
 // Mock imageProcessor
 vi.mock('../../utils/imageProcessor.js', () => ({
@@ -63,12 +67,13 @@ describe('POST /admin/personality', () => {
     // Default: admin user exists (required for ownerId)
     prisma.user.findUnique.mockResolvedValue({ id: 'admin-user-id' });
 
-    // Create Express app with create personality router
+    // Create Express app with the create-personality handler
     app = express();
     app.use(express.json());
-    app.use(
+    stubOwnerIdentity(app);
+    app.post(
       '/admin/personality',
-      createCreatePersonalityRoute({
+      handleCreateGlobalPersonality({
         ...stubRouteResolvers(),
         prisma: prisma as unknown as PrismaClient,
       })
@@ -679,9 +684,10 @@ describe('POST /admin/personality', () => {
       // Create new app with cache service
       const appWithCache = express();
       appWithCache.use(express.json());
-      appWithCache.use(
+      stubOwnerIdentity(appWithCache);
+      appWithCache.post(
         '/admin/personality',
-        createCreatePersonalityRoute({
+        handleCreateGlobalPersonality({
           ...stubRouteResolvers(),
           prisma: prisma as unknown as PrismaClient,
           cacheInvalidationService: mockCacheService,
@@ -737,9 +743,10 @@ describe('POST /admin/personality', () => {
 
       const appWithCache = express();
       appWithCache.use(express.json());
-      appWithCache.use(
+      stubOwnerIdentity(appWithCache);
+      appWithCache.post(
         '/admin/personality',
-        createCreatePersonalityRoute({
+        handleCreateGlobalPersonality({
           ...stubRouteResolvers(),
           prisma: prisma as unknown as PrismaClient,
           cacheInvalidationService: mockCacheService,
@@ -795,9 +802,10 @@ describe('POST /admin/personality', () => {
 
       const appWithCache = express();
       appWithCache.use(express.json());
-      appWithCache.use(
+      stubOwnerIdentity(appWithCache);
+      appWithCache.post(
         '/admin/personality',
-        createCreatePersonalityRoute({
+        handleCreateGlobalPersonality({
           ...stubRouteResolvers(),
           prisma: prisma as unknown as PrismaClient,
           cacheInvalidationService: mockCacheService,

--- a/services/api-gateway/src/routes/admin/createPersonality.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.ts
@@ -1,9 +1,9 @@
 /**
- * POST /admin/personality
+ * POST /api/admin/personality
  * Create a new AI personality
  */
 
-import { Router, type RequestHandler, type Response } from 'express';
+import { type RequestHandler, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   AdminPersonalityResponseSchema,
@@ -14,7 +14,6 @@ import { type Prisma } from '@tzurot/common-types/services/prisma';
 import { generatePersonalityUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type CacheInvalidationService } from '@tzurot/cache-invalidation';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendContractSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -188,9 +187,3 @@ export const handleCreateGlobalPersonality = (deps: RouteDeps): RequestHandler =
     );
   });
 };
-
-export function createCreatePersonalityRoute(deps: RouteDeps): Router {
-  const router = Router();
-  router.post('/', requireOwnerAuth(), handleCreateGlobalPersonality(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/dbSync.test.ts
+++ b/services/api-gateway/src/routes/admin/dbSync.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { createDbSyncRoute } from './dbSync.js';
+import { handleDbSync } from './dbSync.js';
 import type { RouteDeps } from '../routeDeps.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
@@ -46,26 +46,19 @@ vi.mock('@tzurot/common-types/services/prisma', async () => {
   };
 });
 
-// Mock AuthMiddleware
-vi.mock('../../services/AuthMiddleware.js', () => ({
-  requireOwnerAuth: () => (_req: unknown, _res: unknown, next: () => void) => {
-    next(); // Bypass auth for testing
-  },
-}));
-
-describe('POST /admin/db-sync', () => {
+describe('POST /api/admin/db-sync', () => {
   let app: Express;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Create Express app with db-sync router. dbSync doesn't actually
+    // Create Express app with the db-sync handler. dbSync doesn't actually
     // use deps.prisma at runtime (it constructs its own clients from
     // env-var URLs), so a minimal cast satisfies the type contract.
     const deps = { prisma: {} as PrismaClient, ...stubRouteResolvers() } satisfies RouteDeps;
     app = express();
     app.use(express.json());
-    app.use('/admin/db-sync', createDbSyncRoute(deps));
+    app.post('/admin/db-sync', handleDbSync(deps));
   });
 
   it('should perform database sync successfully', async () => {

--- a/services/api-gateway/src/routes/admin/dbSync.ts
+++ b/services/api-gateway/src/routes/admin/dbSync.ts
@@ -1,9 +1,9 @@
 /**
- * POST /admin/db-sync
+ * POST /api/admin/db-sync
  * Bidirectional database synchronization between dev and prod
  */
 
-import { Router, type Request, type RequestHandler, type Response } from 'express';
+import { type Request, type RequestHandler, type Response } from 'express';
 import { getConfig } from '@tzurot/common-types/config/config';
 import { DbSyncSchema } from '@tzurot/common-types/schemas/api/admin';
 import { transientPoolOptions } from '@tzurot/common-types/services/poolConfig';
@@ -11,7 +11,6 @@ import { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { DatabaseSyncService } from '../../services/DatabaseSyncService.js';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -24,8 +23,7 @@ const logger = createLogger('admin-db-sync');
  * POST /api/admin/db-sync — named handler export consumed by the
  * generated mounts.ts codegen. The returned `RequestHandler` is
  * composition-ready; middleware (auth, rate limiters) is applied by
- * the caller — at the prefix mount for codegen-driven routes, or
- * per-route for the legacy factory below.
+ * the caller at the mount site.
  */
 export const handleDbSync = (_deps: RouteDeps): RequestHandler =>
   asyncHandler(async (req: Request, res: Response) => {
@@ -81,14 +79,3 @@ export const handleDbSync = (_deps: RouteDeps): RequestHandler =>
       timestamp: new Date().toISOString(),
     });
   });
-
-/**
- * Legacy factory for the `/admin/db-sync` mount. Wraps the named
- * handler with the per-route middleware for callers that haven't
- * yet migrated to the bare handler export.
- */
-export function createDbSyncRoute(deps: RouteDeps): Router {
-  const router = Router();
-  router.post('/', requireOwnerAuth(), handleDbSync(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/diagnostic.test.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.test.ts
@@ -10,12 +10,18 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createDiagnosticRoutes } from './diagnostic.js';
+import {
+  handleGetDiagnosticByMessage,
+  handleGetDiagnosticByRequestId,
+  handleGetDiagnosticByResponse,
+  handleGetRecentDiagnostics,
+  handleUpdateDiagnosticResponseIds,
+} from './diagnostic.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { DiagnosticPayload } from '@tzurot/common-types/types/diagnostic';
 import express from 'express';
 import request from 'supertest';
-import { findRoute, getAllRoutes } from '../../test/expressRouterUtils.js';
+import { requireServiceAuth, requireUserAuth } from '../../services/AuthMiddleware.js';
 
 /** Configurable userId injected by the mocked requireUserAuth — flip per test. */
 let mockCallerUserId = 'admin-discord-id';
@@ -50,11 +56,9 @@ vi.mock('@tzurot/common-types/utils/ownerMiddleware', async () => {
   };
 });
 
-// Mock AuthMiddleware — auth gating runs unconditionally in tests. Each mock
-// stamps a unique marker on the request so the route-registration test can
-// verify which middleware is wired to each route by identity (not just by
-// stack depth). requireUserAuth injects mockCallerUserId for the
-// isBotOwner branching in the route handlers.
+// Mock AuthMiddleware — auth gating runs unconditionally in tests.
+// requireUserAuth injects mockCallerUserId for the isBotOwner branching in
+// the route handlers.
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth:
     () => (req: { userId?: string; __authMarker?: string }, _res: unknown, next: () => void) => {
@@ -69,57 +73,6 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
 }));
 
 describe('Admin Diagnostic Routes', () => {
-  describe('middleware composition', () => {
-    it('wires an auth middleware on every route', () => {
-      // GET routes get requireUserAuth (with server-side userId filtering for
-      // non-owners); PATCH gets requireServiceAuth (internal call only).
-      // The structural test only inspects the resulting router stack length.
-      const routes = getAllRoutes(createDiagnosticRoutes({} as unknown as PrismaClient));
-      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
-      for (const route of routes) {
-        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
-          2
-        );
-      }
-    });
-
-    // Structural stack-length is not enough — accidentally swapping
-    // requireServiceAuth and requireUserAuth would keep stack depth the same
-    // but flip which authentication contract guards each route. The mocks set
-    // a distinct `__authMarker` on the request so we can verify which
-    // middleware is actually registered at each route by identity.
-    it('wires requireUserAuth on GET routes and requireServiceAuth on PATCH', () => {
-      const router = createDiagnosticRoutes({} as unknown as PrismaClient);
-
-      const expectations: { method: 'get' | 'patch'; path: string; marker: string }[] = [
-        { method: 'get', path: '/recent', marker: 'user' },
-        { method: 'get', path: '/by-message/:messageId', marker: 'user' },
-        { method: 'get', path: '/by-response/:messageId', marker: 'user' },
-        { method: 'get', path: '/:requestId', marker: 'user' },
-        { method: 'patch', path: '/:requestId/response-ids', marker: 'service' },
-      ];
-
-      for (const { method, path, marker } of expectations) {
-        const layer = findRoute(router, method, path);
-        if (layer?.route === undefined) {
-          throw new Error(`Expected route registered: ${method.toUpperCase()} ${path}`);
-        }
-        // The first stack entry is the auth middleware; the last is the
-        // route handler. We invoke the auth middleware directly with a
-        // synthetic req so it stamps its marker.
-        const authMiddleware = layer.route.stack[0].handle;
-        const req: { __authMarker?: string; userId?: string } = {};
-        const next = vi.fn();
-        authMiddleware(req, {} as object, next);
-        expect(
-          req.__authMarker,
-          `${method.toUpperCase()} ${path} wired wrong auth middleware`
-        ).toBe(marker);
-        expect(next).toHaveBeenCalled();
-      }
-    });
-  });
-
   let mockPrisma: {
     llmDiagnosticLog: {
       findMany: ReturnType<typeof vi.fn>;
@@ -211,7 +164,30 @@ describe('Admin Diagnostic Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/admin/diagnostic', createDiagnosticRoutes(mockPrisma as unknown as PrismaClient));
+    // Registration order mirrors routes/_generated/mounts.ts: the `/by-*`
+    // literals precede `/:requestId` so the param doesn't shadow them.
+    const deps = { prisma: mockPrisma as unknown as PrismaClient };
+    app.get('/admin/diagnostic/recent', requireUserAuth(), handleGetRecentDiagnostics(deps));
+    app.get(
+      '/admin/diagnostic/by-message/:messageId',
+      requireUserAuth(),
+      handleGetDiagnosticByMessage(deps)
+    );
+    app.get(
+      '/admin/diagnostic/by-response/:messageId',
+      requireUserAuth(),
+      handleGetDiagnosticByResponse(deps)
+    );
+    app.get(
+      '/admin/diagnostic/:requestId',
+      requireUserAuth(),
+      handleGetDiagnosticByRequestId(deps)
+    );
+    app.patch(
+      '/admin/diagnostic/:requestId/response-ids',
+      requireServiceAuth(),
+      handleUpdateDiagnosticResponseIds(deps)
+    );
   });
 
   describe('GET /admin/diagnostic/recent', () => {

--- a/services/api-gateway/src/routes/admin/diagnostic.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.ts
@@ -16,15 +16,14 @@
  * prompt construction issues.
  */
 
-import { Router, type Response, type Request, type RequestHandler } from 'express';
+import { type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { isValidUUID } from '@tzurot/common-types/constants/service';
 import { DiagnosticUpdateSchema } from '@tzurot/common-types/schemas/api/admin';
-import { Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { Prisma } from '@tzurot/common-types/services/prisma';
 import { type DiagnosticPayload } from '@tzurot/common-types/types/diagnostic';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
-import { requireServiceAuth, requireUserAuth } from '../../services/AuthMiddleware.js';
 import type { AuthenticatedRequest } from '../../types.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -393,6 +392,18 @@ export const handleGetDiagnosticByResponse = (deps: DiagnosticDeps): RequestHand
  * Handler: PATCH /api/internal/diagnostic/:requestId/response-ids
  * Update the response message IDs for a diagnostic log
  * Called by bot-client after sending response to Discord
+ *
+ * Auth: mounted under `/api/internal`, so `requireServiceAuth()` (the shared
+ * INTERNAL_SERVICE_SECRET) gates it rather than a user identity — no human
+ * user is involved.
+ *
+ * Trust assumption: any holder of INTERNAL_SERVICE_SECRET can overwrite
+ * responseMessageIds on any diagnostic row by requestId. In practice
+ * bot-client is the only legitimate caller, and it only PATCHes requestIds it
+ * generated itself — so the realistic blast radius is "if the service secret
+ * leaks, an attacker can corrupt diagnostic response-id arrays." It cannot
+ * create phantom rows (prisma.update throws P2025 on a missing row) and it
+ * cannot read another user's data through this route.
  */
 export const handleUpdateDiagnosticResponseIds = (deps: DiagnosticDeps): RequestHandler => {
   const { prisma } = deps;
@@ -433,54 +444,3 @@ export const handleUpdateDiagnosticResponseIds = (deps: DiagnosticDeps): Request
     }
   });
 };
-
-/**
- * Create diagnostic routes with injected dependencies
- * @param prisma - Prisma client for database operations
- */
-export function createDiagnosticRoutes(prisma: PrismaClient): Router {
-  const router = Router();
-
-  // GET routes use requireUserAuth — any authenticated user can call /inspect.
-  // Each handler then filters by userId for non-owners (server-side filtering,
-  // not client-side, so other users' diagnostic payloads never cross the
-  // service boundary). The bot owner sees all logs unfiltered.
-  //
-  // Service-secret enforcement is provided by the global `requireServiceAuth`
-  // mounted in `index.ts` ahead of route mounting — `requireUserAuth` alone
-  // does NOT validate the shared secret. If these routes are ever extracted
-  // to a sub-app or alternate mount that bypasses the global guard, callers
-  // could query diagnostic logs with only `X-User-Id`. The queued adminFetch /
-  // route-prefix refactor addresses this structurally via explicit prefix
-  // semantics (`/api/internal`, `/api/admin`, `/api/user`).
-  router.get('/recent', requireUserAuth(), handleGetRecentDiagnostics({ prisma }));
-  router.get('/by-message/:messageId', requireUserAuth(), handleGetDiagnosticByMessage({ prisma }));
-  router.get(
-    '/by-response/:messageId',
-    requireUserAuth(),
-    handleGetDiagnosticByResponse({ prisma })
-  );
-  // Note: /:requestId must come after /by-* routes to avoid matching 'by-message' as a requestId
-  router.get('/:requestId', requireUserAuth(), handleGetDiagnosticByRequestId({ prisma }));
-
-  // PATCH is an internal call from bot-client to api-gateway after AI response
-  // delivery — no human user is involved. requireServiceAuth() validates
-  // X-Service-Auth (the shared service secret) rather than gating on a user.
-  //
-  // Trust assumption: any holder of INTERNAL_SERVICE_SECRET can overwrite
-  // responseMessageIds on any diagnostic log row by requestId. In practice
-  // bot-client is the only legitimate caller, and it only PATCHes requestIds
-  // it generated itself — so the realistic blast radius is "if the service
-  // secret leaks, attacker can corrupt diagnostic row response-id arrays."
-  // Cannot create phantom rows (prisma.update throws P2025 on missing).
-  // Cannot read other users' data via this route. The queued adminFetch /
-  // route-prefix refactor will make this trust contract explicit by giving
-  // service-only routes a distinct prefix and middleware path.
-  router.patch(
-    '/:requestId/response-ids',
-    requireServiceAuth(),
-    handleUpdateDiagnosticResponseIds({ prisma })
-  );
-
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/invalidateCache.test.ts
+++ b/services/api-gateway/src/routes/admin/invalidateCache.test.ts
@@ -6,16 +6,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { createInvalidateCacheRoute } from './invalidateCache.js';
+import { handleInvalidateCache } from './invalidateCache.js';
 import type { RouteDeps } from '../routeDeps.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
-
-// Mock AuthMiddleware
-vi.mock('../../services/AuthMiddleware.js', () => ({
-  requireOwnerAuth: () => (_req: unknown, _res: unknown, next: () => void) => {
-    next(); // Bypass auth for testing
-  },
-}));
 
 // Create mock CacheInvalidationService
 const createMockCacheInvalidationService = () => ({
@@ -26,7 +19,7 @@ const createMockCacheInvalidationService = () => ({
   unsubscribe: vi.fn().mockResolvedValue(undefined),
 });
 
-describe('POST /admin/invalidate-cache', () => {
+describe('POST /api/admin/invalidate-cache', () => {
   let app: Express;
   let cacheInvalidationService: ReturnType<typeof createMockCacheInvalidationService>;
 
@@ -36,7 +29,7 @@ describe('POST /admin/invalidate-cache', () => {
     // Create mock cache invalidation service
     cacheInvalidationService = createMockCacheInvalidationService();
 
-    // Create Express app with invalidate cache router
+    // Create Express app with the invalidate-cache handler
     const deps: RouteDeps = {
       ...stubRouteResolvers(),
       prisma: {} as PrismaClient,
@@ -45,7 +38,7 @@ describe('POST /admin/invalidate-cache', () => {
     };
     app = express();
     app.use(express.json());
-    app.use('/admin/invalidate-cache', createInvalidateCacheRoute(deps));
+    app.post('/admin/invalidate-cache', handleInvalidateCache(deps));
   });
 
   it('should invalidate specific personality cache', async () => {

--- a/services/api-gateway/src/routes/admin/invalidateCache.ts
+++ b/services/api-gateway/src/routes/admin/invalidateCache.ts
@@ -1,12 +1,11 @@
 /**
- * POST /admin/invalidate-cache
+ * POST /api/admin/invalidate-cache
  * Manually trigger cache invalidation for personality configurations
  */
 
-import { Router, type Request, type RequestHandler, type Response } from 'express';
+import { type Request, type RequestHandler, type Response } from 'express';
 import { InvalidateCacheSchema } from '@tzurot/common-types/schemas/api/admin';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -57,9 +56,3 @@ export const handleInvalidateCache = (deps: RouteDeps): RequestHandler => {
     }
   });
 };
-
-export function createInvalidateCacheRoute(deps: RouteDeps): Router {
-  const router = Router();
-  router.post('/', requireOwnerAuth(), handleInvalidateCache(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -5,11 +5,20 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
-import { createAdminLlmConfigRoutes } from './llm-config.js';
+import {
+  handleCreateGlobalLlmConfig,
+  handleDeleteGlobalLlmConfig,
+  handleGetGlobalLlmConfig,
+  handleListGlobalLlmConfigs,
+  handleSetGlobalLlmConfigDefault,
+  handleSetGlobalLlmConfigFreeDefault,
+  handleUpdateGlobalLlmConfig,
+} from './llm-config.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
-import { getAllRoutes } from '../../test/expressRouterUtils.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 // Mock the admin auth middleware
 vi.mock('../../services/AuthMiddleware.js', () => ({
@@ -97,24 +106,31 @@ const createMockPrismaClient = () => {
   };
 };
 
-describe('Admin LLM Config Routes', () => {
-  describe('middleware composition', () => {
-    it('wires requireOwnerAuth on every route', () => {
-      const routes = getAllRoutes(
-        createAdminLlmConfigRoutes({
-          prisma: {} as unknown as PrismaClient,
-          ...stubRouteResolvers(),
-        })
-      );
-      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
-      for (const route of routes) {
-        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
-          2
-        );
-      }
-    });
-  });
+/**
+ * Register the admin LLM-config handlers at the paths
+ * routes/_generated/mounts.ts serves them from. Owner auth is applied at the
+ * mount site there too; here the mocked `requireOwnerAuth` stands in and
+ * seeds `req.userId`, which the write handlers read to resolve the owner row.
+ */
+function mountAdminLlmConfig(app: express.Express, deps: RouteDeps): void {
+  app.get('/admin/llm-config', requireOwnerAuth(), handleListGlobalLlmConfigs(deps));
+  app.post('/admin/llm-config', requireOwnerAuth(), handleCreateGlobalLlmConfig(deps));
+  app.get('/admin/llm-config/:id', requireOwnerAuth(), handleGetGlobalLlmConfig(deps));
+  app.put('/admin/llm-config/:id', requireOwnerAuth(), handleUpdateGlobalLlmConfig(deps));
+  app.put(
+    '/admin/llm-config/:id/set-default',
+    requireOwnerAuth(),
+    handleSetGlobalLlmConfigDefault(deps)
+  );
+  app.put(
+    '/admin/llm-config/:id/set-free-default',
+    requireOwnerAuth(),
+    handleSetGlobalLlmConfigFreeDefault(deps)
+  );
+  app.delete('/admin/llm-config/:id', requireOwnerAuth(), handleDeleteGlobalLlmConfig(deps));
+}
 
+describe('Admin LLM Config Routes', () => {
   let app: Express;
   let prisma: ReturnType<typeof createMockPrismaClient>;
 
@@ -127,13 +143,10 @@ describe('Admin LLM Config Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use(
-      '/admin/llm-config',
-      createAdminLlmConfigRoutes({
-        ...stubRouteResolvers(),
-        prisma: prisma as unknown as PrismaClient,
-      })
-    );
+    mountAdminLlmConfig(app, {
+      ...stubRouteResolvers(),
+      prisma: prisma as unknown as PrismaClient,
+    });
   });
 
   // App wired with a vision-aware model cache, for the vision-slot capability gate:
@@ -150,15 +163,12 @@ describe('Admin LLM Config Routes', () => {
     };
     const a = express();
     a.use(express.json());
-    a.use(
-      '/admin/llm-config',
-      createAdminLlmConfigRoutes({
-        ...stubRouteResolvers(),
-        prisma: prisma as unknown as PrismaClient,
-        modelCache:
-          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
-      })
-    );
+    mountAdminLlmConfig(a, {
+      ...stubRouteResolvers(),
+      prisma: prisma as unknown as PrismaClient,
+      modelCache:
+        mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+    });
     return a;
   };
 
@@ -221,17 +231,14 @@ describe('Admin LLM Config Routes', () => {
       };
       const appWithModel = express();
       appWithModel.use(express.json());
-      appWithModel.use(
-        '/admin/llm-config',
-        createAdminLlmConfigRoutes({
-          ...stubRouteResolvers(),
-          prisma: prisma as unknown as PrismaClient,
-          // List handler doesn't touch cache invalidation, so omit it; modelCache
-          // drives the enrichment.
-          modelCache:
-            mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
-        })
-      );
+      mountAdminLlmConfig(appWithModel, {
+        ...stubRouteResolvers(),
+        prisma: prisma as unknown as PrismaClient,
+        // List handler doesn't touch cache invalidation, so omit it; modelCache
+        // drives the enrichment.
+        modelCache:
+          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+      });
       prisma.llmConfig.findMany.mockResolvedValue([
         {
           id: 'vc-1',
@@ -1204,14 +1211,11 @@ describe('Admin LLM Config Routes', () => {
       cacheService = createMockCacheInvalidationService();
       appWithCache = express();
       appWithCache.use(express.json());
-      appWithCache.use(
-        '/admin/llm-config',
-        createAdminLlmConfigRoutes({
-          ...stubRouteResolvers(),
-          prisma: prisma as unknown as PrismaClient,
-          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
-        })
-      );
+      mountAdminLlmConfig(appWithCache, {
+        ...stubRouteResolvers(),
+        prisma: prisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+      });
     });
 
     it('should invalidate cache after updating a global config', async () => {
@@ -1293,16 +1297,13 @@ describe('Admin LLM Config Routes', () => {
 
       const appWithModel = express();
       appWithModel.use(express.json());
-      appWithModel.use(
-        '/admin/llm-config',
-        createAdminLlmConfigRoutes({
-          ...stubRouteResolvers(),
-          prisma: prisma as unknown as PrismaClient,
-          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
-          modelCache:
-            mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
-        })
-      );
+      mountAdminLlmConfig(appWithModel, {
+        ...stubRouteResolvers(),
+        prisma: prisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+        modelCache:
+          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+      });
 
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-1',
@@ -1341,16 +1342,13 @@ describe('Admin LLM Config Routes', () => {
 
       const appWithModel = express();
       appWithModel.use(express.json());
-      appWithModel.use(
-        '/admin/llm-config',
-        createAdminLlmConfigRoutes({
-          ...stubRouteResolvers(),
-          prisma: prisma as unknown as PrismaClient,
-          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
-          modelCache:
-            mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
-        })
-      );
+      mountAdminLlmConfig(appWithModel, {
+        ...stubRouteResolvers(),
+        prisma: prisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+        modelCache:
+          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+      });
 
       prisma.llmConfig.findFirst.mockResolvedValue(null);
       prisma.llmConfig.create.mockResolvedValue({
@@ -1393,16 +1391,13 @@ describe('Admin LLM Config Routes', () => {
 
       const appWithModel = express();
       appWithModel.use(express.json());
-      appWithModel.use(
-        '/admin/llm-config',
-        createAdminLlmConfigRoutes({
-          ...stubRouteResolvers(),
-          prisma: prisma as unknown as PrismaClient,
-          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
-          modelCache:
-            mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
-        })
-      );
+      mountAdminLlmConfig(appWithModel, {
+        ...stubRouteResolvers(),
+        prisma: prisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+        modelCache:
+          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+      });
 
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -3,16 +3,16 @@
  * Owner-only endpoints for managing global LLM configurations
  *
  * Endpoints:
- * - GET /admin/llm-config - List all LLM configs
- * - GET /admin/llm-config/:id - Get single config with full params
- * - POST /admin/llm-config - Create a global LLM config
- * - PUT /admin/llm-config/:id - Edit a global config
- * - PUT /admin/llm-config/:id/set-default - Set a config as system default
- * - PUT /admin/llm-config/:id/set-free-default - Set a config as free tier default
- * - DELETE /admin/llm-config/:id - Delete a global config
+ * - GET /api/admin/llm-config - List all LLM configs
+ * - GET /api/admin/llm-config/:id - Get single config with full params
+ * - POST /api/admin/llm-config - Create a global LLM config
+ * - PUT /api/admin/llm-config/:id - Edit a global config
+ * - PUT /api/admin/llm-config/:id/set-default - Set a config as system default
+ * - PUT /api/admin/llm-config/:id/set-free-default - Set a config as free tier default
+ * - DELETE /api/admin/llm-config/:id - Delete a global config
  */
 
-import { Router, type Response, type Request, type RequestHandler } from 'express';
+import { type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { isFreeTierEligibleModel } from '@tzurot/common-types/constants/ai';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
@@ -22,7 +22,6 @@ import {
 } from '@tzurot/common-types/schemas/api/llm-config';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -413,23 +412,3 @@ export const handleSetGlobalLlmConfigFreeDefault = (deps: RouteDeps): RequestHan
 
 export const handleDeleteGlobalLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createDeleteConfigHandler(buildService(deps), deps.prisma));
-
-// --- Main Route Factory ---
-
-export function createAdminLlmConfigRoutes(deps: RouteDeps): Router {
-  const router = Router();
-
-  router.get('/', requireOwnerAuth(), handleListGlobalLlmConfigs(deps));
-  router.get('/:id', requireOwnerAuth(), handleGetGlobalLlmConfig(deps));
-  router.post('/', requireOwnerAuth(), handleCreateGlobalLlmConfig(deps));
-  router.put('/:id', requireOwnerAuth(), handleUpdateGlobalLlmConfig(deps));
-  router.put('/:id/set-default', requireOwnerAuth(), handleSetGlobalLlmConfigDefault(deps));
-  router.put(
-    '/:id/set-free-default',
-    requireOwnerAuth(),
-    handleSetGlobalLlmConfigFreeDefault(deps)
-  );
-  router.delete('/:id', requireOwnerAuth(), handleDeleteGlobalLlmConfig(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/settings.test.ts
+++ b/services/api-gateway/src/routes/admin/settings.test.ts
@@ -6,13 +6,18 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createAdminSettingsRoutes } from './settings.js';
+import {
+  handleClearAdminSettings,
+  handleGetAdminSettings,
+  handleUpdateAdminSettings,
+} from './settings.js';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import express from 'express';
 import request from 'supertest';
-import { getAllRoutes } from '../../test/expressRouterUtils.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 // Mock isBotOwner - must be before vi.mock to be hoisted
 const mockIsBotOwner = vi.fn().mockReturnValue(true);
@@ -112,33 +117,19 @@ function createDefaultSettings(
   };
 }
 
-describe('Admin Settings Routes (Singleton)', () => {
-  describe('middleware composition', () => {
-    it('GET / stays inline-auth (service-only allowed); PATCH/DELETE use middleware', () => {
-      // settings.ts has a mixed auth shape: GET supports service-only calls
-      // (bot-client hydrates admin settings at startup with no userId), so it
-      // can't migrate to requireOwnerAuth() middleware. PATCH and DELETE are
-      // owner-only writes — they got the standard requireOwnerAuth middleware
-      // in this PR. Lock the asymmetry in by asserting the resulting stack
-      // lengths.
-      const router = createAdminSettingsRoutes({
-        ...stubRouteResolvers(),
-        prisma: createMockPrisma() as unknown as PrismaClient,
-      });
-      const routes = getAllRoutes(router);
-      const byPath = new Map(routes.map(r => [`${r.methods[0]} ${r.path}`, r]));
-      expect(byPath.get('get /')?.stackLength, 'GET / must stay inline-auth (1 handler)').toBe(1);
-      expect(
-        byPath.get('patch /config-defaults')?.stackLength,
-        'PATCH /config-defaults must use requireOwnerAuth middleware'
-      ).toBeGreaterThanOrEqual(2);
-      expect(
-        byPath.get('delete /config-defaults')?.stackLength,
-        'DELETE /config-defaults must use requireOwnerAuth middleware'
-      ).toBeGreaterThanOrEqual(2);
-    });
-  });
+/**
+ * Register the three admin-settings handlers the way
+ * routes/_generated/mounts.ts does: GET keeps its inline `isAuthorizedForRead`
+ * check (so service-only calls with no userId still pass), while the two
+ * writes sit behind `requireOwnerAuth()`.
+ */
+function mountAdminSettings(app: express.Express, deps: RouteDeps): void {
+  app.get('/admin/settings', handleGetAdminSettings(deps));
+  app.patch('/admin/settings/config-defaults', requireOwnerAuth(), handleUpdateAdminSettings(deps));
+  app.delete('/admin/settings/config-defaults', requireOwnerAuth(), handleClearAdminSettings(deps));
+}
 
+describe('Admin Settings Routes (Singleton)', () => {
   let mockPrisma: ReturnType<typeof createMockPrisma>;
   let app: express.Express;
 
@@ -161,13 +152,10 @@ describe('Admin Settings Routes (Singleton)', () => {
       req.headers['x-user-id'] = MOCK_USER_ID;
       next();
     });
-    app.use(
-      '/admin/settings',
-      createAdminSettingsRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      })
-    );
+    mountAdminSettings(app, {
+      ...stubRouteResolvers(),
+      prisma: mockPrisma as unknown as PrismaClient,
+    });
     // Add error handler
     app.use(
       (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
@@ -228,13 +216,10 @@ describe('Admin Settings Routes (Singleton)', () => {
       appWithoutUserId = express();
       appWithoutUserId.use(express.json());
       // Intentionally NOT injecting userId - simulating internal service call
-      appWithoutUserId.use(
-        '/admin/settings',
-        createAdminSettingsRoutes({
-          ...stubRouteResolvers(),
-          prisma: mockPrisma as unknown as PrismaClient,
-        })
-      );
+      mountAdminSettings(appWithoutUserId, {
+        ...stubRouteResolvers(),
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
     });
 
     it('should allow GET request without userId (service-only operation)', async () => {
@@ -335,14 +320,11 @@ describe('Admin Settings Routes (Singleton)', () => {
         (req as express.Request & { userId: string }).userId = MOCK_USER_ID;
         next();
       });
-      appWithInvalidation.use(
-        '/admin/settings',
-        createAdminSettingsRoutes({
-          ...stubRouteResolvers(),
-          prisma: mockPrisma as unknown as PrismaClient,
-          cascadeInvalidation: mockInvalidation as never,
-        })
-      );
+      mountAdminSettings(appWithInvalidation, {
+        ...stubRouteResolvers(),
+        prisma: mockPrisma as unknown as PrismaClient,
+        cascadeInvalidation: mockInvalidation as never,
+      });
 
       const updatedSettings = createDefaultSettings({
         configDefaults: { maxMessages: 30 },
@@ -410,14 +392,11 @@ describe('Admin Settings Routes (Singleton)', () => {
         (req as express.Request & { userId: string }).userId = MOCK_USER_ID;
         next();
       });
-      appWithInvalidation.use(
-        '/admin/settings',
-        createAdminSettingsRoutes({
-          ...stubRouteResolvers(),
-          prisma: mockPrisma as unknown as PrismaClient,
-          cascadeInvalidation: mockInvalidation as never,
-        })
-      );
+      mountAdminSettings(appWithInvalidation, {
+        ...stubRouteResolvers(),
+        prisma: mockPrisma as unknown as PrismaClient,
+        cascadeInvalidation: mockInvalidation as never,
+      });
 
       mockPrisma.adminSettings.update.mockResolvedValue(createDefaultSettings());
 

--- a/services/api-gateway/src/routes/admin/settings.ts
+++ b/services/api-gateway/src/routes/admin/settings.ts
@@ -2,20 +2,22 @@
  * Admin Settings Routes
  * Owner-only endpoints for managing the global AdminSettings singleton
  *
- * Endpoints:
- * - GET /admin/settings - Get the AdminSettings singleton (service-only OR owner)
- * - PATCH /admin/settings/config-defaults - Update configDefaults (owner only)
- * - DELETE /admin/settings/config-defaults - Clear all admin config defaults (owner only)
+ * Endpoints (as mounted in routes/_generated/mounts.ts):
+ * - GET /api/internal/admin-settings - Get the singleton, service-only call
+ * - GET /api/admin/settings - Get the singleton (owner)
+ * - PATCH /api/admin/settings/config-defaults - Update configDefaults (owner only)
+ * - DELETE /api/admin/settings/config-defaults - Clear all admin config defaults (owner only)
  *
- * Auth shape: PATCH and DELETE use the standard `requireOwnerAuth()` middleware
- * (consistent with the other 12 admin route modules). GET cannot — it must
- * accept service-only calls (no Discord user context) so bot-client can
- * hydrate its admin-settings cache at startup. The GET keeps the inline
+ * Auth shape: the two writes sit behind `requireUserAuth()` + `requireOwnerAuth()`
+ * at the mount site. The read is mounted twice — once under `/api/admin` with the
+ * same owner gating, and once under `/api/internal` with no user middleware at
+ * all, because bot-client hydrates its admin-settings cache at startup with no
+ * Discord user context. The handler therefore keeps its inline
  * `isAuthorizedForRead` check, which permits no-userId requests but rejects
  * user-context requests from non-owners (see `GatewayClient.getAdminSettings()`).
  */
 
-import { Router, type Request, type RequestHandler, type Response } from 'express';
+import { type Request, type RequestHandler, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   type GetAdminSettingsResponse,
@@ -29,7 +31,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { mergeConfigOverrides } from '../../utils/configOverrideMerge.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
-import { isAuthorizedForRead, requireOwnerAuth } from '../../services/AuthMiddleware.js';
+import { isAuthorizedForRead } from '../../services/AuthMiddleware.js';
 import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-settings-routes');
@@ -96,7 +98,7 @@ async function resolveUserUuid(prisma: PrismaClient, discordId: string): Promise
 }
 
 /**
- * PATCH /admin/settings/config-defaults handler
+ * PATCH /api/admin/settings/config-defaults handler
  * Accepts flat Partial<ConfigOverrides> body (same shape as all cascade tiers).
  */
 function createConfigDefaultsPatchHandler(
@@ -175,11 +177,3 @@ export const handleClearAdminSettings = (deps: RouteDeps): RequestHandler => {
     sendCustomSuccess(res, { success: true }, StatusCodes.OK);
   });
 };
-
-export function createAdminSettingsRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.get('/', handleGetAdminSettings(deps));
-  router.patch('/config-defaults', requireOwnerAuth(), handleUpdateAdminSettings(deps));
-  router.delete('/config-defaults', requireOwnerAuth(), handleClearAdminSettings(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/systemSettings.ts
+++ b/services/api-gateway/src/routes/admin/systemSettings.ts
@@ -4,8 +4,8 @@
  * NON-CASCADING operational settings (design: admin-runtime-settings D1/D7/D9/D10).
  *
  * Endpoints:
- * - GET /admin/settings/system - Read the bag + the optimistic-concurrency token
- * - PATCH /admin/settings/system - Validated partial write
+ * - GET /api/admin/settings/system - Read the bag + the optimistic-concurrency token
+ * - PATCH /api/admin/settings/system - Validated partial write
  *
  * Write pipeline: wire-schema parse → registry-driven semantic validation
  * (env-key coherence, model catalog/capability, free-route firewall) →

--- a/services/api-gateway/src/routes/admin/tts-config.test.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.test.ts
@@ -7,10 +7,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response, Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { getAllRoutes } from '../../test/expressRouterUtils.js';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { asRouteHandler, stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const sampleRawConfig = {
   id: 'cfg-uuid-1',
@@ -77,7 +77,15 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-const { createAdminTtsConfigRoutes } = await import('./tts-config.js');
+const {
+  handleCreateGlobalTtsConfig,
+  handleDeleteGlobalTtsConfig,
+  handleGetGlobalTtsConfig,
+  handleListGlobalTtsConfigs,
+  handleSetGlobalTtsConfigDefault,
+  handleSetGlobalTtsConfigFreeDefault,
+  handleUpdateGlobalTtsConfig,
+} = await import('./tts-config.js');
 const { TtsInvalidProviderError } = await import('../../services/TtsConfigService.js');
 
 function makeMockRes() {
@@ -99,25 +107,6 @@ function makeMockReq(overrides: Record<string, unknown> = {}): Request {
   } as unknown as Request;
 }
 
-interface RouterLayer {
-  route?: {
-    path: string;
-    methods: Record<string, boolean>;
-    stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
-  };
-}
-
-function extractHandler(router: Router, method: string, path: string) {
-  const stack = (router as unknown as { stack: RouterLayer[] }).stack;
-  const layer = stack.find(
-    l => l.route?.path === path && l.route?.methods[method.toLowerCase()] === true
-  );
-  if (!layer?.route) {
-    throw new Error(`Handler for ${method} ${path} not found`);
-  }
-  return layer.route.stack[layer.route.stack.length - 1].handle;
-}
-
 const mockPrisma = {
   ttsConfig: {
     findUnique: vi.fn(),
@@ -133,26 +122,12 @@ const mockPrisma = {
   },
 };
 
-function buildRouter() {
-  return createAdminTtsConfigRoutes({ ...stubRouteResolvers(), prisma: mockPrisma as never });
+/** Build one bare handler with the mock deps — the shape mounts.ts registers. */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler) {
+  return asRouteHandler(handler({ ...stubRouteResolvers(), prisma: mockPrisma as never }));
 }
 
 describe('admin/tts-config routes', () => {
-  describe('middleware composition', () => {
-    it('wires requireOwnerAuth on every route', () => {
-      // Handler-extraction tests pick the last handler, which bypasses
-      // middleware. Inspect the router stack directly so a regression that
-      // removed requireOwnerAuth() from any route would fail this check.
-      const routes = getAllRoutes(buildRouter());
-      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
-      for (const route of routes) {
-        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
-          2
-        );
-      }
-    });
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(mockService.formatConfigDetail).mockImplementation((c: typeof sampleRawConfig) => ({
@@ -176,7 +151,7 @@ describe('admin/tts-config routes', () => {
   describe('GET / (list)', () => {
     it('returns all GLOBAL configs in the formatted shape', async () => {
       vi.mocked(mockService.list).mockResolvedValue([sampleRawConfig]);
-      const handler = extractHandler(buildRouter(), 'GET', '/');
+      const handler = buildHandler(handleListGlobalTtsConfigs);
       const { res, json, status } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -202,7 +177,7 @@ describe('admin/tts-config routes', () => {
   describe('GET /:id (get)', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'GET', '/:id');
+      const handler = buildHandler(handleGetGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'missing' } }), res);
@@ -211,7 +186,7 @@ describe('admin/tts-config routes', () => {
 
     it('returns formatted config when found', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'GET', '/:id');
+      const handler = buildHandler(handleGetGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -226,7 +201,7 @@ describe('admin/tts-config routes', () => {
   describe('POST / (create)', () => {
     it('returns 403 FORBIDDEN when admin user is not in DB', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { name: 'Sys', provider: 'self-hosted' } }), res);
@@ -239,7 +214,7 @@ describe('admin/tts-config routes', () => {
         exists: true,
         conflictId: 'cfg-existing',
       });
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { name: 'Existing', provider: 'self-hosted' } }), res);
@@ -250,7 +225,7 @@ describe('admin/tts-config routes', () => {
     it('returns 201 on happy path', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ id: 'admin-uuid-1' });
       vi.mocked(mockService.create).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateGlobalTtsConfig);
       const { res, status } = makeMockRes();
 
       await handler(makeMockReq({ body: { name: 'New Global', provider: 'mistral' } }), res);
@@ -266,7 +241,7 @@ describe('admin/tts-config routes', () => {
   describe('PUT /:id (edit)', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'missing' }, body: { description: 'new' } }), res);
@@ -278,7 +253,7 @@ describe('admin/tts-config routes', () => {
         ...sampleRawConfig,
         isGlobal: false,
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -296,7 +271,7 @@ describe('admin/tts-config routes', () => {
     it('translates TtsInvalidProviderError to 400 VALIDATION_ERROR', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(sampleRawConfig);
       vi.mocked(mockService.update).mockRejectedValue(new TtsInvalidProviderError('mistal'));
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -317,7 +292,7 @@ describe('admin/tts-config routes', () => {
         ...sampleRawConfig,
         modelId: 'voxtral-mini-tts-2603',
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateGlobalTtsConfig);
       const { res, status } = makeMockRes();
 
       await handler(
@@ -334,7 +309,7 @@ describe('admin/tts-config routes', () => {
   describe('PUT /:id/set-default', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id/set-default');
+      const handler = buildHandler(handleSetGlobalTtsConfigDefault);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'missing' } }), res);
@@ -346,7 +321,7 @@ describe('admin/tts-config routes', () => {
         ...sampleRawConfig,
         isGlobal: false,
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id/set-default');
+      const handler = buildHandler(handleSetGlobalTtsConfigDefault);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -356,7 +331,7 @@ describe('admin/tts-config routes', () => {
 
     it('calls service.setAsDefault on happy path', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id/set-default');
+      const handler = buildHandler(handleSetGlobalTtsConfigDefault);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -372,7 +347,7 @@ describe('admin/tts-config routes', () => {
         ...sampleRawConfig,
         provider: 'elevenlabs',
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id/set-free-default');
+      const handler = buildHandler(handleSetGlobalTtsConfigFreeDefault);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -391,7 +366,7 @@ describe('admin/tts-config routes', () => {
         provider: 'self-hosted',
         isGlobal: false,
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id/set-free-default');
+      const handler = buildHandler(handleSetGlobalTtsConfigFreeDefault);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -404,7 +379,7 @@ describe('admin/tts-config routes', () => {
         ...sampleRawConfig,
         provider: 'self-hosted',
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id/set-free-default');
+      const handler = buildHandler(handleSetGlobalTtsConfigFreeDefault);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -417,7 +392,7 @@ describe('admin/tts-config routes', () => {
         ...sampleRawConfig,
         provider: 'mistral',
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id/set-free-default');
+      const handler = buildHandler(handleSetGlobalTtsConfigFreeDefault);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -433,7 +408,7 @@ describe('admin/tts-config routes', () => {
   describe('DELETE /:id', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'missing' } }), res);
@@ -445,7 +420,7 @@ describe('admin/tts-config routes', () => {
         ...sampleRawConfig,
         isGlobal: false,
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -461,7 +436,7 @@ describe('admin/tts-config routes', () => {
         globalDefaultTtsConfigId: 'cfg-uuid-1',
         freeDefaultTtsConfigId: null,
       } as never);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -482,7 +457,7 @@ describe('admin/tts-config routes', () => {
         globalDefaultTtsConfigId: null,
         freeDefaultTtsConfigId: 'cfg-uuid-1',
       } as never);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -501,7 +476,7 @@ describe('admin/tts-config routes', () => {
         blocker: 'Cannot delete: TTS config is used as default by 2 personality(ies)',
         warning: null,
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -511,7 +486,7 @@ describe('admin/tts-config routes', () => {
 
     it('returns 200 with deleted: true on happy path', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -528,7 +503,7 @@ describe('admin/tts-config routes', () => {
         blocker: null,
         warning: "Deleting this TTS config will reset 3 user(s)' personal default to NULL",
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -551,7 +526,7 @@ describe('admin/tts-config routes', () => {
         blocker: 'Cannot delete: TTS config is used as default by 2 personality(ies)',
         warning: "Deleting this TTS config will reset 3 user(s)' personal default to NULL",
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteGlobalTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);

--- a/services/api-gateway/src/routes/admin/tts-config.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.ts
@@ -3,13 +3,13 @@
  * Owner-only endpoints for managing global TTS configurations
  *
  * Endpoints:
- * - GET    /admin/tts-config                  - List all TTS configs
- * - GET    /admin/tts-config/:id              - Get single config detail
- * - POST   /admin/tts-config                  - Create a global TTS config
- * - PUT    /admin/tts-config/:id              - Edit a global config
- * - PUT    /admin/tts-config/:id/set-default  - Set a config as system default
- * - PUT    /admin/tts-config/:id/set-free-default - Set a config as free tier default
- * - DELETE /admin/tts-config/:id              - Delete a global config
+ * - GET    /api/admin/tts-config                      - List all TTS configs
+ * - GET    /api/admin/tts-config/:id                  - Get single config detail
+ * - POST   /api/admin/tts-config                      - Create a global TTS config
+ * - PUT    /api/admin/tts-config/:id                  - Edit a global config
+ * - PUT    /api/admin/tts-config/:id/set-default      - Set a config as system default
+ * - PUT    /api/admin/tts-config/:id/set-free-default - Set a config as free tier default
+ * - DELETE /api/admin/tts-config/:id                  - Delete a global config
  *
  * Mirrors `routes/admin/llm-config.ts` shape minus LLM-specific concerns
  * (no model-context enrichment, no model-fields validation).
@@ -21,7 +21,7 @@
  * (LLM-specific OpenRouter convention) but applies the TTS-shaped invariant.
  */
 
-import { Router, type Response, type Request, type RequestHandler } from 'express';
+import { type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
@@ -31,7 +31,6 @@ import {
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { isSelfHostedTtsProvider } from '@tzurot/common-types/services/tts/TtsProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -342,23 +341,3 @@ export const handleSetGlobalTtsConfigFreeDefault = (deps: RouteDeps): RequestHan
 
 export const handleDeleteGlobalTtsConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createDeleteHandler(buildService(deps), deps.prisma));
-
-// --- Main route factory ----------------------------------------------------
-
-export function createAdminTtsConfigRoutes(deps: RouteDeps): Router {
-  const router = Router();
-
-  router.get('/', requireOwnerAuth(), handleListGlobalTtsConfigs(deps));
-  router.get('/:id', requireOwnerAuth(), handleGetGlobalTtsConfig(deps));
-  router.post('/', requireOwnerAuth(), handleCreateGlobalTtsConfig(deps));
-  router.put('/:id', requireOwnerAuth(), handleUpdateGlobalTtsConfig(deps));
-  router.put('/:id/set-default', requireOwnerAuth(), handleSetGlobalTtsConfigDefault(deps));
-  router.put(
-    '/:id/set-free-default',
-    requireOwnerAuth(),
-    handleSetGlobalTtsConfigFreeDefault(deps)
-  );
-  router.delete('/:id', requireOwnerAuth(), handleDeleteGlobalTtsConfig(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/updatePersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/updatePersonality.test.ts
@@ -5,18 +5,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
-import { createUpdatePersonalityRoute } from './updatePersonality.js';
+import { handleUpdateGlobalPersonality } from './updatePersonality.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { CacheInvalidationService } from '@tzurot/cache-invalidation';
 import { optimizeAvatar } from '../../utils/imageProcessor.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
-
-// Mock AuthMiddleware
-vi.mock('../../services/AuthMiddleware.js', () => ({
-  requireOwnerAuth: () => (_req: unknown, _res: unknown, next: () => void) => {
-    next(); // Bypass auth for testing
-  },
-}));
 
 // Mock imageProcessor
 vi.mock('../../utils/imageProcessor.js', () => ({
@@ -54,12 +47,12 @@ describe('PATCH /admin/personality/:slug', () => {
     // Create mock Prisma client
     prisma = createMockPrismaClient();
 
-    // Create Express app with update personality router
+    // Create Express app with the update-personality handler
     app = express();
     app.use(express.json());
-    app.use(
-      '/admin/personality',
-      createUpdatePersonalityRoute({
+    app.patch(
+      '/admin/personality/:slug',
+      handleUpdateGlobalPersonality({
         ...stubRouteResolvers(),
         prisma: prisma as unknown as PrismaClient,
       })
@@ -452,9 +445,9 @@ describe('PATCH /admin/personality/:slug', () => {
 
       appWithCache = express();
       appWithCache.use(express.json());
-      appWithCache.use(
-        '/admin/personality',
-        createUpdatePersonalityRoute({
+      appWithCache.patch(
+        '/admin/personality/:slug',
+        handleUpdateGlobalPersonality({
           ...stubRouteResolvers(),
           prisma: prisma as unknown as PrismaClient,
           cacheInvalidationService: mockCacheService,

--- a/services/api-gateway/src/routes/admin/updatePersonality.ts
+++ b/services/api-gateway/src/routes/admin/updatePersonality.ts
@@ -1,9 +1,9 @@
 /**
- * PATCH /admin/personality/:slug
+ * PATCH /api/admin/personality/:slug
  * Edit an existing AI personality
  */
 
-import { Router, type Request, type RequestHandler, type Response } from 'express';
+import { type Request, type RequestHandler, type Response } from 'express';
 import {
   AdminPersonalityResponseSchema,
   PersonalityUpdateSchema,
@@ -11,7 +11,6 @@ import {
 } from '@tzurot/common-types/schemas/api/personality';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type CacheInvalidationService } from '@tzurot/cache-invalidation';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import type { RouteDeps } from '../routeDeps.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendContractSuccess } from '../../utils/responseHelpers.js';
@@ -186,9 +185,3 @@ export const handleUpdateGlobalPersonality = (deps: RouteDeps): RequestHandler =
     });
   });
 };
-
-export function createUpdatePersonalityRoute(deps: RouteDeps): Router {
-  const router = Router();
-  router.patch('/:slug', requireOwnerAuth(), handleUpdateGlobalPersonality(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/admin/usage.test.ts
+++ b/services/api-gateway/src/routes/admin/usage.test.ts
@@ -3,11 +3,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createAdminUsageRoutes } from './usage.js';
+import { handleGetAdminUsageStats } from './usage.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import express from 'express';
 import request from 'supertest';
-import { getAllRoutes } from '../../test/expressRouterUtils.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 // Mock logger
@@ -26,32 +25,7 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-// Mock AuthMiddleware — owner-auth gating runs unconditionally in tests
-vi.mock('../../services/AuthMiddleware.js', () => ({
-  requireOwnerAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
-    req.userId = 'admin-discord-id';
-    next();
-  },
-}));
-
 describe('Admin Usage Routes', () => {
-  describe('middleware composition', () => {
-    it('wires requireOwnerAuth on every route', () => {
-      const routes = getAllRoutes(
-        createAdminUsageRoutes({
-          prisma: {} as unknown as PrismaClient,
-          ...stubRouteResolvers(),
-        })
-      );
-      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
-      for (const route of routes) {
-        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
-          2
-        );
-      }
-    });
-  });
-
   let mockPrisma: {
     usageLog: {
       findMany: ReturnType<typeof vi.fn>;
@@ -76,9 +50,9 @@ describe('Admin Usage Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use(
+    app.get(
       '/admin/usage',
-      createAdminUsageRoutes({
+      handleGetAdminUsageStats({
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       })
@@ -132,9 +106,9 @@ describe('Admin Usage Routes', () => {
       function appWithRedis(redisGet: ReturnType<typeof vi.fn>): express.Express {
         const withRedis = express();
         withRedis.use(express.json());
-        withRedis.use(
+        withRedis.get(
           '/admin/usage',
-          createAdminUsageRoutes({
+          handleGetAdminUsageStats({
             ...stubRouteResolvers(),
             prisma: mockPrisma as unknown as PrismaClient,
             redis: { get: redisGet } as never,

--- a/services/api-gateway/src/routes/admin/usage.ts
+++ b/services/api-gateway/src/routes/admin/usage.ts
@@ -1,14 +1,13 @@
 /**
  * Admin Usage Routes
- * GET /admin/usage - Get global token usage statistics (all users)
+ * GET /api/admin/usage - Get global token usage statistics (all users)
  */
 
-import { Router, type Response, type Request, type RequestHandler } from 'express';
+import { type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { Duration, DurationParseError } from '@tzurot/common-types/utils/Duration';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { shortModelName } from '@tzurot/common-types/utils/modelNames';
-import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { ZAI_PLAN_METER_SNAPSHOT_KEY } from '@tzurot/common-types/constants/redis-keys';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -216,9 +215,3 @@ export const handleGetAdminUsageStats = (deps: RouteDeps): RequestHandler => {
     sendCustomSuccess(res, stats, StatusCodes.OK);
   });
 };
-
-export function createAdminUsageRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.get('/', requireOwnerAuth(), handleGetAdminUsageStats(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
@@ -1,5 +1,5 @@
 /**
- * POST /internal/conversation/assistant-message
+ * POST /api/internal/conversation/assistant-message
  *
  * Persists the assistant conversation-history row after bot-client confirms
  * Discord delivery. The gateway owns the write: it derives the assistant

--- a/services/api-gateway/src/routes/internal/conversationSync.ts
+++ b/services/api-gateway/src/routes/internal/conversationSync.ts
@@ -1,5 +1,5 @@
 /**
- * POST /internal/conversation/sync
+ * POST /api/internal/conversation/sync
  *
  * Opportunistic edit/delete sync. bot-client ships the Discord snapshot it
  * fetched for a channel+personality; the gateway runs the diff against DB

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.ts
@@ -1,5 +1,5 @@
 /**
- * POST /internal/conversation/user-message
+ * POST /api/internal/conversation/user-message
  *
  * Persists the trigger user message before job submission. A user message is
  * a Discord event, so this gateway (the Discord-event data authority) owns

--- a/services/api-gateway/src/routes/internal/dmSessionSet.ts
+++ b/services/api-gateway/src/routes/internal/dmSessionSet.ts
@@ -1,5 +1,5 @@
 /**
- * POST /internal/channel/dm-session/set
+ * POST /api/internal/channel/dm-session/set
  *
  * Service-only endpoint used by the bot-client's MultiTagCoordinator to
  * record the active personality in a DM channel after a multi-tag fan-out.

--- a/services/api-gateway/src/routes/internal/personalityLoad.ts
+++ b/services/api-gateway/src/routes/internal/personalityLoad.ts
@@ -1,5 +1,5 @@
 /**
- * GET /internal/personality/load
+ * GET /api/internal/personality/load
  *
  * Routing read: resolves a personality by name/slug/alias/UUID with the same
  * access-control semantics as PersonalityService.loadPersonality (public OR

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.ts
@@ -1,7 +1,7 @@
 /**
  * Internal release-broadcast delivery ledger:
- * POST /internal/release-broadcast/:releaseId/pending    — worker's stall-rerun guard
- * POST /internal/release-broadcast/:releaseId/deliveries — per-recipient outcome reporting
+ * POST /api/internal/release-broadcast/:releaseId/pending    — worker's stall-rerun guard
+ * POST /api/internal/release-broadcast/:releaseId/deliveries — per-recipient outcome reporting
  *
  * Both are service-auth-only (bot-client's DM worker). The deliveries write is
  * idempotent (pending→terminal transitions only) — re-reporting a row is a

--- a/services/api-gateway/src/routes/internal/releaseReconcile.ts
+++ b/services/api-gateway/src/routes/internal/releaseReconcile.ts
@@ -1,5 +1,5 @@
 /**
- * POST /internal/release-broadcast/reconcile
+ * POST /api/internal/release-broadcast/reconcile
  *
  * Service-auth trigger for the release reconcile sweep. Called hourly by
  * ai-worker's scheduled job (the only service with a scheduler), and

--- a/services/api-gateway/src/routes/internal/routingContextCreate.ts
+++ b/services/api-gateway/src/routes/internal/routingContextCreate.ts
@@ -1,5 +1,5 @@
 /**
- * POST /internal/v1/routing-context
+ * POST /api/internal/v1/routing-context
  *
  * Hot-path routing read: resolves the per-(user, personality) routing facts a
  * Discord message needs BEFORE its AI job is dispatched — internal user UUID,

--- a/services/api-gateway/src/routes/internal/usersActivity.ts
+++ b/services/api-gateway/src/routes/internal/usersActivity.ts
@@ -1,5 +1,5 @@
 /**
- * POST /internal/users/activity
+ * POST /api/internal/users/activity
  *
  * Service-only endpoint. Records a "the user is active" signal for slash
  * commands that never otherwise reach the gateway — pure-client commands like

--- a/services/api-gateway/src/routes/internal/usersRecent.ts
+++ b/services/api-gateway/src/routes/internal/usersRecent.ts
@@ -1,5 +1,5 @@
 /**
- * GET /internal/users/recent?sinceDays=30
+ * GET /api/internal/users/recent?sinceDays=30
  *
  * Returns Discord IDs of users with usage_logs activity in the last N days.
  * Service-auth protected (global middleware in api-gateway/src/index.ts).

--- a/services/api-gateway/src/routes/user/account/delete.ts
+++ b/services/api-gateway/src/routes/user/account/delete.ts
@@ -1,9 +1,9 @@
 /**
  * Account Data-Rights Deletion Routes
  *
- * GET  /user/account/delete/preview - counts + per-character blast radius
- * POST /user/account/delete/token   - typed phrase → single-use token
- * POST /user/account/delete         - consumes token, erases the account
+ * GET  /api/user/account/delete/preview - counts + per-character blast radius
+ * POST /api/user/account/delete/token   - typed phrase → single-use token
+ * POST /api/user/account/delete         - consumes token, erases the account
  *
  * Purge-pattern handshake (mirrors /memory/purge): the destructive call
  * accepts ONLY the token; the phrase validation happened at token-issue

--- a/services/api-gateway/src/routes/user/account/export.ts
+++ b/services/api-gateway/src/routes/user/account/export.ts
@@ -1,8 +1,8 @@
 /**
  * Account Data-Rights Export Routes (Async)
  *
- * POST /user/account/export        - Start a full-account export job
- * GET  /user/account/export/status - Latest account export job state
+ * POST /api/user/account/export        - Start a full-account export job
+ * GET  /api/user/account/export/status - Latest account export job state
  *
  * Rides the shapes-export spine: an export_jobs row (sentinel
  * sourceService='account') filled asynchronously by ai-worker, downloaded

--- a/services/api-gateway/src/routes/user/channel/activate.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.ts
@@ -1,5 +1,5 @@
 /**
- * POST /user/channel/activate
+ * POST /api/user/channel/activate
  * Activate a personality in a Discord channel
  *
  * Activating a personality means it will respond to ALL messages in the channel,

--- a/services/api-gateway/src/routes/user/channel/configOverrides.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.ts
@@ -3,9 +3,9 @@
  * CRUD for channel-level config cascade overrides
  *
  * Endpoints:
- * - GET /user/channel/:channelId/config-overrides - Get channel overrides
- * - PATCH /user/channel/:channelId/config-overrides - Update channel overrides (merge semantics)
- * - DELETE /user/channel/:channelId/config-overrides - Clear channel overrides
+ * - GET /api/user/channel/:channelId/config-overrides - Get channel overrides
+ * - PATCH /api/user/channel/:channelId/config-overrides - Update channel overrides (merge semantics)
+ * - DELETE /api/user/channel/:channelId/config-overrides - Clear channel overrides
  *
  * Authorization: These endpoints use requireUserAuth() only (no guild permission check).
  * Discord permission enforcement (ManageMessages) happens in the bot-client layer before

--- a/services/api-gateway/src/routes/user/channel/deactivate.ts
+++ b/services/api-gateway/src/routes/user/channel/deactivate.ts
@@ -1,5 +1,5 @@
 /**
- * DELETE /user/channel/deactivate
+ * DELETE /api/user/channel/deactivate
  * Deactivate personality from a Discord channel
  *
  * Removes any personality activation from the channel, so the bot

--- a/services/api-gateway/src/routes/user/channel/get.ts
+++ b/services/api-gateway/src/routes/user/channel/get.ts
@@ -1,6 +1,9 @@
 /**
- * GET /user/channel/:channelId
- * Get settings for a specific channel
+ * Get settings for a specific channel.
+ *
+ * Mounted twice in routes/_generated/mounts.ts:
+ * - GET /api/internal/channel/:channelId - service-to-service read (no user context)
+ * - GET /api/user/channel/:channelId - the user-facing read
  */
 
 import { type Response, type RequestHandler } from 'express';
@@ -17,7 +20,8 @@ import type { RouteDeps } from '../../routeDeps.js';
 const logger = createLogger('channel-get');
 
 /**
- * GET /api/user/channel/:channelId — channel settings (service-only).
+ * Channel settings by ID, served on both the `/api/internal` and `/api/user`
+ * mounts above.
  */
 export const handleGetUserChannel = (deps: RouteDeps): RequestHandler => {
   const { prisma } = deps;

--- a/services/api-gateway/src/routes/user/channel/list.ts
+++ b/services/api-gateway/src/routes/user/channel/list.ts
@@ -1,5 +1,5 @@
 /**
- * GET /user/channel/list
+ * GET /api/user/channel/list
  * List all channel settings with activated personalities
  *
  * Query params:

--- a/services/api-gateway/src/routes/user/channel/updateGuild.ts
+++ b/services/api-gateway/src/routes/user/channel/updateGuild.ts
@@ -1,5 +1,5 @@
 /**
- * PATCH /user/channel/update-guild
+ * PATCH /api/user/channel/update-guild
  * Update guildId for an existing channel settings record (lazy backfill)
  *
  * This endpoint is called by bot-client when it encounters settings

--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 
 // Hoisted mocks for service classes
 const { mockGetOrCreateUser, mockGetOrCreateUserShell, mockResolveOverrides } = vi.hoisted(() => ({
@@ -124,8 +124,17 @@ const mockDeps = {
   } as unknown as import('@tzurot/config-resolver').ConfigCascadeResolver,
 } as unknown as import('../routeDeps.js').RouteDeps;
 
-import { createConfigOverrideRoutes } from './config-overrides.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
+import {
+  handleClearPersonalityOverrides,
+  handleClearUserDefaults,
+  handleGetUserDefaults,
+  handleResolveCascade,
+  handleResolveUserDefaults,
+  handleUpdatePersonalityOverrides,
+  handleUpdateUserDefaults,
+} from './config-overrides.js';
+import { asRouteHandler, type RouteHandler } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 import { HARDCODED_CONFIG_DEFAULTS } from '@tzurot/common-types/schemas/api/configOverrides';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 
@@ -154,12 +163,12 @@ function createMockReqRes(
   return { req, res };
 }
 
-function getHandler(
-  router: ReturnType<typeof createConfigOverrideRoutes>,
-  method: 'get' | 'post' | 'patch' | 'delete',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
+/**
+ * Build a bare handler with the given deps — the same export
+ * routes/_generated/mounts.ts mounts, invoked directly.
+ */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler, deps: RouteDeps): RouteHandler {
+  return asRouteHandler(handler(deps));
 }
 
 describe('/user/config-overrides routes', () => {
@@ -176,25 +185,9 @@ describe('/user/config-overrides routes', () => {
     mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({});
   });
 
-  describe('route factory', () => {
-    it('should create a router with all expected routes', () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-
-      expect(router).toBeDefined();
-      expect(findRoute(router, 'get', '/resolve-defaults')).toBeDefined();
-      expect(findRoute(router, 'get', '/defaults')).toBeDefined();
-      expect(findRoute(router, 'patch', '/defaults')).toBeDefined();
-      expect(findRoute(router, 'delete', '/defaults')).toBeDefined();
-      expect(findRoute(router, 'get', '/resolve/:personalityId')).toBeDefined();
-      expect(findRoute(router, 'patch', '/:personalityId')).toBeDefined();
-      expect(findRoute(router, 'delete', '/:personalityId')).toBeDefined();
-    });
-  });
-
   describe('GET /resolve-defaults', () => {
     it('should return hardcoded defaults when no overrides exist', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve-defaults');
+      const handler = buildHandler(handleResolveUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -218,8 +211,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 75, crossChannelHistoryEnabled: true },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve-defaults');
+      const handler = buildHandler(handleResolveUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -248,8 +240,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 30, maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve-defaults');
+      const handler = buildHandler(handleResolveUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -276,8 +267,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve-defaults');
+      const handler = buildHandler(handleResolveUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -300,8 +290,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('GET /defaults', () => {
     it('should return null when no config defaults set', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/defaults');
+      const handler = buildHandler(handleGetUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -315,8 +304,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 30, maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/defaults');
+      const handler = buildHandler(handleGetUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -336,8 +324,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 30 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/defaults');
+      const handler = buildHandler(handleUpdateUserDefaults, mockDeps);
       const { req, res } = createMockReqRes({ maxImages: 5 });
 
       await handler(req, res);
@@ -356,8 +343,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 30 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/defaults');
+      const handler = buildHandler(handleUpdateUserDefaults, mockDeps);
       const { req, res } = createMockReqRes({ maxAge: -1 });
 
       await handler(req, res);
@@ -377,8 +363,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxAge: null, maxMessages: 30 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/defaults');
+      const handler = buildHandler(handleUpdateUserDefaults, mockDeps);
       const { req, res } = createMockReqRes({ maxAge: null });
 
       await handler(req, res);
@@ -391,8 +376,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject non-object request body', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/defaults');
+      const handler = buildHandler(handleUpdateUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
       req.body = 'not-an-object' as unknown as Record<string, unknown>;
 
@@ -409,8 +393,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject invalid config format', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/defaults');
+      const handler = buildHandler(handleUpdateUserDefaults, mockDeps);
       const { req, res } = createMockReqRes({ maxMessages: 'not-a-number' });
 
       await handler(req, res);
@@ -426,8 +409,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('DELETE /defaults', () => {
     it('should clear user config defaults', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/defaults');
+      const handler = buildHandler(handleClearUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -444,8 +426,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('GET /resolve/:personalityId', () => {
     it('should return resolved cascade overrides', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve/:personalityId');
+      const handler = buildHandler(handleResolveCascade, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
       await handler(req, res);
@@ -462,8 +443,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should pass channelId query param to resolver', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve/:personalityId');
+      const handler = buildHandler(handleResolveCascade, mockDeps);
       const { req, res } = createMockReqRes(
         {},
         { personalityId: TEST_PERSONALITY_ID },
@@ -480,8 +460,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject invalid channelId format', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve/:personalityId');
+      const handler = buildHandler(handleResolveCascade, mockDeps);
       const { req, res } = createMockReqRes(
         {},
         { personalityId: TEST_PERSONALITY_ID },
@@ -495,8 +474,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should pass undefined channelId when query param not provided', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve/:personalityId');
+      const handler = buildHandler(handleResolveCascade, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
       await handler(req, res);
@@ -511,8 +489,7 @@ describe('/user/config-overrides routes', () => {
     it('should reject non-UUID personalityId with 400, matching the sibling mutators', async () => {
       // Without the shared UUID gate, a malformed id reached the resolver and
       // surfaced as a Prisma uuid-cast error (500-shaped) instead of a 400.
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve/:personalityId');
+      const handler = buildHandler(handleResolveCascade, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: 'not-a-uuid' });
 
       await handler(req, res);
@@ -530,8 +507,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('PATCH /:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: 'resolve-defaults' }
@@ -550,8 +526,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject non-object request body', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes(undefined as unknown as Record<string, unknown>, {
         personalityId: TEST_PERSONALITY_ID,
       });
@@ -570,8 +545,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should upsert valid per-personality overrides', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -598,8 +572,7 @@ describe('/user/config-overrides routes', () => {
       mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({});
       mockPrisma.userPersonalityConfig.deleteMany.mockResolvedValue({ count: 1 });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: null },
         { personalityId: TEST_PERSONALITY_ID }
@@ -614,8 +587,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject invalid config format', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: -5 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -636,8 +608,7 @@ describe('/user/config-overrides routes', () => {
         configOverrides: { maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -656,8 +627,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('DELETE /:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:personalityId');
+      const handler = buildHandler(handleClearPersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: 'resolve-defaults' });
 
       await handler(req, res);
@@ -677,8 +647,7 @@ describe('/user/config-overrides routes', () => {
         configOverrides: { maxMessages: 30 },
       });
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:personalityId');
+      const handler = buildHandler(handleClearPersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
       await handler(req, res);
@@ -691,8 +660,7 @@ describe('/user/config-overrides routes', () => {
     it('should succeed even when no overrides exist', async () => {
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue(null);
 
-      const router = createConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:personalityId');
+      const handler = buildHandler(handleClearPersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
       await handler(req, res);
@@ -709,13 +677,12 @@ describe('/user/config-overrides routes', () => {
         invalidateUser: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createConfigOverrideRoutes({
+      const handler = buildHandler(handleUpdateUserDefaults, {
         ...mockDeps,
         cascadeInvalidation: mockInvalidation as unknown as NonNullable<
-          Parameters<typeof createConfigOverrideRoutes>[0]['cascadeInvalidation']
+          RouteDeps['cascadeInvalidation']
         >,
       });
-      const handler = getHandler(router, 'patch', '/defaults');
       const { req, res } = createMockReqRes({ maxMessages: 25 });
 
       await handler(req, res);
@@ -728,13 +695,12 @@ describe('/user/config-overrides routes', () => {
         invalidateUser: vi.fn().mockRejectedValue(new Error('Redis down')),
       };
 
-      const router = createConfigOverrideRoutes({
+      const handler = buildHandler(handleClearUserDefaults, {
         ...mockDeps,
         cascadeInvalidation: mockInvalidation as unknown as NonNullable<
-          Parameters<typeof createConfigOverrideRoutes>[0]['cascadeInvalidation']
+          RouteDeps['cascadeInvalidation']
         >,
       });
-      const handler = getHandler(router, 'delete', '/defaults');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -3,16 +3,16 @@
  * CRUD for user-level and per-personality config cascade overrides
  *
  * Endpoints:
- * - GET /user/config-overrides/resolve-defaults - Resolve admin → user-default cascade
- * - GET /user/config-overrides/resolve/:personalityId - Resolve cascade overrides
- * - PATCH /user/config-overrides/:personalityId - Update per-personality overrides
- * - DELETE /user/config-overrides/:personalityId - Clear per-personality overrides
- * - GET /user/config-overrides/defaults - Get user's global defaults
- * - PATCH /user/config-overrides/defaults - Update user's global defaults
- * - DELETE /user/config-overrides/defaults - Clear user's global defaults
+ * - GET /api/user/config-overrides/resolve-defaults - Resolve admin → user-default cascade
+ * - GET /api/user/config-overrides/resolve/:personalityId - Resolve cascade overrides
+ * - PATCH /api/user/config-overrides/:personalityId - Update per-personality overrides
+ * - DELETE /api/user/config-overrides/:personalityId - Clear per-personality overrides
+ * - GET /api/user/config-overrides/defaults - Get user's global defaults
+ * - PATCH /api/user/config-overrides/defaults - Update user's global defaults
+ * - DELETE /api/user/config-overrides/defaults - Clear user's global defaults
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 import { DISCORD_SNOWFLAKE } from '@tzurot/common-types/constants/discord';
@@ -25,7 +25,6 @@ import {
 import { Prisma } from '@tzurot/common-types/services/prisma';
 import { generateUserPersonalityConfigUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
@@ -291,20 +290,3 @@ export const handleClearPersonalityOverrides = (deps: RouteDeps): RequestHandler
     sendCustomSuccess(res, { success: true }, StatusCodes.OK);
   });
 };
-
-export function createConfigOverrideRoutes(deps: RouteDeps): Router {
-  const router = Router();
-
-  router.use(requireUserAuth());
-  router.use(requireProvisionedUser(deps.prisma));
-
-  router.get('/resolve-defaults', handleResolveUserDefaults(deps));
-  router.get('/defaults', handleGetUserDefaults(deps));
-  router.patch('/defaults', handleUpdateUserDefaults(deps));
-  router.delete('/defaults', handleClearUserDefaults(deps));
-  router.get('/resolve/:personalityId', handleResolveCascade(deps));
-  router.patch('/:personalityId', handleUpdatePersonalityOverrides(deps));
-  router.delete('/:personalityId', handleClearPersonalityOverrides(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/conversationLookup.test.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.test.ts
@@ -37,9 +37,9 @@ vi.mock('../../utils/asyncHandler.js', () => ({
 // Mock Prisma (minimal - route doesn't use it directly)
 const mockPrisma = {};
 
-import { createConversationLookupRoutes } from './conversationLookup.js';
+import { handleLookupPersonalityFromMessage } from './conversationLookup.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { asRouteHandler, stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 // Helper to create mock request/response
 function createMockReqRes(query: Record<string, unknown> = {}) {
@@ -56,23 +56,19 @@ function createMockReqRes(query: Record<string, unknown> = {}) {
 }
 
 describe('conversationLookup routes', () => {
-  let router: ReturnType<typeof createConversationLookupRoutes>;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    router = createConversationLookupRoutes({
-      ...stubRouteResolvers(),
-      prisma: mockPrisma as unknown as PrismaClient,
-    });
   });
 
-  describe('GET /conversation/message-personality', () => {
-    // Helper to get the route handler directly
+  describe('GET /api/internal/conversation/message-personality', () => {
+    // The bare handler export — the shape routes/_generated/mounts.ts mounts.
     function getHandler() {
-      const layer = (router as any).stack.find(
-        (l: any) => l.route?.path === '/message-personality'
+      return asRouteHandler(
+        handleLookupPersonalityFromMessage({
+          ...stubRouteResolvers(),
+          prisma: mockPrisma as unknown as PrismaClient,
+        })
       );
-      return layer?.route?.stack[0]?.handle;
     }
 
     it('should return 400 when discordMessageId is missing', async () => {

--- a/services/api-gateway/src/routes/user/conversationLookup.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.ts
@@ -5,7 +5,7 @@
  * GET /api/internal/conversation/message-personality - Get personality from Discord message ID
  */
 
-import { Router, type Request, type Response, type RequestHandler } from 'express';
+import { type Request, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { ConversationHistoryService } from '@tzurot/conversation-history';
@@ -60,9 +60,3 @@ export const handleLookupPersonalityFromMessage = (deps: RouteDeps): RequestHand
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
 };
-
-export function createConversationLookupRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.get('/message-personality', handleLookupPersonalityFromMessage(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/user/feedback.ts
+++ b/services/api-gateway/src/routes/user/feedback.ts
@@ -1,6 +1,6 @@
 /**
  * User Feedback Intake Route
- * POST /user/feedback - store a feedback submission after the abuse gates
+ * POST /api/user/feedback - store a feedback submission after the abuse gates
  *
  * Gates run cheap-first (owner-set posture: this surface is a spam/DoS
  * vector): Zod length cap → Redis cooldown → Redis daily cap → DB near-dup

--- a/services/api-gateway/src/routes/user/history.test.ts
+++ b/services/api-gateway/src/routes/user/history.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 
 // Mock ConversationHistoryService instance methods
 const mockGetHistoryStats = vi.fn();
@@ -85,10 +85,19 @@ const mockPrisma = {
   }),
 };
 
-import { createHistoryRoutes } from './history.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
+import {
+  handleClearHistory,
+  handleGetHistoryStats,
+  handleHardDeleteHistory,
+  handleUndoHistory,
+} from './history.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import {
+  asRouteHandler,
+  stubRouteResolvers,
+  type RouteHandler,
+} from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 // Test constants
 const TEST_USER_ID = '00000000-0000-0000-0000-000000000001';
@@ -116,13 +125,12 @@ function createMockReqRes(body: Record<string, unknown> = {}, query: Record<stri
   return { req, res };
 }
 
-// Helper to get handler from router
-function getHandler(
-  router: ReturnType<typeof createHistoryRoutes>,
-  method: 'get' | 'post' | 'delete',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
+/**
+ * Build a bare handler with the given deps — the same export
+ * routes/_generated/mounts.ts mounts, invoked directly.
+ */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler, deps: RouteDeps): RouteHandler {
+  return asRouteHandler(handler(deps));
 }
 
 describe('/user/history routes', () => {
@@ -173,52 +181,12 @@ describe('/user/history routes', () => {
     mockClearHistory.mockResolvedValue(5);
   });
 
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createHistoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have POST /clear route registered', () => {
-      const router = createHistoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'post', '/clear')).toBeDefined();
-    });
-
-    it('should have POST /undo route registered', () => {
-      const router = createHistoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'post', '/undo')).toBeDefined();
-    });
-
-    it('should have GET /stats route registered', () => {
-      const router = createHistoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'get', '/stats')).toBeDefined();
-    });
-  });
-
   describe('POST /user/history/clear', () => {
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({});
 
       await handler(req, res);
@@ -233,11 +201,10 @@ describe('/user/history routes', () => {
     });
 
     it('should reject empty personalitySlug', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: '' });
 
       await handler(req, res);
@@ -248,11 +215,10 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -263,11 +229,10 @@ describe('/user/history routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -282,11 +247,10 @@ describe('/user/history routes', () => {
         config: {},
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -295,11 +259,10 @@ describe('/user/history routes', () => {
     });
 
     it('should set epoch on new config', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -344,11 +307,10 @@ describe('/user/history routes', () => {
         previousContextReset: null,
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -370,11 +332,10 @@ describe('/user/history routes', () => {
     });
 
     it('should use explicit personaId when provided', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         personaId: TEST_PERSONA_ID,
@@ -396,11 +357,10 @@ describe('/user/history routes', () => {
     it('should return 404 for explicit personaId not owned by user', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(null); // Persona not found or not owned
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         personaId: 'not-owned-persona-id',
@@ -414,11 +374,10 @@ describe('/user/history routes', () => {
 
   describe('POST /user/history/undo', () => {
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleUndoHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({});
 
       await handler(req, res);
@@ -429,11 +388,10 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleUndoHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -450,11 +408,10 @@ describe('/user/history routes', () => {
         previousContextReset: null, // First clear - no previous epoch
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleUndoHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -485,11 +442,10 @@ describe('/user/history routes', () => {
     it('should return error when config does not exist', async () => {
       mockPrisma.userPersonaHistoryConfig.findUnique.mockResolvedValue(null);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleUndoHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -506,11 +462,10 @@ describe('/user/history routes', () => {
         previousContextReset: null,
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleUndoHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -531,11 +486,10 @@ describe('/user/history routes', () => {
         previousContextReset: previousEpoch,
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleUndoHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -567,11 +521,10 @@ describe('/user/history routes', () => {
 
   describe('GET /user/history/stats', () => {
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleGetHistoryStats, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { channelId: TEST_CHANNEL_ID });
 
       await handler(req, res);
@@ -585,11 +538,10 @@ describe('/user/history routes', () => {
     });
 
     it('should reject missing channelId', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleGetHistoryStats, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -605,11 +557,10 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleGetHistoryStats, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
         { personalitySlug: TEST_PERSONALITY_SLUG, channelId: TEST_CHANNEL_ID }
@@ -629,11 +580,10 @@ describe('/user/history routes', () => {
         newestMessage: new Date('2024-01-02'),
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleGetHistoryStats, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
         { personalitySlug: TEST_PERSONALITY_SLUG, channelId: TEST_CHANNEL_ID }
@@ -687,11 +637,10 @@ describe('/user/history routes', () => {
         newestMessage: new Date('2024-01-02'),
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleGetHistoryStats, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
         { personalitySlug: TEST_PERSONALITY_SLUG, channelId: TEST_CHANNEL_ID }
@@ -738,11 +687,10 @@ describe('/user/history routes', () => {
         previousContextReset: new Date('2024-01-01'), // Has previous epoch
       });
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleGetHistoryStats, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
         { personalitySlug: TEST_PERSONALITY_SLUG, channelId: TEST_CHANNEL_ID }
@@ -759,21 +707,11 @@ describe('/user/history routes', () => {
   });
 
   describe('DELETE /user/history/hard-delete', () => {
-    it('should have DELETE /hard-delete route registered', () => {
-      const router = createHistoryRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'delete', '/hard-delete')).toBeDefined();
-    });
-
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({ channelId: TEST_CHANNEL_ID });
 
       await handler(req, res);
@@ -788,11 +726,10 @@ describe('/user/history routes', () => {
     });
 
     it('should reject missing channelId', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
       await handler(req, res);
@@ -809,11 +746,10 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         channelId: TEST_CHANNEL_ID,
@@ -827,11 +763,10 @@ describe('/user/history routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         channelId: TEST_CHANNEL_ID,
@@ -845,11 +780,10 @@ describe('/user/history routes', () => {
     it('should delete history for resolved persona by default', async () => {
       mockClearHistory.mockResolvedValue(15);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         channelId: TEST_CHANNEL_ID,
@@ -877,11 +811,10 @@ describe('/user/history routes', () => {
     it('should handle singular message count in response', async () => {
       mockClearHistory.mockResolvedValue(1);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         channelId: TEST_CHANNEL_ID,
@@ -897,11 +830,10 @@ describe('/user/history routes', () => {
     });
 
     it('should set irreversible context epoch instead of deleting config', async () => {
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         channelId: TEST_CHANNEL_ID,
@@ -939,11 +871,10 @@ describe('/user/history routes', () => {
     it('should succeed and set epoch even when no messages to delete', async () => {
       mockClearHistory.mockResolvedValue(0);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         channelId: TEST_CHANNEL_ID,
@@ -963,11 +894,10 @@ describe('/user/history routes', () => {
     it('should handle zero messages deleted', async () => {
       mockClearHistory.mockResolvedValue(0);
 
-      const router = createHistoryRoutes({
+      const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
         channelId: TEST_CHANNEL_ID,

--- a/services/api-gateway/src/routes/user/history.ts
+++ b/services/api-gateway/src/routes/user/history.ts
@@ -5,12 +5,13 @@
  * Per-persona epoch tracking: Each user's persona has independent history visibility.
  * Uses UserPersonaHistoryConfig table for per-persona epoch storage.
  *
- * POST /user/history/clear - Set context epoch (soft reset)
- * POST /user/history/undo - Restore previous epoch
- * GET /user/history/stats - Get history statistics
+ * POST /api/user/history/clear - Set context epoch (soft reset)
+ * POST /api/user/history/undo - Restore previous epoch
+ * GET /api/user/history/stats - Get history statistics
+ * DELETE /api/user/history/hard-delete - Permanent, irreversible deletion
  */
 
-import { Router, type Response, type Request, type RequestHandler } from 'express';
+import { type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   ClearHistorySchema,
@@ -25,7 +26,6 @@ import {
   ConversationHistoryService,
   ConversationRetentionService,
 } from '@tzurot/conversation-history';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -49,7 +49,7 @@ interface HistoryHandlerDeps {
 type RouteHandler = (req: Request, res: Response) => Promise<void>;
 
 /**
- * Handle POST /user/history/clear
+ * Handle POST /api/user/history/clear
  * Set context epoch to current time (soft reset)
  */
 function createClearHandler(deps: HistoryHandlerDeps): RouteHandler {
@@ -129,7 +129,7 @@ function createClearHandler(deps: HistoryHandlerDeps): RouteHandler {
 }
 
 /**
- * Handle POST /user/history/undo
+ * Handle POST /api/user/history/undo
  * Restore previous context epoch
  */
 function createUndoHandler(deps: HistoryHandlerDeps): RouteHandler {
@@ -213,7 +213,7 @@ function createUndoHandler(deps: HistoryHandlerDeps): RouteHandler {
 }
 
 /**
- * Handle GET /user/history/stats
+ * Handle GET /api/user/history/stats
  * Get conversation history statistics
  */
 function createStatsHandler(deps: HistoryHandlerDeps): RouteHandler {
@@ -290,7 +290,7 @@ function createStatsHandler(deps: HistoryHandlerDeps): RouteHandler {
 }
 
 /**
- * Handle DELETE /user/history/hard-delete
+ * Handle DELETE /api/user/history/hard-delete
  * Permanently delete conversation history
  */
 function createHardDeleteHandler(deps: HistoryHandlerDeps): RouteHandler {
@@ -381,20 +381,3 @@ export const handleGetHistoryStats = (deps: RouteDeps): RequestHandler =>
 /** DELETE /api/user/history/hard-delete — permanent deletion */
 export const handleHardDeleteHistory = (deps: RouteDeps): RequestHandler =>
   createHardDeleteHandler(buildHistoryDeps(deps));
-
-export function createHistoryRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const requireProvisioned = requireProvisionedUser(deps.prisma);
-
-  router.post('/clear', requireUserAuth(), requireProvisioned, handleClearHistory(deps));
-  router.post('/undo', requireUserAuth(), requireProvisioned, handleUndoHistory(deps));
-  router.get('/stats', requireUserAuth(), requireProvisioned, handleGetHistoryStats(deps));
-  router.delete(
-    '/hard-delete',
-    requireUserAuth(),
-    requireProvisioned,
-    handleHardDeleteHistory(deps)
-  );
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/llm-config.component.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.component.test.ts
@@ -58,7 +58,7 @@ vi.mock('../../services/AuthMiddleware.js', async () => {
 });
 
 // Import after mocking
-const { createLlmConfigRoutes } = await import('./llm-config.js');
+const { handleResolveUserLlmConfig } = await import('./llm-config.js');
 const { ConfigCascadeResolver, LlmConfigResolver } = await import('@tzurot/config-resolver');
 
 describe('LLM Config Resolution Integration', () => {
@@ -81,15 +81,17 @@ describe('LLM Config Resolution Integration', () => {
     app = express();
     app.use(express.json());
 
-    // Mount LLM config routes (auth is mocked above). Resolvers are runtime-
+    // Mount the resolve handler (auth is mocked above). Resolvers are runtime-
     // required on RouteDeps (compile-enforced) — real instances over the PGLite prisma,
     // cleanup timers off.
-    const router = createLlmConfigRoutes({
-      prisma,
-      cascadeResolver: new ConfigCascadeResolver(prisma, { enableCleanup: false }),
-      llmConfigResolver: new LlmConfigResolver(prisma, { enableCleanup: false }),
-    });
-    app.use('/user/llm-config', router);
+    app.post(
+      '/user/llm-config/resolve',
+      handleResolveUserLlmConfig({
+        prisma,
+        cascadeResolver: new ConfigCascadeResolver(prisma, { enableCleanup: false }),
+        llmConfigResolver: new LlmConfigResolver(prisma, { enableCleanup: false }),
+      })
+    );
   }, 30000);
 
   afterAll(async () => {

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 
 // Hoisted mocks for resolvers so they're available before module loading
 const { mockResolveOverrides, mockResolveConfig } = vi.hoisted(() => ({
@@ -177,8 +177,16 @@ const mockCacheInvalidation = {
   invalidateAll: vi.fn().mockResolvedValue(undefined),
 } as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService;
 
-import { createLlmConfigRoutes } from './llm-config.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
+import {
+  handleCreateUserLlmConfig,
+  handleDeleteUserLlmConfig,
+  handleGetUserLlmConfig,
+  handleListUserLlmConfigs,
+  handleResolveUserLlmConfig,
+  handleUpdateUserLlmConfig,
+} from './llm-config.js';
+import { asRouteHandler, type RouteHandler } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { computeLlmConfigPermissions } from '@tzurot/common-types/utils/permissions';
 
@@ -205,13 +213,12 @@ function createMockReqRes(
   return { req, res };
 }
 
-// Helper to get handler from router
-function getHandler(
-  router: ReturnType<typeof createLlmConfigRoutes>,
-  method: 'get' | 'post' | 'put' | 'delete',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
+/**
+ * Build a bare handler with the given deps — the same export
+ * routes/_generated/mounts.ts mounts, invoked directly.
+ */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler, deps: RouteDeps): RouteHandler {
+  return asRouteHandler(handler(deps));
 }
 
 describe('/user/llm-config routes', () => {
@@ -233,48 +240,6 @@ describe('/user/llm-config routes', () => {
     mockPrisma.userApiKey.findFirst.mockResolvedValue(null);
   });
 
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createLlmConfigRoutes(mockDeps);
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have GET / route registered', () => {
-      const router = createLlmConfigRoutes(mockDeps);
-
-      expect(router.stack).toBeDefined();
-      expect(router.stack.length).toBeGreaterThan(0);
-
-      expect(findRoute(router, 'get', '/')).toBeDefined();
-    });
-
-    it('should have GET /:id route registered', () => {
-      const router = createLlmConfigRoutes(mockDeps);
-
-      expect(findRoute(router, 'get', '/:id')).toBeDefined();
-    });
-
-    it('should have POST route registered', () => {
-      const router = createLlmConfigRoutes(mockDeps);
-
-      expect(findRoute(router, 'post', '/')).toBeDefined();
-    });
-
-    it('should have PUT /:id route registered', () => {
-      const router = createLlmConfigRoutes(mockDeps);
-
-      expect(findRoute(router, 'put', '/:id')).toBeDefined();
-    });
-
-    it('should have DELETE route registered', () => {
-      const router = createLlmConfigRoutes(mockDeps);
-
-      expect(findRoute(router, 'delete', '/:id')).toBeDefined();
-    });
-  });
-
   describe('GET /user/llm-config', () => {
     it('should return global configs', async () => {
       const globalConfig = {
@@ -288,8 +253,7 @@ describe('/user/llm-config routes', () => {
       };
       mockPrisma.llmConfig.findMany.mockResolvedValueOnce([globalConfig]).mockResolvedValueOnce([]);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/');
+      const handler = buildHandler(handleListUserLlmConfigs, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -315,8 +279,7 @@ describe('/user/llm-config routes', () => {
       };
       mockPrisma.llmConfig.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([userConfig]);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/');
+      const handler = buildHandler(handleListUserLlmConfigs, mockDeps);
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -370,11 +333,10 @@ describe('/user/llm-config routes', () => {
         ),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleListUserLlmConfigs, {
         ...mockDeps,
         modelCache,
       });
-      const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -396,8 +358,7 @@ describe('/user/llm-config routes', () => {
     it('should return 404 when config not found', async () => {
       mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/:id');
+      const handler = buildHandler(handleGetUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -420,8 +381,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/:id');
+      const handler = buildHandler(handleGetUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -459,11 +419,10 @@ describe('/user/llm-config routes', () => {
         getModelById: vi.fn().mockResolvedValue(null), // glm-5.2 not on OpenRouter
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleGetUserLlmConfig, {
         ...mockDeps,
         modelCache,
       });
-      const handler = getHandler(router, 'get', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -495,11 +454,10 @@ describe('/user/llm-config routes', () => {
         getModelById: vi.fn().mockResolvedValue(null),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleGetUserLlmConfig, {
         ...mockDeps,
         modelCache,
       });
-      const handler = getHandler(router, 'get', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -527,8 +485,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/:id');
+      const handler = buildHandler(handleGetUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -554,8 +511,7 @@ describe('/user/llm-config routes', () => {
       // (otherwise supertest hangs waiting for a response that never comes).
       mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ name: 'My Config', model: 'bad-model' });
 
       await handler(req, res);
@@ -566,8 +522,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject missing name', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ model: 'gpt-4' });
 
       await handler(req, res);
@@ -582,8 +537,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject missing model', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ name: 'My Config' });
 
       await handler(req, res);
@@ -597,8 +551,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject name over 100 characters', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         name: 'a'.repeat(101),
         model: 'gpt-4',
@@ -618,8 +571,7 @@ describe('/user/llm-config routes', () => {
     it('should reject duplicate name for user', async () => {
       mockPrisma.llmConfig.findFirst.mockResolvedValue({ id: 'existing' });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ name: 'My Config', model: 'gpt-4' });
 
       await handler(req, res);
@@ -645,8 +597,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ name: 'My Config', model: 'gpt-4' });
 
       await handler(req, res);
@@ -682,8 +633,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ name: 'GLM Config', model: 'z-ai/glm-5.2' });
 
       await handler(req, res);
@@ -717,11 +667,10 @@ describe('/user/llm-config routes', () => {
         getModelById: vi.fn().mockResolvedValue(null),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleCreateUserLlmConfig, {
         ...mockDeps,
         modelCache,
       });
-      const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({ name: 'GLM Config', model: 'z-ai/glm-5.2' });
 
       await handler(req, res);
@@ -746,8 +695,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         name: 'My Config',
         model: 'gpt-4',
@@ -780,8 +728,7 @@ describe('/user/llm-config routes', () => {
         contextWindowTokens: 100000,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/');
+      const handler = buildHandler(handleCreateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         name: 'Context Config',
         model: 'gpt-4',
@@ -807,11 +754,10 @@ describe('/user/llm-config routes', () => {
     it('should return 400 when model validation fails on update', async () => {
       mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes(
         { contextWindowTokens: 999999999 },
         { id: 'config-123' }
@@ -826,11 +772,10 @@ describe('/user/llm-config routes', () => {
     it('should return 404 when config not found', async () => {
       mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'New Name' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -869,11 +814,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const req = {
         body: { isGlobal: true },
         params: { id: 'config-123' },
@@ -921,11 +865,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes(
         { name: 'Updated Global Config' },
         { id: 'config-123' }
@@ -950,11 +893,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'New Name' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -972,11 +914,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -990,11 +931,10 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject non-boolean isGlobal value', async () => {
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       // Send string instead of boolean - Zod validates before DB lookup
       const { req, res } = createMockReqRes({ isGlobal: 'true' }, { id: 'config-123' });
 
@@ -1038,11 +978,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes(
         { name: 'New Name', advancedParameters: { temperature: 0.9 } },
         { id: 'config-123' }
@@ -1100,11 +1039,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ model: 'z-ai/glm-5.2' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1147,12 +1085,11 @@ describe('/user/llm-config routes', () => {
         getModelById: vi.fn().mockResolvedValue(null),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
         modelCache,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ model: 'z-ai/glm-5.2' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1177,11 +1114,10 @@ describe('/user/llm-config routes', () => {
       });
       mockPrisma.llmConfig.findFirst.mockResolvedValue({ id: 'other-existing' });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'Taken Name' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1219,11 +1155,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'New Name' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1263,8 +1198,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'put', '/:id');
+      const handler = buildHandler(handleUpdateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ model: 'claude-3' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1313,8 +1247,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'put', '/:id');
+      const handler = buildHandler(handleUpdateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ name: 'Renamed Verbatim' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1343,8 +1276,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'put', '/:id');
+      const handler = buildHandler(handleUpdateUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({ model: 'new-model' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1358,8 +1290,7 @@ describe('/user/llm-config routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1371,8 +1302,7 @@ describe('/user/llm-config routes', () => {
       // Service uses findUnique for getById
       mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1396,8 +1326,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(0);
       mockPrisma.llmConfig.delete.mockResolvedValue({} as unknown);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1422,8 +1351,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1445,8 +1373,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(2);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1473,8 +1400,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(0);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1508,8 +1434,7 @@ describe('/user/llm-config routes', () => {
       // Force the service to return a non-null warning via the underlying user.count.
       mockPrisma.user.count.mockResolvedValueOnce(5);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1537,8 +1462,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(0);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1564,8 +1488,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(7);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1589,8 +1512,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(2);
 
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'delete', '/:id');
+      const handler = buildHandler(handleDeleteUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1641,12 +1563,11 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleGetUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
         modelCache: mockModelCache,
       });
-      const handler = getHandler(router, 'get', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
       await handler(req, res);
@@ -1681,12 +1602,11 @@ describe('/user/llm-config routes', () => {
         advancedParameters: null,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleCreateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
         modelCache: mockModelCache,
       });
-      const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'New Config',
         model: 'anthropic/claude-sonnet-4',
@@ -1736,12 +1656,11 @@ describe('/user/llm-config routes', () => {
         advancedParameters: null,
       });
 
-      const router = createLlmConfigRoutes({
+      const handler = buildHandler(handleUpdateUserLlmConfig, {
         ...mockDeps,
         llmConfigCacheInvalidation: mockCacheInvalidation,
         modelCache: mockModelCache,
       });
-      const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'Updated Config' }, { id: 'config-123' });
 
       await handler(req, res);
@@ -1760,8 +1679,7 @@ describe('/user/llm-config routes', () => {
 
   describe('POST /user/llm-config/resolve', () => {
     it('should reject missing personalityId', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/resolve');
+      const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         personalityConfig: { id: 'p-1', name: 'Test', model: 'gpt-4' },
       });
@@ -1772,8 +1690,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject missing personalityConfig', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/resolve');
+      const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
       });
@@ -1784,8 +1701,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject invalid personalityConfig structure', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/resolve');
+      const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
         personalityConfig: { invalid: true }, // Missing required fields
@@ -1797,8 +1713,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should resolve config and include overrides in response', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/resolve');
+      const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
         personalityConfig: { id: 'p-1', name: 'Test', model: 'gpt-4' },
@@ -1823,8 +1738,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should pass channelId to cascade resolver when provided', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/resolve');
+      const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
         personalityConfig: { id: 'p-1', name: 'Test', model: 'gpt-4' },
@@ -1842,8 +1756,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject invalid channelId format', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/resolve');
+      const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
         personalityConfig: { id: 'p-1', name: 'Test', model: 'gpt-4' },
@@ -1857,8 +1770,7 @@ describe('/user/llm-config routes', () => {
 
     it('should return 500 when resolver throws', async () => {
       mockResolveConfig.mockRejectedValueOnce(new Error('DB error'));
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'post', '/resolve');
+      const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
         personalityConfig: { id: 'p-1', name: 'Test', model: 'gpt-4' },

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -3,14 +3,14 @@
  * CRUD operations for user-owned LLM configurations
  *
  * Endpoints:
- * - GET /user/llm-config - List configs (global + user)
- * - GET /user/llm-config/:id - Get single config with full params
- * - POST /user/llm-config - Create user config
- * - PUT /user/llm-config/:id - Update user config (advancedParameters)
- * - DELETE /user/llm-config/:id - Delete user config
+ * - GET /api/user/llm-config - List configs (global + user)
+ * - GET /api/user/llm-config/:id - Get single config with full params
+ * - POST /api/user/llm-config - Create user config
+ * - PUT /api/user/llm-config/:id - Update user config (advancedParameters)
+ * - DELETE /api/user/llm-config/:id - Delete user config
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { AIProvider } from '@tzurot/common-types/constants/ai';
 import {
@@ -22,7 +22,6 @@ import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
 import { computeLlmConfigPermissions } from '@tzurot/common-types/utils/permissions';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -521,19 +520,3 @@ export const handleUpdateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
 
 export const handleDeleteUserLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createDeleteHandler(buildService(deps)));
-
-// --- Main Route Factory ---
-
-export function createLlmConfigRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const requireProvisioned = requireProvisionedUser(deps.prisma);
-
-  router.get('/', requireUserAuth(), requireProvisioned, handleListUserLlmConfigs(deps));
-  router.get('/:id', requireUserAuth(), requireProvisioned, handleGetUserLlmConfig(deps));
-  router.post('/', requireUserAuth(), requireProvisioned, handleCreateUserLlmConfig(deps));
-  router.post('/resolve', requireUserAuth(), requireProvisioned, handleResolveUserLlmConfig(deps));
-  router.put('/:id', requireUserAuth(), requireProvisioned, handleUpdateUserLlmConfig(deps));
-  router.delete('/:id', requireUserAuth(), requireProvisioned, handleDeleteUserLlmConfig(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/llmConfigResolve.ts
+++ b/services/api-gateway/src/routes/user/llmConfigResolve.ts
@@ -1,7 +1,7 @@
 /**
  * LLM Config Resolve Handler
  *
- * POST /user/llm-config/resolve
+ * POST /api/user/llm-config/resolve
  * Resolves the effective LLM config for a user+personality combination.
  * Used by bot-client to get context settings (maxMessages, maxAge, maxImages)
  * before building conversation context.

--- a/services/api-gateway/src/routes/user/memoryBatch.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.ts
@@ -8,10 +8,10 @@
  * the client — eliminating drift between preview and execute.
  *
  * Endpoints:
- *   POST /user/memory/delete/preview  → impact summary + previewToken
- *   POST /user/memory/delete          → consumes previewToken, soft-deletes
- *   POST /user/memory/purge/token     → confirmation phrase + purgeToken
- *   POST /user/memory/purge           → consumes purgeToken, soft-deletes
+ *   POST /api/user/memory/delete/preview  → impact summary + previewToken
+ *   POST /api/user/memory/delete          → consumes previewToken, soft-deletes
+ *   POST /api/user/memory/purge/token     → confirmation phrase + purgeToken
+ *   POST /api/user/memory/purge           → consumes purgeToken, soft-deletes
  *
  * Locked memories are always skipped (never touched by either flow).
  *
@@ -66,12 +66,12 @@ async function resolvePersonaIdForBatch(
 }
 
 /**
- * Handler for POST /user/memory/delete/preview
+ * Handler for POST /api/user/memory/delete/preview
  *
  * Body: { personalityId, personaId?, timeframe? }
  * Returns: { wouldDelete, lockedWouldSkip, previewToken, ... }
  *
- * The previewToken is the ONLY way to invoke POST /user/memory/delete —
+ * The previewToken is the ONLY way to invoke POST /api/user/memory/delete —
  * the filter is stored server-side under the token key, so the execute
  * path is guaranteed to operate on the same filter the user previewed.
  */
@@ -168,7 +168,7 @@ export const handleBatchDeletePreview = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * Handler for POST /user/memory/delete
+ * Handler for POST /api/user/memory/delete
  *
  * Body: { previewToken }
  * Peek-validate-consume: peek the token, validate personality + persona,
@@ -249,14 +249,14 @@ export const handleBatchDelete = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * Handler for POST /user/memory/purge/token
+ * Handler for POST /api/user/memory/purge/token
  *
  * Body: { personalityId, confirmationPhrase }
  * Returns: { purgeToken, personalityName, ... }
  *
  * Validates the confirmation phrase against the personality name. On success,
  * issues a short-lived purge token bound to the personality. The actual
- * destructive purge requires the token at POST /user/memory/purge.
+ * destructive purge requires the token at POST /api/user/memory/purge.
  */
 export const handleIssuePurgeToken = (deps: RouteDeps): RequestHandler => {
   const { prisma } = deps;
@@ -307,7 +307,7 @@ export const handleIssuePurgeToken = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * Handler for POST /user/memory/purge
+ * Handler for POST /api/user/memory/purge
  *
  * Body: { purgeToken }
  * Peek-validate-consume pattern (mirrors handleBatchDelete). Soft-deletes

--- a/services/api-gateway/src/routes/user/memoryFacts.ts
+++ b/services/api-gateway/src/routes/user/memoryFacts.ts
@@ -202,7 +202,7 @@ export const handleGetFact = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * PATCH /user/fact/:id — correct: supersede the fact with a NEW corrected-tier
+ * PATCH /api/user/fact/:id — correct: supersede the fact with a NEW corrected-tier
  * fact carrying the same entity tags / source provenance. The corrected tier
  * itself is what shields it from automatic extraction supersession (user
  * assertion outranks model assertion) — no lock involved, so re-correcting
@@ -331,7 +331,7 @@ export const handleCorrectFact = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * DELETE /user/fact/:id — forget: terminal per-fact removal. Sets
+ * DELETE /api/user/fact/:id — forget: terminal per-fact removal. Sets
  * `forgotten=true` + `superseded_at` so the fact never re-enters retrieval or
  * supersession context, and re-extracting the identical statement no-ops
  * against the dead row. Per-fact only; the source episode is untouched.
@@ -383,7 +383,7 @@ export const handleForgetFact = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * PUT /user/fact/:id/lock — set the extraction-protection lock explicitly.
+ * PUT /api/user/fact/:id/lock — set the extraction-protection lock explicitly.
  * Idempotent: replaying the same body lands the same state.
  */
 export const handleSetFactLock = (deps: RouteDeps): RequestHandler => {

--- a/services/api-gateway/src/routes/user/memoryFresh.ts
+++ b/services/api-gateway/src/routes/user/memoryFresh.ts
@@ -4,10 +4,10 @@
  * replies without using its long-term memories of the user; nothing is
  * deleted (the write-side sibling is incognito mode, which disables saving).
  *
- * GET /user/memory/fresh - Get current fresh status (optional
+ * GET /api/user/memory/fresh - Get current fresh status (optional
  *   `personalityId` query filters to sessions that apply to that character)
- * POST /user/memory/fresh - Enable fresh mode
- * DELETE /user/memory/fresh - Disable fresh mode
+ * POST /api/user/memory/fresh - Enable fresh mode
+ * DELETE /api/user/memory/fresh - Disable fresh mode
  *
  * All three are the shared memory-mode handlers (see memoryModeHandlers.ts);
  * the ai-worker checks the `fresh:` Redis keys at retrieval time. The

--- a/services/api-gateway/src/routes/user/memoryIncognito.ts
+++ b/services/api-gateway/src/routes/user/memoryIncognito.ts
@@ -2,11 +2,11 @@
  * User Memory Incognito Routes
  * Incognito mode management - temporarily disable memory writing
  *
- * GET /user/memory/incognito - Get current incognito status (optional
+ * GET /api/user/memory/incognito - Get current incognito status (optional
  *   `personalityId` query filters to sessions that apply to that character)
- * POST /user/memory/incognito - Enable incognito mode
- * DELETE /user/memory/incognito - Disable incognito mode
- * POST /user/memory/incognito/forget - Retroactively delete recent memories
+ * POST /api/user/memory/incognito - Enable incognito mode
+ * DELETE /api/user/memory/incognito - Disable incognito mode
+ * POST /api/user/memory/incognito/forget - Retroactively delete recent memories
  *
  * Status/enable/disable are the shared memory-mode handlers (see
  * memoryModeHandlers.ts — fresh mode uses the same machinery); `forget` is
@@ -39,7 +39,7 @@ const incognitoHandlers = createMemoryModeHandlers('incognito', {
 });
 
 /**
- * Handler for POST /user/memory/incognito/forget
+ * Handler for POST /api/user/memory/incognito/forget
  * Retroactively delete recent memories
  */
 async function handleForget(

--- a/services/api-gateway/src/routes/user/memoryList.ts
+++ b/services/api-gateway/src/routes/user/memoryList.ts
@@ -52,7 +52,7 @@ interface ListResponse {
 }
 
 /**
- * Handler for GET /user/memory/list
+ * Handler for GET /api/user/memory/list
  *
  * Query parameters:
  * - personalityId: Filter by personality (optional)

--- a/services/api-gateway/src/routes/user/memorySingle.ts
+++ b/services/api-gateway/src/routes/user/memorySingle.ts
@@ -114,7 +114,7 @@ function transformMemory(memory: {
 }
 
 /**
- * Handler for GET /user/memory/:id
+ * Handler for GET /api/user/memory/:id
  * Get a single memory by ID
  */
 export const handleGetMemory = (deps: RouteDeps): RequestHandler => {
@@ -156,7 +156,7 @@ export const handleGetMemory = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * Handler for PATCH /user/memory/:id
+ * Handler for PATCH /api/user/memory/:id
  * Update memory content
  */
 export const handleUpdateMemory = (deps: RouteDeps): RequestHandler => {
@@ -253,7 +253,7 @@ export async function computeMemoryVector(
 }
 
 /**
- * Handler for PUT /user/memory/:id/lock
+ * Handler for PUT /api/user/memory/:id/lock
  * Set memory lock state explicitly. Idempotent on retry — caller passes
  * the desired state in the body rather than relying on server-side toggle
  * of the current state.
@@ -319,7 +319,7 @@ export const handleSetMemoryLock = (deps: RouteDeps): RequestHandler => {
 };
 
 /**
- * Handler for DELETE /user/memory/:id
+ * Handler for DELETE /api/user/memory/:id
  * Delete a memory (soft delete by setting visibility)
  */
 export const handleDeleteMemory = (deps: RouteDeps): RequestHandler => {

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 
 // Mock dependencies before imports
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -80,11 +80,22 @@ const mockPrisma = {
   }),
 };
 
-import { createModelOverrideRoutes } from './model-override.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
+import {
+  handleClearDefaultModelConfig,
+  handleDeleteModelOverride,
+  handleGetDefaultModelConfig,
+  handleListModelOverrides,
+  handleSetDefaultModelConfig,
+  handleSetModelOverride,
+} from './model-override.js';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import {
+  asRouteHandler,
+  stubRouteResolvers,
+  type RouteHandler,
+} from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 // Helper to create mock request/response
 function createMockReqRes(
@@ -109,13 +120,12 @@ function createMockReqRes(
   return { req, res };
 }
 
-// Helper to get handler from router
-function getHandler(
-  router: ReturnType<typeof createModelOverrideRoutes>,
-  method: 'get' | 'put' | 'delete',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
+/**
+ * Build a bare handler with the given deps — the same export
+ * routes/_generated/mounts.ts mounts, invoked directly.
+ */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler, deps: RouteDeps): RouteHandler {
+  return asRouteHandler(handler(deps));
 }
 
 describe('/user/model-override routes', () => {
@@ -133,57 +143,14 @@ describe('/user/model-override routes', () => {
     mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([]);
   });
 
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createModelOverrideRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have GET route registered', () => {
-      const router = createModelOverrideRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router.stack).toBeDefined();
-      expect(router.stack.length).toBeGreaterThan(0);
-
-      expect(findRoute(router, 'get', '/')).toBeDefined();
-    });
-
-    it('should have PUT route registered', () => {
-      const router = createModelOverrideRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'put', '/')).toBeDefined();
-    });
-
-    it('should have DELETE route registered', () => {
-      const router = createModelOverrideRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'delete', '/:personalityId')).toBeDefined();
-    });
-  });
-
   describe('GET /user/model-override', () => {
     it('should return empty list when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleListModelOverrides, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -206,11 +173,10 @@ describe('/user/model-override routes', () => {
         },
       ]);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleListModelOverrides, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -247,12 +213,11 @@ describe('/user/model-override routes', () => {
         ),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleListModelOverrides, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         modelCache,
       });
-      const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -276,11 +241,10 @@ describe('/user/model-override routes', () => {
         },
       ]);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleListModelOverrides, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -299,11 +263,10 @@ describe('/user/model-override routes', () => {
 
   describe('PUT /user/model-override', () => {
     it('should reject missing personalityId', async () => {
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
       await handler(req, res);
@@ -317,11 +280,10 @@ describe('/user/model-override routes', () => {
     });
 
     it('should reject missing configId', async () => {
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
       });
@@ -339,11 +301,10 @@ describe('/user/model-override routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
         configId: '22222222-2222-4222-a222-222222222222',
@@ -366,11 +327,10 @@ describe('/user/model-override routes', () => {
       });
       mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
         configId: '22222222-2222-4222-a222-222222222222',
@@ -402,11 +362,10 @@ describe('/user/model-override routes', () => {
         llmConfig: { name: 'GPT-4' },
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
         configId: '22222222-2222-4222-a222-222222222222',
@@ -474,12 +433,11 @@ describe('/user/model-override routes', () => {
         ),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         modelCache,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes(
         {
           personalityId: '11111111-1111-4111-a111-111111111111',
@@ -528,12 +486,11 @@ describe('/user/model-override routes', () => {
         ),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         modelCache,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes(
         {
           personalityId: '11111111-1111-4111-a111-111111111111',
@@ -570,12 +527,11 @@ describe('/user/model-override routes', () => {
         getModelById: vi.fn(async () => null), // unknown to OpenRouter + not a z.ai member
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         modelCache,
       });
-      const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes(
         {
           personalityId: '11111111-1111-4111-a111-111111111111',
@@ -601,11 +557,10 @@ describe('/user/model-override routes', () => {
     it('should return 200 (idempotent) when override not found', async () => {
       mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleDeleteModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes(
         {},
         { personalityId: '11111111-1111-4111-a111-111111111111' }
@@ -626,11 +581,10 @@ describe('/user/model-override routes', () => {
         personality: { name: 'Lilith' },
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleDeleteModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes(
         {},
         { personalityId: '11111111-1111-4111-a111-111111111111' }
@@ -651,11 +605,10 @@ describe('/user/model-override routes', () => {
         personality: { name: 'Lilith' },
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleDeleteModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes(
         {},
         { personalityId: '11111111-1111-4111-a111-111111111111' }
@@ -684,11 +637,10 @@ describe('/user/model-override routes', () => {
         defaultLlmConfig: null,
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleGetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -711,11 +663,10 @@ describe('/user/model-override routes', () => {
         defaultLlmConfig: { name: 'My Default Config' },
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleGetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -734,11 +685,10 @@ describe('/user/model-override routes', () => {
 
   describe('PUT /user/model-override/default', () => {
     it('should reject missing configId', async () => {
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({});
 
       await handler(req, res);
@@ -752,11 +702,10 @@ describe('/user/model-override routes', () => {
     });
 
     it('should reject empty configId', async () => {
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '  ' });
 
       await handler(req, res);
@@ -767,11 +716,10 @@ describe('/user/model-override routes', () => {
     it('should return 404 when config not found or not accessible', async () => {
       mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
       await handler(req, res);
@@ -790,11 +738,10 @@ describe('/user/model-override routes', () => {
         name: 'Test Config',
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
       await handler(req, res);
@@ -827,12 +774,11 @@ describe('/user/model-override routes', () => {
         ),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         modelCache,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes(
         { configId: '22222222-2222-4222-a222-222222222222' },
         {},
@@ -861,12 +807,11 @@ describe('/user/model-override routes', () => {
         ),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         modelCache,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes(
         { configId: '22222222-2222-4222-a222-222222222222' },
         {},
@@ -895,12 +840,11 @@ describe('/user/model-override routes', () => {
         getModelById: vi.fn(async () => null), // unknown to OpenRouter + not a z.ai member
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         modelCache,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes(
         { configId: '22222222-2222-4222-a222-222222222222' },
         {},
@@ -929,13 +873,12 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
           mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
       await handler(req, res);
@@ -953,13 +896,12 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockRejectedValue(new Error('Redis error')),
       };
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
           mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
       await handler(req, res);
@@ -974,11 +916,10 @@ describe('/user/model-override routes', () => {
         name: 'Test Config',
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
       await handler(req, res);
@@ -992,11 +933,10 @@ describe('/user/model-override routes', () => {
       // Provisioning middleware sets the UUID; handler-level findUnique returns null (e.g., race with user deletion).
       mockPrisma.user.findUnique.mockResolvedValueOnce(null);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1009,11 +949,10 @@ describe('/user/model-override routes', () => {
         defaultLlmConfigId: null,
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1034,11 +973,10 @@ describe('/user/model-override routes', () => {
         defaultLlmConfigId: 'config-123',
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1074,11 +1012,10 @@ describe('/user/model-override routes', () => {
         name: 'gpt-4-free',
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1108,11 +1045,10 @@ describe('/user/model-override routes', () => {
         name: 'gpt-4-free',
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1143,13 +1079,12 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
           mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1167,13 +1102,12 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockRejectedValue(new Error('Redis error')),
       };
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
           mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1193,11 +1127,10 @@ describe('/user/model-override routes', () => {
         defaultLlmConfigId: 'config-123',
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -1224,11 +1157,10 @@ describe('/user/model-override routes', () => {
         defaultVisionConfig: { name: 'Vision Cfg' },
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleGetDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/default');
       const { req, res } = createMockReqRes({}, {}, { slot: 'vision' });
 
       await handler(req, res);
@@ -1251,11 +1183,10 @@ describe('/user/model-override routes', () => {
       });
       mockPrisma.llmConfig.findUnique.mockResolvedValue({ id: 'vision-free', name: 'Vision Free' });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes({}, {}, { slot: 'vision' });
 
       await handler(req, res);
@@ -1295,11 +1226,10 @@ describe('/user/model-override routes', () => {
         },
       ]);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleListModelOverrides, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes({}, {}, { slot: 'vision' });
 
       await handler(req, res);
@@ -1328,11 +1258,10 @@ describe('/user/model-override routes', () => {
         },
       ]);
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleListModelOverrides, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes({}, {}, { slot: 'all' });
 
       await handler(req, res);
@@ -1378,11 +1307,10 @@ describe('/user/model-override routes', () => {
         personality: { name: 'Lilith' },
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleDeleteModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: PERSONALITY }, { slot: 'vision' });
 
       await handler(req, res);
@@ -1411,11 +1339,10 @@ describe('/user/model-override routes', () => {
         .mockResolvedValueOnce({ id: 'text-free', name: 'Text Free' })
         .mockResolvedValueOnce({ id: 'vision-free', name: 'Vision Free' });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleClearDefaultModelConfig, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes({}, {}, { slot: 'all' });
 
       await handler(req, res);
@@ -1446,11 +1373,10 @@ describe('/user/model-override routes', () => {
         personality: { name: 'Lilith' },
       });
 
-      const router = createModelOverrideRoutes({
+      const handler = buildHandler(handleDeleteModelOverride, {
         ...stubRouteResolvers(),
         prisma: mockPrisma as unknown as PrismaClient,
       });
-      const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: PERSONALITY }, { slot: 'all' });
 
       await handler(req, res);

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -3,15 +3,15 @@
  * Set/reset LLM config overrides for personalities
  *
  * Endpoints:
- * - GET /user/model-override - List all user's model overrides
- * - PUT /user/model-override - Set override for a personality
- * - GET /user/model-override/default - Get user's global default config
- * - PUT /user/model-override/default - Set user's global default config
- * - DELETE /user/model-override/default - Clear user's global default config
- * - DELETE /user/model-override/:personalityId - Remove override (MUST be after /default routes)
+ * - GET /api/user/model-override - List all user's model overrides
+ * - PUT /api/user/model-override - Set override for a personality
+ * - GET /api/user/model-override/default - Get user's global default config
+ * - PUT /api/user/model-override/default - Set user's global default config
+ * - DELETE /api/user/model-override/default - Clear user's global default config
+ * - DELETE /api/user/model-override/:personalityId - Remove override (MUST be after /default routes)
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
@@ -23,7 +23,6 @@ import {
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { generateUserPersonalityConfigUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   parseModelSlotQuery,
@@ -461,28 +460,3 @@ export const handleDeleteModelOverride = (deps: RouteDeps): RequestHandler => {
     sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);
   });
 };
-
-export function createModelOverrideRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const requireProvisioned = requireProvisionedUser(deps.prisma);
-
-  router.get('/', requireUserAuth(), requireProvisioned, handleListModelOverrides(deps));
-  router.put('/', requireUserAuth(), requireProvisioned, handleSetModelOverride(deps));
-  // /default routes MUST come before /:personalityId to avoid the parameter shadowing them
-  router.get('/default', requireUserAuth(), requireProvisioned, handleGetDefaultModelConfig(deps));
-  router.put('/default', requireUserAuth(), requireProvisioned, handleSetDefaultModelConfig(deps));
-  router.delete(
-    '/default',
-    requireUserAuth(),
-    requireProvisioned,
-    handleClearDefaultModelConfig(deps)
-  );
-  router.delete(
-    '/:personalityId',
-    requireUserAuth(),
-    requireProvisioned,
-    handleDeleteModelOverride(deps)
-  );
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/notifications.ts
+++ b/services/api-gateway/src/routes/user/notifications.ts
@@ -1,9 +1,9 @@
 /**
  * User Notification-Preference Routes
- * GET /user/notifications - Get release-notes DM preferences
- * PATCH /user/notifications - Partially update them (enabled and/or level)
- * GET /user/notifications/release-dms - Standing release DMs (for cleanup)
- * POST /user/notifications/release-dms/deleted - Stamp deleted release DMs
+ * GET /api/user/notifications - Get release-notes DM preferences
+ * PATCH /api/user/notifications - Partially update them (enabled and/or level)
+ * GET /api/user/notifications/release-dms - Standing release DMs (for cleanup)
+ * POST /api/user/notifications/release-dms/deleted - Stamp deleted release DMs
  */
 
 import { type Response, type RequestHandler } from 'express';

--- a/services/api-gateway/src/routes/user/nsfw.test.ts
+++ b/services/api-gateway/src/routes/user/nsfw.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { StatusCodes } from 'http-status-codes';
-import { createNsfwRoutes } from './nsfw.js';
+import { handleGetNsfwStatus, handleVerifyNsfw } from './nsfw.js';
 import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 // Mock dependencies
@@ -73,7 +73,9 @@ function createTestApp() {
     (req as any).provisionedDefaultPersonaId = 'persona-uuid-default';
     next();
   });
-  app.use('/nsfw', createNsfwRoutes({ ...stubRouteResolvers(), prisma: mockPrisma as any }));
+  const deps = { ...stubRouteResolvers(), prisma: mockPrisma as any };
+  app.get('/nsfw', handleGetNsfwStatus(deps));
+  app.post('/nsfw/verify', handleVerifyNsfw(deps));
   return app;
 }
 

--- a/services/api-gateway/src/routes/user/nsfw.ts
+++ b/services/api-gateway/src/routes/user/nsfw.ts
@@ -1,13 +1,12 @@
 /**
  * User NSFW Verification Routes
- * GET /user/nsfw - Get NSFW verification status
- * POST /user/nsfw/verify - Mark user as NSFW verified (called when user interacts in NSFW channel)
+ * GET /api/user/nsfw - Get NSFW verification status
+ * POST /api/user/nsfw/verify - Mark user as NSFW verified (called when user interacts in NSFW channel)
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -102,20 +101,3 @@ export const handleVerifyNsfw = (deps: RouteDeps): RequestHandler => {
     );
   });
 };
-
-export function createNsfwRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(deps.prisma),
-    handleGetNsfwStatus(deps)
-  );
-  router.post(
-    '/verify',
-    requireUserAuth(),
-    requireProvisionedUser(deps.prisma),
-    handleVerifyNsfw(deps)
-  );
-  return router;
-}

--- a/services/api-gateway/src/routes/user/persona/crud.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.ts
@@ -1,10 +1,10 @@
 /**
  * Persona CRUD Routes
- * - GET / - List user's personas
- * - GET /:id - Get a specific persona
- * - POST / - Create a new persona
- * - PUT /:id - Update a persona
- * - DELETE /:id - Delete a persona
+ * - GET /api/user/persona - List user's personas
+ * - GET /api/user/persona/:id - Get a specific persona
+ * - POST /api/user/persona - Create a new persona
+ * - PUT /api/user/persona/:id - Update a persona
+ * - DELETE /api/user/persona/:id - Delete a persona
  */
 
 import { type Response, type RequestHandler } from 'express';

--- a/services/api-gateway/src/routes/user/persona/default.ts
+++ b/services/api-gateway/src/routes/user/persona/default.ts
@@ -1,6 +1,6 @@
 /**
  * Persona Default Routes
- * - PATCH /:id/default - Set persona as user's default
+ * - PATCH /api/user/persona/:id/default - Set persona as user's default
  */
 
 import { type Response, type RequestHandler } from 'express';

--- a/services/api-gateway/src/routes/user/persona/override.ts
+++ b/services/api-gateway/src/routes/user/persona/override.ts
@@ -1,10 +1,10 @@
 /**
  * Persona Override Routes
- * - GET /override - List persona overrides for personalities
- * - GET /override/:personalitySlug - Get personality info for override modal
- * - PUT /override/:personalitySlug - Set persona override for a personality
- * - DELETE /override/:personalitySlug - Clear persona override
- * - POST /override/by-id/:personalityId - Create persona + set as override
+ * - GET /api/user/persona/override - List persona overrides for personalities
+ * - GET /api/user/persona/override/:personalitySlug - Get personality info for override modal
+ * - PUT /api/user/persona/override/:personalitySlug - Set persona override for a personality
+ * - DELETE /api/user/persona/override/:personalitySlug - Clear persona override
+ * - POST /api/user/persona/override/by-id/:personalityId - Create persona + set as override
  *     (single transaction; atomic)
  */
 

--- a/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 
 // Hoisted mocks
 const { mockGetOrCreateUser, mockGetOrCreateUserShell, mockResolveOverrides } = vi.hoisted(() => ({
@@ -93,9 +93,13 @@ const mockDeps = {
   } as unknown as import('@tzurot/config-resolver').ConfigCascadeResolver,
 } as unknown as import('../routeDeps.js').RouteDeps;
 
-import { createPersonalityConfigOverrideRoutes } from './personality-config-overrides.js';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
+import {
+  handleResolvePersonalityCascade,
+  handleUpdatePersonalityConfigDefaults,
+} from './personality-config-overrides.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { asRouteHandler, type RouteHandler } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const TEST_DISCORD_USER_ID = 'discord-user-123';
 const TEST_PERSONALITY_ID = '00000000-0000-0000-0000-000000000003';
@@ -118,12 +122,12 @@ function createMockReqRes(body: Record<string, unknown> = {}, params: Record<str
   return { req, res };
 }
 
-function getHandler(
-  router: ReturnType<typeof createPersonalityConfigOverrideRoutes>,
-  method: 'get' | 'patch',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
+/**
+ * Build a bare handler with the given deps — the same export
+ * routes/_generated/mounts.ts mounts, invoked directly.
+ */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler, deps: RouteDeps): RouteHandler {
+  return asRouteHandler(handler(deps));
 }
 
 describe('/user/config-overrides personality routes', () => {
@@ -133,20 +137,9 @@ describe('/user/config-overrides personality routes', () => {
     mockPrisma.personality.update.mockResolvedValue({});
   });
 
-  describe('route factory', () => {
-    it('should create a router with personality routes', () => {
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-
-      expect(router).toBeDefined();
-      expect(findRoute(router, 'get', '/resolve-personality/:personalityId')).toBeDefined();
-      expect(findRoute(router, 'patch', '/personality/:personalityId')).toBeDefined();
-    });
-  });
-
   describe('GET /resolve-personality/:personalityId', () => {
     it('should return resolved 3-tier cascade', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve-personality/:personalityId');
+      const handler = buildHandler(handleResolvePersonalityCascade, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
       await handler(req, res);
@@ -156,8 +149,7 @@ describe('/user/config-overrides personality routes', () => {
     });
 
     it('should reject non-UUID personalityId', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/resolve-personality/:personalityId');
+      const handler = buildHandler(handleResolvePersonalityCascade, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: 'not-a-uuid' });
 
       await handler(req, res);
@@ -169,8 +161,7 @@ describe('/user/config-overrides personality routes', () => {
 
   describe('PATCH /personality/:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, mockDeps);
       const { req, res } = createMockReqRes({ maxMessages: 25 }, { personalityId: 'not-a-uuid' });
 
       await handler(req, res);
@@ -179,8 +170,7 @@ describe('/user/config-overrides personality routes', () => {
     });
 
     it('should return 404 when personality not found', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -197,8 +187,7 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: null,
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -215,8 +204,7 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: null,
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -243,8 +231,7 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: { maxImages: 5 },
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -270,13 +257,12 @@ describe('/user/config-overrides personality routes', () => {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createPersonalityConfigOverrideRoutes({
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, {
         ...mockDeps,
         cascadeInvalidation: mockInvalidation as unknown as NonNullable<
-          Parameters<typeof createPersonalityConfigOverrideRoutes>[0]['cascadeInvalidation']
+          RouteDeps['cascadeInvalidation']
         >,
       });
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -297,13 +283,12 @@ describe('/user/config-overrides personality routes', () => {
         invalidatePersonality: vi.fn().mockRejectedValue(new Error('Redis connection lost')),
       };
 
-      const router = createPersonalityConfigOverrideRoutes({
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, {
         ...mockDeps,
         cascadeInvalidation: mockInvalidation as unknown as NonNullable<
-          Parameters<typeof createPersonalityConfigOverrideRoutes>[0]['cascadeInvalidation']
+          RouteDeps['cascadeInvalidation']
         >,
       });
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
         { personalityId: TEST_PERSONALITY_ID }
@@ -322,8 +307,7 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: null,
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockDeps);
-      const handler = getHandler(router, 'patch', '/personality/:personalityId');
+      const handler = buildHandler(handleUpdatePersonalityConfigDefaults, mockDeps);
       const { req, res } = createMockReqRes(
         { maxMessages: -5 },
         { personalityId: TEST_PERSONALITY_ID }

--- a/services/api-gateway/src/routes/user/personality-config-overrides.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.ts
@@ -2,15 +2,14 @@
  * Personality Config Overrides Routes
  *
  * Endpoints for personality-level config cascade overrides (creator-only):
- * - GET /resolve-personality/:personalityId - Resolve hardcoded → admin → personality cascade
- * - PATCH /personality/:personalityId - Update Personality.configDefaults
+ * - GET /api/user/config-overrides/resolve-personality/:personalityId - Resolve hardcoded → admin → personality cascade
+ * - PATCH /api/user/config-overrides/personality/:personalityId - Update Personality.configDefaults
  *
  * These are mounted under /user/config-overrides/ alongside the user-level endpoints.
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
@@ -93,14 +92,3 @@ export const handleUpdatePersonalityConfigDefaults = (deps: RouteDeps): RequestH
     sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
   });
 };
-
-export function createPersonalityConfigOverrideRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.use(requireUserAuth());
-  router.use(requireProvisionedUser(deps.prisma));
-
-  router.get('/resolve-personality/:personalityId', handleResolvePersonalityCascade(deps));
-  router.patch('/personality/:personalityId', handleUpdatePersonalityConfigDefaults(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/personality/create.ts
+++ b/services/api-gateway/src/routes/user/personality/create.ts
@@ -1,5 +1,5 @@
 /**
- * POST /user/personality
+ * POST /api/user/personality
  * Create a new personality owned by the user
  */
 

--- a/services/api-gateway/src/routes/user/personality/delete.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.ts
@@ -1,5 +1,5 @@
 /**
- * DELETE /user/personality/:slug
+ * DELETE /api/user/personality/:slug
  * Delete a personality and all associated data (owned personalities only)
  */
 

--- a/services/api-gateway/src/routes/user/personality/get.ts
+++ b/services/api-gateway/src/routes/user/personality/get.ts
@@ -1,5 +1,5 @@
 /**
- * GET /user/personality/:slug
+ * GET /api/user/personality/:slug
  * Get a single personality by slug (if visible to user)
  */
 

--- a/services/api-gateway/src/routes/user/personality/list.ts
+++ b/services/api-gateway/src/routes/user/personality/list.ts
@@ -1,5 +1,5 @@
 /**
- * GET /user/personality
+ * GET /api/user/personality
  * List all personalities visible to the user
  */
 

--- a/services/api-gateway/src/routes/user/personality/update.ts
+++ b/services/api-gateway/src/routes/user/personality/update.ts
@@ -1,5 +1,5 @@
 /**
- * PUT /user/personality/:slug
+ * PUT /api/user/personality/:slug
  * Update an owned personality
  */
 

--- a/services/api-gateway/src/routes/user/personality/visibility.ts
+++ b/services/api-gateway/src/routes/user/personality/visibility.ts
@@ -1,5 +1,5 @@
 /**
- * PATCH /user/personality/:slug/visibility
+ * PATCH /api/user/personality/:slug/visibility
  * Toggle visibility of an owned personality
  */
 

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -1,9 +1,9 @@
 /**
  * Shapes.inc Credential Routes
  *
- * POST   /user/shapes/auth   - Store encrypted session cookie
- * DELETE /user/shapes/auth   - Remove stored credentials
- * GET    /user/shapes/auth/status - Check credential status
+ * POST   /api/user/shapes/auth   - Store encrypted session cookie
+ * DELETE /api/user/shapes/auth   - Remove stored credentials
+ * GET    /api/user/shapes/auth/status - Check credential status
  *
  * Security:
  * - Session cookies are encrypted with AES-256-GCM (same as API keys)

--- a/services/api-gateway/src/routes/user/shapes/export.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.ts
@@ -1,8 +1,8 @@
 /**
  * Shapes.inc Export Routes (Async)
  *
- * POST /user/shapes/export   - Start an async export job
- * GET  /user/shapes/export/jobs - List export job history
+ * POST /api/user/shapes/export   - Start an async export job
+ * GET  /api/user/shapes/export/jobs - List export job history
  *
  * Export data is fetched asynchronously by ai-worker and stored in PostgreSQL.
  * Users download completed exports via GET /exports/:token (public endpoint).

--- a/services/api-gateway/src/routes/user/shapes/import.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.ts
@@ -1,8 +1,8 @@
 /**
  * Shapes.inc Import Routes
  *
- * POST /user/shapes/import - Start a shapes.inc import job
- * GET  /user/shapes/import/jobs - List import history
+ * POST /api/user/shapes/import - Start a shapes.inc import job
+ * GET  /api/user/shapes/import/jobs - List import history
  */
 
 import { type Response, type RequestHandler } from 'express';

--- a/services/api-gateway/src/routes/user/shapes/list.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.ts
@@ -1,7 +1,7 @@
 /**
  * Shapes.inc List Route
  *
- * GET /user/shapes/list - Fetch owned shapes from shapes.inc
+ * GET /api/user/shapes/list - Fetch owned shapes from shapes.inc
  *
  * Proxies the user's request to shapes.inc /api/shapes?category=self
  * using their stored session cookie.

--- a/services/api-gateway/src/routes/user/stt-override.test.ts
+++ b/services/api-gateway/src/routes/user/stt-override.test.ts
@@ -6,9 +6,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response, Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { asRouteHandler, stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: () => (_req: Request, _res: Response, next: () => void) => next(),
@@ -46,7 +47,8 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-const { createSttOverrideRoutes } = await import('./stt-override.js');
+const { handleClearSttDefaultProvider, handleGetSttDefaultProvider, handleSetSttDefaultProvider } =
+  await import('./stt-override.js');
 
 function makeMockRes() {
   const json = vi.fn();
@@ -67,37 +69,21 @@ function makeMockReq(overrides: Record<string, unknown> = {}): Request {
   } as unknown as Request;
 }
 
-interface RouterLayer {
-  route?: {
-    path: string;
-    methods: Record<string, boolean>;
-    stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
-  };
-}
-
-function extractHandler(router: Router, method: string, path: string) {
-  const stack = (router as unknown as { stack: RouterLayer[] }).stack;
-  const layer = stack.find(
-    l => l.route?.path === path && l.route?.methods[method.toLowerCase()] === true
-  );
-  if (!layer?.route) {
-    throw new Error(`Handler for ${method} ${path} not found`);
-  }
-  return layer.route.stack[layer.route.stack.length - 1].handle;
-}
-
 const mockPrisma = {
   user: { findUnique: vi.fn(), update: vi.fn() },
 };
 
 const mockCache = { invalidateUserStt: vi.fn().mockResolvedValue(undefined) };
 
-function buildRouter() {
-  return createSttOverrideRoutes({
-    ...stubRouteResolvers(),
-    prisma: mockPrisma as never,
-    sttResolverCacheInvalidation: mockCache as never,
-  });
+/** Build one bare handler with the mock deps — the shape mounts.ts registers. */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler) {
+  return asRouteHandler(
+    handler({
+      ...stubRouteResolvers(),
+      prisma: mockPrisma as never,
+      sttResolverCacheInvalidation: mockCache as never,
+    })
+  );
 }
 
 describe('user/stt-override routes', () => {
@@ -108,7 +94,7 @@ describe('user/stt-override routes', () => {
   describe('GET /', () => {
     it('returns the user STT preference when set', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ defaultSttProviderId: 'mistral' });
-      const handler = extractHandler(buildRouter(), 'get', '/');
+      const handler = buildHandler(handleGetSttDefaultProvider);
       const { res, json, status } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -119,7 +105,7 @@ describe('user/stt-override routes', () => {
 
     it('returns null when no preference is set', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ defaultSttProviderId: null });
-      const handler = extractHandler(buildRouter(), 'get', '/');
+      const handler = buildHandler(handleGetSttDefaultProvider);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -129,7 +115,7 @@ describe('user/stt-override routes', () => {
 
     it('narrows unknown DB strings to null (legacy / out-of-band data defense)', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ defaultSttProviderId: 'whisper' });
-      const handler = extractHandler(buildRouter(), 'get', '/');
+      const handler = buildHandler(handleGetSttDefaultProvider);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -141,7 +127,7 @@ describe('user/stt-override routes', () => {
   describe('PUT /', () => {
     it('writes User.defaultSttProviderId and returns the value', async () => {
       mockPrisma.user.update.mockResolvedValue({});
-      const handler = extractHandler(buildRouter(), 'put', '/');
+      const handler = buildHandler(handleSetSttDefaultProvider);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { providerId: 'mistral' } }), res);
@@ -154,7 +140,7 @@ describe('user/stt-override routes', () => {
     });
 
     it('rejects unknown providers via Zod validation', async () => {
-      const handler = extractHandler(buildRouter(), 'put', '/');
+      const handler = buildHandler(handleSetSttDefaultProvider);
       const { res, status, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { providerId: 'whisper' } }), res);
@@ -168,7 +154,7 @@ describe('user/stt-override routes', () => {
   describe('DELETE /', () => {
     it('returns wasSet:false when no preference was set (idempotent)', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ defaultSttProviderId: null });
-      const handler = extractHandler(buildRouter(), 'delete', '/');
+      const handler = buildHandler(handleClearSttDefaultProvider);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -180,7 +166,7 @@ describe('user/stt-override routes', () => {
     it('clears the preference when one was set', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ defaultSttProviderId: 'mistral' });
       mockPrisma.user.update.mockResolvedValue({});
-      const handler = extractHandler(buildRouter(), 'delete', '/');
+      const handler = buildHandler(handleClearSttDefaultProvider);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);

--- a/services/api-gateway/src/routes/user/stt-override.ts
+++ b/services/api-gateway/src/routes/user/stt-override.ts
@@ -8,12 +8,12 @@
  * self-hosted voice-engine.
  *
  * Endpoints:
- *   GET    /user/stt-override — read User.defaultSttProviderId
- *   PUT    /user/stt-override — set
- *   DELETE /user/stt-override — clear
+ *   GET    /api/user/stt-override — read User.defaultSttProviderId
+ *   PUT    /api/user/stt-override — set
+ *   DELETE /api/user/stt-override — clear
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import {
   type UserDefaultSttProvider,
   ClearSttDefaultProviderResponseSchema,
@@ -22,7 +22,6 @@ import {
 } from '@tzurot/common-types/schemas/api/stt-override';
 import { isSttProvider } from '@tzurot/common-types/types/sttProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
@@ -140,14 +139,3 @@ export const handleClearSttDefaultProvider = (deps: RouteDeps): RequestHandler =
     });
   });
 };
-
-export function createSttOverrideRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const requireProvisioned = requireProvisionedUser(deps.prisma);
-
-  router.get('/', requireUserAuth(), requireProvisioned, handleGetSttDefaultProvider(deps));
-  router.put('/', requireUserAuth(), requireProvisioned, handleSetSttDefaultProvider(deps));
-  router.delete('/', requireUserAuth(), requireProvisioned, handleClearSttDefaultProvider(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/timezone.test.ts
+++ b/services/api-gateway/src/routes/user/timezone.test.ts
@@ -65,10 +65,9 @@ const mockPrisma = {
   }),
 };
 
-import { createTimezoneRoutes } from './timezone.js';
+import { handleGetTimezone, handleSetTimezone } from './timezone.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { asRouteHandler, stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 // Helper to create mock request/response
 function createMockReqRes(body: Record<string, unknown> = {}) {
@@ -87,52 +86,20 @@ function createMockReqRes(body: Record<string, unknown> = {}) {
   return { req, res };
 }
 
-// Helper to get handler from router
-function getHandler(
-  router: ReturnType<typeof createTimezoneRoutes>,
-  method: 'get' | 'put',
-  path: string
-) {
-  return getRouteHandler(router, method, path);
+// Build a bare handler with the mock deps — the same shape
+// routes/_generated/mounts.ts mounts in production.
+function makeHandler(method: 'get' | 'put') {
+  const deps = {
+    ...stubRouteResolvers(),
+    prisma: mockPrisma as unknown as PrismaClient,
+  };
+  return asRouteHandler(method === 'get' ? handleGetTimezone(deps) : handleSetTimezone(deps));
 }
 
 describe('/user/timezone routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrisma.user.findUnique.mockResolvedValue({ id: 'user-uuid-123', timezone: 'UTC' });
-  });
-
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have GET route registered', () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router.stack).toBeDefined();
-      expect(router.stack.length).toBeGreaterThan(0);
-
-      expect(findRoute(router, 'get', '/')).toBeDefined();
-    });
-
-    it('should have PUT route registered', () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(findRoute(router, 'put', '/')).toBeDefined();
-    });
   });
 
   describe('GET /user/timezone', () => {
@@ -143,11 +110,7 @@ describe('/user/timezone routes', () => {
     it('should return 404 when user row is missing', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce(null);
 
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'get', '/');
+      const handler = makeHandler('get');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -158,11 +121,7 @@ describe('/user/timezone routes', () => {
     it('should return user timezone', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ timezone: 'America/New_York' });
 
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'get', '/');
+      const handler = makeHandler('get');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -179,11 +138,7 @@ describe('/user/timezone routes', () => {
     it('should return isDefault=true for UTC timezone', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ timezone: 'UTC' });
 
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'get', '/');
+      const handler = makeHandler('get');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -199,11 +154,7 @@ describe('/user/timezone routes', () => {
     it('should query user timezone by internal UUID', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ timezone: 'UTC' });
 
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'get', '/');
+      const handler = makeHandler('get');
       const { req, res } = createMockReqRes();
 
       await handler(req, res);
@@ -217,11 +168,7 @@ describe('/user/timezone routes', () => {
 
   describe('PUT /user/timezone', () => {
     it('should reject missing timezone', async () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'put', '/');
+      const handler = makeHandler('put');
       const { req, res } = createMockReqRes({});
 
       await handler(req, res);
@@ -236,11 +183,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should reject null timezone', async () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'put', '/');
+      const handler = makeHandler('put');
       const { req, res } = createMockReqRes({ timezone: null });
 
       await handler(req, res);
@@ -249,11 +192,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should reject empty timezone', async () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'put', '/');
+      const handler = makeHandler('put');
       const { req, res } = createMockReqRes({ timezone: '' });
 
       await handler(req, res);
@@ -262,11 +201,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should reject invalid timezone', async () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'put', '/');
+      const handler = makeHandler('put');
       const { req, res } = createMockReqRes({ timezone: 'Invalid/Timezone' });
 
       await handler(req, res);
@@ -280,11 +215,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should accept valid IANA timezone', async () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'put', '/');
+      const handler = makeHandler('put');
       const { req, res } = createMockReqRes({ timezone: 'America/New_York' });
 
       await handler(req, res);
@@ -299,11 +230,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should accept UTC timezone', async () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'put', '/');
+      const handler = makeHandler('put');
       const { req, res } = createMockReqRes({ timezone: 'UTC' });
 
       await handler(req, res);
@@ -318,11 +245,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should return timezone info in response', async () => {
-      const router = createTimezoneRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-      const handler = getHandler(router, 'put', '/');
+      const handler = makeHandler('put');
       const { req, res } = createMockReqRes({ timezone: 'America/Los_Angeles' });
 
       await handler(req, res);

--- a/services/api-gateway/src/routes/user/timezone.ts
+++ b/services/api-gateway/src/routes/user/timezone.ts
@@ -1,15 +1,14 @@
 /**
  * User Timezone Routes
- * GET /user/timezone - Get current timezone
- * PUT /user/timezone - Set timezone
+ * GET /api/user/timezone - Get current timezone
+ * PUT /api/user/timezone - Set timezone
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { isValidTimezone, getTimezoneInfo } from '@tzurot/common-types/constants/timezone';
 import { SetTimezoneInputSchema } from '@tzurot/common-types/schemas/api/timezone';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -89,10 +88,3 @@ export const handleSetTimezone = (deps: RouteDeps): RequestHandler => {
     );
   });
 };
-
-export function createTimezoneRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.get('/', requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetTimezone(deps));
-  router.put('/', requireUserAuth(), requireProvisionedUser(deps.prisma), handleSetTimezone(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/user/tts-config.test.ts
+++ b/services/api-gateway/src/routes/user/tts-config.test.ts
@@ -12,8 +12,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response, Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
+import { asRouteHandler } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const sampleRawConfig = {
   id: 'cfg-uuid-1',
@@ -106,7 +108,13 @@ vi.mock('@tzurot/common-types/utils/ownerMiddleware', async () => {
 });
 
 // Imports must come after vi.mock setup
-const { createTtsConfigRoutes } = await import('./tts-config.js');
+const {
+  handleCreateUserTtsConfig,
+  handleDeleteUserTtsConfig,
+  handleGetUserTtsConfig,
+  handleListUserTtsConfigs,
+  handleUpdateUserTtsConfig,
+} = await import('./tts-config.js');
 const { TtsAutoSuffixCollisionError, TtsCloneNameExhaustedError, TtsInvalidProviderError } =
   await import('../../services/TtsConfigService.js');
 const { isBotOwner } = await import('@tzurot/common-types/utils/ownerMiddleware');
@@ -130,29 +138,12 @@ function makeMockReq(overrides: Record<string, unknown> = {}): Request {
   } as unknown as Request;
 }
 
-interface RouterLayer {
-  route?: {
-    path: string;
-    methods: Record<string, boolean>;
-    stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
-  };
-}
-
-function extractHandler(router: Router, method: string, path: string) {
-  const stack = (router as unknown as { stack: RouterLayer[] }).stack;
-  const layer = stack.find(
-    l => l.route?.path === path && l.route?.methods[method.toLowerCase()] === true
-  );
-  if (!layer?.route) {
-    throw new Error(`Handler for ${method} ${path} not found`);
-  }
-  return layer.route.stack[layer.route.stack.length - 1].handle;
-}
-
-function buildRouter() {
-  // The factory's prisma argument doesn't matter — our mocked service
-  // doesn't use it. Pass a thin stub.
-  return createTtsConfigRoutes({} as never);
+/**
+ * Build one bare handler — the shape mounts.ts registers. The deps argument
+ * doesn't matter here: the mocked service ignores prisma entirely.
+ */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler) {
+  return asRouteHandler(handler({} as never));
 }
 
 describe('user/tts-config routes', () => {
@@ -180,7 +171,7 @@ describe('user/tts-config routes', () => {
   describe('GET / (list)', () => {
     it('returns USER-scoped configs with permissions for non-admin', async () => {
       vi.mocked(mockService.list).mockResolvedValue([{ ...sampleRawConfig }]);
-      const handler = extractHandler(buildRouter(), 'GET', '/');
+      const handler = buildHandler(handleListUserTtsConfigs);
       const { res, json, status } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -199,7 +190,7 @@ describe('user/tts-config routes', () => {
     it('uses GLOBAL scope for bot-owner admin', async () => {
       vi.mocked(isBotOwner).mockReturnValueOnce(true);
       vi.mocked(mockService.list).mockResolvedValue([]);
-      const handler = extractHandler(buildRouter(), 'GET', '/');
+      const handler = buildHandler(handleListUserTtsConfigs);
       const { res } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -210,7 +201,7 @@ describe('user/tts-config routes', () => {
   describe('GET /:id (get)', () => {
     it('returns 404 when config does not exist', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'GET', '/:id');
+      const handler = buildHandler(handleGetUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'missing' } }), res);
@@ -219,7 +210,7 @@ describe('user/tts-config routes', () => {
 
     it('returns the formatted config with permissions when found', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'GET', '/:id');
+      const handler = buildHandler(handleGetUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -237,7 +228,7 @@ describe('user/tts-config routes', () => {
         exists: true,
         conflictId: 'cfg-existing',
       });
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { name: 'My Voice', provider: 'elevenlabs' } }), res);
@@ -249,7 +240,7 @@ describe('user/tts-config routes', () => {
       vi.mocked(mockService.create).mockRejectedValue(
         new TtsAutoSuffixCollisionError('Voice (Copy 5)', new Error())
       );
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -268,7 +259,7 @@ describe('user/tts-config routes', () => {
 
     it('returns 400 with stripped baseName when TtsCloneNameExhaustedError fires', async () => {
       vi.mocked(mockService.create).mockRejectedValue(new TtsCloneNameExhaustedError('Voice', 20));
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -287,7 +278,7 @@ describe('user/tts-config routes', () => {
 
     it('returns 201 with the created config on happy path', async () => {
       vi.mocked(mockService.create).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateUserTtsConfig);
       const { res, status } = makeMockRes();
 
       await handler(makeMockReq({ body: { name: 'My Voice', provider: 'elevenlabs' } }), res);
@@ -295,7 +286,7 @@ describe('user/tts-config routes', () => {
     });
 
     it('rejects body without provider via Zod schema (never reaches service)', async () => {
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -307,7 +298,7 @@ describe('user/tts-config routes', () => {
     });
 
     it('rejects invalid provider via Zod schema on create path', async () => {
-      const handler = extractHandler(buildRouter(), 'POST', '/');
+      const handler = buildHandler(handleCreateUserTtsConfig);
       const { res } = makeMockRes();
 
       await handler(makeMockReq({ body: { name: 'X', provider: 'mistal' } }), res);
@@ -319,7 +310,7 @@ describe('user/tts-config routes', () => {
   describe('PUT /:id (update)', () => {
     it('returns 404 when config does not exist', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'missing' }, body: { description: 'new' } }), res);
@@ -331,7 +322,7 @@ describe('user/tts-config routes', () => {
         ...sampleRawConfig,
         ownerId: 'someone-else',
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -373,7 +364,7 @@ describe('user/tts-config routes', () => {
         createdAt: new Date('2026-01-01T00:00:00Z'),
         updatedAt: new Date('2026-01-01T00:00:00Z'),
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateUserTtsConfig);
       const { res } = makeMockRes();
 
       await handler(
@@ -395,7 +386,7 @@ describe('user/tts-config routes', () => {
     it('returns 400 VALIDATION_ERROR when service rejects invalid provider', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(sampleRawConfig);
       vi.mocked(mockService.update).mockRejectedValue(new TtsInvalidProviderError('mistal'));
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -412,7 +403,7 @@ describe('user/tts-config routes', () => {
 
     it('returns 400 when no fields are provided', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' }, body: {} }), res);
@@ -431,7 +422,7 @@ describe('user/tts-config routes', () => {
         ...sampleRawConfig,
         modelId: 'voxtral-mini-tts-2603',
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const handler = buildHandler(handleUpdateUserTtsConfig);
       const { res, status } = makeMockRes();
 
       await handler(
@@ -448,7 +439,7 @@ describe('user/tts-config routes', () => {
   describe('DELETE /:id', () => {
     it('returns 404 when config does not exist', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'missing' } }), res);
@@ -460,7 +451,7 @@ describe('user/tts-config routes', () => {
         ...sampleRawConfig,
         ownerId: 'someone-else',
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -474,7 +465,7 @@ describe('user/tts-config routes', () => {
         blocker: 'Cannot delete: TTS config is used as default by 2 personality(ies)',
         warning: null,
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -484,7 +475,7 @@ describe('user/tts-config routes', () => {
 
     it('returns 200 with deleted: true on happy path', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(sampleRawConfig);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);
@@ -501,7 +492,7 @@ describe('user/tts-config routes', () => {
         blocker: null,
         warning: "Deleting this TTS config will reset 5 user(s)' personal default to NULL",
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:id');
+      const handler = buildHandler(handleDeleteUserTtsConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { id: 'cfg-uuid-1' } }), res);

--- a/services/api-gateway/src/routes/user/tts-config.ts
+++ b/services/api-gateway/src/routes/user/tts-config.ts
@@ -3,11 +3,11 @@
  * CRUD operations for user-owned TTS configurations
  *
  * Endpoints:
- * - GET    /user/tts-config     - List configs (global + user)
- * - GET    /user/tts-config/:id - Get single config detail
- * - POST   /user/tts-config     - Create user config
- * - PUT    /user/tts-config/:id - Update user config
- * - DELETE /user/tts-config/:id - Delete user config
+ * - GET    /api/user/tts-config     - List configs (global + user)
+ * - GET    /api/user/tts-config/:id - Get single config detail
+ * - POST   /api/user/tts-config     - Create user config
+ * - PUT    /api/user/tts-config/:id - Update user config
+ * - DELETE /api/user/tts-config/:id - Delete user config
  *
  * Mirrors `routes/user/llm-config.ts` shape minus LLM-specific concerns
  * (no model-context enrichment via OpenRouterModelCache, no model-fields
@@ -21,7 +21,7 @@
  * filed as a follow-up rather than introduced in PR 3b.
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   type TtsConfigSummary,
@@ -32,7 +32,6 @@ import { type TtsProviderId } from '@tzurot/common-types/services/tts/TtsProvide
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
 import { computeLlmConfigPermissions } from '@tzurot/common-types/utils/permissions';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -379,18 +378,3 @@ export const handleUpdateUserTtsConfig = (deps: RouteDeps): RequestHandler =>
 
 export const handleDeleteUserTtsConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createDeleteHandler(buildService(deps)));
-
-// --- Main route factory ----------------------------------------------------
-
-export function createTtsConfigRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const requireProvisioned = requireProvisionedUser(deps.prisma);
-
-  router.get('/', requireUserAuth(), requireProvisioned, handleListUserTtsConfigs(deps));
-  router.get('/:id', requireUserAuth(), requireProvisioned, handleGetUserTtsConfig(deps));
-  router.post('/', requireUserAuth(), requireProvisioned, handleCreateUserTtsConfig(deps));
-  router.put('/:id', requireUserAuth(), requireProvisioned, handleUpdateUserTtsConfig(deps));
-  router.delete('/:id', requireUserAuth(), requireProvisioned, handleDeleteUserTtsConfig(deps));
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/tts-override.test.ts
+++ b/services/api-gateway/src/routes/user/tts-override.test.ts
@@ -6,9 +6,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response, Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { asRouteHandler, stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: () => (_req: Request, _res: Response, next: () => void) => next(),
@@ -56,7 +57,14 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-const { createTtsOverrideRoutes } = await import('./tts-override.js');
+const {
+  handleClearTtsDefaultConfig,
+  handleDeleteTtsOverride,
+  handleGetTtsDefaultConfig,
+  handleListTtsOverrides,
+  handleSetTtsDefaultConfig,
+  handleSetTtsOverride,
+} = await import('./tts-override.js');
 
 function makeMockRes() {
   const json = vi.fn();
@@ -75,25 +83,6 @@ function makeMockReq(overrides: Record<string, unknown> = {}): Request {
     body: {},
     ...overrides,
   } as unknown as Request;
-}
-
-interface RouterLayer {
-  route?: {
-    path: string;
-    methods: Record<string, boolean>;
-    stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
-  };
-}
-
-function extractHandler(router: Router, method: string, path: string) {
-  const stack = (router as unknown as { stack: RouterLayer[] }).stack;
-  const layer = stack.find(
-    l => l.route?.path === path && l.route?.methods[method.toLowerCase()] === true
-  );
-  if (!layer?.route) {
-    throw new Error(`Handler for ${method} ${path} not found`);
-  }
-  return layer.route.stack[layer.route.stack.length - 1].handle;
 }
 
 const mockPrisma = {
@@ -129,12 +118,15 @@ const mockCache = {
   invalidateAll: vi.fn().mockResolvedValue(undefined),
 };
 
-function buildRouter() {
-  return createTtsOverrideRoutes({
-    ...stubRouteResolvers(),
-    prisma: mockPrisma as never,
-    ttsConfigCacheInvalidation: mockCache as never,
-  });
+/** Build one bare handler with the mock deps — the shape mounts.ts registers. */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler) {
+  return asRouteHandler(
+    handler({
+      ...stubRouteResolvers(),
+      prisma: mockPrisma as never,
+      ttsConfigCacheInvalidation: mockCache as never,
+    })
+  );
 }
 
 const VALID_UUID_A = '11111111-1111-4111-8111-111111111111';
@@ -156,7 +148,7 @@ describe('user/tts-override routes', () => {
           ttsConfig: { name: 'kyutai-self-hosted' },
         },
       ]);
-      const handler = extractHandler(buildRouter(), 'GET', '/');
+      const handler = buildHandler(handleListTtsOverrides);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -180,7 +172,7 @@ describe('user/tts-override routes', () => {
 
     it('handles empty list', async () => {
       vi.mocked(mockPrisma.userPersonalityConfig.findMany).mockResolvedValue([]);
-      const handler = extractHandler(buildRouter(), 'GET', '/');
+      const handler = buildHandler(handleListTtsOverrides);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -190,7 +182,7 @@ describe('user/tts-override routes', () => {
 
   describe('PUT / (set override)', () => {
     it('returns 400 on invalid UUID', async () => {
-      const handler = extractHandler(buildRouter(), 'PUT', '/');
+      const handler = buildHandler(handleSetTtsOverride);
       const { res } = makeMockRes();
 
       await handler(
@@ -202,7 +194,7 @@ describe('user/tts-override routes', () => {
 
     it('returns 404 when personality not found', async () => {
       vi.mocked(mockPrisma.personality.findFirst).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'PUT', '/');
+      const handler = buildHandler(handleSetTtsOverride);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -223,7 +215,7 @@ describe('user/tts-override routes', () => {
         name: 'Alice',
       });
       vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'PUT', '/');
+      const handler = buildHandler(handleSetTtsOverride);
       const { res, json } = makeMockRes();
 
       await handler(
@@ -253,7 +245,7 @@ describe('user/tts-override routes', () => {
         ttsConfigId: VALID_UUID_B,
         ttsConfig: { name: 'kyutai-self-hosted' },
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/');
+      const handler = buildHandler(handleSetTtsOverride);
       const { res, status, json } = makeMockRes();
 
       await handler(
@@ -282,7 +274,7 @@ describe('user/tts-override routes', () => {
         defaultTtsConfigId: null,
         defaultTtsConfig: null,
       });
-      const handler = extractHandler(buildRouter(), 'GET', '/default');
+      const handler = buildHandler(handleGetTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -296,7 +288,7 @@ describe('user/tts-override routes', () => {
         defaultTtsConfigId: 'c1',
         defaultTtsConfig: { name: 'kyutai-self-hosted' },
       });
-      const handler = extractHandler(buildRouter(), 'GET', '/default');
+      const handler = buildHandler(handleGetTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -309,7 +301,7 @@ describe('user/tts-override routes', () => {
   describe('PUT /default', () => {
     it('returns 404 when config not accessible', async () => {
       vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'PUT', '/default');
+      const handler = buildHandler(handleSetTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { configId: VALID_UUID_A } }), res);
@@ -322,7 +314,7 @@ describe('user/tts-override routes', () => {
         id: VALID_UUID_A,
         name: 'kyutai-self-hosted',
       });
-      const handler = extractHandler(buildRouter(), 'PUT', '/default');
+      const handler = buildHandler(handleSetTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ body: { configId: VALID_UUID_A } }), res);
@@ -342,7 +334,7 @@ describe('user/tts-override routes', () => {
     it('returns idempotent success with wasSet:false when no default exists', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ defaultTtsConfigId: null });
       vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/default');
+      const handler = buildHandler(handleClearTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -357,7 +349,7 @@ describe('user/tts-override routes', () => {
     it('clears defaultTtsConfigId when one is set, returning wasSet: true', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ defaultTtsConfigId: 'c1' });
       vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/default');
+      const handler = buildHandler(handleClearTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -382,7 +374,7 @@ describe('user/tts-override routes', () => {
       vi.mocked(mockPrisma.adminSettings.findUnique).mockResolvedValue({
         freeDefaultTtsConfig: { id: 'free-id', name: 'kyutai-self-hosted' },
       } as never);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/default');
+      const handler = buildHandler(handleClearTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -399,7 +391,7 @@ describe('user/tts-override routes', () => {
       vi.mocked(mockPrisma.adminSettings.findUnique).mockResolvedValue({
         freeDefaultTtsConfig: { id: 'free-id', name: 'kyutai-self-hosted' },
       } as never);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/default');
+      const handler = buildHandler(handleClearTtsDefaultConfig);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
@@ -420,7 +412,7 @@ describe('user/tts-override routes', () => {
   describe('DELETE /:personalityId (reset override)', () => {
     it('returns idempotent success when no override exists', async () => {
       vi.mocked(mockPrisma.userPersonalityConfig.findFirst).mockResolvedValue(null);
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:personalityId');
+      const handler = buildHandler(handleDeleteTtsOverride);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { personalityId: VALID_UUID_A } }), res);
@@ -434,7 +426,7 @@ describe('user/tts-override routes', () => {
         ttsConfigId: null,
         personality: { name: 'Alice' },
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:personalityId');
+      const handler = buildHandler(handleDeleteTtsOverride);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { personalityId: VALID_UUID_A } }), res);
@@ -448,7 +440,7 @@ describe('user/tts-override routes', () => {
         ttsConfigId: 'c1',
         personality: { name: 'Alice' },
       });
-      const handler = extractHandler(buildRouter(), 'DELETE', '/:personalityId');
+      const handler = buildHandler(handleDeleteTtsOverride);
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq({ params: { personalityId: VALID_UUID_A } }), res);

--- a/services/api-gateway/src/routes/user/tts-override.ts
+++ b/services/api-gateway/src/routes/user/tts-override.ts
@@ -3,19 +3,19 @@
  * Set/reset TTS config overrides for personalities, plus user global default.
  *
  * Endpoints:
- * - GET    /user/tts-override              - List all user's TTS overrides
- * - PUT    /user/tts-override              - Set override for a personality
- * - GET    /user/tts-override/default      - Get user's global default TTS config
- * - PUT    /user/tts-override/default      - Set user's global default TTS config
- * - DELETE /user/tts-override/default      - Clear user's global default TTS config
- * - DELETE /user/tts-override/:personalityId - Remove override (MUST be after /default)
+ * - GET    /api/user/tts-override              - List all user's TTS overrides
+ * - PUT    /api/user/tts-override              - Set override for a personality
+ * - GET    /api/user/tts-override/default      - Get user's global default TTS config
+ * - PUT    /api/user/tts-override/default      - Set user's global default TTS config
+ * - DELETE /api/user/tts-override/default      - Clear user's global default TTS config
+ * - DELETE /api/user/tts-override/:personalityId - Remove override (MUST be after /default)
  *
  * Mirrors `routes/user/model-override.ts` exactly — same shape, same
  * idempotency contract — but acts on `UserPersonalityConfig.ttsConfigId`
  * and `User.defaultTtsConfigId` instead of the LLM equivalents.
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
@@ -27,7 +27,6 @@ import {
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { generateUserPersonalityConfigUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
@@ -337,28 +336,3 @@ export const handleDeleteTtsOverride = (deps: RouteDeps): RequestHandler => {
     sendCustomSuccess(res, { deleted: true, wasSet: true }, StatusCodes.OK);
   });
 };
-
-export function createTtsOverrideRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const requireProvisioned = requireProvisionedUser(deps.prisma);
-
-  router.get('/', requireUserAuth(), requireProvisioned, handleListTtsOverrides(deps));
-  router.put('/', requireUserAuth(), requireProvisioned, handleSetTtsOverride(deps));
-  // /default routes MUST come before /:personalityId to avoid the parameter shadowing them
-  router.get('/default', requireUserAuth(), requireProvisioned, handleGetTtsDefaultConfig(deps));
-  router.put('/default', requireUserAuth(), requireProvisioned, handleSetTtsDefaultConfig(deps));
-  router.delete(
-    '/default',
-    requireUserAuth(),
-    requireProvisioned,
-    handleClearTtsDefaultConfig(deps)
-  );
-  router.delete(
-    '/:personalityId',
-    requireUserAuth(),
-    requireProvisioned,
-    handleDeleteTtsOverride(deps)
-  );
-
-  return router;
-}

--- a/services/api-gateway/src/routes/user/usage.test.ts
+++ b/services/api-gateway/src/routes/user/usage.test.ts
@@ -49,10 +49,9 @@ const mockPrisma = {
   $executeRaw: vi.fn().mockResolvedValue(1),
 };
 
-import { createUsageRoutes } from './usage.js';
+import { handleGetUserUsage } from './usage.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { findRoute, getRouteHandler } from '../../test/expressRouterUtils.js';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { asRouteHandler, stubRouteResolvers } from '../../test/shared-route-test-utils.js';
 
 // Helper to create mock request/response
 function createMockReqRes(query: Record<string, string> = {}) {
@@ -77,8 +76,9 @@ async function callHandler(
   req: Request & { userId: string },
   res: Response
 ): Promise<void> {
-  const router = createUsageRoutes({ ...stubRouteResolvers(), prisma: prisma as PrismaClient });
-  const handler = getRouteHandler(router, 'get');
+  const handler = asRouteHandler(
+    handleGetUserUsage({ ...stubRouteResolvers(), prisma: prisma as PrismaClient })
+  );
   await handler(req, res);
 }
 
@@ -87,30 +87,6 @@ describe('/user/usage routes', () => {
     vi.clearAllMocks();
     mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
     mockPrisma.usageLog.findMany.mockResolvedValue([]);
-  });
-
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createUsageRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have GET route registered', () => {
-      const router = createUsageRoutes({
-        ...stubRouteResolvers(),
-        prisma: mockPrisma as unknown as PrismaClient,
-      });
-
-      expect(router.stack).toBeDefined();
-      expect(router.stack.length).toBeGreaterThan(0);
-
-      expect(findRoute(router, 'get', '/')).toBeDefined();
-    });
   });
 
   describe('period validation', () => {

--- a/services/api-gateway/src/routes/user/usage.ts
+++ b/services/api-gateway/src/routes/user/usage.ts
@@ -1,14 +1,13 @@
 /**
  * User Usage Routes
- * GET /user/usage - Get token usage statistics
+ * GET /api/user/usage - Get token usage statistics
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { type UsagePeriod, type UsageStats } from '@tzurot/common-types/schemas/api/usage';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { shortModelName } from '@tzurot/common-types/utils/modelNames';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -140,9 +139,3 @@ export const handleGetUserUsage = (deps: RouteDeps): RequestHandler => {
     sendCustomSuccess(res, stats, StatusCodes.OK);
   });
 };
-
-export function createUsageRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.get('/', requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetUserUsage(deps));
-  return router;
-}

--- a/services/api-gateway/src/routes/user/voice-resolution.test.ts
+++ b/services/api-gateway/src/routes/user/voice-resolution.test.ts
@@ -5,9 +5,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Request, Response, Router } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import { asRouteHandler, stubRouteResolvers } from '../../test/shared-route-test-utils.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: () => (_req: Request, _res: Response, next: () => void) => next(),
@@ -59,7 +60,7 @@ vi.mock('@tzurot/config-resolver', () => {
   };
 });
 
-const { createVoiceResolutionRoutes } = await import('./voice-resolution.js');
+const { handleGetVoiceResolution } = await import('./voice-resolution.js');
 
 function makeMockRes() {
   const json = vi.fn();
@@ -75,22 +76,6 @@ function makeMockReq(query: Record<string, unknown> = {}): Request {
   } as unknown as Request;
 }
 
-interface RouterLayer {
-  route?: {
-    path: string;
-    methods: Record<string, boolean>;
-    stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
-  };
-}
-function extractHandler(router: Router, method: string, path: string) {
-  const stack = (router as unknown as { stack: RouterLayer[] }).stack;
-  const layer = stack.find(
-    l => l.route?.path === path && l.route?.methods[method.toLowerCase()] === true
-  );
-  if (!layer?.route) throw new Error(`Handler for ${method} ${path} not found`);
-  return layer.route.stack[layer.route.stack.length - 1].handle;
-}
-
 const VALID_PERSONALITY_ID = '11111111-1111-4111-8111-111111111111';
 
 const mockPrisma = {
@@ -98,8 +83,9 @@ const mockPrisma = {
   user: { findUnique: vi.fn() },
 };
 
-function buildRouter() {
-  return createVoiceResolutionRoutes({ ...stubRouteResolvers(), prisma: mockPrisma as never });
+/** Build one bare handler with the mock deps — the shape mounts.ts registers. */
+function buildHandler(handler: (deps: RouteDeps) => RequestHandler) {
+  return asRouteHandler(handler({ ...stubRouteResolvers(), prisma: mockPrisma as never }));
 }
 
 describe('user/voice-resolution route', () => {
@@ -128,7 +114,7 @@ describe('user/voice-resolution route', () => {
       warnings: [],
     });
 
-    const handler = extractHandler(buildRouter(), 'get', '/');
+    const handler = buildHandler(handleGetVoiceResolution);
     const { res, json, status } = makeMockRes();
 
     await handler(makeMockReq({ personalityId: VALID_PERSONALITY_ID }), res);
@@ -157,7 +143,7 @@ describe('user/voice-resolution route', () => {
     mockResolveStt.mockResolvedValue({ provider: 'voice-engine', source: 'hardcoded' });
     mockResolveAudioProviderKeys.mockResolvedValue({ keys: new Map() });
 
-    const handler = extractHandler(buildRouter(), 'get', '/');
+    const handler = buildHandler(handleGetVoiceResolution);
     const { res, json } = makeMockRes();
 
     await handler(makeMockReq({ personalityId: VALID_PERSONALITY_ID }), res);
@@ -180,7 +166,7 @@ describe('user/voice-resolution route', () => {
     mockResolveStt.mockResolvedValue({ provider: 'voice-engine', source: 'hardcoded' });
     mockResolveAudioProviderKeys.mockResolvedValue({ keys: new Map() });
 
-    const handler = extractHandler(buildRouter(), 'get', '/');
+    const handler = buildHandler(handleGetVoiceResolution);
     const { res, json } = makeMockRes();
 
     await handler(makeMockReq({ personalityId: VALID_PERSONALITY_ID }), res);
@@ -196,7 +182,7 @@ describe('user/voice-resolution route', () => {
   it('returns 404 when personality is missing', async () => {
     mockPrisma.personality.findFirst.mockResolvedValue(null);
 
-    const handler = extractHandler(buildRouter(), 'get', '/');
+    const handler = buildHandler(handleGetVoiceResolution);
     const { res, status } = makeMockRes();
 
     await handler(makeMockReq({ personalityId: VALID_PERSONALITY_ID }), res);
@@ -205,7 +191,7 @@ describe('user/voice-resolution route', () => {
   });
 
   it('rejects non-uuid personalityId via Zod', async () => {
-    const handler = extractHandler(buildRouter(), 'get', '/');
+    const handler = buildHandler(handleGetVoiceResolution);
     const { res, status } = makeMockRes();
 
     await handler(makeMockReq({ personalityId: 'not-a-uuid' }), res);

--- a/services/api-gateway/src/routes/user/voice-resolution.ts
+++ b/services/api-gateway/src/routes/user/voice-resolution.ts
@@ -5,7 +5,7 @@
  * resolved TTS provider for a personality, the resolved STT provider for
  * the user, and a cloned-voice summary in a single round-trip.
  *
- *   GET /user/voice-resolution?personalityId=X
+ *   GET /api/user/voice-resolution?personalityId=X
  *
  * STT resolution uses {@link SttResolver} directly — speaker-bound cascade
  * (override → tts-derived → voice-engine), no per-personality dimension.
@@ -13,7 +13,7 @@
  * does vary per personality.
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   type GetVoiceResolutionResponse,
@@ -25,7 +25,6 @@ import {
 import { type LoadedTtsPersonality } from '@tzurot/common-types/types/configResolution';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { TtsConfigResolver, SttResolver } from '@tzurot/config-resolver';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -141,14 +140,3 @@ export const handleGetVoiceResolution = (deps: RouteDeps): RequestHandler => {
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
 };
-
-export function createVoiceResolutionRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(deps.prisma),
-    handleGetVoiceResolution(deps)
-  );
-  return router;
-}

--- a/services/api-gateway/src/routes/user/voiceModels.ts
+++ b/services/api-gateway/src/routes/user/voiceModels.ts
@@ -5,7 +5,7 @@
  * Extracted from voices.ts to keep that file under the 400-line limit.
  *
  * Endpoint:
- * - GET /models - List TTS-capable models from ElevenLabs
+ * - GET /api/user/voices/models - List TTS-capable models from ElevenLabs
  */
 
 import { z } from 'zod';

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -9,7 +9,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { createVoicesRoutes, describeProviderError } from './voices.js';
+import {
+  describeProviderError,
+  handleClearVoices,
+  handleDeleteVoice,
+  handleListVoiceModels,
+  handleListVoices,
+} from './voices.js';
 import { ErrorCode } from '../../types.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 
@@ -159,7 +165,14 @@ describe('Voice Management Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/voices', createVoicesRoutes({ ...stubRouteResolvers(), prisma: mockPrisma }));
+    // Registration order mirrors routes/_generated/mounts.ts: the `/models` and
+    // `/clear` literals precede `/:provider/:voiceId` so the wildcard doesn't
+    // shadow them.
+    const deps = { ...stubRouteResolvers(), prisma: mockPrisma };
+    app.get('/voices', handleListVoices(deps));
+    app.get('/voices/models', handleListVoiceModels(deps));
+    app.post('/voices/clear', handleClearVoices(deps));
+    app.delete('/voices/:provider/:voiceId', handleDeleteVoice(deps));
 
     // Default: user has ElevenLabs key only (mirrors the legacy single-provider
     // setup that pre-PR-3 was the only supported configuration).

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -6,19 +6,18 @@
  * providers slot in by registering a `VoiceProviderClient` below.
  *
  * Endpoints:
- * - GET /                    — list cloned voices (across all configured providers)
- * - DELETE /:provider/:voiceId — delete a single voice from the named provider
- * - POST /clear              — delete ALL tzurot-prefixed voices across all providers
+ * - GET /api/user/voices                    — list cloned voices (across all configured providers)
+ * - DELETE /api/user/voices/:provider/:voiceId — delete a single voice from the named provider
+ * - POST /api/user/voices/clear              — delete ALL tzurot-prefixed voices across all providers
  */
 
-import { Router, type Response as ExpressResponse, type RequestHandler } from 'express';
+import { type Response as ExpressResponse, type RequestHandler } from 'express';
 import { TTS_VOICE_NAME_PREFIX } from '@tzurot/common-types/constants/ai';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { isAudioProviderId, type AudioProviderId } from '@tzurot/common-types/types/audio-provider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { ErrorCode, type AuthenticatedRequest } from '../../types.js';
 import { type ErrorResponse, ErrorResponses } from '../../utils/errorResponses.js';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import { resolveAudioProviderKeys } from '../../utils/audioProviderKeyResolver.js';
@@ -505,23 +504,3 @@ export const handleDeleteVoice = (deps: RouteDeps): RequestHandler => {
     await deleteVoiceImpl(prisma, req, res);
   });
 };
-
-// ===== Router setup ========================================================
-
-export function createVoicesRoutes(deps: RouteDeps): Router {
-  const router = Router();
-  const requireProvisioned = requireProvisionedUser(deps.prisma);
-
-  router.get('/', requireUserAuth(), requireProvisioned, handleListVoices(deps));
-  // Register /models and /clear before /:provider/:voiceId so the wildcard doesn't shadow them
-  router.get('/models', requireUserAuth(), requireProvisioned, handleListVoiceModels(deps));
-  router.post('/clear', requireUserAuth(), requireProvisioned, handleClearVoices(deps));
-  router.delete(
-    '/:provider/:voiceId',
-    requireUserAuth(),
-    requireProvisioned,
-    handleDeleteVoice(deps)
-  );
-
-  return router;
-}

--- a/services/api-gateway/src/routes/wallet/listKeys.test.ts
+++ b/services/api-gateway/src/routes/wallet/listKeys.test.ts
@@ -49,10 +49,10 @@ const mockPrisma = {
   $executeRaw: vi.fn().mockResolvedValue(1),
 };
 
-import { createListKeysRoute } from './listKeys.js';
+import { handleListWalletKeys } from './listKeys.js';
 import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { findRoute, getRouteHandler } from '../../test/expressRouterUtils.js';
+import { asRouteHandler } from '../../test/shared-route-test-utils.js';
 
 // Helper to create mock request/response
 function createMockReqRes() {
@@ -76,8 +76,7 @@ async function callHandler(
   req: Request & { userId: string },
   res: Response
 ): Promise<void> {
-  const router = createListKeysRoute(prisma as PrismaClient);
-  const handler = getRouteHandler(router, 'get');
+  const handler = asRouteHandler(handleListWalletKeys({ prisma: prisma as PrismaClient }));
   await handler(req, res);
 }
 
@@ -86,24 +85,6 @@ describe('GET /wallet/list', () => {
     vi.clearAllMocks();
     mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
     mockPrisma.userApiKey.findMany.mockResolvedValue([]);
-  });
-
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createListKeysRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have a GET route registered', () => {
-      const router = createListKeysRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(router.stack).toBeDefined();
-      expect(router.stack.length).toBeGreaterThan(0);
-
-      expect(findRoute(router, 'get')).toBeDefined();
-    });
   });
 
   describe('key listing', () => {

--- a/services/api-gateway/src/routes/wallet/listKeys.ts
+++ b/services/api-gateway/src/routes/wallet/listKeys.ts
@@ -1,5 +1,5 @@
 /**
- * GET /wallet/list
+ * GET /api/user/wallet/list
  * List configured API key providers for a user
  *
  * Security:
@@ -7,11 +7,9 @@
  * - Only returns metadata (provider, isActive, dates)
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { ListWalletKeysResponseSchema } from '@tzurot/common-types/schemas/api/wallet';
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -63,14 +61,3 @@ export const handleListWalletKeys = (deps: WalletListDeps): RequestHandler => {
     sendCustomSuccess(res, payload);
   });
 };
-
-export function createListKeysRoute(prisma: PrismaClient): Router {
-  const router = Router();
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    handleListWalletKeys({ prisma })
-  );
-  return router;
-}

--- a/services/api-gateway/src/routes/wallet/removeKey.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.ts
@@ -1,5 +1,5 @@
 /**
- * DELETE /wallet/:provider
+ * DELETE /api/user/wallet/:provider
  * Remove an API key for a provider
  */
 

--- a/services/api-gateway/src/routes/wallet/setKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.test.ts
@@ -104,9 +104,9 @@ const mockPrisma = {
   $executeRaw: vi.fn().mockResolvedValue(1),
 };
 
-import { createSetKeyRoute } from './setKey.js';
+import { handleSetWalletKey } from './setKey.js';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
-import { findRoute, getRouteHandler } from '../../test/expressRouterUtils.js';
+import { asRouteHandler } from '../../test/shared-route-test-utils.js';
 
 // Helper to create mock request/response
 function createMockReqRes(body: Record<string, unknown> = {}) {
@@ -131,8 +131,7 @@ async function callHandler(
   req: Request & { userId: string },
   res: Response
 ): Promise<void> {
-  const router = createSetKeyRoute(prisma as PrismaClient);
-  const handler = getRouteHandler(router, 'post');
+  const handler = asRouteHandler(handleSetWalletKey({ prisma: prisma as PrismaClient }));
   await handler(req, res);
 }
 
@@ -141,25 +140,6 @@ describe('POST /wallet/set', () => {
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue({ valid: true, credits: 100 });
     mockBotOwnerId = undefined; // Reset bot owner for each test
-  });
-
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createSetKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function'); // Express routers are functions
-    });
-
-    it('should have a POST route registered', () => {
-      const router = createSetKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      // Check that the router has routes registered
-      expect(router.stack).toBeDefined();
-      expect(router.stack.length).toBeGreaterThan(0);
-
-      expect(findRoute(router, 'post')).toBeDefined();
-    });
   });
 
   describe('validation', () => {

--- a/services/api-gateway/src/routes/wallet/setKey.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.ts
@@ -1,5 +1,5 @@
 /**
- * POST /wallet/set
+ * POST /api/user/wallet/set
  * Store encrypted API key for a user
  *
  * Security:
@@ -8,16 +8,13 @@
  * - Never logs or returns the actual key
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { WALLET_ERROR_MESSAGES } from '@tzurot/common-types/constants/wallet';
 import { SetWalletKeySchema } from '@tzurot/common-types/schemas/api/wallet';
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { generateUserApiKeyUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import { encryptApiKey } from '@tzurot/common-types/utils/encryption';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { type ApiKeyCacheInvalidationService } from '@tzurot/cache-invalidation';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { stampNotifyOptedIn, liftNotifyAutoDisable } from '../../services/notifyOptIn.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
@@ -56,7 +53,7 @@ function mapValidationErrorToResponse(validation: ApiKeyValidationResult): Error
   }
 }
 
-/** POST /api/user/wallet — store a validated API key for the current user. */
+/** POST /api/user/wallet/set — store a validated API key for the current user. */
 export const handleSetWalletKey = (deps: WalletSetDeps): RequestHandler => {
   const { prisma, apiKeyCacheInvalidation } = deps;
   return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
@@ -140,17 +137,3 @@ export const handleSetWalletKey = (deps: WalletSetDeps): RequestHandler => {
     );
   });
 };
-
-export function createSetKeyRoute(
-  prisma: PrismaClient,
-  apiKeyCacheInvalidation?: ApiKeyCacheInvalidationService
-): Router {
-  const router = Router();
-  router.post(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    handleSetWalletKey({ prisma, apiKeyCacheInvalidation })
-  );
-  return router;
-}

--- a/services/api-gateway/src/routes/wallet/testKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/testKey.test.ts
@@ -70,10 +70,10 @@ const mockPrisma = {
   $executeRaw: vi.fn().mockResolvedValue(1),
 };
 
-import { createTestKeyRoute } from './testKey.js';
+import { handleTestWalletKey } from './testKey.js';
 import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
-import { findRoute, getRouteHandler } from '../../test/expressRouterUtils.js';
+import { asRouteHandler } from '../../test/shared-route-test-utils.js';
 
 // Helper to create mock request/response
 function createMockReqRes(body: Record<string, unknown> = {}) {
@@ -98,8 +98,7 @@ async function callHandler(
   req: Request & { userId: string },
   res: Response
 ): Promise<void> {
-  const router = createTestKeyRoute(prisma as PrismaClient);
-  const handler = getRouteHandler(router, 'post');
+  const handler = asRouteHandler(handleTestWalletKey({ prisma: prisma as PrismaClient }));
   await handler(req, res);
 }
 
@@ -114,24 +113,6 @@ describe('POST /wallet/test', () => {
       tag: 'mock-tag',
     });
     mockPrisma.userApiKey.updateMany.mockResolvedValue({ count: 1 });
-  });
-
-  describe('route factory', () => {
-    it('should create a router', () => {
-      const router = createTestKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(router).toBeDefined();
-      expect(typeof router).toBe('function');
-    });
-
-    it('should have POST route registered', () => {
-      const router = createTestKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(router.stack).toBeDefined();
-      expect(router.stack.length).toBeGreaterThan(0);
-
-      expect(findRoute(router, 'post', '/')).toBeDefined();
-    });
   });
 
   describe('validation', () => {

--- a/services/api-gateway/src/routes/wallet/testKey.ts
+++ b/services/api-gateway/src/routes/wallet/testKey.ts
@@ -1,17 +1,15 @@
 /**
- * POST /wallet/test
+ * POST /api/user/wallet/test
  * Test API key validity
  *
  * Validates the stored API key by making a dry-run API call
  */
 
-import { Router, type Response, type RequestHandler } from 'express';
+import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { TestWalletKeySchema } from '@tzurot/common-types/schemas/api/wallet';
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { decryptApiKey } from '@tzurot/common-types/utils/encryption';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
@@ -122,14 +120,3 @@ export const handleTestWalletKey = (deps: WalletTestDeps): RequestHandler => {
     });
   });
 };
-
-export function createTestKeyRoute(prisma: PrismaClient): Router {
-  const router = Router();
-  router.post(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    handleTestWalletKey({ prisma })
-  );
-  return router;
-}

--- a/services/api-gateway/src/test/shared-route-test-utils.ts
+++ b/services/api-gateway/src/test/shared-route-test-utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { vi } from 'vitest';
-import type { Request, Response, Router } from 'express';
+import type { Request, RequestHandler, Response, Router } from 'express';
 import type { ConfigCascadeResolver, LlmConfigResolver } from '@tzurot/config-resolver';
 import { getRouteHandler } from './expressRouterUtils.js';
 
@@ -94,6 +94,25 @@ export function getHandler(
   path: string
 ): RouteHandler {
   return getRouteHandler(router, method, path) as RouteHandler;
+}
+
+/**
+ * Adapt a bare `RequestHandler` export (the shape `routes/_generated/mounts.ts`
+ * mounts) to the two-argument call shape used across route tests. Express
+ * always supplies `next`; handlers wrapped in `asyncHandler` only reach for it
+ * on a thrown error, so a `vi.fn()` stand-in is enough.
+ *
+ * The parameter is the plain `Request` rather than `RouteHandler`'s
+ * `Request & { userId: string }` so that suites building a bare mock request
+ * can call the result too; contravariance keeps it assignable to
+ * `RouteHandler` for the suites that do attach `userId`.
+ */
+export function asRouteHandler(
+  handler: RequestHandler
+): (req: Request, res: Response) => Promise<void> {
+  return async (req, res) => {
+    await handler(req, res, vi.fn());
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

TASK-412 (2026-08-03 drift audit). `routes/_generated/mounts.ts` imports only bare handlers, and `index.ts` mounts the six public/protected routers directly — every other `create*Routes` factory survived the mounts cutover as test-only dead code. Full census run (every `export function create*` under `routes/`, classified by production importers): **27 dead factories deleted** across `admin/`, `user/`, and `wallet/`.

- **Tests retargeted at the bare handlers** via a new shared `asRouteHandler` adapter in `shared-route-test-utils.ts`; behavioral assertions preserved. Factory-mechanics tests (route registration, stack length) deleted — that invariant belongs to `sortRoutesForExpress` now.
- **Security invariants moved to the level that owns the wiring.** The deleted factory tests carried two auth-identity assertions; both are re-pinned in `mounts.component.test.ts` (7→17 tests): the diagnostic user↔internal audience split (401 on the four unauthenticated GETs; the internal PATCH mounted with no user gate) and the admin-settings dual mount (ungated `/api/internal/admin-settings` read alias vs owner-gated `/api/admin/settings`, with the 401/403 pair per write route distinguishing user-auth from user+owner-auth). Soft assertions were falsification-probed (temporarily inverted to capture the real 400/500 codes proving the handler was reached) before landing.
- **Header sweep**: 72 route files' docblocks (plus same-class in-body handler docblocks) now state the paths `mounts.ts` actually serves instead of pre-cutover forms; 12 were already correct. The diagnostic PATCH trust-assumption paragraph relocated onto its handler with the resolved refactor-archaeology dropped.
- **Deliberately kept**: `admin/denylist.ts` (its factory carries the orphaned rate limiter under TASK-411's pending owner decision — untouched) and `user/{channel,personality}/index.ts` (each file's only export is the dead factory; deleting them orphans the 12-file `create*Handler` tier and ~10 more test retargets — filed as TASK-417). Follow-ups also filed: TASK-418 (`scripts/audit-route-auth-matrix.ts` walks the now-deleted factory tier), TASK-419 (161 test describe-labels still carry pre-cutover paths — label cosmetics, swept separately to keep this diff reviewable).
- Not pinned (flagged, deliberately): the diagnostic GETs carry `requireUserAuth` without `requireProvisionedUser` — a probe would have to lean on stub-failure shapes; too brittle for the value.

## Verification

- `pnpm test` green repo-wide; `pnpm test:component` green (46 files / 624 tests — includes the extended mounts suite); `pnpm quality` green; pre-push gate green.
- api-gateway package: typecheck + typecheck:spec clean, 191 files / 2633 tests green, eslint clean.
- Production-diff audit: the only non-comment added lines across all route files are import trims — zero logic changes outside the deletions.
- Survivor grep for the 8 audit-named factories: only the denylist carve-out and the two TASK-417 files remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)