### PR TITLE
feat(ai-worker): hydrate live quote authors to persona identity (TASK-365 PR-3)

### DIFF
--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -99,7 +99,7 @@ export class ConversationalRAGService {
     this.factRetriever = createFactRetriever(prisma, memoryManager);
     this.promptBuilder = new PromptBuilder();
     const longTermMemory = new LongTermMemoryService(prisma, memoryManager, extractionTrigger);
-    this.referencedMessageFormatter = new ReferencedMessageFormatter();
+    this.referencedMessageFormatter = new ReferencedMessageFormatter(prisma);
     this.contextWindowManager = new ContextWindowManager();
     this.userReferenceResolver = new UserReferenceResolver(prisma);
     this.history = new ConversationHistoryService(prisma);

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -5,15 +5,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
 import { AttachmentType } from '@tzurot/common-types/constants/media';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { type ProcessedAttachment } from './MultimodalProcessor.js';
+import { type ResolvedPersona } from './reference/UserReferencePatterns.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
 const {
   mockDescribeImage,
   mockTranscribeAudio,
   mockFormatPromptTimestamp,
+  mockBatchResolveByDiscordIds,
   mockLogger,
   mockChildLogger,
 } = vi.hoisted(() => {
@@ -26,6 +29,7 @@ const {
     mockDescribeImage: vi.fn(),
     mockTranscribeAudio: vi.fn(),
     mockFormatPromptTimestamp: vi.fn(),
+    mockBatchResolveByDiscordIds: vi.fn(),
     mockChildLogger: child,
     mockLogger: {
       info: vi.fn(),
@@ -41,6 +45,13 @@ const {
 vi.mock('./MultimodalProcessor.js', () => ({
   describeImage: mockDescribeImage,
   transcribeAudio: mockTranscribeAudio,
+}));
+
+// Persona hydration's only database seam. Mocking the resolver rather than
+// Prisma keeps the formatter's stub client trivial and puts the assertions on
+// the arguments that actually cross the seam (which ids, and how many calls).
+vi.mock('./reference/BatchResolvers.js', () => ({
+  batchResolveByDiscordIds: mockBatchResolveByDiscordIds,
 }));
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -70,8 +81,11 @@ describe('ReferencedMessageFormatter', () => {
 
     // Restore default mock implementations after mockReset clears them
     mockFormatPromptTimestamp.mockReturnValue('2025-12-06 (Fri) 00:00 • just now');
+    // Default: nobody resolves, so every quote renders its Discord identity —
+    // the pre-hydration behaviour the rest of this file pins.
+    mockBatchResolveByDiscordIds.mockResolvedValue(new Map<string, ResolvedPersona>());
 
-    formatter = new ReferencedMessageFormatter();
+    formatter = new ReferencedMessageFormatter({} as PrismaClient);
     mockPersonality = {
       id: 'test-personality',
       name: 'TestBot',
@@ -500,6 +514,147 @@ describe('ReferencedMessageFormatter', () => {
       );
 
       expect(result).toContain('role="assistant"');
+    });
+  });
+
+  /**
+   * Live persona hydration — the identity seam.
+   *
+   * Before this, a live quote rendered the Discord display name with no
+   * `from_id`, while <chat_log> and stored quotes rendered the persona name
+   * WITH one: the same person named two ways inside one prompt, and only one of
+   * the names bound to a `<participants>` id. The assertions below run across
+   * the resolver seam (which ids it is called with, how many times) rather than
+   * only on the rendered string, because a batch that silently degrades to
+   * per-reference queries renders identically.
+   */
+  describe('persona hydration (live path)', () => {
+    function resolved(personaId: string, personaName: string): ResolvedPersona {
+      return { personaId, personaName, preferredName: null, pronouns: null, content: '' };
+    }
+
+    function makeRef(overrides: Partial<ReferencedMessage> = {}): ReferencedMessage {
+      return {
+        referenceNumber: 1,
+        discordMessageId: 'msg-1',
+        discordUserId: 'discord-1',
+        authorUsername: 'testuser',
+        authorDisplayName: 'Test User',
+        content: 'quoted text',
+        embeds: '',
+        timestamp: '2025-12-06T00:00:00Z',
+        locationContext: '',
+        ...overrides,
+      };
+    }
+
+    it('resolves the whole batch in ONE call, with the author ids deduplicated', async () => {
+      await formatter.formatReferencedMessages(
+        [
+          makeRef({ referenceNumber: 1, discordUserId: 'discord-1' }),
+          // Same author as #1 — one id, not two.
+          makeRef({ referenceNumber: 2, discordUserId: 'discord-1' }),
+          makeRef({ referenceNumber: 3, discordUserId: 'discord-2' }),
+        ],
+        mockPersonality
+      );
+
+      expect(mockBatchResolveByDiscordIds).toHaveBeenCalledTimes(1);
+      expect(mockBatchResolveByDiscordIds).toHaveBeenCalledWith(expect.anything(), [
+        'discord-1',
+        'discord-2',
+      ]);
+    });
+
+    it('skips the query entirely when no reference carries an author id', async () => {
+      // The resolver short-circuits on an empty array anyway; passing it an
+      // empty list keeps the intent visible at this seam.
+      await formatter.formatReferencedMessages([makeRef({ discordUserId: '' })], mockPersonality);
+
+      expect(mockBatchResolveByDiscordIds).toHaveBeenCalledWith(expect.anything(), []);
+    });
+
+    it.each([
+      ['a full reference', false],
+      ['a DEDUPED reference', true],
+    ])('renders the persona name and from_id on %s', async (_label, isDeduplicated) => {
+      mockBatchResolveByDiscordIds.mockResolvedValue(
+        new Map([['discord-1', resolved('persona-uuid-1', 'Vladlena')]])
+      );
+
+      const { formatted } = await formatter.formatReferencedMessages(
+        [makeRef({ isDeduplicated: isDeduplicated ? true : undefined })],
+        mockPersonality
+      );
+
+      expect(formatted).toContain(
+        '<quote number="1" from="Vladlena" from_id="persona-uuid-1" username="testuser" role="user"'
+      );
+      // The Discord display name is fully replaced, not appended.
+      expect(formatted).not.toContain('from="Test User"');
+    });
+
+    it('falls back to the Discord display name, and emits no from_id, on a resolver miss', async () => {
+      mockBatchResolveByDiscordIds.mockResolvedValue(
+        new Map([['someone-else', resolved('persona-uuid-9', 'Not This Person')]])
+      );
+
+      const { formatted } = await formatter.formatReferencedMessages([makeRef()], mockPersonality);
+
+      expect(formatted).toContain('<quote number="1" from="Test User" username="testuser"');
+      expect(formatted).not.toContain('from_id=');
+      expect(formatted).not.toContain('Not This Person');
+    });
+
+    it('keeps username when the persona name differs from it, and drops it when they match', async () => {
+      mockBatchResolveByDiscordIds.mockResolvedValue(
+        new Map([['discord-1', resolved('persona-uuid-1', 'Vladlena')]])
+      );
+      const differs = await formatter.formatReferencedMessages([makeRef()], mockPersonality);
+      expect(differs.formatted).toContain(
+        'from="Vladlena" from_id="persona-uuid-1" username="testuser"'
+      );
+
+      // Hydration can make `from` equal the username, which is exactly the
+      // duplicated-token case informativeUsername exists to suppress.
+      mockBatchResolveByDiscordIds.mockResolvedValue(
+        new Map([['discord-1', resolved('persona-uuid-1', 'testuser')]])
+      );
+      const matches = await formatter.formatReferencedMessages([makeRef()], mockPersonality);
+      expect(matches.formatted).toContain('from="testuser" from_id="persona-uuid-1" role="user"');
+      expect(matches.formatted).not.toContain('username=');
+    });
+
+    it('derives the role from the DISCORD name, not the hydrated persona name', async () => {
+      // Both directions of the substitution that would break role derivation if
+      // the hydrated name were fed to it. deriveRefRole matches against the
+      // responding personality's displayName ('Test Bot'), which is Discord
+      // vocabulary — a persona name is a different namespace entirely.
+      mockBatchResolveByDiscordIds.mockResolvedValue(
+        new Map([['discord-1', resolved('persona-uuid-1', 'Vladlena')]])
+      );
+      const ownLine = await formatter.formatReferencedMessages(
+        // No authorRole stamp → the name-match fallback runs. The Discord name
+        // matches the personality, so this is still our own line.
+        [makeRef({ authorUsername: 'test-bot', authorDisplayName: 'Test Bot' })],
+        mockPersonality
+      );
+      expect(ownLine.formatted).toContain(
+        '<quote number="1" from="Vladlena" from_id="persona-uuid-1" username="test-bot" role="assistant"'
+      );
+
+      // ...and the converse: a human whose PERSONA name happens to match the
+      // personality must not be promoted to assistant by hydration.
+      mockBatchResolveByDiscordIds.mockResolvedValue(
+        new Map([['discord-1', resolved('persona-uuid-2', 'Test Bot')]])
+      );
+      const human = await formatter.formatReferencedMessages(
+        [makeRef({ authorUsername: 'someone', authorDisplayName: 'Someone' })],
+        mockPersonality
+      );
+      expect(human.formatted).toContain(
+        '<quote number="1" from="Test Bot" from_id="persona-uuid-2" username="someone" role="user"'
+      );
     });
   });
 

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -9,6 +9,7 @@
 import { type AIProvider } from '@tzurot/common-types/constants/ai';
 import { TEXT_LIMITS } from '@tzurot/common-types/constants/discord';
 import { AttachmentType } from '@tzurot/common-types/constants/media';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type ReferencedMessage,
   type StoredReferencedMessage,
@@ -17,6 +18,8 @@ import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/perso
 import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
+import { batchResolveByDiscordIds } from './reference/BatchResolvers.js';
+import type { ResolvedPersona } from './reference/UserReferencePatterns.js';
 import {
   attachmentEnrichment,
   buildRenderableAttachments,
@@ -64,6 +67,22 @@ interface ReferenceVisionAuth {
   visionModel?: string;
   allPersonalityNames?: Set<string>;
   requestId?: string;
+}
+
+/**
+ * Everything the per-reference adapter needs that does NOT vary across the
+ * batch — the responding personality, the guest-mode flag, the persona lookup
+ * resolved once for the whole set, and the vision/STT auth. Bundled as one
+ * object rather than four positional parameters so adding the next
+ * batch-invariant input is an edit to this interface instead of a wider
+ * signature.
+ */
+interface LiveReferenceContext {
+  personality: LoadedPersonality;
+  isGuestMode: boolean;
+  /** Discord user id → resolved persona, for the whole batch. Misses are normal. */
+  personaMap: Map<string, ResolvedPersona>;
+  apiKeys?: ReferenceVisionAuth;
 }
 
 /**
@@ -209,6 +228,14 @@ function countRenderedEnrichment(attachments: BuiltAttachment[]): number {
  */
 export class ReferencedMessageFormatter {
   /**
+   * @param prisma - Backs the persona hydration of quote authors. The live path
+   *   renders the SAME identity vocabulary as <chat_log> and stored quotes —
+   *   persona name plus `from_id` — so one person is not named two ways inside
+   *   one prompt with only one of the names ID-bound.
+   */
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
    * Format referenced messages for inclusion in prompt
    *
    * Processes all attachments (images, voice messages) in parallel for better performance.
@@ -232,13 +259,22 @@ export class ReferencedMessageFormatter {
     const searchParts: string[] = [];
     const durable: StoredReferencedMessage[] = [];
 
+    // ONE lookup for the whole batch, before any rendering: two quotes by the
+    // same author must not become two queries, and the resolver already returns
+    // an empty map for both empty input and a failed query — a database that is
+    // down costs the persona names, never the quotes.
+    const personaMap = await batchResolveByDiscordIds(this.prisma, [
+      ...new Set(
+        references.map(ref => ref.discordUserId).filter(id => id !== undefined && id.length > 0)
+      ),
+    ]);
+    const context: LiveReferenceContext = { personality, isGuestMode, personaMap, apiKeys };
+
     for (const ref of references) {
       const { renderable, built } = await this.fromLiveReference(
         ref,
-        personality,
-        isGuestMode,
         preprocessedAttachments?.[ref.referenceNumber],
-        apiKeys
+        context
       );
 
       // Dedup is a projection of the reference above, never a second build —
@@ -298,14 +334,22 @@ export class ReferencedMessageFormatter {
    * forwarded, and deduped alike — sees the same object, which is why
    * forwarding is now an attribute on it rather than a separate render method
    * that quietly dropped the number, role, username and location.
+   *
+   * Identity is resolved HERE, per the adapter contract on
+   * `RenderableReference`: a quote's author renders under the persona name and
+   * carries the persona UUID that `<participants>` binds, matching what
+   * <chat_log> and a replayed stored quote already render. `context.personaMap`
+   * is the batch the caller resolved for the whole set; a miss falls back to
+   * the Discord display name, which is what the path rendered unconditionally
+   * before.
    */
   private async fromLiveReference(
     ref: ReferencedMessage,
-    personality: LoadedPersonality,
-    isGuestMode: boolean,
     preprocessedForRef: ProcessedAttachment[] | undefined,
-    apiKeys?: ReferenceVisionAuth
+    context: LiveReferenceContext
   ): Promise<{ renderable: RenderableReference; built: BuiltAttachment[] }> {
+    const { personality, isGuestMode, personaMap, apiKeys } = context;
+
     const built = await this.buildAttachments(
       ref,
       personality,
@@ -314,16 +358,25 @@ export class ReferencedMessageFormatter {
       apiKeys
     );
 
+    const discordName = ref.authorDisplayName || ref.authorUsername;
+    const persona = personaMap.get(ref.discordUserId);
+
     return {
       built,
       renderable: {
         number: ref.referenceNumber,
         isForwarded: ref.isForwarded,
-        from: ref.authorDisplayName || ref.authorUsername,
+        from: persona?.personaName ?? discordName,
+        fromId: persona?.personaId,
         username: ref.authorUsername,
+        // Deliberately the DISCORD name, not the hydrated one: role derivation
+        // is a name-match against the responding personality's own display
+        // name and its siblings' — all Discord-vocabulary — so feeding it a
+        // persona name would silently break the self/sibling match that keeps
+        // a persona's own line from reading as a user's.
         role: deriveRefRole(
           ref.authorRole,
-          ref.authorDisplayName || ref.authorUsername,
+          discordName,
           personality.displayName,
           apiKeys?.allPersonalityNames
         ),

--- a/services/ai-worker/src/services/prompt/storedReference.test.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.test.ts
@@ -209,6 +209,25 @@ describe('fromStoredReference', () => {
     expect(renderable.fromId).toBe('persona-9');
   });
 
+  it('derives the role from the DISCORD name, not the hydrated persona name', () => {
+    // A human whose persona name collides with the responding personality must
+    // not be promoted to assistant by hydration...
+    const collision = fromStoredReference(
+      { ...stored, resolvedPersonaName: 'Ref Bot', resolvedPersonaId: 'persona-9' },
+      'Ref Bot'
+    );
+    expect(collision.from).toBe('Ref Bot');
+    expect(collision.role).toBe('user');
+
+    // ...and a webhook line (Discord display name IS the character name, no
+    // persona resolves for a webhook id) still self-matches.
+    const ownLine = fromStoredReference(
+      { ...stored, authorUsername: 'ref-bot', authorDisplayName: 'Ref Bot' },
+      'Ref Bot'
+    );
+    expect(ownLine.role).toBe('assistant');
+  });
+
   it('suppresses a pre-XML location block rather than rendering it as prose', () => {
     const renderable = fromStoredReference(
       { ...stored, locationContext: '**Server**: Test\nThis conversation is taking place in #x' },

--- a/services/ai-worker/src/services/prompt/storedReference.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.ts
@@ -172,12 +172,18 @@ export function fromStoredReference(
   // Hydrated persona name where one resolved, else the Discord display name.
   const from = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
 
+  // Role derivation gets the DISCORD name, never the hydrated one: the
+  // self/sibling name-match runs against personality names, which are Discord
+  // vocabulary — a webhook line's display name IS the character name, while a
+  // human's persona name matching a personality is a collision, not identity.
+  const discordName = ref.authorDisplayName || ref.authorUsername;
+
   return {
     isForwarded: ref.isForwarded,
     from,
     fromId: ref.resolvedPersonaId,
     username: ref.authorUsername,
-    role: deriveRefRole(ref.authorRole, from, personalityName, allPersonalityNames),
+    role: deriveRefRole(ref.authorRole, discordName, personalityName, allPersonalityNames),
     time: promptTime(ref.timestamp),
     content: ref.content,
     locationContext: usableLocationContext(ref.locationContext),


### PR DESCRIPTION
## What

Live quoted references rendered the Discord display name with no `from_id`, while `<chat_log>` and stored quotes render persona names with `<participants>` ID binding — the same person named two ways inside one prompt, with only one of the names ID-bound. This is **TASK-365 PR-3**, the final agent-runnable slice of the reference-render epic (#1881 = vocabulary, #1882 = the collapse).

- `ReferencedMessageFormatter` now takes a `PrismaClient` and batch-resolves all quote authors' `discordUserId`s **once per format call** via `batchResolveByDiscordIds` — the same resolver `storedReferenceHydrator` uses, chosen deliberately over reusing MemoryRetriever's participant resolution so the live and stored quote paths resolve identity **identically** (a quoted author need not be a conversation participant, and any future fidelity upgrade to the resolver now covers both paths at one seam).
- `fromLiveReference` hydrates `from` (persona name, falling back to the Discord display name on a miss) and `fromId` (persona UUID). The dedup projection inherits both by construction.
- `deriveRefRole` deliberately keeps reading the **Discord** display name — its self/sibling name-match runs against personality names (Discord vocabulary); feeding it a persona name would break self-detection. Pinned in both directions by tests.
- The four batch-invariant adapter inputs moved into a `LiveReferenceContext` options object (`max-params` gate).

## Verified, and how

- Full `pnpm test` (207 files / 4513 passed) and `pnpm quality` green, run sequentially.
- New tests assert across the resolver seam: one deduplicated batch call per format; persona name + `from_id` in the emitted XML on **both** the full and deduped arms; miss → display-name fallback with no `from_id`; `username` emit/omit under the hydrated `from`; role derivation pinned to the Discord name in both substitution directions.
- Resolver failure degrades to the pre-hydration render (empty map, fail-soft inside `batchResolveByDiscordIds`) — a DB blip costs persona names, never quotes.

## Known shared edge (not a regression)

An assistant-role quote whose `discordUserId` has a user row with a default persona would hydrate to that persona's name — exactly what the stored path's `resolvePersonas` already does (it is equally unconditional). Parity includes this edge by design; the underlying bot-ID persona-cluster data quirk is tracked as TASK-148, and a live-only guard here would recreate the live/stored divergence class TASK-365 exists to kill.

## Acceptance vs the task record

A persona's live-quoted message now carries the same `from`/`from_id` vocabulary as stored quotes and `<chat_log>` wherever the row's persona is the author's default persona (the resolver's rule, shared with the stored path). Remaining TASK-365 scope after this: PR-4 (message-level vocabulary alignment) — owner-gated per the task's own record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 1 rider

The round-1 review observed that `fromStoredReference` fed the *hydrated* persona name into `deriveRefRole` — the exact class this PR's live path avoids. Verified real (narrow no-stamp + persona/personality name-collision window), fixed in the same invariant: the stored adapter now passes the Discord display name to role derivation, pinned by a two-direction test (collision must not promote a human; a webhook line still self-matches).