### PR TITLE
refactor(api-gateway): retire the dead createRemoveKeyRoute legacy factory

### DIFF
--- a/services/api-gateway/src/routes/wallet/removeKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.test.ts
@@ -49,9 +49,10 @@ const mockPrisma = {
   $executeRaw: vi.fn().mockResolvedValue(1),
 };
 
-import { createRemoveKeyRoute } from './removeKey.js';
+import { handleRemoveWalletKey } from './removeKey.js';
 import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { asRouteHandler } from '../../test/shared-route-test-utils.js';
 
 // Helper to create mock request/response
 function createMockReqRes(provider: string) {
@@ -70,15 +71,13 @@ function createMockReqRes(provider: string) {
   return { req, res };
 }
 
-// Helper to call the handler directly
+// Helper to call the route handler directly
 async function callHandler(
   prisma: unknown,
   req: Request & { userId: string },
   res: Response
 ): Promise<void> {
-  const handlers = createRemoveKeyRoute(prisma as PrismaClient);
-  // handlers layout: [auth, provision, handler]
-  const handler = handlers[2] as (req: Request, res: Response) => Promise<void>;
+  const handler = asRouteHandler(handleRemoveWalletKey({ prisma: prisma as PrismaClient }));
   await handler(req, res);
 }
 
@@ -88,34 +87,6 @@ describe('DELETE /api/user/wallet/:provider', () => {
     mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
     mockPrisma.userApiKey.findFirst.mockResolvedValue({ id: 'key-uuid-123' });
     mockPrisma.userApiKey.delete.mockResolvedValue({ id: 'key-uuid-123' });
-  });
-
-  describe('route factory', () => {
-    it('should create an array of handlers', () => {
-      const handlers = createRemoveKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(handlers).toBeDefined();
-      expect(Array.isArray(handlers)).toBe(true);
-      expect(handlers.length).toBe(3); // [requireUserAuth, requireProvisionedUser, handler]
-    });
-
-    it('should have requireUserAuth as first handler', () => {
-      const handlers = createRemoveKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(typeof handlers[0]).toBe('function');
-    });
-
-    it('should have requireProvisionedUser as second handler', () => {
-      const handlers = createRemoveKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(typeof handlers[1]).toBe('function');
-    });
-
-    it('should have request handler as third handler', () => {
-      const handlers = createRemoveKeyRoute(mockPrisma as unknown as PrismaClient);
-
-      expect(typeof handlers[2]).toBe('function');
-    });
   });
 
   describe('validation', () => {

--- a/services/api-gateway/src/routes/wallet/removeKey.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.ts
@@ -5,10 +5,7 @@
 
 import { type Response, type RequestHandler } from 'express';
 import { AIProvider } from '@tzurot/common-types/constants/ai';
-import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { type ApiKeyCacheInvalidationService } from '@tzurot/cache-invalidation';
-import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
@@ -20,10 +17,6 @@ type WalletRemoveDeps = Pick<RouteDeps, 'prisma' | 'apiKeyCacheInvalidation'>;
 
 const logger = createLogger('wallet-remove-key');
 
-/**
- * Create remove key route handlers
- * Returns an array of middleware: [auth, handler]
- */
 /** DELETE /api/user/wallet/:provider — remove user's API key for a provider. */
 export const handleRemoveWalletKey = (deps: WalletRemoveDeps): RequestHandler => {
   const { prisma, apiKeyCacheInvalidation } = deps;
@@ -72,13 +65,3 @@ export const handleRemoveWalletKey = (deps: WalletRemoveDeps): RequestHandler =>
     });
   });
 };
-
-/** Legacy chain. Aggregator spreads the array into `router.delete(...)`. */
-export const createRemoveKeyRoute = (
-  prisma: PrismaClient,
-  apiKeyCacheInvalidation?: ApiKeyCacheInvalidationService
-): RequestHandler[] => [
-  requireUserAuth(),
-  requireProvisionedUser(prisma),
-  handleRemoveWalletKey({ prisma, apiKeyCacheInvalidation }),
-];


### PR DESCRIPTION
## Summary

First slice of TASK-346 (route-factory dead-wiring audit). `createRemoveKeyRoute` was a legacy pre-codegen factory whose only consumer was its own test file — production wiring registers `handleRemoveWalletKey` directly in `_generated/mounts.ts` (verified: `mounts.ts:99,290`) with the wallet write-limiter path-scoped in `index.ts:448`.

- **`removeKey.ts`**: factory deleted along with the four imports it exclusively consumed (`PrismaClient` type, `ApiKeyCacheInvalidationService` type, `requireUserAuth`/`requireProvisionedUser`) and the stale docblock describing the middleware-array shape. `handleRemoveWalletKey` and its deps untouched.
- **`removeKey.test.ts`**: migrated to the direct-construction idiom the sibling `listKeys.test.ts` already uses (`asRouteHandler(handleRemoveWalletKey({ prisma }))`); the four factory-shape tests deleted (wiring is owned by mounts.ts and pinned by `codegen:routes --check`, per the memory-family retirement precedent). **All 7 behavioral tests preserved unchanged** (11 → 7, delta is exactly the factory block).

The audit's other finding — `createDenylistRoutes` + `expressRouterUtils` — is deliberately NOT in this PR: its retirement orphans the denylist rate limiter, which is the owner-gated TASK-411 decision (denylist mutations are unthrottled in prod today).

## Verification

- Repo-wide survivor grep for `createRemoveKeyRoute`: zero code hits (one tracker-file mention naming the retirement, kept intentionally).
- `pnpm --filter @tzurot/api-gateway test` 190 files / 2614 tests green; full `pnpm test` and `pnpm quality` green sequentially.
- `pnpm knip` clean (no new findings); `pnpm ops codegen:routes --check` green (184 routes, generated files untouched).

Part of TASK-346 (stays open for the denylist slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)