### PR TITLE
perf(ai-worker): memoize eval fact embeddings across scoring passes

### DIFF
--- a/services/ai-worker/src/services/eval/factEquivalence.test.ts
+++ b/services/ai-worker/src/services/eval/factEquivalence.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { LocalEmbeddingService } from '@tzurot/embeddings';
-import { cosineSimilarity, matchFacts, scoreExtraction } from './factEquivalence.js';
+import {
+  cosineSimilarity,
+  matchFacts,
+  scoreExtraction,
+  type EmbeddingSource,
+} from './factEquivalence.js';
 
 /** Deterministic fake embedder: known strings map to fixed orthogonal-ish vectors. */
 function makeEmbeddings(vectors: Record<string, number[]>): LocalEmbeddingService {
@@ -142,5 +147,59 @@ describe('scoreExtraction (source-grounded, methodology v2)', () => {
     expect(score.violationRate).toBe(0);
     expect(score.precision).toBe(1);
     expect(score.recall).toBe(0);
+  });
+});
+
+describe('scoreExtraction embedding memoization', () => {
+  /**
+   * Counting embedder: records every statement it is asked to embed. Resolution
+   * is deferred by a microtask so requests issued in the same tick are genuinely
+   * concurrent — a cache keyed on the RESOLVED vector would miss on those.
+   */
+  function makeCountingSource(): EmbeddingSource & { calls: string[] } {
+    const calls: string[] = [];
+    return {
+      calls,
+      getEmbedding: async (text: string): Promise<Float32Array> => {
+        calls.push(text);
+        await Promise.resolve();
+        return Float32Array.from([text.length, 1, 0]);
+      },
+    };
+  }
+
+  it('embeds each unique statement exactly once across both internal matchFacts passes', async () => {
+    const source = makeCountingSource();
+
+    await scoreExtraction(
+      ['extracted-1', 'extracted-2', 'extracted-3'],
+      ['expected-1', 'expected-2'],
+      ['allowed-1'],
+      source,
+      0.8
+    );
+
+    // Unmemoized this is 11 calls: extracted embedded once per pass (3 × 2),
+    // expectFacts once standalone and once inside the concatenated support
+    // list (2 × 2), plus the single allowed extra.
+    expect(source.calls).toHaveLength(6);
+    expect([...source.calls].sort()).toEqual([
+      'allowed-1',
+      'expected-1',
+      'expected-2',
+      'extracted-1',
+      'extracted-2',
+      'extracted-3',
+    ]);
+  });
+
+  it('dedupes concurrent requests for the same statement', async () => {
+    const source = makeCountingSource();
+
+    // Both copies of the duplicate are requested in the same tick (the matcher
+    // embeds a list with Promise.all), so only a promise-level memo collapses them.
+    await scoreExtraction(['dup', 'dup'], ['expected-1'], [], source, 0.8);
+
+    expect(source.calls).toEqual(['dup', 'expected-1']);
   });
 });

--- a/services/ai-worker/src/services/eval/factEquivalence.ts
+++ b/services/ai-worker/src/services/eval/factEquivalence.ts
@@ -9,10 +9,20 @@
  * scores a match.
  */
 
-import type { LocalEmbeddingService } from '@tzurot/embeddings';
-
 /** Cosine similarity floor for "these two statements express the same fact". */
 export const FACT_EQUIVALENCE_THRESHOLD = 0.8;
+
+/**
+ * The only embedding capability the matcher uses.
+ *
+ * Narrower than `IEmbeddingService` on purpose: the memoizing wrapper below
+ * (and any test fake) satisfies this without implementing the worker-lifecycle
+ * methods the matcher never calls. `LocalEmbeddingService` satisfies it
+ * structurally, so callers keep passing one unchanged.
+ */
+export interface EmbeddingSource {
+  getEmbedding(text: string): Promise<Float32Array | undefined>;
+}
 
 export function cosineSimilarity(a: Float32Array | number[], b: Float32Array | number[]): number {
   let dot = 0;
@@ -47,7 +57,7 @@ export interface MatchResult {
 export async function matchFacts(
   extracted: string[],
   expected: string[],
-  embeddings: LocalEmbeddingService,
+  embeddings: EmbeddingSource,
   threshold = FACT_EQUIVALENCE_THRESHOLD
 ): Promise<MatchResult> {
   if (extracted.length === 0 && expected.length === 0) {
@@ -116,14 +126,19 @@ export async function scoreExtraction(
   extracted: string[],
   expectFacts: string[],
   allowedExtras: string[],
-  embeddings: LocalEmbeddingService,
+  embeddings: EmbeddingSource,
   threshold = FACT_EQUIVALENCE_THRESHOLD
 ): Promise<ExtractionScore> {
-  const recallMatch = await matchFacts(extracted, expectFacts, embeddings, threshold);
+  // Both passes embed every `extracted` statement, and `expectFacts` appears in
+  // both the recall list and the concatenated support list — so one memo shared
+  // across the two calls roughly halves the real model's embedding work.
+  const memo = memoizeEmbeddings(embeddings);
+
+  const recallMatch = await matchFacts(extracted, expectFacts, memo, threshold);
   const supportMatch = await matchFacts(
     extracted,
     [...expectFacts, ...allowedExtras],
-    embeddings,
+    memo,
     threshold
   );
 
@@ -136,6 +151,34 @@ export async function scoreExtraction(
     recall: recallMatch.recall,
     violationRate,
     precision: 1 - violationRate,
+  };
+}
+
+/**
+ * Wraps an embedding source so each unique statement is embedded exactly once.
+ *
+ * The cache holds the PROMISE rather than the resolved vector: the matcher
+ * embeds a whole list with `Promise.all`, so two in-flight requests for the
+ * same statement must share one call instead of both missing an
+ * only-populated-on-resolve cache.
+ *
+ * Scoped to a single scoring call by construction (no module-level cache) —
+ * an eval run over a large golden corpus would otherwise retain every
+ * statement it ever scored, and statements rarely repeat across goldens.
+ */
+function memoizeEmbeddings(source: EmbeddingSource): EmbeddingSource {
+  const inFlight = new Map<string, Promise<Float32Array | undefined>>();
+
+  return {
+    getEmbedding: async (text: string): Promise<Float32Array | undefined> => {
+      const cached = inFlight.get(text);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const pending = source.getEmbedding(text);
+      inFlight.set(text, pending);
+      return pending;
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Closes TASK-245. `scoreExtraction` runs `matchFacts` twice per golden — recall against `expectFacts`, then support against the `expectFacts + allowedExtras` concat — so every extracted statement was embedded twice and every expected statement twice. A per-call promise memo shared across both passes embeds each unique statement exactly once (11 → 6 embedding calls on a 3-extracted / 2-expected / 1-extra golden, ~45% off; matters as the golden corpus grows toward its 100-sample re-open trigger).

- `matchFacts`/`scoreExtraction` now depend on a minimal `EmbeddingSource` structural interface (`getEmbedding` only) instead of the concrete `LocalEmbeddingService` — the wrapper and test fakes satisfy it without stubbing worker-lifecycle methods, and existing callers pass unchanged. (The fatter `IEmbeddingService` was considered and deliberately not used.)
- The memo caches the **promise**, not the resolved vector, so `Promise.all`-concurrent requests for the same statement share one call. Cache is scoped to a single `scoreExtraction` call — no module-global retention across a large eval run.
- Eval-support code only; nothing under `services/ai-worker/src/services/prompt/` touched (pending voice-consistency gate freezes that area).

## Verification

- Two new tests: exactly one `getEmbedding` call per unique statement across both internal passes, and promise-level dedup under concurrency. Both were verified to FAIL with the memo short-circuited (11 calls observed), then pass with it restored.
- Full ai-worker suite 206 files / 4336 tests green; `pnpm test` and `pnpm quality` green locally, run sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)