### PR TITLE
fix(ai-worker): stop unsupported attachments reading as failed audio

### DIFF
--- a/packages/common-types/src/constants/media.ts
+++ b/packages/common-types/src/constants/media.ts
@@ -111,6 +111,12 @@ export const AUDIO_MIME_ALIASES: Record<string, string> = {
 export enum AttachmentType {
   Image = 'image',
   Audio = 'audio',
+  /**
+   * Any attachment with no content processor (video, documents, archives…).
+   * Carries an honest "not supported" stub description so the model knows a
+   * file was attached — never a fabricated image/audio failure.
+   */
+  File = 'file',
 }
 
 /**

--- a/services/ai-worker/src/services/MultimodalProcessor.test.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.test.ts
@@ -480,6 +480,37 @@ describe('MultimodalProcessor', () => {
       vi.useFakeTimers();
     });
 
+    it('returns an honest File stub for unsupported types without calling any processor', async () => {
+      // The regression shape: a soundless screen-recording video used to fall
+      // into the failure-mapping and read as "Audio transcription failed".
+      vi.useRealTimers();
+
+      const attachments: AttachmentMetadata[] = [
+        {
+          url: 'https://cdn.discordapp.com/screen-recording.mp4',
+          name: 'screen-recording.mp4',
+          contentType: 'video/mp4',
+          size: 4096,
+        },
+      ];
+
+      const results = await processAttachments(attachments, mockPersonality, {
+        isGuestMode: false,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        type: AttachmentType.File,
+        description: 'Attachment type video/mp4 is not supported — content not analyzed',
+        originalUrl: 'https://cdn.discordapp.com/screen-recording.mp4',
+      });
+      // Neither paid boundary may fire for an unsupported type.
+      expect(mockTranscribeAudio).not.toHaveBeenCalled();
+      expect(results[0].description).not.toContain('transcription failed');
+
+      vi.useFakeTimers();
+    });
+
     it('should process multiple attachments in parallel', async () => {
       // Use real timers for this test - we're not testing timeout logic
       vi.useRealTimers();

--- a/services/ai-worker/src/services/MultimodalProcessor.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.ts
@@ -247,8 +247,21 @@ async function processSingleAttachment(
       metadata: attachment,
     };
   }
-  // Unsupported type
-  return null;
+  // No processor exists for this content-type (video, documents, archives…).
+  // Return an honest stub rather than null: a null here used to fall into the
+  // failure-mapping in processAttachments, which fabricated an "Audio
+  // transcription failed" description — a soundless video then read to the
+  // model (and the user) as a broken voice message.
+  logger.info(
+    { name: attachment.name, contentType: attachment.contentType },
+    'Attachment type unsupported — passing through as file stub'
+  );
+  return {
+    type: AttachmentType.File,
+    description: `Attachment type ${attachment.contentType} is not supported — content not analyzed`,
+    originalUrl: attachment.url,
+    metadata: attachment,
+  };
 }
 
 /**

--- a/services/ai-worker/src/services/RAGUtils.test.ts
+++ b/services/ai-worker/src/services/RAGUtils.test.ts
@@ -100,6 +100,20 @@ describe('RAGUtils', () => {
       expect(buildAttachmentDescriptions(attachments)).toBe('[Image: photo.png]\nA photo');
     });
 
+    it('formats an unsupported-type File stub under a [File:] header', () => {
+      const attachments: ProcessedAttachment[] = [
+        createAttachment(
+          AttachmentType.File,
+          'Attachment type video/mp4 is not supported — content not analyzed',
+          { name: 'screen-recording.mp4', contentType: 'video/mp4' }
+        ),
+      ];
+
+      expect(buildAttachmentDescriptions(attachments)).toBe(
+        '[File: screen-recording.mp4]\nAttachment type video/mp4 is not supported — content not analyzed'
+      );
+    });
+
     it('should format voice message with duration and wrap transcript in structured tags', () => {
       const attachments: ProcessedAttachment[] = [
         createAttachment(AttachmentType.Audio, 'User said hello and asked about the weather', {

--- a/services/ai-worker/src/services/RAGUtils.ts
+++ b/services/ai-worker/src/services/RAGUtils.ts
@@ -108,6 +108,11 @@ function formatProcessedAttachmentEntry(a: ProcessedAttachment): string {
     const safeTranscript = neutralizeWrapperClosingTags(a.description);
     return `${header}\n<voice_transcripts><transcript>${safeTranscript}</transcript></voice_transcripts>`;
   }
+  if (a.type === AttachmentType.File) {
+    const name =
+      a.metadata.name !== undefined && a.metadata.name.length > 0 ? a.metadata.name : 'attachment';
+    return `[File: ${name}]\n${a.description}`;
+  }
   return '';
 }
 


### PR DESCRIPTION
## Summary

Prod bug (owner report 2026-08-03, runtime-confirmed same night): a soundless screen-recording MP4 made the persona apologize for a failed **voice message** — the prompt carried `Audio transcription failed after 1 attempts (unknown)` for an attachment that never touched STT.

## Root cause (runtime-verified, jobs `llm-84373be6` / `llm-323fdd9c`, 02:12–02:13 UTC)

The June fix (`17cfb4e1b` / `bdbf27a67`, `isVoiceAttachment`) **holds**: the gateway's `categorizeAttachments` created zero transcription children and no STT ran (no spend). The residual half of the bug is in ai-worker's in-band path:

- `MultimodalProcessor.processSingleAttachment` returns `null` for content-types with no processor (video, PDF, archives).
- `processAttachments`' result-mapping treats success-with-`null` as a **failure**, and its fallback labeler only distinguishes image vs "everything else = audio" — so it fabricated `type: Audio` + "Audio transcription failed after 1 attempts (unknown)" (the `unknown` category is the tell: there was no error object because nothing failed).

Evidence: memory-search `queryPreview` carries the exact fabricated string; `[MultimodalProcessor] Using fallback description after all retries failed` fired at 02:13:01.528 with `attempts=1`; the gateway logged `totalChildren=0`.

## Fix

- `AttachmentType.File` (new enum member, worker-internal type — no cross-service schema pins the enum).
- Unsupported types return an honest stub: `Attachment type video/mp4 is not supported — content not analyzed`, rendered under a `[File: name]` header by `RAGUtils`. The model now knows a file was attached and says so, instead of apologizing for broken voice.
- The failure-mapping is untouched for genuine image/audio processing failures — those fallbacks remain correct.
- Follows the documented `BARE_PLACEHOLDERS` precedent: informative failure/stub text stays in content because "it tells the model an attachment was there and how to respond."

## Tests

- `MultimodalProcessor`: video/mp4 → File stub, `transcribeAudio` boundary asserted NOT called, description asserted free of "transcription failed".
- `RAGUtils`: `[File: name]` header formatting.

## Gates

`pnpm test` (all packages) · `pnpm test:component` (624 passed) · `pnpm quality` — green, sequential.

Backlog rider: real video processing for OpenRouter BYOK users (length-capped, config-cascaded) filed as tracker `doc-59` per owner ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)