### PR TITLE
fix(bot-client): guest mode keys on chat-capable providers, not any key

### DIFF
--- a/docs/reference/testing/BYOK_MANUAL_TESTING.md
+++ b/docs/reference/testing/BYOK_MANUAL_TESTING.md
@@ -68,11 +68,13 @@ Only OpenRouter and ElevenLabs report a remaining balance; the other two show no
 credit field.
 
 **OpenRouter is the primary LLM provider.** The voice providers (ElevenLabs,
-Mistral) do not make chat responses stop being guest-mode at generation time.
+Mistral) do not take you out of chat guest-mode anywhere — not in the preset UI,
+not at generation time; their keys authorize voice endpoints only.
 The one exception is **Z.AI Coding Plan**: when the resolved preset's model is a
 `z-ai/<model>` on the coding-plan catalog AND you hold a zai-coding key, the
 request auto-promotes to direct z.ai routing and is **not** guest mode — no
-OpenRouter key required. See the known-asymmetry note at the end of Pass E.
+OpenRouter key required. See the voice-keys note at the end of Pass E for how
+this plays out across the UI and the generation path.
 
 ### 0.4 The command surface under test
 
@@ -94,8 +96,9 @@ First match wins:
 3. The character's own preset
 4. The system default preset — `/preset global default` (owner)
 
-**Guest mode cuts across all four.** With no OpenRouter key of your own, the
-ai-worker substitutes a free model whenever the resolved preset is not free —
+**Guest mode cuts across all four.** With no chat-capable key of your own (a
+voice-only ElevenLabs/Mistral key does not count — see §0.3), the ai-worker
+substitutes a free model whenever the resolved preset is not free —
 resolution continues down the guest ladder (your free selection → the free-tier
 default set by `/preset global free-default` → the `openrouter/free` router as a
 last resort). You do not get an error; you get a different model.
@@ -208,7 +211,7 @@ both, a slot-scoped clear must clear exactly one._
 ## Pass E — Multiple providers
 
 **Proves**: keys are per-provider, and that the LLM guest-mode decision is
-driven by the OpenRouter key specifically.
+driven by a chat-capable key (OpenRouter or z.ai Coding Plan) specifically.
 
 **Rate-limit budget**: 2 writes. Skip this pass if you have no second provider key.
 
@@ -222,16 +225,20 @@ driven by the OpenRouter key specifically.
 | E.4  | `/settings apikey remove` provider:**ElevenLabs (Voice)** | Embed **🗑️ API Key Removed** — “Your **ElevenLabs** API key has been deleted. The bot will now use the default system key (if available) for this provider.” |
 | E.5  | `/settings apikey browse`                                 | Only the OpenRouter row remains — removing one provider does not touch another.                                                                              |
 
-**Known asymmetry — report what you see, don't assume it's a bug.** The
-bot-client UI treats you as a key-holder when you have an active key for **any**
-provider, while the ai-worker decides chat guest-mode from your **OpenRouter**
-key (with the z.ai auto-promotion exception in §0.3 — a zai-coding key exits
-guest mode only for presets targeting a `z-ai/<model>` on the coding-plan
-catalog). So with only an ElevenLabs key stored: `/preset browse` would show no
-Guest Mode preamble, but a chat response would still carry the
-`🆓 Using free model` footer. If you want to check that combination, remove the
-OpenRouter key first (Pass F), store only an ElevenLabs key, and record both
+**Voice keys don't buy models — both services agree on this.** Chat guest-mode
+is decided by whether you hold an active **chat-capable** key (OpenRouter, or a
+z.ai Coding Plan key); ElevenLabs and Mistral are voice-only. So with only an
+ElevenLabs or Mistral key stored, the UI and the generation path line up:
+`/preset browse` shows the Guest Mode preamble **and** a chat response carries
+the `🆓 Using free model` footer. To check that combination, remove the
+OpenRouter key first (Pass F), store only a voice key, and record both
 observables.
+
+One nuance survives, per §0.3: the ai-worker's z.ai promotion is
+preset-dependent — a zai-coding key exits guest mode only for presets targeting
+a `z-ai/<model>` on the coding-plan catalog — while the bot-client UI treats a
+zai-coding key as full access globally. That optimism is deliberate (the UI
+never blocks what the worker would allow); the worker remains authoritative.
 
 ---
 

--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -4,6 +4,10 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  AIProvider,
+  CHAT_CAPABLE_PROVIDERS,
+  hasActiveChatCapableKey,
+  isChatCapableProvider,
   isFreeModel,
   isFreeModelForUser,
   GUEST_MODE,
@@ -210,6 +214,82 @@ describe('isFreeModelForUser', () => {
   it('paid models are never free', () => {
     expect(isFreeModelForUser('anthropic/claude-sonnet-4', true)).toBe(false);
     expect(isFreeModelForUser('anthropic/claude-sonnet-4', false)).toBe(false);
+  });
+});
+
+describe('isChatCapableProvider', () => {
+  it('classifies every AIProvider: LLM providers in, voice providers out', () => {
+    expect(isChatCapableProvider(AIProvider.OpenRouter)).toBe(true);
+    expect(isChatCapableProvider(AIProvider.ZaiCoding)).toBe(true);
+    // Voice-only: ElevenLabs is synthesis/cloning/STT; a Mistral key authorizes
+    // only /v1/audio/*. Neither can serve a chat generation.
+    expect(isChatCapableProvider(AIProvider.ElevenLabs)).toBe(false);
+    expect(isChatCapableProvider(AIProvider.Mistral)).toBe(false);
+  });
+
+  it('accepts raw provider strings (wire values) and rejects unknown ones', () => {
+    expect(isChatCapableProvider('openrouter')).toBe(true);
+    expect(isChatCapableProvider('zai-coding')).toBe(true);
+    expect(isChatCapableProvider('elevenlabs')).toBe(false);
+    expect(isChatCapableProvider('not-a-provider')).toBe(false);
+    expect(isChatCapableProvider('')).toBe(false);
+  });
+
+  it('CHAT_CAPABLE_PROVIDERS holds exactly the LLM providers', () => {
+    expect([...CHAT_CAPABLE_PROVIDERS].sort()).toEqual(
+      [AIProvider.OpenRouter, AIProvider.ZaiCoding].sort()
+    );
+  });
+});
+
+describe('hasActiveChatCapableKey', () => {
+  it('is true for an active OpenRouter or z.ai coding-plan key', () => {
+    expect(hasActiveChatCapableKey([{ provider: AIProvider.OpenRouter, isActive: true }])).toBe(
+      true
+    );
+    expect(hasActiveChatCapableKey([{ provider: AIProvider.ZaiCoding, isActive: true }])).toBe(
+      true
+    );
+  });
+
+  it('is false for a voice-only wallet (ElevenLabs / Mistral) — the guest case', () => {
+    expect(hasActiveChatCapableKey([{ provider: AIProvider.ElevenLabs, isActive: true }])).toBe(
+      false
+    );
+    expect(hasActiveChatCapableKey([{ provider: AIProvider.Mistral, isActive: true }])).toBe(false);
+    expect(
+      hasActiveChatCapableKey([
+        { provider: AIProvider.ElevenLabs, isActive: true },
+        { provider: AIProvider.Mistral, isActive: true },
+      ])
+    ).toBe(false);
+  });
+
+  it('requires the chat key to be ACTIVE (inactive keys buy nothing)', () => {
+    expect(hasActiveChatCapableKey([{ provider: AIProvider.OpenRouter, isActive: false }])).toBe(
+      false
+    );
+    // The conjunction, not either half: a deactivated chat key next to an
+    // active voice key must still read as guest.
+    expect(
+      hasActiveChatCapableKey([
+        { provider: AIProvider.OpenRouter, isActive: false },
+        { provider: AIProvider.ElevenLabs, isActive: true },
+      ])
+    ).toBe(false);
+  });
+
+  it('finds the chat key among voice keys', () => {
+    expect(
+      hasActiveChatCapableKey([
+        { provider: AIProvider.ElevenLabs, isActive: true },
+        { provider: AIProvider.OpenRouter, isActive: true },
+      ])
+    ).toBe(true);
+  });
+
+  it('is false for an empty wallet', () => {
+    expect(hasActiveChatCapableKey([])).toBe(false);
   });
 });
 

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -616,6 +616,44 @@ export function isFreeTierEligibleModel(modelId: string): boolean {
 }
 
 /**
+ * Providers whose BYOK key authorizes LLM chat/generation. The rest of
+ * `AIProvider` is voice-only — ElevenLabs (synthesis/cloning/STT) and Mistral
+ * (whose key authorizes only `/v1/audio/*`) — so holding one of those keys
+ * grants no chat capability whatsoever.
+ *
+ * This is the classification behind "does the user have a key that buys them
+ * models?": guest-mode predicates key off THIS set, never off "has any active
+ * key at all", or a voice-only key-holder is silently treated as a paid chat
+ * user and shown models they cannot run. Add a new LLM provider here when one
+ * is added to `AIProvider`.
+ */
+// eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: immutable lookup set used as a constant (mirrors VisionProcessor's terminate-set). Exported so the classification is greppable and the exhaustiveness test in ai.test.ts can assert its membership.
+export const CHAT_CAPABLE_PROVIDERS: ReadonlySet<AIProvider> = new Set([
+  AIProvider.OpenRouter,
+  AIProvider.ZaiCoding,
+]);
+
+/** True when `provider` serves LLM chat/generation (see {@link CHAT_CAPABLE_PROVIDERS}). */
+export function isChatCapableProvider(provider: AIProvider | string): boolean {
+  return CHAT_CAPABLE_PROVIDERS.has(provider as AIProvider);
+}
+
+/**
+ * True when the wallet holds at least one ACTIVE chat-capable key — the
+ * canonical "not a guest" predicate for chat/preset UI. An ElevenLabs- or
+ * Mistral-only wallet is a guest here, because neither key can serve a
+ * generation.
+ *
+ * The parameter is structural (not `WalletKey`) so `constants/` stays free of
+ * a `schemas/` dependency while wallet responses still satisfy it.
+ */
+export function hasActiveChatCapableKey(
+  keys: readonly { provider: AIProvider | string; isActive: boolean }[]
+): boolean {
+  return keys.some(key => key.isActive === true && isChatCapableProvider(key.provider));
+}
+
+/**
  * May this model serve THIS user for free? Guests (no active key) get the
  * conditionally-free piggyback model — admission decides at runtime and a
  * denial degrades to the free router — so it presents as free to them.

--- a/packages/common-types/src/constants/discord.test.ts
+++ b/packages/common-types/src/constants/discord.test.ts
@@ -281,7 +281,7 @@ describe('Bot Footer Text Constants', () => {
 
     it('never surfaces a VOICE provider as an LLM footer label (structural guard)', () => {
       // elevenlabs / mistral are in DISCORD_PROVIDER_CHOICES but are voice providers; the
-      // LLM_FOOTER_PROVIDERS allowlist keeps them out of the model footer even if a future
+      // chat-capable allowlist keeps them out of the model footer even if a future
       // change wired one into the LLM `providerUsed` path.
       for (const voiceProvider of ['elevenlabs', 'mistral']) {
         expect(

--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -4,6 +4,7 @@
  * Discord API limits, colors, and text truncation limits.
  */
 
+import { isChatCapableProvider } from './ai.js';
 import type { QuotaFallbackCategoryValue } from './error.js';
 
 /**
@@ -302,19 +303,18 @@ export const BOT_FOOTER_TEXT = {
  * ever populate the model footer's `providerUsed`, so this allowlist makes that
  * constraint STRUCTURAL — a voice provider can never surface as "• via ElevenLabs (Voice)"
  * on an LLM response even if a future change wired one into the LLM `providerUsed` path.
- * Add a new entry here when a new LLM provider is added to `DISCORD_PROVIDER_CHOICES`.
- */
-const LLM_FOOTER_PROVIDERS: ReadonlySet<(typeof DISCORD_PROVIDER_CHOICES)[number]['value']> =
-  new Set(['openrouter', 'zai-coding']);
-
-/**
+ *
+ * The allowlist is `isChatCapableProvider` — the single classification of which
+ * providers serve LLM generation, shared with the guest-mode predicates — so the
+ * footer and the UI can never disagree about what counts as an LLM provider.
+ *
  * Provider value → human-readable footer label, derived from the slash-command
- * choices (filtered to LLM providers) so the two never drift. Used to make the
- * served-by provider explicit in the model footer (e.g. "via Z.AI Coding Plan" vs
- * "via OpenRouter") rather than leaving users to infer it from the `z-ai/` vendor-prefix.
+ * choices so the two never drift. Used to make the served-by provider explicit in
+ * the model footer (e.g. "via Z.AI Coding Plan" vs "via OpenRouter") rather than
+ * leaving users to infer it from the `z-ai/` vendor-prefix.
  */
 const PROVIDER_FOOTER_LABEL: Readonly<Record<string, string>> = Object.fromEntries(
-  DISCORD_PROVIDER_CHOICES.filter(choice => LLM_FOOTER_PROVIDERS.has(choice.value)).map(choice => [
+  DISCORD_PROVIDER_CHOICES.filter(choice => isChatCapableProvider(choice.value)).map(choice => [
     choice.value,
     choice.name,
   ])

--- a/packages/common-types/src/constants/wallet.ts
+++ b/packages/common-types/src/constants/wallet.ts
@@ -11,10 +11,6 @@ export const WALLET_ERROR_MESSAGES = {
   /** Missing required fields in set key request */
   MISSING_FIELDS: 'provider and apiKey are required',
 
-  /** Invalid provider specified - shows valid options */
-  INVALID_PROVIDER: (provider: string) =>
-    `Invalid provider: ${provider}. Supported providers: openrouter, elevenlabs`,
-
   /** Generic invalid API key message */
   INVALID_API_KEY: 'Invalid API key',
 
@@ -34,7 +30,8 @@ export const WALLET_ERROR_MESSAGES = {
 /**
  * API key format patterns and placeholders
  *
- * OpenRouter and ElevenLabs are supported for user-facing BYOK.
+ * Every provider in `AIProvider` (openrouter, elevenlabs, zai-coding, mistral)
+ * is supported for user-facing BYOK; not all have a recognizable key prefix.
  * Other prefixes are kept for log sanitization (redacting leaked keys).
  */
 export const API_KEY_FORMATS = {

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { mockListLlmConfigsResponse, mockListWalletKeysResponse } from '@tzurot/test-factories';
 import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
@@ -439,6 +440,58 @@ describe('handleBrowse', () => {
     expect(embedData.description).toContain('Claude Default');
     expect(embedData.description).not.toContain('GPT Config');
     expect(embedData.description).toContain('Searching: "claude"');
+  });
+
+  it('shows guest mode for a voice-ONLY (ElevenLabs) wallet and dims paid presets', async () => {
+    // A voice key buys no models, so this wallet is a guest for chat UI: the
+    // preamble must appear AND the paid preset must be struck through.
+    configurePresets(stub, [
+      {
+        id: '00000000-0000-4000-8000-00000000000e',
+        name: 'Claude Paid',
+        model: 'anthropic/claude-sonnet-4',
+        provider: 'openrouter',
+        isGlobal: true,
+        isDefault: false,
+        isOwned: false,
+      },
+    ]);
+    stub.listWalletKeys.mockResolvedValue(
+      makeOk(mockListWalletKeysResponse([{ provider: AIProvider.ElevenLabs, isActive: true }]))
+    );
+
+    await handleBrowse(createMockContext());
+
+    const description =
+      (mockEditReply.mock.calls[0][0] as { embeds: { data: { description?: string } }[] }).embeds[0]
+        .data.description ?? '';
+    expect(description).toContain('Guest Mode');
+    expect(description).toContain('~~Claude Paid~~');
+  });
+
+  it('treats a z.ai coding-plan key as full access (no guest preamble)', async () => {
+    configurePresets(stub, [
+      {
+        id: '00000000-0000-4000-8000-00000000000f',
+        name: 'Claude Paid',
+        model: 'anthropic/claude-sonnet-4',
+        provider: 'openrouter',
+        isGlobal: true,
+        isDefault: false,
+        isOwned: false,
+      },
+    ]);
+    stub.listWalletKeys.mockResolvedValue(
+      makeOk(mockListWalletKeysResponse([{ provider: AIProvider.ZaiCoding, isActive: true }]))
+    );
+
+    await handleBrowse(createMockContext());
+
+    const description =
+      (mockEditReply.mock.calls[0][0] as { embeds: { data: { description?: string } }[] }).embeds[0]
+        .data.description ?? '';
+    expect(description).not.toContain('Guest Mode');
+    expect(description).not.toContain('~~Claude Paid~~');
   });
 
   it('should show guest mode warning when no active wallet', async () => {

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -16,7 +16,11 @@ import {
   type ButtonInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
-import { isFreeModelForUser, isFreeTierEligibleModel } from '@tzurot/common-types/constants/ai';
+import {
+  hasActiveChatCapableKey,
+  isFreeModelForUser,
+  isFreeTierEligibleModel,
+} from '@tzurot/common-types/constants/ai';
 import { ENTITY_EMOJI, buildBadgeLegend } from '@tzurot/common-types/constants/uxVocabulary';
 import { AUTOCOMPLETE_BADGES } from '@tzurot/common-types/utils/autocompleteFormat';
 import { presetBrowseOptions } from '@tzurot/common-types/generated/commandOptions';
@@ -324,7 +328,9 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
       return;
     }
 
-    // Check if user is in guest mode (no active wallet keys)
+    // Check if user is in guest mode (no active CHAT-capable wallet key —
+    // a voice-only ElevenLabs/Mistral key buys no models, so it must not
+    // read as full access)
     // Only show guest mode warning when we successfully verified no active keys
     // If wallet API failed, assume user might have keys (don't restrict them)
     if (!walletResult.ok) {
@@ -333,7 +339,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
         'Wallet check failed, assuming not guest mode'
       );
     }
-    const isGuestMode = walletResult.ok && !walletResult.data.keys.some(k => k.isActive === true);
+    const isGuestMode = walletResult.ok && !hasActiveChatCapableKey(walletResult.data.keys);
 
     const { embed, components } = buildBrowsePage(presets, filter, query, 0, isGuestMode);
 
@@ -372,9 +378,10 @@ export async function buildBrowseResponse(
     return null;
   }
 
-  // Only show guest mode when we successfully verified no active keys
+  // Only show guest mode when we successfully verified no active chat-capable
+  // keys (voice-only keys don't count)
   // If wallet API failed, assume user might have keys (don't restrict them)
-  const isGuestMode = walletResult.ok && !walletResult.data.keys.some(k => k.isActive === true);
+  const isGuestMode = walletResult.ok && !hasActiveChatCapableKey(walletResult.data.keys);
 
   return buildBrowsePage(presets, filter, query, page, isGuestMode);
 }

--- a/services/bot-client/src/commands/preset/override/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/override/autocomplete.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { handleAutocomplete } from './autocomplete.js';
 import type { AutocompleteInteraction, User } from 'discord.js';
+import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { type PersonalitySummary } from '@tzurot/common-types/schemas/api/personality';
 import { mockListWalletKeysResponse, mockLlmConfigSummary } from '@tzurot/test-factories';
 
@@ -508,6 +509,89 @@ describe('handleAutocomplete', () => {
       expect(choices).toHaveLength(2);
       expect(choices[0].value).toBe('00000000-0000-4000-8000-0000000000c3');
       expect(choices[0].name).toContain('GLM 4.5 Air');
+    });
+
+    it('free-filters and upsells for a voice-ONLY (ElevenLabs) wallet', async () => {
+      // An ElevenLabs key is a voice key: it unlocks no models, so the picker
+      // must behave exactly as it does for an empty wallet.
+      vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
+        name: 'preset',
+        value: '',
+      } as unknown as string);
+      stub.listUserLlmConfigs.mockResolvedValue({
+        ok: true,
+        data: {
+          configs: [
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c1',
+              name: 'Claude Pro',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+              isGlobal: true,
+              isOwned: false,
+            }),
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c2',
+              name: 'Grok Free',
+              model: 'x-ai/grok-4.1-fast:free',
+              provider: 'openrouter',
+              isGlobal: true,
+              isOwned: false,
+            }),
+          ],
+        },
+      });
+      stub.listWalletKeys.mockResolvedValue({
+        ok: true,
+        data: mockListWalletKeysResponse([{ provider: AIProvider.ElevenLabs, isActive: true }]),
+      });
+
+      await handleAutocomplete(mockInteraction);
+
+      const choices = vi.mocked(mockInteraction.respond).mock.calls[0][0] as {
+        name: string;
+        value: string;
+      }[];
+      // Paid preset filtered out; free preset + the upsell slot remain.
+      expect(choices).toHaveLength(2);
+      expect(choices[0].value).toBe('00000000-0000-4000-8000-0000000000c2');
+      expect(choices[1]).toEqual({ name: '✨ Unlock All Models...', value: UNLOCK_MODELS_VALUE });
+    });
+
+    it('shows paid presets with no upsell for a z.ai coding-plan key (not a guest)', async () => {
+      vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
+        name: 'preset',
+        value: '',
+      } as unknown as string);
+      stub.listUserLlmConfigs.mockResolvedValue({
+        ok: true,
+        data: {
+          configs: [
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c1',
+              name: 'Claude Pro',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+              isGlobal: true,
+              isOwned: false,
+            }),
+          ],
+        },
+      });
+      stub.listWalletKeys.mockResolvedValue({
+        ok: true,
+        data: mockListWalletKeysResponse([{ provider: AIProvider.ZaiCoding, isActive: true }]),
+      });
+
+      await handleAutocomplete(mockInteraction);
+
+      const choices = vi.mocked(mockInteraction.respond).mock.calls[0][0] as {
+        name: string;
+        value: string;
+      }[];
+      expect(choices).toHaveLength(1);
+      expect(choices[0].value).toBe('00000000-0000-4000-8000-0000000000c1');
+      expect(choices.some(c => c.value === UNLOCK_MODELS_VALUE)).toBe(false);
     });
 
     it('should add upsell option at the end for guest users', async () => {

--- a/services/bot-client/src/commands/preset/override/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/override/autocomplete.ts
@@ -5,7 +5,11 @@
  */
 
 import type { AutocompleteInteraction } from 'discord.js';
-import { isFreeModelForUser, isFreeTierEligibleModel } from '@tzurot/common-types/constants/ai';
+import {
+  hasActiveChatCapableKey,
+  isFreeModelForUser,
+  isFreeTierEligibleModel,
+} from '@tzurot/common-types/constants/ai';
 import { DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
 import {
   AUTOCOMPLETE_BADGES,
@@ -71,18 +75,21 @@ async function handlePresetAutocomplete(
     return;
   }
 
-  // Check if user is in guest mode (no active wallet keys).
+  // Check if user is in guest mode (no active CHAT-capable wallet key — a
+  // voice-only ElevenLabs/Mistral key can't serve a generation, so it must
+  // not unlock the paid model list).
   //
   // Fails OPEN on wallet-API failure: a transient `/wallet/list` error
-  // would otherwise collapse with `!hasActiveWallet` to force `isGuestMode
-  // = true`, hiding paid models from users who actually have active keys.
+  // would otherwise collapse with `!hasActiveChatCapableKey` to force
+  // `isGuestMode = true`, hiding paid models from users who actually have
+  // active keys.
   // Mirrors the pattern in guestModeValidation.checkGuestModePremiumAccess —
   // the ai-worker's ApiKeyResolver + AuthStep enforce the gate
   // authoritatively at generation time, so showing extra options here can't
   // bypass the real check.
   let isGuestMode: boolean;
   if (walletResult.ok) {
-    isGuestMode = !walletResult.data.keys.some(k => k.isActive === true);
+    isGuestMode = !hasActiveChatCapableKey(walletResult.data.keys);
   } else {
     logger.warn(
       { userId, error: walletResult.error },

--- a/services/bot-client/src/commands/preset/override/guestModeValidation.test.ts
+++ b/services/bot-client/src/commands/preset/override/guestModeValidation.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AIProvider } from '@tzurot/common-types/constants/ai';
+import { mockListWalletKeysResponse } from '@tzurot/test-factories';
 import { handleUnlockModelsUpsell, checkGuestModePremiumAccess } from './guestModeValidation.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { makeOk, makeErr, asUserClient } from '../../../test/gatewayClientStubs.js';
@@ -81,6 +83,77 @@ describe('guestModeValidation', () => {
       expect(result).toMatchObject({ blocked: false, reason: 'paid' });
       // Paid path: configs not fetched
       expect(stub.listUserLlmConfigs).not.toHaveBeenCalled();
+    });
+
+    it('treats a voice-ONLY ElevenLabs wallet as guest (no chat-capable key)', async () => {
+      // An ElevenLabs key buys voice, not models — the premium gate must fire.
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk(mockListWalletKeysResponse([{ provider: AIProvider.ElevenLabs, isActive: true }]))
+      );
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({ configs: [{ id: 'config-1', name: 'Premium Config', model: 'claude-sonnet' }] })
+      );
+
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
+      expect(result).toMatchObject({ blocked: true, reason: 'guest-premium' });
+      expect(mockEditReply).toHaveBeenCalled();
+    });
+
+    it('treats a voice-ONLY Mistral wallet as guest (key authorizes only /v1/audio/*)', async () => {
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk(mockListWalletKeysResponse([{ provider: AIProvider.Mistral, isActive: true }]))
+      );
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({ configs: [{ id: 'config-1', name: 'Premium Config', model: 'claude-sonnet' }] })
+      );
+
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
+      expect(result).toMatchObject({ blocked: true, reason: 'guest-premium' });
+    });
+
+    it('treats a z.ai coding-plan key as full access (not a guest)', async () => {
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk(mockListWalletKeysResponse([{ provider: AIProvider.ZaiCoding, isActive: true }]))
+      );
+
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
+      expect(result).toMatchObject({ blocked: false, reason: 'paid' });
+      expect(stub.listUserLlmConfigs).not.toHaveBeenCalled();
+    });
+
+    it('is guest when the only chat key is INACTIVE and the active one is voice-only', async () => {
+      // Guards the conjunction: active-ness alone and chat-capability alone
+      // each look like access; only both together grant it.
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk(
+          mockListWalletKeysResponse([
+            { provider: AIProvider.OpenRouter, isActive: false },
+            { provider: AIProvider.ElevenLabs, isActive: true },
+          ])
+        )
+      );
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({ configs: [{ id: 'config-1', name: 'Premium Config', model: 'claude-sonnet' }] })
+      );
+
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
+      expect(result).toMatchObject({ blocked: true, reason: 'guest-premium' });
     });
 
     it('should not block guest user selecting free model', async () => {

--- a/services/bot-client/src/commands/preset/override/guestModeValidation.ts
+++ b/services/bot-client/src/commands/preset/override/guestModeValidation.ts
@@ -7,7 +7,10 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import { isFreeTierEligibleModel } from '@tzurot/common-types/constants/ai';
+import {
+  hasActiveChatCapableKey,
+  isFreeTierEligibleModel,
+} from '@tzurot/common-types/constants/ai';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type UserClient } from '@tzurot/clients';
@@ -90,9 +93,11 @@ export async function checkGuestModePremiumAccess(
     return { blocked: false, reason: 'check-failed' };
   }
 
-  const hasActiveWallet = walletResult.data.keys.some(k => k.isActive === true);
+  // Only a CHAT-capable key (OpenRouter / z.ai coding plan) buys model access;
+  // a voice-only ElevenLabs or Mistral key leaves the user in guest mode.
+  const hasChatKey = hasActiveChatCapableKey(walletResult.data.keys);
 
-  if (hasActiveWallet) {
+  if (hasChatKey) {
     return { blocked: false, reason: 'paid' };
   }
 

--- a/services/bot-client/src/utils/modelCatalog.test.ts
+++ b/services/bot-client/src/utils/modelCatalog.test.ts
@@ -193,6 +193,17 @@ describe('annotateUsability', () => {
     expect(r.canUse).toBe(true);
   });
 
+  it('marks the piggyback model free/usable for a VOICE-only key-holder (still a guest)', () => {
+    // An ElevenLabs key buys voice, not models — the wallet is non-empty but
+    // holds no chat-capable key, so the free-tier presentation still applies.
+    const [r] = annotateUsability(
+      [cat({ id: 'z-ai/glm-4.5-air', source: 'both' })],
+      new Set(['elevenlabs'])
+    );
+    expect(r.usability).toBe('free');
+    expect(r.canUse).toBe(true);
+  });
+
   it('keeps key-based verdicts for the piggyback model when the user HAS a key', () => {
     // Key-holders are billed on their own key — normal source-based routing
     const [r] = annotateUsability(

--- a/services/bot-client/src/utils/modelCatalog.ts
+++ b/services/bot-client/src/utils/modelCatalog.ts
@@ -15,6 +15,7 @@
 import {
   AIProvider,
   ZAI_MODEL_PREFIX,
+  isChatCapableProvider,
   isFreeModel,
   isZaiFreeTierModel,
   isZaiCodingPlanModel,
@@ -250,16 +251,20 @@ export function annotateUsability(
   const keysUnknown = activeProviders === null;
   const hasOpenRouter = activeProviders?.has(AIProvider.OpenRouter) ?? false;
   const hasZai = activeProviders?.has(AIProvider.ZaiCoding) ?? false;
+  // "Is this user a guest?" is a chat-capability question, not a key-count one:
+  // a wallet holding only voice keys (ElevenLabs, Mistral) buys no models.
+  const hasChatKey = [...(activeProviders ?? [])].some(isChatCapableProvider);
 
   return models.map(model => {
     if (isFreeModel(model.id)) {
       return { ...model, usability: 'free', canUse: true };
     }
-    // The conditionally-free piggyback model: a KEYLESS (guest) user runs it
-    // via free-tier admission (denial degrades to the free router), so it
-    // presents as free to them. Key-holders fall through to the key-based
-    // verdicts below — they are billed on their own key.
-    if (isZaiFreeTierModel(model.id) && activeProviders !== null && activeProviders.size === 0) {
+    // The conditionally-free piggyback model: a guest — nobody with a
+    // CHAT-capable key, so a voice-only ElevenLabs/Mistral wallet counts —
+    // runs it via free-tier admission (denial degrades to the free router),
+    // so it presents as free to them. Chat key-holders fall through to the
+    // key-based verdicts below; they are billed on their own key.
+    if (isZaiFreeTierModel(model.id) && activeProviders !== null && !hasChatKey) {
       return { ...model, usability: 'free', canUse: true };
     }
     if (keysUnknown) {


### PR DESCRIPTION
## Summary

Closes TASK-416 (owner call 2026-08-04: the chat-capable-keys semantic wins).

**The bug**: a user whose only active BYOK key is ElevenLabs or Mistral saw the full-access preset UI — no Guest Mode preamble, paid presets selectable, no upsell — while generation still substituted the free model and showed the free-model footer. bot-client derived "is this user a guest" from ANY active wallet key; ai-worker derives it from chat-capable keys (OpenRouter, or z.ai-coding via the preset-dependent auto-promotion). `/models browse` already used the chat-capable semantic (`hasOpenRouter || hasZai` in `modelCatalog.ts`), so two bot-client surfaces contradicted each other too.

**The fix**:
- New in `common-types/constants/ai.ts`: `CHAT_CAPABLE_PROVIDERS` (OpenRouter + ZaiCoding), `isChatCapableProvider`, `hasActiveChatCapableKey` (structural param, so no constants→schemas dependency). This **consolidates** the private `LLM_FOOTER_PROVIDERS` copy of the same classification in `discord.ts` — the footer allowlist now derives from the shared predicate, so the footer and the UI can never disagree.
- Flipped the four any-key derivation sites: `preset/browse.ts` (×2 — preamble, dimming, badges), `preset/override/guestModeValidation.ts` (the premium-selection block), `preset/override/autocomplete.ts` (free-filter + upsell slot). The fail-open contract on wallet-fetch failure is preserved byte-for-byte at every site.
- Fifth site: `modelCatalog.ts`'s keyless-guest check (`activeProviders.size === 0`) was the any-key semantic in disguise — it denied the z.ai free-tier piggyback presentation to a voice-only key-holder. Now "no chat-capable provider"; the `null` (keys-unknown) handling is unchanged, and the fine-grained `hasOpenRouter`/`hasZai` usability states are untouched.
- ai-worker untouched — it already implements the target semantic.

**Deliberate asymmetry, documented**: the UI treats a zai-coding key as full access globally, while the worker's z.ai promotion is preset-dependent (z-ai/<model> on the coding catalog). Optimistic by design — the UI never blocks what the worker would allow; the worker stays authoritative. Documented in the rewritten Pass E note in BYOK_MANUAL_TESTING.md (plus §0.3/§0.5/Proves-line consistency edits).

**Riders**: removed the dead `WALLET_ERROR_MESSAGES.INVALID_PROVIDER` entry (zero consumers — grep returns only its own definition) and corrected the stale "OpenRouter and ElevenLabs are supported" comment in the same file.

## Tests

Existing suite had ~zero flips (the wallet factory defaults to OpenRouter), which means the fixed behavior was entirely unguarded — coverage is additive:
- 8 new unit tests for the helpers in `ai.test.ts`
- 9 new behavior tests across `browse.test.ts`, `guestModeValidation.test.ts`, `autocomplete.test.ts`, `modelCatalog.test.ts`: ElevenLabs-only ⇒ guest (preamble + dimming, premium block, free-filter + upsell), Mistral-only ⇒ guest, ZaiCoding-only ⇒ not guest, inactive-chat-key + active-voice-key ⇒ guest (guards the conjunction), voice-only wallet still gets the z.ai free-tier presentation
- **Flip-guard verified by mutation**: with `isChatCapableProvider` temporarily forced to `true`, exactly the six new behavior-flip tests fail — they are genuine guards, not decoration.

## Verification

- `pnpm --filter @tzurot/common-types test`: 110 files / 2691 tests green
- `pnpm --filter bot-client test`: 391 files / 6084 tests green
- `pnpm test`: 26/26 tasks green
- `pnpm quality`: green (gate parity confirmed)
- Survivor grep: the only remaining `isActive`-only expressions in bot-client are the three deliberately untouched sites (apikey inventory display, and the two already-provider-aware `/models` derivations)

Follow-up filed as TASK-434: ai-worker's guest mode still suppresses BYOK *audio*-key resolution, so an ElevenLabs-only user's own TTS key goes unused — this PR makes that coupling honestly visible in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)