### PR TITLE
fix: render forwarded sticker names in snapshot references

### DIFF
--- a/services/bot-client/src/handlers/references/SnapshotFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/SnapshotFormatter.test.ts
@@ -91,6 +91,74 @@ describe('SnapshotFormatter', () => {
       expect(result.attachments).toEqual([
         expect.objectContaining({ id: '77', isSticker: true, contentType: 'image/png' }),
       ]);
+      // The rasterizable case carries BOTH halves: image attachment above,
+      // name line in content (default mock content is 'Snapshot content').
+      expect(result.content).toBe('Snapshot content\n\n[Stickers: shipit]');
+    });
+
+    it('renders the sticker name line for a non-rasterizable (Lottie) sticker', () => {
+      // A Lottie sticker has no raster form, so stickersToAttachments filters
+      // it out — the name line is its ONLY trace. Before this, a forwarded
+      // Lottie sticker was entirely invisible to the model: empty content,
+      // undefined attachments.
+      const snapshot = createMockSnapshot({
+        content: '',
+        stickers: new Map([
+          [
+            '88',
+            {
+              id: '88',
+              name: 'wave',
+              description: 'Wumpus waves hello',
+              format: 3, // StickerFormatType.Lottie
+              url: 'https://cdn.discordapp.com/stickers/88.json',
+            },
+          ],
+        ]),
+      });
+
+      const result = formatter.formatSnapshot(snapshot, 1, createMockMessage());
+
+      expect(result.content).toBe('[Stickers: wave — Wumpus waves hello]');
+      expect(result.attachments).toBeUndefined();
+    });
+
+    it('appends the sticker name line after existing snapshot content', () => {
+      const snapshot = createMockSnapshot({
+        content: 'look at this',
+        stickers: new Map([
+          [
+            '77',
+            {
+              id: '77',
+              name: 'shipit',
+              description: null,
+              format: 1, // StickerFormatType.PNG
+              url: 'https://cdn.discordapp.com/stickers/77.png',
+            },
+          ],
+        ]),
+      });
+
+      const result = formatter.formatSnapshot(snapshot, 1, createMockMessage());
+
+      expect(result.content).toBe('look at this\n\n[Stickers: shipit]');
+    });
+
+    it('scopes the name line to THIS snapshot — the forwarding message stickers stay out', () => {
+      // formatSnapshot runs once per snapshot; pulling the containing
+      // message's (or sibling snapshots') stickers in would duplicate names
+      // across every reference entry of a multi-snapshot forward.
+      const snapshot = createMockSnapshot({ content: 'plain text', stickers: new Map() });
+      const forwardedFrom = createMockMessage({
+        stickers: new Map([
+          ['99', { id: '99', name: 'container-sticker', description: null, format: 1 }],
+        ]),
+      });
+
+      const result = formatter.formatSnapshot(snapshot, 1, forwardedFrom);
+
+      expect(result.content).toBe('plain text');
     });
   });
 

--- a/services/bot-client/src/handlers/references/SnapshotFormatter.ts
+++ b/services/bot-client/src/handlers/references/SnapshotFormatter.ts
@@ -12,6 +12,7 @@ import { extractDiscordEnvironment } from '../../utils/discordContext.js';
 import { extractAttachments } from '../../utils/attachmentExtractor.js';
 import { extractEmbedImages } from '../../utils/embedImageExtractor.js';
 import { extractSnapshotStickerImages } from '../../utils/stickerAttachments.js';
+import { withSnapshotStickerDescriptions } from '../../utils/stickerPollDescriptions.js';
 import { EmbedParser } from '../../utils/EmbedParser.js';
 
 /**
@@ -74,7 +75,10 @@ export class SnapshotFormatter {
     const embedImages = extractEmbedImages(snapshot.embeds);
 
     // Forwarded stickers get the same treatment — without this a forwarded
-    // sticker reached the model as a name with no image behind it.
+    // sticker reached the model as an image with no name behind it. The NAME
+    // half renders below via withSnapshotStickerDescriptions, matching what
+    // MessageFormatter does for the paths that format the containing message;
+    // for a non-rasterizable (Lottie) sticker the name line is the only trace.
     const stickerImages = extractSnapshotStickerImages(snapshot);
 
     // Combine all attachment kinds
@@ -111,7 +115,7 @@ export class SnapshotFormatter {
       discordUserId: UNKNOWN_USER_DISCORD_ID, // Snapshots don't include author info
       authorUsername: UNKNOWN_USER_NAME,
       authorDisplayName: UNKNOWN_USER_NAME,
-      content: snapshot.content || '',
+      content: withSnapshotStickerDescriptions(snapshot, snapshot.content || ''),
       embeds: embedString,
       timestamp: snapshot.createdTimestamp
         ? new Date(snapshot.createdTimestamp).toISOString()

--- a/services/bot-client/src/utils/forwardedMessageUtils.test.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.test.ts
@@ -50,6 +50,7 @@ function createMockMessage(options: {
     duration?: number | null;
   }>;
   embeds?: Array<{ title?: string; description?: string }>;
+  stickers?: Array<{ id: string; name: string; format: number; url: string }>;
 }): Message {
   // Create attachments map with Discord.js Collection-like .some() method
   const attachmentsMap = new Map() as Map<string, unknown> & {
@@ -125,6 +126,8 @@ function createMockMessage(options: {
     messageSnapshots,
     attachments: attachmentsMap,
     embeds: options.embeds ?? [],
+    stickers:
+      options.stickers === undefined ? undefined : new Map(options.stickers.map(st => [st.id, st])),
   } as unknown as Message;
 }
 
@@ -473,6 +476,40 @@ describe('forwardedMessageUtils', () => {
       const message = createMockMessage({
         referenceType: MessageReferenceType.Forward,
         content: 'Fallback content',
+      });
+
+      expect(hasForwardedContent(message)).toBe(true);
+    });
+
+    it('returns true for a Lottie-sticker-only forward (no raster attachment to count)', () => {
+      // The attachment walk carries only RASTERIZABLE stickers; a Lottie-only
+      // forward has empty content, no attachments, no embeds — the direct
+      // sticker check is what keeps it from being dropped as empty.
+      const message = createMockMessage({
+        referenceType: MessageReferenceType.Forward,
+        snapshots: [
+          {
+            content: '',
+            stickers: [
+              { id: '88', name: 'wave', format: 3, url: 'https://cdn.discordapp.com/88.json' },
+            ],
+          },
+        ],
+      });
+
+      expect(hasForwardedContent(message)).toBe(true);
+    });
+
+    it('returns true for a sticker-only forward on the no-snapshot fallback path', () => {
+      // When Discord doesn't populate snapshots, the fallback reads the main
+      // message — which carries no sticker in its attachments/content/embeds
+      // either, so only the direct sticker check sees it.
+      const message = createMockMessage({
+        referenceType: MessageReferenceType.Forward,
+        content: '',
+        stickers: [
+          { id: '77', name: 'shipit', format: 1, url: 'https://cdn.discordapp.com/77.png' },
+        ],
       });
 
       expect(hasForwardedContent(message)).toBe(true);

--- a/services/bot-client/src/utils/forwardedMessageUtils.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.ts
@@ -29,6 +29,7 @@ import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/disc
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
 import { extractSnapshotStickerImages } from './stickerAttachments.js';
+import { collectAllStickers } from './stickerPollDescriptions.js';
 import { isVoiceAttachment } from './voiceAttachment.js';
 
 /**
@@ -285,6 +286,7 @@ export function extractAllForwardedContent(message: Message): ForwardedContentRe
  * - Text content (in snapshots or main message)
  * - Attachments (in snapshots or main message)
  * - Embeds (in snapshots or main message)
+ * - Stickers (in snapshots or main message, rasterizable or not)
  *
  * Use this for filtering - a forwarded message is worth processing if it has content.
  *
@@ -298,7 +300,16 @@ export function hasForwardedContent(message: Message): boolean {
 
   const { content, attachments, embeds } = extractAllForwardedContent(message);
 
-  return content.length > 0 || attachments.length > 0 || embeds.length > 0;
+  // Stickers are checked directly rather than through the extraction result:
+  // the attachment walk only carries RASTERIZABLE stickers (Lottie has no
+  // image form), and the no-snapshot fallback carries none at all — either
+  // way a sticker-only forward would read as empty and be dropped.
+  return (
+    content.length > 0 ||
+    attachments.length > 0 ||
+    embeds.length > 0 ||
+    collectAllStickers(message).length > 0
+  );
 }
 
 /**

--- a/services/bot-client/src/utils/stickerPollDescriptions.test.ts
+++ b/services/bot-client/src/utils/stickerPollDescriptions.test.ts
@@ -3,12 +3,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { Message } from 'discord.js';
+import type { Message, Sticker } from 'discord.js';
 import {
   describePoll,
   describeStickers,
   describeStickersAndPoll,
   hasStickerOrPoll,
+  withSnapshotStickerDescriptions,
   withStickerAndPollDescriptions,
 } from './stickerPollDescriptions.js';
 
@@ -224,5 +225,41 @@ describe('withStickerAndPollDescriptions', () => {
         ''
       )
     ).toBe('[Poll: Q? — options: A]');
+  });
+});
+
+describe('withSnapshotStickerDescriptions', () => {
+  const snapshotWith = (
+    stickers: StickerFixture[]
+  ): { stickers: { values(): Iterable<Sticker> } } => ({
+    stickers: new Map(
+      stickers.map((s, i) => [
+        String(i),
+        { name: s.name, description: s.description === undefined ? null : s.description },
+      ])
+    ) as unknown as { values(): Iterable<Sticker> },
+  });
+
+  it('returns the text byte-identical when the snapshot has no stickers', () => {
+    expect(withSnapshotStickerDescriptions(snapshotWith([]), 'hello')).toBe('hello');
+  });
+
+  it('tolerates an absent stickers field (MessageSnapshot is a Partialize)', () => {
+    expect(withSnapshotStickerDescriptions({}, 'hello')).toBe('hello');
+  });
+
+  it('yields name-only content for a sticker-only snapshot (the invisible-Lottie fix)', () => {
+    expect(
+      withSnapshotStickerDescriptions(
+        snapshotWith([{ name: 'wave', description: 'Wumpus waves hello' }]),
+        ''
+      )
+    ).toBe('[Stickers: wave — Wumpus waves hello]');
+  });
+
+  it('appends the name line below existing snapshot text', () => {
+    expect(withSnapshotStickerDescriptions(snapshotWith([{ name: 'shipit' }]), 'look')).toBe(
+      'look\n\n[Stickers: shipit]'
+    );
   });
 });

--- a/services/bot-client/src/utils/stickerPollDescriptions.ts
+++ b/services/bot-client/src/utils/stickerPollDescriptions.ts
@@ -43,14 +43,29 @@ function collectionValues<T>(collection: { values(): Iterable<T> } | undefined |
   return collection === undefined || collection === null ? [] : [...collection.values()];
 }
 
-/** `name` alone, or `name — description` when Discord supplies a description. */
+/**
+ * `name` alone, or `name — description` when Discord supplies a description.
+ *
+ * `description` is typed `string | null` but tolerates `undefined` too: a
+ * snapshot-carried sticker is Partialize-shaped (see {@link collectionValues})
+ * and may omit the field entirely.
+ */
 function describeSticker(sticker: Sticker): string {
   const name = flatten(sticker.name);
+  const rawDescription: string | null | undefined = sticker.description;
   const description =
-    sticker.description === null || sticker.description.length === 0
+    rawDescription === null || rawDescription === undefined || rawDescription.length === 0
       ? undefined
-      : flatten(sticker.description);
+      : flatten(rawDescription);
   return description === undefined ? name : `${name} — ${description}`;
+}
+
+/** `[Stickers: …]` for an explicit sticker list. Empty string when there are none. */
+function describeStickerList(stickers: Sticker[]): string {
+  if (stickers.length === 0) {
+    return '';
+  }
+  return `[Stickers: ${stickers.map(describeSticker).join(', ')}]`;
 }
 
 /**
@@ -60,11 +75,7 @@ function describeSticker(sticker: Sticker): string {
  * unconditionally and filter falsy.
  */
 export function describeStickers(message: Message): string {
-  const all = collectAllStickers(message);
-  if (all.length === 0) {
-    return '';
-  }
-  return `[Stickers: ${all.map(describeSticker).join(', ')}]`;
+  return describeStickerList(collectAllStickers(message));
 }
 
 /**
@@ -169,4 +180,26 @@ export function withStickerAndPollDescriptions(message: Message, text: string): 
     return text;
   }
   return [...(text.length > 0 ? [text] : []), ...parts].join('\n\n');
+}
+
+/**
+ * Append the `[Stickers: …]` line for ONE snapshot's own stickers to that
+ * snapshot's already-resolved text. `SnapshotFormatter` renders each snapshot
+ * as its own reference and the containing `Message` never goes through
+ * {@link withStickerAndPollDescriptions} on that path — so the scope must be
+ * exactly this snapshot; the message-level renderer would pull sibling
+ * snapshots' stickers into every entry. The name line renders regardless of
+ * rasterizability: a Lottie sticker has no raster form for the vision path, so
+ * this line is the only way it reaches the model at all. (Snapshots never
+ * carry a poll, hence no poll half.)
+ */
+export function withSnapshotStickerDescriptions(
+  snapshot: { stickers?: { values(): Iterable<Sticker> } | null },
+  text: string
+): string {
+  const line = describeStickerList(collectionValues<Sticker>(snapshot.stickers));
+  if (line.length === 0) {
+    return text;
+  }
+  return [...(text.length > 0 ? [text] : []), line].join('\n\n');
 }


### PR DESCRIPTION
## Summary

Fixes TASK-397 (raised by #1895's review): `SnapshotFormatter` never called the sticker name renderer — before or after #1895 — so on the common (non-deduplicated) forward path a forwarded **Lottie sticker was entirely invisible to the model**: no raster form for the vision path, no name line, typically empty snapshot content. Rasterizable stickers had the image half only.

## Changes

- **`stickerPollDescriptions.ts`**: new `withSnapshotStickerDescriptions` — appends the `[Stickers: …]` line for ONE snapshot's own stickers. Snapshot-scoped deliberately: `ReferenceFormatter` routes a forward through *either* the per-snapshot path *or* the deduped `buildRawReference` path (which already renders names via `collectAllStickers`), so no double-render is possible; the message-level renderer would leak sibling snapshots' stickers into every entry. `describeSticker` also becomes total over `Partialize`-shaped stickers lacking `description` (the module's own never-throw-for-a-label rule — surfaced by the pre-existing fixture that omits the field).
- **`SnapshotFormatter.ts`**: `formatSnapshot` runs content through the new helper; comment updated to describe the name+image pairing.
- **`forwardedMessageUtils.ts`** (second site from the same review): `hasForwardedContent` checks stickers directly — the attachment walk carries only *rasterizable* stickers and the no-snapshot fallback carried none, so a sticker-only forward read as empty and was dropped by the meaningful-content gate. One check covers both the Lottie-only-snapshot case and the fallback case.

## Verification

- `SnapshotFormatter` tests: Lottie-only snapshot → name line with no attachments (the exact bug); name line appended after existing content; scope test proving the forwarding message's own stickers stay out.
- `withSnapshotStickerDescriptions` unit tests: byte-identical passthrough, absent-`stickers` tolerance, name-only content, append join.
- `hasForwardedContent` tests: Lottie-sticker-only snapshot forward → true; sticker-only no-snapshot fallback → true.
- `pnpm test` (26 packages) and `pnpm quality` both green, run sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)