### PR TITLE
fix: voice purge no longer counts 404'd voices as deleted

### DIFF
--- a/packages/common-types/src/schemas/api/voices.test.ts
+++ b/packages/common-types/src/schemas/api/voices.test.ts
@@ -117,6 +117,21 @@ describe('Voices API Contract Tests', () => {
       };
       expect(ClearVoicesResponseSchema.safeParse(data).success).toBe(true);
     });
+
+    it('alreadyGone survives the parse (strip-mode would silently drop an undeclared field)', () => {
+      const parsed = ClearVoicesResponseSchema.safeParse({
+        deleted: 5,
+        total: 170,
+        alreadyGone: 165,
+      });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.alreadyGone).toBe(165);
+    });
+
+    it('rejects negative alreadyGone', () => {
+      const data = { deleted: 1, total: 2, alreadyGone: -1 };
+      expect(ClearVoicesResponseSchema.safeParse(data).success).toBe(false);
+    });
   });
 
   describe('DeleteVoiceResponseSchema', () => {

--- a/packages/common-types/src/schemas/api/voices.ts
+++ b/packages/common-types/src/schemas/api/voices.ts
@@ -62,6 +62,8 @@ export const ListVoiceModelsResponseSchema = z.object({
 export const ClearVoicesResponseSchema = z.object({
   deleted: z.number().int().nonnegative(),
   total: z.number().int().nonnegative(),
+  /** Voices that 404'd at the provider — already gone, NOT deleted by this run. Omitted when 0. */
+  alreadyGone: z.number().int().nonnegative().optional(),
   message: z.string().optional(),
   errors: z.array(z.string()).optional(),
 });

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -463,7 +463,7 @@ describe('Voice Management Routes', () => {
       expect(res.body.errors[0]).toContain('elevenlabs');
     });
 
-    it('counts a 404 delete as removed, not failed (voice already gone)', async () => {
+    it('counts a 404 delete as alreadyGone, not deleted and not failed', async () => {
       userWithKeys(['elevenlabs']);
       let deleteCallCount = 0;
       setProviderFetchMocks({
@@ -479,10 +479,26 @@ describe('Voice Management Routes', () => {
       const res = await request(app).post('/voices/clear');
 
       expect(res.status).toBe(200);
-      // Already-gone voices satisfy the purge goal — no scary failure output
-      expect(res.body.deleted).toBe(2);
+      // Already-gone voices satisfy the purge goal — no scary failure output —
+      // but they were not deleted by THIS run, so `deleted` must not claim them.
+      expect(res.body.deleted).toBe(1);
+      expect(res.body.alreadyGone).toBe(1);
       expect(res.body.total).toBe(2);
       expect(res.body.errors).toBeUndefined();
+    });
+
+    it('omits alreadyGone when every delete is a real deletion', async () => {
+      userWithKeys(['elevenlabs']);
+      setProviderFetchMocks({
+        elevenlabsList: () => jsonOk(elevenLabsVoicesResponse),
+        elevenlabsDelete: () => ({ ok: true, status: 200 }) as unknown as Response,
+      });
+
+      const res = await request(app).post('/voices/clear');
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(2);
+      expect(res.body.alreadyGone).toBeUndefined();
     });
 
     it('shows actionable message for rate-limited deletions', async () => {

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -376,11 +376,82 @@ async function deleteVoiceImpl(
 }
 
 /**
+ * Delete one voice at its provider during bulk clear.
+ *
+ * A 404 means the voice is already absent (deleted concurrently, or a stale
+ * listing entry) — the purge goal for it is met, so it's not a failure, but
+ * it was NOT deleted by this run and must not inflate the `deleted` count.
+ */
+async function deleteOneVoiceForClear(
+  voice: TaggedVoice,
+  keys: Map<AudioProviderId, string>
+): Promise<'deleted' | 'already-gone'> {
+  const apiKey = keys.get(voice.provider);
+  if (apiKey === undefined) {
+    // Defensive: voice came from fetchAllTzurotVoices, so its provider had a key.
+    // If it disappeared mid-clear, fail loudly with a meaningful message.
+    throw new Error(`${voice.name}: ${voice.provider} key disappeared mid-clear`);
+  }
+  const response = await deleteVoiceAtProvider(voice.provider, apiKey, voice.voiceId);
+  if (response.status === 404) {
+    return 'already-gone';
+  }
+  if (!response.ok) {
+    // Surface actionable messages — "429" alone is meaningless to end users.
+    // voice.name is safe to embed: it's tzurot-prefix-filtered (no user-controlled
+    // injection risk).
+    const detail =
+      response.status === 429
+        ? `${voice.name} (${voice.provider}): rate limited — try again shortly`
+        : `${voice.name} (${voice.provider}): ${response.status}`;
+    throw new Error(detail);
+  }
+  return 'deleted';
+}
+
+/**
+ * Delete voices in small batches (balancing speed vs provider rate limits)
+ * and tally outcomes. Bot-client uses GATEWAY_TIMEOUTS.BULK_OPERATION (30s)
+ * for this call; gateway timeout would abort but deletions continue
+ * server-side.
+ */
+async function deleteVoicesInBatches(
+  voices: TaggedVoice[],
+  keys: Map<AudioProviderId, string>
+): Promise<{ deleted: number; alreadyGone: number; errors: string[] }> {
+  let deleted = 0;
+  let alreadyGone = 0;
+  const errors: string[] = [];
+
+  for (let i = 0; i < voices.length; i += DELETE_BATCH_SIZE) {
+    const batch = voices.slice(i, i + DELETE_BATCH_SIZE);
+    const results = await Promise.allSettled(
+      batch.map(async voice => deleteOneVoiceForClear(voice, keys))
+    );
+
+    for (const result of results) {
+      if (result.status !== 'fulfilled') {
+        errors.push(result.reason instanceof Error ? result.reason.message : 'Unknown error');
+      } else if (result.value === 'already-gone') {
+        alreadyGone++;
+      } else {
+        deleted++;
+      }
+    }
+  }
+
+  return { deleted, alreadyGone, errors };
+}
+
+/**
  * POST /clear — delete ALL tzurot-prefixed voices across all configured providers.
  *
  * Always returns 200 OK, even on partial failure. Callers must inspect the
- * response body: `{ deleted, total, errors? }`. When `errors` is present,
- * some deletions failed but others succeeded.
+ * response body: `{ deleted, total, alreadyGone?, errors? }`. When `errors`
+ * is present, some deletions failed but others succeeded. `alreadyGone`
+ * counts voices that 404'd at the provider (deleted concurrently or stale
+ * listing entries) — the purge goal is met for them, but they were not
+ * deleted by this run.
  */
 async function clearVoicesImpl(
   prisma: PrismaClient,
@@ -412,52 +483,7 @@ async function clearVoicesImpl(
     return;
   }
 
-  // Delete in small batches to balance speed vs provider rate limits.
-  // Bot-client uses GATEWAY_TIMEOUTS.BULK_OPERATION (30s) for this call;
-  // gateway timeout would abort but deletions continue server-side.
-  let deleted = 0;
-  let alreadyGone = 0;
-  const errors: string[] = [];
-
-  for (let i = 0; i < voices.length; i += DELETE_BATCH_SIZE) {
-    const batch = voices.slice(i, i + DELETE_BATCH_SIZE);
-    const results = await Promise.allSettled(
-      batch.map(async voice => {
-        const apiKey = keysResult.keys.get(voice.provider);
-        if (apiKey === undefined) {
-          // Defensive: voice came from fetchAllTzurotVoices, so its provider had a key.
-          // If it disappeared mid-clear, fail loudly with a meaningful message.
-          throw new Error(`${voice.name}: ${voice.provider} key disappeared mid-clear`);
-        }
-        const response = await deleteVoiceAtProvider(voice.provider, apiKey, voice.voiceId);
-        if (response.status === 404) {
-          // Already absent at the provider (deleted concurrently, or a stale
-          // listing entry). The purge goal for this voice is met — reporting
-          // it as a failure just alarms the user about a voice that's gone.
-          alreadyGone++;
-          return;
-        }
-        if (!response.ok) {
-          // Surface actionable messages — "429" alone is meaningless to end users.
-          // voice.name is safe to embed: it's tzurot-prefix-filtered (no user-controlled
-          // injection risk).
-          const detail =
-            response.status === 429
-              ? `${voice.name} (${voice.provider}): rate limited — try again shortly`
-              : `${voice.name} (${voice.provider}): ${response.status}`;
-          throw new Error(detail);
-        }
-      })
-    );
-
-    for (const result of results) {
-      if (result.status === 'fulfilled') {
-        deleted++;
-      } else {
-        errors.push(result.reason instanceof Error ? result.reason.message : 'Unknown error');
-      }
-    }
-  }
+  const { deleted, alreadyGone, errors } = await deleteVoicesInBatches(voices, keysResult.keys);
 
   logger.info(
     { discordUserId, deleted, alreadyGone, total: voices.length, errors: errors.length },
@@ -467,6 +493,7 @@ async function clearVoicesImpl(
   sendCustomSuccess(res, {
     deleted,
     total: voices.length,
+    alreadyGone: alreadyGone > 0 ? alreadyGone : undefined,
     errors: errors.length > 0 ? errors : undefined,
   });
 }

--- a/services/bot-client/src/commands/voice/voices/purge.test.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.test.ts
@@ -252,4 +252,60 @@ describe('handleVoicePurgeModal', () => {
 
     expect(stub.clearVoices).toHaveBeenCalled();
   });
+
+  /**
+   * Drive the destructive-modal mock so the inner callback runs, and capture
+   * the DestructiveOperationResult it returns for embed assertions.
+   */
+  async function runPurgeCallback(clearVoicesData: Record<string, unknown>): Promise<{
+    success: boolean;
+    successEmbed?: { data: { description?: string } };
+  }> {
+    let opResult: { success: boolean; successEmbed?: { data: { description?: string } } } = {
+      success: false,
+    };
+    mockHandleDestructiveModalSubmit.mockImplementationOnce(
+      async (_interaction, _word, callback) => {
+        opResult = await (callback as () => Promise<typeof opResult>)();
+      }
+    );
+    stub.clearVoices.mockResolvedValue({ ok: true, data: clearVoicesData });
+    const interaction = {
+      customId: `voice::destructive::modal_submit::${VOICE_PURGE_OPERATION}::all`,
+      user: { id: 'user-123' },
+    } as unknown as ModalSubmitInteraction;
+
+    await handleVoicePurgeModal(interaction);
+    return opResult;
+  }
+
+  it('surfaces alreadyGone in the success embed instead of folding it into deleted', async () => {
+    const result = await runPurgeCallback({ deleted: 5, total: 170, alreadyGone: 165 });
+
+    expect(result.success).toBe(true);
+    expect(result.successEmbed?.data.description).toBe(
+      'Deleted **5** cloned voices (165 already gone).'
+    );
+  });
+
+  it('omits the already-gone note when the field is absent', async () => {
+    const result = await runPurgeCallback({ deleted: 3, total: 3 });
+
+    expect(result.success).toBe(true);
+    expect(result.successEmbed?.data.description).toBe('Deleted **3** cloned voices.');
+  });
+
+  it('keeps the already-gone note alongside partial-failure errors', async () => {
+    const result = await runPurgeCallback({
+      deleted: 1,
+      total: 3,
+      alreadyGone: 1,
+      errors: ['tzurot-x (elevenlabs): rate limited — try again shortly'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.successEmbed?.data.description).toContain(
+      'Deleted **1/3** voices (1 already gone). 1 failed:'
+    );
+  });
 });

--- a/services/bot-client/src/commands/voice/voices/purge.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.ts
@@ -143,12 +143,17 @@ export async function handleVoicePurgeModalSubmit(
       };
     }
 
-    const { deleted, total, errors } = result.data;
+    const { deleted, total, alreadyGone, errors } = result.data;
 
     const embed = new EmbedBuilder()
       .setTitle('🗑️ Voices Purged')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setTimestamp();
+
+    // 404-at-provider voices satisfied the purge goal without being deleted by
+    // this run — folding them into `deleted` would over-claim, so say it plainly.
+    const alreadyGoneNote =
+      alreadyGone !== undefined && alreadyGone > 0 ? ` (${alreadyGone} already gone)` : '';
 
     if (errors !== undefined && errors.length > 0) {
       // Truncate error list to avoid exceeding Discord's 2048-char embed description limit.
@@ -158,13 +163,15 @@ export async function handleVoicePurgeModalSubmit(
       const overflow =
         errors.length > MAX_ERRORS_SHOWN ? `\n…and ${errors.length - MAX_ERRORS_SHOWN} more` : '';
       embed.setDescription(
-        `Deleted **${deleted}/${total}** voices. ${errors.length} failed:\n` +
+        `Deleted **${deleted}/${total}** voices${alreadyGoneNote}. ${errors.length} failed:\n` +
           shownErrors.map(e => `• ${e}`).join('\n') +
           overflow
       );
       embed.setColor(DISCORD_COLORS.WARNING);
     } else {
-      embed.setDescription(`Deleted **${deleted}** cloned voice${deleted !== 1 ? 's' : ''}.`);
+      embed.setDescription(
+        `Deleted **${deleted}** cloned voice${deleted !== 1 ? 's' : ''}${alreadyGoneNote}.`
+      );
     }
 
     // Invalidate autocomplete cache so deleted voices don't appear in /voice voices delete


### PR DESCRIPTION
## Summary

Fixes TASK-380: in `clearVoicesImpl`, a provider 404 incremented `alreadyGone` and then resolved the batch promise — so the outer `fulfilled` branch counted the same voice into `deleted`. The purge embed's "Deleted **N**" over-claimed by exactly the 404 count, while `alreadyGone` was computed, logged, and thrown away.

Latent, not currently firing (the owner's 2026-07-31 dev purge ran `deleted=170 alreadyGone=0`), but it fires exactly when a user is most likely to be confused by the number: a voice disappearing between the list fetch and its delete (concurrent purge, provider-side expiry).

## Changes

- **api-gateway** `voices.ts`: per-voice delete extracted to `deleteOneVoiceForClear` returning a discriminated `'deleted' | 'already-gone'`; the batch loop (also extracted, for the complexity ceiling) tallies the two separately. Response gains `alreadyGone`, omitted when 0 (same convention as `errors`).
- **common-types** `ClearVoicesResponseSchema`: `alreadyGone` optional nonnegative int — required for the field to survive the typed client's strip-mode parse.
- **bot-client** `purge.ts`: embed appends "(N already gone)" in both the clean and partial-failure branches; no note when 0.

## Verification

- Route test now pins `deleted=1, alreadyGone=1` for a one-success-one-404 run — the prior test pinned the over-claim (`deleted=2`) and was the gap the task named. Added an all-success test pinning `alreadyGone` omission.
- Schema test pins strip-mode survival (`parsed.data.alreadyGone === 165`) and rejects negatives.
- Purge test drives the destructive-modal callback and asserts the exact embed description for all three shapes (already-gone note, absent field, note + errors).
- `pnpm test` (26 packages) and `pnpm quality` both green, run sequentially.

Deliberately NOT ridden along: TASK-167 (clearVoices sequential-call timeout shape → BullMQ job) — same file, different mechanism, stays filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)