### PR TITLE
perf(ai-worker): run the two audio-provider key lookups concurrently

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
@@ -1143,6 +1143,126 @@ describe('AuthStep', () => {
       expect(fields.err?.message).toBe('db connection refused');
     });
 
+    it('should start both audio lookups before either resolves', async () => {
+      // The concurrency pin proper: a revert to sequential awaiting would pass
+      // every outcome-shaped test (same map, same logs), so this one observes
+      // the call pattern instead — with the first audio lookup parked on an
+      // unresolved promise, the second lookup must already have been issued.
+      const openRouterResult: ApiKeyResolutionResult = {
+        apiKey: 'sk-or-test',
+        provider: AIProvider.OpenRouter,
+        source: 'user',
+        isGuestMode: false,
+      };
+      let releaseElevenLabs!: (value: ApiKeyResolutionResult) => void;
+      const parkedElevenLabs = new Promise<ApiKeyResolutionResult>(resolve => {
+        releaseElevenLabs = resolve;
+      });
+      const mistralByok: ApiKeyResolutionResult = {
+        apiKey: 'sk-mistral-byok',
+        provider: AIProvider.Mistral,
+        source: 'user',
+        isGuestMode: false,
+      };
+
+      vi.mocked(mockApiKeyResolver.resolveApiKey)
+        .mockResolvedValueOnce(openRouterResult)
+        .mockReturnValueOnce(parkedElevenLabs)
+        .mockResolvedValueOnce(mistralByok);
+
+      step = new AuthStep(mockApiKeyResolver);
+
+      const config: ResolvedConfig = {
+        effectivePersonality: TEST_PERSONALITY,
+        configSource: 'personality',
+      };
+
+      const context: GenerationContext = {
+        job: createMockJob(),
+        startTime: Date.now(),
+        config,
+      };
+
+      const processPromise = step.process(context);
+
+      // Drain microtasks until process() has issued all three lookups (bounded
+      // so a regression cannot hang the test). The ElevenLabs promise is still
+      // parked, so under a sequential loop the Mistral call can never be issued
+      // and the drain exhausts with only two calls recorded.
+      for (
+        let i = 0;
+        i < 50 && vi.mocked(mockApiKeyResolver.resolveApiKey).mock.calls.length < 3;
+        i++
+      ) {
+        await Promise.resolve();
+      }
+      expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledTimes(3);
+      expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledWith('user-456', AIProvider.Mistral);
+
+      releaseElevenLabs({
+        apiKey: 'sk-el-byok',
+        provider: AIProvider.ElevenLabs,
+        source: 'user',
+        isGuestMode: false,
+      });
+
+      const result = await processPromise;
+      expect(result.auth?.audioProviderKeys?.get('elevenlabs')).toBe('sk-el-byok');
+      expect(result.auth?.audioProviderKeys?.get('mistral')).toBe('sk-mistral-byok');
+    });
+
+    it('should isolate per-provider failures when both audio lookups reject', async () => {
+      // The isolation pin: each concurrent lookup must own its rejection. A
+      // naive Promise.all over bare lookups would let the first rejection
+      // abort the whole resolution (and leave the second one unhandled) —
+      // here each provider still gets its own log at its own level.
+      const openRouterResult: ApiKeyResolutionResult = {
+        apiKey: 'sk-or-test',
+        provider: AIProvider.OpenRouter,
+        source: 'user',
+        isGuestMode: false,
+      };
+
+      vi.mocked(mockApiKeyResolver.resolveApiKey)
+        .mockResolvedValueOnce(openRouterResult)
+        .mockRejectedValueOnce(
+          new NoApiKeyAvailableError('No API key available for provider elevenlabs.')
+        )
+        .mockRejectedValueOnce(new Error('db down'));
+
+      step = new AuthStep(mockApiKeyResolver);
+
+      const config: ResolvedConfig = {
+        effectivePersonality: TEST_PERSONALITY,
+        configSource: 'personality',
+      };
+
+      const context: GenerationContext = {
+        job: createMockJob(),
+        startTime: Date.now(),
+        config,
+      };
+
+      const result = await step.process(context);
+
+      expect(result.auth?.audioProviderKeys?.size).toBe(0);
+
+      const debugCalls = loggerMock.debug.mock.calls.filter(call =>
+        String(call[1]).includes('ElevenLabs key resolution failed')
+      );
+      expect(debugCalls).toHaveLength(1);
+      expect(debugCalls[0]?.[0]).toEqual({ userId: 'user-456', provider: 'elevenlabs' });
+
+      const warnCalls = loggerMock.warn.mock.calls.filter(call =>
+        String(call[1]).includes('Mistral key resolution failed')
+      );
+      expect(warnCalls).toHaveLength(1);
+      const warnFields = warnCalls[0]?.[0] as { userId?: string; err?: Error };
+      expect(warnFields.userId).toBe('user-456');
+      expect(warnFields.err).toBeInstanceOf(Error);
+      expect(warnFields.err?.message).toBe('db down');
+    });
+
     describe('sttDispatch', () => {
       function setupResolvers(): {
         openRouter: ApiKeyResolutionResult;

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -315,7 +315,8 @@ export class AuthStep implements IPipelineStep {
     userId: string
   ): Promise<ReadonlyMap<AudioProviderId, string>> {
     const audioKeysBuilder = new Map<AudioProviderId, string>();
-    if (!this.apiKeyResolver) {
+    const resolver = this.apiKeyResolver;
+    if (!resolver) {
       return audioKeysBuilder;
     }
     const providers: { id: AudioProviderId; provider: AIProvider; failNote: string }[] = [
@@ -330,25 +331,37 @@ export class AuthStep implements IPipelineStep {
         failNote: 'Mistral key resolution failed (non-fatal — TTS dispatcher will skip Mistral)',
       },
     ];
-    for (const { id, provider, failNote } of providers) {
-      try {
-        const result = await this.apiKeyResolver.resolveApiKey(userId, provider);
-        if (!result.isGuestMode && result.apiKey !== undefined) {
-          audioKeysBuilder.set(id, result.apiKey);
-          logger.debug({ userId, source: result.source, provider: id }, 'Resolved audio API key');
+    // The lookups are independent (one per provider, no shared state) and both
+    // sit on an uncached path for keyless users, so they run concurrently and
+    // each owns its failure handling — one provider's error never affects the
+    // other.
+    const resolutions = await Promise.all(
+      providers.map(async ({ id, provider, failNote }) => {
+        try {
+          return { id, result: await resolver.resolveApiKey(userId, provider) };
+        } catch (error) {
+          if (error instanceof NoApiKeyAvailableError) {
+            // Expected for BYOK-only audio providers: a user without their own
+            // key hits this on EVERY job (negative results aren't cached). The
+            // fallback is deterministic and the note already names it, so this
+            // is compact debug — no stack, no err object.
+            logger.debug({ userId, provider: id }, failNote);
+          } else {
+            // Unexpected resolution failure (DB down, decryption error) — keep
+            // the stack; this one IS an incident.
+            logger.warn({ err: error, userId }, failNote);
+          }
+          return { id, result: undefined };
         }
-      } catch (error) {
-        if (error instanceof NoApiKeyAvailableError) {
-          // Expected for BYOK-only audio providers: a user without their own
-          // key hits this on EVERY job (negative results aren't cached). The
-          // fallback is deterministic and the note already names it, so this
-          // is compact debug — no stack, no err object.
-          logger.debug({ userId, provider: id }, failNote);
-        } else {
-          // Unexpected resolution failure (DB down, decryption error) — keep
-          // the stack; this one IS an incident.
-          logger.warn({ err: error, userId }, failNote);
-        }
+      })
+    );
+
+    // Populate in providers-array order (Promise.all preserves it) so map
+    // insertion order stays deterministic regardless of resolution timing.
+    for (const { id, result } of resolutions) {
+      if (result !== undefined && !result.isGuestMode && result.apiKey !== undefined) {
+        audioKeysBuilder.set(id, result.apiKey);
+        logger.debug({ userId, source: result.source, provider: id }, 'Resolved audio API key');
       }
     }
     return audioKeysBuilder;


### PR DESCRIPTION
## Summary

The fast-follow both of #1974's review rounds converged on. `resolveAudioProviderKeys`' ElevenLabs and Mistral lookups are independent per-provider calls that ran sequentially — and both sit on an uncached exception path for keyless users, which since the guest-mode decouple means every chat-guest job. `Promise.all` halves the added wall-clock latency for that block.

Per-provider semantics are byte-preserved: each lookup keeps its own try/catch (no-key → compact debug; unexpected failure → warn with stack; one provider's error never affects the other), and admission plus the success log run in a post-await populate loop in providers-array order, so map insertion order and success-log order stay deterministic. (Failure logs fire inside the concurrent callbacks, so their relative order follows resolution timing — nothing consumes log order; noted for precision per review.)

TASK-439 now owns only the remaining negative-cache decision, still gated on the pool-saturation/latency observable.

## Verified

- **Concurrency pin**: a test parks the ElevenLabs lookup on an unresolved promise and asserts the Mistral call was already issued — under sequential awaiting the third call can never happen, so a revert to `for...of` fails this test rather than passing silently (added per review suggestion).
- **Isolation pin**: both lookups rejecting simultaneously with different error classes still resolves to an empty map, with each provider logged at its own level — the case a naive `Promise.all` over bare lookups would break.
- All existing AuthStep tests pass unchanged; full ai-worker suite green (4,506 tests); `pnpm test` + `pnpm quality` green sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)