### PR TITLE
feat(tooling): backlog lint enforces triage labels on open tasks

### DIFF
--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -165,13 +165,13 @@ The first five run in the CI `lint` job; all guards hard-fail on findings. `guar
 ### Backlog lint + digest
 
 ```bash
-pnpm ops backlog                     # Gate: now.md caps + queue.md doc references + tracker task-file integrity
+pnpm ops backlog                     # Gate: now.md caps + queue.md doc references + task-file integrity + open-task triage labels
 pnpm backlog:lint                    # Same check (root-level shortcut)
 pnpm ops backlog:digest              # Session-start briefing from tracker/: per-area counts, oldest 20, newest 10
 pnpm tracker task list --search <t> --plain   # Query the small-item pool (Backlog.md CLI)
 ```
 
-The lint verifies the caps (Current Focus ≤ 3, Quick Wins ≤ 5, Untriaged ≤ 10), flags `cold/queue.md` doc references (`doc-N`) that don't resolve in `tracker/docs/`, and fails on any `tracker/tasks/` file whose frontmatter won't parse (a broken task silently vanishes from every query surface). **Wired into `pnpm quality` AND the CI lint job** (they are separate lists — CI does not run `quality`; `guard:gate-parity` keeps the two in sync). Like the binary guards above, it's a layout sync-check, not an audit-class tool — no WHY.md / canary / `--summary`. The digest is informational (never gates) — the aging-escalation surface lives there, read at session start per `06-backlog.md`.
+The lint verifies the caps (Current Focus ≤ 3, Quick Wins ≤ 5, Untriaged ≤ 10), flags `cold/queue.md` doc references (`doc-N`) that don't resolve in `tracker/docs/`, fails on any `tracker/tasks/` file whose frontmatter won't parse (a broken task silently vanishes from every query surface), and enforces triage on every OPEN task — ≥1 `area:*` label, exactly one `size:S|M|L`, and a high/medium/low priority, the three axes every selection query filters on. **Wired into `pnpm quality` AND the CI lint job** (they are separate lists — CI does not run `quality`; `guard:gate-parity` keeps the two in sync). Like the binary guards above, it's a layout sync-check, not an audit-class tool — no WHY.md / canary / `--summary`. The digest is informational (never gates) — the aging-escalation surface lives there, read at session start per `06-backlog.md`.
 
 ### Audit-tool infrastructure (Layers 1-3)
 

--- a/packages/tooling/src/dev/backlogDigest.test.ts
+++ b/packages/tooling/src/dev/backlogDigest.test.ts
@@ -21,6 +21,7 @@ function task(
     status,
     createdDate,
     labels,
+    priority: 'medium',
     body: '',
     file: `tracker/tasks/${id}.md`,
   };

--- a/packages/tooling/src/dev/backlogLint.test.ts
+++ b/packages/tooling/src/dev/backlogLint.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { extractQueueDocRefs, parseSectionCaps, runBacklogLint } from './backlogLint.js';
+import {
+  checkTaskTriage,
+  extractQueueDocRefs,
+  parseSectionCaps,
+  runBacklogLint,
+} from './backlogLint.js';
+import type { TrackerTask } from './trackerTasks.js';
 
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
@@ -53,17 +59,84 @@ describe('extractQueueDocRefs', () => {
   });
 });
 
+// Fully triaged: the lint now gates on area + size + priority, so a fixture
+// standing in for "a healthy store" has to carry all three.
 const VALID_TASK = [
   '---',
   'id: TASK-1',
   "title: 'A valid task'",
   'status: To Do',
   "created_date: '2026-05-16 00:00'",
-  'labels: []',
+  'labels:',
+  "  - 'area:db'",
+  "  - 'size:S'",
+  'priority: medium',
   '---',
   '',
   'Body.',
 ].join('\n');
+
+describe('checkTaskTriage', () => {
+  function task(overrides: Partial<TrackerTask> = {}): TrackerTask {
+    return {
+      id: 'TASK-1',
+      title: 'A task',
+      status: 'To Do',
+      createdDate: '2026-05-16',
+      labels: ['area:db', 'size:S'],
+      priority: 'medium',
+      body: '',
+      file: 'tracker/tasks/task-1 - a-task.md',
+      ...overrides,
+    };
+  }
+
+  it('passes a fully triaged open task', () => {
+    expect(checkTaskTriage([task()])).toEqual([]);
+  });
+
+  it('flags an open task with no size label', () => {
+    const [problem] = checkTaskTriage([task({ labels: ['area:db'] })]);
+    expect(problem).toBe(
+      'tracker/tasks/task-1 - a-task.md: open task has no size label (size:S | size:M | size:L)'
+    );
+  });
+
+  it('flags an open task carrying more than one size label', () => {
+    const [problem] = checkTaskTriage([task({ labels: ['area:db', 'size:S', 'size:L'] })]);
+    expect(problem).toBe(
+      'tracker/tasks/task-1 - a-task.md: open task has 2 size labels — exactly one is required'
+    );
+  });
+
+  it('flags an open task with no area label', () => {
+    const [problem] = checkTaskTriage([task({ labels: ['size:M'] })]);
+    expect(problem).toBe(
+      'tracker/tasks/task-1 - a-task.md: open task has no area label (area:<package-or-domain>)'
+    );
+  });
+
+  it('flags an open task whose priority is absent or off the allowed set', () => {
+    expect(checkTaskTriage([task({ priority: '' })])).toEqual([
+      "tracker/tasks/task-1 - a-task.md: open task has priority '' — must be high | medium | low",
+    ]);
+    expect(checkTaskTriage([task({ priority: 'urgent' })])).toEqual([
+      "tracker/tasks/task-1 - a-task.md: open task has priority 'urgent' — must be high | medium | low",
+    ]);
+  });
+
+  it('exempts Done tasks entirely — finished work awaiting archive', () => {
+    expect(checkTaskTriage([task({ status: 'Done', labels: [], priority: '' })])).toEqual([]);
+  });
+
+  it('reports every problem on a single task, not just the first', () => {
+    const problems = checkTaskTriage([task({ labels: [], priority: '' })]);
+    expect(problems).toHaveLength(3);
+    expect(problems.join('\n')).toContain('no size label');
+    expect(problems.join('\n')).toContain('no area label');
+    expect(problems.join('\n')).toContain('must be high | medium | low');
+  });
+});
 
 describe('runBacklogLint', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;

--- a/packages/tooling/src/dev/backlogLint.ts
+++ b/packages/tooling/src/dev/backlogLint.ts
@@ -12,6 +12,11 @@
  *    search, and the aging surface — the same content-destroying failure the
  *    old markdown table had (a merged row hid a real item for a month), so it
  *    gates rather than warns.
+ *  - `tracker/tasks/` triage: every OPEN task carries the labels
+ *    `06-backlog.md` requires at filing — at least one `area:*`, exactly one
+ *    `size:S|M|L`, and a high/medium/low priority. Those three fields are what
+ *    every selection query filters on, so an unlabelled task is filed into a
+ *    blind spot. Done tasks are exempt: they're finished work awaiting archive.
  *
  * Run via `pnpm ops backlog`. Exits non-zero on a structural problem so it can
  * gate in `pnpm quality` and CI. This is a binary "is the layout in sync?"
@@ -26,7 +31,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import chalk from 'chalk';
-import { loadTrackerTasks } from './trackerTasks.js';
+import { loadTrackerTasks, openTasks, type TrackerTask } from './trackerTasks.js';
 
 /** @internal Exported for testing */
 export interface SectionCap {
@@ -119,10 +124,51 @@ function checkQueueDocRefs(rootDir: string): string[] {
     .map(ref => `queue.md: dangling doc reference → ${ref} (no tracker/docs/ file)`);
 }
 
+const SIZE_LABEL_PATTERN = /^size:[SML]$/;
+const AREA_LABEL_PREFIX = 'area:';
+const VALID_PRIORITIES = new Set(['high', 'medium', 'low']);
+
+/**
+ * Triage completeness on the open pool: area label, size label, priority.
+ *
+ * `06-backlog.md` requires all three at filing, and they are exactly the axes
+ * the selection queries filter on (`-l area:x`, `-l size:S --priority high`) —
+ * a task missing any of them is filed somewhere no query looks. Enforcing it
+ * here converts the filing rule from memory-dependent to structural.
+ *
+ * Only open tasks are checked; a Done task is finished work waiting on the
+ * archive sweep, and back-filling labels onto it buys nothing.
+ * @internal Exported for testing
+ */
+export function checkTaskTriage(tasks: TrackerTask[]): string[] {
+  const problems: string[] = [];
+  for (const task of openTasks(tasks)) {
+    const sizeLabels = task.labels.filter(label => SIZE_LABEL_PATTERN.test(label));
+    if (sizeLabels.length === 0) {
+      problems.push(`${task.file}: open task has no size label (size:S | size:M | size:L)`);
+    } else if (sizeLabels.length > 1) {
+      problems.push(
+        `${task.file}: open task has ${sizeLabels.length} size labels — exactly one is required`
+      );
+    }
+    if (!task.labels.some(label => label.startsWith(AREA_LABEL_PREFIX))) {
+      problems.push(`${task.file}: open task has no area label (area:<package-or-domain>)`);
+    }
+    if (!VALID_PRIORITIES.has(task.priority)) {
+      problems.push(
+        `${task.file}: open task has priority '${task.priority}' — must be high | medium | low`
+      );
+    }
+  }
+  return problems;
+}
+
 function reportProblems(problems: string[]): void {
   if (problems.length === 0) {
     console.log(
-      chalk.green('✓ Backlog layout in sync (caps respected, links resolve, tracker store parses)')
+      chalk.green(
+        '✓ Backlog layout in sync (caps respected, links resolve, tracker store parses, open tasks triaged)'
+      )
     );
     return;
   }
@@ -134,15 +180,20 @@ function reportProblems(problems: string[]): void {
 
 /**
  * CLI entry point. Sets a non-zero exit code on any structural problem (cap
- * exceeded, dangling doc reference, unreadable tracker task).
+ * exceeded, dangling doc reference, unreadable tracker task, untriaged open
+ * task).
  */
 export async function runBacklogLint(options: LintOptions = {}): Promise<void> {
   const rootDir = options.rootDir ?? process.cwd();
 
+  // A task that failed to parse is already in `problems` and absent from
+  // `tasks`, so the triage check never double-reports it.
+  const { tasks, problems: trackerProblems } = loadTrackerTasks(rootDir);
   const problems = [
     ...checkNowCaps(rootDir),
     ...checkQueueDocRefs(rootDir),
-    ...loadTrackerTasks(rootDir).problems,
+    ...trackerProblems,
+    ...checkTaskTriage(tasks),
   ];
   reportProblems(problems);
 

--- a/packages/tooling/src/dev/check-deferred-refs.test.ts
+++ b/packages/tooling/src/dev/check-deferred-refs.test.ts
@@ -30,6 +30,7 @@ function task(id: string, title: string, body: string, status = 'To Do'): Tracke
     status,
     createdDate: '2026-05-16',
     labels: [],
+    priority: 'medium',
     body,
     file: `tracker/tasks/${id.toLowerCase()} - sample.md`,
   };

--- a/packages/tooling/src/dev/trackerTasks.test.ts
+++ b/packages/tooling/src/dev/trackerTasks.test.ts
@@ -72,6 +72,37 @@ describe('parseTaskFile', () => {
     }
   });
 
+  it('parses the priority field, defaulting to empty string when absent', () => {
+    const withPriority = parseTaskFile(
+      frontmatter([
+        'id: TASK-2',
+        "title: 'Prioritized'",
+        'status: To Do',
+        "created_date: '2026-06-01 00:00'",
+        'priority: high',
+      ]),
+      'tracker/tasks/t.md'
+    );
+    expect(withPriority.ok).toBe(true);
+    if (withPriority.ok) {
+      expect(withPriority.task.priority).toBe('high');
+    }
+
+    const without = parseTaskFile(
+      frontmatter([
+        'id: TASK-3',
+        "title: 'Unprioritized'",
+        'status: To Do',
+        "created_date: '2026-06-01 00:00'",
+      ]),
+      'tracker/tasks/t.md'
+    );
+    expect(without.ok).toBe(true);
+    if (without.ok) {
+      expect(without.task.priority).toBe('');
+    }
+  });
+
   it('rejects a file with no frontmatter block', () => {
     const result = parseTaskFile('just prose, no frontmatter', 'tracker/tasks/broken.md');
     expect(result).toEqual({ ok: false, problem: 'tracker/tasks/broken.md: no frontmatter block' });
@@ -157,6 +188,7 @@ describe('openTasks', () => {
       status,
       createdDate: '2026-06-01',
       labels: [],
+      priority: 'medium',
       body: '',
       file: `tracker/tasks/${id}.md`,
     });

--- a/packages/tooling/src/dev/trackerTasks.ts
+++ b/packages/tooling/src/dev/trackerTasks.ts
@@ -33,6 +33,8 @@ export interface TrackerTask {
   /** Filing date (YYYY-MM-DD) — the aging anchor. Null when unparseable. */
   createdDate: string | null;
   labels: string[];
+  /** Priority from frontmatter ('high' | 'medium' | 'low'); empty string when absent */
+  priority: string;
   /** Markdown body after the frontmatter block */
   body: string;
   /** Path of the task file relative to the repo root */
@@ -116,6 +118,7 @@ export function parseTaskFile(content: string, file: string): TaskParseResult {
       status: asString(record.status) ?? '',
       createdDate,
       labels: parseLabels(record.labels),
+      priority: asString(record.priority) ?? '',
       body: content.slice(frontmatter[0].length),
       file,
     },


### PR DESCRIPTION
## Why

`06-backlog.md` requires area + size + priority at filing, but the rule had no enforcement point — a sizing audit today found ~30 open tasks filed over the past month with no `area:` and/or `size:` label, invisible to every selection query (the digest's per-area counts, `-l size:S --priority high` drains). Per `00-critical.md` § Fix Recurring Failures Structurally, a violated rule gets a gate, not a louder rule.

## What

- `trackerTasks.ts`: `TrackerTask` gains a `priority` field parsed from frontmatter (empty string when absent).
- `backlogLint.ts`: new `checkTaskTriage` — every **open** task must carry ≥1 `area:*` label, exactly one `size:S|M|L` label, and a `high`/`medium`/`low` priority. Done tasks are exempt (finished work awaiting archive). Wired into `runBacklogLint`, so it gates everywhere `pnpm ops backlog` already runs: `pnpm quality`, the CI lint job, and the docs-only pre-push path.
- `05-tooling.md`: the lint's description updated (both the bash-block comment and the prose paragraph).
- Tests: 7 new `checkTaskTriage` cases (clean pass, missing/duplicate size, missing area, bad priority, Done exemption, multi-problem reporting), priority-parse cases in `trackerTasks.test.ts`, and `priority` added to the three test fixture builders the interface change touches.

## Verified

- `pnpm --filter @tzurot/tooling test`: 1876 passed. Full `pnpm test`: 26/26 packages green. `pnpm quality`: green (sequential).
- `pnpm ops backlog` passes on the live store — all 310 open tasks were backfilled in two prior develop commits (`9e6b6907c`, `3c61b191e`) so the gate lands on a clean pool with no grandfathering logic.
- `pnpm ops backlog:digest` unaffected (shares the parser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)