### PR TITLE
fix(ai-worker): live deduped quotes stop repeating chat-log image descriptions (TASK-387)

### DIFF
--- a/services/ai-worker/src/services/ConversationInputProcessor.test.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.test.ts
@@ -15,6 +15,7 @@ import type { ConversationContext } from './ConversationalRAGTypes.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
+import { enrichmentKey } from './prompt/QuoteFormatter.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
 const { mockProcessAttachments, mockExtractRecentHistoryWindow } = vi.hoisted(() => ({
@@ -335,6 +336,9 @@ describe('ConversationInputProcessor', () => {
           visionProvider: undefined,
           visionModel: undefined,
           allPersonalityNames: new Set(['Test Bot']),
+          // Nothing to subtract: the reference is not deduplicated, so the
+          // chat log has no copy of it to defer to.
+          carriedByChatLog: new Map(),
         }
       );
       expect(result.referencedMessagesDescriptions).toBe('<references>formatted</references>');
@@ -570,8 +574,112 @@ describe('ConversationInputProcessor', () => {
           visionProvider: undefined,
           visionModel: undefined,
           allPersonalityNames: new Set(['Test Bot']),
+          carriedByChatLog: new Map(),
         }
       );
+    });
+
+    describe('carriedByChatLog (what the chat log already renders for a deduped quote)', () => {
+      const IMAGE_DESCRIPTION = 'SENTINEL_HISTORY_VISION: a tabby asleep on a keyboard';
+
+      function dedupedRef(): ReferencedMessage {
+        return {
+          referenceNumber: 1,
+          discordMessageId: 'msg1',
+          discordUserId: 'user1',
+          authorUsername: 'user1',
+          authorDisplayName: 'User One',
+          content: 'look at my cat',
+          embeds: '',
+          timestamp: '2025-01-01T00:00:00Z',
+          locationContext: '',
+          isDeduplicated: true,
+        };
+      }
+
+      /** The map as the formatter received it. */
+      function carriedArg(): Map<string, ReadonlySet<string>> | undefined {
+        const call = (
+          mockReferencedMessageFormatter.formatReferencedMessages as ReturnType<typeof vi.fn>
+        ).mock.calls[0] as [
+          unknown,
+          unknown,
+          unknown,
+          unknown,
+          { carriedByChatLog?: Map<string, ReadonlySet<string>> },
+        ];
+        return call[4].carriedByChatLog;
+      }
+
+      it('reports the image description history renders for the quoted message', async () => {
+        const context = createMockContext({
+          referencedMessages: [dedupedRef()],
+          rawConversationHistory: [
+            {
+              id: 'db-row-uuid-1',
+              discordMessageId: ['msg1'],
+              role: 'user',
+              content: 'look at my cat',
+              messageMetadata: {
+                imageDescriptions: [{ filename: 'cat.png', description: IMAGE_DESCRIPTION }],
+              },
+            },
+          ],
+        });
+
+        await processor.processInputs(mockPersonality, mockMessage, context, {
+          isGuestMode: true,
+        });
+
+        expect(carriedArg()?.get('msg1')).toEqual(
+          new Set([enrichmentKey('image', IMAGE_DESCRIPTION)])
+        );
+      });
+
+      it('reports nothing for a deduped quote whose message is not in history', async () => {
+        // The time-window dedup path: flagged duplicate, no matching entry. No
+        // map entry means no subtraction — the safe default, since there is no
+        // chat-log copy to defer to.
+        const context = createMockContext({
+          referencedMessages: [dedupedRef()],
+          rawConversationHistory: [
+            {
+              id: 'db-row-uuid-2',
+              discordMessageId: ['some-other-message'],
+              role: 'user',
+              content: 'unrelated',
+            },
+          ],
+        });
+
+        await processor.processInputs(mockPersonality, mockMessage, context, {
+          isGuestMode: true,
+        });
+
+        expect(carriedArg()?.has('msg1')).toBe(false);
+      });
+
+      it('reports an EMPTY set for a matched entry that renders no enrichment', async () => {
+        // Distinct from the miss above: the entry exists and carries nothing, so
+        // the quote keeps its media (an empty set subtracts nothing).
+        const context = createMockContext({
+          referencedMessages: [dedupedRef()],
+          rawConversationHistory: [
+            {
+              id: 'db-row-uuid-1',
+              discordMessageId: ['msg1'],
+              role: 'user',
+              content: 'look at my cat',
+            },
+          ],
+        });
+
+        await processor.processInputs(mockPersonality, mockMessage, context, {
+          isGuestMode: true,
+        });
+
+        expect(carriedArg()?.get('msg1')).toEqual(new Set());
+      });
     });
 
     it('should return complete ProcessedInputs structure', async () => {

--- a/services/ai-worker/src/services/ConversationInputProcessor.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.ts
@@ -9,6 +9,7 @@
  */
 
 import { type MessageContent } from '@tzurot/common-types/types/ai';
+import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -19,7 +20,12 @@ import {
 } from './MultimodalProcessor.js';
 import { extractRecentHistoryWindow } from './RAGUtils.js';
 import { shouldFoldSearchQuery } from './prompt/queryFoldGate.js';
-import { collectPersonalityNames } from '../jobs/utils/conversationUtils.js';
+import {
+  buildHistoryEntryIndex,
+  collectPersonalityNames,
+} from '../jobs/utils/conversationUtils.js';
+import type { RawHistoryEntry } from '../jobs/utils/conversationTypes.js';
+import { chatLogEnrichmentFor } from '../jobs/utils/xmlMetadataFormatters.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
 import type {
@@ -29,6 +35,55 @@ import type {
 } from './ConversationalRAGTypes.js';
 
 const logger = createLogger('ConversationInputProcessor');
+
+/**
+ * What `<chat_log>` will already render for each DEDUPED reference, keyed by
+ * Discord message id — the subtraction set the stub renderer cannot derive.
+ *
+ * The live path's ordering problem in one function. A deduped stub asks "does
+ * history already carry this quote's image description?", which is a fact about
+ * the chat-log renderer's output for that quote's OWN history entry; the replay
+ * path answers it from the entry it deduped against, and this is the live
+ * equivalent. It is only answerable AFTER history enrichment has run, because
+ * enrichment is what populates `imageDescriptions` — hence the step ordering in
+ * `ConversationalRAGService.generateResponse`.
+ *
+ * Keyed the same way the dedup DECISION was made: `referenceEnricher` flags a
+ * reference duplicate when its Discord id is in the assembled history's id set,
+ * so every exact-id dedup resolves to an entry here. Its time-window fallback
+ * flags references with no matching entry at all — those get no map entry and
+ * subtract nothing, which is correct: there is no chat-log copy to defer to.
+ *
+ * `personalityName`/`allPersonalityNames` mirror what the chat-log renderer will
+ * be handed (`personality.name`), so this reports what that renderer emits
+ * rather than a second opinion about it.
+ */
+function buildCarriedChatLogEnrichment(
+  references: ReferencedMessage[],
+  history: RawHistoryEntry[],
+  personalityName: string
+): Map<string, ReadonlySet<string>> {
+  const carried = new Map<string, ReadonlySet<string>>();
+  const deduped = references.filter(ref => ref.isDeduplicated === true);
+  if (deduped.length === 0 || history.length === 0) {
+    return carried;
+  }
+
+  const historyEntries = buildHistoryEntryIndex(history);
+  const allPersonalityNames = collectPersonalityNames(history, personalityName);
+
+  for (const ref of deduped) {
+    const entry = historyEntries.get(ref.discordMessageId);
+    if (entry !== undefined) {
+      carried.set(
+        ref.discordMessageId,
+        chatLogEnrichmentFor(entry, personalityName, allPersonalityNames)
+      );
+    }
+  }
+
+  return carried;
+}
 
 /**
  * Processes conversation inputs for the RAG pipeline
@@ -150,10 +205,22 @@ export class ConversationInputProcessor {
               visionProvider,
               visionModel,
               // Personalities visible in history — enables the sibling-persona
-              // quote demotion (assistant → character) in deriveRefRole.
+              // quote demotion (assistant → character) in deriveRefRole. Seeded
+              // with the DISPLAY name because role derivation is a match against
+              // Discord-vocabulary names (see fromLiveReference), which is also
+              // why it is not the set below.
               allPersonalityNames: collectPersonalityNames(
                 context.rawConversationHistory ?? [],
                 personality.displayName
+              ),
+              // What <chat_log> already renders for each deduped quote, so the
+              // stub subtracts it instead of printing the same paid vision
+              // description twice in one prompt. Derived from history AFTER
+              // enrichment ran — the ordering is load-bearing (see the helper).
+              carriedByChatLog: buildCarriedChatLogEnrichment(
+                references,
+                context.rawConversationHistory ?? [],
+                personality.name
               ),
               // Correlation only: the formatter's enrichment-drop warnings name
               // the request that paid for the lost vision/transcription work.

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -164,6 +164,7 @@ import {
 } from '../test/mocks/index.js';
 import { checkModelContextLength } from '../redis.js';
 import { retrieveFactsForPrompt } from './factRetrievalHelper.js';
+import { enrichmentKey } from './prompt/QuoteFormatter.js';
 
 // Prisma is injected into the constructor, but every DB-touching child
 // (MemoryRetriever, LongTermMemoryService, UserReferenceResolver) is mocked
@@ -285,6 +286,64 @@ describe('ConversationalRAGService', () => {
           personalityId: personality.id,
           scope: expect.objectContaining({ channelId: context.channelId }),
         })
+      );
+    });
+
+    it('enriches history BEFORE rendering references, so a deduped stub can subtract', async () => {
+      // The step ORDER, asserted at the hop that depends on it. The subtraction
+      // set is derived from `imageDescriptions` on the history entry, and the
+      // only thing that populates that field is history enrichment — so a
+      // populated set crossing into the formatter is proof enrichment already
+      // ran. Reversing the two steps leaves the set empty and the same paid
+      // description prints in <contextual_references> AND <chat_log>.
+      const VISION_SENTINEL = 'SENTINEL_ORDER_VISION_3f9a: a tabby asleep on a keyboard';
+      const imageUrl = 'https://cdn.discordapp.com/attachments/1/2/cat.png';
+      const personality = createMockPersonality();
+      const context = createMockContext({
+        rawConversationHistory: [
+          {
+            id: 'db-row-uuid-1',
+            discordMessageId: ['ref-9'],
+            role: 'user',
+            content: 'look at my cat',
+          },
+        ],
+        preprocessedExtendedContextAttachments: [
+          {
+            type: AttachmentType.Image,
+            description: VISION_SENTINEL,
+            originalUrl: imageUrl,
+            metadata: {
+              url: imageUrl,
+              name: 'cat.png',
+              contentType: CONTENT_TYPES.IMAGE_PNG,
+              size: 1000,
+              sourceDiscordMessageId: 'ref-9',
+            },
+          },
+        ],
+        referencedMessages: [
+          {
+            referenceNumber: 1,
+            discordMessageId: 'ref-9',
+            discordUserId: 'user-9',
+            authorUsername: 'quoted',
+            authorDisplayName: 'Quoted',
+            content: 'look at my cat',
+            embeds: '',
+            timestamp: '2026-07-31T12:00:00.000Z',
+            locationContext: '',
+            isDeduplicated: true,
+          },
+        ],
+      });
+
+      await service.generateResponse(personality, 'what breed is that', context);
+
+      const batchInputs = getReferencedMessageFormatterMock().formatReferencedMessages.mock
+        .calls[0]?.[4] as { carriedByChatLog?: Map<string, ReadonlySet<string>> } | undefined;
+      expect(batchInputs?.carriedByChatLog?.get('ref-9')).toEqual(
+        new Set([enrichmentKey('image', VISION_SENTINEL)])
       );
     });
 

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -273,6 +273,9 @@ export class ConversationalRAGService {
    * Generate a response using conversational RAG
    *
    * Architecture: This method orchestrates the response generation pipeline:
+   * 0. Enrich history (inline image descriptions, stored references) — first,
+   *    because the reference render in step 1 subtracts against what history
+   *    will carry
    * 1. Process inputs (attachments, messages, search query)
    * 2. Load personas and resolve user references
    * 3. Retrieve relevant memories from vector store
@@ -315,6 +318,27 @@ export class ConversationalRAGService {
         apiKeyResolver: this.apiKeyResolver,
       });
 
+      // Step 0.5: Enrich history with inline image descriptions + hydrated stored
+      // references, using the cross-provider-resolved vision auth.
+      //
+      // BEFORE Step 1, and that ordering is load-bearing rather than incidental.
+      // The two steps communicate through a shared mutable object — this one
+      // writes `imageDescriptions` onto `context.rawConversationHistory`
+      // entries, and the reference render reads them back to decide how much of
+      // a deduped quote <chat_log> already carries. Run the other way round, the
+      // renderer sees pre-enrichment history, subtracts nothing, and the same
+      // paid vision description is printed twice in one prompt (once in
+      // <contextual_references>, once in <chat_log>). Nothing in Step 1 feeds
+      // this call — all of its inputs are resolved above.
+      await enrichRagHistory({
+        prisma: this.prisma,
+        context,
+        personality,
+        visionAuth,
+        isGuestMode,
+        sttDispatch,
+      });
+
       // Step 1: Process inputs (attachments, messages, search query)
       const inputs = await this.inputProcessor.processInputs(personality, message, context, {
         isGuestMode,
@@ -345,17 +369,6 @@ export class ConversationalRAGService {
           searchQuery: inputs.searchQuery,
         });
       }
-
-      // Step 1.5: Enrich history with inline image descriptions + hydrated stored
-      // references, using the cross-provider-resolved vision auth.
-      await enrichRagHistory({
-        prisma: this.prisma,
-        context,
-        personality,
-        visionAuth,
-        isGuestMode,
-        sttDispatch,
-      });
 
       // Step 2: Load personas and resolve user references
       const { participantPersonas, processedPersonality } = await loadPersonasAndResolveReferences(
@@ -403,7 +416,7 @@ export class ConversationalRAGService {
 
       // Step 4: Allocate token budgets and select content
       // Note: Image descriptions and stored reference hydration are handled by
-      // enrichConversationHistory (Step 1.5) — history is already enriched here
+      // enrichConversationHistory (Step 0.5) — history is already enriched here
       const budgetResult = this.contentBudgetManager.allocate(
         { ...budgetOptionsBase, retrievedMemories, facts },
         preselected

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -127,6 +127,15 @@ export interface ConversationContext {
   rawConversationHistory?: {
     /** Message ID - for extended context messages this IS the Discord message ID */
     id?: string;
+    /**
+     * Discord snowflakes for this row (several when a long message was chunked).
+     * Declared because the assembled entries have always carried it — the
+     * producer is `ConversationMessage` — and the reference paths key on it:
+     * the enricher's dedup decision and the deduped stub's subtraction index
+     * both ask "which history entry is this quote?" by Discord id, never by
+     * `id` (a database UUID on DB-sourced rows).
+     */
+    discordMessageId?: string[];
     role: string;
     content: string;
     tokenCount?: number;

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -9,6 +9,7 @@ import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { type ProcessedAttachment } from './MultimodalProcessor.js';
+import { enrichmentKey } from './prompt/QuoteFormatter.js';
 import { type ResolvedPersona } from './reference/UserReferencePatterns.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
@@ -2234,6 +2235,173 @@ describe('ReferencedMessageFormatter', () => {
           expect.stringContaining('not reaching the prompt')
         );
       });
+    });
+  });
+
+  /**
+   * The other half of the enrichment contract: paid work must appear ONCE.
+   *
+   * A deduped stub whose description <chat_log> also renders prints the same
+   * paid text twice in one prompt. The stub cannot know that — it is a fact
+   * about the other renderer's output — so the caller hands it what history
+   * carries and `dedupeReference` subtracts. These cases pin both directions,
+   * because both fixed answers are wrong in half the input.
+   */
+  describe('carriedByChatLog: the chat log copy is subtracted from the stub', () => {
+    const VISION_SENTINEL = 'SENTINEL_CARRIED_VISION_9d41ab';
+    const QUOTED_MESSAGE_ID = 'quoted-msg-1';
+    const IMAGE_URL = 'https://cdn.example.com/quoted-cat.png';
+
+    /**
+     * The real wire shape of a deduped reference with media: the enricher
+     * flags it and strips nothing, and its descriptions arrive via
+     * preprocessing (the deduped branch never calls vision itself).
+     */
+    function dedupedRefWithImage(): ReferencedMessage {
+      return {
+        referenceNumber: 1,
+        discordMessageId: QUOTED_MESSAGE_ID,
+        discordUserId: 'user-1',
+        authorUsername: 'testuser',
+        authorDisplayName: 'Test User',
+        content: 'look at my cat',
+        embeds: '',
+        timestamp: '2025-12-06T00:00:00Z',
+        locationContext: '',
+        isDeduplicated: true,
+      };
+    }
+
+    const preprocessedImage: Record<number, ProcessedAttachment[]> = {
+      1: [
+        {
+          type: AttachmentType.Image,
+          description: VISION_SENTINEL,
+          originalUrl: IMAGE_URL,
+          metadata: {
+            url: IMAGE_URL,
+            name: 'quoted-cat.png',
+            contentType: 'image/png',
+            size: 1000,
+          },
+        },
+      ],
+    };
+
+    it('drops the description — and the "described here" clause — when the chat log carries it', async () => {
+      const { formatted, searchText, durable } = await formatter.formatReferencedMessages(
+        [dedupedRefWithImage()],
+        mockPersonality,
+        false,
+        preprocessedImage,
+        {
+          carriedByChatLog: new Map([
+            [QUOTED_MESSAGE_ID, new Set([enrichmentKey('image', VISION_SENTINEL)])],
+          ]),
+        }
+      );
+
+      expect(formatted).not.toContain(VISION_SENTINEL);
+      // Nothing enriched survives, so the stub must not promise media here.
+      expect(formatted).toContain('[Referenced message — full text in the chat log]');
+      expect(formatted).not.toContain('its media is described here');
+
+      // Subtraction is prompt-shaping only: retrieval and the durable row are
+      // built from the PRE-projection reference and keep the paid text.
+      expect(searchText).toContain(VISION_SENTINEL);
+      expect(JSON.stringify(durable)).toContain(VISION_SENTINEL);
+    });
+
+    it('keeps the description when the map has no entry for that reference', async () => {
+      // The miss case — a time-window dedup matches no history entry at all.
+      // Subtracting nothing is the safe default: a duplicated description costs
+      // tokens, a dropped one costs the answer.
+      const { formatted } = await formatter.formatReferencedMessages(
+        [dedupedRefWithImage()],
+        mockPersonality,
+        false,
+        preprocessedImage,
+        { carriedByChatLog: new Map() }
+      );
+
+      expect(formatted).toContain(VISION_SENTINEL);
+      expect(formatted).toContain('its media is described here');
+    });
+
+    it('keeps the description when no map is threaded at all', async () => {
+      const { formatted } = await formatter.formatReferencedMessages(
+        [dedupedRefWithImage()],
+        mockPersonality,
+        false,
+        preprocessedImage
+      );
+
+      expect(formatted).toContain(VISION_SENTINEL);
+      expect(formatted).toContain('its media is described here');
+    });
+
+    it('keeps a description the chat log renders DIFFERENTLY', async () => {
+      // The set is matched on the enrichment text, not on the message id: an
+      // entry whose chat-log copy is some other description subtracts nothing,
+      // so the quote's own media still reaches the model.
+      const { formatted } = await formatter.formatReferencedMessages(
+        [dedupedRefWithImage()],
+        mockPersonality,
+        false,
+        preprocessedImage,
+        {
+          carriedByChatLog: new Map([
+            [QUOTED_MESSAGE_ID, new Set([enrichmentKey('image', 'a completely different photo')])],
+          ]),
+        }
+      );
+
+      expect(formatted).toContain(VISION_SENTINEL);
+    });
+
+    it('subtracts only the modality the chat log actually carries', async () => {
+      // Same text, wrong kind: the key is (kind, text), so an image description
+      // is not cancelled by an identical-looking transcript.
+      const { formatted } = await formatter.formatReferencedMessages(
+        [dedupedRefWithImage()],
+        mockPersonality,
+        false,
+        preprocessedImage,
+        {
+          carriedByChatLog: new Map([
+            [QUOTED_MESSAGE_ID, new Set([enrichmentKey('voice', VISION_SENTINEL)])],
+          ]),
+        }
+      );
+
+      expect(formatted).toContain(VISION_SENTINEL);
+    });
+
+    it('never subtracts from a FULL reference, however the map is populated', async () => {
+      // Only a deduped stub defers to <chat_log>; a full reference is the only
+      // place its media appears. It carries its own attachment row (the full
+      // branch renders from the reference, correlating preprocessing by URL).
+      const { formatted } = await formatter.formatReferencedMessages(
+        [
+          {
+            ...dedupedRefWithImage(),
+            isDeduplicated: undefined,
+            attachments: [
+              { url: IMAGE_URL, contentType: 'image/png', name: 'quoted-cat.png', size: 1000 },
+            ],
+          },
+        ],
+        mockPersonality,
+        false,
+        preprocessedImage,
+        {
+          carriedByChatLog: new Map([
+            [QUOTED_MESSAGE_ID, new Set([enrichmentKey('image', VISION_SENTINEL)])],
+          ]),
+        }
+      );
+
+      expect(formatted).toContain(VISION_SENTINEL);
     });
   });
 });

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -67,6 +67,19 @@ interface ReferenceVisionAuth {
   visionModel?: string;
   allPersonalityNames?: Set<string>;
   requestId?: string;
+  /**
+   * Per-reference: the enrichment `<chat_log>` will already render for that
+   * reference's own history entry, keyed by Discord message id. Batch-invariant
+   * (one derivation for the whole set) and READ-ONLY here — the caller derives
+   * it from the enriched history, because whether history carries a quote's
+   * image description is a fact about the OTHER renderer's output, not one this
+   * module can see.
+   *
+   * A reference with no entry in the map subtracts nothing, which is the safe
+   * default `dedupeReference` documents: a duplicated description costs tokens,
+   * a dropped one costs the answer.
+   */
+  carriedByChatLog?: Map<string, ReadonlySet<string>>;
 }
 
 /**
@@ -245,7 +258,9 @@ export class ReferencedMessageFormatter {
    * @param personality - Personality configuration for vision/transcription models
    * @param isGuestMode - Whether the user is in guest mode (no BYOK API key)
    * @param preprocessedAttachments - Pre-processed attachments keyed by reference number (avoids inline API calls)
-   * @param apiKeys - Vision/STT auth plus the personality-name set for role derivation
+   * @param apiKeys - Vision/STT auth plus the batch-invariant render inputs: the
+   *   personality-name set for role derivation and the per-reference set of
+   *   enrichment `<chat_log>` already carries (see `carriedByChatLog`)
    * @returns The prompt XML plus the plain-text search rendering
    */
   async formatReferencedMessages(
@@ -279,8 +294,17 @@ export class ReferencedMessageFormatter {
 
       // Dedup is a projection of the reference above, never a second build —
       // so a field this formatter learns to carry reaches the stub for free.
+      //
+      // The subtraction set is looked up per reference: it says what <chat_log>
+      // renders for THIS quote's own history entry, so the stub stops repeating
+      // a description the model reads twenty lines later anyway. A miss (no
+      // matching entry, or a caller that threads no map) subtracts nothing.
       referenceElements.push(
-        renderReference(ref.isDeduplicated === true ? dedupeReference(renderable) : renderable)
+        renderReference(
+          ref.isDeduplicated === true
+            ? dedupeReference(renderable, apiKeys?.carriedByChatLog?.get(ref.discordMessageId))
+            : renderable
+        )
       );
 
       // Persisted from the PRE-projection reference, and from the enrichment as

--- a/services/ai-worker/src/services/liveDedupSubtractionSeam.test.ts
+++ b/services/ai-worker/src/services/liveDedupSubtractionSeam.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Seam test: history enrichment → live reference render.
+ *
+ * These two steps run back-to-back in `ConversationalRAGService.generateResponse`
+ * and they do not call each other — they communicate by writing and reading a
+ * field on a shared mutable object (`context.rawConversationHistory`). Per
+ * `02-code-standards.md` § "A shared mutable context is a seam too", that is a
+ * seam with no mock in it: enrichment's unit tests build the history themselves,
+ * and the formatter's unit tests build the carried-enrichment set themselves, so
+ * neither can observe what the other actually produced.
+ *
+ * The bug this pins was exactly that. The render ran FIRST, so at stub-build
+ * time `imageDescriptions` was still unpopulated, the subtraction set was empty,
+ * and one quoted image's 1374-character vision description was printed twice in
+ * one prompt — once inside <contextual_references>, once inside <chat_log>.
+ * Every unit test on both sides passed throughout.
+ *
+ * Only the paid boundary (vision/transcription) and the persona lookup are
+ * mocked; the enrichment write, the id matching, the enrichment-key derivation
+ * and the stub projection all run for real, in order.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AttachmentType } from '@tzurot/common-types/constants/media';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
+import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
+import { ConversationInputProcessor } from './ConversationInputProcessor.js';
+import { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
+import { enrichRagHistory } from './multimodal/ragVisionAuth.js';
+import type { ConversationContext } from './ConversationalRAGTypes.js';
+import type { ProcessedAttachment } from './MultimodalProcessor.js';
+import type { PromptBuilder } from './PromptBuilder.js';
+
+// THE paid boundary — the only computation mocked. Nothing in these cases
+// should reach it: every description arrives pre-computed from the dependency
+// stage, which is what the production deduped path relies on.
+const mockProcessAttachments = vi.fn();
+const mockDescribeImage = vi.fn();
+const mockTranscribeAudio = vi.fn();
+vi.mock('./MultimodalProcessor.js', () => ({
+  processAttachments: (...args: unknown[]) => mockProcessAttachments(...args),
+  describeImage: (...args: unknown[]) => mockDescribeImage(...args),
+  transcribeAudio: (...args: unknown[]) => mockTranscribeAudio(...args),
+  deriveApiKeySource: (): 'system' => 'system',
+}));
+
+// The persona-hydration database seam (and the module that would otherwise
+// construct a Redis client at import time).
+vi.mock('./reference/BatchResolvers.js', () => ({
+  batchResolveByDiscordIds: vi.fn().mockResolvedValue(new Map()),
+}));
+vi.mock('../redis.js', () => ({
+  visionDescriptionCache: { get: vi.fn().mockResolvedValue(null) },
+}));
+
+const VISION_SENTINEL = 'SENTINEL_SEAM_VISION_4c17fe: a tabby asleep on a keyboard';
+const QUOTED_MESSAGE_ID = 'quoted-msg-77';
+const IMAGE_URL = 'https://cdn.discordapp.com/attachments/1/2/cat.png';
+
+const TEST_PERSONALITY: LoadedPersonality = {
+  id: 'personality-1',
+  name: 'TestBot',
+  displayName: 'Test Bot',
+  slug: 'testbot',
+  ownerId: 'owner-uuid-test',
+  systemPrompt: 'x',
+  model: 'test-model',
+  provider: 'openrouter',
+  temperature: 0.7,
+  maxTokens: 2000,
+  contextWindowTokens: 131072,
+  characterInfo: 'x',
+  personalityTraits: 'x',
+  voiceEnabled: false,
+};
+
+/** The vision result the dependency stage produces for the quoted message. */
+function extendedContextImage(): ProcessedAttachment {
+  return {
+    type: AttachmentType.Image,
+    description: VISION_SENTINEL,
+    originalUrl: IMAGE_URL,
+    metadata: {
+      url: IMAGE_URL,
+      name: 'cat.png',
+      contentType: 'image/png',
+      size: 1000,
+      // The correlation key enrichment injects on: this description belongs to
+      // the history entry for the quoted message.
+      sourceDiscordMessageId: QUOTED_MESSAGE_ID,
+    },
+  };
+}
+
+/** The SAME description, reaching the reference render as preprocessing. */
+const preprocessedForReference: Record<number, ProcessedAttachment[]> = {
+  1: [extendedContextImage()],
+};
+
+/** A reply to a message that is also in history → the enricher flags it deduped. */
+function dedupedReference(): ReferencedMessage {
+  return {
+    referenceNumber: 1,
+    discordMessageId: QUOTED_MESSAGE_ID,
+    discordUserId: 'user-1',
+    authorUsername: 'testuser',
+    authorDisplayName: 'Test User',
+    content: 'look at my cat',
+    embeds: '',
+    timestamp: '2025-12-06T00:00:00Z',
+    locationContext: '',
+    isDeduplicated: true,
+  };
+}
+
+function contextWithQuotedMessageInHistory(
+  overrides: Partial<ConversationContext> = {}
+): ConversationContext {
+  return {
+    userId: 'user-1',
+    channelId: 'channel-1',
+    referencedMessages: [dedupedReference()],
+    rawConversationHistory: [
+      {
+        id: 'db-row-uuid-1',
+        discordMessageId: [QUOTED_MESSAGE_ID],
+        role: 'user',
+        content: 'look at my cat',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('live deduped stubs subtract what history enrichment just wrote', () => {
+  let processor: ConversationInputProcessor;
+  const prisma = {} as unknown as PrismaClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessAttachments.mockResolvedValue([]);
+
+    // Not part of this seam: a stub keeps the assertions on the reference XML.
+    const promptBuilder = {
+      formatUserMessage: vi.fn().mockReturnValue('formatted user message'),
+      buildSearchQuery: vi.fn().mockReturnValue('search query'),
+    } as unknown as PromptBuilder;
+
+    processor = new ConversationInputProcessor(
+      promptBuilder,
+      new ReferencedMessageFormatter(prisma)
+    );
+  });
+
+  /** The production order: enrich history, THEN render the references. */
+  async function runInProductionOrder(
+    context: ConversationContext
+  ): Promise<{ referencedMessagesDescriptions?: string }> {
+    await enrichRagHistory({
+      prisma,
+      context,
+      personality: TEST_PERSONALITY,
+      visionAuth: {},
+      isGuestMode: true,
+    });
+    return processor.processInputs(TEST_PERSONALITY, 'what breed is that', context, {
+      isGuestMode: true,
+    });
+  }
+
+  it('renders the vision description once: in the chat log, not in the quote', async () => {
+    const context = contextWithQuotedMessageInHistory({
+      preprocessedExtendedContextAttachments: [extendedContextImage()],
+      preprocessedReferenceAttachments: preprocessedForReference,
+    });
+
+    const { referencedMessagesDescriptions } = await runInProductionOrder(context);
+
+    // The stub defers to the chat log…
+    expect(referencedMessagesDescriptions).not.toContain(VISION_SENTINEL);
+    expect(referencedMessagesDescriptions).toContain(
+      '[Referenced message — full text in the chat log]'
+    );
+    expect(referencedMessagesDescriptions).not.toContain('its media is described here');
+
+    // …and the chat log's own copy is still there to defer TO. Asserting the
+    // entry's data rather than a second render: this is the write the reference
+    // render read, and losing it would make the subtraction a deletion.
+    expect(context.rawConversationHistory?.[0].messageMetadata?.imageDescriptions).toEqual([
+      { filename: 'cat.png', description: VISION_SENTINEL },
+    ]);
+
+    // No new spend bought either copy.
+    expect(mockDescribeImage).not.toHaveBeenCalled();
+  });
+
+  it('keeps the description in the quote when history carries nothing for it', async () => {
+    // The inverse, and the reason subtraction cannot be unconditional: with no
+    // extended-context enrichment, <chat_log> renders that message as text
+    // only, so the stub is the ONLY place its image is described.
+    const context = contextWithQuotedMessageInHistory({
+      preprocessedReferenceAttachments: preprocessedForReference,
+    });
+
+    const { referencedMessagesDescriptions } = await runInProductionOrder(context);
+
+    expect(referencedMessagesDescriptions).toContain(VISION_SENTINEL);
+    expect(referencedMessagesDescriptions).toContain('its media is described here');
+    expect(context.rawConversationHistory?.[0].messageMetadata?.imageDescriptions).toBeUndefined();
+  });
+
+  it('keeps the description when the quoted message is not the enriched one', async () => {
+    // Enrichment landed on a DIFFERENT history entry. The subtraction is
+    // per-reference, so a description belonging to someone else's message must
+    // not silence this quote.
+    const context = contextWithQuotedMessageInHistory({
+      preprocessedExtendedContextAttachments: [
+        {
+          ...extendedContextImage(),
+          metadata: { ...extendedContextImage().metadata, sourceDiscordMessageId: 'other-msg-99' },
+        },
+      ],
+      preprocessedReferenceAttachments: preprocessedForReference,
+    });
+    context.rawConversationHistory?.push({
+      id: 'db-row-uuid-2',
+      discordMessageId: ['other-msg-99'],
+      role: 'user',
+      content: 'unrelated',
+    });
+
+    const { referencedMessagesDescriptions } = await runInProductionOrder(context);
+
+    expect(referencedMessagesDescriptions).toContain(VISION_SENTINEL);
+  });
+
+  it('prints the description TWICE when the steps run in the wrong order', async () => {
+    // The regression itself, pinned as a property of the ORDER rather than of
+    // either step. Rendering first is what produced the shipped bug: the stub
+    // has nothing to subtract against yet, and enrichment then adds the second
+    // copy behind it. If someone moves the enrichment call back below
+    // `processInputs`, the first case above goes red and this one explains why.
+    const context = contextWithQuotedMessageInHistory({
+      preprocessedExtendedContextAttachments: [extendedContextImage()],
+      preprocessedReferenceAttachments: preprocessedForReference,
+    });
+
+    const { referencedMessagesDescriptions } = await processor.processInputs(
+      TEST_PERSONALITY,
+      'what breed is that',
+      context,
+      { isGuestMode: true }
+    );
+    await enrichRagHistory({
+      prisma,
+      context,
+      personality: TEST_PERSONALITY,
+      visionAuth: {},
+      isGuestMode: true,
+    });
+
+    expect(referencedMessagesDescriptions).toContain(VISION_SENTINEL);
+    expect(context.rawConversationHistory?.[0].messageMetadata?.imageDescriptions?.[0]).toEqual({
+      filename: 'cat.png',
+      description: VISION_SENTINEL,
+    });
+  });
+});


### PR DESCRIPTION
## What

**Runtime-confirmed prompt bloat** (owner repro, req `1ab06c8d`): replying to an image rendered the identical 1374-character vision description twice in one prompt — once in the live deduped quote inside `<contextual_references>`, once in the referenced message's own `<chat_log>` entry. TASK-387; the third instance of the shared-mutable-context seam class.

**Mechanism**: `enrichRagHistory` (which writes `imageDescriptions` onto `context.rawConversationHistory`) ran *after* `processInputs` (which renders the live deduped stub). At render time history carried no descriptions yet, so "does the chat log already carry this?" always answered no — `dedupeReference` was called with no subtraction set. The replay path already solved this in #1887 via `chatLogEnrichmentFor`; the live path just couldn't reach it.

## How

1. **Reorder**: `enrichRagHistory` moves to Step 0.5, before `processInputs`. Every input it needs resolves earlier; nothing between the old and new positions reads enriched history. The site comment documents why the ordering is load-bearing. Vision spend is unchanged — the description cache dedups whichever side pays first.
2. **Single-source derivation**: `ConversationInputProcessor` builds the per-deduped-ref carried set using the replay path's own exported `chatLogEnrichmentFor` + `buildHistoryEntryIndex` — no second copy of the "what will history render?" logic. Keyed by Discord message id, mirroring how the dedup *decision* itself is keyed in `referenceEnricher`; a ref with no matching entry subtracts nothing (the safe default `dedupeReference` documents).
3. **Formatter plumbing**: `carriedByChatLog` joins the batch-invariant options object; the deduped projection passes the per-ref set to `dedupeReference`, whose existing post-subtraction `hasMedia` logic automatically drops the "its media is described here" clause when everything subtracts.

Also declared `discordMessageId?: string[]` on the context's history-entry type — the producer has always populated it and both reference paths key on it; the declaration had just never caught up.

## Verified, and how

- **Sequencing seam test** (`liveDedupSubtractionSeam.test.ts`, per the rule-7 shared-context clause): runs real `enrichRagHistory` → real `processInputs` against one shared context, mocking only the paid vision boundary, persona lookup, and redis. Asserts the description renders once (chat-log side), the inverse (nothing carried → stub keeps its media), and **pins the failure mode**: with the steps deliberately reversed, the description prints twice.
- **Mutation checks**: removing `dedupeReference`'s second arg → 2 tests fail; reverting the reorder → the seam test fails. Both restored.
- Formatter tests cover subtract-when-carried, miss, no-map, different-text, wrong-modality, and full-reference-never-subtracts; `searchText` and the durable persisted reference keep the paid text (they build pre-projection).
- Full `pnpm test` and `pnpm quality` green sequentially (one `typecheck:spec` fixture error caught by the full gate and fixed — the worker's package-level typecheck had missed the spec tsconfig).
- `pnpm depcruise` clean on the new `services/` → `jobs/utils` import direction; contract tier (17 tests) green.

## Model-visible change (deliberate)

A live deduped quote whose image description the chat log already renders now shows the stub marker without the duplicated description — the same shape replay has rendered since #1887. This is the removal of redundancy the owner explicitly flagged; per-turn token cost drops by the size of the duplicated descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round 1 disposition

The review's Medium finding is real and was verified: the carried set derives from PRE-truncation history while <chat_log> renders POST-truncation, so a budget-dropped quoted entry would lose its description from both places. The in-PR fix is structurally blocked — the rendered reference block feeds `budgetOptionsBase`, so selection depends on reference size (the circular shape the replay path avoids by construction). Taking the review's accept-and-track option: **TASK-440** now owns the reconciliation (fix shapes recorded: post-preselect projection with a shipped-id reconcile, or fold into the doc-8 pre/post-truncation family). Trigger requires reply-dedup + enriched description + an entry old enough to be budget-dropped; the text side of the same family predates this PR. Findings 2 (enrichmentKey text-collision) and 3 (repeated history scans) are review-self-dismissed as awareness-only.