### PR TITLE
test(api-gateway): sweep stale pre-cutover paths from route-test describe labels

### DIFF
--- a/services/api-gateway/src/routes/admin/broadcast.test.ts
+++ b/services/api-gateway/src/routes/admin/broadcast.test.ts
@@ -51,7 +51,7 @@ function createMockReqRes(body: Record<string, unknown>) {
   return { req, res };
 }
 
-describe('POST /admin/broadcast', () => {
+describe('POST /api/admin/broadcast', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/services/api-gateway/src/routes/admin/cleanup.test.ts
+++ b/services/api-gateway/src/routes/admin/cleanup.test.ts
@@ -58,7 +58,7 @@ describe('Admin Cleanup Route', () => {
     );
   });
 
-  describe('POST /admin/cleanup', () => {
+  describe('POST /api/admin/cleanup', () => {
     it('should cleanup history with default daysToKeep', async () => {
       mockService.cleanupOldHistory.mockResolvedValue(10);
 

--- a/services/api-gateway/src/routes/admin/createPersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.test.ts
@@ -54,7 +54,7 @@ const createMockPrismaClient = () => ({
   },
 });
 
-describe('POST /admin/personality', () => {
+describe('POST /api/admin/personality', () => {
   let app: Express;
   let prisma: ReturnType<typeof createMockPrismaClient>;
 

--- a/services/api-gateway/src/routes/admin/denylist.test.ts
+++ b/services/api-gateway/src/routes/admin/denylist.test.ts
@@ -106,7 +106,7 @@ describe('Denylist Admin Routes', () => {
     );
   });
 
-  describe('GET /admin/denylist', () => {
+  describe('GET /api/admin/denylist', () => {
     it('should list all entries', async () => {
       const response = await request(app).get('/admin/denylist');
 
@@ -135,7 +135,7 @@ describe('Denylist Admin Routes', () => {
     });
   });
 
-  describe('GET /admin/denylist/cache', () => {
+  describe('GET /api/internal/denylist/cache', () => {
     it('should return all entries for hydration', async () => {
       const response = await request(app).get('/admin/denylist/cache');
 
@@ -147,7 +147,7 @@ describe('Denylist Admin Routes', () => {
     });
   });
 
-  describe('POST /admin/denylist', () => {
+  describe('POST /api/admin/denylist', () => {
     it('should add a USER + BOT entry', async () => {
       const response = await request(app).post('/admin/denylist').send({
         type: 'USER',
@@ -321,7 +321,7 @@ describe('Denylist Admin Routes', () => {
     });
   });
 
-  describe('DELETE /admin/denylist/:type/:discordId/:scope/:scopeId', () => {
+  describe('DELETE /api/admin/denylist/:type/:discordId/:scope/:scopeId', () => {
     it('should remove an existing entry', async () => {
       mockPrisma.denylistedEntity.findUnique.mockResolvedValue({
         id: 'test-uuid',

--- a/services/api-gateway/src/routes/admin/diagnostic.test.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.test.ts
@@ -190,7 +190,7 @@ describe('Admin Diagnostic Routes', () => {
     );
   });
 
-  describe('GET /admin/diagnostic/recent', () => {
+  describe('GET /api/user/diagnostic/recent', () => {
     it('should return recent logs with personalityName from JSONB', async () => {
       mockPrisma.$queryRaw.mockResolvedValue([
         {
@@ -322,7 +322,7 @@ describe('Admin Diagnostic Routes', () => {
     });
   });
 
-  describe('GET /admin/diagnostic/by-message/:messageId', () => {
+  describe('GET /api/user/diagnostic/by-message/:messageId', () => {
     it('should return logs for a valid message ID', async () => {
       mockPrisma.llmDiagnosticLog.findMany.mockResolvedValue([
         {
@@ -440,7 +440,7 @@ describe('Admin Diagnostic Routes', () => {
     });
   });
 
-  describe('GET /admin/diagnostic/:requestId', () => {
+  describe('GET /api/user/diagnostic/:requestId', () => {
     it('should return full diagnostic log', async () => {
       mockPrisma.llmDiagnosticLog.findUnique.mockResolvedValue({
         id: 'log-uuid',
@@ -563,7 +563,7 @@ describe('Admin Diagnostic Routes', () => {
     });
   });
 
-  describe('GET /admin/diagnostic/by-response/:messageId', () => {
+  describe('GET /api/user/diagnostic/by-response/:messageId', () => {
     it('should return log for a valid response message ID', async () => {
       mockPrisma.llmDiagnosticLog.findFirst.mockResolvedValue({
         id: 'log-uuid',
@@ -630,7 +630,7 @@ describe('Admin Diagnostic Routes', () => {
     });
   });
 
-  describe('PATCH /admin/diagnostic/:requestId/response-ids', () => {
+  describe('PATCH /api/internal/diagnostic/:requestId/response-ids', () => {
     it('should update response message IDs', async () => {
       mockPrisma.llmDiagnosticLog.update.mockResolvedValue({
         requestId: 'test-req-123',

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -172,7 +172,7 @@ describe('Admin LLM Config Routes', () => {
     return a;
   };
 
-  describe('GET /admin/llm-config', () => {
+  describe('GET /api/admin/llm-config', () => {
     it('should list all LLM configs', async () => {
       prisma.llmConfig.findMany.mockResolvedValue([
         {
@@ -289,7 +289,7 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('GET /admin/llm-config/:id', () => {
+  describe('GET /api/admin/llm-config/:id', () => {
     it('should return a single global config', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-1',
@@ -410,7 +410,7 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('POST /admin/llm-config', () => {
+  describe('POST /api/admin/llm-config', () => {
     it('should return 400 when model validation fails on create', async () => {
       // Mock must write the error to res before returning false — matches the
       // real helper's contract. Otherwise supertest hangs waiting for a response.
@@ -607,7 +607,7 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('PUT /admin/llm-config/:id', () => {
+  describe('PUT /api/admin/llm-config/:id', () => {
     it('should return 400 when model validation fails on update', async () => {
       // The config must exist before model validation runs — validation is
       // after the row fetch, so mock findUnique.
@@ -776,7 +776,7 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('PUT /admin/llm-config/:id/set-default', () => {
+  describe('PUT /api/admin/llm-config/:id/set-default', () => {
     it('writes the global chat-slot pointer (default text slot)', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',
@@ -871,7 +871,7 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('PUT /admin/llm-config/:id/set-free-default', () => {
+  describe('PUT /api/admin/llm-config/:id/set-free-default', () => {
     it('writes the free chat-slot pointer (default text slot)', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',
@@ -967,7 +967,7 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('DELETE /admin/llm-config/:id', () => {
+  describe('DELETE /api/admin/llm-config/:id', () => {
     it('should delete a global config', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',
@@ -1144,7 +1144,7 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('PUT /admin/llm-config/:id - duplicate name check', () => {
+  describe('PUT /api/admin/llm-config/:id - duplicate name check', () => {
     it('should reject duplicate name when renaming config', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',

--- a/services/api-gateway/src/routes/admin/settings.test.ts
+++ b/services/api-gateway/src/routes/admin/settings.test.ts
@@ -164,7 +164,7 @@ describe('Admin Settings Routes (Singleton)', () => {
     );
   });
 
-  describe('GET /admin/settings', () => {
+  describe('GET /api/admin/settings', () => {
     it('should return the AdminSettings singleton', async () => {
       const settings = createDefaultSettings();
       mockPrisma.adminSettings.upsert.mockResolvedValue(settings);
@@ -235,7 +235,7 @@ describe('Admin Settings Routes (Singleton)', () => {
     });
   });
 
-  describe('PATCH /admin/settings/config-defaults', () => {
+  describe('PATCH /api/admin/settings/config-defaults', () => {
     it('should accept flat body and update configDefaults', async () => {
       const updatedSettings = createDefaultSettings({
         configDefaults: { maxMessages: 42 },
@@ -341,7 +341,7 @@ describe('Admin Settings Routes (Singleton)', () => {
     });
   });
 
-  describe('DELETE /admin/settings/config-defaults', () => {
+  describe('DELETE /api/admin/settings/config-defaults', () => {
     it('should clear configDefaults and return success', async () => {
       mockPrisma.adminSettings.update.mockResolvedValue(
         createDefaultSettings({ configDefaults: null, updatedBy: MOCK_USER_UUID })

--- a/services/api-gateway/src/routes/admin/systemSettings.test.ts
+++ b/services/api-gateway/src/routes/admin/systemSettings.test.ts
@@ -100,7 +100,7 @@ describe('Admin System Settings Routes', () => {
     app.patch('/system', handleUpdateSystemSettings(deps));
   });
 
-  describe('GET', () => {
+  describe('GET /api/admin/settings/system', () => {
     it('returns the stored bag and the concurrency token', async () => {
       mockPrisma.adminSettings.upsert.mockResolvedValue(
         settingsRow({ zaiHeadroomPercent: 60, futureKey: 'preserved' })
@@ -126,7 +126,7 @@ describe('Admin System Settings Routes', () => {
     });
   });
 
-  describe('PATCH — wire validation', () => {
+  describe('PATCH /api/admin/settings/system — wire validation', () => {
     it('rejects an out-of-bounds value', async () => {
       const res = await request(app)
         .patch('/system')
@@ -159,7 +159,7 @@ describe('Admin System Settings Routes', () => {
     });
   });
 
-  describe('PATCH — coherence (D7)', () => {
+  describe('PATCH /api/admin/settings/system — coherence (D7)', () => {
     it('rejects zaiFreeTierEnabled=true without the system z.ai key', async () => {
       mockZaiKey = undefined;
 
@@ -190,7 +190,7 @@ describe('Admin System Settings Routes', () => {
     });
   });
 
-  describe('PATCH — model validation (D9/D10)', () => {
+  describe('PATCH /api/admin/settings/system — model validation (D9/D10)', () => {
     it('accepts router aliases without a catalog lookup', async () => {
       const res = await request(app)
         .patch('/system')
@@ -279,7 +279,7 @@ describe('Admin System Settings Routes', () => {
     });
   });
 
-  describe('PATCH — merge + concurrency', () => {
+  describe('PATCH /api/admin/settings/system — merge + concurrency', () => {
     it('merges over the existing bag, preserving unknown keys', async () => {
       mockPrisma.adminSettings.upsert.mockResolvedValue(
         settingsRow({ futureKey: 'preserved', zaiHeadroomPercent: 75 })
@@ -343,7 +343,7 @@ describe('Admin System Settings Routes', () => {
     });
   });
 
-  describe('PATCH — cross-field window pair', () => {
+  describe('PATCH /api/admin/settings/system — cross-field window pair', () => {
     it('rejects a floor raised above the stored ceiling', async () => {
       mockPrisma.adminSettings.upsert.mockResolvedValue(settingsRow({ freeTierMaxPerWindow: 30 }));
 

--- a/services/api-gateway/src/routes/admin/tts-config.test.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.test.ts
@@ -148,7 +148,7 @@ describe('admin/tts-config routes', () => {
     });
   });
 
-  describe('GET / (list)', () => {
+  describe('GET /api/admin/tts-config (list)', () => {
     it('returns all GLOBAL configs in the formatted shape', async () => {
       vi.mocked(mockService.list).mockResolvedValue([sampleRawConfig]);
       const handler = buildHandler(handleListGlobalTtsConfigs);
@@ -174,7 +174,7 @@ describe('admin/tts-config routes', () => {
     });
   });
 
-  describe('GET /:id (get)', () => {
+  describe('GET /api/admin/tts-config/:id (get)', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
       const handler = buildHandler(handleGetGlobalTtsConfig);
@@ -198,7 +198,7 @@ describe('admin/tts-config routes', () => {
     });
   });
 
-  describe('POST / (create)', () => {
+  describe('POST /api/admin/tts-config (create)', () => {
     it('returns 403 FORBIDDEN when admin user is not in DB', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue(null);
       const handler = buildHandler(handleCreateGlobalTtsConfig);
@@ -238,7 +238,7 @@ describe('admin/tts-config routes', () => {
     });
   });
 
-  describe('PUT /:id (edit)', () => {
+  describe('PUT /api/admin/tts-config/:id (edit)', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(null);
       const handler = buildHandler(handleUpdateGlobalTtsConfig);
@@ -306,7 +306,7 @@ describe('admin/tts-config routes', () => {
     });
   });
 
-  describe('PUT /:id/set-default', () => {
+  describe('PUT /api/admin/tts-config/:id/set-default', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(null);
       const handler = buildHandler(handleSetGlobalTtsConfigDefault);
@@ -340,7 +340,7 @@ describe('admin/tts-config routes', () => {
     });
   });
 
-  describe('PUT /:id/set-free-default', () => {
+  describe('PUT /api/admin/tts-config/:id/set-free-default', () => {
     it('returns 400 when target is not self-hosted', async () => {
       // ElevenLabs config (BYOK provider) — should be rejected
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue({
@@ -405,7 +405,7 @@ describe('admin/tts-config routes', () => {
     });
   });
 
-  describe('DELETE /:id', () => {
+  describe('DELETE /api/admin/tts-config/:id', () => {
     it('returns 404 when config not found', async () => {
       vi.mocked(mockPrisma.ttsConfig.findUnique).mockResolvedValue(null);
       const handler = buildHandler(handleDeleteGlobalTtsConfig);

--- a/services/api-gateway/src/routes/admin/updatePersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/updatePersonality.test.ts
@@ -37,7 +37,7 @@ const createMockPrismaClient = () => ({
   },
 });
 
-describe('PATCH /admin/personality/:slug', () => {
+describe('PATCH /api/admin/personality/:slug', () => {
   let app: Express;
   let prisma: ReturnType<typeof createMockPrismaClient>;
 

--- a/services/api-gateway/src/routes/admin/usage.test.ts
+++ b/services/api-gateway/src/routes/admin/usage.test.ts
@@ -59,7 +59,7 @@ describe('Admin Usage Routes', () => {
     );
   });
 
-  describe('GET /admin/usage', () => {
+  describe('GET /api/admin/usage', () => {
     it('should return usage stats with default 7d timeframe', async () => {
       mockPrisma.usageLog.findMany.mockResolvedValue([
         {

--- a/services/api-gateway/src/routes/ai/confirmDelivery.test.ts
+++ b/services/api-gateway/src/routes/ai/confirmDelivery.test.ts
@@ -17,7 +17,7 @@ const createMockPrismaClient = () => ({
   },
 });
 
-describe('POST /job/:jobId/confirm-delivery', () => {
+describe('POST /api/internal/ai/job/:jobId/confirm-delivery', () => {
   let app: Express;
   let prisma: ReturnType<typeof createMockPrismaClient>;
 

--- a/services/api-gateway/src/routes/ai/generate.test.ts
+++ b/services/api-gateway/src/routes/ai/generate.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../utils/jobChainOrchestrator.js', () => ({
   createJobChain: vi.fn().mockResolvedValue('llm-req-123'),
 }));
 
-describe('POST /generate', () => {
+describe('POST /api/internal/ai/generate', () => {
   let app: Express;
 
   beforeEach(() => {

--- a/services/api-gateway/src/routes/ai/jobStatus.test.ts
+++ b/services/api-gateway/src/routes/ai/jobStatus.test.ts
@@ -19,7 +19,7 @@ const createMockQueue = () => ({
   getFailedCount: vi.fn().mockResolvedValue(0),
 });
 
-describe('GET /job/:jobId', () => {
+describe('GET /api/internal/ai/job/:jobId', () => {
   let app: Express;
   let aiQueue: ReturnType<typeof createMockQueue>;
 

--- a/services/api-gateway/src/routes/ai/transcribe.test.ts
+++ b/services/api-gateway/src/routes/ai/transcribe.test.ts
@@ -34,7 +34,7 @@ const createMockPrisma = () =>
     },
   }) as unknown as PrismaClient;
 
-describe('POST /transcribe', () => {
+describe('POST /api/internal/ai/transcribe', () => {
   let app: Express;
   let aiQueue: ReturnType<typeof createMockQueue>;
   let queueEvents: ReturnType<typeof createMockQueueEvents>;

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.test.ts
@@ -44,7 +44,7 @@ const EXPECTED_ID = generateConversationHistoryUuid(
   new Date('2026-06-04T12:00:00.001Z')
 );
 
-describe('POST /internal/conversation/assistant-message', () => {
+describe('POST /api/internal/conversation/assistant-message', () => {
   let mockPrisma: {
     conversationHistory: {
       findUnique: ReturnType<typeof vi.fn>;

--- a/services/api-gateway/src/routes/internal/conversationSync.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationSync.test.ts
@@ -41,7 +41,7 @@ const VALID_BODY = {
   ],
 };
 
-describe('POST /internal/conversation/sync', () => {
+describe('POST /api/internal/conversation/sync', () => {
   let app: express.Express;
   let runSyncSpy: ReturnType<typeof vi.spyOn>;
 

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
@@ -56,7 +56,7 @@ const EXPECTED_ID = generateConversationHistoryUuid(
   new Date(VALID_BODY.messageTime)
 );
 
-describe('POST /internal/conversation/user-message', () => {
+describe('POST /api/internal/conversation/user-message', () => {
   let mockPrisma: {
     conversationHistory: {
       findUnique: ReturnType<typeof vi.fn>;

--- a/services/api-gateway/src/routes/internal/dmSessionSet.test.ts
+++ b/services/api-gateway/src/routes/internal/dmSessionSet.test.ts
@@ -24,7 +24,7 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-describe('POST /internal/channel/dm-session/set', () => {
+describe('POST /api/internal/channel/dm-session/set', () => {
   let mockPrisma: {
     personality: { findUnique: ReturnType<typeof vi.fn> };
     channelSettings: { upsert: ReturnType<typeof vi.fn> };

--- a/services/api-gateway/src/routes/internal/personalityLoad.test.ts
+++ b/services/api-gateway/src/routes/internal/personalityLoad.test.ts
@@ -41,7 +41,7 @@ const MOCK_PERSONALITY = {
   voiceEnabled: false,
 };
 
-describe('GET /internal/personality/load', () => {
+describe('GET /api/internal/personality/load', () => {
   let app: express.Express;
   let loadSpy: ReturnType<typeof vi.spyOn>;
 

--- a/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseBroadcast.test.ts
@@ -72,7 +72,7 @@ function createMockReqRes(body: Record<string, unknown>) {
   return { req, res };
 }
 
-describe('POST /internal/release-broadcast/:releaseId/pending', () => {
+describe('POST /api/internal/release-broadcast/:releaseId/pending', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -103,7 +103,7 @@ describe('POST /internal/release-broadcast/:releaseId/pending', () => {
   });
 });
 
-describe('POST /internal/release-broadcast/:releaseId/deliveries', () => {
+describe('POST /api/internal/release-broadcast/:releaseId/deliveries', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrisma.releaseDeliveryLog.updateMany.mockResolvedValue({ count: 1 });

--- a/services/api-gateway/src/routes/internal/releaseReconcile.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseReconcile.test.ts
@@ -65,7 +65,7 @@ const RESWEEP = {
   capped: false,
 };
 
-describe('POST /internal/release-broadcast/reconcile', () => {
+describe('POST /api/internal/release-broadcast/reconcile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     configMock.value = { GITHUB_API_TOKEN: undefined };

--- a/services/api-gateway/src/routes/internal/retentionPreview.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionPreview.test.ts
@@ -48,7 +48,7 @@ function createMockReqRes() {
   return { req, res };
 }
 
-describe('GET /internal/retention/preview', () => {
+describe('GET /api/internal/retention/preview', () => {
   it('returns the service preview in the manifest-declared shape', async () => {
     buildPreviewMock.mockResolvedValue(PREVIEW);
     const { req, res } = createMockReqRes();

--- a/services/api-gateway/src/routes/internal/retentionPurge.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionPurge.test.ts
@@ -29,7 +29,7 @@ function payloadOf(res: Response): Record<string, unknown> {
   return (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
 }
 
-describe('POST /internal/retention/purge', () => {
+describe('POST /api/internal/retention/purge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/services/api-gateway/src/routes/internal/retentionReconcileOffDb.test.ts
+++ b/services/api-gateway/src/routes/internal/retentionReconcileOffDb.test.ts
@@ -24,7 +24,7 @@ function createMockReqRes() {
   return { req, res };
 }
 
-describe('POST /internal/retention/reconcile-off-db', () => {
+describe('POST /api/internal/retention/reconcile-off-db', () => {
   it('returns the sweep tally in the manifest-declared shape', async () => {
     reconcileMock.mockResolvedValue({ settled: 3, stillFailing: 1, remaining: 0 });
     const { req, res } = createMockReqRes();

--- a/services/api-gateway/src/routes/internal/routingContextCreate.test.ts
+++ b/services/api-gateway/src/routes/internal/routingContextCreate.test.ts
@@ -68,7 +68,7 @@ function buildApp(): express.Express {
   return app;
 }
 
-describe('POST /internal/v1/routing-context', () => {
+describe('POST /api/internal/v1/routing-context', () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.restoreAllMocks());
 

--- a/services/api-gateway/src/routes/internal/secretRotationStatus.test.ts
+++ b/services/api-gateway/src/routes/internal/secretRotationStatus.test.ts
@@ -32,7 +32,7 @@ function createMockReqRes() {
   return { req, res };
 }
 
-describe('GET /internal/secret-rotations', () => {
+describe('GET /api/internal/secret-rotations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();

--- a/services/api-gateway/src/routes/internal/usersActivity.test.ts
+++ b/services/api-gateway/src/routes/internal/usersActivity.test.ts
@@ -26,7 +26,7 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
 
 const VALID_DISCORD_ID = '123456789012345678';
 
-describe('POST /internal/users/activity', () => {
+describe('POST /api/internal/users/activity', () => {
   let mockPrisma: { $executeRaw: ReturnType<typeof vi.fn> };
   let app: express.Express;
 

--- a/services/api-gateway/src/routes/internal/usersRecent.test.ts
+++ b/services/api-gateway/src/routes/internal/usersRecent.test.ts
@@ -26,7 +26,7 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-describe('GET /internal/users/recent', () => {
+describe('GET /api/internal/users/recent', () => {
   let mockPrisma: { $queryRaw: ReturnType<typeof vi.fn> };
   let app: express.Express;
 

--- a/services/api-gateway/src/routes/user/account/delete.test.ts
+++ b/services/api-gateway/src/routes/user/account/delete.test.ts
@@ -149,7 +149,7 @@ describe('Account Deletion Routes', () => {
     deletionServiceMock.deleteAccount.mockResolvedValue(SUMMARY);
   });
 
-  describe('GET /account/delete/preview', () => {
+  describe('GET /api/user/account/delete/preview', () => {
     it('403s superuser accounts before computing anything', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ isSuperuser: true });
       const { req, res } = createMockReqRes();
@@ -170,7 +170,7 @@ describe('Account Deletion Routes', () => {
     });
   });
 
-  describe('POST /account/delete/token', () => {
+  describe('POST /api/user/account/delete/token', () => {
     it('rejects a wrong phrase without minting a token', async () => {
       const { req, res } = createMockReqRes({ confirmationPhrase: 'delete my stuff' });
       await handleIssueAccountDeleteToken(makeDeps())(req, res, vi.fn());
@@ -197,7 +197,7 @@ describe('Account Deletion Routes', () => {
     });
   });
 
-  describe('POST /account/delete', () => {
+  describe('POST /api/user/account/delete', () => {
     const VALID_BODY = { deleteToken: 'acctdel_0123456789abcdef' };
 
     it('400s an unknown token at the peek without consuming', async () => {

--- a/services/api-gateway/src/routes/user/account/export.test.ts
+++ b/services/api-gateway/src/routes/user/account/export.test.ts
@@ -69,7 +69,7 @@ describe('Account Export Routes', () => {
     mockPrisma.exportJob.findFirst.mockResolvedValue(null);
   });
 
-  describe('POST /account/export', () => {
+  describe('POST /api/user/account/export', () => {
     async function callStart(body: Record<string, unknown> = {}) {
       const { req, res } = createMockReqRes(body);
       const handler = handleStartAccountExport({
@@ -155,7 +155,7 @@ describe('Account Export Routes', () => {
     });
   });
 
-  describe('GET /account/export/status', () => {
+  describe('GET /api/user/account/export/status', () => {
     async function callStatus() {
       const { req, res } = createMockReqRes();
       const handler = handleGetAccountExportStatus({

--- a/services/api-gateway/src/routes/user/channel/activate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.test.ts
@@ -52,25 +52,6 @@ vi.mock('@tzurot/common-types/utils/ownerMiddleware', async () => {
   };
 });
 
-// Intentionally uses the inline `importActual` + spread pattern (not the
-// shared `__mocks__/AuthMiddleware.ts` auto-discovery) because this file
-// also stubs `requireServiceAuth`, which the shared mock omits.
-vi.mock('../../../services/AuthMiddleware.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../services/AuthMiddleware.js')>(
-    '../../../services/AuthMiddleware.js'
-  );
-  return {
-    ...actual,
-    requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
-    requireServiceAuth: vi.fn(() =>
-      vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-    ),
-    requireProvisionedUser: vi.fn(() =>
-      vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-    ),
-  };
-});
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -78,7 +59,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleActivateChannel } from './activate.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('POST /user/channel/activate', () => {
+describe('POST /api/user/channel/activate', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/channel/configOverrides.test.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.test.ts
@@ -13,34 +13,8 @@ import {
   handleClearChannelConfigOverrides,
 } from './configOverrides.js';
 import type { RouteDeps } from '../../routeDeps.js';
-import { createMockPrisma, setupStandardMocks, MOCK_DISCORD_USER_ID } from './test-utils.js';
+import { createMockPrisma, setupStandardMocks } from './test-utils.js';
 import { stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
-
-// Mock AuthMiddleware
-vi.mock('../../../services/AuthMiddleware.js', () => ({
-  requireUserAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
-    req.userId = MOCK_DISCORD_USER_ID;
-    next();
-  },
-  requireServiceAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
-    req.userId = 'service';
-    next();
-  },
-  requireProvisionedUser: () => (_req: unknown, _res: unknown, next: () => void) => {
-    next();
-  },
-}));
-
-// Mock isBotOwner
-vi.mock('@tzurot/common-types/utils/ownerMiddleware', async () => {
-  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/ownerMiddleware')>(
-    '@tzurot/common-types/utils/ownerMiddleware'
-  );
-  return {
-    ...actual,
-    isBotOwner: vi.fn().mockReturnValue(false),
-  };
-});
 
 const CHANNEL_ID = '999888777666555444';
 
@@ -91,7 +65,7 @@ describe('Channel Config Overrides Routes', () => {
     });
   });
 
-  describe('GET /:channelId/config-overrides', () => {
+  describe('GET /api/user/channel/:channelId/config-overrides', () => {
     it('should return null when no overrides exist', async () => {
       mockPrisma.channelSettings.findUnique.mockResolvedValue(null);
 
@@ -114,7 +88,7 @@ describe('Channel Config Overrides Routes', () => {
     });
   });
 
-  describe('PATCH /:channelId/config-overrides', () => {
+  describe('PATCH /api/user/channel/:channelId/config-overrides', () => {
     it('should merge valid overrides', async () => {
       mockPrisma.channelSettings.findUnique.mockResolvedValue({
         configOverrides: { maxMessages: 30 },
@@ -176,7 +150,7 @@ describe('Channel Config Overrides Routes', () => {
     });
   });
 
-  describe('PATCH /:channelId/config-overrides (cascade invalidation)', () => {
+  describe('PATCH /api/user/channel/:channelId/config-overrides (cascade invalidation)', () => {
     it('should swallow cascade invalidation errors', async () => {
       mockPrisma.channelSettings.findUnique.mockResolvedValue(null);
       mockPrisma.channelSettings.upsert.mockResolvedValue({});
@@ -201,7 +175,7 @@ describe('Channel Config Overrides Routes', () => {
     });
   });
 
-  describe('DELETE /:channelId/config-overrides (cascade invalidation)', () => {
+  describe('DELETE /api/user/channel/:channelId/config-overrides (cascade invalidation)', () => {
     it('should swallow cascade invalidation errors on delete', async () => {
       mockPrisma.channelSettings.updateMany.mockResolvedValue({ count: 1 });
 
@@ -225,7 +199,7 @@ describe('Channel Config Overrides Routes', () => {
     });
   });
 
-  describe('DELETE /:channelId/config-overrides', () => {
+  describe('DELETE /api/user/channel/:channelId/config-overrides', () => {
     it('should clear overrides via updateMany', async () => {
       mockPrisma.channelSettings.updateMany.mockResolvedValue({ count: 1 });
 

--- a/services/api-gateway/src/routes/user/channel/deactivate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/deactivate.test.ts
@@ -29,16 +29,6 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-vi.mock('../../../services/AuthMiddleware.js', () => ({
-  requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
-  requireServiceAuth: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-  requireProvisionedUser: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-}));
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -46,7 +36,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleDeactivateChannel } from './deactivate.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('DELETE /user/channel/deactivate', () => {
+describe('DELETE /api/user/channel/deactivate', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/channel/get.test.ts
+++ b/services/api-gateway/src/routes/user/channel/get.test.ts
@@ -30,16 +30,6 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-vi.mock('../../../services/AuthMiddleware.js', () => ({
-  requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
-  requireServiceAuth: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-  requireProvisionedUser: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-}));
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -47,7 +37,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleGetUserChannel } from './get.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('GET /user/channel/:channelId', () => {
+describe('GET /api/user/channel/:channelId', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/channel/list.test.ts
+++ b/services/api-gateway/src/routes/user/channel/list.test.ts
@@ -33,16 +33,6 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-vi.mock('../../../services/AuthMiddleware.js', () => ({
-  requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
-  requireServiceAuth: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-  requireProvisionedUser: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-}));
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -50,7 +40,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleListUserChannels } from './list.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('GET /user/channel/list', () => {
+describe('GET /api/user/channel/list', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/channel/updateGuild.test.ts
+++ b/services/api-gateway/src/routes/user/channel/updateGuild.test.ts
@@ -28,16 +28,6 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-vi.mock('../../../services/AuthMiddleware.js', () => ({
-  requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
-  requireServiceAuth: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-  requireProvisionedUser: vi.fn(() =>
-    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
-  ),
-}));
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -45,7 +35,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleUpdateChannelGuild } from './updateGuild.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('PATCH /user/channel/update-guild', () => {
+describe('PATCH /api/user/channel/update-guild', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -185,7 +185,7 @@ describe('/user/config-overrides routes', () => {
     mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({});
   });
 
-  describe('GET /resolve-defaults', () => {
+  describe('GET /api/user/config-overrides/resolve-defaults', () => {
     it('should return hardcoded defaults when no overrides exist', async () => {
       const handler = buildHandler(handleResolveUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
@@ -288,7 +288,7 @@ describe('/user/config-overrides routes', () => {
     });
   });
 
-  describe('GET /defaults', () => {
+  describe('GET /api/user/config-overrides/defaults', () => {
     it('should return null when no config defaults set', async () => {
       const handler = buildHandler(handleGetUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
@@ -318,7 +318,7 @@ describe('/user/config-overrides routes', () => {
     });
   });
 
-  describe('PATCH /defaults', () => {
+  describe('PATCH /api/user/config-overrides/defaults', () => {
     it('should merge valid overrides with existing defaults', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         configDefaults: { maxMessages: 30 },
@@ -407,7 +407,7 @@ describe('/user/config-overrides routes', () => {
     });
   });
 
-  describe('DELETE /defaults', () => {
+  describe('DELETE /api/user/config-overrides/defaults', () => {
     it('should clear user config defaults', async () => {
       const handler = buildHandler(handleClearUserDefaults, mockDeps);
       const { req, res } = createMockReqRes();
@@ -424,7 +424,7 @@ describe('/user/config-overrides routes', () => {
     });
   });
 
-  describe('GET /resolve/:personalityId', () => {
+  describe('GET /api/user/config-overrides/resolve/:personalityId', () => {
     it('should return resolved cascade overrides', async () => {
       const handler = buildHandler(handleResolveCascade, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
@@ -505,7 +505,7 @@ describe('/user/config-overrides routes', () => {
     });
   });
 
-  describe('PATCH /:personalityId', () => {
+  describe('PATCH /api/user/config-overrides/:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
       const handler = buildHandler(handleUpdatePersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes(
@@ -625,7 +625,7 @@ describe('/user/config-overrides routes', () => {
     });
   });
 
-  describe('DELETE /:personalityId', () => {
+  describe('DELETE /api/user/config-overrides/:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
       const handler = buildHandler(handleClearPersonalityOverrides, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: 'resolve-defaults' });

--- a/services/api-gateway/src/routes/user/history.test.ts
+++ b/services/api-gateway/src/routes/user/history.test.ts
@@ -181,7 +181,7 @@ describe('/user/history routes', () => {
     mockClearHistory.mockResolvedValue(5);
   });
 
-  describe('POST /user/history/clear', () => {
+  describe('POST /api/user/history/clear', () => {
     it('should reject missing personalitySlug', async () => {
       const handler = buildHandler(handleClearHistory, {
         ...stubRouteResolvers(),
@@ -372,7 +372,7 @@ describe('/user/history routes', () => {
     });
   });
 
-  describe('POST /user/history/undo', () => {
+  describe('POST /api/user/history/undo', () => {
     it('should reject missing personalitySlug', async () => {
       const handler = buildHandler(handleUndoHistory, {
         ...stubRouteResolvers(),
@@ -519,7 +519,7 @@ describe('/user/history routes', () => {
     });
   });
 
-  describe('GET /user/history/stats', () => {
+  describe('GET /api/user/history/stats', () => {
     it('should reject missing personalitySlug', async () => {
       const handler = buildHandler(handleGetHistoryStats, {
         ...stubRouteResolvers(),
@@ -706,7 +706,7 @@ describe('/user/history routes', () => {
     });
   });
 
-  describe('DELETE /user/history/hard-delete', () => {
+  describe('DELETE /api/user/history/hard-delete', () => {
     it('should reject missing personalitySlug', async () => {
       const handler = buildHandler(handleHardDeleteHistory, {
         ...stubRouteResolvers(),

--- a/services/api-gateway/src/routes/user/llm-config.component.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.component.test.ts
@@ -130,7 +130,7 @@ describe('LLM Config Resolution Integration', () => {
     });
   });
 
-  describe('POST /user/llm-config/resolve', () => {
+  describe('POST /api/user/llm-config/resolve', () => {
     const mockPersonality = {
       id: TEST_PERSONALITY_ID,
       name: 'test-personality',

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -240,7 +240,7 @@ describe('/user/llm-config routes', () => {
     mockPrisma.userApiKey.findFirst.mockResolvedValue(null);
   });
 
-  describe('GET /user/llm-config', () => {
+  describe('GET /api/user/llm-config', () => {
     it('should return global configs', async () => {
       const globalConfig = {
         id: 'config-1',
@@ -354,7 +354,7 @@ describe('/user/llm-config routes', () => {
     });
   });
 
-  describe('GET /user/llm-config/:id', () => {
+  describe('GET /api/user/llm-config/:id', () => {
     it('should return 404 when config not found', async () => {
       mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
 
@@ -503,7 +503,7 @@ describe('/user/llm-config routes', () => {
     });
   });
 
-  describe('POST /user/llm-config', () => {
+  describe('POST /api/user/llm-config', () => {
     it('should return 400 when model validation fails on create', async () => {
       // Mock req/res approach — no real HTTP client, so returning `false` without
       // calling res.status()/res.json() is safe. Contrast with admin/llm-config.test.ts
@@ -750,7 +750,7 @@ describe('/user/llm-config routes', () => {
     });
   });
 
-  describe('PUT /user/llm-config/:id', () => {
+  describe('PUT /api/user/llm-config/:id', () => {
     it('should return 400 when model validation fails on update', async () => {
       mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
 
@@ -1286,7 +1286,7 @@ describe('/user/llm-config routes', () => {
     });
   });
 
-  describe('DELETE /user/llm-config/:id', () => {
+  describe('DELETE /api/user/llm-config/:id', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
@@ -1677,7 +1677,7 @@ describe('/user/llm-config routes', () => {
     });
   });
 
-  describe('POST /user/llm-config/resolve', () => {
+  describe('POST /api/user/llm-config/resolve', () => {
     it('should reject missing personalityId', async () => {
       const handler = buildHandler(handleResolveUserLlmConfig, mockDeps);
       const { req, res } = createMockReqRes({

--- a/services/api-gateway/src/routes/user/memory.test.ts
+++ b/services/api-gateway/src/routes/user/memory.test.ts
@@ -143,7 +143,7 @@ describe('/user/memory routes', () => {
   // Route wiring (paths, middleware, registration order) is owned by the
   // generated mounts.ts — `pnpm ops codegen:routes --check` pins it against
   // the manifest, so these tests exercise the handlers directly.
-  describe('GET /user/memory/stats', () => {
+  describe('GET /api/user/memory/stats', () => {
     it('should reject missing personalityId', async () => {
       const handler = handleGetStats({
         ...stubRouteResolvers(),
@@ -271,7 +271,7 @@ describe('/user/memory routes', () => {
     });
   });
 
-  describe('POST /user/memory/search', () => {
+  describe('POST /api/user/memory/search', () => {
     const TEST_EMBEDDING = new Array(1536).fill(0.1);
 
     beforeEach(() => {
@@ -611,7 +611,7 @@ describe('/user/memory routes', () => {
     });
   });
 
-  describe('GET /user/memory/list', () => {
+  describe('GET /api/user/memory/list', () => {
     it('should return empty list when user has no persona', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ defaultPersonaId: null });
 

--- a/services/api-gateway/src/routes/user/memoryFresh.test.ts
+++ b/services/api-gateway/src/routes/user/memoryFresh.test.ts
@@ -96,7 +96,7 @@ describe('/user/memory/fresh routes', () => {
   // Route wiring (paths, middleware, registration) is owned by the generated
   // mounts.ts — `pnpm ops codegen:routes --check` pins it against the
   // manifest, so these tests exercise the handlers directly.
-  describe('POST / (enable)', () => {
+  describe('POST /api/user/memory/fresh (enable)', () => {
     it('stores the session under the fresh: prefix and says memories are kept', async () => {
       const handler = handleEnableFresh(modeDeps());
       const { req, res } = createMockReqRes({
@@ -138,7 +138,7 @@ describe('/user/memory/fresh routes', () => {
     });
   });
 
-  describe('DELETE / (disable)', () => {
+  describe('DELETE /api/user/memory/fresh (disable)', () => {
     it('deletes the fresh session and says memories will be used again', async () => {
       const handler = handleDisableFresh(modeDeps());
       const { req, res } = createMockReqRes({ personalityId: TEST_PERSONALITY_ID });
@@ -157,7 +157,7 @@ describe('/user/memory/fresh routes', () => {
     });
   });
 
-  describe('GET / (status)', () => {
+  describe('GET /api/user/memory/fresh (status)', () => {
     it('scans the fresh: keyspace, not incognito', async () => {
       const handler = handleGetFreshStatus(modeDeps());
       const { req, res } = createMockReqRes();

--- a/services/api-gateway/src/routes/user/memoryIncognito.test.ts
+++ b/services/api-gateway/src/routes/user/memoryIncognito.test.ts
@@ -128,7 +128,7 @@ describe('/user/memory/incognito routes', () => {
   // Route wiring (paths, middleware, registration) is owned by the generated
   // mounts.ts — `pnpm ops codegen:routes --check` pins it against the
   // manifest, so these tests exercise the handlers directly.
-  describe('GET /user/memory/incognito (status)', () => {
+  describe('GET /api/user/memory/incognito (status)', () => {
     it('should return inactive status when no sessions', async () => {
       mockRedis.scan.mockResolvedValue(['0', []]);
 
@@ -179,7 +179,7 @@ describe('/user/memory/incognito routes', () => {
     });
   });
 
-  describe('POST /user/memory/incognito (enable)', () => {
+  describe('POST /api/user/memory/incognito (enable)', () => {
     it('should reject missing personalityId', async () => {
       const handler = handleEnableIncognito(modeDeps());
       const { req, res } = createMockReqRes({ duration: '1h' });
@@ -341,7 +341,7 @@ describe('/user/memory/incognito routes', () => {
     });
   });
 
-  describe('DELETE /user/memory/incognito (disable)', () => {
+  describe('DELETE /api/user/memory/incognito (disable)', () => {
     it('should reject missing personalityId', async () => {
       const handler = handleDisableIncognito(modeDeps());
       const { req, res } = createMockReqRes({});
@@ -394,7 +394,7 @@ describe('/user/memory/incognito routes', () => {
     });
   });
 
-  describe('POST /user/memory/incognito/forget', () => {
+  describe('POST /api/user/memory/incognito/forget', () => {
     it('should reject missing personalityId', async () => {
       const handler = handleIncognitoForget(modeDeps());
       const { req, res } = createMockReqRes({ timeframe: '15m' });

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -143,7 +143,7 @@ describe('/user/model-override routes', () => {
     mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([]);
   });
 
-  describe('GET /user/model-override', () => {
+  describe('GET /api/user/model-override', () => {
     it('should return empty list when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
@@ -261,7 +261,7 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('PUT /user/model-override', () => {
+  describe('PUT /api/user/model-override', () => {
     it('should reject missing personalityId', async () => {
       const handler = buildHandler(handleSetModelOverride, {
         ...stubRouteResolvers(),
@@ -553,7 +553,7 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('DELETE /user/model-override/:personalityId', () => {
+  describe('DELETE /api/user/model-override/:personalityId', () => {
     it('should return 200 (idempotent) when override not found', async () => {
       mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue(null);
 
@@ -629,7 +629,7 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('GET /user/model-override/default', () => {
+  describe('GET /api/user/model-override/default', () => {
     it('should return null default when user has none set', async () => {
       // Provisioning middleware sets the UUID; handler's findUnique for the default config returns null.
       mockPrisma.user.findUnique.mockResolvedValueOnce({
@@ -683,7 +683,7 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('PUT /user/model-override/default', () => {
+  describe('PUT /api/user/model-override/default', () => {
     it('should reject missing configId', async () => {
       const handler = buildHandler(handleSetDefaultModelConfig, {
         ...stubRouteResolvers(),
@@ -863,7 +863,7 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('PUT /user/model-override/default cache invalidation', () => {
+  describe('PUT /api/user/model-override/default cache invalidation', () => {
     it('should call invalidateUserLlmConfig on success', async () => {
       mockPrisma.llmConfig.findFirst.mockResolvedValue({
         id: '22222222-2222-4222-a222-222222222222',
@@ -928,7 +928,7 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('DELETE /user/model-override/default', () => {
+  describe('DELETE /api/user/model-override/default', () => {
     it('should return 404 when user lookup returns null after provisioning', async () => {
       // Provisioning middleware sets the UUID; handler-level findUnique returns null (e.g., race with user deletion).
       mockPrisma.user.findUnique.mockResolvedValueOnce(null);
@@ -1070,7 +1070,7 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('DELETE /user/model-override/default cache invalidation', () => {
+  describe('DELETE /api/user/model-override/default cache invalidation', () => {
     it('should call invalidateUserLlmConfig on success', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         defaultLlmConfigId: 'config-123',

--- a/services/api-gateway/src/routes/user/notifications.test.ts
+++ b/services/api-gateway/src/routes/user/notifications.test.ts
@@ -72,7 +72,7 @@ function createMockReqRes(body: Record<string, unknown> = {}) {
   return { req, res };
 }
 
-describe('GET /user/notifications', () => {
+describe('GET /api/user/notifications', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -105,7 +105,7 @@ describe('GET /user/notifications', () => {
   });
 });
 
-describe('PATCH /user/notifications', () => {
+describe('PATCH /api/user/notifications', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -216,7 +216,7 @@ describe('PATCH /user/notifications', () => {
   });
 });
 
-describe('GET /user/notifications/release-dms', () => {
+describe('GET /api/user/notifications/release-dms', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -255,7 +255,7 @@ describe('GET /user/notifications/release-dms', () => {
   });
 });
 
-describe('POST /user/notifications/release-dms/deleted', () => {
+describe('POST /api/user/notifications/release-dms/deleted', () => {
   const LOG_1 = '123e4567-e89b-42d3-a456-426614174001';
   const LOG_2 = '123e4567-e89b-42d3-a456-426614174002';
 

--- a/services/api-gateway/src/routes/user/nsfw.test.ts
+++ b/services/api-gateway/src/routes/user/nsfw.test.ts
@@ -91,7 +91,7 @@ describe('NSFW Routes', () => {
     vi.restoreAllMocks();
   });
 
-  describe('GET /nsfw', () => {
+  describe('GET /api/user/nsfw', () => {
     it('should return verified status for verified user', async () => {
       const verifiedAt = new Date('2024-01-15T10:00:00Z');
       // First findUnique: getOrCreateUserShell lookup by discordId.
@@ -138,7 +138,7 @@ describe('NSFW Routes', () => {
     });
   });
 
-  describe('POST /nsfw/verify', () => {
+  describe('POST /api/user/nsfw/verify', () => {
     it('should verify a new user', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         nsfwVerified: false,

--- a/services/api-gateway/src/routes/user/persona/crud.test.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.test.ts
@@ -72,7 +72,7 @@ describe('persona CRUD routes', () => {
     });
   });
 
-  describe('GET /user/persona', () => {
+  describe('GET /api/user/persona', () => {
     it('should return empty array when user has no personas', async () => {
       mockPrisma.persona.findMany.mockResolvedValue([]);
       const handler = handleListPersonas({
@@ -169,7 +169,7 @@ describe('persona CRUD routes', () => {
     });
   });
 
-  describe('GET /user/persona/:id', () => {
+  describe('GET /api/user/persona/:id', () => {
     it('should return persona details', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(mockPersona);
       const handler = handleGetPersona({
@@ -226,7 +226,7 @@ describe('persona CRUD routes', () => {
     });
   });
 
-  describe('POST /user/persona', () => {
+  describe('POST /api/user/persona', () => {
     it('should create a new persona', async () => {
       mockPrisma.persona.create.mockResolvedValue({
         ...mockPersona,
@@ -330,7 +330,7 @@ describe('persona CRUD routes', () => {
     });
   });
 
-  describe('PUT /user/persona/:id', () => {
+  describe('PUT /api/user/persona/:id', () => {
     it('should update persona', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID });
       mockPrisma.persona.update.mockResolvedValue({
@@ -485,7 +485,7 @@ describe('persona CRUD routes', () => {
     });
   });
 
-  describe('DELETE /user/persona/:id', () => {
+  describe('DELETE /api/user/persona/:id', () => {
     it('should delete persona', async () => {
       // Delete a non-default persona (MOCK_PERSONA_ID_2) — provisioning
       // middleware sets req.provisionedDefaultPersonaId = MOCK_PERSONA_ID,

--- a/services/api-gateway/src/routes/user/persona/default.test.ts
+++ b/services/api-gateway/src/routes/user/persona/default.test.ts
@@ -43,7 +43,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleSetPersonaDefault } from './default.js';
 import { stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('PATCH /user/persona/:id/default', () => {
+describe('PATCH /api/user/persona/:id/default', () => {
   const mockPrisma = createMockPrisma();
 
   beforeEach(() => {

--- a/services/api-gateway/src/routes/user/persona/override.test.ts
+++ b/services/api-gateway/src/routes/user/persona/override.test.ts
@@ -63,7 +63,7 @@ describe('persona override routes', () => {
     mockPrisma.user.findFirst.mockResolvedValue(mockUser);
   });
 
-  describe('GET /user/persona/override', () => {
+  describe('GET /api/user/persona/override', () => {
     it('should return list of persona overrides', async () => {
       mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([
         {
@@ -110,7 +110,7 @@ describe('persona override routes', () => {
     });
   });
 
-  describe('GET /user/persona/override/:personalitySlug', () => {
+  describe('GET /api/user/persona/override/:personalitySlug', () => {
     it('should return personality info for override modal', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: MOCK_PERSONALITY_ID,
@@ -150,7 +150,7 @@ describe('persona override routes', () => {
     });
   });
 
-  describe('PUT /user/persona/override/:personalitySlug', () => {
+  describe('PUT /api/user/persona/override/:personalitySlug', () => {
     it('should set persona override for personality', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue({
         id: MOCK_PERSONA_ID_2,
@@ -251,7 +251,7 @@ describe('persona override routes', () => {
     });
   });
 
-  describe('DELETE /user/persona/override/:personalitySlug', () => {
+  describe('DELETE /api/user/persona/override/:personalitySlug', () => {
     it('clears the persona slice and issues the atomic all-null prune', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: MOCK_PERSONALITY_ID,
@@ -381,7 +381,7 @@ describe('persona override routes', () => {
     });
   });
 
-  describe('POST /user/persona/override/by-id/:personalityId', () => {
+  describe('POST /api/user/persona/override/by-id/:personalityId', () => {
     const validBody = {
       name: 'Override Persona',
       content: 'Persona content for testing.',

--- a/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
@@ -137,7 +137,7 @@ describe('/user/config-overrides personality routes', () => {
     mockPrisma.personality.update.mockResolvedValue({});
   });
 
-  describe('GET /resolve-personality/:personalityId', () => {
+  describe('GET /api/user/config-overrides/resolve-personality/:personalityId', () => {
     it('should return resolved 3-tier cascade', async () => {
       const handler = buildHandler(handleResolvePersonalityCascade, mockDeps);
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
@@ -159,7 +159,7 @@ describe('/user/config-overrides personality routes', () => {
     });
   });
 
-  describe('PATCH /personality/:personalityId', () => {
+  describe('PATCH /api/user/config-overrides/personality/:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
       const handler = buildHandler(handleUpdatePersonalityConfigDefaults, mockDeps);
       const { req, res } = createMockReqRes({ maxMessages: 25 }, { personalityId: 'not-a-uuid' });

--- a/services/api-gateway/src/routes/user/personality/aliases.test.ts
+++ b/services/api-gateway/src/routes/user/personality/aliases.test.ts
@@ -97,7 +97,7 @@ describe('personality alias routes', () => {
     mockInvalidate.mockResolvedValue(undefined);
   });
 
-  describe('GET list (visibility-gated)', () => {
+  describe('GET /api/user/personality/:slug/aliases (visibility-gated)', () => {
     it('404s on an unknown slug', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
       const { req, res } = createMockReqRes({}, { slug: 'ghost' });
@@ -189,7 +189,7 @@ describe('personality alias routes', () => {
     }
   });
 
-  describe('POST add — user tier (default)', () => {
+  describe('POST /api/user/personality/:slug/aliases — user tier (default)', () => {
     it('creates a PERSONAL alias on a visible character with the user-scoped id', async () => {
       // Public character owned by someone else — visible, not editable.
       mockPrisma.personality.findUnique.mockResolvedValue({
@@ -307,7 +307,7 @@ describe('personality alias routes', () => {
     });
   });
 
-  describe('POST add — global tier (bot-owner only)', () => {
+  describe('POST /api/user/personality/:slug/aliases — global tier (bot-owner only)', () => {
     it('403s a non-bot-owner before touching anything', async () => {
       const { req, res } = createMockReqRes(
         { alias: 'Lila', scope: 'global' },
@@ -361,7 +361,7 @@ describe('personality alias routes', () => {
     });
   });
 
-  describe('DELETE remove', () => {
+  describe('DELETE /api/user/personality/:slug/aliases/:alias', () => {
     it('defaults to the USER tier: removes only the caller΄s own row', async () => {
       mockPrisma.personalityAlias.findFirst.mockResolvedValue({
         id: 'row-1',
@@ -446,7 +446,7 @@ describe('personality alias routes', () => {
     });
   });
 
-  describe('GET my-aliases (cross-character overview)', () => {
+  describe('GET /api/user/personality/my-aliases (cross-character overview)', () => {
     it('returns the caller΄s personal rows with personality context and shadow flags', async () => {
       mockPrisma.personalityAlias.findMany.mockResolvedValue([
         {

--- a/services/api-gateway/src/routes/user/personality/create.test.ts
+++ b/services/api-gateway/src/routes/user/personality/create.test.ts
@@ -42,12 +42,6 @@ vi.mock('@tzurot/common-types/utils/typeGuards', async () => {
   };
 });
 
-// Uses the shared mock at `src/services/__mocks__/AuthMiddleware.ts`
-// (auto-discovered by vitest). Passes `getOrCreateUserService` through to
-// the real implementation and stubs `requireUserAuth` / `requireProvisionedUser`
-// as passthrough middleware.
-vi.mock('../../../services/AuthMiddleware.js');
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -65,7 +59,7 @@ vi.mock('../../../utils/imageProcessor.js', () => ({
 import { handleCreatePersonality } from './create.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('POST /user/personality (create)', () => {
+describe('POST /api/user/personality (create)', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/personality/delete.test.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.test.ts
@@ -40,12 +40,6 @@ vi.mock('@tzurot/common-types/utils/ownerMiddleware', async () => {
   };
 });
 
-// Uses the shared mock at `src/services/__mocks__/AuthMiddleware.ts`
-// (auto-discovered by vitest). Passes `getOrCreateUserService` through to
-// the real implementation and stubs `requireUserAuth` / `requireProvisionedUser`
-// as passthrough middleware.
-vi.mock('../../../services/AuthMiddleware.js');
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -74,7 +68,7 @@ import { handleDeletePersonality } from './delete.js';
 import type { RouteDeps } from '../../routeDeps.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('DELETE /user/personality/:slug', () => {
+describe('DELETE /api/user/personality/:slug', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/personality/get.test.ts
+++ b/services/api-gateway/src/routes/user/personality/get.test.ts
@@ -27,12 +27,6 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-// Uses the shared mock at `src/services/__mocks__/AuthMiddleware.ts`
-// (auto-discovered by vitest). Passes `getOrCreateUserService` through to
-// the real implementation and stubs `requireUserAuth` / `requireProvisionedUser`
-// as passthrough middleware.
-vi.mock('../../../services/AuthMiddleware.js');
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -40,7 +34,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleGetPersonality } from './get.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('GET /user/personality/:slug', () => {
+describe('GET /api/user/personality/:slug', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/personality/list.test.ts
+++ b/services/api-gateway/src/routes/user/personality/list.test.ts
@@ -64,12 +64,6 @@ vi.mock('@tzurot/common-types/utils/permissions', async () => {
   };
 });
 
-// Uses the shared mock at `src/services/__mocks__/AuthMiddleware.ts`
-// (auto-discovered by vitest). Passes `getOrCreateUserService` through to
-// the real implementation and stubs `requireUserAuth` / `requireProvisionedUser`
-// as passthrough middleware.
-vi.mock('../../../services/AuthMiddleware.js');
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -77,7 +71,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleListPersonalities } from './list.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('GET /user/personality (list)', () => {
+describe('GET /api/user/personality (list)', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/personality/update.test.ts
+++ b/services/api-gateway/src/routes/user/personality/update.test.ts
@@ -41,12 +41,6 @@ vi.mock('@tzurot/common-types/utils/ownerMiddleware', async () => {
   };
 });
 
-// Uses the shared mock at `src/services/__mocks__/AuthMiddleware.ts`
-// (auto-discovered by vitest). Passes `getOrCreateUserService` through to
-// the real implementation and stubs `requireUserAuth` / `requireProvisionedUser`
-// as passthrough middleware.
-vi.mock('../../../services/AuthMiddleware.js');
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -85,7 +79,7 @@ import { handleUpdatePersonality } from './update.js';
 import type { RouteDeps } from '../../routeDeps.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('PUT /user/personality/:slug (update)', () => {
+describe('PUT /api/user/personality/:slug (update)', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/personality/visibility.test.ts
+++ b/services/api-gateway/src/routes/user/personality/visibility.test.ts
@@ -29,12 +29,6 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   };
 });
 
-// Uses the shared mock at `src/services/__mocks__/AuthMiddleware.ts`
-// (auto-discovered by vitest). Passes `getOrCreateUserService` through to
-// the real implementation and stubs `requireUserAuth` / `requireProvisionedUser`
-// as passthrough middleware.
-vi.mock('../../../services/AuthMiddleware.js');
-
 vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
@@ -42,7 +36,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 import { handleSetPersonalityVisibility } from './visibility.js';
 import { asRouteHandler, stubRouteResolvers } from '../../../test/shared-route-test-utils.js';
 
-describe('PATCH /user/personality/:slug/visibility', () => {
+describe('PATCH /api/user/personality/:slug/visibility', () => {
   const mockPrisma = createMockPrisma();
 
   /** The bare handler export — the shape routes/_generated/mounts.ts mounts. */

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -132,7 +132,7 @@ describe('Shapes Auth Routes', () => {
     mockProbeShapesSession.mockResolvedValue('valid');
   });
 
-  describe('POST / (store credentials)', () => {
+  describe('POST /api/user/shapes/auth (store credentials)', () => {
     async function callStoreHandler(
       body: Record<string, unknown>,
       prisma = mockPrisma
@@ -321,7 +321,7 @@ describe('Shapes Auth Routes', () => {
     });
   });
 
-  describe('DELETE / (remove credentials)', () => {
+  describe('DELETE /api/user/shapes/auth (remove credentials)', () => {
     async function callDeleteHandler(
       prisma = mockPrisma
     ): Promise<{ req: Request & { userId: string }; res: Response }> {
@@ -354,7 +354,7 @@ describe('Shapes Auth Routes', () => {
     });
   });
 
-  describe('GET /status', () => {
+  describe('GET /api/user/shapes/auth/status', () => {
     async function callStatusHandler(
       prisma = mockPrisma
     ): Promise<{ req: Request & { userId: string }; res: Response }> {

--- a/services/api-gateway/src/routes/user/shapes/export.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.test.ts
@@ -102,7 +102,7 @@ describe('Shapes Export Routes', () => {
     vi.clearAllMocks();
   });
 
-  describe('POST / (create export job)', () => {
+  describe('POST /api/user/shapes/export (create export job)', () => {
     async function callExportHandler(body: Record<string, unknown>) {
       const { req, res } = createMockReqRes(body);
       const handler = handleStartShapesExport({
@@ -201,7 +201,7 @@ describe('Shapes Export Routes', () => {
     });
   });
 
-  describe('GET /jobs (list export history)', () => {
+  describe('GET /api/user/shapes/export/jobs (list export history)', () => {
     async function callListHandler(query: Record<string, string> = {}) {
       const { req, res } = createMockReqRes({}, query);
       const handler = handleListShapesExportJobs({

--- a/services/api-gateway/src/routes/user/shapes/import.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.test.ts
@@ -94,7 +94,7 @@ describe('Shapes Import Routes', () => {
     vi.clearAllMocks();
   });
 
-  describe('POST / (create import job)', () => {
+  describe('POST /api/user/shapes/import (create import job)', () => {
     async function callImportHandler(body: Record<string, unknown>) {
       const { req, res } = createMockReqRes(body);
       const handler = handleStartShapesImport({
@@ -187,7 +187,7 @@ describe('Shapes Import Routes', () => {
     });
   });
 
-  describe('GET /jobs (list import history)', () => {
+  describe('GET /api/user/shapes/import/jobs (list import history)', () => {
     async function callListHandler(query: Record<string, string> = {}) {
       const { req, res } = createMockReqRes({}, query);
       const handler = handleListShapesImportJobs({

--- a/services/api-gateway/src/routes/user/shapes/list.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.test.ts
@@ -85,7 +85,7 @@ describe('Shapes List Routes', () => {
     vi.clearAllMocks();
   });
 
-  describe('GET / (list shapes)', () => {
+  describe('GET /api/user/shapes/list (list shapes)', () => {
     async function callListHandler(
       prisma = mockPrisma
     ): Promise<{ req: Request & { userId: string }; res: Response }> {

--- a/services/api-gateway/src/routes/user/stt-override.test.ts
+++ b/services/api-gateway/src/routes/user/stt-override.test.ts
@@ -91,7 +91,7 @@ describe('user/stt-override routes', () => {
     vi.clearAllMocks();
   });
 
-  describe('GET /', () => {
+  describe('GET /api/user/stt-override', () => {
     it('returns the user STT preference when set', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ defaultSttProviderId: 'mistral' });
       const handler = buildHandler(handleGetSttDefaultProvider);
@@ -124,7 +124,7 @@ describe('user/stt-override routes', () => {
     });
   });
 
-  describe('PUT /', () => {
+  describe('PUT /api/user/stt-override', () => {
     it('writes User.defaultSttProviderId and returns the value', async () => {
       mockPrisma.user.update.mockResolvedValue({});
       const handler = buildHandler(handleSetSttDefaultProvider);
@@ -151,7 +151,7 @@ describe('user/stt-override routes', () => {
     });
   });
 
-  describe('DELETE /', () => {
+  describe('DELETE /api/user/stt-override', () => {
     it('returns wasSet:false when no preference was set (idempotent)', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ defaultSttProviderId: null });
       const handler = buildHandler(handleClearSttDefaultProvider);

--- a/services/api-gateway/src/routes/user/timezone.test.ts
+++ b/services/api-gateway/src/routes/user/timezone.test.ts
@@ -102,7 +102,7 @@ describe('/user/timezone routes', () => {
     mockPrisma.user.findUnique.mockResolvedValue({ id: 'user-uuid-123', timezone: 'UTC' });
   });
 
-  describe('GET /user/timezone', () => {
+  describe('GET /api/user/timezone', () => {
     // Provisioning middleware sets `req.provisionedUserId`; route reads it
     // directly (no shadow-mode resolver call). Each GET/PUT handler issues a
     // SINGLE `user.findUnique` call: the timezone data read.
@@ -166,7 +166,7 @@ describe('/user/timezone routes', () => {
     });
   });
 
-  describe('PUT /user/timezone', () => {
+  describe('PUT /api/user/timezone', () => {
     it('should reject missing timezone', async () => {
       const handler = makeHandler('put');
       const { req, res } = createMockReqRes({});

--- a/services/api-gateway/src/routes/user/tts-config.test.ts
+++ b/services/api-gateway/src/routes/user/tts-config.test.ts
@@ -168,7 +168,7 @@ describe('user/tts-config routes', () => {
     });
   });
 
-  describe('GET / (list)', () => {
+  describe('GET /api/user/tts-config (list)', () => {
     it('returns USER-scoped configs with permissions for non-admin', async () => {
       vi.mocked(mockService.list).mockResolvedValue([{ ...sampleRawConfig }]);
       const handler = buildHandler(handleListUserTtsConfigs);
@@ -198,7 +198,7 @@ describe('user/tts-config routes', () => {
     });
   });
 
-  describe('GET /:id (get)', () => {
+  describe('GET /api/user/tts-config/:id (get)', () => {
     it('returns 404 when config does not exist', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
       const handler = buildHandler(handleGetUserTtsConfig);
@@ -222,7 +222,7 @@ describe('user/tts-config routes', () => {
     });
   });
 
-  describe('POST / (create)', () => {
+  describe('POST /api/user/tts-config (create)', () => {
     it('returns 400 NAME_COLLISION when name already exists', async () => {
       vi.mocked(mockService.checkNameExists).mockResolvedValue({
         exists: true,
@@ -307,7 +307,7 @@ describe('user/tts-config routes', () => {
     });
   });
 
-  describe('PUT /:id (update)', () => {
+  describe('PUT /api/user/tts-config/:id (update)', () => {
     it('returns 404 when config does not exist', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
       const handler = buildHandler(handleUpdateUserTtsConfig);
@@ -436,7 +436,7 @@ describe('user/tts-config routes', () => {
     });
   });
 
-  describe('DELETE /:id', () => {
+  describe('DELETE /api/user/tts-config/:id', () => {
     it('returns 404 when config does not exist', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(null);
       const handler = buildHandler(handleDeleteUserTtsConfig);

--- a/services/api-gateway/src/routes/user/tts-override.test.ts
+++ b/services/api-gateway/src/routes/user/tts-override.test.ts
@@ -138,7 +138,7 @@ describe('user/tts-override routes', () => {
     vi.mocked(mockPrisma.userPersonalityConfig.findUnique).mockResolvedValue(null);
   });
 
-  describe('GET / (list overrides)', () => {
+  describe('GET /api/user/tts-override (list overrides)', () => {
     it('returns formatted overrides', async () => {
       vi.mocked(mockPrisma.userPersonalityConfig.findMany).mockResolvedValue([
         {
@@ -180,7 +180,7 @@ describe('user/tts-override routes', () => {
     });
   });
 
-  describe('PUT / (set override)', () => {
+  describe('PUT /api/user/tts-override (set override)', () => {
     it('returns 400 on invalid UUID', async () => {
       const handler = buildHandler(handleSetTtsOverride);
       const { res } = makeMockRes();
@@ -268,7 +268,7 @@ describe('user/tts-override routes', () => {
     });
   });
 
-  describe('GET /default', () => {
+  describe('GET /api/user/tts-override/default', () => {
     it('returns null default when none set', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({
         defaultTtsConfigId: null,
@@ -298,7 +298,7 @@ describe('user/tts-override routes', () => {
     });
   });
 
-  describe('PUT /default', () => {
+  describe('PUT /api/user/tts-override/default', () => {
     it('returns 404 when config not accessible', async () => {
       vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
       const handler = buildHandler(handleSetTtsDefaultConfig);
@@ -330,7 +330,7 @@ describe('user/tts-override routes', () => {
     });
   });
 
-  describe('DELETE /default', () => {
+  describe('DELETE /api/user/tts-override/default', () => {
     it('returns idempotent success with wasSet:false when no default exists', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ defaultTtsConfigId: null });
       vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
@@ -409,7 +409,7 @@ describe('user/tts-override routes', () => {
     });
   });
 
-  describe('DELETE /:personalityId (reset override)', () => {
+  describe('DELETE /api/user/tts-override/:personalityId (reset override)', () => {
     it('returns idempotent success when no override exists', async () => {
       vi.mocked(mockPrisma.userPersonalityConfig.findFirst).mockResolvedValue(null);
       const handler = buildHandler(handleDeleteTtsOverride);

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -190,7 +190,7 @@ describe('Voice Management Routes', () => {
 
   // ===== GET / ============================================================
 
-  describe('GET / - List voices', () => {
+  describe('GET /api/user/voices - List voices', () => {
     it('returns tzurot-prefixed voices from ElevenLabs only when only that key is configured', async () => {
       userWithKeys(['elevenlabs']);
 
@@ -295,7 +295,7 @@ describe('Voice Management Routes', () => {
 
   // ===== DELETE /:provider/:voiceId =======================================
 
-  describe('DELETE /:provider/:voiceId - Delete a voice', () => {
+  describe('DELETE /api/user/voices/:provider/:voiceId - Delete a voice', () => {
     it('deletes an ElevenLabs tzurot-prefixed voice via the new route shape', async () => {
       userWithKeys(['elevenlabs']);
       setProviderFetchMocks({
@@ -401,7 +401,7 @@ describe('Voice Management Routes', () => {
 
   // ===== POST /clear ======================================================
 
-  describe('POST /clear - Clear all tzurot voices', () => {
+  describe('POST /api/user/voices/clear - Clear all tzurot voices', () => {
     it('deletes all tzurot voices across all providers the user has keys for', async () => {
       userWithKeys(['elevenlabs', 'mistral']);
       setProviderFetchMocks({

--- a/services/api-gateway/src/routes/wallet/listKeys.test.ts
+++ b/services/api-gateway/src/routes/wallet/listKeys.test.ts
@@ -80,7 +80,7 @@ async function callHandler(
   await handler(req, res);
 }
 
-describe('GET /wallet/list', () => {
+describe('GET /api/user/wallet/list', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });

--- a/services/api-gateway/src/routes/wallet/removeKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.test.ts
@@ -82,7 +82,7 @@ async function callHandler(
   await handler(req, res);
 }
 
-describe('DELETE /wallet/:provider', () => {
+describe('DELETE /api/user/wallet/:provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });

--- a/services/api-gateway/src/routes/wallet/setKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.test.ts
@@ -135,7 +135,7 @@ async function callHandler(
   await handler(req, res);
 }
 
-describe('POST /wallet/set', () => {
+describe('POST /api/user/wallet/set', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue({ valid: true, credits: 100 });

--- a/services/api-gateway/src/routes/wallet/testKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/testKey.test.ts
@@ -102,7 +102,7 @@ async function callHandler(
   await handler(req, res);
 }
 
-describe('POST /wallet/test', () => {
+describe('POST /api/user/wallet/test', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockValidateApiKey.mockResolvedValue({ valid: true, credits: 50 });


### PR DESCRIPTION
## Summary

TASK-419, both parts — a test-only sweep of `services/api-gateway/src/routes`:

1. **169 describe labels rewritten** across 69 files to the real mounted `/api/...` paths, taken from `routes/_generated/mounts.ts` (join key: each mount line's trailing `handleX(deps)` reference). TASK-412 fixed the source docblocks and deliberately deferred the test labels to keep that diff reviewable; the stale labels mislead CI-failure triage. Method + path-shape disambiguate files exporting multiple handlers; suffix text (`(list)`, `— duplicate name check`, `(cascade invalidation)`) is preserved.
2. **Inert middleware mocks removed** (deferred from #1932, reviewer-endorsed): 12 retargeted `user/channel` and `user/personality` suites dropped their `vi.mock(AuthMiddleware)` / `vi.mock(ownerMiddleware)` blocks — after the `asRouteHandler` retarget the bare handlers never import that middleware, so the mocks intercepted nothing. One now-unused import (`MOCK_DISCORD_USER_ID`) removed with them.

## Deliberate exclusions (verified, not skipped)

- **3 labels stay router-relative**: `public/githubWebhook`, `public/avatars`, `protected/voiceReferences` — mounted via `app.use(...)` in `index.ts`, not the generated mounts file; their labels are relative to their own routers.
- **ownerMiddleware mocks stay in 4 suites** (`personality/{update,list,aliases,helpers,delete}`, `channel/activate` — 4 of the candidate set): their sources reach `isBotOwner` directly or transitively via `personality/helpers.js`, so those mocks are live, not inert.

## Notable label corrections

The sweep surfaced two labels that were wrong about more than the prefix — both verified against mounts.ts:
- `admin/diagnostic.test.ts`: handlers actually mount under `/api/user/diagnostic/...` (+ one `/api/internal/...`), not `/admin/...`.
- `admin/denylist.test.ts`: `handleGetDenylistCache` mounts at `/api/internal/denylist/cache`, not `/admin/...`.

## Verification

- Acceptance grep: non-`/api` describe labels now return ONLY the 3 router-mounted surfaces above.
- Repo-wide grep: zero `vi.mock` of AuthMiddleware remains in any suite whose handler closure doesn't import it.
- `pnpm test` green (all packages; api-gateway 190 files / 2617 tests), `pnpm quality` green, run sequentially.
- Diff audit: every changed line is a describe label, a mock-block removal, or the one import trim; no `it()` text, supertest paths, or source files touched. `_generated/mounts.ts` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)