### PR TITLE
feat(bot-client): nightly scheduled real db-sync with owner reporting

### DIFF
--- a/services/bot-client/src/commands/admin/db-sync.test.ts
+++ b/services/bot-client/src/commands/admin/db-sync.test.ts
@@ -12,7 +12,6 @@ import {
   handleDbSync,
   handleDbSyncDetailsButton,
   isDbSyncDetailsButton,
-  buildSyncSummary,
   buildSyncReportText,
 } from './db-sync.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
@@ -352,53 +351,6 @@ describe('handleDbSync', () => {
     expect(context.editReply).toHaveBeenCalledWith({
       content: expect.stringContaining('❌ Database sync failed'),
     });
-  });
-});
-
-describe('buildSyncSummary — embed backstop', () => {
-  it('caps the active-table list at 30 lines with a see-report tail', () => {
-    const stats = Object.fromEntries(
-      Array.from({ length: 35 }, (_, i) => [
-        `table_${i}`,
-        { devToProd: 1, prodToDev: 0, conflicts: 0, deleted: 0 },
-      ])
-    );
-    const summary = buildSyncSummary({ stats }, false);
-
-    expect(summary).toContain('`table_0`:');
-    expect(summary).toContain('`table_29`:');
-    expect(summary).not.toContain('`table_30`:');
-    expect(summary).toContain('…and 5 more — see the report below.');
-  });
-});
-
-describe('buildSyncSummary', () => {
-  it('reports the in-sync state when no table has activity', () => {
-    const summary = buildSyncSummary(
-      {
-        schemaVersion: 'v1',
-        stats: { users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 } },
-      },
-      false
-    );
-
-    expect(summary).toContain('No changes — databases already in sync.');
-  });
-
-  it('appends conflict and deleted suffixes only when nonzero', () => {
-    const summary = buildSyncSummary(
-      {
-        stats: {
-          users: { devToProd: 1, prodToDev: 0, conflicts: 2, deleted: 3 },
-          personas: { devToProd: 4, prodToDev: 0, conflicts: 0, deleted: 0 },
-        },
-      },
-      false
-    );
-
-    expect(summary).toContain('`users`: 1 dev→prod, 0 prod→dev, 2 conflicts, 3 deleted');
-    expect(summary).toContain('`personas`: 4 dev→prod, 0 prod→dev');
-    expect(summary).not.toContain('`personas`: 4 dev→prod, 0 prod→dev,');
   });
 });
 

--- a/services/bot-client/src/commands/admin/db-sync.ts
+++ b/services/bot-client/src/commands/admin/db-sync.ts
@@ -32,112 +32,12 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { escapeFenceBreaks } from '../../utils/fenceEscape.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
+import { buildSyncSummary, type SyncResult, type TableStats } from '../../utils/dbSyncSummary.js';
 import { storeDbSyncReport, fetchDbSyncReport } from './dbSyncReportStore.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { ackUpdate } from '../../ux/render/reply.js';
 
 const logger = createLogger('admin-db-sync');
-
-interface TableStats {
-  devToProd?: number;
-  prodToDev?: number;
-  conflicts?: number;
-  deleted?: number;
-}
-
-interface DeletionDetail {
-  table: string;
-  rowKey: string;
-  target: 'dev' | 'prod';
-}
-
-interface SyncResult {
-  timestamp?: string;
-  schemaVersion?: string;
-  stats?: Record<string, TableStats>;
-  warnings?: string[];
-  info?: string[];
-  deletions?: DeletionDetail[];
-  deletionsTruncated?: boolean;
-}
-
-function sumCounters(stats: Record<string, TableStats>): Required<TableStats> {
-  const totals = { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 };
-  for (const s of Object.values(stats)) {
-    totals.devToProd += s.devToProd ?? 0;
-    totals.prodToDev += s.prodToDev ?? 0;
-    totals.conflicts += s.conflicts ?? 0;
-    totals.deleted += s.deleted ?? 0;
-  }
-  return totals;
-}
-
-function hasActivity(s: TableStats): boolean {
-  return (
-    (s.devToProd ?? 0) > 0 ||
-    (s.prodToDev ?? 0) > 0 ||
-    (s.conflicts ?? 0) > 0 ||
-    (s.deleted ?? 0) > 0
-  );
-}
-
-/** Embed-cap backstop: the active-table list is otherwise unbounded as the
- * synced-table set grows; the chunked follow-up report is the full surface. */
-const ACTIVE_TABLE_LINES_MAX = 30;
-
-/** One `table: N dev→prod, M prod→dev[, ...]` line per table with activity. */
-function buildActiveTableLines(stats: Record<string, TableStats>): string[] {
-  const active = Object.entries(stats).filter(([, s]) => hasActivity(s));
-  if (active.length === 0) {
-    return ['', 'No changes — databases already in sync.'];
-  }
-  const lines = [''];
-  for (const [table, s] of active.slice(0, ACTIVE_TABLE_LINES_MAX)) {
-    const conflicts = (s.conflicts ?? 0) > 0 ? `, ${s.conflicts} conflicts` : '';
-    const deleted = (s.deleted ?? 0) > 0 ? `, ${s.deleted} deleted` : '';
-    lines.push(
-      `\`${table}\`: ${s.devToProd ?? 0} dev→prod, ${s.prodToDev ?? 0} prod→dev${conflicts}${deleted}`
-    );
-  }
-  if (active.length > ACTIVE_TABLE_LINES_MAX) {
-    lines.push(`_…and ${active.length - ACTIVE_TABLE_LINES_MAX} more — see the report below._`);
-  }
-  return lines;
-}
-
-/**
- * The tight embed description: totals line + tables with activity only.
- * Full per-table detail (including quiet tables) lives in the chunked
- * follow-up report, so the embed can never outgrow Discord's description cap.
- */
-export function buildSyncSummary(result: SyncResult, dryRun: boolean): string {
-  const lines: string[] = [];
-
-  if (result.schemaVersion !== undefined && result.schemaVersion.length > 0) {
-    lines.push(`**Schema Version**: \`${result.schemaVersion}\``);
-  }
-
-  const stats = result.stats ?? {};
-  const tableCount = Object.keys(stats).length;
-  if (tableCount > 0) {
-    const totals = sumCounters(stats);
-    lines.push(
-      '',
-      `**${tableCount} tables** · ${totals.devToProd} dev→prod · ${totals.prodToDev} prod→dev · ${totals.conflicts} conflicts · ${totals.deleted} deleted`
-    );
-    lines.push(...buildActiveTableLines(stats));
-  }
-
-  const warningCount = result.warnings?.length ?? 0;
-  if (warningCount > 0) {
-    lines.push('', `⚠️ ${warningCount} warning(s) — full list in the report below`);
-  }
-  if (dryRun) {
-    lines.push('', '*Dry run — no changes were applied.*');
-  }
-
-  return lines.join('\n');
-}
 
 /** The `## Per-table stats` section — every table, active or not. Fixed-width
  * rows in a code fence: Discord doesn't render markdown pipe-tables, and the

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -72,6 +72,10 @@ import {
   stopRetentionNagScheduler,
 } from './services/RetentionNagScheduler.js';
 import {
+  startNightlyDbSyncScheduler,
+  stopNightlyDbSyncScheduler,
+} from './services/NightlyDbSyncScheduler.js';
+import {
   validateDiscordToken,
   validateRedisUrl,
   validateInternalServiceSecret,
@@ -465,6 +469,11 @@ client.once(Events.ClientReady, () => {
   // restart-friendly cadence; nothing purges automatically in Phase 2).
   startRetentionNagScheduler(client, services.cacheRedis);
 
+  // Daily REAL dev↔prod sync — silent when already in agreement, owner-channel
+  // summary when rows moved. Its Redis cooldown gates the sync itself (not just
+  // the post); see NightlyDbSyncScheduler for that inversion.
+  startNightlyDbSyncScheduler(client, services.cacheRedis);
+
   // Restore saved bot presence from Redis
   void restoreBotPresence(client).catch(err => logger.warn({ err }, 'Failed to restore presence'));
 
@@ -539,6 +548,7 @@ async function disposeBotClient(): Promise<void> {
     stopVerificationCleanupScheduler();
     stopSecretRotationNagScheduler();
     stopRetentionNagScheduler();
+    stopNightlyDbSyncScheduler();
     // ioredis Redis#disconnect is synchronous (returns void) — kept outside
     // the awaited Promise.all because there's no Promise to await.
     services.cacheRedis.disconnect();

--- a/services/bot-client/src/services/NightlyDbSyncScheduler.test.ts
+++ b/services/bot-client/src/services/NightlyDbSyncScheduler.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the nightly db-sync scheduler's run cycle.
+ *
+ * The seam that matters most here is the dbSync call itself: this scheduler
+ * writes to prod, so the options it forwards (real sync, no schema-skew
+ * override — the manual command's defaults) are asserted directly rather than
+ * inferred from the embed it produces.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Client } from 'discord.js';
+import type { Redis } from 'ioredis';
+
+const mockDbSync = vi.fn();
+vi.mock('../utils/gatewayClients.js', () => ({
+  getOwnerClient: () => ({ dbSync: mockDbSync }),
+}));
+
+// vi.hoisted: the module under test calls createIntervalScheduler at import
+// time, so plain consts would not be initialized when the factory runs.
+const { mockSchedulerStart, mockSchedulerStop } = vi.hoisted(() => ({
+  mockSchedulerStart: vi.fn(),
+  mockSchedulerStop: vi.fn(),
+}));
+vi.mock('../utils/intervalScheduler.js', () => ({
+  createIntervalScheduler: () => ({ start: mockSchedulerStart, stop: mockSchedulerStop }),
+}));
+
+// Mutable so the boot-guard tests can vary the configured owner id per case.
+let mockOwnerId: string | undefined = '123456789012345678';
+vi.mock('@tzurot/common-types/config/config', () => ({
+  getConfig: () => ({ BOT_OWNER_ID: mockOwnerId }),
+}));
+
+const mockPostOwnerChannelEmbed = vi.fn();
+vi.mock('../utils/ownerChannel.js', () => ({
+  postOwnerChannelEmbed: (...args: unknown[]) => mockPostOwnerChannelEmbed(...args),
+}));
+
+import {
+  runNightlyDbSync,
+  startNightlyDbSyncScheduler,
+  stopNightlyDbSyncScheduler,
+} from './NightlyDbSyncScheduler.js';
+
+const QUIET_STATS = { users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 } };
+const BUSY_STATS = {
+  users: { devToProd: 3, prodToDev: 1, conflicts: 0, deleted: 0 },
+  personas: { devToProd: 0, prodToDev: 0, conflicts: 2, deleted: 5 },
+};
+
+function okResult(stats: Record<string, Record<string, number>>, warnings: string[] = []): unknown {
+  return {
+    ok: true,
+    data: {
+      success: true,
+      timestamp: '2026-07-11T00:00:00.000Z',
+      schemaVersion: '20260710230428_add_sync_tombstones',
+      stats,
+      warnings,
+      info: [],
+      deletions: [],
+      deletionsTruncated: false,
+    },
+  };
+}
+
+function makeRedis(cooldownValue: string | null): Redis {
+  return {
+    get: vi.fn().mockResolvedValue(cooldownValue),
+    setex: vi.fn().mockResolvedValue('OK'),
+  } as unknown as Redis;
+}
+
+/** The rendered description of the single posted embed. */
+function postedDescription(): string {
+  const [, embed] = mockPostOwnerChannelEmbed.mock.calls[0] as [Client, { data: unknown }];
+  const { description } = embed.data as { description?: string };
+  return description ?? '';
+}
+
+function postedTitle(): string {
+  const [, embed] = mockPostOwnerChannelEmbed.mock.calls[0] as [Client, { data: unknown }];
+  const { title } = embed.data as { title?: string };
+  return title ?? '';
+}
+
+const client = {} as Client;
+
+describe('startNightlyDbSyncScheduler boot guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOwnerId = '123456789012345678';
+  });
+
+  it('starts the interval scheduler when an owner id is configured', () => {
+    startNightlyDbSyncScheduler(client, makeRedis(null));
+
+    expect(mockSchedulerStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to start when BOT_OWNER_ID is unset (warn once, not a daily failure post)', () => {
+    mockOwnerId = undefined;
+
+    startNightlyDbSyncScheduler(client, makeRedis(null));
+
+    expect(mockSchedulerStart).not.toHaveBeenCalled();
+  });
+
+  it('refuses to start when BOT_OWNER_ID is an empty string (same emptiness test as getOwnerClient)', () => {
+    mockOwnerId = '';
+
+    startNightlyDbSyncScheduler(client, makeRedis(null));
+
+    expect(mockSchedulerStart).not.toHaveBeenCalled();
+  });
+
+  it('stop delegates to the interval scheduler', () => {
+    stopNightlyDbSyncScheduler();
+
+    expect(mockSchedulerStop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('NightlyDbSyncScheduler runNightlyDbSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockPostOwnerChannelEmbed.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('runs a REAL sync with the manual command defaults', async () => {
+    mockDbSync.mockResolvedValue(okResult(QUIET_STATS));
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    // Seam assertion: dryRun MUST be false (a dry run would report work it
+    // never did) and the skew override MUST stay off, matching /admin db-sync.
+    expect(mockDbSync).toHaveBeenCalledWith({ dryRun: false, allowSchemaSkew: false });
+  });
+
+  it('arms the daily cooldown before calling the gateway (deploys must not re-sync)', async () => {
+    mockDbSync.mockResolvedValue(okResult(QUIET_STATS));
+    const redis = makeRedis(null);
+
+    await runNightlyDbSync(client, redis);
+
+    expect(redis.setex).toHaveBeenCalledWith(
+      'nightly-db-sync:cooldown',
+      23 * 60 * 60,
+      expect.any(String)
+    );
+    const setexOrder = (redis.setex as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(setexOrder).toBeLessThan(mockDbSync.mock.invocationCallOrder[0]);
+  });
+
+  it('does NOT sync at all while the cooldown key exists', async () => {
+    const redis = makeRedis('2026-07-15T00:00:00.000Z');
+
+    await runNightlyDbSync(client, redis);
+
+    expect(mockDbSync).not.toHaveBeenCalled();
+    expect(redis.setex).not.toHaveBeenCalled();
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+  });
+
+  it('posts NOTHING when the sync moved no rows', async () => {
+    mockDbSync.mockResolvedValue(okResult(QUIET_STATS));
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+  });
+
+  it('posts a warning embed when a zero-change sync carries warnings (quiet-failure shape)', async () => {
+    mockDbSync.mockResolvedValue(okResult(QUIET_STATS, ['deletion propagation skipped: users']));
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(postedTitle()).toContain('completed with warnings');
+    expect(postedDescription()).toContain('1 warning(s)');
+  });
+
+  it('posts an owner-channel summary carrying the per-table counts when rows moved', async () => {
+    mockDbSync.mockResolvedValue(okResult(BUSY_STATS));
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(postedTitle()).toContain('Nightly database sync applied changes');
+    const description = postedDescription();
+    expect(description).toContain(
+      '**2 tables** · 3 dev→prod · 1 prod→dev · 2 conflicts · 5 deleted'
+    );
+    expect(description).toContain('`users`: 3 dev→prod, 1 prod→dev');
+    expect(description).toContain('`personas`: 0 dev→prod, 0 prod→dev, 2 conflicts, 5 deleted');
+    // A real run must never render the dry-run disclaimer.
+    expect(description).not.toContain('Dry run');
+  });
+
+  it('posts a failure embed on an error result, carrying status and message', async () => {
+    mockDbSync.mockResolvedValue({
+      ok: false,
+      kind: 'http',
+      status: 503,
+      error: 'schema version mismatch',
+    });
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(postedTitle()).toContain('Nightly database sync failed');
+    expect(postedDescription()).toContain('HTTP 503');
+    expect(postedDescription()).toContain('schema version mismatch');
+  });
+
+  it('posts a failure embed when the call throws, and never rethrows', async () => {
+    mockDbSync.mockRejectedValue(new Error('gateway unreachable'));
+
+    await expect(runNightlyDbSync(client, makeRedis(null))).resolves.toBeUndefined();
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(postedTitle()).toContain('Nightly database sync failed');
+    expect(postedDescription()).toContain('gateway unreachable');
+  });
+
+  it('neutralizes fence breaks in provider error text before embedding it', async () => {
+    mockDbSync.mockResolvedValue({
+      ok: false,
+      kind: 'http',
+      status: 500,
+      error: 'broke the fence ``` and spilled',
+    });
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    // The raw triple-backtick run must not survive into the description —
+    // Discord closes a fence at ANY ``` occurrence, mid-line included.
+    // escapeFenceBreaks interleaves zero-width spaces, written as explicit
+    // escapes because the character is invisible in source.
+    expect(postedDescription()).toContain('broke the fence `\u200b`\u200b` and spilled');
+  });
+
+  it('posts a failure embed when the cooldown read itself throws', async () => {
+    const redis = {
+      get: vi.fn().mockRejectedValue(new Error('redis down')),
+      setex: vi.fn(),
+    } as unknown as Redis;
+
+    await expect(runNightlyDbSync(client, redis)).resolves.toBeUndefined();
+
+    expect(mockDbSync).not.toHaveBeenCalled();
+    expect(postedDescription()).toContain('redis down');
+  });
+});

--- a/services/bot-client/src/services/NightlyDbSyncScheduler.ts
+++ b/services/bot-client/src/services/NightlyDbSyncScheduler.ts
@@ -1,0 +1,169 @@
+/**
+ * Nightly DB Sync Scheduler
+ *
+ * Runs the same REAL dev↔prod sync that `/admin db-sync` runs by hand, once
+ * per day, unattended. Silent when the databases are already in agreement;
+ * posts an owner-channel summary when rows actually moved or the sync raised
+ * warnings, and an owner-channel failure notice when the call fails.
+ *
+ * Cadence design — one deliberate inversion of the nag schedulers. Those run
+ * a CHEAP check every tick and use the Redis cooldown to rate-limit the POST.
+ * Here the tick's action IS the expensive, consequential step: a real sync
+ * that writes to both databases. So the cooldown gates the SYNC itself and is
+ * armed BEFORE the call — bot-client restarts on every deploy, and without
+ * that ordering a deploy-heavy day would fire a real sync per deploy, and a
+ * crash loop would fire one per restart. The cost of arming first is that a
+ * process death mid-sync skips that day's run, which is the right trade for
+ * an operation that writes to prod.
+ *
+ * The cadence is once per day anchored to process start, not to a wall-clock
+ * hour — the same property every scheduler here has. "Nightly" is the budget,
+ * not a guaranteed 03:00.
+ */
+
+import { EmbedBuilder, type Client } from 'discord.js';
+import type { Redis } from 'ioredis';
+import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { escapeFenceBreaks } from '../utils/fenceEscape.js';
+import { getOwnerClient } from '../utils/gatewayClients.js';
+import { createIntervalScheduler } from '../utils/intervalScheduler.js';
+import { postOwnerChannelEmbed } from '../utils/ownerChannel.js';
+import {
+  buildSyncSummary,
+  hasSyncChanges,
+  sumSyncCounters,
+  type SyncResult,
+} from '../utils/dbSyncSummary.js';
+
+const logger = createLogger('nightly-db-sync');
+
+const SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const STARTUP_DELAY_MS = 60_000;
+/**
+ * At most one real sync per day, across restarts. Deliberately a little under
+ * the 24h interval so ordinary tick jitter can never make a scheduled run land
+ * inside its own previous cooldown and skip a day.
+ */
+const SYNC_COOLDOWN_SECONDS = 23 * 60 * 60;
+const COOLDOWN_KEY = 'nightly-db-sync:cooldown';
+
+/**
+ * The scheduled run mirrors `/admin db-sync`'s defaults exactly: a real sync
+ * (never a dry run — a dry run would report work it never did), and no schema
+ * -skew override, so a migration-soak window fails loudly here just as it does
+ * for the manual command.
+ */
+const SCHEDULED_SYNC_OPTIONS = { dryRun: false, allowSchemaSkew: false } as const;
+
+const scheduler = createIntervalScheduler<[Client, Redis]>({
+  intervalMs: SYNC_INTERVAL_MS,
+  startupDelayMs: STARTUP_DELAY_MS,
+  logger,
+  run: (client, redis) => runNightlyDbSync(client, redis),
+});
+
+/**
+ * Start the daily sync (call once from the composition root). Refuses to start
+ * without a configured owner id: every `/api/admin/*` call is gated on the
+ * actor header matching it, so an unconfigured deployment could only ever
+ * produce a daily rejection.
+ */
+export function startNightlyDbSyncScheduler(client: Client, redis: Redis): void {
+  const ownerId = getConfig().BOT_OWNER_ID;
+  // Same emptiness test as getOwnerClient — an empty string would pass a bare
+  // undefined check, start the scheduler, and turn a config gap into a daily
+  // failure post instead of one boot-time warn.
+  if (ownerId === undefined || ownerId.length === 0) {
+    logger.warn('BOT_OWNER_ID is not configured — nightly db-sync will not run');
+    return;
+  }
+  scheduler.start(client, redis);
+}
+
+/** Stop the scheduler (graceful shutdown). */
+export function stopNightlyDbSyncScheduler(): void {
+  scheduler.stop();
+}
+
+/**
+ * Owner-channel embed for a sync worth reporting. Rows moving is the normal
+ * reportable outcome; warnings WITHOUT row movement (a failed deletion
+ * propagation, a partial skip) are the quieter failure shape and get warning
+ * framing — an unattended job that lets those pass silently is how a sync
+ * degrades for weeks before anyone notices.
+ */
+function buildNightlySyncEmbed(result: SyncResult, rowsMoved: boolean): EmbedBuilder {
+  return new EmbedBuilder()
+    .setColor(rowsMoved ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.WARNING)
+    .setTitle(
+      rowsMoved
+        ? '🌙 Nightly database sync applied changes'
+        : '⚠️ Nightly database sync completed with warnings'
+    )
+    .setDescription(buildSyncSummary(result, false))
+    .setFooter({ text: 'Full per-table report: /admin db-sync' })
+    .setTimestamp();
+}
+
+/** Owner-channel embed for a failed sync. */
+function buildNightlySyncFailureEmbed(reason: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setColor(DISCORD_COLORS.ERROR)
+    .setTitle('❌ Nightly database sync failed')
+    .setDescription(reason)
+    .setFooter({ text: 'Retry by hand: /admin db-sync' })
+    .setTimestamp();
+}
+
+/** Exported for tests — one full sync cycle. */
+export async function runNightlyDbSync(client: Client, redis: Redis): Promise<void> {
+  try {
+    // Cooldown FIRST, and armed before the call — see the cadence note above.
+    const cooling = await redis.get(COOLDOWN_KEY);
+    if (cooling !== null) {
+      logger.info({ since: cooling }, 'Nightly sync already ran within the cooldown window');
+      return;
+    }
+    await redis.setex(COOLDOWN_KEY, SYNC_COOLDOWN_SECONDS, new Date().toISOString());
+
+    const result = await getOwnerClient().dbSync(SCHEDULED_SYNC_OPTIONS);
+
+    if (!result.ok) {
+      logger.error({ status: result.status, error: result.error }, 'Nightly db sync failed');
+      await postOwnerChannelEmbed(
+        client,
+        buildNightlySyncFailureEmbed(
+          `The scheduled sync did not complete (HTTP ${String(result.status)}):\n\`\`\`\n${escapeFenceBreaks(result.error)}\n\`\`\``
+        )
+      );
+      return;
+    }
+
+    const stats = result.data.stats;
+    const totals = sumSyncCounters(stats);
+    const rowsMoved = hasSyncChanges(stats);
+    const warningCount = result.data.warnings?.length ?? 0;
+
+    // Silent only when nothing moved AND nothing warned: a "nothing happened"
+    // post every night trains the owner to ignore the channel, but a
+    // warnings-only result is the quiet failure shape and must surface.
+    if (!rowsMoved && warningCount === 0) {
+      logger.info({ tableCount: Object.keys(stats).length }, 'Nightly sync applied no changes');
+      return;
+    }
+
+    await postOwnerChannelEmbed(client, buildNightlySyncEmbed(result.data, rowsMoved));
+    logger.info({ ...totals, warningCount }, 'Nightly sync reportable — posted owner summary');
+  } catch (error) {
+    logger.error({ err: error }, 'Nightly db sync threw');
+    // postOwnerChannelEmbed never throws, so this stays inside the swallow.
+    await postOwnerChannelEmbed(
+      client,
+      buildNightlySyncFailureEmbed(
+        `The scheduled sync threw before completing: \`${escapeFenceBreaks(error instanceof Error ? error.message : String(error))}\``
+      )
+    );
+  }
+}

--- a/services/bot-client/src/utils/dbSyncSummary.test.ts
+++ b/services/bot-client/src/utils/dbSyncSummary.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the shared db-sync response interpretation + summary rendering.
+ *
+ * The `buildSyncSummary` cases moved here verbatim when the renderer was
+ * extracted from the `/admin db-sync` handler so the nightly scheduler could
+ * share it; `hasSyncChanges` / `sumSyncCounters` are the scheduler-facing
+ * additions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildSyncSummary, hasSyncChanges, sumSyncCounters } from './dbSyncSummary.js';
+
+describe('buildSyncSummary — embed backstop', () => {
+  it('caps the active-table list at 30 lines with a see-report tail', () => {
+    const stats = Object.fromEntries(
+      Array.from({ length: 35 }, (_, i) => [
+        `table_${i}`,
+        { devToProd: 1, prodToDev: 0, conflicts: 0, deleted: 0 },
+      ])
+    );
+    const summary = buildSyncSummary({ stats }, false);
+
+    expect(summary).toContain('`table_0`:');
+    expect(summary).toContain('`table_29`:');
+    expect(summary).not.toContain('`table_30`:');
+    expect(summary).toContain('…and 5 more — see the report below.');
+  });
+});
+
+describe('buildSyncSummary', () => {
+  it('reports the in-sync state when no table has activity', () => {
+    const summary = buildSyncSummary(
+      {
+        schemaVersion: 'v1',
+        stats: { users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 } },
+      },
+      false
+    );
+
+    expect(summary).toContain('No changes — databases already in sync.');
+  });
+
+  it('appends conflict and deleted suffixes only when nonzero', () => {
+    const summary = buildSyncSummary(
+      {
+        stats: {
+          users: { devToProd: 1, prodToDev: 0, conflicts: 2, deleted: 3 },
+          personas: { devToProd: 4, prodToDev: 0, conflicts: 0, deleted: 0 },
+        },
+      },
+      false
+    );
+
+    expect(summary).toContain('`users`: 1 dev→prod, 0 prod→dev, 2 conflicts, 3 deleted');
+    expect(summary).toContain('`personas`: 4 dev→prod, 0 prod→dev');
+    expect(summary).not.toContain('`personas`: 4 dev→prod, 0 prod→dev,');
+  });
+});
+
+describe('sumSyncCounters', () => {
+  it('adds every counter across tables, defaulting missing ones to zero', () => {
+    expect(
+      sumSyncCounters({
+        users: { devToProd: 1, prodToDev: 2, conflicts: 3, deleted: 4 },
+        personas: { devToProd: 10 },
+      })
+    ).toEqual({ devToProd: 11, prodToDev: 2, conflicts: 3, deleted: 4 });
+  });
+
+  it('returns all zeros for an empty stats map', () => {
+    expect(sumSyncCounters({})).toEqual({
+      devToProd: 0,
+      prodToDev: 0,
+      conflicts: 0,
+      deleted: 0,
+    });
+  });
+});
+
+describe('hasSyncChanges', () => {
+  it('is false for an empty stats map', () => {
+    expect(hasSyncChanges({})).toBe(false);
+  });
+
+  it('is false when every counter on every table is zero', () => {
+    expect(
+      hasSyncChanges({
+        users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 },
+        personas: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 },
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    ['devToProd', { devToProd: 1 }],
+    ['prodToDev', { prodToDev: 1 }],
+    ['conflicts', { conflicts: 1 }],
+    ['deleted', { deleted: 1 }],
+  ])('is true when only %s moved', (_label, stats) => {
+    expect(hasSyncChanges({ users: stats })).toBe(true);
+  });
+
+  it('agrees with the summary renderer: false exactly when it prints the in-sync line', () => {
+    const quiet = { users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 } };
+    const busy = { users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 2 } };
+
+    expect(hasSyncChanges(quiet)).toBe(false);
+    expect(buildSyncSummary({ stats: quiet }, false)).toContain('No changes');
+    expect(hasSyncChanges(busy)).toBe(true);
+    expect(buildSyncSummary({ stats: busy }, false)).not.toContain('No changes');
+  });
+});

--- a/services/bot-client/src/utils/dbSyncSummary.ts
+++ b/services/bot-client/src/utils/dbSyncSummary.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared interpretation + summary rendering for db-sync responses.
+ *
+ * Two surfaces consume a sync response — the `/admin db-sync` slash command
+ * (interactive, either mode) and the nightly scheduler (real sync, unattended)
+ * — so the "did anything move?" predicate and the summary text live here
+ * rather than in either consumer. The full report renderer stays with the
+ * command: it exists to back the command's own "Show details" button.
+ *
+ * The `SyncResult` view is deliberately lenient (every field optional) so the
+ * render guards read naturally; the tightened `DbSyncResponse` is structurally
+ * assignable to it, so consumers annotate rather than assert.
+ */
+
+export interface TableStats {
+  devToProd?: number;
+  prodToDev?: number;
+  conflicts?: number;
+  deleted?: number;
+}
+
+interface DeletionDetail {
+  table: string;
+  rowKey: string;
+  target: 'dev' | 'prod';
+}
+
+export interface SyncResult {
+  timestamp?: string;
+  schemaVersion?: string;
+  stats?: Record<string, TableStats>;
+  warnings?: string[];
+  info?: string[];
+  deletions?: DeletionDetail[];
+  deletionsTruncated?: boolean;
+}
+
+export function sumSyncCounters(stats: Record<string, TableStats>): Required<TableStats> {
+  const totals = { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 };
+  for (const s of Object.values(stats)) {
+    totals.devToProd += s.devToProd ?? 0;
+    totals.prodToDev += s.prodToDev ?? 0;
+    totals.conflicts += s.conflicts ?? 0;
+    totals.deleted += s.deleted ?? 0;
+  }
+  return totals;
+}
+
+function hasActivity(s: TableStats): boolean {
+  return (
+    (s.devToProd ?? 0) > 0 ||
+    (s.prodToDev ?? 0) > 0 ||
+    (s.conflicts ?? 0) > 0 ||
+    (s.deleted ?? 0) > 0
+  );
+}
+
+/**
+ * True when any table moved, resolved, or deleted a row. Deliberately the
+ * SAME condition that decides the summary's "No changes — databases already
+ * in sync." line, so an unattended run stays silent exactly when the
+ * interactive run would have rendered that line.
+ */
+export function hasSyncChanges(stats: Record<string, TableStats>): boolean {
+  return Object.values(stats).some(hasActivity);
+}
+
+/** Embed-cap backstop: the active-table list is otherwise unbounded as the
+ * synced-table set grows; the chunked follow-up report is the full surface. */
+const ACTIVE_TABLE_LINES_MAX = 30;
+
+/** One `table: N dev→prod, M prod→dev[, ...]` line per table with activity. */
+function buildActiveTableLines(stats: Record<string, TableStats>): string[] {
+  const active = Object.entries(stats).filter(([, s]) => hasActivity(s));
+  if (active.length === 0) {
+    return ['', 'No changes — databases already in sync.'];
+  }
+  const lines = [''];
+  for (const [table, s] of active.slice(0, ACTIVE_TABLE_LINES_MAX)) {
+    const conflicts = (s.conflicts ?? 0) > 0 ? `, ${s.conflicts} conflicts` : '';
+    const deleted = (s.deleted ?? 0) > 0 ? `, ${s.deleted} deleted` : '';
+    lines.push(
+      `\`${table}\`: ${s.devToProd ?? 0} dev→prod, ${s.prodToDev ?? 0} prod→dev${conflicts}${deleted}`
+    );
+  }
+  if (active.length > ACTIVE_TABLE_LINES_MAX) {
+    lines.push(`_…and ${active.length - ACTIVE_TABLE_LINES_MAX} more — see the report below._`);
+  }
+  return lines;
+}
+
+/**
+ * The tight embed description: totals line + tables with activity only.
+ * Full per-table detail (including quiet tables) lives in the chunked
+ * follow-up report, so the embed can never outgrow Discord's description cap.
+ */
+export function buildSyncSummary(result: SyncResult, dryRun: boolean): string {
+  const lines: string[] = [];
+
+  if (result.schemaVersion !== undefined && result.schemaVersion.length > 0) {
+    lines.push(`**Schema Version**: \`${result.schemaVersion}\``);
+  }
+
+  const stats = result.stats ?? {};
+  const tableCount = Object.keys(stats).length;
+  if (tableCount > 0) {
+    const totals = sumSyncCounters(stats);
+    lines.push(
+      '',
+      `**${tableCount} tables** · ${totals.devToProd} dev→prod · ${totals.prodToDev} prod→dev · ${totals.conflicts} conflicts · ${totals.deleted} deleted`
+    );
+    lines.push(...buildActiveTableLines(stats));
+  }
+
+  const warningCount = result.warnings?.length ?? 0;
+  if (warningCount > 0) {
+    lines.push('', `⚠️ ${warningCount} warning(s) — full list in the report below`);
+  }
+  if (dryRun) {
+    lines.push('', '*Dry run — no changes were applied.*');
+  }
+
+  return lines.join('\n');
+}

--- a/services/bot-client/src/utils/gatewayClients.test.ts
+++ b/services/bot-client/src/utils/gatewayClients.test.ts
@@ -22,6 +22,7 @@ vi.mock('@tzurot/common-types/config/config', async () => {
     getConfig: () => ({
       GATEWAY_URL: 'http://localhost:3000',
       INTERNAL_SERVICE_SECRET: 'test-service-secret',
+      BOT_OWNER_ID: '999888777666555444',
     }),
   };
 });
@@ -34,6 +35,7 @@ import {
   clientsFor,
   clientsForUser,
   getServiceClient,
+  getOwnerClient,
   toGatewayUser,
   isGatewayConfigured,
 } from './gatewayClients.js';
@@ -149,6 +151,36 @@ describe('getServiceClient', () => {
     }));
     const mod = await import('./gatewayClients.js');
     expect(() => mod.getServiceClient()).toThrow('GATEWAY_URL');
+    vi.doUnmock('@tzurot/common-types/config/config');
+    vi.doUnmock('../startup.js');
+  });
+});
+
+describe('getOwnerClient', () => {
+  // No-interaction factory for scheduled owner-scoped maintenance. The gateway
+  // gates /api/admin/* on the actor header, so the configured owner id is the
+  // only actor this can mint.
+  it('returns an OwnerClient actored as the configured bot owner', () => {
+    const client = getOwnerClient();
+
+    expect(client).toBeInstanceOf(OwnerClient);
+    expect(client.actor).toBe('999888777666555444');
+  });
+
+  it('throws when BOT_OWNER_ID is unset (the call could only be rejected)', async () => {
+    vi.resetModules();
+    vi.doMock('@tzurot/common-types/config/config', async () => {
+      const actual = await vi.importActual('@tzurot/common-types/config/config');
+      return {
+        ...actual,
+        getConfig: () => ({ GATEWAY_URL: 'http://localhost:3000', BOT_OWNER_ID: undefined }),
+      };
+    });
+    vi.doMock('../startup.js', () => ({
+      getValidatedServiceSecret: () => 'test-service-secret',
+    }));
+    const mod = await import('./gatewayClients.js');
+    expect(() => mod.getOwnerClient()).toThrow('BOT_OWNER_ID');
     vi.doUnmock('@tzurot/common-types/config/config');
     vi.doUnmock('../startup.js');
   });

--- a/services/bot-client/src/utils/gatewayClients.ts
+++ b/services/bot-client/src/utils/gatewayClients.ts
@@ -150,3 +150,23 @@ export function getServiceClient(): ServiceClient {
     serviceSecret: getValidatedServiceSecret(),
   });
 }
+
+/**
+ * Build an `OwnerClient` for `/api/admin/*` calls made outside any Discord
+ * interaction (scheduled background maintenance). The gateway gates those
+ * routes on the actor header matching the configured bot owner, so
+ * `BOT_OWNER_ID` is the ONLY valid actor here — there is no user to read one
+ * from. Throws when it is unset, same fail-fast shape as a missing
+ * `GATEWAY_URL`: without an owner id the call could only ever be rejected.
+ */
+export function getOwnerClient(): OwnerClient {
+  const ownerId = getConfig().BOT_OWNER_ID;
+  if (ownerId === undefined || ownerId.length === 0) {
+    throw new Error('BOT_OWNER_ID is not configured');
+  }
+  return new OwnerClient({
+    baseUrl: getGatewayBaseUrl(),
+    serviceSecret: getValidatedServiceSecret(),
+    actor: asActor(ownerId),
+  });
+}


### PR DESCRIPTION
## Why

Owner-requested fast follow: db-sync currently runs only on demand via `/admin db-sync`; the owner approved running the real sync nightly. Semantics confirmed this session: real sync (not dry-run), silent no-op, report when reportable.

## What

- `NightlyDbSyncScheduler` on the vetted `createIntervalScheduler` shape (daily + startup firing), registered at boot beside the retention scheduler, stopped in `disposeBotClient`.
- **Cooldown inversion (deliberate)**: unlike the nag schedulers where the cooldown rate-limits the post, here the 23h Redis cooldown gates the sync itself and is armed BEFORE the call — bot-client restarts on every deploy, and without this a deploy-heavy day fires a real prod sync per deploy. Cost: a process death mid-sync skips that day (next day retries).
- Posting policy: silent when zero changes AND zero warnings; success-framed summary when rows moved; **warning-framed post when a zero-change sync carries warnings** (failed deletion propagation etc. — the quiet-failure shape); failure embed on error/throw.
- `getOwnerClient()`: admin routes are owner-actor gated and there's no interaction to read an actor from, so the factory mints the configured `BOT_OWNER_ID` and fails fast when unset; the scheduler also refuses to start (boot warn) on a missing/empty owner id rather than producing daily failure posts.
- Sync options mirror the slash command's defaults exactly (`dryRun: false, allowSchemaSkew: false`) — nothing widened.
- `buildSyncSummary` + types extracted verbatim to `utils/dbSyncSummary.ts`, shared by the command and the scheduler; command behavior byte-identical, its tests moved unmodified.

## Verified

- `pnpm --filter @tzurot/bot-client test` green (391 files / 6059 tests at worker handoff; 9 scheduler tests after review additions), full `pnpm test` 26/26, `pnpm quality` green (sequential).
- Seam-asserted: dbSync called with the exact manual-command defaults; cooldown `setex` invocation-ordered BEFORE the dbSync call; no-post on quiet result; warning post on warnings-only; failure post on error result, throw, and Redis-read failure.
- Orchestrator review added: warnings-only escalation (was silent per original spec — the reviewer-of-record decision is warnings must surface on an unattended job) and the empty-string owner-id boot guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)