### PR TITLE
fix(ai-worker): unwrap invented wrapper tags like <action> from replies

### DIFF
--- a/services/ai-worker/src/services/ResponsePostProcessor.test.ts
+++ b/services/ai-worker/src/services/ResponsePostProcessor.test.ts
@@ -47,11 +47,18 @@ vi.mock('../utils/responseArtifacts.js', () => ({
   stripUserMessageEcho: mockStripUserMessageEcho,
 }));
 
-vi.mock('../utils/thinkingExtraction.js', () => ({
-  extractThinkingBlocks: mockExtractThinkingBlocks,
-  extractApiReasoningContent: mockExtractApiReasoningContent,
-  mergeThinkingContent: mockMergeThinkingContent,
-}));
+vi.mock('../utils/thinkingExtraction.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils/thinkingExtraction.js')>();
+  return {
+    // Real, not mocked: `wrapperTagUnwrap` (reached through the processor, not
+    // stubbed here) derives its exclusion set from this vocabulary at module
+    // load, so a stubbed-out constant would crash the import.
+    KNOWN_THINKING_TAGS: actual.KNOWN_THINKING_TAGS,
+    extractThinkingBlocks: mockExtractThinkingBlocks,
+    extractApiReasoningContent: mockExtractApiReasoningContent,
+    mergeThinkingContent: mockMergeThinkingContent,
+  };
+});
 
 vi.mock('../utils/promptPlaceholders.js', () => ({
   replacePromptPlaceholders: mockReplacePromptPlaceholders,
@@ -335,6 +342,133 @@ describe('ResponsePostProcessor', () => {
 
       expect(result.thinkingContent).toBe('API level\n\n---\n\nInline');
       expect(result.cleanedContent).toBe('Response');
+    });
+  });
+
+  describe('processResponse wrapper-tag unwrap (seam)', () => {
+    // Every other test in this file mocks the pipeline's collaborators, which
+    // is exactly what cannot catch this bug: the failure lives in the ORDER of
+    // two real passes. `stripResponseArtifacts` carries a generic
+    // trailing-closing-tag pattern that eats a reply-final `</action>` and
+    // leaves the opener behind, so the unwrap has to reach the pair first.
+    // These cases therefore run the real chain end-to-end.
+    beforeEach(async () => {
+      const [dedup, thinking, artifacts, placeholders] = await Promise.all([
+        vi.importActual<typeof import('../utils/duplicateDetection.js')>(
+          '../utils/duplicateDetection.js'
+        ),
+        vi.importActual<typeof import('../utils/thinkingExtraction.js')>(
+          '../utils/thinkingExtraction.js'
+        ),
+        vi.importActual<typeof import('../utils/responseArtifacts.js')>(
+          '../utils/responseArtifacts.js'
+        ),
+        vi.importActual<typeof import('../utils/promptPlaceholders.js')>(
+          '../utils/promptPlaceholders.js'
+        ),
+      ]);
+
+      mockRemoveDuplicateResponse.mockImplementation(dedup.removeDuplicateResponse);
+      mockExtractThinkingBlocks.mockImplementation(thinking.extractThinkingBlocks);
+      mockExtractApiReasoningContent.mockImplementation(thinking.extractApiReasoningContent);
+      mockMergeThinkingContent.mockImplementation(thinking.mergeThinkingContent);
+      mockStripResponseArtifacts.mockImplementation(artifacts.stripResponseArtifacts);
+      mockStripUserMessageEcho.mockImplementation(artifacts.stripUserMessageEcho);
+      mockReplacePromptPlaceholders.mockImplementation(placeholders.replacePromptPlaceholders);
+    });
+
+    const seamContext = {
+      personalityName: 'Lilith',
+      userName: 'Lila',
+    };
+
+    it('delivers the unwrapped text for a reply-final wrapped stage direction', () => {
+      // The production shape: dialogue lines plus a stage direction the model
+      // wrapped in invented markup, with the closing tag last in the message.
+      const raw = [
+        '"You should not be here."',
+        '<action>She steps back into the shadows.</action>',
+      ].join('\n');
+
+      const result = processor.processResponse(raw, undefined, undefined, seamContext);
+
+      expect(result.cleanedContent).toBe(
+        '"You should not be here."\nShe steps back into the shadows.'
+      );
+      // The orphan-opener assertion is the regression: if the artifact pass ran
+      // first it would strip the trailing `</action>` and leave `<action>`.
+      expect(result.cleanedContent).not.toContain('<action>');
+      expect(result.cleanedContent).not.toContain('</action>');
+    });
+
+    it('delivers the unwrapped text for a mid-reply wrapped stage direction', () => {
+      const raw = [
+        '"You should not be here."',
+        '<action>She steps back into the shadows.</action>',
+        '"Go home, Lila."',
+      ].join('\n');
+
+      const result = processor.processResponse(raw, undefined, undefined, seamContext);
+
+      expect(result.cleanedContent).toBe(
+        '"You should not be here."\nShe steps back into the shadows.\n"Go home, Lila."'
+      );
+      expect(result.cleanedContent).not.toContain('action>');
+    });
+
+    it('leaves an inline wrapped stage direction byte-identical rather than orphaning its opener', () => {
+      // The residual shape the unwrap DECLINES by design: the pair shares a line
+      // with other text, so it is indistinguishable from prose that mentions
+      // markup. Declining is only safe if the next pass leaves it alone too —
+      // the artifact pass's generic trailing-closer strip used to delete the
+      // reply-final `</action>` and ship the orphaned `<action>` to the reader.
+      const raw = '"You should not be here." <action>She steps back into the shadows.</action>';
+
+      const result = processor.processResponse(raw, undefined, undefined, seamContext);
+
+      expect(result.cleanedContent).toBe(raw);
+    });
+
+    it('delivers the unwrapped text for a multi-line wrapped block mid-reply', () => {
+      // The span shape: delimiters on their own lines around a block. Neither
+      // the whole-message mode (content does not start with the tag) nor the
+      // line mode (the opener's line has no closer) reaches it, so before the
+      // span mode existed both literal tags shipped to the reader.
+      const raw = [
+        '"Dialogue here."',
+        '',
+        '<action>',
+        'She walks to the window, pauses, and looks out at the rain falling',
+        'gently on the street below.',
+        '</action>',
+        '',
+        '"More dialogue."',
+      ].join('\n');
+
+      const result = processor.processResponse(raw, undefined, undefined, seamContext);
+
+      expect(result.cleanedContent).toBe(
+        [
+          '"Dialogue here."',
+          '',
+          'She walks to the window, pauses, and looks out at the rain falling',
+          'gently on the street below.',
+          '',
+          '"More dialogue."',
+        ].join('\n')
+      );
+      expect(result.cleanedContent).not.toContain('action>');
+    });
+
+    it('leaves a reply that merely discusses the markup byte-identical', () => {
+      const raw = [
+        '"It kept doing it," she says. "Sticking <action>walks away</action> into the',
+        'middle of a sentence like the tag was part of the prose."',
+      ].join('\n');
+
+      const result = processor.processResponse(raw, undefined, undefined, seamContext);
+
+      expect(result.cleanedContent).toBe(raw);
     });
   });
 

--- a/services/ai-worker/src/services/ResponsePostProcessor.ts
+++ b/services/ai-worker/src/services/ResponsePostProcessor.ts
@@ -19,6 +19,7 @@ import {
   mergeThinkingContent,
 } from '../utils/thinkingExtraction.js';
 import { replacePromptPlaceholders } from '../utils/promptPlaceholders.js';
+import { unwrapUnknownWrapperTags } from '../utils/wrapperTagUnwrap.js';
 
 const logger = createLogger('ResponsePostProcessor');
 
@@ -204,8 +205,9 @@ export class ResponsePostProcessor {
    * 1. Remove duplicate content (stop-token failure handling)
    * 2. Extract API-level reasoning
    * 3. Extract inline thinking blocks
-   * 4. Strip response artifacts (system prompt leakage)
-   * 5. Replace prompt placeholders with actual names
+   * 4. Unwrap invented content-shaped wrapper tags
+   * 5. Strip response artifacts (system prompt leakage)
+   * 6. Replace prompt placeholders with actual names
    */
   processResponse(
     rawContent: string,
@@ -226,10 +228,19 @@ export class ResponsePostProcessor {
       apiReasoning
     );
 
-    // Step 4: Strip artifacts
-    let cleanedContent = stripResponseArtifacts(visibleContent, context.personalityName);
+    // Step 4: Unwrap invented content-shaped wrapper tags (e.g. a reply whose
+    // stage direction came back as a literal <action>…</action> line).
+    //
+    // Placement is load-bearing: it MUST run before artifact stripping. That
+    // pass carries a generic trailing-closing-tag pattern, which eats a
+    // reply-final </action> and orphans the opener — so the pair has to be
+    // unwrapped while it is still intact.
+    const { content: unwrappedContent } = unwrapUnknownWrapperTags(visibleContent);
 
-    // Step 4b: Strip leading verbatim echo of the user's incoming message.
+    // Step 5: Strip artifacts
+    let cleanedContent = stripResponseArtifacts(unwrappedContent, context.personalityName);
+
+    // Step 5b: Strip leading verbatim echo of the user's incoming message.
     // Some LLMs learned to echo the incoming message as a prefix; existing
     // stripResponseArtifacts catches XML-wrapped variants, this catches the
     // plain-text variant. Safe no-op when userMessage is undefined.
@@ -239,7 +250,7 @@ export class ResponsePostProcessor {
       context.personalityName
     );
 
-    // Step 5: Replace placeholders
+    // Step 6: Replace placeholders
     cleanedContent = replacePromptPlaceholders(
       cleanedContent,
       context.userName,
@@ -247,7 +258,7 @@ export class ResponsePostProcessor {
       context.discordUsername
     );
 
-    // Step 6: Glitch detection — check for leaked chain-of-thought
+    // Step 7: Glitch detection — check for leaked chain-of-thought
     // Only fires when reasoning was enabled AND tag-based extraction found nothing
     let onlyThinkingProduced = false;
     if (
@@ -264,7 +275,7 @@ export class ResponsePostProcessor {
       );
     }
 
-    // Step 7: Reasoning-mode actual-vs-requested telemetry. Some models
+    // Step 8: Reasoning-mode actual-vs-requested telemetry. Some models
     // (notably `z-ai/glm-4.5-air:free`) accept a reasoning flag but don't
     // always actually emit reasoning — the response comes back as if
     // reasoning was disabled. When we're investigating model-inference

--- a/services/ai-worker/src/utils/responseArtifacts.test.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.test.ts
@@ -73,6 +73,81 @@ describe('stripResponseArtifacts', () => {
       expect(stripResponseArtifacts('Hello!</my-tag>', 'Emily')).toBe('Hello!');
       expect(stripResponseArtifacts('Hello!</section2>', 'Emily')).toBe('Hello!');
     });
+
+    describe('opener-aware: a closer whose opener is present is not an orphan', () => {
+      // Deleting the closer of a COMPLETE pair does not clean the reply, it
+      // corrupts it: the opening tag is left behind and ships to the reader.
+      // `unwrapUnknownWrapperTags` deliberately declines inline pairs (a tag pair
+      // sharing a line with prose is as likely to be quotation as markup), so
+      // this is the shape that reaches here — and the safe outcome is symmetric
+      // visible markup rather than a mangled sentence.
+
+      it('strips a trailing closer that nothing earlier opened', () => {
+        // The pattern's original purpose, pinned: a bare stray closer.
+        expect(stripResponseArtifacts('She steps back into the shadows.</action>', 'Lilith')).toBe(
+          'She steps back into the shadows.'
+        );
+      });
+
+      it('keeps BOTH halves of an inline pair at the end of a reply', () => {
+        const content =
+          '"You should not be here." <action>She steps back into the shadows.</action>';
+        expect(stripResponseArtifacts(content, 'Lilith')).toBe(content);
+      });
+
+      it('keeps a pair whose opener carries attributes', () => {
+        const content = 'Then it happened. <action type="move">She crosses the room.</action>';
+        expect(stripResponseArtifacts(content, 'Lilith')).toBe(content);
+      });
+
+      it('does NOT treat a LONGER earlier tag name as the opener', () => {
+        // `<actionable>` must not count as an opener for `</action>` — the
+        // `(?:\s|>)` boundary is what makes the two distinct.
+        expect(stripResponseArtifacts('<actionable> is the widget name.</action>', 'Emily')).toBe(
+          '<actionable> is the widget name.'
+        );
+      });
+
+      it('leaves two complete pairs on one line untouched', () => {
+        const content = '<action>a</action> and <action>b</action>';
+        expect(stripResponseArtifacts(content, 'Emily')).toBe(content);
+      });
+
+      it('re-evaluates against the CURRENT content on each iteration', () => {
+        // The stray `</message>` goes first; only then is `</action>` trailing —
+        // and by then its opener is visible, so it survives. A one-shot check
+        // made before the loop could not see this.
+        const content = 'Hello! <action>She waves.</action></message>';
+        expect(stripResponseArtifacts(content, 'Emily')).toBe('Hello! <action>She waves.</action>');
+      });
+
+      it('KNOWN LIMIT: a mismatched-name pair still loses its trailing closer', () => {
+        // `<action>…</actionable>` is a model typo, not the incident class this
+        // opener-awareness exists for. The unwrap pass upstream declines (no
+        // matching closer), and the opener probe here finds no `<actionable`, so
+        // the closer strips and a lone `<action>` ships. Catching it would need
+        // fuzzy tag matching — a materially different mechanism, and one whose
+        // false positives would delete the closers of pairs that are genuinely
+        // complete. Pinned so the boundary is visible rather than discovered.
+        expect(stripResponseArtifacts('<action>text</actionable>', 'Emily')).toBe('<action>text');
+      });
+
+      it('composes with the other steps in the loop and converges', () => {
+        const content = [
+          '"Stay back." <action>She raises a hand.</action>',
+          '<reactions>',
+          '<reaction from="Lila" from_id="abc-123">😮</reaction>',
+          '</reactions>',
+          '</module>',
+        ].join('\n');
+
+        // Orphan `</module>` stripped, the reactions block stripped, the complete
+        // `<action>` pair left alone.
+        expect(stripResponseArtifacts(content, 'Lilith')).toBe(
+          '"Stay back." <action>She raises a hand.</action>'
+        );
+      });
+    });
   });
 
   describe('<last_message> block stripping', () => {
@@ -330,12 +405,14 @@ describe('stripResponseArtifacts', () => {
     });
 
     it('should NOT strip self-contained tag with long content via single pattern', () => {
-      // Self-contained pattern has 100-char limit, but individual leading/trailing patterns
-      // still strip the tags separately. Use a tag NOT in our known lists to verify.
+      // Self-contained pattern has 100-char limit, so the pair is not stripped as
+      // a unit. Use a tag NOT in our known lists to verify.
       const longContent = 'A'.repeat(150);
       const content = `<dialogue>${longContent}</dialogue>`;
-      // Only </dialogue> gets stripped by generic trailing closer; <dialogue> is not in our list
-      expect(stripResponseArtifacts(content, 'Emily')).toBe(`<dialogue>${longContent}`);
+      // The generic trailing closer is opener-aware: `<dialogue>` is right there
+      // in the content, so deleting `</dialogue>` alone would orphan it. Nothing
+      // else in the list owns `dialogue`, so the content survives whole.
+      expect(stripResponseArtifacts(content, 'Emily')).toBe(content);
     });
 
     it('should handle combined leading XML wrappers + trailing closing tags', () => {

--- a/services/ai-worker/src/utils/responseArtifacts.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.ts
@@ -16,6 +16,13 @@
  * asked about the very structures these patterns hunt for. Matches inside code
  * markup are therefore left alone (`replaceOutsideCodeMarkup`), which is the
  * same discriminator the reasoning-tag extractor settled on for the same reason.
+ *
+ * The generic trailing-closing-tag cleanup is additionally OPENER-AWARE: a
+ * trailing `</tag>` is deleted only when no matching `<tag>` appears earlier in
+ * the content. Deleting the closer of a complete pair does not clean the reply,
+ * it CORRUPTS it — the opener is left orphaned and ships to the reader. A
+ * surviving pair is symmetric visible markup, which is cosmetic; a surviving
+ * lone opener is not.
  */
 
 import { type MessageContent } from '@tzurot/common-types/types/ai';
@@ -42,56 +49,120 @@ const MIN_ECHO_LENGTH = 30;
 const MAX_STRIP_RATIO = 0.8;
 
 /**
- * Build artifact patterns for a given personality name
+ * One cleanup step. Takes the current content and returns it with at most one
+ * artifact family removed, or unchanged when the step does not apply.
+ *
+ * Most steps are a single regex deletion (see {@link patternStep}); the generic
+ * trailing-closer step is a function because "strip only when no matching opener
+ * exists earlier" is a condition no static regex can express, and it has to be
+ * evaluated against the CURRENT content on every iteration — earlier steps
+ * expose trailing closers that were not trailing when the pass began.
  */
-function buildArtifactPatterns(personalityName: string): RegExp[] {
+type ArtifactStep = (content: string) => string;
+
+/**
+ * Adapt a deletion regex to a step, preserving the code-markup gate and the
+ * trim that every pattern has always applied.
+ */
+function patternStep(pattern: RegExp): ArtifactStep {
+  return content => replaceOutsideCodeMarkup(content, pattern).trim();
+}
+
+/**
+ * Generic trailing closing tag: catches </message>, </module>, </current_turn>,
+ * etc. — the stray tags models learn to append from XML training data.
+ */
+const TRAILING_CLOSER_PATTERN = /<\/([a-z][a-z0-9_-]*)>\s*$/i;
+
+/**
+ * Strip a trailing closing tag ONLY when nothing earlier in the content opened
+ * it. A trailing `</action>` whose `<action>` sits on the same line is half of a
+ * pair the model emitted deliberately (or that an upstream pass declined to
+ * unwrap); deleting just the closer orphans the opener and ships corrupted text.
+ * Leaving the pair intact is the conservative direction — visible but symmetric
+ * markup rather than a mangled reply.
+ *
+ * The opener probe is a plain scan of everything before the match: an opener
+ * inside code markup still counts as "exists", which fails toward preserving
+ * content, consistent with the rest of this module.
+ */
+function stripOrphanTrailingCloser(content: string): string {
+  const match = TRAILING_CLOSER_PATTERN.exec(content);
+  if (match === null) {
+    return content;
+  }
+
+  // Tag name comes from the `[a-z][a-z0-9_-]*` capture, so it carries no regex
+  // metacharacters (`-` is literal outside a character class) and needs no
+  // escaping. The `(?:\s|>)` boundary stops `<actionable ` from counting as an
+  // opener for `</action>`, and a closing tag can never match because `</` puts
+  // a `/` where the pattern requires the tag's first letter.
+  const opener = new RegExp(`<${match[1]}(?:\\s|>)`, 'i');
+  if (opener.test(content.slice(0, match.index))) {
+    return content;
+  }
+
+  return replaceOutsideCodeMarkup(content, TRAILING_CLOSER_PATTERN).trim();
+}
+
+/**
+ * Build the ordered artifact-cleanup steps for a given personality name.
+ */
+function buildArtifactPatterns(personalityName: string): ArtifactStep[] {
   const escapedName = personalityName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   return [
     // Leading <last_message> block: model echoes prompt structure (learned from training data)
     // '<last_message>User: hello</last_message>\n\nResponse' → 'Response'
-    /^<last_message>[\s\S]*?<\/last_message>\s*/i,
+    patternStep(/^<last_message>[\s\S]*?<\/last_message>\s*/i),
     // Leading <from> tag: model echoes speaker identification from prompt
     // '<from id="abc">Kevbear</from>\n\nHello' → 'Hello'
-    /^<from\b[^>]*>[^<]*<\/from>\s*/i,
+    patternStep(/^<from\b[^>]*>[^<]*<\/from>\s*/i),
     // Self-contained hallucinated tags with short content: catches metadata echoes like
     // <result>PersonalityName</result> or <parameter name="char">Name</parameter>.
     // Max 100 chars prevents stripping tags that contain the actual response.
     // MUST come before leading opening tag pattern so matched pairs are stripped as a unit.
-    /^<(result|result_text|parameter|character|name|content)(?:\s[^>]*)?>[^<\n]{0,100}<\/\1>\s*/i,
+    patternStep(
+      /^<(result|result_text|parameter|character|name|content)(?:\s[^>]*)?>[^<\n]{0,100}<\/\1>\s*/i
+    ),
     // Leading hallucinated tool-use opening tags: GLM 4.5 Air (and similar models trained on
     // Anthropic/OpenAI data) wrap responses in XML tool-use structures like <function_calls>,
     // <invoke>, <results>, etc. Strip known tag families at start of content only.
-    /^<(?:function_calls|function_results|invoke|results|result|result_text|parameter|content|character|name|tool_calls|tool_results|tool_call|tool_result)(?:\s[^>]*)?>[ \t]*\n?/i,
+    patternStep(
+      /^<(?:function_calls|function_results|invoke|results|result|result_text|parameter|content|character|name|tool_calls|tool_results|tool_call|tool_result)(?:\s[^>]*)?>[ \t]*\n?/i
+    ),
     // Leading hallucinated closing tags: after inner content is stripped, orphaned closing tags
     // like </result> or </function_results> remain at the start. Strip them too.
-    /^<\/(?:function_calls|function_results|invoke|results|result|result_text|parameter|content|character|name|tool_calls|tool_results|tool_call|tool_result)>[ \t]*\n?/i,
+    patternStep(
+      /^<\/(?:function_calls|function_results|invoke|results|result|result_text|parameter|content|character|name|tool_calls|tool_results|tool_call|tool_result)>[ \t]*\n?/i
+    ),
     // Leading <received message>...</received> block: GLM 4.5 Air echoes the user's message
     // in a hallucinated receipt structure before responding
-    /^<received(?:\s+message)?(?:\s[^>]*)?>[\s\S]*?<\/received>\s*/i,
+    patternStep(/^<received(?:\s+message)?(?:\s[^>]*)?>[\s\S]*?<\/received>\s*/i),
     // Prompt template orphan closing tags: model echoes closing tags from the prompt's
     // XML structure (e.g., </chat_log> from PromptBuilder.ts). Stripped from anywhere in content
     // since they can appear mid-response, not just trailing. `facts` joined the list when the
     // V-tier blocks moved into the user message, directly adjacent to the current turn —
     // the echo-probability position. (`context` is deliberately absent: too collision-prone
     // as prose.)
-    /<\/(?:chat_log|participants|protocol|memory_archive|contextual_references|facts)>/gi,
+    patternStep(
+      /<\/(?:chat_log|participants|protocol|memory_archive|contextual_references|facts)>/gi
+    ),
     // Trailing <reactions> block: LLM mimics history metadata. ReDoS: leading `\s{0,64}` bounded (unbounded `\s*` before literal retries at every position).
-    /\s{0,64}<reactions>[\s\S]*?<\/reactions>\s*$/i,
-    // Generic trailing closing tag: catches </message>, </module>, </current_turn>, etc.
-    // Models learn XML patterns from training data and append stray closing tags
-    /<\/[a-z][a-z0-9_-]*>\s*$/i,
+    patternStep(/\s{0,64}<reactions>[\s\S]*?<\/reactions>\s*$/i),
+    // Generic trailing closing tag, opener-aware — see `stripOrphanTrailingCloser`.
+    stripOrphanTrailingCloser,
     // XML message prefix: '<message speaker="Emily">Hello' → 'Hello'
-    new RegExp(`^<message\\s+speaker=["']${escapedName}["'][^>]*>\\s*`, 'i'),
+    patternStep(new RegExp(`^<message\\s+speaker=["']${escapedName}["'][^>]*>\\s*`, 'i')),
     // Simple name prefix: "Emily: Hello" → "Hello"
-    new RegExp(`^${escapedName}:\\s*(?:\\[[^\\]]+?\\]\\s*)?`, 'i'),
+    patternStep(new RegExp(`^${escapedName}:\\s*(?:\\[[^\\]]+?\\]\\s*)?`, 'i')),
     // Standalone timestamp: "[2m ago] Hello" → "Hello"
-    /^\[[^\]]+?\]\s*/,
+    patternStep(/^\[[^\]]+?\]\s*/),
   ];
 }
 
 /**
- * Apply patterns iteratively until no more matches.
+ * Apply cleanup steps iteratively until none of them changes the content.
  *
  * Every pattern here deletes, so each strip runs through
  * `replaceOutsideCodeMarkup`: a reply demonstrating `` `</chat_log>` `` is
@@ -105,7 +176,7 @@ function buildArtifactPatterns(personalityName: string): RegExp[] {
  */
 function applyPatternsIteratively(
   content: string,
-  patterns: RegExp[],
+  patterns: ArtifactStep[],
   maxIterations: number
 ): { cleaned: string; strippedCount: number } {
   let cleaned = content;
@@ -115,8 +186,8 @@ function applyPatternsIteratively(
     const beforeStrip = cleaned;
     let matched = false;
 
-    for (const pattern of patterns) {
-      cleaned = replaceOutsideCodeMarkup(cleaned, pattern).trim();
+    for (const step of patterns) {
+      cleaned = step(cleaned);
       if (cleaned !== beforeStrip) {
         strippedCount++;
         matched = true;

--- a/services/ai-worker/src/utils/wrapperTagUnwrap.test.ts
+++ b/services/ai-worker/src/utils/wrapperTagUnwrap.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Tests for Unknown Wrapper-Tag Unwrapping
+ */
+
+import { describe, it, expect } from 'vitest';
+import { KNOWN_THINKING_TAGS } from './thinkingExtraction.js';
+import { unwrapUnknownWrapperTags, WRAPPER_UNWRAP_EXCLUDED_TAGS } from './wrapperTagUnwrap.js';
+
+describe('unwrapUnknownWrapperTags', () => {
+  describe('whole-message wrap', () => {
+    it('unwraps a tag pair that wraps the entire message', () => {
+      const result = unwrapUnknownWrapperTags('<action>He walks away.</action>');
+
+      expect(result.content).toBe('He walks away.');
+      expect(result.unwrappedTags).toEqual(['action']);
+    });
+
+    it('keeps multi-line inner text verbatim', () => {
+      const result = unwrapUnknownWrapperTags(
+        '<narration>\nThe door creaks open.\n\nNobody is there.\n</narration>'
+      );
+
+      expect(result.content).toBe('The door creaks open.\n\nNobody is there.');
+      expect(result.unwrappedTags).toEqual(['narration']);
+    });
+
+    it('unwraps a tag carrying attributes', () => {
+      const result = unwrapUnknownWrapperTags('<action type="move">She crosses the room.</action>');
+
+      expect(result.content).toBe('She crosses the room.');
+      expect(result.unwrappedTags).toEqual(['action']);
+    });
+
+    it('tolerates surrounding whitespace', () => {
+      const result = unwrapUnknownWrapperTags('\n  <emote>grins</emote>\n');
+
+      expect(result.content).toBe('grins');
+      expect(result.unwrappedTags).toEqual(['emote']);
+    });
+
+    it('does NOT italicize, delete, or otherwise reformat the inner text', () => {
+      const inner = '*She waves.*  Then—quietly—she leaves. 5 < 6, after all.';
+      const result = unwrapUnknownWrapperTags(`<action>${inner}</action>`);
+
+      expect(result.content).toBe(inner);
+    });
+  });
+
+  describe('line-level wrap', () => {
+    it('unwraps a wrapped line and leaves its neighbours byte-identical', () => {
+      const content = '"Hello."\n<action>waves</action>\n"Bye."';
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe('"Hello."\nwaves\n"Bye."');
+      expect(result.unwrappedTags).toEqual(['action']);
+
+      const lines = result.content.split('\n');
+      expect(lines[0]).toBe('"Hello."');
+      expect(lines[2]).toBe('"Bye."');
+    });
+
+    it('unwraps several wrapped lines in one pass', () => {
+      const content = '<action>stands</action>\n"Enough."\n<action>leaves</action>';
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe('stands\n"Enough."\nleaves');
+      expect(result.unwrappedTags).toEqual(['action', 'action']);
+    });
+
+    it('preserves the indentation of an unwrapped line', () => {
+      const content = 'Intro.\n    <action>waves</action>\nOutro.';
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe('Intro.\n    waves\nOutro.');
+    });
+  });
+
+  describe('line-span wrap', () => {
+    it('unwraps a multi-line block embedded in a longer reply', () => {
+      // The residual shape neither of the other modes reaches: the whole-message
+      // mode declines because the content does not start with the tag, and the
+      // line mode declines because the opener's line carries no closer.
+      const content = [
+        '"Dialogue here."',
+        '',
+        '<action>',
+        'She walks to the window, pauses, and looks out at the rain falling',
+        'gently on the street below.',
+        '</action>',
+        '',
+        '"More dialogue."',
+      ].join('\n');
+
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe(
+        [
+          '"Dialogue here."',
+          '',
+          'She walks to the window, pauses, and looks out at the rain falling',
+          'gently on the street below.',
+          '',
+          '"More dialogue."',
+        ].join('\n')
+      );
+      expect(result.unwrappedTags).toEqual(['action']);
+
+      // Every surviving line byte-identical to its original — only the two
+      // delimiter lines are gone.
+      const original = content.split('\n');
+      const rewritten = result.content.split('\n');
+      expect(rewritten).toEqual([
+        ...original.slice(0, 2),
+        ...original.slice(3, 5),
+        ...original.slice(6),
+      ]);
+    });
+
+    it('unwraps a span whose opener carries attributes', () => {
+      const content = [
+        '"Hi."',
+        '<action type="move">',
+        'She crosses the room.',
+        '</action>',
+        '"Bye."',
+      ].join('\n');
+
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe('"Hi."\nShe crosses the room.\n"Bye."');
+      expect(result.unwrappedTags).toEqual(['action']);
+    });
+
+    it('preserves the indentation and blank lines of the inner block', () => {
+      const content = [
+        'Intro.',
+        '<narration>',
+        '    She waves,',
+        '',
+        '      then leaves.',
+        '</narration>',
+        'Outro.',
+      ].join('\n');
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(
+        ['Intro.', '    She waves,', '', '      then leaves.', 'Outro.'].join('\n')
+      );
+    });
+
+    it('leaves a span that never closes untouched', () => {
+      const content = ['"Hi."', '<action>', 'She walks away.'].join('\n');
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it('leaves an empty span untouched', () => {
+      const content = ['"Hi."', '<action>', '</action>', '"Bye."'].join('\n');
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it('leaves a closer-alone line with no earlier opener untouched', () => {
+      // A genuinely orphan closer is `responseArtifacts.ts`'s business (its
+      // opener-aware trailing strip), not this pass's — there is no pair here to
+      // unwrap, so the conservative move is to hand it along unchanged.
+      const content = ['"Hi."', '</action>', '"Bye."'].join('\n');
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it.each(WRAPPER_UNWRAP_EXCLUDED_TAGS)('does not unwrap <%s> as a line span', tag => {
+      const content = [
+        '"Hello."',
+        `<${tag}>`,
+        'Inner text that another pass owns.',
+        `</${tag}>`,
+        '"Bye."',
+      ].join('\n');
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe(content);
+      expect(result.unwrappedTags).toEqual([]);
+    });
+
+    it('does not unwrap a span inside a fenced block', () => {
+      const content = [
+        'Here is the markup it kept emitting:',
+        '',
+        '```',
+        '<action>',
+        'She walks away.',
+        '</action>',
+        '```',
+        '',
+        'That is the bug.',
+      ].join('\n');
+
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe(content);
+      expect(result.unwrappedTags).toEqual([]);
+    });
+
+    it('does not unwrap a span whose inner text carries a tag pair of another name', () => {
+      const content = [
+        '"Look."',
+        '<action>',
+        'She points at the <b>old</b> map.',
+        '</action>',
+        '"See?"',
+      ].join('\n');
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it('resolves nested same-name spans within the pass bound', () => {
+      const content = [
+        '"Hi."',
+        '<action>',
+        '<action>',
+        'She waves.',
+        '</action>',
+        '</action>',
+        '"Bye."',
+      ].join('\n');
+
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe('"Hi."\nShe waves.\n"Bye."');
+      expect(result.unwrappedTags).toEqual(['action', 'action']);
+    });
+  });
+
+  describe('nesting', () => {
+    it('resolves a nested double-wrap within the pass bound', () => {
+      const result = unwrapUnknownWrapperTags('<action><action>He walks away.</action></action>');
+
+      expect(result.content).toBe('He walks away.');
+      expect(result.unwrappedTags).toEqual(['action', 'action']);
+    });
+
+    it('resolves a nested double-wrap on a single line', () => {
+      const content = '"Hi."\n<action><action>waves</action></action>';
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe('"Hi."\nwaves');
+    });
+  });
+
+  describe('partial and inline wraps are left alone', () => {
+    it('does not touch a tag pair sharing a line with other text', () => {
+      const content = 'She said this <action>and did that</action> before leaving.';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it('does not touch two tag pairs on one line', () => {
+      // Depth-counted closer matching is what makes this decline: an
+      // end-anchored regex would treat the LAST closer as the match and produce
+      // a mangled `a</action> and <action>b` body.
+      const content = '<action>a</action> and <action>b</action>';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+
+    it('does not touch an unclosed opening tag', () => {
+      const content = '<action>She walks away.';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+
+    it('does not touch a bare closing tag', () => {
+      const content = 'She walks away.</action>';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+  });
+
+  describe('excluded tags', () => {
+    it('excludes every known thinking tag', () => {
+      for (const tag of KNOWN_THINKING_TAGS) {
+        expect(WRAPPER_UNWRAP_EXCLUDED_TAGS).toContain(tag);
+      }
+    });
+
+    it.each(WRAPPER_UNWRAP_EXCLUDED_TAGS)('does not unwrap <%s> as a whole message', tag => {
+      const content = `<${tag}>Inner text that another pass owns.</${tag}>`;
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe(content);
+      expect(result.unwrappedTags).toEqual([]);
+    });
+
+    it.each(WRAPPER_UNWRAP_EXCLUDED_TAGS)('does not unwrap <%s> as a wrapped line', tag => {
+      const content = `"Hello."\n<${tag}>Inner text that another pass owns.</${tag}>\n"Bye."`;
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe(content);
+      expect(result.unwrappedTags).toEqual([]);
+    });
+  });
+
+  describe('code protection', () => {
+    it('does not unwrap a tag pair inside a fenced block', () => {
+      const content = [
+        'Here is the markup it kept emitting:',
+        '',
+        '```',
+        '<action>She walks away.</action>',
+        '```',
+        '',
+        'That is the bug.',
+      ].join('\n');
+
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe(content);
+      expect(result.unwrappedTags).toEqual([]);
+    });
+
+    it('does not unwrap a tag pair quoted in inline backticks', () => {
+      // Declined by shape as well as by the code-span gate: the line starts
+      // with a backtick, so it is not a whole-line wrap in the first place.
+      // Pinned because either guard failing would corrupt the quotation.
+      const content = 'It writes this:\n`<action>She walks away.</action>`\nEvery single time.';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+
+    it('does not unwrap a whole message that is one fenced example', () => {
+      const content = '```\n<action>She walks away.</action>\n```';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+  });
+
+  describe('XML-document guard', () => {
+    it('does not unwrap a document whose inner text carries other tag pairs', () => {
+      const content = '<root><child>x</child></root>';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it('does not unwrap a whole-message wrap whose inner text contains a tag pair', () => {
+      const content = '<action>She reads the <em>old</em> letter.</action>';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+
+    it('does not unwrap a wrapped line whose inner text contains a tag pair', () => {
+      const content = '"Look."\n<action>She points at <b>that</b>.</action>\n"See?"';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+
+    it('still unwraps when the inner text has an orphan angle bracket', () => {
+      const result = unwrapUnknownWrapperTags('<action>She holds up 3 fingers <3 always</action>');
+
+      expect(result.content).toBe('She holds up 3 fingers <3 always');
+      expect(result.unwrappedTags).toEqual(['action']);
+    });
+  });
+
+  describe('quoted control syntax', () => {
+    // This product hosts AI characters, so replies routinely DISCUSS markup —
+    // a character complaining about the tags it emits produces the same bytes
+    // as a model actually emitting them. Whole-unit-only matching is the
+    // discriminator that covers the unfenced case, where code markup cannot.
+
+    it('preserves a reply that discusses wrapper tags mid-sentence', () => {
+      const reply = [
+        '"It kept happening," she says, still annoyed. "Every third message it would',
+        'stick <action>walks away</action> right into the middle of a sentence, like',
+        'the tag was part of the prose."',
+        '',
+        'She shrugs. "Nobody asked it to do that."',
+      ].join('\n');
+
+      const result = unwrapUnknownWrapperTags(reply);
+
+      expect(result.content).toBe(reply);
+      expect(result.unwrappedTags).toEqual([]);
+    });
+
+    it('preserves a reply that names an opening and closing tag separately', () => {
+      const reply = [
+        'The pattern is simple enough: it opens with <action> and then, several',
+        'words later, closes with </action>. Nothing between them is markup —',
+        'it is just narration that the model decided to decorate.',
+      ].join('\n');
+
+      expect(unwrapUnknownWrapperTags(reply).content).toBe(reply);
+    });
+
+    it('preserves a reply explaining the tag inside code markup', () => {
+      const reply = [
+        'Think of `<action>` as a habit it picked up from training data.',
+        '',
+        '```',
+        '<action>She walks away.</action>',
+        '```',
+        '',
+        'It means nothing to Discord, which is why you see it raw.',
+      ].join('\n');
+
+      expect(unwrapUnknownWrapperTags(reply).content).toBe(reply);
+    });
+
+    it('KNOWN LIMIT: an unfenced quoted wrap on its own line is still unwrapped', () => {
+      // Positionally and byte-identical to the production shape this pass
+      // exists to fix, with no code markup to separate them. Unwrapping stays
+      // the default when the only available signal is absent — and the cost is
+      // one pair of angle brackets, not the text. Pinned so the boundary is
+      // visible rather than discovered.
+      const content = 'It writes lines like this one:\n<action>She walks away.</action>';
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe('It writes lines like this one:\nShe walks away.');
+    });
+  });
+
+  describe('tag-name shape', () => {
+    it('KNOWN LIMIT: an uppercase tag is not unwrapped', () => {
+      // Lowercase-only by design, matching the generic tag pattern in
+      // `responseArtifacts.ts`. Angle-bracketed capitalized words are a
+      // name-labelling convention in prose (`<Bob>`), and the observed model
+      // output is lowercase, so the narrower rule is the safer one.
+      const content = '<Action>She walks away.</Action>';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+    });
+
+    it('unwraps tags with digits, underscores, and hyphens', () => {
+      expect(unwrapUnknownWrapperTags('<stage-direction>waves</stage-direction>').content).toBe(
+        'waves'
+      );
+      expect(unwrapUnknownWrapperTags('<action_2>waves</action_2>').content).toBe('waves');
+    });
+
+    it('does not treat a longer tag as the excluded prefix tag', () => {
+      // `think` is excluded; `thinker` is not, and must not inherit the
+      // exclusion by prefix.
+      const result = unwrapUnknownWrapperTags('<thinker>She ponders.</thinker>');
+
+      expect(result.content).toBe('She ponders.');
+    });
+  });
+
+  describe('empty and degenerate input', () => {
+    it('leaves an empty-bodied tag pair untouched', () => {
+      const content = '<action></action>';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it('leaves a whitespace-only body untouched', () => {
+      const content = '<action>   </action>';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+
+    it('handles an empty string', () => {
+      const result = unwrapUnknownWrapperTags('');
+
+      expect(result.content).toBe('');
+      expect(result.unwrappedTags).toEqual([]);
+    });
+
+    it('leaves ordinary prose byte-identical', () => {
+      const content = '"Good morning," she says, pouring the coffee.\n\nIt is going to rain.';
+
+      expect(unwrapUnknownWrapperTags(content).content).toBe(content);
+      expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
+    });
+  });
+});

--- a/services/ai-worker/src/utils/wrapperTagUnwrap.ts
+++ b/services/ai-worker/src/utils/wrapperTagUnwrap.ts
@@ -1,0 +1,464 @@
+/**
+ * Unknown Wrapper-Tag Unwrapping
+ *
+ * Free-tier models (observed: GLM 4.5 Air) invent content-shaped XML markup and
+ * wrap parts of an in-character reply in it — a persona's stage direction comes
+ * back as a literal `<action>She walks away.</action>` line in Discord. The tag
+ * vocabulary is invented per-response, so a blocklist structurally loses: the
+ * next response uses `<gesture>`, `<emote>`, `<narration>`.
+ *
+ * This module therefore unwraps GENERICALLY, in three modes: any lowercase tag
+ * pair that wraps an entire message, an entire line, or a contiguous SPAN of
+ * whole lines — and is not in {@link WRAPPER_UNWRAP_EXCLUDED_TAGS} — has its
+ * delimiters removed and its inner text kept VERBATIM. Unwrap is not deletion
+ * and not reformatting — no italicizing, no content loss.
+ *
+ * The span mode exists because the other two both decline a multi-line wrapped
+ * block embedded in a longer reply: the whole-message mode because the content
+ * does not start with the tag, the line mode because the opener's line carries
+ * no closer. Without it those literal tags ship to the reader.
+ *
+ * Why an exclusion set rather than a pure blocklist-free design: two other
+ * passes in this pipeline own specific tag vocabularies, and both would be
+ * broken by unwrapping.
+ * - Thinking tags (`thinkingExtraction.ts`) are EXTRACTED upstream — their
+ *   inner text is reasoning, routed to spoiler output, never to the reply.
+ * - Artifact tags (`responseArtifacts.ts`) are deliberately DELETED downstream —
+ *   their inner text is prompt-scaffolding echo that must not survive.
+ * Unwrapping either would preserve content another handler means to remove, so
+ * both vocabularies are excluded here and left to their owners.
+ *
+ * Conservative by construction. Three guards keep it away from legitimate
+ * content, and each fails toward "leave the text alone":
+ * 1. Whole-unit only — a tag pair sharing a line with other text is untouched,
+ *    and a span's two delimiters must each sit alone on their own line.
+ * 2. Code markup — a reply that DEMONSTRATES `<action>` syntax inside backticks
+ *    or a fence is left byte-identical (same discriminator the reasoning-tag
+ *    extractor settled on, for the same reason: this product hosts AI
+ *    characters and they routinely discuss markup).
+ * 3. XML documents — if the inner text carries tag pairs of a DIFFERENT name,
+ *    the model is emitting structured XML rather than a stray wrapper, and it
+ *    survives intact.
+ */
+
+import { isInsideCodeSpan } from '@tzurot/common-types/utils/codeSpanDetection';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { KNOWN_THINKING_TAGS } from './thinkingExtraction.js';
+
+const logger = createLogger('wrapper-tag-unwrap');
+
+/**
+ * Tag names this pass must never unwrap, because another pass in the pipeline
+ * owns them and unwrapping would defeat that pass.
+ *
+ * Three groups:
+ * - `KNOWN_THINKING_TAGS` — imported rather than restated, so a tag added for a
+ *   new model revision inherits the exclusion instead of arriving unguarded.
+ * - The `responseArtifacts.ts` deletion vocabulary — every tag family named by
+ *   `buildArtifactPatterns` there. Those patterns DELETE their contents; keeping
+ *   the contents by unwrapping first would resurrect prompt-scaffolding echo.
+ * - Prompt-template tags emitted by `PromptBuilder` — the model echoing one back
+ *   is scaffolding leakage, not a stage direction.
+ *
+ * Exported so the guard suite can enumerate the vocabulary rather than restate
+ * it; a hand-maintained copy in the tests would drift on exactly the revision
+ * that needed it.
+ */
+export const WRAPPER_UNWRAP_EXCLUDED_TAGS: readonly string[] = [
+  // Reasoning vocabulary — extracted upstream by `extractThinkingBlocks`.
+  ...KNOWN_THINKING_TAGS,
+  // Artifact vocabulary — deleted downstream by `stripResponseArtifacts`.
+  'last_message',
+  'from',
+  'result',
+  'result_text',
+  'parameter',
+  'character',
+  'name',
+  'content',
+  'function_calls',
+  'function_results',
+  'invoke',
+  'results',
+  'tool_calls',
+  'tool_results',
+  'tool_call',
+  'tool_result',
+  'received',
+  'reactions',
+  'message',
+  // Prompt-template vocabulary — scaffolding echo from PromptBuilder's format.
+  'chat_log',
+  'participants',
+  'protocol',
+  'memory_archive',
+  'contextual_references',
+  'facts',
+];
+
+const EXCLUDED_TAG_SET: ReadonlySet<string> = new Set(WRAPPER_UNWRAP_EXCLUDED_TAGS);
+
+/**
+ * Tag-name shape. Lowercase-only, matching the generic trailing-closing-tag
+ * pattern in `responseArtifacts.ts` — the models that emit these wrappers emit
+ * them lowercase, and requiring lowercase keeps prose like `<Bob>` (a
+ * name-in-angle-brackets convention some characters use) out of scope.
+ */
+const TAG_NAME = '[a-z][a-z0-9_-]*';
+
+/** Opening tag anchored at the start of a candidate, with optional attributes. */
+const OPENING_TAG_PATTERN = new RegExp(`^<(${TAG_NAME})(?:\\s[^>]*)?>`);
+
+/**
+ * A span's delimiters: a tag ALONE on its (trimmed) line, nothing else on it.
+ *
+ * The trailing `$` is what separates the span mode from the line-level sweep. A
+ * line carrying both delimiters is a whole-line wrap and belongs to that sweep;
+ * a line carrying an opener plus prose is the partial-wrap shape both modes
+ * decline.
+ */
+const SPAN_OPENER_PATTERN = new RegExp(`^<(${TAG_NAME})(?:\\s[^>]*)?>$`);
+const SPAN_CLOSER_PATTERN = new RegExp(`^<\\/(${TAG_NAME})>$`);
+
+/**
+ * Any complete tag pair, capturing both names. Used by the XML-document guard:
+ * a pair whose names differ from the wrapper's means the inner text is a
+ * structured document, not stray markup around prose. Opener and closer names
+ * are captured separately (rather than backreferenced) so a MISMATCHED pair —
+ * which is even less like a stray wrapper — also trips the guard.
+ */
+const ANY_TAG_PAIR_PATTERN = new RegExp(
+  `<(${TAG_NAME})(?:\\s[^>]*)?>[\\s\\S]*?<\\/(${TAG_NAME})>`,
+  'g'
+);
+
+/**
+ * Passes to run. Each pass removes at most one layer, so a double-wrap
+ * (`<action><action>x</action></action>`) needs two. Bounded rather than
+ * looped-to-fixpoint because the input is adversarial model output and this
+ * runs on every response; three layers is already far past anything observed.
+ */
+const MAX_PASSES = 3;
+
+/**
+ * Whether the inner text is a structured XML document rather than prose.
+ *
+ * Pairs of the SAME name as the wrapper are exempt: they are exactly the
+ * double-wrap shape the pass bound exists to resolve, and blocking on them
+ * would leave the outer layer visible. Pairs of any other name mean a persona
+ * legitimately emitted markup, which must survive byte-identical.
+ */
+function innerLooksLikeXmlDocument(inner: string, wrapperTag: string): boolean {
+  ANY_TAG_PAIR_PATTERN.lastIndex = 0;
+  for (const match of inner.matchAll(ANY_TAG_PAIR_PATTERN)) {
+    if (match[1] !== wrapperTag || match[2] !== wrapperTag) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Locate the closing tag that MATCHES the opener at the start of `text`.
+ *
+ * Depth-counting rather than a `</tag>$`-anchored regex, because the anchored
+ * form silently picks the LAST closer on the line. On
+ * `<action>a</action> and <action>b</action>` that yields an "inner" of
+ * `a</action> and <action>b` — a partial-wrap line the pass is supposed to
+ * decline. Depth counting reports the first closer instead, which is not at the
+ * end, so the caller correctly declines.
+ *
+ * @returns Span of the matching closer, or null when it never closes
+ */
+function findMatchingCloser(
+  text: string,
+  tag: string,
+  searchFrom: number
+): { start: number; end: number } | null {
+  const tagPattern = new RegExp(`<(\\/?)${tag}(?:\\s[^>]*)?>`, 'g');
+  tagPattern.lastIndex = searchFrom;
+
+  let depth = 1;
+  let match = tagPattern.exec(text);
+  while (match !== null) {
+    depth += match[1] === '/' ? -1 : 1;
+    if (depth === 0) {
+      return { start: match.index, end: match.index + match[0].length };
+    }
+    match = tagPattern.exec(text);
+  }
+
+  return null;
+}
+
+/**
+ * Inner text of a wrapper tag pair that spans the WHOLE of `candidate`, or null.
+ *
+ * `candidate` is expected pre-trimmed. Every rejection path here is a
+ * conservatism decision, in order: unknown-shape opener, an owned vocabulary,
+ * an unclosed or partial wrap, an empty body, and a structured document.
+ */
+function extractWholeWrap(candidate: string): { tag: string; inner: string } | null {
+  const opening = OPENING_TAG_PATTERN.exec(candidate);
+  if (opening === null) {
+    return null;
+  }
+
+  const tag = opening[1];
+  if (EXCLUDED_TAG_SET.has(tag)) {
+    return null;
+  }
+
+  const closer = findMatchingCloser(candidate, tag, opening[0].length);
+  // A closer short of the end means the pair wraps only PART of the candidate —
+  // the deliberate false-positive conservatism: `text <action>x</action> more`
+  // is prose that mentions markup as often as it is a stray wrapper.
+  if (closer?.end !== candidate.length) {
+    return null;
+  }
+
+  const inner = candidate.slice(opening[0].length, closer.start);
+  if (inner.trim().length === 0) {
+    return null;
+  }
+
+  if (innerLooksLikeXmlDocument(inner, tag)) {
+    return null;
+  }
+
+  return { tag, inner: inner.trim() };
+}
+
+/**
+ * Unwrap a tag pair that wraps the entire message.
+ *
+ * No code-markup probe here, deliberately: the opening `<` sits at the very
+ * start of the trimmed content, and a code span or fence would have to OPEN
+ * before it — but everything before it is whitespace, so `isInsideCodeSpan`
+ * can never be true at that offset. The fenced-example case self-declines
+ * instead: a message that is one ``` block starts with a backtick, which
+ * `OPENING_TAG_PATTERN` does not match. (The line-level sweep genuinely needs
+ * the probe — a line can sit inside a fence opened lines earlier.)
+ *
+ * @returns The unwrapped content, or null when nothing applied
+ */
+function unwrapWholeMessage(content: string, unwrappedTags: string[]): string | null {
+  const wrap = extractWholeWrap(content.trim());
+  if (wrap === null) {
+    return null;
+  }
+
+  unwrappedTags.push(wrap.tag);
+  return wrap.inner;
+}
+
+/**
+ * Index of the line whose closer matches the span opened at `openIndex`, or
+ * null when the span never closes.
+ *
+ * Depth-counted over opener-alone and closer-alone lines of the SAME name, for
+ * the same reason `findMatchingCloser` counts depth within a line: a nested
+ * same-name span must resolve outermost-first, leaving the layer beneath it to
+ * the next pass, rather than closing the outer span on the inner closer.
+ */
+function findSpanCloserLine(lines: string[], openIndex: number, tag: string): number | null {
+  let depth = 1;
+
+  for (let i = openIndex + 1; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (SPAN_OPENER_PATTERN.exec(trimmed)?.[1] === tag) {
+      depth++;
+    } else if (SPAN_CLOSER_PATTERN.exec(trimmed)?.[1] === tag) {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The span opened by `lines[openIndex]`, or null when that line does not open
+ * one that qualifies.
+ *
+ * Every rejection path the other two modes carry, in the same order and for the
+ * same reasons: unknown-shape opener, an owned vocabulary, code markup, an
+ * unclosed span, an empty body, and a structured document. The code-markup
+ * probe is taken at the opener's own offset in the FULL content — a span
+ * demonstrated inside a fence opened lines earlier must stay byte-identical,
+ * which is exactly the case the whole-message mode can skip and the line-level
+ * sweep cannot.
+ *
+ * @param lineStart - Offset of `lines[openIndex]` within `content`
+ * @returns The tag name and the closer's line index, or null
+ */
+function extractSpanAt(
+  lines: string[],
+  openIndex: number,
+  lineStart: number,
+  content: string
+): { tag: string; end: number } | null {
+  const line = lines[openIndex];
+  const opening = SPAN_OPENER_PATTERN.exec(line.trim());
+  if (opening === null) {
+    return null;
+  }
+
+  const tag = opening[1];
+  if (EXCLUDED_TAG_SET.has(tag)) {
+    return null;
+  }
+
+  const indent = line.length - line.trimStart().length;
+  if (isInsideCodeSpan(content, lineStart + indent)) {
+    return null;
+  }
+
+  const end = findSpanCloserLine(lines, openIndex, tag);
+  if (end === null) {
+    return null;
+  }
+
+  const inner = lines.slice(openIndex + 1, end).join('\n');
+  if (inner.trim().length === 0) {
+    return null;
+  }
+
+  if (innerLooksLikeXmlDocument(inner, tag)) {
+    return null;
+  }
+
+  return { tag, end };
+}
+
+/**
+ * Unwrap contiguous line-SPANS: an opener alone on its line, a matching closer
+ * alone on a later line, and the block of lines between them.
+ *
+ * Unwrapping DELETES the two delimiter lines outright, line breaks included;
+ * the inner lines keep their own text, blank lines, and indentation verbatim.
+ * That is the only shape "remove the delimiters, keep the content" can take
+ * when the delimiters occupy whole lines of their own.
+ *
+ * @returns The content with qualifying spans unwrapped (unchanged string when none did)
+ */
+function unwrapSpans(content: string, unwrappedTags: string[]): string {
+  const lines = content.split('\n');
+  let offset = 0;
+  const lineStarts = lines.map(line => {
+    const start = offset;
+    offset += line.length + 1; // +1 for the '\n' consumed by the split
+    return start;
+  });
+
+  const kept: string[] = [];
+  let unwrapped = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const span = extractSpanAt(lines, i, lineStarts[i], content);
+    if (span === null) {
+      kept.push(lines[i]);
+      continue;
+    }
+
+    unwrappedTags.push(span.tag);
+    unwrapped = true;
+    // Inner lines verbatim; the opener line and `lines[span.end]` are dropped.
+    for (let inner = i + 1; inner < span.end; inner++) {
+      kept.push(lines[inner]);
+    }
+    i = span.end;
+  }
+
+  return unwrapped ? kept.join('\n') : content;
+}
+
+/**
+ * Unwrap tag pairs that wrap an entire line, leaving every other line alone.
+ *
+ * This is the shape the production incident took: a Discord roleplay reply
+ * where dialogue lines are plain and the stage direction arrived as its own
+ * `<action>…</action>` line.
+ *
+ * @returns The content with qualifying lines unwrapped (unchanged string when none did)
+ */
+function unwrapLines(content: string, unwrappedTags: string[]): string {
+  const lines = content.split('\n');
+  let lineStart = 0;
+
+  const rewritten = lines.map(line => {
+    const start = lineStart;
+    lineStart += line.length + 1; // +1 for the '\n' consumed by the split
+
+    const indent = line.length - line.trimStart().length;
+    const wrap = extractWholeWrap(line.trim());
+    if (wrap === null) {
+      return line;
+    }
+
+    if (isInsideCodeSpan(content, start + indent)) {
+      return line;
+    }
+
+    unwrappedTags.push(wrap.tag);
+    return line.slice(0, indent) + wrap.inner;
+  });
+
+  return rewritten.join('\n');
+}
+
+/**
+ * Remove invented content-shaped wrapper tags from a model response.
+ *
+ * Modes are tried widest-first — whole message, then line spans, then single
+ * lines — and a pass that unwraps anything stops there, because the layer
+ * beneath it may qualify for a wider mode and gets the next pass.
+ *
+ * @param content - The response content (post thinking-extraction)
+ * @returns The content with unknown wrapper tags removed, and the tag names removed
+ *
+ * @example
+ * ```typescript
+ * unwrapUnknownWrapperTags('"Hi."\n<action>She waves.</action>');
+ * // { content: '"Hi."\nShe waves.', unwrappedTags: ['action'] }
+ * ```
+ */
+export function unwrapUnknownWrapperTags(content: string): {
+  content: string;
+  unwrappedTags: string[];
+} {
+  const unwrappedTags: string[] = [];
+  let current = content;
+
+  for (let pass = 0; pass < MAX_PASSES; pass++) {
+    const whole = unwrapWholeMessage(current, unwrappedTags);
+    if (whole !== null) {
+      current = whole;
+      continue;
+    }
+
+    const spanSwept = unwrapSpans(current, unwrappedTags);
+    if (spanSwept !== current) {
+      current = spanSwept;
+      continue;
+    }
+
+    const lineSwept = unwrapLines(current, unwrappedTags);
+    if (lineSwept === current) {
+      break;
+    }
+    current = lineSwept;
+  }
+
+  if (unwrappedTags.length > 0) {
+    // Tag names and lengths only — response text is user content and never logged.
+    logger.info(
+      { tags: unwrappedTags, contentLength: current.length },
+      'Unwrapped unknown wrapper tags from response'
+    );
+  }
+
+  return { content: current, unwrappedTags };
+}


### PR DESCRIPTION
## Summary

Fixes the prod output-quality bug from the Untriaged board: GLM 4.5 Air (free tier) wraps RP stage directions in invented content-shaped XML — observed as a literal `<action>…</action>` line rendered in a delivered webhook reply. Owner triage on record: recurring class (long whack-a-mole history with this model), fix generically, ride-along release.

**Why generic:** the tag vocabulary is invented per-response, so per-tag blocklisting structurally loses — next time it's `<gesture>` or `<narration>`. This adds `unwrapUnknownWrapperTags`: any lowercase tag pair fully wrapping the message or a single line has its delimiters removed and inner text kept **verbatim** (no italicizing — deliberately deferred: italics would be this pipeline's first content rewrite and would trip the leaked-CoT retry detector's dialogue heuristic; it can layer on later if a fresh incident log argues for it).

## Design guards (each fails toward leave-it-alone)

- **Exclusion set** (`WRAPPER_UNWRAP_EXCLUDED_TAGS`, exported for test enumeration): `KNOWN_THINKING_TAGS` (extracted upstream — imported, not restated), the full `responseArtifacts` deletion vocabulary (deliberately deleted downstream — unwrapping first would resurrect scaffolding echo), and prompt-template tags.
- **Whole-unit only**: partial/inline wraps (`text <action>x</action> more`) untouched.
- **Code protection**: pairs inside fences/inline code untouched (`isInsideCodeSpan`, same discriminator the reasoning-tag extractor uses).
- **XML-document guard**: inner text carrying tag pairs of a *different* name means legitimately structured output — survives byte-identical. Same-name pairs are exempt (that's exactly the nested double-wrap the bounded 3-pass loop resolves).
- **Depth-counted closer matching** (not an end-anchored regex, which silently picks the LAST closer and mis-unwraps two-pairs-on-one-line).

## Placement (load-bearing)

New Step 4 in `ResponsePostProcessor`, between thinking extraction and artifact stripping. `responseArtifacts.ts` has a generic trailing-closing-tag pattern that eats a reply-final `</action>` and orphans the opener — **runtime-probed during implementation**, not just code-read: `stripResponseArtifacts` alone turns the incident reply into `"…"\n<action>She steps back…`. The pair must be unwrapped while intact.

## Tests

- 103 unit tests in colocated `wrapperTagUnwrap.test.ts`: whole-message/line/nesting/partial/exclusion-enumeration (looped over the exported constant, both positions)/code protection/XML-document guard/tag-name shape/degenerate inputs, plus the mandatory quoted-control-syntax false-positive suite (realistic replies *discussing* tag syntax, asserted byte-identical) and honest `KNOWN LIMIT` pins (uppercase tags; unfenced quoted wrap on its own line).
- 3 seam-tier tests in `ResponsePostProcessor.test.ts` running the real chain (`vi.importActual`) on the incident shape — asserting the unwrapped text is delivered and no orphan opener survives.
- Bug-remediation protocol notes: runtime evidence gate discharged by owner's recurring-class determination on the board entry; the generic handler IS the class-level fix and its own structural guard; regression pinned at both unit and seam tiers.

## Verification

- Full `pnpm test` (26 tasks, ai-worker 207 files / 4448 tests including the new 106) and `pnpm quality` green, run sequentially
- ai-worker lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 1 (review response)

The review's main finding was **confirmed and fixed**: inline-trailing wraps (`"dialogue." <action>direction.</action>` at message end) are declined by the unwrap by design, but the artifact pass's blind trailing-closer strip then orphaned the opener — same corruption, sibling shape. Fix shipped per the review's preferred shape: the generic trailing-closer strip is now **opener-aware** (a trailing closer with a matching earlier opener is kept; the pair survives intact — symmetric cosmetic markup instead of corruption). This kills the orphan-opener mechanism for every declined shape, including two-pairs-on-one-line.

- Fourth seam test pins the exact repro, **verified to fail pre-fix** (pre-fix output dropped the trailing closer — failure output captured in the round summary).
- One pre-existing test expectation updated: it had pinned the corruption itself (`<dialogue>long…</dialogue>` → orphaned opener) as expected behavior.
- Nit addressed: unreachable `'antml'` exclusion removed.
- Codecov's 1 uncovered line traced to a structurally dead guard (whole-message code-span probe over a whitespace-only prefix — empirically probed); guard removed with a comment explaining why the fence case self-declines.
- Finding 2 (hand-restated artifact vocabulary risks drift) → tracker task, per the review's own scoping.

## Round 2 (review response)

- **Multi-line wrapped block mid-reply (round-2 finding 1): implemented, not just pinned.** A third mode — contiguous line-SPAN unwrap (opener alone on its line, matching closer alone on a later line, depth-counted for same-name nesting) — with every existing guard applied (exclusion set, fence protection at the opener's offset, XML-document guard over the span's inner, empty-span decline). Modes now run widest-first: whole message → spans → single lines. Fifth seam test with the review's exact repro, verified to fail pre-fix (both literal tag lines shipped). Module coverage 100%.
- **Mismatched-name pair (finding 2): KNOWN LIMIT pin** — `<action>text</actionable>` still loses its trailing closer; fixing it needs fuzzy tag matching, deliberately out of scope. Pinned visibly next to the opener-aware tests.
- **Perf note: dismissed** per the reviewer's own framing (bounded by Discord's message cap).