### PR TITLE
chore(ci): pin claude-code-action to v1.0.183 (main-cut for #1943)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Carries dependabot #1943's exact hunks via the sanctioned main-cut path: the two claude workflow files self-validate against main, so this change must not merge through develop (it would silently no-op claude-review on every PR until the next release reaches main).

- `claude-code-review.yml` / `claude.yml`: `anthropics/claude-code-action@v1` → `@v1.0.183` (pin-tightening; matches the repo's exact-pin norm, e.g. `pnpm/action-setup@6.0.9`)
- Note: claude-review will show as a skip/no-op **on this PR itself** (its own workflow files differ from main until merge) — that's the documented behavior for main-cut workflow PRs.
- After merge: `pnpm ops release:finalize` to resync develop, then #1943 closes as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)