### PR TITLE
chore: cap cache:prefix-diff --limit + document the cache commands

### DIFF
--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -301,6 +301,24 @@ Filtered copy-paste detection ratchet — same structural shape as test:audit:
 
 `cpd:check` fails on either `filteredLines > baseline + graceMargin` OR `configHash` drift. The post-filter excludes fragments where ≥80% of classifiable lines are call-expression shape — see [`docs/reference/CPD_CAMPAIGN_AUDIT.md`](../CPD_CAMPAIGN_AUDIT.md) for the rationale. Bump `FILTER_IMPL_VERSION` (in `packages/tooling/src/cpd/postFilter.ts`) when the heuristic changes.
 
+## Cache Commands
+
+Two unrelated caches share the `cache:` namespace: `cache:inspect` / `cache:clear` act on the **local Turborepo build cache** (`.turbo/`, dev-machine only), while `cache:clear-credit-exhaustion` / `cache:prefix-diff` act on **runtime state in a target environment** (Redis and the diagnostic store) and therefore take `--env`.
+
+| Command                                                                   | Description                                                                                            |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `pnpm ops cache:inspect`                                                  | Report local Turborepo cache size, file count, and oldest/newest entry                                 |
+| `pnpm ops cache:clear`                                                    | Delete the local Turborepo cache to force fresh builds (`--dry-run` previews)                          |
+| `pnpm ops cache:clear-credit-exhaustion --env prod --user-id <discordId>` | Delete one BYOK user's OpenRouter credit-exhaustion Redis entry (operator escape valve after a top-up) |
+| `pnpm ops cache:clear-credit-exhaustion --env dev --system`               | Same, for the system-bucket entry (guest mode / system-key fallback)                                   |
+| `pnpm ops cache:prefix-diff --env dev --channel <snowflake>`              | Diff consecutive requests' system prompts for a channel to diagnose provider prompt-cache misses       |
+| `... --personality <uuid>`                                                | Restrict the diff to one personality                                                                   |
+| `... --limit <pairs>`                                                     | Consecutive pairs to compare — default 5, **max 100**                                                  |
+
+**`cache:clear-credit-exhaustion`** requires exactly one of `--user-id` or `--system`; supplying both or neither is rejected. Keys mirror `CreditExhaustionCache` in ai-worker (`nocredits:openrouter:user:<discordId>` / `nocredits:openrouter:system`).
+
+**`cache:prefix-diff`** requires `--channel` (read verbatim from argv — a Discord snowflake exceeds `MAX_SAFE_INTEGER` and would be corrupted by cac's number coercion). It fetches the channel's diagnostic rows in a subprocess against the target env, finds the first byte divergence between each consecutive pair of system prompts, and names the prompt section the divergence landed in. Diagnostic rows live 24h, so it diagnoses live cache behavior, not history. The `--limit` cap exists because the subprocess returns `limit + 1` full prompt payloads over a 128MB `maxBuffer`; an uncapped limit against prod overflows it and the run dies mid-transfer.
+
 ## Guard Commands
 
 Structural enforcement checks that hard-fail CI on findings:

--- a/packages/tooling/src/commands/cache.test.ts
+++ b/packages/tooling/src/commands/cache.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cac } from 'cac';
+
+import { registerCacheCommands } from './cache.js';
+
+// The action calls validateEnvironment (Railway CLI probe + process.exit) and
+// dynamically imports the fetcher; both are stubbed so the bounds checks run
+// with no Railway/Redis/DB contact.
+vi.mock('../utils/env-runner.js', () => ({
+  validateEnvironment: vi.fn(),
+}));
+
+vi.mock('../cache/prefix-diff.js', () => ({
+  runPrefixDiff: vi.fn().mockResolvedValue(undefined),
+}));
+
+const CHANNEL = '123456789012345678';
+
+describe('cache:prefix-diff --limit bounds', () => {
+  let cli: ReturnType<typeof cac>;
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalArgv = process.argv;
+    // --channel is read from the REAL process.argv, not cac's parsed options
+    // (snowflake precision — see utils/cli-args.ts), so it has to be stubbed
+    // there for the action to get past the required-channel guard.
+    process.argv = ['node', 'ops', 'cache:prefix-diff', '--channel', CHANNEL];
+    cli = cac('test');
+    registerCacheCommands(cli);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  /**
+   * cac's parse() discards the action's returned promise; runMatchedCommand()
+   * returns it, which is what makes an async validation throw assertable.
+   */
+  async function runWithLimit(limit: string): Promise<void> {
+    cli.parse(['node', 'test', 'cache:prefix-diff', '--env', 'dev', '--limit', limit], {
+      run: false,
+    });
+    await (cli.runMatchedCommand() as Promise<void>);
+  }
+
+  it('rejects a limit above the 100-pair cap', async () => {
+    const { runPrefixDiff } = await import('../cache/prefix-diff.js');
+
+    await expect(runWithLimit('101')).rejects.toThrow('--limit must be at most 100, got: 101');
+    expect(runPrefixDiff).not.toHaveBeenCalled();
+  });
+
+  it('accepts a limit exactly at the cap', async () => {
+    const { runPrefixDiff } = await import('../cache/prefix-diff.js');
+
+    await runWithLimit('100');
+
+    expect(runPrefixDiff).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: CHANNEL, limit: 100 })
+    );
+  });
+
+  it('still rejects a non-positive limit (the lower bound is unchanged)', async () => {
+    const { runPrefixDiff } = await import('../cache/prefix-diff.js');
+
+    await expect(runWithLimit('0')).rejects.toThrow('--limit must be a positive integer, got: 0');
+    expect(runPrefixDiff).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tooling/src/commands/cache.ts
+++ b/packages/tooling/src/commands/cache.ts
@@ -9,6 +9,17 @@ import type { CAC } from 'cac';
 import { validateEnvironment, type Environment } from '../utils/env-runner.js';
 import { rawOptionValue } from '../utils/cli-args.js';
 
+/**
+ * Upper bound on `cache:prefix-diff --limit` (pair count).
+ *
+ * The fetch runs in a subprocess whose stdout carries `limit + 1` full
+ * diagnostic payloads — every compared pair costs two complete system
+ * prompts — over a 128MB `maxBuffer` (see cache/prefix-diff.ts). Against a
+ * prod channel with large prompts an unbounded limit overflows that buffer
+ * and the run dies mid-transfer instead of producing a diff.
+ */
+const PREFIX_DIFF_MAX_PAIRS = 100;
+
 export function registerCacheCommands(cli: CAC): void {
   cli.command('cache:inspect', 'Inspect Turborepo cache size and status').action(async () => {
     const { inspectCache } = await import('../cache/inspect-cache.js');
@@ -31,7 +42,9 @@ export function registerCacheCommands(cli: CAC): void {
     .option('--env <env>', 'Environment to target (local, dev, prod)', { default: 'dev' })
     .option('--channel <channelId>', 'Discord channel to trace (snowflake)')
     .option('--personality <uuid>', 'Restrict to one personality')
-    .option('--limit <pairs>', 'Consecutive pairs to compare', { default: 5 })
+    .option('--limit <pairs>', `Consecutive pairs to compare (max ${PREFIX_DIFF_MAX_PAIRS})`, {
+      default: 5,
+    })
     .example('ops cache:prefix-diff --env dev --channel 123456789012345678')
     .example('ops cache:prefix-diff --env prod --channel 123456789012345678 --limit 10')
     .action(async (options: { env: string; personality?: string; limit: number }) => {
@@ -45,6 +58,11 @@ export function registerCacheCommands(cli: CAC): void {
       const limit = Number(options.limit);
       if (!Number.isInteger(limit) || limit < 1) {
         throw new Error(`--limit must be a positive integer, got: ${String(options.limit)}`);
+      }
+      if (limit > PREFIX_DIFF_MAX_PAIRS) {
+        throw new Error(
+          `--limit must be at most ${PREFIX_DIFF_MAX_PAIRS}, got: ${String(options.limit)}`
+        );
       }
       const { runPrefixDiff } = await import('../cache/prefix-diff.js');
       await runPrefixDiff({


### PR DESCRIPTION
## Summary

Closes TASK-401 (both halves, from #1906's round-5 review): `cache:prefix-diff --limit` had no upper bound — a typoed `500000` against prod would fetch that many full diagnostic payloads and overflow the subprocess's 128MB `maxBuffer` mid-transfer — and OPS_CLI_REFERENCE.md had no Cache Commands section despite the namespace now holding four commands.

## Changes

- **`packages/tooling/src/commands/cache.ts`**: `PREFIX_DIFF_MAX_PAIRS = 100`, enforced next to the existing lower-bound check with a matching error-message style, invariant documented at the constant (verified against `cache/prefix-diff.ts:276-281` — the subprocess really does carry `limit + 1` payloads over a 128MB `maxBuffer`), and the cap surfaced in the `--limit` help text.
- **`packages/tooling/src/commands/cache.test.ts`** (new — the module's first tests): above-cap throws the named error and `runPrefixDiff` is never called; exactly-at-cap passes and the limit crosses the seam (`toHaveBeenCalledWith({ channelId, limit: 100 })`); the untouched lower bound still rejects `0`.
- **`docs/reference/tooling/OPS_CLI_REFERENCE.md`**: new `## Cache Commands` section (between CPD and Guard) — the four-command table, the namespace split note (Turborepo build cache vs runtime state), credit-exhaustion's exactly-one-of `--user-id`/`--system` rule with the Redis key shapes, and prefix-diff's snowflake-argv quirk + cap rationale.

## Verification

- `pnpm --filter @tzurot/tooling test`: 137 files, 1868 tests green (including the new file).
- `pnpm --filter @tzurot/tooling lint`: clean.
- The pre-push gate additionally ran build+lint+test for the affected scope.

Implementation by an Opus worker against a written spec; diff reviewed in full before commit. One spec finding worth noting: **nothing programmatically cross-checks ops commands against OPS_CLI_REFERENCE.md** (the `commands-doc` guard covers `docs/commands.md` slash commands only) — so this doc section, like the rest of the file, can drift silently.

## Acceptance (from the task)

- [x] Limit above the cap fails fast with a named error
- [x] All four cache commands documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)