### PR TITLE
refactor(bot-client): delete the dead enriched-references pipeline (TASK-379)

### DIFF
--- a/services/bot-client/src/handlers/MessageReferenceExtractor.test.ts
+++ b/services/bot-client/src/handlers/MessageReferenceExtractor.test.ts
@@ -79,7 +79,8 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
         channel: mockChannel,
       });
 
-      const references = await extractor.extractReferences(message);
+      const { rawReferences: references } =
+        await extractor.extractReferencesWithReplacement(message);
 
       expect(references).toEqual([]);
     });
@@ -107,7 +108,8 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
         fetch: vi.fn().mockResolvedValue(message),
       };
 
-      const references = await extractor.extractReferences(message);
+      const { rawReferences: references } =
+        await extractor.extractReferencesWithReplacement(message);
 
       expect(references).toHaveLength(1);
       expect(references[0].referenceNumber).toBe(1);
@@ -154,7 +156,8 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
       });
       Object.defineProperty(message, 'channel', { value: mockChannel, writable: true });
 
-      const references = await extractor.extractReferences(message);
+      const { rawReferences: references } =
+        await extractor.extractReferencesWithReplacement(message);
 
       expect(references).toHaveLength(1);
       expect(references[0].referenceNumber).toBe(1);
@@ -202,7 +205,7 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
 
       const result = await extractor.extractReferencesWithReplacement(message);
 
-      expect(result.references).toHaveLength(1);
+      expect(result.rawReferences).toHaveLength(1);
       expect(result.updatedContent).toBe('See [Reference 1]');
     });
 
@@ -259,7 +262,8 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
         embedProcessingDelayMs: 0,
       });
 
-      const references = await limitedExtractor.extractReferences(message);
+      const { rawReferences: references } =
+        await limitedExtractor.extractReferencesWithReplacement(message);
 
       // Should limit to 10
       expect(references.length).toBeLessThanOrEqual(10);
@@ -296,7 +300,8 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
         conversationHistoryMessageIds: ['referenced-123'], // Mark as already in history
       });
 
-      const references = await dedupExtractor.extractReferences(message);
+      const { rawReferences: references } =
+        await dedupExtractor.extractReferencesWithReplacement(message);
 
       expect(references.length).toBe(1);
       expect(references[0].isDeduplicated).toBeUndefined();
@@ -306,10 +311,10 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
     it('ships dedup-INVARIANT rawReferences + content (getChannelHistory is vestigial for the envelope)', async () => {
       // `conversationHistoryMessageIds` IS bot-client's getChannelHistory output. It
       // drives the dedup decision, which routes a reference between the formatter's
-      // full and stub branches. This proves that decision changes ONLY the local
-      // enriched `references` (full vs stub) — the SHIPPED `rawReferences` and the
-      // rewritten content are byte-identical either way, because both branches push
-      // the same full raw snapshot and increment the same reference number. That
+      // deduped and regular branches. This proves that decision leaves the SHIPPED
+      // `rawReferences` and the rewritten content byte-identical either way, because
+      // both branches push the same full raw snapshot and increment the same
+      // reference number. That
       // invariance is precisely why the worker can re-derive dedup from the raw
       // snapshots against its OWN history and bot-client's getChannelHistory read is
       // vestigial for the thin envelope (2.5d getChannelHistory-eviction precondition).
@@ -340,14 +345,11 @@ describe('MessageReferenceExtractor (Orchestration)', () => {
           conversationHistoryMessageIds: historyIds,
         }).extractReferencesWithReplacement(buildTrigger());
 
-      const notDeduped = await extract([]); // ref NOT in history → full reference
-      const deduped = await extract(['referenced-123']); // ref in history → stubbed
+      const notDeduped = await extract([]); // ref NOT in history → regular branch
+      const deduped = await extract(['referenced-123']); // ref in history → deduped branch
 
       // The dedup decision now leaves no trace ANYWHERE on this side — not just
-      // on the wire. It used to diverge the local enriched references (full vs.
-      // stub); that stub reached two log statements and nothing else, while
-      // giving the stub shape a second home to drift in.
-      expect(deduped.references).toEqual(notDeduped.references);
+      // on the wire.
       expect(deduped.rawReferences).toEqual(notDeduped.rawReferences);
       expect(deduped.updatedContent).toEqual(notDeduped.updatedContent);
     });

--- a/services/bot-client/src/handlers/MessageReferenceExtractor.ts
+++ b/services/bot-client/src/handlers/MessageReferenceExtractor.ts
@@ -4,15 +4,12 @@
  * Thin coordinator that delegates to:
  * - ReferenceCrawler: BFS traversal and message fetching
  * - ReferenceFormatter: Sorting, numbering, and presentation
- *
- * This facade maintains the original public API for backwards compatibility
  */
 
 import { INTERVALS } from '@tzurot/common-types/constants/timing';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { type Message } from 'discord.js';
-import { TranscriptRetriever } from './references/TranscriptRetriever.js';
 import { SnapshotFormatter } from './references/SnapshotFormatter.js';
 import { MessageFormatter } from './references/MessageFormatter.js';
 import { LinkExtractor } from './references/LinkExtractor.js';
@@ -27,16 +24,14 @@ const logger = createLogger('MessageReferenceExtractor');
  * Result of reference extraction with link replacement
  */
 interface ReferenceExtractionResult {
-  /** Extracted referenced messages */
-  references: ReferencedMessage[];
   /** Updated message content with Discord links replaced by [Reference N] */
   updatedContent: string;
   /**
-   * Raw pre-enrichment reference snapshots for the assembly envelope —
-   * present only when CONTEXT_RAW_ENVELOPE=true. Full content always (no
-   * transcripts, no dedup stubs), same numbering as `references`.
+   * Raw pre-enrichment reference snapshots for the assembly envelope — full
+   * content always (no transcripts, no dedup stubs), numbered depth-first
+   * and chronologically within each depth.
    */
-  rawReferences?: ReferencedMessage[];
+  rawReferences: ReferencedMessage[];
 }
 
 /**
@@ -82,9 +77,8 @@ export class MessageReferenceExtractor {
       options.embedProcessingDelayMs ?? INTERVALS.EMBED_PROCESSING_DELAY;
 
     // Initialize dependencies
-    const transcriptRetriever = new TranscriptRetriever();
     const snapshotFormatter = new SnapshotFormatter();
-    const messageFormatter = new MessageFormatter(transcriptRetriever);
+    const messageFormatter = new MessageFormatter();
     const linkExtractor = new LinkExtractor();
 
     // Initialize extraction strategies
@@ -104,16 +98,6 @@ export class MessageReferenceExtractor {
   }
 
   /**
-   * Extract all referenced messages from a Discord message
-   * @param message - Discord message to extract references from
-   * @returns Array of referenced messages
-   */
-  async extractReferences(message: Message): Promise<ReferencedMessage[]> {
-    const result = await this.extractReferencesWithReplacement(message);
-    return result.references;
-  }
-
-  /**
    * Extract all referenced messages and replace Discord links with [Reference N]
    * Uses breadth-first search to handle nested references.
    *
@@ -128,8 +112,8 @@ export class MessageReferenceExtractor {
    *   replacement to. For forwarded messages the real text lives in a snapshot,
    *   so `message.content` (top-level) is empty; the caller passes the
    *   snapshot-extracted content here. Falls back to `message.content` when
-   *   omitted (the references-only public path).
-   * @returns References and updated content with links replaced
+   *   omitted.
+   * @returns Raw reference snapshots and updated content with links replaced
    */
   async extractReferencesWithReplacement(
     message: Message,
@@ -164,21 +148,15 @@ export class MessageReferenceExtractor {
     // Apply link replacement to the effective content (snapshot text for
     // forwards), not the empty top-level content — otherwise a forward's real
     // text is lost when the caller adopts updatedContent.
-    const formattedResult = await this.formatter.format(
+    const formattedResult = this.formatter.format(
       effectiveContent ?? updatedMessage.content,
       crawlResult.messages,
-      this.maxReferences,
-      // Raw references always captured — the thin envelope is the only payload
-      // shape, and the worker re-derives from these.
-      { collectRaw: true }
+      this.maxReferences
     );
 
     return {
-      references: formattedResult.references,
       updatedContent: formattedResult.updatedContent,
-      ...(formattedResult.rawReferences !== undefined && {
-        rawReferences: formattedResult.rawReferences,
-      }),
+      rawReferences: formattedResult.rawReferences,
     };
   }
 

--- a/services/bot-client/src/handlers/references/MessageFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MessageFormatter } from './MessageFormatter.js';
 import { createMockMessage, createMockUser } from '../../test/mocks/Discord.mock.js';
-import type { TranscriptRetriever } from './TranscriptRetriever.js';
 
 // Mock the utility functions
 vi.mock('../../utils/discordContext.js', () => ({
@@ -55,20 +54,15 @@ vi.mock('../../utils/forwardedMessageUtils.js', () => ({
 
 describe('MessageFormatter', () => {
   let formatter: MessageFormatter;
-  let mockTranscriptRetriever: TranscriptRetriever;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockTranscriptRetriever = {
-      retrieveTranscript: vi.fn().mockResolvedValue(null),
-    } as any;
-
-    formatter = new MessageFormatter(mockTranscriptRetriever);
+    formatter = new MessageFormatter();
   });
 
   describe('Basic Formatting', () => {
-    it('should format a simple message', async () => {
+    it('should format a simple message', () => {
       const message = createMockMessage({
         id: 'msg-123',
         content: 'Hello world',
@@ -83,7 +77,7 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result).toEqual({
         referenceNumber: 1,
@@ -103,7 +97,7 @@ describe('MessageFormatter', () => {
       });
     });
 
-    it('should include webhook ID if present', async () => {
+    it('should include webhook ID if present', () => {
       const message = createMockMessage({
         id: 'msg-123',
         content: 'Webhook message',
@@ -113,12 +107,12 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.webhookId).toBe('webhook-789');
     });
 
-    it('should describe a sticker-only referenced message instead of rendering it blank', async () => {
+    it('should describe a sticker-only referenced message instead of rendering it blank', () => {
       const stickers = new Map([['1', { name: 'partyblob', description: null }]]);
       const message = createMockMessage({
         content: '',
@@ -128,12 +122,12 @@ describe('MessageFormatter', () => {
         stickers: stickers as any,
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.content).toBe('[Stickers: partyblob]');
     });
 
-    it('should attach a referenced sticker so vision can describe it, not just name it', async () => {
+    it('should attach a referenced sticker so vision can describe it, not just name it', () => {
       // The name line above is only half. Without the sticker reaching
       // `attachments`, a character replying to a sticker saw what it was CALLED
       // and never what it depicted — while the same sticker sent directly was
@@ -159,14 +153,14 @@ describe('MessageFormatter', () => {
         stickers: stickers as any,
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.attachments).toEqual([
         expect.objectContaining({ id: '99', isSticker: true, contentType: 'image/png' }),
       ]);
     });
 
-    it('should mark message as forwarded when flag is set', async () => {
+    it('should mark message as forwarded when flag is set', () => {
       const message = createMockMessage({
         content: 'Forwarded message',
         author: createMockUser(),
@@ -174,12 +168,12 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1, true);
+      const result = formatter.buildRawReference(message, 1, true).reference;
 
       expect(result.isForwarded).toBe(true);
     });
 
-    it('should presence-encode authorIsBot for bot authors', async () => {
+    it('should presence-encode authorIsBot for bot authors', () => {
       const message = createMockMessage({
         content: 'Bot message',
         author: createMockUser({ username: 'SomeBot', bot: true }),
@@ -187,12 +181,12 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.authorIsBot).toBe(true);
     });
 
-    it('should omit authorIsBot for human authors', async () => {
+    it('should omit authorIsBot for human authors', () => {
       const message = createMockMessage({
         content: 'Human message',
         author: createMockUser({ username: 'Human', bot: false }),
@@ -200,12 +194,12 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.authorIsBot).toBeUndefined();
     });
 
-    it('stamps authorRole="assistant" for our own bot webhook (applicationId === client id)', async () => {
+    it('stamps authorRole="assistant" for our own bot webhook (applicationId === client id)', () => {
       // Wiring check: applicationId matching the mock's client.user.id classifies as
       // our own persona. (Mock client.user.id is 'mock-client-bot-id'.)
       const message = createMockMessage({
@@ -216,12 +210,12 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.authorRole).toBe('assistant');
     });
 
-    it('stamps authorRole="bot" for a non-persona webhook (different applicationId)', async () => {
+    it('stamps authorRole="bot" for a non-persona webhook (different applicationId)', () => {
       const message = createMockMessage({
         applicationId: 'some-other-app',
         webhookId: 'wh-other',
@@ -230,12 +224,12 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.authorRole).toBe('bot');
     });
 
-    it('should use username as displayName when displayName is null', async () => {
+    it('should use username as displayName when displayName is null', () => {
       const message = createMockMessage({
         content: 'Test',
         author: createMockUser({ username: 'TestUser', globalName: null }),
@@ -243,7 +237,7 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.authorDisplayName).toBe('TestUser');
     });
@@ -267,7 +261,7 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.attachments).toHaveLength(1);
       expect(result.attachments?.[0].url).toBe('https://example.com/image.png');
@@ -299,166 +293,11 @@ describe('MessageFormatter', () => {
         embeds: [{} as any],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.attachments).toHaveLength(2);
       expect(result.attachments?.[0].url).toBe('https://example.com/file.pdf');
       expect(result.attachments?.[1].url).toBe('https://example.com/embed-image.png');
-    });
-  });
-
-  describe('Voice Transcript Handling', () => {
-    it('should retrieve and append voice transcript when available', async () => {
-      const { extractAttachments } = await import('../../utils/attachmentExtractor.js');
-
-      vi.mocked(extractAttachments).mockReturnValue([
-        {
-          url: 'https://example.com/voice.ogg',
-          contentType: 'audio/ogg',
-          name: 'voice.ogg',
-          isVoiceMessage: true,
-        },
-      ]);
-
-      vi.mocked(mockTranscriptRetriever.retrieveTranscript).mockResolvedValue(
-        'This is the voice transcript'
-      );
-
-      const message = createMockMessage({
-        id: 'msg-voice',
-        content: 'Original text',
-        author: createMockUser(),
-        attachments: new Map() as any,
-        embeds: [],
-      });
-
-      const result = await formatter.formatMessage(message, 1);
-
-      expect(result.content).toBe(
-        'Original text\n\n[Voice transcript]: This is the voice transcript'
-      );
-      expect(mockTranscriptRetriever.retrieveTranscript).toHaveBeenCalledWith(
-        'msg-voice',
-        'https://example.com/voice.ogg'
-      );
-    });
-
-    it('should handle voice message with no text content', async () => {
-      const { extractAttachments } = await import('../../utils/attachmentExtractor.js');
-
-      vi.mocked(extractAttachments).mockReturnValue([
-        {
-          url: 'https://example.com/voice.ogg',
-          contentType: 'audio/ogg',
-          name: 'voice.ogg',
-          isVoiceMessage: true,
-        },
-      ]);
-
-      vi.mocked(mockTranscriptRetriever.retrieveTranscript).mockResolvedValue(
-        'Voice only transcript'
-      );
-
-      const message = createMockMessage({
-        id: 'msg-voice',
-        content: '',
-        author: createMockUser(),
-        attachments: new Map() as any,
-        embeds: [],
-      });
-
-      const result = await formatter.formatMessage(message, 1);
-
-      expect(result.content).toBe('[Voice transcript]: Voice only transcript');
-    });
-
-    it('should handle multiple voice messages', async () => {
-      const { extractAttachments } = await import('../../utils/attachmentExtractor.js');
-
-      vi.mocked(extractAttachments).mockReturnValue([
-        {
-          url: 'https://example.com/voice1.ogg',
-          contentType: 'audio/ogg',
-          name: 'voice1.ogg',
-          isVoiceMessage: true,
-        },
-        {
-          url: 'https://example.com/voice2.ogg',
-          contentType: 'audio/ogg',
-          name: 'voice2.ogg',
-          isVoiceMessage: true,
-        },
-      ]);
-
-      vi.mocked(mockTranscriptRetriever.retrieveTranscript)
-        .mockResolvedValueOnce('First transcript')
-        .mockResolvedValueOnce('Second transcript');
-
-      const message = createMockMessage({
-        id: 'msg-voice',
-        content: 'Text content',
-        author: createMockUser(),
-        attachments: new Map() as any,
-        embeds: [],
-      });
-
-      const result = await formatter.formatMessage(message, 1);
-
-      expect(result.content).toBe(
-        'Text content\n\n[Voice transcript]: First transcript\n\nSecond transcript'
-      );
-    });
-
-    it('should skip voice attachments when transcript is unavailable', async () => {
-      const { extractAttachments } = await import('../../utils/attachmentExtractor.js');
-
-      vi.mocked(extractAttachments).mockReturnValue([
-        {
-          url: 'https://example.com/voice.ogg',
-          contentType: 'audio/ogg',
-          name: 'voice.ogg',
-          isVoiceMessage: true,
-        },
-      ]);
-
-      vi.mocked(mockTranscriptRetriever.retrieveTranscript).mockResolvedValue(null);
-
-      const message = createMockMessage({
-        content: 'Original content',
-        author: createMockUser(),
-        attachments: new Map() as any,
-        embeds: [],
-      });
-
-      const result = await formatter.formatMessage(message, 1);
-
-      // Content should remain unchanged
-      expect(result.content).toBe('Original content');
-    });
-
-    it('should not retrieve transcripts for non-voice audio attachments', async () => {
-      const { extractAttachments } = await import('../../utils/attachmentExtractor.js');
-
-      vi.mocked(extractAttachments).mockReturnValue([
-        {
-          url: 'https://example.com/music.mp3',
-          contentType: 'audio/mpeg',
-          name: 'music.mp3',
-          isVoiceMessage: false, // Not a voice message
-        },
-      ]);
-
-      const message = createMockMessage({
-        content: 'Music file',
-        author: createMockUser(),
-        attachments: new Map() as any,
-        embeds: [],
-      });
-
-      await formatter.formatMessage(message, 1);
-
-      // Should not try to retrieve transcript
-      expect(mockTranscriptRetriever.retrieveTranscript).not.toHaveBeenCalled();
     });
   });
 
@@ -475,14 +314,14 @@ describe('MessageFormatter', () => {
         embeds: [{} as any],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       expect(result.embeds).toBe('Embed Title\nEmbed Description');
     });
   });
 
-  describe('Forwarded Voice Message Handling', () => {
-    it('should extract voice attachments from forwarded message snapshots and retrieve transcripts', async () => {
+  describe('Forwarded Message Handling', () => {
+    it('should extract voice attachments from forwarded message snapshots', async () => {
       // Setup forwarded message detection
       const {
         isForwardedMessage,
@@ -504,11 +343,6 @@ describe('MessageFormatter', () => {
         },
       ]);
 
-      // Mock transcript retrieval - uses forwarding message ID
-      vi.mocked(mockTranscriptRetriever.retrieveTranscript).mockResolvedValue(
-        'Forwarded voice transcript'
-      );
-
       const message = createMockMessage({
         id: 'forwarding-msg-999', // The forwarding message's ID
         content: '', // Forwarded messages often have empty main content
@@ -517,75 +351,18 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       // Should be marked as forwarded
       expect(result.isForwarded).toBe(true);
 
-      // Content should include forwarded text and voice transcript
-      expect(result.content).toContain('Forwarded text content');
-      expect(result.content).toContain('[Voice transcript]: Forwarded voice transcript');
-
-      // Transcript should be retrieved using FORWARDING message ID (not original)
-      expect(mockTranscriptRetriever.retrieveTranscript).toHaveBeenCalledWith(
-        'forwarding-msg-999',
-        'https://cdn.discord.com/voice.ogg'
-      );
+      // Content comes from the snapshot, unenriched — the worker appends the
+      // transcript itself from the raw attachment record below.
+      expect(result.content).toBe('Forwarded text content');
 
       // Voice attachment should be in attachments
       expect(result.attachments).toHaveLength(1);
       expect(result.attachments?.[0].isVoiceMessage).toBe(true);
-    });
-
-    it('should handle forwarded voice message when no transcript is available', async () => {
-      const {
-        isForwardedMessage,
-        hasForwardedSnapshots,
-        extractForwardedAttachments,
-        extractForwardedContent,
-      } = await import('../../utils/forwardedMessageUtils.js');
-
-      vi.mocked(isForwardedMessage).mockReturnValue(true);
-      vi.mocked(hasForwardedSnapshots).mockReturnValue(true);
-      vi.mocked(extractForwardedContent).mockReturnValue('');
-      vi.mocked(extractForwardedAttachments).mockReturnValue([
-        {
-          url: 'https://cdn.discord.com/voice-no-transcript.ogg',
-          contentType: 'audio/ogg',
-          name: 'voice.ogg',
-          isVoiceMessage: true,
-          duration: 8.2,
-        },
-      ]);
-
-      // No transcript available
-      vi.mocked(mockTranscriptRetriever.retrieveTranscript).mockResolvedValue(null);
-
-      const message = createMockMessage({
-        id: 'forwarding-msg-no-transcript',
-        content: '',
-        author: createMockUser(),
-        attachments: new Map() as any,
-        embeds: [],
-      });
-
-      const result = await formatter.formatMessage(message, 1);
-
-      // Should still be marked as forwarded
-      expect(result.isForwarded).toBe(true);
-
-      // Content should not contain voice transcript
-      expect(result.content).not.toContain('[Voice transcript]');
-
-      // Voice attachment should still be in attachments
-      expect(result.attachments).toHaveLength(1);
-      expect(result.attachments?.[0].isVoiceMessage).toBe(true);
-
-      // Transcript retrieval should have been attempted
-      expect(mockTranscriptRetriever.retrieveTranscript).toHaveBeenCalledWith(
-        'forwarding-msg-no-transcript',
-        'https://cdn.discord.com/voice-no-transcript.ogg'
-      );
     });
 
     it('should extract images from forwarded message snapshots', async () => {
@@ -615,7 +392,7 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       // Should be marked as forwarded
       expect(result.isForwarded).toBe(true);
@@ -627,9 +404,6 @@ describe('MessageFormatter', () => {
       expect(result.attachments).toHaveLength(1);
       expect(result.attachments?.[0].url).toBe('https://cdn.discord.com/forwarded-image.png');
       expect(result.attachments?.[0].contentType).toBe('image/png');
-
-      // Should NOT try to retrieve transcript for non-voice attachment
-      expect(mockTranscriptRetriever.retrieveTranscript).not.toHaveBeenCalled();
     });
 
     it('should fall back to regular attachment extraction when forwarded message has no snapshots', async () => {
@@ -667,7 +441,7 @@ describe('MessageFormatter', () => {
         embeds: [],
       });
 
-      const result = await formatter.formatMessage(message, 1);
+      const result = formatter.buildRawReference(message, 1).reference;
 
       // Should still be marked as forwarded
       expect(result.isForwarded).toBe(true);

--- a/services/bot-client/src/handlers/references/MessageFormatter.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.ts
@@ -8,17 +8,12 @@
 import type { Message } from 'discord.js';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { formatLocationAsXml } from '@tzurot/common-types/utils/environmentFormatter';
-import { createLogger } from '@tzurot/common-types/utils/logger';
-import { appendVoiceTranscripts } from '@tzurot/common-types/utils/referenceEnrichment';
-
-const logger = createLogger('MessageFormatter');
 import { extractDiscordEnvironment } from '../../utils/discordContext.js';
 import { extractAttachments } from '../../utils/attachmentExtractor.js';
 import { extractEmbedImages } from '../../utils/embedImageExtractor.js';
 import { extractStickerImages } from '../../utils/stickerAttachments.js';
 import { EmbedParser } from '../../utils/EmbedParser.js';
 import { withStickerAndPollDescriptions } from '../../utils/stickerPollDescriptions.js';
-import { type TranscriptRetriever } from './TranscriptRetriever.js';
 import { classifyReferenceAuthorRole } from './authorRole.js';
 import {
   isForwardedMessage,
@@ -34,8 +29,6 @@ type AttachmentList = NonNullable<ReturnType<typeof extractAttachments>>;
  * Service for formatting Discord messages into referenced messages
  */
 export class MessageFormatter {
-  constructor(private readonly transcriptRetriever: TranscriptRetriever) {}
-
   /**
    * Resolve message content and attachments, handling forwarded vs regular messages
    */
@@ -71,42 +64,10 @@ export class MessageFormatter {
   }
 
   /**
-   * Append voice transcripts to message content — shared kernel drives the
-   * format; this wrapper supplies the bot-side retriever (Redis cache + DB
-   * tiers) and the not-found debug log.
-   */
-  private async appendTranscriptsWithRetriever(
-    content: string,
-    attachments: AttachmentList,
-    messageId: string
-  ): Promise<string> {
-    return appendVoiceTranscripts({
-      content,
-      attachments,
-      discordMessageId: messageId,
-      retrieve: async (discordMessageId, attachmentUrl) => {
-        // The retriever is typed `string | null`; `?? null` up front keeps
-        // this adapter total over `undefined` too should that ever drift.
-        const transcript =
-          (await this.transcriptRetriever.retrieveTranscript(discordMessageId, attachmentUrl)) ??
-          null;
-        if (transcript === null || transcript.length === 0) {
-          logger.debug(
-            { messageId: discordMessageId, attachmentUrl },
-            'Voice transcript not found for attachment'
-          );
-        }
-        return transcript;
-      },
-    });
-  }
-
-  /**
    * Build the RAW referenced message — every Discord-origin field, with
-   * content BEFORE the voice-transcript append (the one DB/Redis-derived
-   * enrichment in this formatter). Pure and synchronous; this is the shape
-   * the raw assembly envelope ships so the worker-side assembler can re-run
-   * the transcript enrichment itself.
+   * content BEFORE any transcript enrichment. Pure and synchronous; this is
+   * the shape the raw assembly envelope ships so the worker-side assembler
+   * can run the transcript enrichment itself.
    */
   buildRawReference(
     message: Message,
@@ -146,44 +107,5 @@ export class MessageFormatter {
         isForwarded: messageIsForwarded || undefined,
       },
     };
-  }
-
-  /**
-   * Format a Discord message as a referenced message, returning both the
-   * enriched form (voice transcripts appended) and the raw pre-enrichment
-   * snapshot for the assembly envelope.
-   */
-  async formatMessageWithRaw(
-    message: Message,
-    referenceNumber: number,
-    isForwardedFlag?: boolean
-  ): Promise<{ enriched: ReferencedMessage; raw: ReferencedMessage }> {
-    const { reference: raw, attachments } = this.buildRawReference(
-      message,
-      referenceNumber,
-      isForwardedFlag
-    );
-    const contentWithTranscript = await this.appendTranscriptsWithRetriever(
-      raw.content,
-      attachments,
-      message.id
-    );
-    return { raw, enriched: { ...raw, content: contentWithTranscript } };
-  }
-
-  /**
-   * Format a Discord message as a referenced message
-   * @param message - Discord message
-   * @param referenceNumber - Reference number
-   * @param isForwardedFlag - Whether this is a forwarded message snapshot (passed from caller)
-   * @returns Formatted referenced message
-   */
-  async formatMessage(
-    message: Message,
-    referenceNumber: number,
-    isForwardedFlag?: boolean
-  ): Promise<ReferencedMessage> {
-    const { enriched } = await this.formatMessageWithRaw(message, referenceNumber, isForwardedFlag);
-    return enriched;
   }
 }

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
@@ -30,15 +30,6 @@ describe('ReferenceFormatter', () => {
       locationContext: 'this channel',
     });
     mockMessageFormatter = {
-      formatMessage: vi
-        .fn()
-        .mockImplementation(async (message: Message, refNum: number) => buildRef(message, refNum)),
-      formatMessageWithRaw: vi
-        .fn()
-        .mockImplementation(async (message: Message, refNum: number) => ({
-          enriched: buildRef(message, refNum),
-          raw: buildRef(message, refNum),
-        })),
       buildRawReference: vi.fn().mockImplementation((message: Message, refNum: number) => ({
         reference: {
           ...buildRef(message, refNum),
@@ -77,7 +68,7 @@ describe('ReferenceFormatter', () => {
   });
 
   describe('Sorting', () => {
-    it('should sort by depth first (BFS order)', async () => {
+    it('should sort by depth first (BFS order)', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'depth-2',
@@ -109,17 +100,17 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
       // Depth 1 should come before depth 2
-      expect(result.references).toHaveLength(2);
-      expect(result.references[0].discordMessageId).toBe('depth-1');
-      expect(result.references[0].referenceNumber).toBe(1);
-      expect(result.references[1].discordMessageId).toBe('depth-2');
-      expect(result.references[1].referenceNumber).toBe(2);
+      expect(result.rawReferences).toHaveLength(2);
+      expect(result.rawReferences[0].discordMessageId).toBe('depth-1');
+      expect(result.rawReferences[0].referenceNumber).toBe(1);
+      expect(result.rawReferences[1].discordMessageId).toBe('depth-2');
+      expect(result.rawReferences[1].referenceNumber).toBe(2);
     });
 
-    it('should sort chronologically within same depth level', async () => {
+    it('should sort chronologically within same depth level', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'newer',
@@ -151,15 +142,15 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
       // Older message should come first within same depth
-      expect(result.references).toHaveLength(2);
-      expect(result.references[0].discordMessageId).toBe('older');
-      expect(result.references[1].discordMessageId).toBe('newer');
+      expect(result.rawReferences).toHaveLength(2);
+      expect(result.rawReferences[0].discordMessageId).toBe('older');
+      expect(result.rawReferences[1].discordMessageId).toBe('newer');
     });
 
-    it('should combine depth and chronological sorting', async () => {
+    it('should combine depth and chronological sorting', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'depth1-newer',
@@ -205,18 +196,18 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
       // Expected order: depth 1 (older), depth 1 (newer), depth 2 (older)
-      expect(result.references).toHaveLength(3);
-      expect(result.references[0].discordMessageId).toBe('depth1-older');
-      expect(result.references[1].discordMessageId).toBe('depth1-newer');
-      expect(result.references[2].discordMessageId).toBe('depth2-older');
+      expect(result.rawReferences).toHaveLength(3);
+      expect(result.rawReferences[0].discordMessageId).toBe('depth1-older');
+      expect(result.rawReferences[1].discordMessageId).toBe('depth1-newer');
+      expect(result.rawReferences[2].discordMessageId).toBe('depth2-older');
     });
   });
 
   describe('Reference Numbering', () => {
-    it('should assign sequential reference numbers starting from 1', async () => {
+    it('should assign sequential reference numbers starting from 1', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'ref-1',
@@ -262,16 +253,16 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
-      expect(result.references[0].referenceNumber).toBe(1);
-      expect(result.references[1].referenceNumber).toBe(2);
-      expect(result.references[2].referenceNumber).toBe(3);
+      expect(result.rawReferences[0].referenceNumber).toBe(1);
+      expect(result.rawReferences[1].referenceNumber).toBe(2);
+      expect(result.rawReferences[2].referenceNumber).toBe(3);
     });
   });
 
   describe('Link Replacement', () => {
-    it('should replace Discord links with [Reference N] placeholders', async () => {
+    it('should replace Discord links with [Reference N] placeholders', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'ref-1',
@@ -292,12 +283,12 @@ describe('ReferenceFormatter', () => {
 
       const originalContent = 'Check this https://discord.com/channels/123/456/789';
 
-      const result = await formatter.format(originalContent, crawledMessages, 10);
+      const result = formatter.format(originalContent, crawledMessages, 10);
 
       expect(result.updatedContent).toBe('Check this [Reference 1]');
     });
 
-    it('should replace multiple links with correct reference numbers', async () => {
+    it('should replace multiple links with correct reference numbers', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'ref-1',
@@ -334,12 +325,12 @@ describe('ReferenceFormatter', () => {
       const originalContent =
         'See https://discord.com/channels/111/222/333 and https://discord.com/channels/444/555/666';
 
-      const result = await formatter.format(originalContent, crawledMessages, 10);
+      const result = formatter.format(originalContent, crawledMessages, 10);
 
       expect(result.updatedContent).toBe('See [Reference 1] and [Reference 2]');
     });
 
-    it('should not replace links for references without discordUrl', async () => {
+    it('should not replace links for references without discordUrl', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'ref-1',
@@ -360,7 +351,7 @@ describe('ReferenceFormatter', () => {
 
       const originalContent = 'This is a reply reference';
 
-      const result = await formatter.format(originalContent, crawledMessages, 10);
+      const result = formatter.format(originalContent, crawledMessages, 10);
 
       // Content should remain unchanged
       expect(result.updatedContent).toBe('This is a reply reference');
@@ -372,7 +363,7 @@ describe('ReferenceFormatter', () => {
   // history and projects the stub at render time, so this side ships the full
   // snapshot and lets the worker subtract.
   describe('Deduplicated References', () => {
-    it('emits the FULL snapshot for a deduped reference', async () => {
+    it('emits the FULL snapshot for a deduped reference', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'deduped-1',
@@ -392,20 +383,23 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
-      expect(result.references).toHaveLength(1);
-      const ref = result.references[0];
+      expect(result.rawReferences).toHaveLength(1);
+      const ref = result.rawReferences[0];
       // Not flagged here: the flag is the WORKER's, set when its own dedup
       // re-run agrees. Flagging it on this side would be a second opinion.
       expect(ref.isDeduplicated).toBeUndefined();
       expect(ref.content).toBe('This is the original message content');
       expect(ref.referenceNumber).toBe(1);
-      // Still skips the enrichment path — a deduped reference needs no transcripts.
-      expect(mockMessageFormatter.formatMessage).not.toHaveBeenCalled();
+      // The deduped branch builds the raw snapshot like any other reference.
+      expect(mockMessageFormatter.buildRawReference).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'deduped-1' }),
+        1
+      );
     });
 
-    it("does NOT truncate the content — capping is the renderer's single decision", async () => {
+    it("does NOT truncate the content — capping is the renderer's single decision", () => {
       const longContent = 'A'.repeat(200);
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
@@ -426,12 +420,12 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
-      expect(result.references[0].content).toBe(longContent);
+      expect(result.rawReferences[0].content).toBe(longContent);
     });
 
-    it('leaves short content alone too', async () => {
+    it('leaves short content alone too', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'deduped-short',
@@ -451,12 +445,12 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
-      expect(result.references[0].content).toBe('Short');
+      expect(result.rawReferences[0].content).toBe('Short');
     });
 
-    it('ships an image-only reference with its attachments INTACT', async () => {
+    it('ships an image-only reference with its attachments INTACT', () => {
       // The stub this replaced folded a `[image/png: photo.png]` text marker
       // into the content and dropped the attachment list. That cost the worker
       // the only structured record of what was attached, so an image whose
@@ -498,16 +492,16 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
-      const ref = result.references[0];
+      const ref = result.rawReferences[0];
       expect(ref.content).toBe('');
       expect(ref.attachments).toEqual([
         { url: 'https://cdn/photo.png', contentType: 'image/png', name: 'photo.png' },
       ]);
     });
 
-    it('should use snapshot content for deduped forwarded messages', async () => {
+    it('should use snapshot content for deduped forwarded messages', () => {
       // Forwarded messages have empty message.content — real content is in snapshots
       const snapshotsMap = new Map();
       snapshotsMap.set('snapshot-0', {
@@ -544,15 +538,15 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
-      expect(result.references).toHaveLength(1);
-      const ref = result.references[0];
+      expect(result.rawReferences).toHaveLength(1);
+      const ref = result.rawReferences[0];
       // Should use snapshot content, not empty message.content
       expect(ref.content).toBe('Forwarded snapshot content here');
     });
 
-    it('should replace Discord links for deduped stubs with discordUrl', async () => {
+    it('should replace Discord links for deduped stubs with discordUrl', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'deduped-link',
@@ -573,7 +567,7 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format(
+      const result = formatter.format(
         'See https://discord.com/channels/1/2/3',
         crawledMessages,
         10
@@ -584,7 +578,7 @@ describe('ReferenceFormatter', () => {
   });
 
   describe('Limit Enforcement', () => {
-    it('should apply maxReferences limit', async () => {
+    it('should apply maxReferences limit', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>();
 
       // Add 15 messages
@@ -602,15 +596,15 @@ describe('ReferenceFormatter', () => {
         });
       }
 
-      const result = await formatter.format('', crawledMessages, 10);
+      const result = formatter.format('', crawledMessages, 10);
 
       // Should limit to 10
-      expect(result.references).toHaveLength(10);
+      expect(result.rawReferences).toHaveLength(10);
     });
   });
 
-  describe('collectRaw (raw assembly envelope)', () => {
-    it('returns the same full snapshot on both sides for a deduped reference', async () => {
+  describe('Raw assembly envelope', () => {
+    it('carries the untruncated snapshot for a deduped reference', () => {
       const longContent = 'B'.repeat(200);
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
@@ -627,19 +621,16 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('content', crawledMessages, 10, { collectRaw: true });
+      const result = formatter.format('content', crawledMessages, 10);
 
-      // Both sides carry the full snapshot now. The enriched side used to hold
-      // a truncated stub, which existed only to reach two log statements — the
-      // envelope has always carried `rawReferences` alone, and the worker
-      // re-derives dedup against its own hydrated history.
-      expect(result.references[0].content).toBe(longContent);
+      // The deduped branch ships the full snapshot: the worker re-derives dedup
+      // against its own hydrated history and projects the stub at render time.
       expect(result.rawReferences).toHaveLength(1);
-      expect(result.rawReferences?.[0].content).toBe(longContent);
-      expect(result.rawReferences?.[0].referenceNumber).toBe(result.references[0].referenceNumber);
+      expect(result.rawReferences[0].content).toBe(longContent);
+      expect(result.rawReferences[0].referenceNumber).toBe(1);
     });
 
-    it('collects the raw snapshot for regular messages (raw = pre-transcript content)', async () => {
+    it('collects the raw snapshot for regular messages (pre-enrichment content)', () => {
       const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
         [
           'regular-raw',
@@ -654,14 +645,14 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('content', crawledMessages, 10, { collectRaw: true });
+      const result = formatter.format('content', crawledMessages, 10);
 
       expect(result.rawReferences).toHaveLength(1);
-      expect(result.rawReferences?.[0].content).toBe('plain message');
-      expect(result.rawReferences?.[0].referenceNumber).toBe(result.references[0].referenceNumber);
+      expect(result.rawReferences[0].content).toBe('plain message');
+      expect(result.rawReferences[0].referenceNumber).toBe(1);
     });
 
-    it('collects one raw entry per forwarded snapshot with consistent numbering', async () => {
+    it('collects one raw entry per forwarded snapshot with consistent numbering', () => {
       const snapshotsMap = new Map();
       snapshotsMap.set('s0', { content: 'first snapshot', attachments: new Map(), embeds: [] });
       snapshotsMap.set('s1', { content: 'second snapshot', attachments: new Map(), embeds: [] });
@@ -693,36 +684,12 @@ describe('ReferenceFormatter', () => {
         ],
       ]);
 
-      const result = await formatter.format('', crawledMessages, 10, { collectRaw: true });
+      const result = formatter.format('', crawledMessages, 10);
 
-      // Each snapshot expands to its own enriched AND raw entry, numbers aligned.
-      expect(result.references).toHaveLength(2);
+      // Each snapshot expands to its own raw entry, numbered sequentially.
       expect(result.rawReferences).toHaveLength(2);
-      expect(result.rawReferences?.map(r => r.referenceNumber)).toEqual(
-        result.references.map(r => r.referenceNumber)
-      );
-      expect(result.rawReferences?.[1].content).toBe('second snapshot');
-    });
-
-    it('omits rawReferences entirely when collectRaw is not requested', async () => {
-      const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
-        [
-          'regular-1',
-          {
-            message: createMockMessage({ id: 'regular-1', content: 'hello' }),
-            metadata: {
-              messageId: 'regular-1',
-              depth: 1,
-              timestamp: new Date('2025-01-01T00:00:00Z'),
-            },
-          },
-        ],
-      ]);
-
-      const result = await formatter.format('content', crawledMessages, 10);
-
-      expect(result.rawReferences).toBeUndefined();
-      expect(result.references).toHaveLength(1);
+      expect(result.rawReferences.map(r => r.referenceNumber)).toEqual([1, 2]);
+      expect(result.rawReferences[1].content).toBe('second snapshot');
     });
   });
 });

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.ts
@@ -19,24 +19,19 @@ const logger = createLogger('ReferenceFormatter');
  * Formatted reference result
  */
 interface FormattedResult {
-  /** Formatted references with numbers assigned */
-  references: ReferencedMessage[];
   /** Updated message content with links replaced by [Reference N] */
   updatedContent: string;
   /**
-   * Raw pre-enrichment snapshots (only when `collectRaw` was requested):
-   * same numbering as `references`, but full content always — no transcript
-   * append, no dedup stubbing — so the worker-side assembler can re-run both
-   * enrichments itself.
+   * Raw pre-enrichment snapshots — full content always, no transcript append
+   * and no dedup stubbing, so the worker-side assembler can run both
+   * enrichments itself. This is the only reference payload that ships.
    */
-  rawReferences?: ReferencedMessage[];
+  rawReferences: ReferencedMessage[];
 }
 
 /** Mutable accumulation state threaded through the per-message branch handlers. */
 interface FormatState {
-  references: ReferencedMessage[];
   rawReferences: ReferencedMessage[];
-  collectRaw: boolean;
   linkMap: Map<string, number>;
   nextNumber: number;
 }
@@ -57,13 +52,11 @@ export class ReferenceFormatter {
    * @param maxReferences - Maximum number of references to include
    * @returns Formatted references and updated content
    */
-  async format(
+  format(
     originalContent: string,
     crawledMessages: Map<string, { message: Message; metadata: ReferenceMetadata }>,
-    maxReferences: number,
-    options: { collectRaw?: boolean } = {}
-  ): Promise<FormattedResult> {
-    const collectRaw = options.collectRaw === true;
+    maxReferences: number
+  ): FormattedResult {
     const rawReferences: ReferencedMessage[] = [];
     // Convert to array for sorting
     const messagesArray = Array.from(crawledMessages.values());
@@ -91,17 +84,19 @@ export class ReferenceFormatter {
     }
 
     // Format messages and assign reference numbers
-    const references: ReferencedMessage[] = [];
     const linkMap = new Map<string, number>(); // Map Discord URL to reference number
 
-    const state: FormatState = { references, rawReferences, collectRaw, linkMap, nextNumber: 1 };
+    const state: FormatState = { rawReferences, linkMap, nextNumber: 1 };
     for (const { message, metadata } of selected) {
-      if (metadata.isDeduplicated === true) {
-        this.appendDedupedReference(message, metadata, state);
-      } else if (isForwardedMessage(message)) {
+      // A deduped reference takes the single-entry path even when it is a
+      // forward: no stub is built on this side any more (deduplication is
+      // decided and rendered worker-side, against ai-worker's OWN assembled
+      // history), so the deduped branch is exactly the regular one — it just
+      // must not fan a forward out into one entry per snapshot.
+      if (metadata.isDeduplicated !== true && isForwardedMessage(message)) {
         this.appendForwardedSnapshots(message, metadata, state);
       } else {
-        await this.appendRegular(message, metadata, state);
+        this.appendSingleReference(message, metadata, state);
       }
     }
 
@@ -110,40 +105,19 @@ export class ReferenceFormatter {
 
     logger.info(
       {
-        referencesFormatted: references.length,
+        referencesFormatted: rawReferences.length,
         linksReplaced: linkMap.size,
       },
       'Formatting complete'
     );
 
     return {
-      references,
       updatedContent,
-      ...(collectRaw && { rawReferences }),
+      rawReferences,
     };
   }
 
-  /** Deduped: the full snapshot, on both sides. */
-  private appendDedupedReference(
-    message: Message,
-    metadata: ReferenceMetadata,
-    s: FormatState
-  ): void {
-    // No stub is built here any more. Deduplication is decided and rendered
-    // worker-side (ai-worker re-runs it against its OWN assembled history), and
-    // the thin envelope carries `rawReferences` only — so a stub built here
-    // reached nothing but two log statements while giving the stub shape a
-    // second, drift-prone home.
-    const raw = this.messageFormatter.buildRawReference(message, s.nextNumber).reference;
-    s.references.push(raw);
-    if (s.collectRaw) {
-      s.rawReferences.push(raw);
-    }
-    this.trackLink(metadata, s.nextNumber, s.linkMap);
-    s.nextNumber++;
-  }
-
-  /** Forwarded: each snapshot becomes a reference; raw = enriched (no DB enrichment). */
+  /** Forwarded: each snapshot becomes its own reference. */
   private appendForwardedSnapshots(
     message: Message & { messageSnapshots: NonNullable<Message['messageSnapshots']> },
     metadata: ReferenceMetadata,
@@ -155,10 +129,7 @@ export class ReferenceFormatter {
         s.nextNumber,
         message
       );
-      s.references.push(snapshotReference);
-      if (s.collectRaw) {
-        s.rawReferences.push({ ...snapshotReference });
-      }
+      s.rawReferences.push(snapshotReference);
       // All snapshots of one forward share the crawled entry's discordUrl, and
       // trackLink uses Map.set — so the LAST snapshot's number wins and the
       // [Reference N] link resolves to the forward's final snapshot.
@@ -176,20 +147,14 @@ export class ReferenceFormatter {
     }
   }
 
-  /** Regular: enriched (transcripts appended) + raw pre-enrichment snapshot. */
-  private async appendRegular(
+  /** One reference: the raw pre-enrichment snapshot of the whole message. */
+  private appendSingleReference(
     message: Message,
     metadata: ReferenceMetadata,
     s: FormatState
-  ): Promise<void> {
-    const { enriched, raw } = await this.messageFormatter.formatMessageWithRaw(
-      message,
-      s.nextNumber
-    );
-    s.references.push(enriched);
-    if (s.collectRaw) {
-      s.rawReferences.push(raw);
-    }
+  ): void {
+    const raw = this.messageFormatter.buildRawReference(message, s.nextNumber).reference;
+    s.rawReferences.push(raw);
     this.trackLink(metadata, s.nextNumber, s.linkMap);
     s.nextNumber++;
   }

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -245,7 +245,7 @@ describe('MessageContextBuilder', () => {
   describe('buildContext', () => {
     it('attaches rawAssemblyInputs — the worker re-derives the context from it', async () => {
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'REWRITTEN content',
       });
       // The mention resolver is the LAST rewriter — its output is the
@@ -288,7 +288,7 @@ describe('MessageContextBuilder', () => {
         imageAttachments: [{ url: 'https://cdn/x.png', contentType: 'image/png', id: 'x' }],
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'REWRITTEN content',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -344,7 +344,7 @@ describe('MessageContextBuilder', () => {
         history: [],
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello world',
       });
 
@@ -397,7 +397,7 @@ describe('MessageContextBuilder', () => {
         history: [],
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
 
@@ -416,7 +416,7 @@ describe('MessageContextBuilder', () => {
 
     it('should handle empty conversation history', async () => {
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'First message',
       });
 
@@ -442,7 +442,6 @@ describe('MessageContextBuilder', () => {
       ];
 
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: mockReferences,
         updatedContent: 'Check [Reference 1]',
         rawReferences: mockReferences,
       });
@@ -469,7 +468,7 @@ describe('MessageContextBuilder', () => {
 
     it('does not run the extended-context fetch by default (no Postgres history service wired for dedup)', async () => {
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
 
@@ -493,7 +492,7 @@ describe('MessageContextBuilder', () => {
       ];
 
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Check this image',
       });
       vi.mocked(extractAttachments).mockReturnValue(mockAttachments as any);
@@ -512,7 +511,7 @@ describe('MessageContextBuilder', () => {
       };
 
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       vi.mocked(extractDiscordEnvironment).mockReturnValue(mockEnvironment as any);
@@ -525,7 +524,7 @@ describe('MessageContextBuilder', () => {
 
     it('should handle empty content with fallback', async () => {
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: null,
       });
       mockResolveAllMentions.mockReturnValue({
@@ -569,7 +568,7 @@ describe('MessageContextBuilder', () => {
       } as any;
 
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Voice message',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -589,15 +588,16 @@ describe('MessageContextBuilder', () => {
 
     it('should not include referencedMessages in context when empty', async () => {
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
 
       const result = await builder.buildContext(mockMessage, mockPersonality, 'Hello');
 
       expect(result.context.referencedMessages).toBeUndefined();
-      // No references extracted → the raw envelope carries none either.
-      expect(result.context.rawAssemblyInputs?.rawReferencedMessages).toBeUndefined();
+      // No references extracted → the raw envelope carries an empty list. The
+      // extractor always returns an array, so absence is not a reachable state.
+      expect(result.context.rawAssemblyInputs?.rawReferencedMessages).toEqual([]);
     });
 
     it('does NOT resolve user mentions bot-side (worker re-derives) — channel/role only', async () => {
@@ -612,7 +612,7 @@ describe('MessageContextBuilder', () => {
       (mockMessage.mentions.users as Map<string, User>).set('123456', mockMentionedUser);
 
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hey <@123456>, how are you?',
       });
       // Channel/role rewriting leaves the user mention untouched.
@@ -654,7 +654,7 @@ describe('MessageContextBuilder', () => {
         history: [],
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello after clear',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -704,7 +704,7 @@ describe('MessageContextBuilder', () => {
         history: [],
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Weigh in',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -745,7 +745,7 @@ describe('MessageContextBuilder', () => {
       vi.mocked(mockPrisma.userPersonaHistoryConfig.findUnique).mockResolvedValue(null);
 
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -802,7 +802,7 @@ describe('MessageContextBuilder', () => {
       mockMergeWithHistory.mockReturnValue(extendedMessages);
 
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -858,7 +858,7 @@ describe('MessageContextBuilder', () => {
         keptCount: 0,
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'hi',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -897,7 +897,7 @@ describe('MessageContextBuilder', () => {
         keptCount: 0,
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: '',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -955,7 +955,7 @@ describe('MessageContextBuilder', () => {
       });
       mockMergeWithHistory.mockReturnValue([]);
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -1010,7 +1010,7 @@ describe('MessageContextBuilder', () => {
 
     it('should not fetch extended context when botUserId is not provided', async () => {
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -1082,7 +1082,7 @@ describe('MessageContextBuilder', () => {
       });
       mockMergeWithHistory.mockReturnValue(extendedMessages);
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -1147,7 +1147,7 @@ describe('MessageContextBuilder', () => {
       });
       mockMergeWithHistory.mockReturnValue(extendedMessages);
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -1221,7 +1221,7 @@ describe('MessageContextBuilder', () => {
 
       mockMergeWithHistory.mockReturnValue(extendedMessages);
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'Hello',
       });
       mockResolveAllMentions.mockReturnValue({
@@ -1269,7 +1269,7 @@ describe('MessageContextBuilder', () => {
         keptCount: 0,
       });
       mockExtractReferencesWithReplacement.mockResolvedValue({
-        references: [],
+        rawReferences: [],
         updatedContent: 'content',
       });
       mockResolveAllMentions.mockReturnValue({

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -334,7 +334,7 @@ export class MessageContextBuilder {
       isWeighInMode: options.isWeighInMode,
       maxReferences: options.extendedContext?.maxMessages,
     });
-    const { messageContent, referencedMessages } = refsAndMentions;
+    const { messageContent } = refsAndMentions;
 
     // Step 5: Convert conversation history to API format
     // Include messageMetadata so referenced messages can be formatted at prompt time
@@ -397,7 +397,7 @@ export class MessageContextBuilder {
         activePersonaId: context.activePersonaId,
         activePersonaName: context.activePersonaName,
         historyLength: history.length,
-        referencedMessagesCount: referencedMessages.length,
+        referencedMessagesCount: refsAndMentions.rawReferencedMessages?.length ?? 0,
       },
       'Context built successfully'
     );

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.test.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.test.ts
@@ -94,7 +94,7 @@ describe('extractReferencesAndMentions', () => {
     // Discord links rewritten to [Reference N]. With no links it echoes the
     // content unchanged.
     mockExtractReferences.mockResolvedValue({
-      references: [],
+      rawReferences: [],
       updatedContent: 'Hello world',
     });
     mockResolveAllMentions.mockReturnValue({
@@ -107,7 +107,6 @@ describe('extractReferencesAndMentions', () => {
 
   it('captures raw envelope fields', async () => {
     mockExtractReferences.mockResolvedValue({
-      references: [],
       updatedContent: 'Hello world',
       rawReferences: [{ referenceNumber: 1, content: 'raw snapshot' }],
     });
@@ -146,14 +145,14 @@ describe('extractReferencesAndMentions', () => {
     });
 
     expect(result.messageContent).toBe('Hello world');
-    expect(result.referencedMessages).toEqual([]);
+    expect(result.rawReferencedMessages).toBeUndefined();
     expect(mockExtractReferences).not.toHaveBeenCalled();
     expect(mockResolveAllMentions).not.toHaveBeenCalled();
   });
 
   it('should extract references and resolve mentions in normal mode', async () => {
     mockExtractReferences.mockResolvedValue({
-      references: [{ referenceNumber: 1, content: 'quoted text', authorName: 'User' }],
+      rawReferences: [{ referenceNumber: 1, content: 'quoted text', authorName: 'User' }],
       updatedContent: 'Hello [1]',
     });
     mockResolveAllMentions.mockReturnValue({
@@ -172,7 +171,7 @@ describe('extractReferencesAndMentions', () => {
     });
 
     expect(result.messageContent).toBe('Hello [1]');
-    expect(result.referencedMessages).toHaveLength(1);
+    expect(result.rawReferencedMessages).toHaveLength(1);
   });
 
   it('returns empty messageContent when mention resolution drops non-empty content', async () => {
@@ -206,7 +205,7 @@ describe('extractReferencesAndMentions', () => {
     // empty by formatting the empty top-level content.
     const effectiveContent = 'Forwarded snapshot text the user actually sent';
     mockExtractReferences.mockResolvedValue({
-      references: [],
+      rawReferences: [],
       updatedContent: effectiveContent, // no links → echoed unchanged
     });
     mockResolveAllMentions.mockReturnValue({

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
@@ -24,7 +24,6 @@ const logger = createLogger('MessageContextBuilder');
 /** Result of extracting references and resolving mentions */
 export interface ReferencesAndMentionsResult {
   messageContent: string;
-  referencedMessages: ReferencedMessage[];
   /**
    * Raw-envelope fields: pre-enrichment reference snapshots plus the
    * guild-cache-resolved channel and role mention data the worker needs to
@@ -59,7 +58,6 @@ export async function extractReferencesAndMentions(
   if (isWeighInMode) {
     return {
       messageContent: content,
-      referencedMessages: [],
     };
   }
 
@@ -79,17 +77,14 @@ export async function extractReferencesAndMentions(
     conversationHistoryTimestamps,
   });
 
-  const {
-    references: referencedMessages,
-    updatedContent,
-    rawReferences,
-  } = await referenceExtractor.extractReferencesWithReplacement(message, content);
+  const { updatedContent, rawReferences } =
+    await referenceExtractor.extractReferencesWithReplacement(message, content);
 
-  if (referencedMessages.length > 0) {
+  if (rawReferences.length > 0) {
     logger.info(
       {
-        count: referencedMessages.length,
-        referenceNumbers: referencedMessages.map(r => r.referenceNumber),
+        count: rawReferences.length,
+        referenceNumbers: rawReferences.map(r => r.referenceNumber),
       },
       'Extracted referenced messages (after deduplication)'
     );
@@ -110,7 +105,6 @@ export async function extractReferencesAndMentions(
 
   return {
     messageContent,
-    referencedMessages,
     ...rawEnvelopeFields,
   };
 }
@@ -154,13 +148,13 @@ type RawEnvelopeFields = Pick<
 >;
 
 function captureRawEnvelopeFields(
-  rawReferences: ReferencedMessage[] | undefined,
+  rawReferences: ReferencedMessage[],
   mentionResult: Awaited<ReturnType<MentionResolver['resolveAllMentions']>>
 ): RawEnvelopeFields {
   return {
-    // No `?? []` fallback: the extractor always produced an array, and if a
-    // future path legitimately passes undefined, ABSENT is the accurate signal
-    // to propagate (see schema semantics).
+    // Always an array here — extraction ran. ABSENT on the wire means
+    // extraction was skipped entirely (the weigh-in early return above never
+    // reaches this function), so `[]` and absent stay distinct signals.
     rawReferencedMessages: rawReferences,
     rawMentionedChannels: mentionResult.mentionedChannels.map(ch => ({
       channelId: ch.channelId,

--- a/services/bot-client/src/utils/gatewayServiceCalls.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.ts
@@ -241,9 +241,6 @@ export async function generate(
   // the first place to look if the heavy-attachment submit timeout recurs.
   logger.debug(
     {
-      hasReferencedMessages:
-        context.referencedMessages !== undefined && context.referencedMessages !== null,
-      referencedCount: context.referencedMessages?.length ?? 0,
       contextKeys: Object.keys(context),
     },
     'Submitting generation context'


### PR DESCRIPTION
## What

`ReferenceFormatter.format()` built an ENRICHED `references` array alongside `rawReferences` — running a Redis voice-transcript lookup per voice reply to enrich it — and the enriched array reached **exactly two log lines**. It never entered the gateway envelope (`RawEnvelopeBuilder` ships `rawReferences` only), never the DB (`saveUserMessage` is called without the arg), and never the model (ai-worker re-derives everything from `rawReferencedMessages`). This deletes the whole enriched pipeline: `formatMessageWithRaw`/`appendTranscriptsWithRetriever`/`formatMessage`, the `collectRaw` option (hardcoded `true` by its only caller), the test-only `extractReferences()` wrapper, and the always-`false`/`0` `referencedMessages` fields in the submit log (bot-client never populates `context.referencedMessages`). `rawReferences` becomes the formatter's sole, required output. Net **−406 lines**. TASK-379, filed out of TASK-365 PR-2's close-out.

## Verified before deleting (the keep-list check)

- **No cache warming**: the bot-side lookup is `VoiceTranscriptCache.get()` — a bare Redis `GET`, no write-back, no DB tier (`TranscriptRetriever`'s own doc: Redis only). Structurally incapable of warming anything.
- **Disjoint key spaces**: ai-worker's reference enrichment reads the conversation-history DB row by Discord message id (`ContextAssembler.enrichReferences`), never this attachment-URL-keyed Redis cache. Deletion changes neither correctness nor latency downstream.
- **Dedup unaffected**: ai-worker stamps `isDeduplicated` itself against its own assembled history (`referenceEnricher.ts:105`); the old bot-side deduped branch was already raw-only since #1882.
- **`TranscriptRetriever` survives** — the extended-context fetch path still uses it (only the reference-path consumer is deleted). `appendVoiceTranscripts` in common-types survives via ai-worker's `referenceEnricher`. `pnpm knip` clean.
- Consumer enumeration was done by a dedicated read-only grounding pass (every transitive reader of the enriched array traced to a terminal log line, file:line).

## Behavior notes

- The deduped and regular branches merged into one `appendSingleReference` — their bodies became identical once enrichment left (and `sonarjs/no-identical-functions` enforces the merge). Routing preserved exactly: a deduped forward still takes the single-entry path rather than fanning out per snapshot (comment at the branch site).
- `format()` is now synchronous (no remaining `await`).
- One test expectation corrected rather than deleted: the "empty references" context test asserted `rawReferencedMessages` `undefined`, which only held because the old mock omitted the field — production always collected raw, so `[]` is the faithful value.
- Two log lines repointed at `rawReferences` counts; the submit-log's dead `hasReferencedMessages`/`referencedCount` (hardcoded `false`/`0` since the thin envelope) deleted outright.

## Verification

Full `pnpm test` (bot-client 392 files / 6082 tests) and `pnpm quality` green, sequentially. Survivor greps for `formatMessageWithRaw`/`appendTranscriptsWithRetriever`/`collectRaw` and bare `.references` in the touched directories: zero source hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round 1 addendum (wire-shape note, per review)

`rawReferencedMessages` now ships `[]` instead of being ABSENT when extraction ran and found zero references. Absent now exclusively means extraction was skipped (weigh-in mode) — previously it was overloaded with 'ran, found nothing'. Every ai-worker consumer was traced (`?? []` / optional-chaining / length guards throughout): `[]` and `undefined` are handled equivalently, so no functional change — the signal just got cleaner. The review's three doc/type nits (stale facade line, stale-optional `captureRawEnvelopeFields` param, imprecise ordering comment) were applied in the amended commit.