### PR TITLE
refactor(ai-worker): derive the wrapper-unwrap exclusion set from responseArtifacts

### DIFF
--- a/services/ai-worker/src/services/ResponsePostProcessor.test.ts
+++ b/services/ai-worker/src/services/ResponsePostProcessor.test.ts
@@ -42,10 +42,17 @@ vi.mock('../utils/duplicateDetection.js', () => ({
   removeDuplicateResponse: mockRemoveDuplicateResponse,
 }));
 
-vi.mock('../utils/responseArtifacts.js', () => ({
-  stripResponseArtifacts: mockStripResponseArtifacts,
-  stripUserMessageEcho: mockStripUserMessageEcho,
-}));
+vi.mock('../utils/responseArtifacts.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils/responseArtifacts.js')>();
+  return {
+    // Real, not mocked, for the same reason `KNOWN_THINKING_TAGS` is below:
+    // `wrapperTagUnwrap` derives its exclusion set from this vocabulary at
+    // module load, so a stubbed-out constant would crash the import.
+    ARTIFACT_TAG_NAMES: actual.ARTIFACT_TAG_NAMES,
+    stripResponseArtifacts: mockStripResponseArtifacts,
+    stripUserMessageEcho: mockStripUserMessageEcho,
+  };
+});
 
 vi.mock('../utils/thinkingExtraction.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../utils/thinkingExtraction.js')>();

--- a/services/ai-worker/src/utils/responseArtifacts.test.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  ARTIFACT_TAG_NAMES,
   stripResponseArtifacts,
   stripUserMessageEcho,
   normalizeForEchoMatch,
@@ -130,6 +131,18 @@ describe('stripResponseArtifacts', () => {
         // false positives would delete the closers of pairs that are genuinely
         // complete. Pinned so the boundary is visible rather than discovered.
         expect(stripResponseArtifacts('<action>text</actionable>', 'Emily')).toBe('<action>text');
+      });
+
+      it('KNOWN LIMIT: a completed pair earlier keeps a separate trailing orphan closer', () => {
+        // The opener probe is not pair-aware: it scans for `<action` anywhere
+        // before the trailing closer and declines on the first hit, even when
+        // that opener already has its own closer and the trailing one is a
+        // genuine orphan. Pair-tracking would be a materially different
+        // mechanism, and this direction under-cleans (one visible closing tag)
+        // rather than risking corruption of a real pair. Pinned so the boundary
+        // is visible rather than discovered.
+        const content = '<action>waves</action> hello</action>';
+        expect(stripResponseArtifacts(content, 'Emily')).toBe(content);
       });
 
       it('composes with the other steps in the loop and converges', () => {
@@ -858,5 +871,15 @@ describe('stripUserMessageEcho', () => {
         '*tilting head, horns casting thoughtful shadows*\n\nThat question deserves a careful answer.';
       expect(stripUserMessageEcho(response, LONG_USER_MSG, LILITH)).toBe(response);
     });
+  });
+});
+
+describe('ARTIFACT_TAG_NAMES', () => {
+  it('is a nonempty, duplicate-free vocabulary', () => {
+    // The Set-dedup in the definition makes duplicates impossible today; the
+    // pin documents the contract for `wrapperTagUnwrap.ts`, which spreads this
+    // list into an `it.each` sweep that a duplicate would silently double.
+    expect(ARTIFACT_TAG_NAMES.length).toBeGreaterThan(0);
+    expect(new Set(ARTIFACT_TAG_NAMES).size).toBe(ARTIFACT_TAG_NAMES.length);
   });
 });

--- a/services/ai-worker/src/utils/responseArtifacts.ts
+++ b/services/ai-worker/src/utils/responseArtifacts.ts
@@ -106,6 +106,83 @@ function stripOrphanTrailingCloser(content: string): string {
 }
 
 /**
+ * Self-contained metadata echoes: a short-bodied pair the model emits as a
+ * whole (`<result>PersonalityName</result>`). Order is the alternation order of
+ * the pattern built from it.
+ */
+const SELF_CONTAINED_ECHO_TAGS = [
+  'result',
+  'result_text',
+  'parameter',
+  'character',
+  'name',
+  'content',
+] as const;
+
+/**
+ * Hallucinated tool-use scaffolding: GLM 4.5 Air (and similar models trained on
+ * Anthropic/OpenAI data) wrap responses in these XML structures. Both the
+ * leading-opener and leading-orphan-closer patterns are built from this list,
+ * so the two can never disagree about the vocabulary.
+ */
+const TOOL_USE_SCAFFOLD_TAGS = [
+  'function_calls',
+  'function_results',
+  'invoke',
+  'results',
+  'result',
+  'result_text',
+  'parameter',
+  'content',
+  'character',
+  'name',
+  'tool_calls',
+  'tool_results',
+  'tool_call',
+  'tool_result',
+] as const;
+
+/**
+ * Closing tags from the prompt's own XML structure (PromptBuilder.ts) that the
+ * model echoes back. (`context` is deliberately absent: too collision-prone as
+ * prose.)
+ */
+const PROMPT_TEMPLATE_ORPHAN_TAGS = [
+  'chat_log',
+  'participants',
+  'protocol',
+  'memory_archive',
+  'contextual_references',
+  'facts',
+] as const;
+
+/**
+ * The deletion vocabulary of `buildArtifactPatterns` — every tag name whose
+ * contents (or whose closer) this module removes.
+ *
+ * Exported so `wrapperTagUnwrap.ts` DERIVES its exclusion set from it instead of
+ * restating the names: drift between the two silently reopens a
+ * scaffolding-resurrection risk, where the unwrap pass keeps the inner text of a
+ * tag family this module means to delete.
+ *
+ * `message` is a member via the personality-parameterized `<message speaker=...>`
+ * prefix pattern and the module's generic trailing-closer handling, not via any
+ * alternation literal.
+ */
+export const ARTIFACT_TAG_NAMES: readonly string[] = [
+  ...new Set([
+    'last_message',
+    'from',
+    ...SELF_CONTAINED_ECHO_TAGS,
+    ...TOOL_USE_SCAFFOLD_TAGS,
+    'received',
+    'reactions',
+    'message',
+    ...PROMPT_TEMPLATE_ORPHAN_TAGS,
+  ]),
+];
+
+/**
  * Build the ordered artifact-cleanup steps for a given personality name.
  */
 function buildArtifactPatterns(personalityName: string): ArtifactStep[] {
@@ -123,31 +200,29 @@ function buildArtifactPatterns(personalityName: string): ArtifactStep[] {
     // Max 100 chars prevents stripping tags that contain the actual response.
     // MUST come before leading opening tag pattern so matched pairs are stripped as a unit.
     patternStep(
-      /^<(result|result_text|parameter|character|name|content)(?:\s[^>]*)?>[^<\n]{0,100}<\/\1>\s*/i
+      new RegExp(
+        `^<(${SELF_CONTAINED_ECHO_TAGS.join('|')})(?:\\s[^>]*)?>[^<\\n]{0,100}<\\/\\1>\\s*`,
+        'i'
+      )
     ),
     // Leading hallucinated tool-use opening tags: GLM 4.5 Air (and similar models trained on
     // Anthropic/OpenAI data) wrap responses in XML tool-use structures like <function_calls>,
     // <invoke>, <results>, etc. Strip known tag families at start of content only.
     patternStep(
-      /^<(?:function_calls|function_results|invoke|results|result|result_text|parameter|content|character|name|tool_calls|tool_results|tool_call|tool_result)(?:\s[^>]*)?>[ \t]*\n?/i
+      new RegExp(`^<(?:${TOOL_USE_SCAFFOLD_TAGS.join('|')})(?:\\s[^>]*)?>[ \\t]*\\n?`, 'i')
     ),
     // Leading hallucinated closing tags: after inner content is stripped, orphaned closing tags
     // like </result> or </function_results> remain at the start. Strip them too.
-    patternStep(
-      /^<\/(?:function_calls|function_results|invoke|results|result|result_text|parameter|content|character|name|tool_calls|tool_results|tool_call|tool_result)>[ \t]*\n?/i
-    ),
+    patternStep(new RegExp(`^<\\/(?:${TOOL_USE_SCAFFOLD_TAGS.join('|')})>[ \\t]*\\n?`, 'i')),
     // Leading <received message>...</received> block: GLM 4.5 Air echoes the user's message
     // in a hallucinated receipt structure before responding
     patternStep(/^<received(?:\s+message)?(?:\s[^>]*)?>[\s\S]*?<\/received>\s*/i),
     // Prompt template orphan closing tags: model echoes closing tags from the prompt's
     // XML structure (e.g., </chat_log> from PromptBuilder.ts). Stripped from anywhere in content
-    // since they can appear mid-response, not just trailing. `facts` joined the list when the
-    // V-tier blocks moved into the user message, directly adjacent to the current turn —
-    // the echo-probability position. (`context` is deliberately absent: too collision-prone
-    // as prose.)
-    patternStep(
-      /<\/(?:chat_log|participants|protocol|memory_archive|contextual_references|facts)>/gi
-    ),
+    // since they can appear mid-response, not just trailing. `facts` is a member because the
+    // V-tier blocks sit in the user message, directly adjacent to the current turn — the
+    // echo-probability position.
+    patternStep(new RegExp(`<\\/(?:${PROMPT_TEMPLATE_ORPHAN_TAGS.join('|')})>`, 'gi')),
     // Trailing <reactions> block: LLM mimics history metadata. ReDoS: leading `\s{0,64}` bounded (unbounded `\s*` before literal retries at every position).
     patternStep(/\s{0,64}<reactions>[\s\S]*?<\/reactions>\s*$/i),
     // Generic trailing closing tag, opener-aware — see `stripOrphanTrailingCloser`.

--- a/services/ai-worker/src/utils/wrapperTagUnwrap.test.ts
+++ b/services/ai-worker/src/utils/wrapperTagUnwrap.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { ARTIFACT_TAG_NAMES } from './responseArtifacts.js';
 import { KNOWN_THINKING_TAGS } from './thinkingExtraction.js';
 import { unwrapUnknownWrapperTags, WRAPPER_UNWRAP_EXCLUDED_TAGS } from './wrapperTagUnwrap.js';
 
@@ -217,6 +218,44 @@ describe('unwrapUnknownWrapperTags', () => {
       expect(unwrapUnknownWrapperTags(content).unwrappedTags).toEqual([]);
     });
 
+    it('counts only same-name tags ALONE on a line, so an inline mention survives verbatim', () => {
+      // Span depth is counted over delimiter-shaped lines (`^<action>$`), never
+      // over prose that happens to name the tag mid-line. An inline mention
+      // must therefore neither open a nested level (which would leave the span
+      // unclosed and the delimiters visible) nor be rewritten — it is the
+      // character's own words about the markup.
+      const content = [
+        '"Hi."',
+        '<action>',
+        'She waves, then pauses.',
+        '"Every time," she says, "she typed <action> at me and left it there."',
+        'She looks away.',
+        '</action>',
+        '"Bye."',
+      ].join('\n');
+
+      const result = unwrapUnknownWrapperTags(content);
+
+      expect(result.content).toBe(
+        [
+          '"Hi."',
+          'She waves, then pauses.',
+          '"Every time," she says, "she typed <action> at me and left it there."',
+          'She looks away.',
+          '"Bye."',
+        ].join('\n')
+      );
+      expect(result.unwrappedTags).toEqual(['action']);
+
+      // Only the two delimiter lines are gone; every body line byte-identical.
+      const original = content.split('\n');
+      expect(result.content.split('\n')).toEqual([
+        original[0],
+        ...original.slice(2, 5),
+        original[6],
+      ]);
+    });
+
     it('resolves nested same-name spans within the pass bound', () => {
       const content = [
         '"Hi."',
@@ -284,6 +323,16 @@ describe('unwrapUnknownWrapperTags', () => {
   describe('excluded tags', () => {
     it('excludes every known thinking tag', () => {
       for (const tag of KNOWN_THINKING_TAGS) {
+        expect(WRAPPER_UNWRAP_EXCLUDED_TAGS).toContain(tag);
+      }
+    });
+
+    it('excludes every artifact tag name', () => {
+      // Trivially true while the exclusion set spreads `ARTIFACT_TAG_NAMES`.
+      // The pin is for the future hand-edit that replaces the spread with a
+      // literal list: the copy would drift from `responseArtifacts.ts` and
+      // resurrect scaffolding echo silently, so this fails loudly instead.
+      for (const tag of ARTIFACT_TAG_NAMES) {
         expect(WRAPPER_UNWRAP_EXCLUDED_TAGS).toContain(tag);
       }
     });

--- a/services/ai-worker/src/utils/wrapperTagUnwrap.ts
+++ b/services/ai-worker/src/utils/wrapperTagUnwrap.ts
@@ -43,6 +43,7 @@
 
 import { isInsideCodeSpan } from '@tzurot/common-types/utils/codeSpanDetection';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { ARTIFACT_TAG_NAMES } from './responseArtifacts.js';
 import { KNOWN_THINKING_TAGS } from './thinkingExtraction.js';
 
 const logger = createLogger('wrapper-tag-unwrap');
@@ -51,14 +52,15 @@ const logger = createLogger('wrapper-tag-unwrap');
  * Tag names this pass must never unwrap, because another pass in the pipeline
  * owns them and unwrapping would defeat that pass.
  *
- * Three groups:
- * - `KNOWN_THINKING_TAGS` — imported rather than restated, so a tag added for a
- *   new model revision inherits the exclusion instead of arriving unguarded.
- * - The `responseArtifacts.ts` deletion vocabulary — every tag family named by
- *   `buildArtifactPatterns` there. Those patterns DELETE their contents; keeping
- *   the contents by unwrapping first would resurrect prompt-scaffolding echo.
- * - Prompt-template tags emitted by `PromptBuilder` — the model echoing one back
- *   is scaffolding leakage, not a stage direction.
+ * Two groups, both imported rather than restated, so a tag added for a new model
+ * revision or a new prompt block inherits the exclusion instead of arriving
+ * unguarded:
+ * - `KNOWN_THINKING_TAGS` — the reasoning vocabulary.
+ * - `ARTIFACT_TAG_NAMES` — the `responseArtifacts.ts` deletion vocabulary, every
+ *   tag family named by `buildArtifactPatterns` there. Those patterns DELETE
+ *   their contents; keeping the contents by unwrapping first would resurrect
+ *   prompt-scaffolding echo. It includes the `PromptBuilder` prompt-template
+ *   orphan-closer vocabulary, since those closers are part of that pattern list.
  *
  * Exported so the guard suite can enumerate the vocabulary rather than restate
  * it; a hand-maintained copy in the tests would drift on exactly the revision
@@ -68,32 +70,7 @@ export const WRAPPER_UNWRAP_EXCLUDED_TAGS: readonly string[] = [
   // Reasoning vocabulary — extracted upstream by `extractThinkingBlocks`.
   ...KNOWN_THINKING_TAGS,
   // Artifact vocabulary — deleted downstream by `stripResponseArtifacts`.
-  'last_message',
-  'from',
-  'result',
-  'result_text',
-  'parameter',
-  'character',
-  'name',
-  'content',
-  'function_calls',
-  'function_results',
-  'invoke',
-  'results',
-  'tool_calls',
-  'tool_results',
-  'tool_call',
-  'tool_result',
-  'received',
-  'reactions',
-  'message',
-  // Prompt-template vocabulary — scaffolding echo from PromptBuilder's format.
-  'chat_log',
-  'participants',
-  'protocol',
-  'memory_archive',
-  'contextual_references',
-  'facts',
+  ...ARTIFACT_TAG_NAMES,
 ];
 
 const EXCLUDED_TAG_SET: ReadonlySet<string> = new Set(WRAPPER_UNWRAP_EXCLUDED_TAGS);


### PR DESCRIPTION
## Summary

Closes TASK-437 (filed off #1970's review rounds 1 and 3).

`WRAPPER_UNWRAP_EXCLUDED_TAGS` hand-restated the ~25 artifact tag names that live inline in regex literals inside `buildArtifactPatterns` (`responseArtifacts.ts`). A pattern-list change there would silently drift the exclusion set here, reopening the scaffolding-resurrection risk for whichever tag fell out of sync — the unwrap pass would preserve inner text that the artifact pass means to delete.

- `responseArtifacts.ts` now defines its pattern alternations from three named arrays (`SELF_CONTAINED_ECHO_TAGS`, `TOOL_USE_SCAFFOLD_TAGS`, `PROMPT_TEMPLATE_ORPHAN_TAGS`; orders preserved verbatim) and exports their deduped union as `ARTIFACT_TAG_NAMES`.
- `wrapperTagUnwrap.ts` spreads `ARTIFACT_TAG_NAMES` instead of restating the names — the same derivation shape the file already uses for `KNOWN_THINKING_TAGS`.
- Two KNOWN LIMIT pins from the same review thread: the opener probe in `stripOrphanTrailingCloser` is not pair-aware (a completed pair earlier keeps a separate trailing orphan closer — under-cleaning, never corruption), and span-mode depth counting only counts same-name tags alone on a line (an inline mention in prose survives verbatim).

## Verified

- Derived list confirmed byte-identical in order and membership to the removed hand-list (the `it.each(WRAPPER_UNWRAP_EXCLUDED_TAGS)` sweeps depend on both).
- Full ai-worker suite green (207 files / 4503 tests), including both constrained suites unchanged; new pins added on top.
- `pnpm test` + `pnpm quality` green sequentially.
- `ResponsePostProcessor.test.ts`'s full mock of `responseArtifacts.js` needed the `importOriginal` passthrough for the new constant (module-load dependency) — same pattern, same reason, as its existing `KNOWN_THINKING_TAGS` passthrough; assertion surface unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)