### PR TITLE
fix(ai-worker): render File stubs in deduped quotes; exclude them from the enrichment tripwire

### DIFF
--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -7,6 +7,7 @@ import { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
 import { AttachmentType } from '@tzurot/common-types/constants/media';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
+import { type ProcessedAttachment } from './MultimodalProcessor.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
 const { mockDescribeImage, mockTranscribeAudio, mockFormatPromptTimestamp, mockLogger } =
@@ -1838,9 +1839,11 @@ describe('ReferencedMessageFormatter', () => {
       // discarded — and the silence around it was why a human was the only
       // detector the first two times.
       //
-      // The cast is the point: `AttachmentType` has only Image and Audio today,
-      // so the unhandled arm is not otherwise constructible. Pinning it now
-      // means the warn is proven to fire before anyone needs it to.
+      // The cast is the point: every `AttachmentType` that exists today either
+      // renders (Image, Audio) or is deliberately excluded from the denominator
+      // (File — a free stub, not paid work), so the unhandled arm is not
+      // otherwise constructible. Pinning it now means the warn is proven to
+      // fire before anyone needs it to.
       await formatter.formatReferencedMessages(
         [refWithImage({ isDeduplicated: true, attachments: undefined })],
         mockPersonality,
@@ -1894,6 +1897,99 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The other half of "paid work must appear": work that was never paid for
+     * must not be reported as missing.
+     *
+     * An attachment with no content processor comes back as a File-typed
+     * result carrying a locally-generated "not supported" stub. It renders as a
+     * bare <file/> — `RenderableFile` has no enrichment slot by design — so
+     * counting the stub as available enrichment would make the drop tripwire
+     * fire on any deduped quote of a video or a document, naming
+     * vision/transcription spend that never happened.
+     */
+    describe('file stubs are identity-only, and never counted as paid work', () => {
+      const FILE_STUB_DESCRIPTION =
+        'Attachment type video/mp4 is not supported — content not analyzed';
+
+      /** The shape MultimodalProcessor returns for an unprocessable type. */
+      function fileStubEntry(url: string, name: string): ProcessedAttachment {
+        return {
+          type: AttachmentType.File,
+          description: FILE_STUB_DESCRIPTION,
+          originalUrl: url,
+          metadata: { url, name, contentType: 'video/mp4', size: 4000 },
+        };
+      }
+
+      it('renders a correlated file entry as a bare <file/> without warning', async () => {
+        const url = 'https://cdn.example.com/clip.mp4';
+        const { formatted } = await formatter.formatReferencedMessages(
+          [
+            refWithImage({
+              isDeduplicated: true,
+              attachments: [{ url, contentType: 'video/mp4', name: 'clip.mp4', size: 4000 }],
+            }),
+          ],
+          mockPersonality,
+          false,
+          { 1: [fileStubEntry(url, 'clip.mp4')] }
+        );
+
+        // Identity from the reference's own attachment row, which carries the
+        // real content type.
+        expect(formatted).toContain('<file filename="clip.mp4" type="video/mp4"/>');
+        expect(formatted).not.toContain(FILE_STUB_DESCRIPTION);
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+      });
+
+      it('renders an ORPHANED file entry rather than dropping it', async () => {
+        // No attachment row correlates, so the entry falls to the orphan loop —
+        // where a File used to have no arm and vanished from the quote entirely.
+        const { formatted } = await formatter.formatReferencedMessages(
+          [refWithImage({ isDeduplicated: true, attachments: undefined })],
+          mockPersonality,
+          false,
+          { 1: [fileStubEntry('https://cdn.example.com/orphan.mp4', 'orphan.mp4')] }
+        );
+
+        expect(formatted).toContain('<file filename="orphan.mp4"/>');
+        expect(formatted).not.toContain(FILE_STUB_DESCRIPTION);
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+      });
+
+      it('excludes only the file stub from the denominator — a real drop still warns', async () => {
+        // Both in one reference: the tripwire must subtract the stub and still
+        // count the unrenderable paid result. `renderable: 1`, not 2.
+        await formatter.formatReferencedMessages(
+          [refWithImage({ isDeduplicated: true, attachments: undefined })],
+          mockPersonality,
+          false,
+          {
+            1: [
+              fileStubEntry('https://cdn.example.com/orphan.mp4', 'orphan.mp4'),
+              {
+                type: 'video' as AttachmentType,
+                description: 'a clip the splitter cannot render yet',
+                originalUrl: 'https://cdn.example.com/clip.mkv',
+                metadata: {
+                  url: 'https://cdn.example.com/clip.mkv',
+                  name: 'clip.mkv',
+                  contentType: 'video/x-matroska',
+                  size: 1000,
+                },
+              } satisfies ProcessedAttachment,
+            ],
+          }
+        );
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ referenceNumber: 1, renderable: 1, rendered: 0 }),
+          expect.stringContaining('not reaching the prompt')
+        );
+      });
     });
   });
 });

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -124,6 +124,14 @@ function buildDedupedAttachments(
   // class this module exists to close. Modality comes from the entry's own
   // `type`; the content type does not, per the note above.
   //
+  // A `file` entry renders IDENTITY-ONLY, and that is the whole rendering it
+  // gets: its "description" is the unsupported-type stub, static text nobody
+  // paid a model for, and `RenderableFile` has no slot for it by design. The
+  // stub's wording travels the processed-attachment path instead, where
+  // RAGUtils renders it as a `[File: name]` line. Rendering the element at all
+  // still matters — otherwise an orphaned file vanishes and the quote claims
+  // the message had no attachment.
+  //
   // Any OTHER modality is deliberately left unrendered and stays counted, so
   // the drop tripwire fires: silently downgrading an unknown type to a bare
   // image would misdescribe it AND discard the description.
@@ -150,6 +158,14 @@ function buildDedupedAttachments(
           description: entry.description,
         },
       });
+    } else if (entry.type === AttachmentType.File) {
+      attachments.push({
+        url: entry.originalUrl,
+        attachment: {
+          kind: 'file',
+          filename: entry.metadata.name,
+        },
+      });
     }
   }
 
@@ -157,14 +173,22 @@ function buildDedupedAttachments(
 }
 
 /**
- * How much enrichment the dependency stage produced for this reference.
+ * How much PAID enrichment the dependency stage produced for this reference.
  *
- * The denominator for the drop tripwire below. Empty descriptions are excluded:
- * a silent audio clip transcribes to `''` on SUCCESS, so counting it would warn
- * on ordinary traffic.
+ * The denominator for the drop tripwire below, so it counts only what a model
+ * was actually billed for. Two exclusions:
+ *
+ * - Empty descriptions: a silent audio clip transcribes to `''` on SUCCESS, so
+ *   counting it would warn on ordinary traffic.
+ * - `file` entries: their description is the unsupported-type stub, generated
+ *   locally from the content type, and a file renders identity-only by design.
+ *   Counting it would make the tripwire fire on any deduped quote of a video
+ *   or a document, claiming vision/transcription spend that never happened.
  */
 function countAvailableEnrichment(preprocessed: ProcessedAttachment[] | undefined): number {
-  return (preprocessed ?? []).filter(entry => entry.description.length > 0).length;
+  return (preprocessed ?? []).filter(
+    entry => entry.description.length > 0 && entry.type !== AttachmentType.File
+  ).length;
 }
 
 /** How much of it survived into the rendered attachments. */
@@ -360,9 +384,15 @@ export class ReferencedMessageFormatter {
    * succeeded, cost 47s, and were discarded with zero log output, so the only
    * detector in the system was a human noticing the character couldn't see the
    * images. The projection makes the old drop unreachable, but one route
-   * survives: enrichment for an attachment that classifies as a `file` has
-   * nowhere to go, because `RenderableFile` carries no description. If that
-   * ever happens, this says so instead of swallowing it.
+   * survives: a modality this renderer has no arm for at all — what a third
+   * enrichment type looks like on the day it is added and the deduped branch is
+   * not taught about it. If that ever happens, this says so instead of
+   * swallowing it.
+   *
+   * It guards PAID modalities only. A `file` entry's stub description is free
+   * static text and has nowhere to go by design (`RenderableFile` carries no
+   * enrichment slot), so it is excluded from the denominator rather than
+   * reported as purchased work that went missing.
    */
   private warnOnDroppedEnrichment(
     referenceNumber: number,


### PR DESCRIPTION
## Summary

TASK-421 — parity follow-up to #1934 in the deduped reference-quote path (`ReferencedMessageFormatter`), which predates the honest `AttachmentType.File` stub:

1. **Orphan drop**: the orphan render loop (enrichment whose attachment row didn't correlate by URL) had arms only for Image and Audio — an orphaned File entry vanished from the quote entirely. It now renders an identity-only `<file filename="…"/>`, matching the sibling arms' provenance-safe no-contentType shape (the correlated path already renders the real content type from the reference's own attachment row).
2. **Tripwire false positive**: `countAvailableEnrichment` counted the File stub's description toward the dropped-enrichment tripwire, but the stub is free static text — `RenderableFile` has no enrichment slot by design, so a File entry reaching this path would fire "vision/transcription work was paid for and is not reaching the prompt" about spend that never happened. File entries are now excluded from the denominator; the tripwire guards paid modalities only.

## Honest scope note: both defects are latent, not live

Code-reading (not runtime-confirmed): the only current producer of `preprocessedReferenceAttachments` is `DependencyStep.buildPreprocessingResults`, which emits Image/Audio entries only — a File-typed entry cannot reach `buildDedupedAttachments` on today's wiring. This PR is defense-in-depth for the day the dependency stage forwards file stubs (the natural follow-on from #1934), not a fix for a warn currently firing in prod.

## Tests

Seam tests per the render-mode rule (02-code-standards §7), added to the existing deduped-mode matrix:
- Correlated File → bare `<file filename="clip.mp4" type="video/mp4"/>`, stub text absent, no warn.
- Orphaned File → `<file filename="orphan.mp4"/>` renders instead of vanishing, no warn.
- Mixed reference (File stub + an unrenderable paid entry) → the warn still fires with `renderable: 1`, proving the exclusion is narrow, not a blanket mute.

Oracle-checked: all three new tests fail against the pre-fix source (verified by temporarily reverting the two hunks). Fixtures typed via `satisfies ProcessedAttachment`.

## Verification

`pnpm test` green (ai-worker 206 files / 4321 tests), `pnpm quality` green, run sequentially. `_generated` and `QuoteFormatter.ts` untouched — the `RenderableFile`-carries-no-enrichment compiler invariant stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)