### PR TITLE
ci: review prompt reports all findings; summary must enumerate them

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,6 +60,8 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
+            Report every issue you find — do not pre-filter by severity; label severity instead and let the reader triage. Keep the review proportional to its findings (no padding), and if you write a summary or actionable-items section, it must enumerate EVERY actionable item from the body — a finding that appears only mid-body and not in the summary is a defect of the review.
+
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

The main-cut half of TASK-431 (apply Anthropic's Opus 5 prompting guide to our Claude-facing prompts; the develop half — the opus-implementer no-subagent clause — shipped in #1971). Cut from and targeting `main` per the `/tzurot-git-workflow` claude-workflow-file procedure: these files validate against the default branch, and a develop-first change would silently disable reviews until the next release.

## The change

One paragraph added to the feature-review prompt, applying two guide recommendations:

1. **Report everything, filter nowhere**: the guide warns the model follows severity-filter instructions literally ("only report high-severity issues" → it reports less). The prompt now asks for every finding, severity-labeled, reader-triaged.
2. **Summary must enumerate all body findings**: the guide's deliverable-length calibration, aimed at our specific observed failure — trailing summaries under-reporting items the body flags, seen on three consecutive PRs and already documented as a skimming hazard in `05-tooling.md` § PR Monitoring. The clause makes an incomplete summary a defect of the review itself.

The release-PR holistic prompt and `claude.yml` were assessed against the guide and are fine as-is (already carry explicit scope constraints and post-even-if-fine output contracts).

**Not included, owner call**: pinning the review model. Neither workflow pins one today, so the runtime model drifts with the action's default — pinning Opus 5 explicitly is the lever if you want the guide's review properties guaranteed, and it's a spend decision.

## After merge

`pnpm ops release:finalize` immediately, to resync develop onto main before work piles up (per the procedure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)