### PR TITLE
fix(ai-worker): stop logging message content on passed duplicate checks (TASK-422)

### DIFF
--- a/services/ai-worker/src/utils/crossTurnDetection.test.ts
+++ b/services/ai-worker/src/utils/crossTurnDetection.test.ts
@@ -34,7 +34,9 @@ describe('crossTurnDetection diagnostic telemetry', () => {
   });
 
   describe('comparisonReport', () => {
-    it('emits a per-message report with hash, prefix, scores, and hashMatch flag on PASSED', () => {
+    it('logs numerics and hash only on PASSED — no snippets, no report', () => {
+      // Owner decision: routine PASSED checks must log no message text
+      // (no-PII logging); content-bearing diagnostics are NEAR_MISS/WARN-only.
       const newResponse =
         'The morning light filters through the window, casting long thoughtful shadows.';
       const recentMessages = [
@@ -46,25 +48,47 @@ describe('crossTurnDetection diagnostic telemetry', () => {
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({
+          outcome: 'PASSED',
+          newResponseHash: expect.any(String),
+          recentMessagesCount: 2,
+        }),
+        expect.stringContaining('no duplicate detected')
+      );
+      const [fields] = mockLogger.info.mock.calls[0] as [Record<string, unknown>];
+      expect(fields).not.toHaveProperty('comparisonReport');
+      expect(fields).not.toHaveProperty('newResponseSnippet');
+      expect(fields).not.toHaveProperty('closestMatchSnippet');
+      const serialized = JSON.stringify(fields);
+      expect(serialized).not.toContain('morning light');
+      expect(serialized).not.toContain('Previous unrelated');
+    });
+
+    it('retains snippets and the full report on NEAR_MISS', () => {
+      // High bigram overlap, sub-Jaccard word overlap, and a threshold above
+      // the similarity puts this in the near-miss band — the rare
+      // reconstruct-a-slipped-duplicate case that justifies carrying content.
+      const newResponse =
+        'The morning light filters through the window, casting long thoughtful shadows everywhere.';
+      const nearMissMessage =
+        'The morning light filters through the doorway, casting tall thoughtful shadows anywhere.';
+
+      isRecentDuplicate(newResponse, [nearMissMessage], 0.99);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: 'NEAR_MISS',
+          newResponseSnippet: expect.stringContaining('morning light'),
+          closestMatchSnippet: expect.stringContaining('doorway'),
           comparisonReport: [
             expect.objectContaining({
               turnsBack: 1,
               hash: expect.stringMatching(/^[a-f0-9]{8}$/),
-              prefix: expect.stringContaining('Previous unrelated'),
-              length: recentMessages[0].length,
-              jaccard: expect.any(Number),
-              bigram: expect.any(Number),
-              hashMatch: false,
-            }),
-            expect.objectContaining({
-              turnsBack: 2,
-              hash: expect.stringMatching(/^[a-f0-9]{8}$/),
-              prefix: expect.stringContaining('Another earlier'),
+              prefix: expect.stringContaining('The morning light'),
               hashMatch: false,
             }),
           ],
         }),
-        expect.stringContaining('no duplicate detected')
+        expect.stringContaining('NEAR-MISS')
       );
     });
 
@@ -83,26 +107,31 @@ describe('crossTurnDetection diagnostic telemetry', () => {
       );
     });
 
-    it('populates jaccard/bigram as null when a comparison message is below MIN_LENGTH', () => {
+    it('populates jaccard/bigram as null for below-MIN_LENGTH messages in a NEAR_MISS report', () => {
+      // Two comparison messages: one drives the near-miss band, one is too
+      // short to score — the report row for the short one carries nulls.
       const newResponse =
-        'A sufficiently long response to make it past the 30-char minimum for scoring.';
+        'The morning light filters through the window, casting long thoughtful shadows everywhere.';
       const recentMessages = [
+        'The morning light filters through the doorway, casting tall thoughtful shadows anywhere.',
         'short', // below the 30-char MIN_LENGTH_FOR_SIMILARITY_CHECK
       ];
 
-      isRecentDuplicate(newResponse, recentMessages);
+      isRecentDuplicate(newResponse, recentMessages, 0.99);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({
+          outcome: 'NEAR_MISS',
           comparisonReport: [
+            expect.objectContaining({ turnsBack: 1, jaccard: expect.any(Number) }),
             expect.objectContaining({
-              turnsBack: 1,
+              turnsBack: 2,
               jaccard: null,
               bigram: null,
             }),
           ],
         }),
-        expect.stringContaining('no duplicate detected')
+        expect.stringContaining('NEAR-MISS')
       );
     });
 

--- a/services/ai-worker/src/utils/crossTurnDetection.ts
+++ b/services/ai-worker/src/utils/crossTurnDetection.ts
@@ -103,39 +103,56 @@ function snippet(content: string, maxLength = 60): string {
   return content.substring(0, maxLength) + '...';
 }
 
-/** Log diagnostic info about duplicate detection outcome */
-function logDuplicateCheckResult(params: {
-  outcome: 'NEAR_MISS' | 'PASSED';
+/** Numeric/hash fields shared by both duplicate-check log outcomes. */
+interface DuplicateCheckNumericFields {
   maxSimilarity: number;
   threshold: number;
   maxSimilarityIndex: number;
   recentMessagesCount: number;
   newResponseLength: number;
-  newResponseSnippet: string;
-  closestMatchSnippet: string;
   newResponseHash: string;
-  /** Full per-message comparison details for diagnostic purposes. When a
-   *  user-reported duplicate slips past all 4 layers, this is the only way
-   *  to reconstruct what the detector actually saw at the time. */
-  comparisonReport: ComparisonReportEntry[];
-}): void {
+}
+
+/**
+ * Discriminated union making the content/no-content split compiler-enforced:
+ * a NEAR_MISS without content (or a PASSED with it) is unrepresentable, so
+ * the no-PII property of the PASSED arm can't be broken by a call-site slip.
+ */
+type DuplicateCheckLogParams =
+  | ({ outcome: 'PASSED' } & DuplicateCheckNumericFields)
+  | ({
+      outcome: 'NEAR_MISS';
+      content: {
+        newResponseSnippet: string;
+        closestMatchSnippet: string;
+        comparisonReport: ComparisonReportEntry[];
+      };
+    } & DuplicateCheckNumericFields);
+
+/**
+ * Log diagnostic info about duplicate detection outcome.
+ *
+ * Content-bearing fields (snippets + the per-message comparison report) are
+ * carried ONLY on the NEAR_MISS arm — owner decision: a routine PASSED check
+ * must log no message text (structured logs are no-PII per 00-critical), so
+ * the common path emits numerics and hashes only. NEAR_MISS and the WARN
+ * detection paths are the rare reconstruct-a-slipped-duplicate cases that
+ * justify carrying content.
+ */
+function logDuplicateCheckResult(params: DuplicateCheckLogParams): void {
   const {
-    outcome,
     maxSimilarity,
     threshold,
     maxSimilarityIndex,
     recentMessagesCount,
     newResponseLength,
-    newResponseSnippet,
-    closestMatchSnippet,
     newResponseHash,
-    comparisonReport,
   } = params;
 
-  if (outcome === 'NEAR_MISS') {
+  if (params.outcome === 'NEAR_MISS') {
     logger.info(
       {
-        outcome,
+        outcome: params.outcome,
         maxSimilarity: maxSimilarity.toFixed(3),
         threshold,
         nearMissThreshold: NEAR_MISS_THRESHOLD,
@@ -143,10 +160,10 @@ function logDuplicateCheckResult(params: {
         turnsBack: maxSimilarityIndex + 1,
         recentMessagesCount,
         newResponseLength,
-        newResponseSnippet,
-        closestMatchSnippet,
+        newResponseSnippet: params.content.newResponseSnippet,
+        closestMatchSnippet: params.content.closestMatchSnippet,
         newResponseHash,
-        comparisonReport,
+        comparisonReport: params.content.comparisonReport,
       },
       `NEAR-MISS: Similarity ${(maxSimilarity * 100).toFixed(1)}% ` +
         `is high but below ${(threshold * 100).toFixed(0)}% threshold.`
@@ -154,16 +171,13 @@ function logDuplicateCheckResult(params: {
   } else {
     logger.info(
       {
-        outcome,
+        outcome: params.outcome,
         maxSimilarity: maxSimilarity.toFixed(3),
         threshold,
         maxSimilarityIndex,
         recentMessagesCount,
         newResponseLength,
-        newResponseSnippet: snippet(newResponseSnippet, 40),
-        closestMatchSnippet: snippet(closestMatchSnippet, 40),
         newResponseHash,
-        comparisonReport,
       },
       'Check complete - no duplicate detected'
     );
@@ -333,9 +347,11 @@ export function isRecentDuplicate(
 
 /**
  * Tail-of-function log emission for `isRecentDuplicate`. Extracted so the
- * parent stays under the `max-lines-per-function` limit while all three
- * telemetry fields (`comparisonReport` ground-truth data, near-miss band,
- * closest-match snippet) remain emitted for every non-matching check.
+ * parent stays under the `max-lines-per-function` limit.
+ *
+ * The comparison report is built only for the NEAR_MISS band — its sole
+ * consumer is the log line, and the routine PASSED path neither logs nor
+ * pays for it.
  */
 function emitPassedOrNearMissLog(args: {
   cleanNewResponse: string;
@@ -361,19 +377,31 @@ function emitPassedOrNearMissLog(args: {
   }
 
   const isNearMiss = highestSimilarity >= NEAR_MISS_THRESHOLD && highestSimilarity < threshold;
-  const comparisonReport = buildComparisonReport(cleanNewResponse, newResponseHash, recentMessages);
-  logDuplicateCheckResult({
-    outcome: isNearMiss ? 'NEAR_MISS' : 'PASSED',
+  const numericFields = {
     maxSimilarity: highestSimilarity,
     threshold,
     maxSimilarityIndex: highestSimilarityIndex,
     recentMessagesCount: recentMessages.length,
     newResponseLength: cleanNewResponse.length,
-    newResponseSnippet: snippet(cleanNewResponse),
-    closestMatchSnippet,
     newResponseHash,
-    comparisonReport,
-  });
+  };
+  logDuplicateCheckResult(
+    isNearMiss
+      ? {
+          outcome: 'NEAR_MISS',
+          ...numericFields,
+          content: {
+            newResponseSnippet: snippet(cleanNewResponse),
+            closestMatchSnippet,
+            comparisonReport: buildComparisonReport(
+              cleanNewResponse,
+              newResponseHash,
+              recentMessages
+            ),
+          },
+        }
+      : { outcome: 'PASSED', ...numericFields }
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Owner-approved outcome of the 2026-08-04 prod-log sweep (TASK-422). The PASSED branch of the cross-turn duplicate check logged **message content** — the new reply's snippet, the closest match's snippet, and the full `comparisonReport` (80-char prefixes of up to 25 history messages) — at INFO on **every** generation (~97 per 6h in prod, the largest log-line class by bytes). That sits against `00-critical.md`'s no-message-content logging rule.

## The approved split

- **PASSED** (the ~always case): numerics + hashes only — `outcome`, similarity scores, thresholds, counts, `newResponseHash`. No message text; the comparison report is no longer even **built** (its only consumer was the log line).
- **NEAR_MISS** (rare band): retains snippets + the full report — with the WARN detection paths (which already carried snippets and are untouched), these are exactly the reconstruct-a-slipped-duplicate cases the report exists for, per its own docstring.

Implementation: `logDuplicateCheckResult` now takes content-bearing fields as an optional `content` block, populated only when `emitPassedOrNearMissLog` computes a near-miss.

## Tests

- PASSED: asserts the log fields carry no `comparisonReport`/`newResponseSnippet`/`closestMatchSnippet`, plus a serialized-fields assertion that no message text appears at all.
- NEAR_MISS: a deterministic fixture in the near-miss band (high bigram, sub-Jaccard word overlap, threshold above similarity) pins that snippets and the report survive.
- The below-MIN_LENGTH null-scores case re-pinned on the NEAR_MISS arm (the only arm that now emits a report).

## Gates

`pnpm test` · `pnpm test:component` (46 files, 624 passed — includes the DuplicateDetectionFlow component suite) · `pnpm quality` — all green, sequential. Full ai-worker suite: 206 files, 4,316 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)