### PR TITLE
fix(ai-worker): resolve BYOK audio keys independently of chat guest mode

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
@@ -923,15 +923,21 @@ describe('AuthStep', () => {
       expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledWith('user-456', AIProvider.Mistral);
     });
 
-    it('should skip ElevenLabs resolution in guest mode', async () => {
-      const keyResult: ApiKeyResolutionResult = {
+    it('should still probe audio providers in chat guest mode, admitting none that resolve guest', async () => {
+      // One guest-mode result per probed provider, each carrying its own
+      // provider id — AuthStep never reads result.provider, but the fixtures
+      // should still describe the calls they answer.
+      const guestResultFor = (provider: AIProvider): ApiKeyResolutionResult => ({
         apiKey: 'system-key',
-        provider: AIProvider.OpenRouter,
+        provider,
         source: 'system',
         isGuestMode: true,
-      };
+      });
 
-      vi.mocked(mockApiKeyResolver.resolveApiKey).mockResolvedValue(keyResult);
+      vi.mocked(mockApiKeyResolver.resolveApiKey)
+        .mockResolvedValueOnce(guestResultFor(AIProvider.OpenRouter))
+        .mockResolvedValueOnce(guestResultFor(AIProvider.ElevenLabs))
+        .mockResolvedValueOnce(guestResultFor(AIProvider.Mistral));
       vi.mocked(mockConfigResolver.getFreeDefaultConfig).mockResolvedValue(null);
 
       step = new AuthStep(mockApiKeyResolver, mockConfigResolver);
@@ -950,8 +956,62 @@ describe('AuthStep', () => {
       const result = await step.process(context);
 
       expect(result.auth?.audioProviderKeys?.has('elevenlabs')).toBe(false);
-      // Only called once (OpenRouter), not twice
-      expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledTimes(1);
+      // Chat guest mode does not short-circuit the audio probe — every provider
+      // is asked (OpenRouter + ElevenLabs + Mistral), and it is each provider's
+      // OWN guest-mode result that keeps it out of the map.
+      expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledTimes(3);
+    });
+
+    it('should resolve a BYOK audio key for a user who is a chat guest', async () => {
+      // The decoupling pin: chat guest mode is an OpenRouter/LLM verdict. A user
+      // whose only key is ElevenLabs is a chat guest AND a BYOK audio customer.
+      const openRouterGuest: ApiKeyResolutionResult = {
+        apiKey: 'system-key',
+        provider: AIProvider.OpenRouter,
+        source: 'system',
+        isGuestMode: true,
+      };
+
+      const elevenLabsByok: ApiKeyResolutionResult = {
+        apiKey: 'sk_el_guest_byok',
+        provider: AIProvider.ElevenLabs,
+        source: 'user',
+        isGuestMode: false,
+      };
+
+      // A no-key Mistral lookup THROWS in the real resolver (no system
+      // fallback exists for Mistral) — the fixture goes through that path
+      // rather than a synthetic resolved result the resolver never produces.
+      vi.mocked(mockApiKeyResolver.resolveApiKey)
+        .mockResolvedValueOnce(openRouterGuest)
+        .mockResolvedValueOnce(elevenLabsByok)
+        .mockRejectedValueOnce(
+          new NoApiKeyAvailableError('No API key available for provider mistral.')
+        );
+      vi.mocked(mockConfigResolver.getFreeDefaultConfig).mockResolvedValue(null);
+
+      step = new AuthStep(mockApiKeyResolver, mockConfigResolver);
+
+      const config: ResolvedConfig = {
+        effectivePersonality: TEST_PERSONALITY,
+        configSource: 'personality',
+      };
+
+      const context: GenerationContext = {
+        job: createMockJob(),
+        startTime: Date.now(),
+        config,
+      };
+
+      const result = await step.process(context);
+
+      expect(result.auth?.isGuestMode).toBe(true);
+      expect(result.auth?.audioProviderKeys?.get('elevenlabs')).toBe('sk_el_guest_byok');
+      expect(result.auth?.audioProviderKeys?.has('mistral')).toBe(false);
+      expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledWith(
+        'user-456',
+        AIProvider.ElevenLabs
+      );
     });
 
     it('should silently handle ElevenLabs resolution failure', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -89,7 +89,7 @@ export class AuthStep implements IPipelineStep {
       quotaFallback,
     } = llmAuth;
 
-    const audioProviderKeys = await this.resolveAudioProviderKeys(jobContext.userId, isGuestMode);
+    const audioProviderKeys = await this.resolveAudioProviderKeys(jobContext.userId);
 
     // Resolve STT dispatch once here so downstream steps (DependencyStep,
     // GenerationStep → MultimodalProcessor) don't each re-resolve. SttResolver
@@ -303,19 +303,19 @@ export class AuthStep implements IPipelineStep {
    * Resolve audio-provider keys (ElevenLabs + Mistral). Each provider's key
    * authorizes ALL of that provider's audio endpoints — TTS, STT, cloning.
    *
-   * Skipped in guest mode: isGuestMode is determined by OpenRouter resolution,
-   * so a user with ONLY an audio key (no OpenRouter) won't get BYOK TTS/STT.
-   * This is an intentional v1 coupling — decoupling requires per-provider
-   * guest mode logic and is tracked as a follow-up. Per-provider resolution
-   * failure is logged and tolerated; the dispatcher skips providers whose
-   * entry is missing from the map.
+   * Independent of the chat guest-mode decision: that verdict comes from
+   * OpenRouter/LLM resolution, whereas these are provider-scoped lookups. Each
+   * provider's OWN resolution result is the admission guard — a guest-mode
+   * result or a missing key keeps that provider out of the map — so a user who
+   * is a chat guest but holds a BYOK audio key still gets BYOK TTS/STT.
+   * Per-provider resolution failure is logged and tolerated; the dispatcher
+   * skips providers whose entry is missing from the map.
    */
   private async resolveAudioProviderKeys(
-    userId: string,
-    isGuestMode: boolean
+    userId: string
   ): Promise<ReadonlyMap<AudioProviderId, string>> {
     const audioKeysBuilder = new Map<AudioProviderId, string>();
-    if (!this.apiKeyResolver || isGuestMode) {
+    if (!this.apiKeyResolver) {
       return audioKeysBuilder;
     }
     const providers: { id: AudioProviderId; provider: AIProvider; failNote: string }[] = [

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -127,8 +127,9 @@ export class TTSStep implements IPipelineStep {
 
       // Build dispatcher inputs. The audioProviderKeys map carries any BYOK
       // credentials the user has set (populated by AuthStep — empty Map is
-      // expected for guest mode or no-key users). Typed fallback avoids a
-      // narrowing cast at the dispatcher boundary.
+      // expected for a user with no audio keys; chat guest mode does NOT imply
+      // an empty map, since audio keys resolve per provider). Typed fallback
+      // avoids a narrowing cast at the dispatcher boundary.
       const audioProviderKeys =
         context.auth?.audioProviderKeys ?? new Map<AudioProviderId, string>();
 


### PR DESCRIPTION
## Summary

Closes TASK-434 (surfaced by the TASK-416 chat-capable alignment, which made the gap visible: an ElevenLabs-only user now correctly sees Guest Mode UI while holding an audio key the system ignored).

`AuthStep.resolveAudioProviderKeys` skipped resolution entirely when the CHAT guest verdict (an OpenRouter/LLM resolution outcome) was true — so a user whose only active key is ElevenLabs or Mistral, who is a chat guest by construction, never got their own audio key and TTS/STT fell back to the shared path despite valid BYOK credentials. The old comment called this an "intentional v1 coupling … tracked as a follow-up"; no tracking existed until TASK-434.

The per-provider loop already admits keys on each provider's **own** resolution result (`!result.isGuestMode` + key present), so the outer chat-mode parameter was the entire coupling. It's removed; each provider's verdict is now the sole admission guard.

## Verified

- **Regression test failed pre-fix** (captured verbatim before applying the src change): chat guest + BYOK ElevenLabs key → `audioProviderKeys` empty, expected key. Passes post-fix; `auth.isGuestMode` stays true throughout.
- The old "skip resolution in guest mode" test pinned exactly the removed behavior — rewritten to pin exclusion via the per-provider guard (same exclusion assertion, probe-count assertion updated 1→3, per-provider mock fixtures). Deliberate behavior-change edit per the task, not a test-weakening.
- **Consumer sweep** (`audioProviderKeys` + `isGuestMode`, all of ai-worker src): TtsDispatcher, TTSStep, and `resolveSttDispatch` gate purely on map contents; `AIJobProcessor`'s standalone transcription path carries its own independent per-provider admission guard (already decoupled). No site reads the chat verdict for audio decisions. One stale TTSStep comment (asserting guest mode implies an empty map) corrected in the same diff.
- Full ai-worker suite green (4,504 tests); `pnpm test` + `pnpm quality` green sequentially.

## Runtime note (corrected per review)

Every chat-guest job now performs the two audio-provider lookups it previously skipped — two sequential, never-cached DB reads applied to the **whole guest population**, not just BYOK holders (the review rightly flagged the original framing as understating the scale). At current prod volume this sits inside the noise floor of an LLM-call pipeline, and the pool-saturation gauge is already armed; tracked as a post-deploy watch with the fix shapes (`Promise.all` the independent lookups / short-TTL negative cache) in TASK-439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)