### PR TITLE
refactor(bot-client): delete dead hasForwardedContent (TASK-427)

### DIFF
--- a/services/bot-client/src/utils/forwardedMessageUtils.test.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.test.ts
@@ -16,7 +16,6 @@ import {
   extractForwardedContent,
   extractForwardedAttachments,
   extractAllForwardedContent,
-  hasForwardedContent,
   hasForwardedVoiceAttachment,
   hasVoiceAttachments,
   getEffectiveContent,
@@ -422,97 +421,6 @@ describe('forwardedMessageUtils', () => {
       expect(result.embeds).toHaveLength(1);
       expect(result.fromSnapshot).toBe(false);
       expect(result.originalMessageId).toBe('original-456');
-    });
-  });
-
-  describe('hasForwardedContent', () => {
-    it('should return true when forwarded message has text content', () => {
-      const message = createMockMessage({
-        referenceType: MessageReferenceType.Forward,
-        snapshots: [{ content: 'Some content' }],
-      });
-
-      expect(hasForwardedContent(message)).toBe(true);
-    });
-
-    it('should return true when forwarded message has only attachments', () => {
-      const message = createMockMessage({
-        referenceType: MessageReferenceType.Forward,
-        snapshots: [
-          {
-            content: '',
-            attachments: [{ url: 'https://cdn.discord.com/image.png' }],
-          },
-        ],
-      });
-
-      expect(hasForwardedContent(message)).toBe(true);
-    });
-
-    it('should return true when forwarded message has only embeds', () => {
-      const message = createMockMessage({
-        referenceType: MessageReferenceType.Forward,
-        snapshots: [
-          {
-            content: '',
-            embeds: [{ title: 'Embed' }],
-          },
-        ],
-      });
-
-      expect(hasForwardedContent(message)).toBe(true);
-    });
-
-    it('should return false for non-forwarded message', () => {
-      const message = createMockMessage({
-        content: 'Regular message',
-      });
-
-      expect(hasForwardedContent(message)).toBe(false);
-    });
-
-    it('should return true when forwarded message has main content but no snapshots', () => {
-      // Edge case: forwarded with no snapshots falls back to main content
-      const message = createMockMessage({
-        referenceType: MessageReferenceType.Forward,
-        content: 'Fallback content',
-      });
-
-      expect(hasForwardedContent(message)).toBe(true);
-    });
-
-    it('returns true for a Lottie-sticker-only forward (no raster attachment to count)', () => {
-      // The attachment walk carries only RASTERIZABLE stickers; a Lottie-only
-      // forward has empty content, no attachments, no embeds — the direct
-      // sticker check is what keeps it from being dropped as empty.
-      const message = createMockMessage({
-        referenceType: MessageReferenceType.Forward,
-        snapshots: [
-          {
-            content: '',
-            stickers: [
-              { id: '88', name: 'wave', format: 3, url: 'https://cdn.discordapp.com/88.json' },
-            ],
-          },
-        ],
-      });
-
-      expect(hasForwardedContent(message)).toBe(true);
-    });
-
-    it('returns true for a sticker-only forward on the no-snapshot fallback path', () => {
-      // When Discord doesn't populate snapshots, the fallback reads the main
-      // message — which carries no sticker in its attachments/content/embeds
-      // either, so only the direct sticker check sees it.
-      const message = createMockMessage({
-        referenceType: MessageReferenceType.Forward,
-        content: '',
-        stickers: [
-          { id: '77', name: 'shipit', format: 1, url: 'https://cdn.discordapp.com/77.png' },
-        ],
-      });
-
-      expect(hasForwardedContent(message)).toBe(true);
     });
   });
 

--- a/services/bot-client/src/utils/forwardedMessageUtils.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.ts
@@ -29,7 +29,6 @@ import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/disc
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
 import { extractSnapshotStickerImages } from './stickerAttachments.js';
-import { collectAllStickers } from './stickerPollDescriptions.js';
 import { isVoiceAttachment } from './voiceAttachment.js';
 
 /**
@@ -277,39 +276,6 @@ export function extractAllForwardedContent(message: Message): ForwardedContentRe
     fromSnapshot: true,
     originalMessageId: message.reference?.messageId,
   };
-}
-
-/**
- * Check if a forwarded message has any meaningful content.
- *
- * Returns true if the forwarded message has:
- * - Text content (in snapshots or main message)
- * - Attachments (in snapshots or main message)
- * - Embeds (in snapshots or main message)
- * - Stickers (in snapshots or main message, rasterizable or not)
- *
- * Use this for filtering - a forwarded message is worth processing if it has content.
- *
- * @param message - Discord message (should be a forwarded message)
- * @returns true if the forwarded message has meaningful content
- */
-export function hasForwardedContent(message: Message): boolean {
-  if (!isForwardedMessage(message)) {
-    return false;
-  }
-
-  const { content, attachments, embeds } = extractAllForwardedContent(message);
-
-  // Stickers are checked directly rather than through the extraction result:
-  // the attachment walk only carries RASTERIZABLE stickers (Lottie has no
-  // image form), and the no-snapshot fallback carries none at all — either
-  // way a sticker-only forward would read as empty and be dropped.
-  return (
-    content.length > 0 ||
-    attachments.length > 0 ||
-    embeds.length > 0 ||
-    collectAllStickers(message).length > 0
-  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Deletes `hasForwardedContent` from `forwardedMessageUtils.ts` and its test block — TASK-427's "remove" disposition, executing the owner's standing drain directive.

**Why removal, not wiring:** #1948's round-2 review found (and repo-wide grep re-confirmed today) that the function has zero production callers. `EmptyMessageFilter` short-circuits forwarded messages to never-empty before any content gate reaches it, and the extended-context path uses `hasStickerOrPoll` — so there is no candidate consumer to wire it into. Its #1948 sticker-awareness fix was correct, tested, and unreachable. Dead canonical-API surface invites a future caller to assume it's live; knip can't flag it (test imports count as usage under current config).

## Changes

- Delete `hasForwardedContent` + its JSDoc (−34 lines)
- Delete the now-unused `collectAllStickers` import (its only use in this file was inside the deleted function; `stickerAttachments.ts` / `stickerPollDescriptions.ts` consumers unaffected)
- Delete the `describe('hasForwardedContent')` test block + import (−92 lines)

Deletions only: `2 files changed, 126 deletions(-)`.

## Verification

- Repo-wide grep for `hasForwardedContent` (excl. node_modules/dist): zero survivors
- `collectAllStickers` grep in the target file: zero survivors; other consumers intact
- The mock helper's snapshot-level `stickers` branch was checked for orphaning: still used by the surviving vision/sticker-description test — left in place
- Full `pnpm test` (26 tasks) and `pnpm quality` green, run sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)