### PR TITLE
feat(ai-worker): correlate enrichment-drop warns with requestId

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
@@ -109,7 +109,8 @@ export class GenerationStep implements IPipelineStep {
       const conversationContext = buildConversationContext(
         jobContext,
         preparedContext,
-        preprocessing
+        preprocessing,
+        requestId
       );
 
       // Get recent assistant messages for cross-turn duplicate detection

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.test.ts
@@ -9,6 +9,9 @@ import { MessageRole } from '@tzurot/common-types/constants/message';
 import { type LLMGenerationJobData } from '@tzurot/common-types/types/jobs';
 import type { PreparedContext, PreprocessingResults } from '../types.js';
 
+/** Correlation id the job payload carries alongside (not inside) its context. */
+const TEST_REQUEST_ID = 'req-test-0001';
+
 function createMinimalJobContext(): LLMGenerationJobData['context'] {
   return {
     kind: 'envelope',
@@ -31,7 +34,7 @@ describe('buildConversationContext', () => {
     const jobContext = createMinimalJobContext();
     const prepared = createMinimalPreparedContext();
 
-    const result = buildConversationContext(jobContext, prepared, undefined);
+    const result = buildConversationContext(jobContext, prepared, undefined, TEST_REQUEST_ID);
 
     expect(result.userId).toBe('user-123');
     expect(result.userName).toBe('TestUser');
@@ -47,9 +50,23 @@ describe('buildConversationContext', () => {
     const jobContext = { ...createMinimalJobContext(), triggerMessageId: '810000000000000042' };
     const prepared = createMinimalPreparedContext();
 
-    const result = buildConversationContext(jobContext, prepared, undefined);
+    const result = buildConversationContext(jobContext, prepared, undefined, TEST_REQUEST_ID);
 
     expect(result.triggerMessageId).toBe('810000000000000042');
+  });
+
+  it('forwards the requestId that travels beside the job context', () => {
+    // The correlation seam: requestId lives on the job payload's top level, not
+    // inside its context, so this hop is the only thing that puts it where the
+    // renderer's enrichment-drop warnings can read it.
+    const result = buildConversationContext(
+      createMinimalJobContext(),
+      createMinimalPreparedContext(),
+      undefined,
+      'req-correlation-9'
+    );
+
+    expect(result.requestId).toBe('req-correlation-9');
   });
 
   it('should include preprocessed attachments when present', () => {
@@ -68,7 +85,7 @@ describe('buildConversationContext', () => {
       referenceAttachments: {},
     };
 
-    const result = buildConversationContext(jobContext, prepared, preprocessing);
+    const result = buildConversationContext(jobContext, prepared, preprocessing, TEST_REQUEST_ID);
 
     expect(result.preprocessedAttachments).toHaveLength(1);
     expect(result.preprocessedAttachments?.[0].description).toBe('A sunset');
@@ -83,7 +100,7 @@ describe('buildConversationContext', () => {
       referenceAttachments: {},
     };
 
-    const result = buildConversationContext(jobContext, prepared, preprocessing);
+    const result = buildConversationContext(jobContext, prepared, preprocessing, TEST_REQUEST_ID);
 
     expect(result.preprocessedAttachments).toBeUndefined();
   });
@@ -96,7 +113,7 @@ describe('buildConversationContext', () => {
     };
     const prepared = createMinimalPreparedContext();
 
-    const result = buildConversationContext(jobContext, prepared, undefined);
+    const result = buildConversationContext(jobContext, prepared, undefined, TEST_REQUEST_ID);
 
     expect(result.activePersonaGuildInfo).toEqual({
       roles: ['Admin'],
@@ -124,7 +141,7 @@ describe('buildConversationContext', () => {
       },
     ];
 
-    const result = buildConversationContext(jobContext, prepared, undefined);
+    const result = buildConversationContext(jobContext, prepared, undefined, TEST_REQUEST_ID);
 
     expect(result.crossChannelHistory).toHaveLength(1);
     expect(result.crossChannelHistory?.[0].channelEnvironment.type).toBe('dm');
@@ -143,7 +160,8 @@ describe('buildConversationContext', () => {
       const result = buildConversationContext(
         jobContext,
         createMinimalPreparedContext(),
-        undefined
+        undefined,
+        TEST_REQUEST_ID
       );
 
       expect(result.summonAnonymity).toEqual({
@@ -160,7 +178,8 @@ describe('buildConversationContext', () => {
       const result = buildConversationContext(
         jobContext,
         createMinimalPreparedContext(),
-        undefined
+        undefined,
+        TEST_REQUEST_ID
       );
 
       expect(result.summonAnonymity).toEqual({ kind: 'incognito' });
@@ -176,7 +195,8 @@ describe('buildConversationContext', () => {
       const result = buildConversationContext(
         jobContext,
         createMinimalPreparedContext(),
-        undefined
+        undefined,
+        TEST_REQUEST_ID
       );
 
       expect(result.summonAnonymity).toEqual({
@@ -194,7 +214,8 @@ describe('buildConversationContext', () => {
       const result = buildConversationContext(
         jobContext,
         createMinimalPreparedContext(),
-        undefined
+        undefined,
+        TEST_REQUEST_ID
       );
 
       expect(result.summonAnonymity).toEqual({ kind: 'incognito' });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
@@ -10,11 +10,18 @@ import { resolveSummonAnonymity } from '@tzurot/common-types/types/summon-anonym
 import type { ConversationContext } from '../../../../services/ConversationalRAGTypes.js';
 import type { PreparedContext, PreprocessingResults } from '../types.js';
 
-/** Build the conversation context for RAG service */
+/**
+ * Build the conversation context for RAG service.
+ *
+ * `requestId` is a separate parameter because it lives on the job payload's
+ * top level, not inside `job.data.context` — it travels with the context only
+ * so downstream warnings can name the producing request.
+ */
 export function buildConversationContext(
   jobContext: LLMGenerationJobData['context'],
   preparedContext: PreparedContext,
-  preprocessing: PreprocessingResults | undefined
+  preprocessing: PreprocessingResults | undefined,
+  requestId: string
 ): ConversationContext {
   // Resolve the personal-vs-incognito union once here so the memory consumers
   // (LTM read/write skip) switch on `summonAnonymity.kind` instead of each
@@ -36,6 +43,7 @@ export function buildConversationContext(
   });
   return {
     userId: jobContext.userId,
+    requestId,
     userName: jobContext.userName,
     userTimezone: jobContext.userTimezone,
     channelId: jobContext.channelId,

--- a/services/ai-worker/src/services/ConversationInputProcessor.test.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.test.ts
@@ -340,6 +340,39 @@ describe('ConversationInputProcessor', () => {
       expect(result.referencedMessagesDescriptions).toBe('<references>formatted</references>');
     });
 
+    it("forwards the context's requestId so the formatter's warnings are correlated", async () => {
+      // Pure correlation, but it crosses a mocked seam: the formatter's
+      // enrichment-drop warnings identify the request that paid for the lost
+      // vision/transcription work, and dropping this hop makes them anonymous
+      // without changing a single rendered byte.
+      const referencedMessages: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'msg1',
+          discordUserId: 'user1',
+          authorUsername: 'user1',
+          authorDisplayName: 'User One',
+          content: 'Referenced content',
+          embeds: '',
+          timestamp: '2025-01-01T00:00:00Z',
+          locationContext: '<location/>',
+        },
+      ];
+      const context = createMockContext({ referencedMessages, requestId: 'req-input-5' });
+
+      await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
+
+      expect(mockReferencedMessageFormatter.formatReferencedMessages).toHaveBeenCalledWith(
+        referencedMessages,
+        mockPersonality,
+        false,
+        undefined,
+        expect.objectContaining({ requestId: 'req-input-5' })
+      );
+    });
+
     it("forwards the formatter's durable references verbatim", async () => {
       // The hop between building a reference and writing it down. A test that
       // only checked the prompt XML would pass with this dropped, and the

--- a/services/ai-worker/src/services/ConversationInputProcessor.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.ts
@@ -155,6 +155,9 @@ export class ConversationInputProcessor {
                 context.rawConversationHistory ?? [],
                 personality.displayName
               ),
+              // Correlation only: the formatter's enrichment-drop warnings name
+              // the request that paid for the lost vision/transcription work.
+              requestId: context.requestId,
             }
           )
         : undefined;

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -73,6 +73,16 @@ export interface DiscordEnvironment {
 
 export interface ConversationContext {
   userId: string;
+  /**
+   * Correlation id of the job that produced this turn, threaded from the job
+   * payload so renderer-level warnings (dropped paid enrichment, unkeyable
+   * enrichment) name the producing request instead of forcing timestamp
+   * archaeology across the pipeline's logs. Never a semantic input to
+   * generation — nothing downstream may branch on it. Optional so tests and
+   * non-job callers need not supply one; absent means the warn simply carries
+   * no correlation id.
+   */
+  requestId?: string;
   channelId?: string;
   serverId?: string;
   sessionId?: string;

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -1860,14 +1860,57 @@ describe('ReferencedMessageFormatter', () => {
                 contentType: 'video/mp4',
                 size: 1000,
               },
-            },
+            } satisfies ProcessedAttachment,
           ],
-        }
+        },
+        // The correlation id the warning is close to useless without: the counts
+        // say enrichment was lost, this says which request lost it.
+        { requestId: 'req-dropped-7' }
       );
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ referenceNumber: 1, renderable: 1, rendered: 0 }),
+        expect.objectContaining({
+          requestId: 'req-dropped-7',
+          referenceNumber: 1,
+          renderable: 1,
+          rendered: 0,
+        }),
         expect.stringContaining('not reaching the prompt')
+      );
+    });
+
+    it('forwards the request id to the durable writer, so its keyless warn is correlated too', async () => {
+      // The seam this pins is the formatter → toStoredReference hop: the second
+      // warning about lost paid work lives inside the durable writer, and a
+      // correlation id that reaches only the renderer's own warn leaves that one
+      // anonymous. Modelled on the reachable shape — a transcription result the
+      // dependency step could not key by URL (`originalUrl: ''`), which renders
+      // fine for this turn and cannot be persisted for the next.
+      await formatter.formatReferencedMessages(
+        [refWithImage({ isDeduplicated: true, attachments: undefined })],
+        mockPersonality,
+        false,
+        {
+          1: [
+            {
+              type: AttachmentType.Audio,
+              description: TRANSCRIPT_SENTINEL,
+              originalUrl: '',
+              metadata: {
+                url: '',
+                name: 'voice-message.ogg',
+                contentType: 'audio/ogg',
+                size: 1000,
+              },
+            } satisfies ProcessedAttachment,
+          ],
+        },
+        { requestId: 'req-keyless-11' }
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: 'req-keyless-11', kind: 'voice' }),
+        expect.stringContaining('no attachment URL')
       );
     });
 

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -53,7 +53,9 @@ const CONTEXTUAL_REFERENCES_INSTRUCTION = `<instruction>Messages the user's curr
  * transcription independently. `allPersonalityNames` (personalities seen in the
  * visible history) enables the sibling-persona quote demotion in `deriveRefRole`
  * — without it a sibling's stamped-assistant quote renders as the responding
- * persona's own line. All fields optional — legacy callers degrade.
+ * persona's own line. `requestId` is pure correlation: it never changes what is
+ * rendered, it only lets this module's warnings name the request whose paid
+ * enrichment went missing. All fields optional — legacy callers degrade.
  */
 interface ReferenceVisionAuth {
   userApiKey?: string;
@@ -61,6 +63,7 @@ interface ReferenceVisionAuth {
   visionProvider?: AIProvider;
   visionModel?: string;
   allPersonalityNames?: Set<string>;
+  requestId?: string;
 }
 
 /**
@@ -248,7 +251,7 @@ export class ReferencedMessageFormatter {
       // built rather than as rendered: the stub subtracts content for THIS
       // turn's prompt, but replay decides dedup for itself and needs the whole
       // reference to decide from.
-      durable.push(toStoredReference(ref, built));
+      durable.push(toStoredReference(ref, built, apiKeys?.requestId));
 
       // Search text comes from the PRE-projection reference: the stub's prose
       // marker and its truncation are prompt-shaping, not semantic content.
@@ -353,7 +356,8 @@ export class ReferencedMessageFormatter {
       this.warnOnDroppedEnrichment(
         ref.referenceNumber,
         countAvailableEnrichment(preprocessedForRef),
-        countRenderedEnrichment(attachments)
+        countRenderedEnrichment(attachments),
+        apiKeys?.requestId
       );
       return attachments;
     }
@@ -393,15 +397,21 @@ export class ReferencedMessageFormatter {
    * static text and has nowhere to go by design (`RenderableFile` carries no
    * enrichment slot), so it is excluded from the denominator rather than
    * reported as purchased work that went missing.
+   *
+   * `requestId` carries the correlation the alert is useless without: the
+   * counts say enrichment was lost, and the id says which request lost it, so
+   * the producing job's own logs are one query away rather than a timestamp
+   * search. Undefined for callers that thread no correlation id.
    */
   private warnOnDroppedEnrichment(
     referenceNumber: number,
     available: number,
-    rendered: number
+    rendered: number,
+    requestId: string | undefined
   ): void {
     if (available > rendered) {
       logger.warn(
-        { referenceNumber, renderable: available, rendered },
+        { requestId, referenceNumber, renderable: available, rendered },
         '[ReferencedMessageFormatter] Preprocessed reference enrichment was not rendered — ' +
           'vision/transcription work was paid for and is not reaching the prompt'
       );

--- a/services/ai-worker/src/services/prompt/storedReference.test.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.test.ts
@@ -99,15 +99,18 @@ describe('toStoredReference', () => {
     // the deduped path's orphan tail. Persisting it would write a row nothing
     // at replay could ever correlate — a key that matches every attachment or
     // none, depending on the reader.
-    const stored = toStoredReference(liveRef(), [
-      { url: '', attachment: { kind: 'voice', filename: 'x.ogg', description: 'orphaned' } },
-    ]);
+    const stored = toStoredReference(
+      liveRef(),
+      [{ url: '', attachment: { kind: 'voice', filename: 'x.ogg', description: 'orphaned' } }],
+      'req-keyless-3'
+    );
 
     expect(stored.attachmentEnrichment).toBeUndefined();
     // Silence is the habit this change exists to break: it reached the prompt
-    // and will not survive replay, so the log is the only place that shows up.
+    // and will not survive replay, so the log is the only place that shows up —
+    // carrying the request id, or the log names no owner for the lost work.
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: 'voice', filename: 'x.ogg' }),
+      expect.objectContaining({ requestId: 'req-keyless-3', kind: 'voice', filename: 'x.ogg' }),
       expect.stringContaining('no attachment URL')
     );
   });

--- a/services/ai-worker/src/services/prompt/storedReference.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.ts
@@ -49,10 +49,14 @@ const logger = createLogger('StoredReference');
  * - the derived `role` — `authorRole` is stored raw instead, because the
  *   sibling-persona demotion depends on which personalities are visible in the
  *   replaying turn's history, not this one's.
+ *
+ * `requestId` is not stored and never shapes the row: it exists only so the
+ * keyless-enrichment warning below can name the request that lost the work.
  */
 export function toStoredReference(
   ref: ReferencedMessage,
-  built: BuiltAttachment[]
+  built: BuiltAttachment[],
+  requestId?: string
 ): StoredReferencedMessage {
   return {
     discordMessageId: ref.discordMessageId,
@@ -66,7 +70,7 @@ export function toStoredReference(
     locationContext: ref.locationContext,
     attachments: ref.attachments,
     isForwarded: ref.isForwarded,
-    attachmentEnrichment: collectEnrichment(built),
+    attachmentEnrichment: collectEnrichment(built, requestId),
   };
 }
 
@@ -82,7 +86,10 @@ export function toStoredReference(
  * "never computed" (retryable), and an empty array would read as "computed,
  * found nothing".
  */
-function collectEnrichment(built: BuiltAttachment[]): AttachmentEnrichment[] | undefined {
+function collectEnrichment(
+  built: BuiltAttachment[],
+  requestId?: string
+): AttachmentEnrichment[] | undefined {
   const entries = built.flatMap(({ url, attachment }): AttachmentEnrichment[] => {
     const description = attachmentEnrichment(attachment);
     if (attachment.kind === 'file' || description === undefined || description.length === 0) {
@@ -95,7 +102,7 @@ function collectEnrichment(built: BuiltAttachment[]): AttachmentEnrichment[] | u
       // habit this whole change exists to break. Reachable when a transcription
       // result carries no attachment URL and the processor defaults it to ''.
       logger.warn(
-        { kind: attachment.kind, filename: attachment.filename },
+        { requestId, kind: attachment.kind, filename: attachment.filename },
         'Enrichment has no attachment URL to key it by — reached the prompt, will not survive replay'
       );
       return [];

--- a/tracker/tasks/task-429 - Reference-pipeline-failure-logs-are-uncorrelated-—-consider-a-requestId-bound-child-logger.md
+++ b/tracker/tasks/task-429 - Reference-pipeline-failure-logs-are-uncorrelated-—-consider-a-requestId-bound-child-logger.md
@@ -1,0 +1,23 @@
+---
+id: TASK-429
+title: >-
+  Reference-pipeline failure logs are uncorrelated — consider a requestId-bound
+  child logger
+status: To Do
+assignee: []
+created_date: '2026-08-04 15:00'
+labels:
+  - 'area:ai-worker'
+  - 'size:S'
+dependencies: []
+priority: medium
+ordinal: 429000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Why: the enrichment-drop tripwires now carry requestId, but the three logger.error sites in AttachmentProcessor.ts (attachment processing, image, voice transcription failures) do not. Lower severity than the tripwires — they fire at failure time with err+url — but the same correlation gap.
+Fix shape: rather than threading requestId as a parameter into every helper, evaluate binding it once via a pino child logger at the formatter/processor entry point; that would correlate every log in the path and could later replace the per-param threading.
+Acceptance: failure logs in the reference pipeline carry requestId, or the approach is ruled out with the reason in the removing commit.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## Why

Close-out of the enrichment-traceability follow-up: the runtime tripwires and sentinel test matrix already shipped, but both warn sites logged without any correlation id — a prod firing could only be traced to its producing job by timestamp archaeology. The tracker item explicitly asked for id + count.

## What

- `ConversationContext` gains optional `requestId`, documented as correlation-only (nothing downstream may branch on it).
- `buildConversationContext` takes it as a required 4th param (it lives on the job payload's top level, not inside `job.data.context`); `GenerationStep` passes the already-destructured value.
- Threaded via the formatter's options object into `warnOnDroppedEnrichment` and one layer further into `storedReference.ts`'s keyless-enrichment warn. `requestId` is the id the surrounding pipeline already logs, and it spans the preprocessing and generation jobs of one Discord message, so the warn joins the existing correlation stream.

## Verified

- `pnpm --filter @tzurot/ai-worker test`: 206 files / 4327 tests green; full `pnpm test` 26/26; `pnpm quality` green (sequential).
- Non-triviality checked: reverting either forwarding hop to `undefined` fails 3 tests (the new assertions actually pin the plumbing).
- New seam tests assert across the previously-mocked hops: context-builder → context, processor → formatter options, formatter → stored-reference writer (real, unmocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)