### PR TITLE
feat(bot-client): autocompletable model option pre-seeds /preset create

### DIFF
--- a/packages/common-types/src/generated/commandOptions.ts
+++ b/packages/common-types/src/generated/commandOptions.ts
@@ -560,6 +560,13 @@ export const presetBrowseOptions = defineTypedOptions({
 });
 
 /**
+ * /preset create <model>
+ */
+export const presetCreateOptions = defineTypedOptions({
+  model: { type: 'string', required: false },
+});
+
+/**
  * /preset edit <preset>
  */
 export const presetEditOptions = defineTypedOptions({

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -1815,7 +1815,15 @@
             "type": 1,
             "name": "create",
             "description": "Create a new model preset",
-            "options": []
+            "options": [
+              {
+                "autocomplete": true,
+                "type": 3,
+                "name": "model",
+                "description": "Model ID (e.g., anthropic/claude-sonnet-4)",
+                "required": false
+              }
+            ]
           },
           {
             "type": 1,

--- a/services/bot-client/src/commands/models/autocomplete.ts
+++ b/services/bot-client/src/commands/models/autocomplete.ts
@@ -1,49 +1,13 @@
 /**
  * Models Autocomplete Handler
  *
- * Autocomplete for `/models view <model>`. Uses the merged catalog so z.ai-only
- * models (e.g. `glm-5.2`, absent from OpenRouter) are suggestable too.
+ * Autocomplete for `/models view <model>` — delegates to the shared
+ * merged-catalog responder so z.ai-only models are suggestable too.
  */
 
 import type { AutocompleteInteraction } from 'discord.js';
-import { DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
-import {
-  AUTOCOMPLETE_BADGES,
-  formatAutocompleteOption,
-} from '@tzurot/common-types/utils/autocompleteFormat';
-import { createLogger } from '@tzurot/common-types/utils/logger';
-import { formatContextLength } from '../../utils/modelAutocomplete.js';
-import { fetchModelCatalog } from '../../utils/modelCatalog.js';
-
-const logger = createLogger('models-autocomplete');
-
-/** Discord caps choice name/value at 100 chars (the formatter caps the name). */
-const MAX_CHOICE_VALUE_LEN = 100;
+import { respondWithCatalogAutocomplete } from '../../utils/modelCatalogAutocomplete.js';
 
 export async function handleAutocomplete(interaction: AutocompleteInteraction): Promise<void> {
-  const query = interaction.options.getFocused();
-
-  try {
-    const catalog = await fetchModelCatalog({
-      search: query.length > 0 ? query : undefined,
-      limit: DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES,
-    });
-
-    // Re-cap after the catalog merge: the fetch limit bounds only the OpenRouter
-    // half, and fetchModelCatalog adds up to ~6 z.ai entries on top, so the
-    // merged list can exceed Discord's 25-choice ceiling.
-    const choices = catalog.slice(0, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES).map(model =>
-      formatAutocompleteOption({
-        name: model.name,
-        value: model.id.slice(0, MAX_CHOICE_VALUE_LEN),
-        statusBadges: model.isZaiCoding ? [AUTOCOMPLETE_BADGES.ZAI_CODING] : undefined,
-        metadata: formatContextLength(model.contextLength),
-      })
-    );
-
-    await interaction.respond(choices);
-  } catch (error) {
-    logger.error({ err: error, query }, 'Model autocomplete failed');
-    await interaction.respond([]);
-  }
+  await respondWithCatalogAutocomplete(interaction, interaction.options.getFocused());
 }

--- a/services/bot-client/src/commands/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AutocompleteInteraction, User } from 'discord.js';
 import { mockListLlmConfigsResponse, mockLlmConfigSummary } from '@tzurot/test-factories';
 import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
+import type { CatalogModel } from '../../utils/modelCatalog.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -27,7 +28,37 @@ vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: clientsForMock,
 }));
 
+// Only the catalog fetch (the gateway boundary) is mocked — the choices below
+// are built by the real `formatAutocompleteOption`/`formatContextLength`, so a
+// formatting regression fails these tests rather than being mocked away.
+const catalogMock = vi.hoisted(() => ({ fetchModelCatalog: vi.fn() }));
+vi.mock('../../utils/modelCatalog.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/modelCatalog.js')>();
+  return {
+    ...actual,
+    fetchModelCatalog: (...args: unknown[]) => catalogMock.fetchModelCatalog(...args),
+  };
+});
+
 const { handleAutocomplete, __resetGlobalConfigCacheForTests } = await import('./autocomplete.js');
+
+function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
+  return {
+    name: overrides.id,
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    isZaiCoding: false,
+    docsUrl: null,
+    source: 'openrouter',
+    hasPricing: true,
+    ...overrides,
+  };
+}
 
 interface UserClientStub {
   listUserLlmConfigs: ReturnType<typeof vi.fn>;
@@ -291,6 +322,99 @@ describe('handleAutocomplete', () => {
 
       const respondCall = vi.mocked(mockInteraction.respond).mock.calls[0][0];
       expect(respondCall).toHaveLength(25);
+    });
+  });
+
+  describe('model autocomplete', () => {
+    const focusModel = (value: string): void => {
+      vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
+        name: 'model',
+        value,
+      } as unknown as string);
+    };
+
+    it('suggests merged-catalog models and ⚡-badges z.ai coding-plan entries', async () => {
+      catalogMock.fetchModelCatalog.mockResolvedValue([
+        catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }),
+        // z.ai-only model: absent from OpenRouter, present only because
+        // fetchModelCatalog merges the static coding-plan catalog in.
+        catalogModel({
+          id: 'z-ai/glm-5.2',
+          name: 'GLM-5.2',
+          contextLength: 1_000_000,
+          isZaiCoding: true,
+          source: 'zai-catalog',
+          hasPricing: false,
+        }),
+      ]);
+      focusModel('glm');
+
+      await handleAutocomplete(mockInteraction);
+
+      expect(mockInteraction.respond).toHaveBeenCalledWith([
+        { name: 'Claude Sonnet 4 · 200K', value: 'anthropic/claude-sonnet-4' },
+        { name: '⚡ GLM-5.2 · 1M', value: 'z-ai/glm-5.2' },
+      ]);
+    });
+
+    it('forwards the typed query as the catalog search term', async () => {
+      catalogMock.fetchModelCatalog.mockResolvedValue([]);
+      focusModel('sonnet');
+
+      await handleAutocomplete(mockInteraction);
+
+      expect(catalogMock.fetchModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'sonnet' })
+      );
+    });
+
+    it('omits the search term entirely when nothing has been typed', async () => {
+      catalogMock.fetchModelCatalog.mockResolvedValue([]);
+      focusModel('');
+
+      await handleAutocomplete(mockInteraction);
+
+      expect(catalogMock.fetchModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({ search: undefined })
+      );
+    });
+
+    it('re-caps the merged catalog at the 25-choice Discord ceiling', async () => {
+      // The fetch limit bounds only the OpenRouter half; the z.ai merge can push
+      // the returned list past 25, so the handler must cap again after the merge.
+      catalogMock.fetchModelCatalog.mockResolvedValue(
+        Array.from({ length: 31 }, (_, i) => catalogModel({ id: `vendor/model-${i}` }))
+      );
+      focusModel('');
+
+      await handleAutocomplete(mockInteraction);
+
+      const choices = vi.mocked(mockInteraction.respond).mock.calls[0][0];
+      expect(choices).toHaveLength(25);
+    });
+
+    it('truncates an over-long model id to the 100-char Discord value limit', async () => {
+      catalogMock.fetchModelCatalog.mockResolvedValue([
+        catalogModel({ id: `vendor/${'x'.repeat(120)}`, name: 'Long Model' }),
+      ]);
+      focusModel('');
+
+      await handleAutocomplete(mockInteraction);
+
+      const choices = vi.mocked(mockInteraction.respond).mock.calls[0][0] as {
+        name: string;
+        value: string;
+      }[];
+      expect(choices[0].value).toHaveLength(100);
+    });
+
+    it('responds with an empty list when the catalog fetch fails', async () => {
+      catalogMock.fetchModelCatalog.mockRejectedValue(new Error('gateway down'));
+      focusModel('gpt');
+
+      await handleAutocomplete(mockInteraction);
+
+      expect(mockInteraction.respond).toHaveBeenCalledWith([]);
     });
   });
 

--- a/services/bot-client/src/commands/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.ts
@@ -16,11 +16,7 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 import { shortModelName } from '@tzurot/common-types/utils/modelNames';
 import { clientsFor } from '../../utils/gatewayClients.js';
-import {
-  fetchTextModels,
-  fetchVisionModels,
-  formatModelChoice,
-} from '../../utils/modelAutocomplete.js';
+import { respondWithCatalogAutocomplete } from '../../utils/modelCatalogAutocomplete.js';
 
 import { runGuardedAutocomplete } from '../../utils/autocomplete/guardedAutocomplete.js';
 
@@ -93,9 +89,9 @@ export async function handleAutocomplete(interaction: AutocompleteInteraction): 
         await handlePresetAutocomplete(interaction, focusedOption.value, userId);
       }
     } else if (focusedOption.name === 'model') {
-      await handleModelAutocomplete(interaction, focusedOption.value);
-    } else if (focusedOption.name === 'vision-model') {
-      await handleVisionModelAutocomplete(interaction, focusedOption.value);
+      // `/preset create <model>` — merged-catalog suggestions, capability-agnostic
+      // like the preset picker (vision-capability derives from the chosen model).
+      await respondWithCatalogAutocomplete(interaction, focusedOption.value);
     } else {
       await interaction.respond([]);
     }
@@ -198,34 +194,6 @@ async function handlePresetAutocomplete(
       metadata: shortModelName(c.model),
     });
   });
-
-  await interaction.respond(choices);
-}
-
-/**
- * Handle model autocomplete - fetches text generation models from OpenRouter
- */
-async function handleModelAutocomplete(
-  interaction: AutocompleteInteraction,
-  query: string
-): Promise<void> {
-  const models = await fetchTextModels(query, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES);
-
-  const choices = models.map(m => formatModelChoice(m));
-
-  await interaction.respond(choices);
-}
-
-/**
- * Handle vision-model autocomplete - fetches vision-capable models from OpenRouter
- */
-async function handleVisionModelAutocomplete(
-  interaction: AutocompleteInteraction,
-  query: string
-): Promise<void> {
-  const models = await fetchVisionModels(query, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES);
-
-  const choices = models.map(m => formatModelChoice(m));
 
   await interaction.respond(choices);
 }

--- a/services/bot-client/src/commands/preset/create.test.ts
+++ b/services/bot-client/src/commands/preset/create.test.ts
@@ -51,11 +51,23 @@ vi.mock('../../utils/dashboard/index.js', () => ({
   }),
 }));
 
+/** Read the seed modal's `model` TextInput value out of the showModal call. */
+function modelInputValue(showModal: ReturnType<typeof vi.fn>): string | undefined {
+  const modalBuilder = vi.mocked(showModal).mock.calls[0][0] as {
+    toJSON: () => {
+      components: Array<{ component?: { custom_id: string; value?: string } }>;
+    };
+  };
+  return modalBuilder
+    .toJSON()
+    .components.find(labelRow => labelRow.component?.custom_id === 'model')?.component?.value;
+}
+
 describe('Preset Create', () => {
   describe('handleCreate', () => {
     // /preset create has no kind/slot option — a preset's vision-capability is
-    // derived from its model, not chosen at creation. handleCreate just shows
-    // the seed modal.
+    // derived from its model, not chosen at creation. handleCreate shows the
+    // seed modal, optionally pre-seeded from the `model` command option.
     const mockContext = {
       showModal: vi.fn(),
       interaction: { options: { getString: vi.fn().mockReturnValue(null) } },
@@ -63,6 +75,9 @@ describe('Preset Create', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
+      // Re-establish the no-option default: `clearAllMocks` clears calls but not
+      // implementations, so a per-test override would otherwise leak forward.
+      vi.mocked(mockContext.interaction.options.getString).mockReturnValue(null);
     });
 
     it('should show modal for preset creation', async () => {
@@ -95,6 +110,22 @@ describe('Preset Create', () => {
 
       expect(fieldIds).toContain('name');
       expect(fieldIds).toContain('model');
+    });
+
+    it('pre-seeds the modal Model ID field from the model command option', async () => {
+      vi.mocked(mockContext.interaction.options.getString).mockReturnValue('z-ai/glm-5.2');
+
+      await handleCreate(mockContext as unknown as Parameters<typeof handleCreate>[0]);
+
+      // Seam: the option value must survive the read → buildPresetSeedModal →
+      // TextInput hop, since Discord modals have no autocomplete of their own.
+      expect(modelInputValue(mockContext.showModal)).toBe('z-ai/glm-5.2');
+    });
+
+    it('leaves the Model ID field unset when the model option is absent', async () => {
+      await handleCreate(mockContext as unknown as Parameters<typeof handleCreate>[0]);
+
+      expect(modelInputValue(mockContext.showModal)).toBeUndefined();
     });
   });
 

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -8,6 +8,7 @@
  */
 
 import { MessageFlags, type ModalBuilder, type ModalSubmitInteraction } from 'discord.js';
+import { presetCreateOptions } from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import {
@@ -43,7 +44,12 @@ export async function handleCreate(context: ModalCommandContext): Promise<void> 
   // No slot option: a preset's vision-capability is derived from its model
   // (`supportsVision`), not chosen at creation. The vision SLOT is picked later
   // when the preset is assigned (override set/default set/global).
-  await context.showModal(buildPresetSeedModal());
+  //
+  // Reading the option is synchronous, so it costs nothing against the 3-second
+  // showModal budget. Absent option → no initial values, leaving the modal's own
+  // placeholder visible rather than prefilling an empty string.
+  const model = presetCreateOptions(context.interaction).model();
+  await context.showModal(buildPresetSeedModal(model !== null ? { model } : undefined));
 }
 
 /** Seed modal builder — shared by create and the retry affordance. */

--- a/services/bot-client/src/commands/preset/index.ts
+++ b/services/bot-client/src/commands/preset/index.ts
@@ -286,7 +286,19 @@ export default defineCommand({
       // No slot option: a preset's vision-capability is derived from its
       // model (`supportsVision`), not chosen at creation. The vision SLOT is
       // picked later when the preset is assigned (override set/default set/global).
-      subcommand.setName('create').setDescription('Create a new model preset')
+      subcommand
+        .setName('create')
+        .setDescription('Create a new model preset')
+        // Optional pre-seed: prefills the seed modal's Model ID field so the
+        // model can be picked from autocomplete instead of typed into the modal
+        // (Discord modals have no autocomplete).
+        .addStringOption(option =>
+          option
+            .setName('model')
+            .setDescription('Model ID (e.g., anthropic/claude-sonnet-4)')
+            .setRequired(false)
+            .setAutocomplete(true)
+        )
     )
     .addSubcommand(subcommand =>
       subcommand

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.component.test.ts.snap
@@ -2226,7 +2226,20 @@ exports[`CommandHandler (component) > command structure snapshots > has a stable
     "description_localizations": undefined,
     "name": "create",
     "name_localizations": undefined,
-    "options": [],
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Model ID (e.g., anthropic/claude-sonnet-4)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "model",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
     "type": 1,
   },
   {

--- a/services/bot-client/src/utils/modelCatalogAutocomplete.test.ts
+++ b/services/bot-client/src/utils/modelCatalogAutocomplete.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the shared merged-catalog autocomplete responder.
+ *
+ * Consumer-side wiring (dispatch, query plumbing) is pinned by the
+ * models/ and preset/ autocomplete suites; this suite pins the responder's
+ * own contract directly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AutocompleteInteraction } from 'discord.js';
+import type { CatalogModel } from './modelCatalog.js';
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const catalogMock = { fetchModelCatalog: vi.fn() };
+vi.mock('./modelCatalog.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./modelCatalog.js')>();
+  return {
+    ...actual,
+    fetchModelCatalog: (...args: unknown[]) => catalogMock.fetchModelCatalog(...args),
+  };
+});
+
+import { respondWithCatalogAutocomplete } from './modelCatalogAutocomplete.js';
+
+function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
+  return {
+    name: overrides.id,
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    isZaiCoding: overrides.id.startsWith('z-ai/'),
+    source: overrides.id.startsWith('z-ai/') ? 'zai-catalog' : 'openrouter',
+    ...overrides,
+  } as CatalogModel;
+}
+
+function mockInteraction(): AutocompleteInteraction {
+  return { respond: vi.fn() } as unknown as AutocompleteInteraction;
+}
+
+function respondedChoices(ix: AutocompleteInteraction): { name: string; value: string }[] {
+  return vi.mocked(ix.respond).mock.calls[0][0] as { name: string; value: string }[];
+}
+
+describe('respondWithCatalogAutocomplete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('formats catalog entries and ⚡-badges z.ai coding-plan models', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }),
+      catalogModel({ id: 'z-ai/glm-5.2', name: 'GLM 5.2' }),
+    ]);
+    const ix = mockInteraction();
+
+    await respondWithCatalogAutocomplete(ix, 'glm');
+
+    expect(catalogMock.fetchModelCatalog).toHaveBeenCalledWith({ search: 'glm', limit: 25 });
+    const choices = respondedChoices(ix);
+    expect(choices[0].value).toBe('anthropic/claude-sonnet-4');
+    expect(choices[1].value).toBe('z-ai/glm-5.2');
+    expect(choices[1].name).toContain('⚡');
+    expect(choices[0].name).not.toContain('⚡');
+  });
+
+  it('omits the search term for an empty query and re-caps at the 25-choice ceiling', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue(
+      Array.from({ length: 30 }, (_, i) => catalogModel({ id: `vendor/model-${i}` }))
+    );
+    const ix = mockInteraction();
+
+    await respondWithCatalogAutocomplete(ix, '');
+
+    expect(catalogMock.fetchModelCatalog).toHaveBeenCalledWith({ search: undefined, limit: 25 });
+    expect(respondedChoices(ix)).toHaveLength(25);
+  });
+
+  it('truncates an over-long model id to the 100-char Discord value limit', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: `vendor/${'x'.repeat(120)}` }),
+    ]);
+    const ix = mockInteraction();
+
+    await respondWithCatalogAutocomplete(ix, 'x');
+
+    expect(respondedChoices(ix)[0].value).toHaveLength(100);
+  });
+
+  it('responds with an empty list when the catalog fetch throws (lenient contract)', async () => {
+    catalogMock.fetchModelCatalog.mockRejectedValue(new Error('gateway down'));
+    const ix = mockInteraction();
+
+    await respondWithCatalogAutocomplete(ix, 'claude');
+
+    expect(vi.mocked(ix.respond)).toHaveBeenCalledWith([]);
+  });
+});

--- a/services/bot-client/src/utils/modelCatalogAutocomplete.ts
+++ b/services/bot-client/src/utils/modelCatalogAutocomplete.ts
@@ -1,0 +1,59 @@
+/**
+ * Merged-Catalog Model Autocomplete
+ *
+ * Shared responder for slash options that suggest a model ID. Uses the merged
+ * catalog so z.ai-only models (e.g. `glm-5.2`, absent from OpenRouter) are
+ * suggestable too — consumers (`/models view`, `/preset create`) accept either.
+ * Lives apart from `modelCatalog.ts` so tests stubbing `fetchModelCatalog`
+ * still intercept the call (a same-module internal call would bypass the mock).
+ */
+
+import type { AutocompleteInteraction } from 'discord.js';
+import { DISCORD_LIMITS } from '@tzurot/common-types/constants/discord';
+import {
+  AUTOCOMPLETE_BADGES,
+  formatAutocompleteOption,
+} from '@tzurot/common-types/utils/autocompleteFormat';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { formatContextLength } from './modelAutocomplete.js';
+import { fetchModelCatalog } from './modelCatalog.js';
+
+const logger = createLogger('model-catalog-autocomplete');
+
+/** Discord caps choice name/value at 100 chars (the formatter caps the name). */
+const MAX_CHOICE_VALUE_LEN = 100;
+
+/**
+ * Respond to a model-ID autocomplete interaction from the merged catalog.
+ *
+ * Lenient contract: never throws — an empty dropdown beats an error popup for
+ * a transient blip.
+ */
+export async function respondWithCatalogAutocomplete(
+  interaction: AutocompleteInteraction,
+  query: string
+): Promise<void> {
+  try {
+    const catalog = await fetchModelCatalog({
+      search: query.length > 0 ? query : undefined,
+      limit: DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES,
+    });
+
+    // Re-cap after the catalog merge: the fetch limit bounds only the OpenRouter
+    // half, and fetchModelCatalog adds up to ~6 z.ai entries on top, so the
+    // merged list can exceed Discord's 25-choice ceiling.
+    const choices = catalog.slice(0, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES).map(model =>
+      formatAutocompleteOption({
+        name: model.name,
+        value: model.id.slice(0, MAX_CHOICE_VALUE_LEN),
+        statusBadges: model.isZaiCoding ? [AUTOCOMPLETE_BADGES.ZAI_CODING] : undefined,
+        metadata: formatContextLength(model.contextLength),
+      })
+    );
+
+    await interaction.respond(choices);
+  } catch (error) {
+    logger.error({ err: error, query }, 'Model autocomplete failed');
+    await interaction.respond([]);
+  }
+}


### PR DESCRIPTION
## Summary

Closes TASK-207 (owner call 2026-08-04: shape (a) — slash-option prefill).

**The problem**: `/preset create`'s model field is a MODAL text input, and Discord has no autocomplete for modal inputs — so model IDs were freeform and typo-prone. (The original task asked to "autocomplete the model field"; that's not implementable as filed, hence this shape.)

**The change**:
- `/preset create` gains one optional autocompleting `model` string option that **prefills** the seed modal's Model ID field. Reading the option is synchronous, so nothing is spent against the 3-second showModal budget; absent option → unchanged behavior (placeholder visible, no prefill). The prefill is advisory — the gateway's model validation (Phase 1b) still gates the actual submit, and a bad value degrades through the existing retry affordance.
- History note: this option existed before the seed-modal redesign removed it — and its autocomplete dispatch branch survived as unreachable code. This PR re-activates that branch rather than adding new routing.
- **Autocomplete upgraded to the merged catalog** (`fetchModelCatalog`) so z.ai-only models (`glm-5.2` etc.) are suggestable — matching exactly what the server-side validator accepts (it takes z-ai/* catalog models; the old OpenRouter-only fetch under-suggested precisely those).
- **Shared responder extraction**: the catalog→choices body was verbatim-identical between `/models view` autocomplete and the new handler (the CPD ratchet caught the 24-line clone — the extraction brought filtered lines to 1803, *below* the pre-PR baseline). `respondWithCatalogAutocomplete` lives in a new `utils/modelCatalogAutocomplete.ts` — deliberately apart from `modelCatalog.ts` so both suites' `fetchModelCatalog` stubs still intercept the call (a same-module internal call would bypass vi.mock).
- The dead `vision-model` autocomplete branch + handler are deleted (vision capability derives from the model per the existing design note; `fetchVisionModels` keeps its live consumer in admin/settingsSet).

## Tests

- 2 new `create` cases assert the seam: the option value must survive read → `buildPresetSeedModal` → TextInput (and absent option → no initial value). Plus a test-isolation fix: the `getString` default is re-established in `beforeEach` since `clearAllMocks` clears calls, not implementations.
- 6 new preset autocomplete cases (badge formatting through the real formatter, query forwarding, empty-query handling, 25-choice re-cap, 100-char value truncation, fetch-failure → `[]`).
- 4 direct cases for the extracted responder (colocated, per structure gate).
- Snapshots updated: the component command-structure snap and `command-manifest.json` each show exactly one hunk — the new optional `model` option under `preset create`.

## Verification

- `pnpm ops codegen:command-types --check` green (generated `presetCreateOptions` in sync)
- `pnpm --filter bot-client test`: 392 files / 6096 tests green
- `pnpm test:component`: 46 files / 624 passed green
- `pnpm test` (26/26) then `pnpm quality` green, sequentially — including the CPD ratchet at 1803/1809

Worker-flagged follow-up not taken here: the snapshot-refresh command documented in `commandManifest.test.ts`'s header (`pnpm --filter @tzurot/bot-client test -- -u <path>`) doesn't actually forward `-u` through pnpm — stale doc comment, one-line fix riding the next touch of that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)