### PR TITLE
feat(ai-worker): correlate reference-pipeline logs via a request-bound child logger

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
@@ -158,6 +158,11 @@ interface EchoResponseCheckOptions {
  * Below this length an echo is not evidence of a misplaced reply: a short input
  * ("lol", "goodnight") can legitimately be repeated back as a stylistic reply,
  * and a false-positive retry spends budget and tokens for nothing.
+ *
+ * Deliberately stricter than the cross-turn detector's
+ * `MIN_LENGTH_FOR_SIMILARITY_CHECK` (30, in utils/crossTurnDetection.ts): a
+ * false-positive echo retry burns a paid generation, while a false-positive
+ * similarity comparison only affects a free dedup check.
  */
 const MIN_LENGTH_FOR_ECHO_CHECK = 40;
 

--- a/services/ai-worker/src/services/AttachmentProcessor.test.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.test.ts
@@ -12,17 +12,41 @@ import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/perso
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
-const { mockDescribeImage, mockTranscribeAudio, mockGetSystemSetting } = vi.hoisted(() => ({
-  mockDescribeImage: vi.fn(),
-  mockTranscribeAudio: vi.fn(),
-  // Defaults to the registry default (sticker vision ON) so every pre-existing
-  // case behaves exactly as before; only the kill-switch case flips it.
-  mockGetSystemSetting: vi.fn(() => true),
-}));
+const {
+  mockDescribeImage,
+  mockTranscribeAudio,
+  mockGetSystemSetting,
+  mockLogger,
+  mockChildLogger,
+} = vi.hoisted(() => {
+  const child = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return {
+    mockDescribeImage: vi.fn(),
+    mockTranscribeAudio: vi.fn(),
+    // Defaults to the registry default (sticker vision ON) so every pre-existing
+    // case behaves exactly as before; only the kill-switch case flips it.
+    mockGetSystemSetting: vi.fn(() => true),
+    mockChildLogger: child,
+    mockLogger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => child),
+    },
+  };
+});
 
 vi.mock('@tzurot/common-types/services/SystemSettingsService', () => ({
   getSystemSetting: mockGetSystemSetting,
 }));
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return { ...actual, createLogger: () => mockLogger };
+});
 
 // Mock the MultimodalProcessor module
 vi.mock('./MultimodalProcessor.js', () => ({
@@ -666,6 +690,134 @@ describe('AttachmentProcessor', () => {
         contentType: 'audio/mp3',
       });
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestId correlation', () => {
+    // The reason this module logs at all is to explain a reference whose
+    // enrichment went missing, and a failure line nobody can tie back to the
+    // request that produced it is close to unusable. The binding is pure
+    // correlation — nothing below asserts on rendered output, because none of it
+    // changes.
+    const imageOptions = (
+      requestId?: string
+    ): Parameters<typeof processAttachmentsParallel>[0] => ({
+      attachments: [
+        {
+          url: 'https://example.com/broken.png',
+          contentType: 'image/png',
+          name: 'broken.png',
+          size: 1000,
+        },
+      ],
+      referenceNumber: 1,
+      personality: mockPersonality,
+      isGuestMode: false,
+      requestId,
+    });
+
+    it('emits the image failure through a logger bound to the requestId', async () => {
+      mockDescribeImage.mockRejectedValue(new Error('Vision API failed'));
+
+      await processAttachmentsParallel(imageOptions('req-image'));
+
+      expect(mockLogger.child).toHaveBeenCalledWith({ requestId: 'req-image' });
+      expect(mockChildLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ referenceNumber: 1, url: 'https://example.com/broken.png' }),
+        'Image processing failed'
+      );
+      // The unbound module logger must not carry the line — an uncorrelated copy
+      // is the state this change exists to remove.
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('emits the voice failure through the bound logger', async () => {
+      mockTranscribeAudio.mockRejectedValue(new Error('STT failed'));
+
+      await processAttachmentsParallel({
+        attachments: [
+          {
+            url: 'https://example.com/voice.ogg',
+            contentType: 'audio/ogg',
+            name: 'voice.ogg',
+            size: 5000,
+            isVoiceMessage: true,
+            duration: 5,
+          },
+        ],
+        referenceNumber: 2,
+        personality: mockPersonality,
+        isGuestMode: false,
+        requestId: 'req-voice',
+      });
+
+      expect(mockLogger.child).toHaveBeenCalledWith({ requestId: 'req-voice' });
+      expect(mockChildLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ referenceNumber: 2, url: 'https://example.com/voice.ogg' }),
+        'Voice transcription failed'
+      );
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('correlates the fan-out catch, not only the per-modality failures', async () => {
+      // The pre-dispatch throw (same forced shape as the modality-preservation
+      // cases above) is the one failure site OUTSIDE the two helpers, so it is
+      // the one that would silently keep the unbound logger.
+      const exploding = [
+        {
+          type: AttachmentType.Image,
+          description: 'unused',
+          originalUrl: 'https://example.com/other.png',
+          metadata: {
+            url: 'https://example.com/other.png',
+            name: 'other.png',
+            contentType: 'image/png',
+            size: 1,
+          },
+        },
+      ];
+      exploding.find = () => {
+        throw new Error('boom before dispatch');
+      };
+
+      await processAttachmentsParallel({
+        ...imageOptions('req-fanout'),
+        preprocessedAttachments: exploding,
+      });
+
+      expect(mockLogger.child).toHaveBeenCalledWith({ requestId: 'req-fanout' });
+      expect(mockChildLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ referenceNumber: 1, url: 'https://example.com/broken.png' }),
+        'Unexpected error in attachment processing'
+      );
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('threads the bound logger into withRetry so retry warnings correlate too', async () => {
+      // withRetry raises its own warnings between attempts. Those are the lines
+      // that say a paid call was retried, so leaving them on the module logger
+      // would strand exactly the spend evidence next to a correlated failure.
+      mockDescribeImage.mockRejectedValue(new Error('Vision API failed'));
+
+      await processAttachmentsParallel(imageOptions('req-retry'));
+
+      expect(mockChildLogger.warn).toHaveBeenCalled();
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('uses the module logger when no requestId is threaded', async () => {
+      // Legacy callers thread nothing; they must not pay for a child binding and
+      // must keep logging exactly as before.
+      mockDescribeImage.mockRejectedValue(new Error('Vision API failed'));
+
+      await processAttachmentsParallel(imageOptions());
+
+      expect(mockLogger.child).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ referenceNumber: 1, url: 'https://example.com/broken.png' }),
+        'Image processing failed'
+      );
+      expect(mockChildLogger.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/ai-worker/src/services/AttachmentProcessor.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.ts
@@ -6,6 +6,7 @@
  * Extracted from ReferencedMessageFormatter for maintainability.
  */
 
+import type { Logger } from 'pino';
 import { type AIProvider } from '@tzurot/common-types/constants/ai';
 import { RETRY_CONFIG } from '@tzurot/common-types/constants/timing';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
@@ -48,6 +49,8 @@ interface ProcessSingleAttachmentOptions {
   visionProvider?: AIProvider;
   /** Pre-resolved vision model (from `resolveVisionConfig`); honored over `selectVisionModel`. */
   model?: string;
+  /** Logger bound to the request (or the module logger when no id was threaded) */
+  log: Logger;
 }
 
 /**
@@ -67,6 +70,8 @@ interface ProcessImageOptions {
   visionProvider?: AIProvider;
   /** Pre-resolved vision model (from `resolveVisionConfig`); honored over `selectVisionModel`. */
   model?: string;
+  /** Logger bound to the request (or the module logger when no id was threaded) */
+  log: Logger;
 }
 
 /**
@@ -88,6 +93,13 @@ export interface ProcessAttachmentsOptions {
   visionProvider?: AIProvider;
   /** Pre-resolved vision model (from `resolveVisionConfig`); honored over `selectVisionModel`. */
   model?: string;
+  /**
+   * Pure correlation: it never changes what is rendered, it only lets this
+   * module's logs name the request whose attachment enrichment failed. Undefined
+   * for callers that thread no correlation id — those fall back to the module
+   * logger and behave exactly as before.
+   */
+  requestId?: string;
 }
 
 /**
@@ -115,7 +127,12 @@ export async function processAttachmentsParallel(
     loggingContext,
     visionProvider,
     model,
+    requestId,
   } = options;
+  // Bound once and threaded down, so every log this path emits — including the
+  // retry warnings withRetry raises — names the request rather than only the
+  // three failure sites.
+  const log = requestId === undefined ? logger : logger.child({ requestId });
   if (!attachments || attachments.length === 0) {
     return [];
   }
@@ -160,6 +177,7 @@ export async function processAttachmentsParallel(
             loggingContext,
             visionProvider,
             model,
+            log,
           }),
         };
       } catch (error) {
@@ -174,7 +192,7 @@ export async function processAttachmentsParallel(
       rendered.push(outcome.built);
       continue;
     }
-    logger.error(
+    log.error(
       { err: outcome.error, url: outcome.attachment.url, referenceNumber },
       'Unexpected error in attachment processing'
     );
@@ -231,6 +249,7 @@ function findPreprocessedByUrl(
 async function processVoiceAttachment(
   attachment: ProcessSingleAttachmentOptions['attachment'],
   referenceNumber: number,
+  log: Logger,
   preprocessed?: ProcessedAttachment,
   sttDispatch?: SttDispatch
 ): Promise<BuiltAttachment> {
@@ -245,10 +264,7 @@ async function processVoiceAttachment(
   } as const;
 
   if (preprocessed?.description !== undefined && preprocessed.description !== '') {
-    logger.debug(
-      { referenceNumber, url: attachment.url },
-      'Using preprocessed voice transcription'
-    );
+    log.debug({ referenceNumber, url: attachment.url }, 'Using preprocessed voice transcription');
     return {
       url: attachment.url,
       attachment: { ...identity, description: preprocessed.description },
@@ -256,7 +272,7 @@ async function processVoiceAttachment(
   }
 
   try {
-    logger.info(
+    log.info(
       {
         referenceNumber,
         url: attachment.url,
@@ -269,16 +285,13 @@ async function processVoiceAttachment(
       () => transcribeAudio(attachment, sttDispatch ?? { provider: 'voice-engine' }),
       {
         maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
-        logger,
+        logger: log,
         operationName: `Voice transcription (reference ${referenceNumber})`,
       }
     );
     return { url: attachment.url, attachment: { ...identity, description: result.value.text } };
   } catch (error) {
-    logger.error(
-      { err: error, referenceNumber, url: attachment.url },
-      'Voice transcription failed'
-    );
+    log.error({ err: error, referenceNumber, url: attachment.url }, 'Voice transcription failed');
     return { url: attachment.url, attachment: { ...identity, status: 'untranscribed' } };
   }
 }
@@ -295,6 +308,7 @@ async function processImageAttachment(options: ProcessImageOptions): Promise<Bui
     loggingContext = {},
     visionProvider,
     model,
+    log,
   } = options;
   // Identity only — see the note in processVoiceAttachment.
   const identity = {
@@ -304,7 +318,7 @@ async function processImageAttachment(options: ProcessImageOptions): Promise<Bui
   } as const;
 
   if (preprocessed?.description !== undefined && preprocessed.description !== '') {
-    logger.debug({ referenceNumber, url: attachment.url }, 'Using preprocessed image description');
+    log.debug({ referenceNumber, url: attachment.url }, 'Using preprocessed image description');
     return {
       url: attachment.url,
       attachment: { ...identity, description: preprocessed.description },
@@ -312,7 +326,7 @@ async function processImageAttachment(options: ProcessImageOptions): Promise<Bui
   }
 
   try {
-    logger.info(
+    log.info(
       {
         referenceNumber,
         url: attachment.url,
@@ -331,13 +345,13 @@ async function processImageAttachment(options: ProcessImageOptions): Promise<Bui
         }),
       {
         maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
-        logger,
+        logger: log,
         operationName: `Image description (reference ${referenceNumber})`,
       }
     );
     return { url: attachment.url, attachment: { ...identity, description: result.value } };
   } catch (error) {
-    logger.error({ err: error, referenceNumber, url: attachment.url }, 'Image processing failed');
+    log.error({ err: error, referenceNumber, url: attachment.url }, 'Image processing failed');
     return { url: attachment.url, attachment: { ...identity, status: 'undescribed' } };
   }
 }
@@ -360,12 +374,13 @@ async function processSingleAttachment(
     loggingContext,
     visionProvider,
     model,
+    log,
   } = options;
   const preprocessed = findPreprocessedByUrl(attachment.url, preprocessedAttachments);
 
   switch (classifyAttachment(attachment)) {
     case 'voice':
-      return processVoiceAttachment(attachment, referenceNumber, preprocessed, sttDispatch);
+      return processVoiceAttachment(attachment, referenceNumber, log, preprocessed, sttDispatch);
     case 'image':
       return processImageAttachment({
         attachment,
@@ -377,6 +392,7 @@ async function processSingleAttachment(
         loggingContext,
         visionProvider,
         model,
+        log,
       });
     case 'file':
       return {

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -10,13 +10,32 @@ import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/perso
 import { type ProcessedAttachment } from './MultimodalProcessor.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
-const { mockDescribeImage, mockTranscribeAudio, mockFormatPromptTimestamp, mockLogger } =
-  vi.hoisted(() => ({
+const {
+  mockDescribeImage,
+  mockTranscribeAudio,
+  mockFormatPromptTimestamp,
+  mockLogger,
+  mockChildLogger,
+} = vi.hoisted(() => {
+  // AttachmentProcessor binds a request-scoped child off the same mocked
+  // createLogger, so `child` has to exist here for the live attachment path to
+  // run at all — and the implementation is passed to vi.fn() rather than
+  // configured afterwards so a mock reset restores it.
+  const child = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return {
     mockDescribeImage: vi.fn(),
     mockTranscribeAudio: vi.fn(),
     mockFormatPromptTimestamp: vi.fn(),
-    mockLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
-  }));
+    mockChildLogger: child,
+    mockLogger: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => child),
+    },
+  };
+});
 
 // Mock the MultimodalProcessor module
 vi.mock('./MultimodalProcessor.js', () => ({
@@ -1911,6 +1930,33 @@ describe('ReferencedMessageFormatter', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ requestId: 'req-keyless-11', kind: 'voice' }),
         expect.stringContaining('no attachment URL')
+      );
+    });
+
+    it('forwards the request id into the live attachment path, so its logs correlate too', async () => {
+      // The third correlation seam, and the only one on the COMPUTING arm: the
+      // deduped arm's two warnings are correlated above, but a full reference
+      // reaches vision and transcription through processAttachmentsParallel,
+      // where every failure line is about work that was actually paid for. This
+      // runs the real chain (AttachmentProcessor is not mocked here), so the
+      // binding is observed where it lands rather than at a mocked call's args.
+      mockDescribeImage.mockResolvedValue(VISION_SENTINEL);
+
+      await formatter.formatReferencedMessages(
+        [refWithImage()],
+        mockPersonality,
+        false,
+        undefined,
+        {
+          requestId: 'req-live-3',
+        }
+      );
+
+      expect(mockLogger.child).toHaveBeenCalledWith({ requestId: 'req-live-3' });
+      // Bound, and actually used — a child nobody logs through correlates nothing.
+      expect(mockChildLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ referenceNumber: 1 }),
+        'Processing image (inline fallback)'
       );
     });
 

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -377,6 +377,7 @@ export class ReferencedMessageFormatter {
       sttDispatch,
       visionProvider,
       model: visionModel,
+      requestId: apiKeys?.requestId,
     });
   }
 


### PR DESCRIPTION
## Summary

The enrichment-drop tripwires added earlier carry `requestId`, but the failure sites in `AttachmentProcessor.ts` — the attachment fan-out catch, image-description failures, voice-transcription failures — logged uncorrelated, so a prod failure in the reference pipeline couldn't be tied back to the request that hit it (TASK-429).

- **`AttachmentProcessor.ts`**: `ProcessAttachmentsOptions` gains `requestId?: string` (pure correlation — never changes what is rendered). A pino child logger is bound **once** at `processAttachmentsParallel`'s entry and threaded through the path, so every line correlates — including `withRetry`'s between-attempt warnings, which are the spend evidence. No log message text changed, no events added or removed; callers threading no id keep the module logger and behave exactly as before.
- **`ReferencedMessageFormatter.ts`**: one line — forwards `apiKeys?.requestId` into the call (the id already rides `ReferenceVisionAuth`).
- **Rider** (from TASK-429's filing): comment on `MIN_LENGTH_FOR_ECHO_CHECK` explaining why 40 is deliberately stricter than the cross-turn detector's 30 — a false-positive echo retry burns a paid generation.

## Verification

- New tests: 5 cases in `AttachmentProcessor.test.ts` (image failure, voice failure, fan-out catch, retry warnings on the child, and the no-requestId fallback pinning that `child()` is never called), plus a live-path test in `ReferencedMessageFormatter.test.ts` that runs the real formatter→processor chain (that seam is not mocked there) and asserts the binding is created **and logged through**.
- The forwarding assertion was negative-checked: removing the `requestId:` line in the formatter fails exactly the new test.
- Full ai-worker suite 206 files / 4342 tests green; `pnpm test` and `pnpm quality` both green sequentially.

Closes TASK-429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)