### PR TITLE
fix(bot-client): correct the voice-transcript fallback log to the real mechanism

### DIFF
--- a/services/bot-client/src/handlers/references/TranscriptRetriever.ts
+++ b/services/bot-client/src/handlers/references/TranscriptRetriever.ts
@@ -10,9 +10,9 @@
  *   fully covered regardless of this cache.
  * - Extended-context messages (room awareness): the worker trusts the transcripts
  *   bot-client ships. A voice message whose transcript has aged out of the Redis
- *   cache (5-min TTL) therefore ships without its text — an accepted divergence
- *   that mirrors the worker's reference path, which is likewise DB-tier-only with
- *   no Redis equivalent.
+ *   cache (1-hour TTL, INTERVALS.VOICE_TRANSCRIPT_TTL) therefore ships without
+ *   its text — an accepted divergence that mirrors the worker's reference path,
+ *   which is likewise DB-tier-only with no Redis equivalent.
  *
  * If aged-out extended-context transcripts ever measurably degrade room awareness,
  * the fix is the envelope flat-list pattern (mirroring `rawExtendedContextImageAttachments`):

--- a/services/bot-client/src/services/DiscordChannelFetcher.test.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.test.ts
@@ -27,18 +27,25 @@ vi.mock('@tzurot/common-types/constants/message', async () => {
   };
 });
 
+// One stable logger instance (createLogger runs once at module load), so tests
+// can assert on the LEVEL a given path logs at — the transcript-cache-miss
+// fallback recurs by design and must stay off the info stream.
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
   );
   return {
     ...actual,
-    createLogger: () => ({
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
+    createLogger: () => loggerMock,
   };
 });
 
@@ -1470,7 +1477,7 @@ describe('DiscordChannelFetcher', () => {
   });
 
   describe('voice transcript fallback', () => {
-    it('should use DB transcript when available', async () => {
+    it('should use the retriever transcript when available', async () => {
       // Voice message with a bot transcript reply in channel
       const voiceMessageId = 'voice-msg-1';
       const messages = [
@@ -1508,8 +1515,8 @@ describe('DiscordChannelFetcher', () => {
 
       const channel = createMockChannel(messages);
 
-      // DB returns transcript - should use DB, not fallback
-      const getTranscript = vi.fn().mockResolvedValue('DB transcript content');
+      // Retriever returns transcript - should use it, not fallback
+      const getTranscript = vi.fn().mockResolvedValue('Cached transcript content');
 
       const result = await fetcher.fetchRecentMessages(channel, {
         botUserId: 'bot123',
@@ -1520,7 +1527,7 @@ describe('DiscordChannelFetcher', () => {
       expect(result.keptCount).toBe(1);
       // Voice transcripts are now in messageMetadata for structured XML formatting
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
-        'DB transcript content'
+        'Cached transcript content'
       );
       // Fallback transcript should not appear
       expect(result.messages[0].messageMetadata?.voiceTranscripts?.join('') ?? '').not.toContain(
@@ -1555,7 +1562,7 @@ describe('DiscordChannelFetcher', () => {
         }),
       ];
       const channel = createMockChannel(messages);
-      // No DB transcript, no bot reply in window ⇒ unresolved.
+      // No cached transcript, no bot reply in window ⇒ unresolved.
       const getTranscript = vi.fn().mockResolvedValue(null);
 
       const result = await fetcher.fetchRecentMessages(channel, {
@@ -1570,7 +1577,7 @@ describe('DiscordChannelFetcher', () => {
       expect(result.voiceAttachments?.[0].isVoiceMessage).toBe(true);
     });
 
-    it('should fall back to bot reply when DB returns null', async () => {
+    it('should fall back to bot reply when the retriever returns null', async () => {
       const voiceMessageId = 'voice-msg-1';
       const messages = [
         createMockMessage({
@@ -1607,7 +1614,7 @@ describe('DiscordChannelFetcher', () => {
 
       const channel = createMockChannel(messages);
 
-      // DB returns null - should fall back to bot reply
+      // Retriever returns null - should fall back to bot reply
       const getTranscript = vi.fn().mockResolvedValue(null);
 
       const result = await fetcher.fetchRecentMessages(channel, {
@@ -1620,9 +1627,20 @@ describe('DiscordChannelFetcher', () => {
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
         'Fallback transcript from bot reply'
       );
+      // The cache-miss fallback recurs by design for any voice message older
+      // than the transcript cache TTL — it logs at debug, never info, and the
+      // message names the real mechanism (Redis cache, not a DB).
+      expect(loggerMock.debug).toHaveBeenCalledWith(
+        { messageId: voiceMessageId },
+        'Using bot reply fallback for voice transcript (not in Redis cache)'
+      );
+      expect(loggerMock.info).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('bot reply fallback')
+      );
     });
 
-    it('should fall back to bot reply when DB returns empty string', async () => {
+    it('should fall back to bot reply when the retriever returns empty string', async () => {
       const voiceMessageId = 'voice-msg-1';
       const messages = [
         createMockMessage({
@@ -1648,7 +1666,7 @@ describe('DiscordChannelFetcher', () => {
         // Bot transcript reply
         createMockMessage({
           id: 'transcript-reply-1',
-          content: 'Fallback from empty DB',
+          content: 'Fallback from empty retriever result',
           authorId: 'bot123',
           authorUsername: 'TestBot',
           isBot: true,
@@ -1659,7 +1677,7 @@ describe('DiscordChannelFetcher', () => {
 
       const channel = createMockChannel(messages);
 
-      // DB returns empty string (corrupted data) - should fall back to bot reply
+      // Retriever returns empty string (corrupted data) - should fall back to bot reply
       const getTranscript = vi.fn().mockResolvedValue('');
 
       const result = await fetcher.fetchRecentMessages(channel, {
@@ -1670,11 +1688,11 @@ describe('DiscordChannelFetcher', () => {
       expect(result.keptCount).toBe(1);
       // Voice transcripts are now in messageMetadata for structured XML formatting
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
-        'Fallback from empty DB'
+        'Fallback from empty retriever result'
       );
     });
 
-    it('should return null transcript when neither DB nor fallback available', async () => {
+    it('should return null transcript when neither retriever nor fallback available', async () => {
       const voiceMessageId = 'voice-msg-1';
       const messages = [
         createMockMessage({
@@ -1702,7 +1720,7 @@ describe('DiscordChannelFetcher', () => {
 
       const channel = createMockChannel(messages);
 
-      // DB returns null, no bot reply available
+      // Retriever returns null, no bot reply available
       const getTranscript = vi.fn().mockResolvedValue(null);
 
       const result = await fetcher.fetchRecentMessages(channel, {
@@ -1742,7 +1760,7 @@ describe('DiscordChannelFetcher', () => {
         // Bot transcript reply
         createMockMessage({
           id: 'transcript-reply-1',
-          content: 'Fallback when no DB function',
+          content: 'Fallback when no getTranscript function',
           authorId: 'bot123',
           authorUsername: 'TestBot',
           isBot: true,
@@ -1762,7 +1780,7 @@ describe('DiscordChannelFetcher', () => {
       expect(result.keptCount).toBe(1);
       // Voice transcripts are now in messageMetadata for structured XML formatting
       expect(result.messages[0].messageMetadata?.voiceTranscripts).toContain(
-        'Fallback when no DB function'
+        'Fallback when no getTranscript function'
       );
     });
 

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -202,22 +202,28 @@ export class DiscordChannelFetcher {
       );
     }
 
-    // Create wrapped getTranscript that tries DB first, then falls back to bot replies
+    // Wrap getTranscript: try the caller's retriever first (in production the
+    // Redis-only TranscriptRetriever — bot-client has no DB tier), then fall
+    // back to the bot's own in-channel transcript reply.
     const getTranscriptWithFallback = async (
       discordMessageId: string,
       attachmentUrl: string
     ): Promise<string | null> => {
       if (options.getTranscript) {
-        const dbTranscript = await options.getTranscript(discordMessageId, attachmentUrl);
-        if (dbTranscript !== null && dbTranscript.length > 0) {
-          return dbTranscript;
+        const primaryTranscript = await options.getTranscript(discordMessageId, attachmentUrl);
+        if (primaryTranscript !== null && primaryTranscript.length > 0) {
+          return primaryTranscript;
         }
       }
       const fallbackTranscript = botTranscriptFallback.get(discordMessageId);
       if (fallbackTranscript !== undefined) {
-        logger.info(
+        // Debug, not info: any voice message older than the transcript cache
+        // TTL misses the cache on EVERY extended-context fetch by design (the
+        // accepted divergence documented in TranscriptRetriever), so this
+        // recurs indefinitely for the same messages and is not an anomaly.
+        logger.debug(
           { messageId: discordMessageId },
-          'Using bot reply fallback for voice transcript (DB lookup failed)'
+          'Using bot reply fallback for voice transcript (not in Redis cache)'
         );
         return fallbackTranscript;
       }


### PR DESCRIPTION
## Summary

TASK-424, the last item from the 2026-08-04 prod-log sweep: `DiscordChannelFetcher` logged `Using bot reply fallback for voice transcript (DB lookup failed)` at info for the same 4 messageIds on every extended-context fetch of one channel (80 lines/6h). The line is false on both counts:

- **There is no DB lookup in this path.** bot-client is deliberately Prisma-free; `TranscriptRetriever` reads only the shared Redis transcript cache (1h TTL). The "lookup" that "fails" is a cache GET for a voice message older than the TTL — the accepted divergence explicitly documented in `TranscriptRetriever`'s docblock, with its own named escalation path (the envelope flat-list pattern) if room-awareness ever measurably degrades.
- **Nothing is failing.** The bot-reply fallback works and recurs by design, indefinitely, for the same aged messages.

## Change

Reword the line to name the real mechanism ("not in Redis cache") and demote info → debug. The fallback test now pins the level and message; the suite's logger mock becomes one hoisted instance (the established sibling-suite pattern) so level assertions reach the logger the module captures at load.

## Why not the task's proposed fix shapes (investigated, rejected on mechanism)

The task as filed proposed write-back or negative caching — both traced and rejected:

- **Write-back would poison a paid-work cache**: the fallback text is the bot's *reply* content — chunked for Discord's 2000-char limit (last chunk wins in the fallback map) and potentially footer-bearing — while ai-worker's `AudioProcessor` reads the same cache key to skip paid re-transcription. Caching decorated/truncated text under that key trades log noise for transcript corruption.
- **Negative caching** saves a microsecond Redis GET per absent id and risks masking a transcript that arrives later (re-transcription via reply). Not worth the state.

The repeated GETs the task called "doomed DB lookups" are ordinary L1 misses costing effectively nothing; the actual defect was the lying log line.

## Verification

`pnpm test` green (bot-client 389 files / 6028 tests), `pnpm quality` green, sequential. The extended fallback test asserts debug is called with the new message and info is never called with fallback text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)