### PR TITLE
fix(ai-worker): retry when the model echoes the user message as its reply

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
@@ -154,6 +154,7 @@ export class GenerationStep implements IPipelineStep {
         response,
         duplicateRetries,
         emptyRetries,
+        echoRetries,
         leakedThinkingRetries,
         effectiveProviderUsed,
         quotaFallback: reactiveQuotaFallback,
@@ -204,7 +205,14 @@ export class GenerationStep implements IPipelineStep {
 
       const processingTimeMs = Date.now() - startTime;
       logger.info(
-        { jobId: job.id, processingTimeMs, duplicateRetries, emptyRetries, leakedThinkingRetries },
+        {
+          jobId: job.id,
+          processingTimeMs,
+          duplicateRetries,
+          emptyRetries,
+          echoRetries,
+          leakedThinkingRetries,
+        },
         'Generation completed'
       );
 

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   shouldRetryEmptyResponse,
+  shouldRetryEchoResponse,
   logDuplicateDetection,
   logRetryEscalation,
   logRetrySuccess,
@@ -98,6 +99,96 @@ describe('shouldRetryEmptyResponse', () => {
       jobId: 'test-job',
     });
     expect(result).toBe('retry');
+  });
+});
+
+describe('shouldRetryEchoResponse', () => {
+  // Long enough to clear the echo check's minimum-length gate.
+  const USER_MESSAGE =
+    'Tell me about the garden you were describing yesterday, the one behind the old chapel.';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return "retry" when the content is an exact echo of the user message', () => {
+    const response = createMockResponse(USER_MESSAGE);
+    const result = shouldRetryEchoResponse({
+      response,
+      userMessage: USER_MESSAGE,
+      attempt: 1,
+      maxAttempts: 3,
+      jobId: 'test-job',
+    });
+    expect(result).toBe('retry');
+  });
+
+  it('should return "return" when the echo persists on the final attempt', () => {
+    const response = createMockResponse(USER_MESSAGE);
+    const result = shouldRetryEchoResponse({
+      response,
+      userMessage: USER_MESSAGE,
+      attempt: 3,
+      maxAttempts: 3,
+      jobId: 'test-job',
+    });
+    expect(result).toBe('return');
+  });
+
+  it('should return "retry" for a near-identical echo above the similarity threshold', () => {
+    // Same text with the terminal punctuation swapped — well above 0.85.
+    const response = createMockResponse(USER_MESSAGE.replace(/\.$/, '!'));
+    const result = shouldRetryEchoResponse({
+      response,
+      userMessage: USER_MESSAGE,
+      attempt: 1,
+      maxAttempts: 3,
+      jobId: 'test-job',
+    });
+    expect(result).toBe('retry');
+  });
+
+  it('should retry an echo that also carries reasoning content', () => {
+    // The reasoning-holds-the-reply signature: thinking content does not
+    // exempt the response from the echo gate.
+    const response = createMockResponse(USER_MESSAGE, 'The character would answer warmly...');
+    const result = shouldRetryEchoResponse({
+      response,
+      userMessage: USER_MESSAGE,
+      attempt: 1,
+      maxAttempts: 3,
+      jobId: 'test-job',
+    });
+    expect(result).toBe('retry');
+  });
+
+  it('should return "continue" when a SHORT user message is echoed back', () => {
+    // Short inputs can legitimately be repeated as a stylistic reply.
+    const shortMessage = 'goodnight, my dear friend';
+    const response = createMockResponse(shortMessage);
+    const result = shouldRetryEchoResponse({
+      response,
+      userMessage: shortMessage,
+      attempt: 1,
+      maxAttempts: 3,
+      jobId: 'test-job',
+    });
+    expect(result).toBe('continue');
+  });
+
+  it('should return "continue" for a normal reply that is not an echo', () => {
+    const response = createMockResponse(
+      'The chapel garden has gone wild since the frost — the roses climb the wall now, ' +
+        'and nobody prunes them.'
+    );
+    const result = shouldRetryEchoResponse({
+      response,
+      userMessage: USER_MESSAGE,
+      attempt: 1,
+      maxAttempts: 3,
+      jobId: 'test-job',
+    });
+    expect(result).toBe('continue');
   });
 });
 
@@ -282,6 +373,7 @@ describe('logRetrySuccess', () => {
         attempt: 2,
         duplicateRetries: 1,
         emptyRetries: 0,
+        echoRetries: 0,
         leakedThinkingRetries: 0,
       })
     ).not.toThrow();
@@ -295,6 +387,7 @@ describe('logRetrySuccess', () => {
         attempt: 3,
         duplicateRetries: 2,
         emptyRetries: 1,
+        echoRetries: 0,
         leakedThinkingRetries: 0,
       })
     ).not.toThrow();

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
@@ -5,8 +5,13 @@
  * Extracted from GenerationStep to maintain file size limits.
  */
 
+import { stripBotFooters } from '@tzurot/common-types/utils/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { RAGResponse } from '../../../../services/ConversationalRAGTypes.js';
+import {
+  stringSimilarity,
+  DEFAULT_SIMILARITY_THRESHOLD,
+} from '../../../../utils/duplicateDetection.js';
 
 const logger = createLogger('RetryDecisionHelper');
 
@@ -16,7 +21,7 @@ type RetryAction = 'retry' | 'return' | 'continue';
 /** A rejected-but-valid response preserved as a fallback in case later attempts fail entirely */
 export interface FallbackResponse {
   response: RAGResponse;
-  reason: 'empty' | 'duplicate' | 'leaked-thinking';
+  reason: 'empty' | 'duplicate' | 'leaked-thinking' | 'echo';
   attempt: number;
 }
 
@@ -38,20 +43,22 @@ export function restoreThinking(response: RAGResponse, preserved: string | undef
 }
 
 /**
- * Fallback quality ranking: duplicate > leaked-thinking > empty.
+ * Fallback quality ranking: duplicate > leaked-thinking > echo > empty.
  * - duplicate: in-character content, just repeated
  * - leaked-thinking: has content, just wrong kind (raw CoT)
+ * - echo: the user's own words handed back — model-authored nothing, but still text
  * - empty: no content at all
  */
 const FALLBACK_RANK: Record<FallbackResponse['reason'], number> = {
-  duplicate: 2,
-  'leaked-thinking': 1,
+  duplicate: 3,
+  'leaked-thinking': 2,
+  echo: 1,
   empty: 0,
 };
 
 /**
  * Select the better fallback between existing and candidate.
- * Uses quality ranking (duplicate > leaked-thinking > empty).
+ * Uses quality ranking (duplicate > leaked-thinking > echo > empty).
  * At equal rank, prefers the more recent attempt (escalated params).
  */
 export function selectBetterFallback(
@@ -121,6 +128,7 @@ export function logRetrySuccess(opts: {
   attempt: number;
   duplicateRetries: number;
   emptyRetries: number;
+  echoRetries: number;
   leakedThinkingRetries: number;
 }): void {
   logger.info(opts, 'Retry succeeded - got valid unique response');
@@ -133,6 +141,25 @@ interface EmptyResponseCheckOptions {
   maxAttempts: number;
   jobId: string | undefined;
 }
+
+/** Options for echoed-input check */
+interface EchoResponseCheckOptions {
+  response: RAGResponse;
+  /** Text of the user's current turn, as the model received it */
+  userMessage: string;
+  attempt: number;
+  maxAttempts: number;
+  jobId: string | undefined;
+}
+
+/**
+ * Minimum normalized user-message length for the echo check.
+ *
+ * Below this length an echo is not evidence of a misplaced reply: a short input
+ * ("lol", "goodnight") can legitimately be repeated back as a stylistic reply,
+ * and a false-positive retry spends budget and tokens for nothing.
+ */
+const MIN_LENGTH_FOR_ECHO_CHECK = 40;
 
 /** Options for duplicate detection logging */
 interface DuplicateDetectionOptions {
@@ -171,6 +198,82 @@ export function shouldRetryEmptyResponse(opts: EmptyResponseCheckOptions): Retry
     logger.error(
       { jobId, attempt, modelUsed: response.modelUsed, hasThinking, totalAttempts: maxAttempts },
       'All retries produced empty responses.'
+    );
+  }
+
+  return canRetry ? 'retry' : 'return';
+}
+
+/**
+ * Check whether the response is just the user's own message handed back, and
+ * determine the retry action.
+ *
+ * A provider can misplace the actual reply into the reasoning channel and emit
+ * the input verbatim as content. Such a response is non-empty (so the empty
+ * check passes it) and matches no recent ASSISTANT message (so cross-turn
+ * duplicate detection passes it too) — the user ends up receiving their own
+ * words in the character's voice.
+ *
+ * The comparison deliberately reuses the cross-turn detector's synchronous text
+ * layer — same normalization (`stripBotFooters`), same similarity function
+ * (`stringSimilarity`), same threshold (`DEFAULT_SIMILARITY_THRESHOLD`) — so
+ * both gates agree on what "the same text" means.
+ *
+ * `hasThinking` rides the log payload because reasoning-carrying-the-reply is
+ * the diagnostic tell for this failure; it deliberately does NOT gate the
+ * decision. An echo is an echo whether or not reasoning came with it.
+ *
+ * @returns 'continue' if the response is not an echo, 'retry' if can retry, 'return' if exhausted
+ */
+export function shouldRetryEchoResponse(opts: EchoResponseCheckOptions): RetryAction {
+  const { response, userMessage, attempt, maxAttempts, jobId } = opts;
+
+  const cleanUserMessage = stripBotFooters(userMessage);
+  if (cleanUserMessage.length < MIN_LENGTH_FOR_ECHO_CHECK) {
+    return 'continue';
+  }
+
+  const cleanContent = stripBotFooters(response.content);
+  const similarity = stringSimilarity(cleanContent, cleanUserMessage);
+  if (similarity < DEFAULT_SIMILARITY_THRESHOLD) {
+    return 'continue';
+  }
+
+  const canRetry = attempt < maxAttempts;
+  const hasThinking = response.thinkingContent !== undefined && response.thinkingContent !== '';
+
+  // NOTE: Do NOT extract logger methods (e.g., const logFn = logger.warn) as this loses
+  // the `this` context and causes "Cannot read properties of undefined" pino errors.
+  // Also, ESLint requires inline object literals for logger calls.
+  if (canRetry) {
+    logger.warn(
+      {
+        jobId,
+        attempt,
+        modelUsed: response.modelUsed,
+        hasThinking,
+        similarity: similarity.toFixed(3),
+        threshold: DEFAULT_SIMILARITY_THRESHOLD,
+        contentLength: cleanContent.length,
+        userMessageLength: cleanUserMessage.length,
+        totalAttempts: maxAttempts,
+      },
+      'Response echoes the user message. Retrying...'
+    );
+  } else {
+    logger.error(
+      {
+        jobId,
+        attempt,
+        modelUsed: response.modelUsed,
+        hasThinking,
+        similarity: similarity.toFixed(3),
+        threshold: DEFAULT_SIMILARITY_THRESHOLD,
+        contentLength: cleanContent.length,
+        userMessageLength: cleanUserMessage.length,
+        totalAttempts: maxAttempts,
+      },
+      'All retries echoed the user message.'
     );
   }
 

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
@@ -70,6 +70,7 @@ const successResult: GenerateAttemptResult = {
   response: { content: 'ok', retrievedMemories: 0, tokensIn: 1, tokensOut: 1 },
   duplicateRetries: 0,
   emptyRetries: 0,
+  echoRetries: 0,
   leakedThinkingRetries: 0,
 };
 

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
@@ -35,9 +35,10 @@ import { deriveCacheKeyId } from '../../../../services/RateLimitCache.js';
 const logger = createLogger('AutoPromotionFallback');
 
 /**
- * Shape of a single generation attempt — matches the option object
- * `GenerationStep.generateWithDuplicateRetry` accepts. Kept locally rather
- * than imported because it's an internal contract between these two files.
+ * Shape of a single generation attempt — the option object
+ * `generateWithDuplicateRetry` accepts. Single source of the contract:
+ * `duplicateRetry` types its own parameter with this, so the two files
+ * cannot drift by a field.
  */
 export interface GenerateAttemptOpts {
   personality: Parameters<ConversationalRAGService['generateResponse']>[0];
@@ -60,6 +61,7 @@ export interface GenerateAttemptResult {
   response: RAGResponse;
   duplicateRetries: number;
   emptyRetries: number;
+  echoRetries: number;
   leakedThinkingRetries: number;
   /**
    * The provider that actually served the request when it differs from the

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/duplicateRetry.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/duplicateRetry.test.ts
@@ -64,6 +64,27 @@ describe('generateWithDuplicateRetry', () => {
     expect(vi.mocked(ragService.generateResponse)).toHaveBeenCalledTimes(2);
   });
 
+  it('retries an ECHO of the user message and returns the real reply', async () => {
+    // The provider misplaced the reply into the reasoning channel and emitted
+    // the input verbatim as content — non-empty, and unlike any prior
+    // assistant message, so only the echo gate catches it.
+    const userMessage =
+      'Tell me about the garden you were describing yesterday, the one behind the old chapel.';
+    const realReply =
+      'The chapel garden has gone wild since the frost — the roses climb the wall now.';
+    const ragService = ragServiceReturning(ragResponse(userMessage), ragResponse(realReply));
+
+    const result = await generateWithDuplicateRetry(ragService, undefined, {
+      ...baseOpts(),
+      message: userMessage as MessageContent,
+    });
+
+    expect(result.response.content).toBe(realReply);
+    expect(result.echoRetries).toBe(1);
+    expect(result.emptyRetries).toBe(0);
+    expect(vi.mocked(ragService.generateResponse)).toHaveBeenCalledTimes(2);
+  });
+
   it('retries an exact cross-turn DUPLICATE and returns the fresh attempt', async () => {
     // Similarity checking requires >=30 cleaned chars — short strings skip it.
     const dup = 'these are exactly the same words the assistant already said before';

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/duplicateRetry.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/duplicateRetry.ts
@@ -5,24 +5,18 @@
  * recent assistant message, escalating params per attempt.
  */
 
-import { type AIProvider } from '@tzurot/common-types/constants/ai';
 import { RETRY_CONFIG } from '@tzurot/common-types/constants/timing';
-import { type ResolvedConfigOverrides } from '@tzurot/common-types/schemas/api/configOverrides';
-import { type MessageContent } from '@tzurot/common-types/types/ai';
-import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
 import type { ConversationalRAGService } from '../../../../services/ConversationalRAGService.js';
-import type {
-  RAGResponse,
-  ConversationContext,
-} from '../../../../services/ConversationalRAGTypes.js';
+import type { RAGResponse } from '../../../../services/ConversationalRAGTypes.js';
+import type { GenerateAttemptOpts } from './autoPromotionFallback.js';
 import {
   buildRetryConfig,
   type EmbeddingServiceInterface,
 } from '../../../../utils/duplicateDetection.js';
 import { isRecentDuplicateAsync } from '../../../../utils/crossTurnDetection.js';
-import { type DiagnosticCollector } from '../../../../services/DiagnosticCollector.js';
 import {
   shouldRetryEmptyResponse,
+  shouldRetryEchoResponse,
   logDuplicateDetection,
   logRetryEscalation,
   logRetrySuccess,
@@ -43,30 +37,22 @@ const logger = createLogger('duplicateRetry');
  *
  * Retries on:
  * - Empty content after post-processing (e.g., model produced only thinking blocks)
+ * - Content that merely echoes the user's own message back
  * - Duplicate responses matching recent assistant messages (up to 5)
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity, max-lines-per-function, max-statements -- single cohesive retry loop; extracting sub-steps would scatter the state machine across files
 export async function generateWithDuplicateRetry(
   ragService: ConversationalRAGService,
   embeddingService: EmbeddingServiceInterface | undefined,
-  opts: {
-    personality: Parameters<ConversationalRAGService['generateResponse']>[0];
-    message: MessageContent;
-    conversationContext: ConversationContext;
-    recentAssistantMessages: string[];
-    apiKey: string | undefined;
-    sttDispatch: SttDispatch | undefined;
-    isGuestMode: boolean;
-    jobId: string | undefined;
-    diagnosticCollector?: DiagnosticCollector;
-    configOverrides?: ResolvedConfigOverrides;
-    effectiveProvider?: AIProvider;
-    maxLlmAttempts?: number;
-  }
+  // Single-sourced with autoPromotionFallback: both files pass this exact
+  // contract to the same attempt function, and a locally redeclared copy can
+  // drift by one field without the compiler noticing at either end.
+  opts: GenerateAttemptOpts
 ): Promise<{
   response: RAGResponse;
   duplicateRetries: number;
   emptyRetries: number;
+  echoRetries: number;
   leakedThinkingRetries: number;
 }> {
   const {
@@ -84,10 +70,16 @@ export async function generateWithDuplicateRetry(
 
   let duplicateRetries = 0;
   let emptyRetries = 0;
+  let echoRetries = 0;
   let leakedThinkingRetries = 0;
   let preservedThinking: string | undefined;
   let fallback: FallbackResponse | undefined;
   const maxAttempts = RETRY_CONFIG.MAX_ATTEMPTS; // 3 = 1 initial + 2 retries
+
+  // The echo check compares against the user's CURRENT turn. `message` carries
+  // that turn either bare or wrapped alongside reference/attachment metadata;
+  // `content` is the text in both shapes.
+  const userMessageText = typeof message === 'string' ? message : message.content;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     // Reset diagnostic timing to prevent stale end timestamps from a prior
@@ -135,6 +127,7 @@ export async function generateWithDuplicateRetry(
           response: fallback.response,
           duplicateRetries,
           emptyRetries,
+          echoRetries,
           leakedThinkingRetries,
         };
       }
@@ -159,7 +152,30 @@ export async function generateWithDuplicateRetry(
     if (emptyAction === 'return') {
       emptyRetries++;
       restoreThinking(response, preservedThinking);
-      return { response, duplicateRetries, emptyRetries, leakedThinkingRetries };
+      return { response, duplicateRetries, emptyRetries, echoRetries, leakedThinkingRetries };
+    }
+
+    // Echoed input: content that is the user's own message back. Checked after
+    // the empty gate so an empty response keeps reporting as empty. The
+    // reasoning content is deliberately NOT promoted into the reply slot — on a
+    // response whose reasoning holds the real reply, that would publish raw
+    // chain-of-thought as the character's voice.
+    const echoAction = shouldRetryEchoResponse({
+      response,
+      userMessage: userMessageText,
+      attempt,
+      maxAttempts,
+      jobId,
+    });
+    if (echoAction === 'retry') {
+      echoRetries++;
+      fallback = selectBetterFallback(fallback, { response, reason: 'echo', attempt });
+      continue;
+    }
+    if (echoAction === 'return') {
+      echoRetries++;
+      restoreThinking(response, preservedThinking);
+      return { response, duplicateRetries, emptyRetries, echoRetries, leakedThinkingRetries };
     }
 
     // Leaked chain-of-thought (reasoning glitch) — retry with fallback
@@ -189,18 +205,24 @@ export async function generateWithDuplicateRetry(
     );
 
     if (!isDuplicate) {
-      if (duplicateRetries > 0 || emptyRetries > 0 || leakedThinkingRetries > 0) {
+      if (
+        duplicateRetries > 0 ||
+        emptyRetries > 0 ||
+        echoRetries > 0 ||
+        leakedThinkingRetries > 0
+      ) {
         logRetrySuccess({
           jobId,
           modelUsed: response.modelUsed,
           attempt,
           duplicateRetries,
           emptyRetries,
+          echoRetries,
           leakedThinkingRetries,
         });
       }
       restoreThinking(response, preservedThinking);
-      return { response, duplicateRetries, emptyRetries, leakedThinkingRetries };
+      return { response, duplicateRetries, emptyRetries, echoRetries, leakedThinkingRetries };
     }
 
     // Duplicate detected - log and determine action
@@ -216,7 +238,7 @@ export async function generateWithDuplicateRetry(
     });
     if (dupAction === 'return') {
       restoreThinking(response, preservedThinking);
-      return { response, duplicateRetries, emptyRetries, leakedThinkingRetries };
+      return { response, duplicateRetries, emptyRetries, echoRetries, leakedThinkingRetries };
     }
   }
 


### PR DESCRIPTION
## Why

Prod bug (TASK-430, observed 2026-08-04 hitting a real user): glm-4.5-air returned `content` = byte-identical echo of the user's message with the actual in-character reply misplaced into `additional_kwargs.reasoning_content` (`finishReason=stop`, both texts billed). Every existing gate passed it — non-empty (empty check), no assistant-history match (duplicate check) — so the user received their own message back in the character's voice. Sibling of TASK-391's empty-visible quirk on the same model; third distinct failure shape from it.

## What

- `shouldRetryEchoResponse` in `RetryDecisionHelper`, sibling of `shouldRetryEmptyResponse`: compares the post-processed reply against the user's current turn using the cross-turn detector's own text layer — same `stripBotFooters` normalizer, same `stringSimilarity` (Dice bigrams), same exported `DEFAULT_SIMILARITY_THRESHOLD` (0.85) — so both gates agree on what "the same text" means. A 40-char minimum on the normalized user message keeps short stylistic echoes ("lol", "goodnight") from tripping it.
- Wired into the retry loop immediately after the empty check: retry within the existing 3-attempt budget, `'echo'` added to the fallback ranking (`duplicate > leaked-thinking > echo > empty` — an echo is text but the model authored none of it), `echoRetries` threaded through the loop result, auto-promotion result shape, and the completion log.
- Exhausted-case log carries the diagnostic signature (`similarity`, both lengths, `hasThinking`) — reasoning-carrying-the-reply is the tell for this failure class. Reasoning content is deliberately NEVER promoted into the reply slot: on an echo that also carries genuine thinking, that would publish raw chain-of-thought as the character.
- CPD ratchet: the new opts-contract clone was resolved by single-sourcing `GenerateAttemptOpts` (duplicateRetry imports it from autoPromotionFallback instead of redeclaring the same 12-line contract inline — the copy's own comment claimed to "match" the other, which is exactly the drift shape the ratchet exists to catch).

## Verified

- `pnpm --filter @tzurot/ai-worker test`: 206 files / 4334 tests green; full `pnpm test` 26/26; `pnpm quality` green including the CPD ratchet (1803 ≤ 1809 ceiling).
- New tests: 6 decision cases (exact echo retry/exhaust, near-identical, echo-with-reasoning, short-message exemption, normal reply) + a loop-level wiring case (attempt 1 echoes → attempt 2 real reply delivered, `echoRetries: 1`).
- The observed prod payload's shape (324-char echo vs 2,827-char reasoning) scores 1.0 similarity and would have retried on attempt 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)