### PR TITLE
fix(ai-worker): stop logging stacks for expected no-key TTS fallbacks

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
@@ -15,9 +15,10 @@ import { type LLMGenerationJobData } from '@tzurot/common-types/types/jobs';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { AuthStep } from './AuthStep.js';
 import type { GenerationContext, ResolvedConfig } from '../types.js';
-import type {
-  ApiKeyResolver,
-  ApiKeyResolutionResult,
+import {
+  NoApiKeyAvailableError,
+  type ApiKeyResolver,
+  type ApiKeyResolutionResult,
 } from '../../../../services/ApiKeyResolver.js';
 import type { SttProvider } from '@tzurot/common-types/types/sttProvider';
 import type { LlmConfigResolver, SttResolver } from '@tzurot/config-resolver';
@@ -33,18 +34,25 @@ vi.mock('@tzurot/common-types/constants/ai', async () => {
   };
 });
 
+// One stable logger instance (createLogger runs once at AuthStep module load),
+// so tests can assert on the LEVEL a given path logs at — the no-key audio
+// fallbacks are expected control flow and must stay off the warn stream.
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
   );
   return {
     ...actual,
-    createLogger: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    }),
+    createLogger: () => loggerMock,
   };
 });
 
@@ -976,6 +984,103 @@ describe('AuthStep', () => {
       expect(result.auth?.apiKey).toBe('sk-or-test');
       expect(result.auth?.audioProviderKeys?.has('elevenlabs')).toBe(false);
       expect(result.auth?.isGuestMode).toBe(false);
+    });
+
+    it('should log no-key audio fallbacks at debug, without a stack', async () => {
+      const openRouterResult: ApiKeyResolutionResult = {
+        apiKey: 'sk-or-test',
+        provider: AIProvider.OpenRouter,
+        source: 'user',
+        isGuestMode: false,
+      };
+
+      // A non-BYOK user hits this on EVERY job: both audio providers are
+      // BYOK-only with no system key, so resolution throws by design and the
+      // dispatcher falls back to voice-engine.
+      vi.mocked(mockApiKeyResolver.resolveApiKey)
+        .mockResolvedValueOnce(openRouterResult)
+        .mockRejectedValueOnce(
+          new NoApiKeyAvailableError('No API key available for provider elevenlabs.')
+        )
+        .mockRejectedValueOnce(
+          new NoApiKeyAvailableError('No API key available for provider mistral.')
+        );
+
+      step = new AuthStep(mockApiKeyResolver);
+
+      const config: ResolvedConfig = {
+        effectivePersonality: TEST_PERSONALITY,
+        configSource: 'personality',
+      };
+
+      const context: GenerationContext = {
+        job: createMockJob(),
+        startTime: Date.now(),
+        config,
+      };
+
+      const result = await step.process(context);
+
+      expect(result.auth?.audioProviderKeys?.size).toBe(0);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+
+      const debugFields = loggerMock.debug.mock.calls
+        .filter(call => String(call[1]).includes('key resolution failed'))
+        .map(call => call[0] as Record<string, unknown>);
+
+      expect(debugFields).toHaveLength(2);
+      expect(debugFields).toContainEqual({ userId: 'user-456', provider: 'elevenlabs' });
+      expect(debugFields).toContainEqual({ userId: 'user-456', provider: 'mistral' });
+      for (const fields of debugFields) {
+        // The whole point of the compact form: no serialized stack trace.
+        expect(fields).not.toHaveProperty('err');
+      }
+    });
+
+    it('should keep the warn + stack for an unexpected audio-key failure', async () => {
+      const openRouterResult: ApiKeyResolutionResult = {
+        apiKey: 'sk-or-test',
+        provider: AIProvider.OpenRouter,
+        source: 'user',
+        isGuestMode: false,
+      };
+
+      const mistralNotConfigured: ApiKeyResolutionResult = {
+        apiKey: '',
+        provider: AIProvider.Mistral,
+        source: 'system',
+        isGuestMode: true,
+      };
+
+      vi.mocked(mockApiKeyResolver.resolveApiKey)
+        .mockResolvedValueOnce(openRouterResult)
+        .mockRejectedValueOnce(new Error('db connection refused'))
+        .mockResolvedValueOnce(mistralNotConfigured);
+
+      step = new AuthStep(mockApiKeyResolver);
+
+      const config: ResolvedConfig = {
+        effectivePersonality: TEST_PERSONALITY,
+        configSource: 'personality',
+      };
+
+      const context: GenerationContext = {
+        job: createMockJob(),
+        startTime: Date.now(),
+        config,
+      };
+
+      await step.process(context);
+
+      const warnCalls = loggerMock.warn.mock.calls.filter(call =>
+        String(call[1]).includes('ElevenLabs key resolution failed')
+      );
+      expect(warnCalls).toHaveLength(1);
+
+      const fields = warnCalls[0]?.[0] as { userId?: string; err?: Error };
+      expect(fields.userId).toBe('user-456');
+      expect(fields.err).toBeInstanceOf(Error);
+      expect(fields.err?.message).toBe('db connection refused');
     });
 
     describe('sttDispatch', () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -10,7 +10,10 @@ import { type AudioProviderId } from '@tzurot/common-types/types/audio-provider'
 import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { SttResolver, LlmConfigResolver } from '@tzurot/config-resolver';
-import type { ApiKeyResolver } from '../../../../services/ApiKeyResolver.js';
+import {
+  NoApiKeyAvailableError,
+  type ApiKeyResolver,
+} from '../../../../services/ApiKeyResolver.js';
 import { ProviderRouter } from '../../../../services/ProviderRouter.js';
 import {
   applyConfigToPersonality,
@@ -335,7 +338,17 @@ export class AuthStep implements IPipelineStep {
           logger.debug({ userId, source: result.source, provider: id }, 'Resolved audio API key');
         }
       } catch (error) {
-        logger.warn({ err: error, userId }, failNote);
+        if (error instanceof NoApiKeyAvailableError) {
+          // Expected for BYOK-only audio providers: a user without their own
+          // key hits this on EVERY job (negative results aren't cached). The
+          // fallback is deterministic and the note already names it, so this
+          // is compact debug — no stack, no err object.
+          logger.debug({ userId, provider: id }, failNote);
+        } else {
+          // Unexpected resolution failure (DB down, decryption error) — keep
+          // the stack; this one IS an incident.
+          logger.warn({ err: error, userId }, failNote);
+        }
       }
     }
     return audioKeysBuilder;

--- a/services/ai-worker/src/services/ApiKeyResolver.test.ts
+++ b/services/ai-worker/src/services/ApiKeyResolver.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
-import { ApiKeyResolver } from './ApiKeyResolver.js';
+import { ApiKeyResolver, NoApiKeyAvailableError } from './ApiKeyResolver.js';
 import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { decryptApiKey } from '@tzurot/common-types/utils/encryption';
@@ -365,6 +365,20 @@ describe('ApiKeyResolver', () => {
       // route requests to a wrong/missing key.
       await expect(resolver.resolveApiKey('user-123', AIProvider.ZaiCoding)).rejects.toThrow(
         /No API key available for provider zai-coding/
+      );
+    });
+
+    it('should throw NoApiKeyAvailableError so callers can treat it as control flow', async () => {
+      mockPrisma.userApiKey.findFirst.mockResolvedValue(null);
+
+      // The typed subclass is what lets AuthStep distinguish "user simply has
+      // no BYOK key for this provider" (expected, debug-level) from a genuine
+      // resolution failure such as a DB outage (warn-level, with stack).
+      await expect(resolver.resolveApiKey('user-123', AIProvider.ZaiCoding)).rejects.toBeInstanceOf(
+        NoApiKeyAvailableError
+      );
+      await expect(resolver.resolveApiKey('user-123', AIProvider.ZaiCoding)).rejects.toBeInstanceOf(
+        Error
       );
     });
 

--- a/services/ai-worker/src/services/ApiKeyResolver.ts
+++ b/services/ai-worker/src/services/ApiKeyResolver.ts
@@ -50,6 +50,22 @@ export interface ApiKeyResolutionResult {
 }
 
 /**
+ * Thrown by {@link ApiKeyResolver.resolveApiKey} when no key is configured
+ * anywhere for the requested provider — neither a user BYOK key nor a system
+ * fallback. This is an EXPECTED outcome for BYOK-only providers (Mistral,
+ * z.ai coding, ElevenLabs without an operator key): callers treat it as
+ * control flow (fall back to another provider) rather than as an incident,
+ * so it must be distinguishable from a genuine resolution failure such as a
+ * DB outage or a decryption error.
+ */
+export class NoApiKeyAvailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NoApiKeyAvailableError';
+  }
+}
+
+/**
  * Cache entry for API keys (to avoid repeated DB lookups)
  *
  * Note: Cache is local to each ai-worker instance. When users update/remove
@@ -99,7 +115,7 @@ export class ApiKeyResolver {
    * @param userId - The user making the request
    * @param provider - The AI provider (openrouter, openai, etc.)
    * @returns The resolved API key and its source
-   * @throws Error if no API key is available
+   * @throws NoApiKeyAvailableError if no key is configured anywhere for the provider
    */
   async resolveApiKey(
     userId: string | undefined,
@@ -150,7 +166,7 @@ export class ApiKeyResolver {
     }
 
     // No API key available at all - cannot make API calls
-    throw new Error(
+    throw new NoApiKeyAvailableError(
       `No API key available for provider ${provider}. ` +
         'Please configure your own API key or contact the bot administrator.'
     );


### PR DESCRIPTION
## Summary

TASK-423, from the 2026-08-04 prod-log sweep: every TTS job for a non-BYOK user emitted two full stack traces ("ElevenLabs key resolution failed" + "Mistral key resolution failed", 85 lines/6h, mostly one user). Both audio providers are BYOK-only — `ApiKeyResolver.resolveApiKey` throws when no key is configured anywhere, `AuthStep.resolveAudioProviderKeys` catches and warn-logs with the full `err`. The fallback to voice-engine is deterministic, designed behavior; the logs made it read as a recurring incident.

## Change

- **`ApiKeyResolver`**: the no-key-at-all throw site now throws a typed `NoApiKeyAvailableError` (same message text) so callers can distinguish "user simply has no key for this provider" from a genuine resolution failure. All other `resolveApiKey` call sites (ProviderRouter ×3, visionAuthResolver ×2, AIJobProcessor) catch/propagate `Error` subtypes and are behaviorally unchanged — verified by grep, deliberately untouched.
- **`AuthStep`** audio-key loop: `instanceof NoApiKeyAvailableError` → `logger.debug({ userId, provider }, failNote)`, no `err` object. Anything else (DB outage, decryption failure) keeps the existing `logger.warn` with the stack.

## Tests

- Resolver: the rejection is `instanceof NoApiKeyAvailableError` (and still `instanceof Error`).
- AuthStep: both audio providers rejecting with the typed error → zero warns, two compact debug entries asserted `not.toHaveProperty('err')`; a generic `Error('db connection refused')` → exactly one warn carrying the error. Falsification-checked: reverting the debug branch makes the first test fail.
- The suite's logger mock previously returned a fresh object per `createLogger` call, so the instance AuthStep captures at module load was unreachable — converted to one hoisted instance (the established pattern in sibling step tests). No existing assertions depended on the old shape.

## Acceptance (from the task)

A non-BYOK TTS request now logs at most one compact line per provider (debug level — silent in prod at INFO); unexpected errors still carry stacks.

Related follow-up already filed: TASK-82 (negative caching for no-key lookups) — this PR fixes the log level; that one would remove the repeated DB lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)