### PR TITLE
fix(bot-client): raise /inspect reasoning and input chunk caps to 10

### DIFF
--- a/services/bot-client/src/commands/inspect/extendedViews.test.ts
+++ b/services/bot-client/src/commands/inspect/extendedViews.test.ts
@@ -225,7 +225,7 @@ describe('buildInputView', () => {
     expect(text).toContain('### Referenced messages');
     expect(text).toContain('`111`');
     expect(text).toContain('### Memory search query');
-    expect(result.chunkedText?.maxChunks).toBe(3);
+    expect(result.chunkedText?.maxChunks).toBe(10);
     expect(result.chunkedText?.overflowFilename).toBe('input-full.txt');
   });
 

--- a/services/bot-client/src/commands/inspect/extendedViews.ts
+++ b/services/bot-client/src/commands/inspect/extendedViews.ts
@@ -160,7 +160,10 @@ export function buildInputView(
     chunkedText: {
       text: sections.join('\n'),
       continuedHeader: '_(input continued)_\n',
-      maxChunks: 3,
+      // Input carries the full user message plus referenced-message content
+      // and attachment descriptions, so it can legitimately run long — same
+      // never-force-a-download decision as the Reasoning view.
+      maxChunks: 10,
       overflowFilename: 'input-full.txt',
     },
     flags: MessageFlags.Ephemeral,
@@ -271,6 +274,10 @@ export function buildPostProcessingView(
     chunkedText: {
       text: sections.join('\n'),
       continuedHeader: '_(post-processing continued)_\n',
+      // Deliberately lower than the other chunked views: this is a two-version
+      // diff of the same reply (raw vs final), inherently bounded and skimmed
+      // rather than read end-to-end — past 3 chunks the full file is the
+      // better artifact.
       maxChunks: 3,
       overflowFilename: 'post-processing-full.txt',
     },

--- a/services/bot-client/src/commands/inspect/views.test.ts
+++ b/services/bot-client/src/commands/inspect/views.test.ts
@@ -220,6 +220,9 @@ describe('buildReasoningView', () => {
     expect(result.files).toBeUndefined();
     expect(result.chunkedText!.text).toContain('x'.repeat(2500));
     expect(result.chunkedText!.continuedHeader).toContain('reasoning continued');
+    // Owner decision: reading text must never require a download — the cap is
+    // an outlier guard, so pin it rather than letting it silently drop.
+    expect(result.chunkedText!.maxChunks).toBe(10);
   });
 });
 

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -210,15 +210,13 @@ export function buildSystemPromptView(
 // ---------------------------------------------------------------------------
 
 /**
- * Reasoning content, chunked across ephemeral messages.
+ * Reasoning content, rendered inline and chunked across ephemeral messages.
  *
  * The standing owner decision is that reading text must never require a file
- * download. The `maxChunks` cap below does NOT currently honour it: past the
- * cap `sendChunkedReply` sends the overflow as a text-file attachment, so a
- * long reasoning dump still lands as a download. Stated rather than implied
- * because the previous wording ("always inline") read as a guarantee the code
- * thirty lines down contradicts. Raising the cap is the open decision; until
- * then this is the honest description of what happens.
+ * download. The `maxChunks` cap of 10 (~19k chars) covers every realistic
+ * reasoning size, so the attachment overflow tail only fires on pathological
+ * dumps — a 50k-char reasoning flood that would otherwise arrive as ~26
+ * ephemeral messages.
  *
  * Reasoning content is shown to non-owners by design (per project decision —
  * model thinking is genuinely interesting and the user already saw the
@@ -246,9 +244,10 @@ export function buildReasoningView(
     chunkedText: {
       text: `## Reasoning\n\n${thinking}`,
       continuedHeader: '_(reasoning continued)_\n',
-      // A reasoning dump can run tens of chunks — cap the inline flood and
-      // deliver the rest (complete, self-contained) as an attachment tail.
-      maxChunks: 3,
+      // Outlier guard, not the normal reading path: realistic reasoning fits
+      // inline well under this, and only a pathological dump trips the tail
+      // (which then carries the COMPLETE text, self-contained).
+      maxChunks: 10,
       overflowFilename: 'reasoning-full.txt',
     },
     flags: MessageFlags.Ephemeral,

--- a/services/bot-client/src/utils/gatewayClients.ts
+++ b/services/bot-client/src/utils/gatewayClients.ts
@@ -16,6 +16,9 @@
  * - `userClient` — user-callable routes at `/api/user/*`. Always carries
  *   the full Discord user context (id + username + displayName) so the
  *   gateway can provision the row + apply per-user filters.
+ *
+ * Outside an interaction (schedulers, startup tasks), `getOwnerClient()`
+ * mints the owner-actor flavor directly from `BOT_OWNER_ID`.
  */
 
 import type {


### PR DESCRIPTION
## Summary

Resolves the docstring/code contradiction in the `/inspect` Reasoning view (TASK-371): the docstring records the owner decision that reading text must never require a file download, while the code capped inline rendering at 3 chunks and shipped the remainder as `reasoning-full.txt`. Per the recorded owner decision, the cap moves to 10.

- **Reasoning** `maxChunks` 3 → **10** (~19k chars inline) — the attachment overflow tail now only fires on pathological dumps (a 50k flood would otherwise be ~26 ephemeral messages). Docstring rewritten to describe what the code actually does.
- **Input** 3 → **10** — carries the full user message plus referenced-message content and attachment descriptions, so it has the same legitimate-length case.
- **Post-Processing** deliberately **stays 3** — a two-version diff of the same reply, inherently bounded and skimmed rather than read end-to-end; comment added stating the rationale.
- Rider: `gatewayClients.ts` module docblock now mentions `getOwnerClient()` (the outside-an-interaction owner-actor flavor), which the three-flavors list predated.

## Verification

- All three caps are now test-pinned: Input pin updated to 10, Post-Processing pin confirmed at 3, and a new Reasoning pin added (none existed — the unpinned cap is how the contradiction shipped unnoticed).
- `pnpm test` (391 files / 6065 tests in bot-client, all packages green) and `pnpm quality` both pass locally, run sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)