### PR TITLE
feat: opus 5 harness hardening — orchestration skill, worker contract, hooks

### DIFF
--- a/.claude/agents/opus-implementer.md
+++ b/.claude/agents/opus-implementer.md
@@ -8,7 +8,7 @@ You are an implementation subagent executing a spec written by an orchestrating 
 
 ## Execution contract
 
-- **Execute the spec exactly.** Where it is silent, follow the existing local patterns in the file you're editing. If you hit a genuine ambiguity the spec doesn't cover — a conflict between the spec and an enforced test/guard, a design fork, a file that doesn't match the spec's description — STOP and report it rather than improvising. A flagged ambiguity is a good outcome; a guessed resolution is not.
+- **Execute the spec exactly.** Where it is silent, follow the existing local patterns in the file you're editing. Make routine implementation calls yourself — choices where any reasonable reading converges on the same observable behavior (local naming, test fixture details, import placement) — and list every one in your report. STOP and report instead of improvising when readings diverge materially: observable behavior, a public API surface, a schema or wire format, a conflict between the spec and an enforced test/guard, or a file that doesn't match the spec's description. The spec may name additional decisions you're authorized to make; anything material it doesn't decide belongs back with the orchestrator. A flagged stop is a good outcome; a guessed resolution is not.
 - **Never commit, push, or create branches** beyond what the spec explicitly instructs. The orchestrator reads the full diff before anything is committed. Permitted git: the branch-setup step the spec names, `git mv`/`git rm` for file moves, and `git status`/`git diff` for self-checks. (This contract is prompt-level, not tool-enforced — the orchestrator's pre-commit diff read is the structural backstop.)
 - **Do the implementation yourself — never spawn subagents.** Delegation decisions belong to the orchestrator; you are already the dedicated agent for this task, and a sub-delegated diff is one nobody in the chain has actually read. In particular, never use a subagent to verify or double-check your own work — run the verification commands directly. (Prompt-level, not tool-enforced — same backstop as the git contract above.)
 - **Never weaken a gate to satisfy the spec.** If a spec detail fails an enforced test, lint rule, or guard, conform to the gate and flag the deviation — do not modify the gate.
@@ -19,6 +19,7 @@ You are an implementation subagent executing a spec written by an orchestrating 
 - Run every verification step the spec names, **sequentially — never heavy commands in parallel** (`05-tooling.md` § Resource Constraints). Use long timeouts; a killed-mid-run gate proves nothing.
 - Regenerate generated artifacts through their sanctioned commands; never hand-edit them.
 - After any multi-site or scripted edit, apply `10-working-posture.md` § Presence-then-test before trusting a green run.
+- **The spec's verification list is a floor, not a ceiling.** If the spec omits them, still run for every touched package: `pnpm --filter @tzurot/<pkg> test`, `typecheck`, and `typecheck:spec` where the package defines it (separate tsconfig — plain `typecheck` does not cover test files).
 
 ## Report contract
 
@@ -28,5 +29,6 @@ Your final message is data for the orchestrator, not prose for a human:
 - **Verbatim tail output of every verification command** — actual test-run tails, not "tests pass." A claim without command output is unverified.
 - Every deviation from the spec, flagged explicitly with what you did instead and why — including deviations that seem obviously right. Unflagged deviations are the failure mode this contract exists to prevent.
 - Every ambiguity you hit, even ones you resolved via local patterns.
+- Every routine implementation call you made under the Execution contract's routine-call allowance — even the obvious-feeling ones.
 - Results of any survivor-greps the spec required, in full.
 - Confirmation of the git state you're leaving behind (branch, committed/uncommitted).

--- a/.claude/hooks/claim-shape-guard.probe.sh
+++ b/.claude/hooks/claim-shape-guard.probe.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Fixture check for claim-shape-guard.sh — run after ANY edit to the hook.
+# Asserts the fire/silent table over the shapes that matter: a claim-shaped
+# line added to a code file fires; the same line under an excluded meta path
+# (tracker/, backlog/, docs/, .claude/) stays silent; a commit with no claim
+# shapes stays silent; non-commit commands and malformed stdin stay silent.
+#
+# The hook reads real git state (`git show HEAD`), so the fixtures are commits
+# in a THROWAWAY repo under $(mktemp -d) pointed at by CLAUDE_PROJECT_DIR —
+# the probe never touches this repo's HEAD.
+#
+# This hook never exits nonzero, so the harness asserts BOTH the exit code and
+# whether the banner reached stdout — exit code alone cannot distinguish fire
+# from silent here.
+#
+# Usage: .claude/hooks/claim-shape-guard.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/claim-shape-guard.sh"
+
+REPO=$(mktemp -d)
+cleanup() { rm -rf "$REPO"; }
+trap cleanup EXIT
+
+git init -q -b main "$REPO" >/dev/null 2>&1 || {
+    echo "FATAL: could not init throwaway repo" >&2
+    exit 1
+}
+git -C "$REPO" config user.email probe@example.invalid
+git -C "$REPO" config user.name 'Probe Harness'
+git -C "$REPO" config commit.gpgsign false
+
+COMMIT_JSON='{"tool_name":"Bash","tool_input":{"command":"git add -A && git commit -m \"probe\""}}'
+
+fail=0
+
+# commit_fixture <relpath> <content>  — one file, one commit, in the fixture repo.
+commit_fixture() {
+    local relpath="$1" content="$2"
+    mkdir -p "$REPO/$(dirname "$relpath")"
+    printf '%s\n' "$content" >"$REPO/$relpath"
+    git -C "$REPO" add -A >/dev/null 2>&1
+    git -C "$REPO" commit -q --no-verify -m "probe: $relpath" >/dev/null 2>&1
+}
+
+check() { # $1=expected_exit  $2=fire|silent  $3=label  $4=json
+    local out got fired
+    out=$(echo "$4" | CLAUDE_PROJECT_DIR="$REPO" "$HOOK" 2>/dev/null)
+    got=$?
+    if grep -q 'CLAIM-SHAPE GUARD' <<<"$out"; then
+        fired="fire"
+    elif [ -z "${out//[[:space:]]/}" ]; then
+        fired="silent"
+    else
+        fired="unexpected-output"
+    fi
+    if [ "$got" != "$1" ] || [ "$fired" != "$2" ]; then
+        echo "FAIL [exit=$got want=$1 | $fired want=$2]: $3"
+        fail=1
+    else
+        echo "ok   [exit=$got | $fired]: $3"
+    fi
+}
+
+commit_fixture 'src/claim.ts' '// this field is always populated by the enqueue path'
+check 0 fire "claim-shaped comment added to a .ts file" "$COMMIT_JSON"
+
+commit_fixture 'tracker/task-1.md' '// this field is always populated by the enqueue path'
+check 0 silent "same claim line under tracker/ (excluded meta path)" "$COMMIT_JSON"
+
+commit_fixture 'docs/reference/notes.md' 'The producer guarantees the id is never null here.'
+check 0 silent "claim line under docs/ (excluded meta path)" "$COMMIT_JSON"
+
+commit_fixture '.claude/rules/probe.md' 'A field that is always set needs a producer citation.'
+check 0 silent "claim line under .claude/ (excluded meta path)" "$COMMIT_JSON"
+
+commit_fixture 'CLAUDE.md' 'The pool max is guaranteed to apply at boot.'
+check 0 silent "claim line in root CLAUDE.md (excluded meta file)" "$COMMIT_JSON"
+
+commit_fixture 'services/voice-engine/CLAUDE.md' 'Responses are always present here.'
+check 0 silent "claim line in a per-service CLAUDE.md (excluded meta file)" "$COMMIT_JSON"
+
+commit_fixture 'CURRENT.md' 'The nightly sync is always gated on the hour window.'
+check 0 silent "claim line in a root .md (markdown-wide exclusion)" "$COMMIT_JSON"
+
+commit_fixture 'src/plain.ts' 'export const limit = 100;'
+check 0 silent "commit with no claim shapes" "$COMMIT_JSON"
+
+commit_fixture 'src/never.ts' 'const id = row.id; // never undefined once the job is queued'
+check 0 fire "never-<state> phrasing in a code file" "$COMMIT_JSON"
+
+commit_fixture 'src/cannot.ts' 'return dedupe(rows); // a duplicate id cannot happen here'
+check 0 fire "cannot-<verb> phrasing in a code file" "$COMMIT_JSON"
+
+commit_fixture 'src/isalways.ts' 'seed(map); // the map is always seeded before first read'
+check 0 fire "is-always phrasing in a code file" "$COMMIT_JSON"
+
+commit_fixture 'src/onlyever.ts' 'const job = queue[0]; // this queue only ever holds one job'
+check 0 fire "only-ever phrasing in a code file" "$COMMIT_JSON"
+
+# Mixed commit: the excluded path must not suppress the code file beside it.
+mkdir -p "$REPO/docs" "$REPO/src"
+printf '%s\n' 'Docs prose: the value is always present.' >"$REPO/docs/mixed.md"
+printf '%s\n' 'const v = ctx.value; // guaranteed to exist after step 2' >"$REPO/src/mixed.ts"
+git -C "$REPO" add -A >/dev/null 2>&1
+git -C "$REPO" commit -q --no-verify -m 'probe: mixed' >/dev/null 2>&1
+check 0 fire "mixed commit: excluded doc beside a claim-shaped code file" "$COMMIT_JSON"
+
+# HEAD still carries a claim shape for these — only the COMMAND differs.
+check 0 silent "non-commit Bash command" \
+    '{"tool_name":"Bash","tool_input":{"command":"pnpm test"}}'
+check 0 silent "git command that is not a commit" \
+    '{"tool_name":"Bash","tool_input":{"command":"git log --oneline -5"}}'
+check 0 silent "plumbing subcommand is not a commit (commit-tree)" \
+    '{"tool_name":"Bash","tool_input":{"command":"git commit-tree abc1234 -m x"}}'
+check 0 fire "fixup commit form (any commit variant scans HEAD)" \
+    '{"tool_name":"Bash","tool_input":{"command":"git commit --fixup=abc1234"}}'
+check 0 silent "non-Bash tool" \
+    '{"tool_name":"Read","tool_input":{"file_path":"x"}}'
+check 0 silent "malformed stdin" \
+    '{"tool_name":"Bash", not json'
+check 0 silent "empty stdin" \
+    ''
+
+[ "$fail" = 0 ] && echo "ALL PASS" || {
+    echo "FAILURES"
+    exit 1
+}

--- a/.claude/hooks/claim-shape-guard.sh
+++ b/.claude/hooks/claim-shape-guard.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# PostToolUse hook: after a `git commit` lands, scan the new commit's ADDED
+# lines for claim-shaped assertions — "always populated", "never null",
+# "cannot happen", "guaranteed to", "only ever".
+#
+# Those phrasings state what a field or value HOLDS at runtime, which is a
+# claim only the producer can settle (.claude/rules/00-critical.md § "The
+# producer is authoritative on what a field HOLDS"). A doc comment states the
+# author's intent at writing time and drifts silently; near-identical sibling
+# interfaces make a plausible-looking declaration weak evidence. This hook
+# fires at the moment the claim enters history, when amending is still cheap.
+#
+# Path exclusions: tracker/, backlog/, docs/, .claude/, and ALL *.md files.
+# Markdown is prose that legitimately DESCRIBES these phrasings (CLAUDE.md,
+# CURRENT.md, BACKLOG.md, READMEs — this hook's own source too); the guarded
+# surface is claims entering CODE. Filtering happens on the diff's
+# `+++ b/<path>` headers, so a mixed commit still scans its code files.
+#
+# Advisory only: never blocks, always exits 0, and every git/grep failure
+# fails open.
+#
+# Fixture check: run .claude/hooks/claim-shape-guard.probe.sh after ANY edit.
+
+set -uo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$COMMAND" ] && exit 0
+
+# Cheap bash-native short-circuit before any git work.
+case "$COMMAND" in
+*git*commit*) ;;
+*) exit 0 ;;
+esac
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/git-command.sh
+. "$SCRIPT_DIR/lib/git-command.sh" 2>/dev/null || exit 0
+is_git_commit_command "$COMMAND" || exit 0
+
+# Known limitations (accepted, matching develop-code-commit-guard.sh): the
+# scan targets CLAUDE_PROJECT_DIR's HEAD, so a commit aimed elsewhere —
+# `git -C <other-checkout>` or a cd into a worktree — scans the wrong commit.
+# Accepted because worker agents never commit (opus-implementer contract: the
+# orchestrator commits from the main checkout) and the hook is advisory. The
+# command-text match also can't tell whether a commit LANDED: a failed commit
+# (hook rejection, nothing-to-commit) or a command that merely mentions
+# `git commit` (heredoc, echo) re-scans the current HEAD and may repeat an
+# already-seen banner. Accepted for the same advisory-only reason.
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+
+# Single `git show` piped through one awk pass: file-header tracking for the
+# path exclusions, then the claim-shape match over added lines only.
+# `--format=` suppresses the commit header so only diff lines reach awk; the
+# -c overrides force canonical a/ b/ unquoted headers regardless of the
+# user's diff.mnemonicPrefix / core.quotePath config, which the path
+# exclusions depend on.
+# The 3-line cap lives INSIDE awk rather than in a `head -3`: under
+# `pipefail`, head closing the pipe early makes the whole substitution exit
+# nonzero, and a fail-open `|| MATCHES=""` there would silently discard the
+# very matches it just found. The cap is COMMIT-wide, not per-file — the
+# banner is a pointer to the commit, not an exhaustive report; the amend
+# pass reads the full diff anyway.
+MATCHES=$(git -c diff.mnemonicprefix=false -c core.quotepath=false show --format= HEAD 2>/dev/null | awk '
+/^\+\+\+ /{
+    path = substr($0, 5)
+    sub(/^b\//, "", path)
+    skip = (path ~ /^(tracker|backlog|docs|\.claude)\// || path ~ /\.md$/) ? 1 : 0
+    next
+}
+/^\+/{
+    if (skip || n >= 3) next
+    line = substr($0, 2)
+    if (tolower(line) ~ /always (populated|set|non-null|present|returns)|never (null|empty|undefined|happens|fires)|cannot (be|happen|match|occur)|guaranteed to|(is|are) always|only ever/) {
+        print substr(line, 1, 100)
+        n++
+    }
+}
+')
+
+# Any git/awk failure leaves this empty, which is the fail-open path.
+[ -z "${MATCHES//[[:space:]]/}" ] && exit 0
+
+printf 'CLAIM-SHAPE GUARD: added line(s) assert what a field/value always or never holds:\n'
+printf '%s\n' "$MATCHES" | sed 's/^/  /'
+printf 'Per 00-critical § the producer is authoritative: verify each at its producer/assignment site and cite it; amend if unverified.\n'

--- a/.claude/hooks/fixup-rider-check.probe.sh
+++ b/.claude/hooks/fixup-rider-check.probe.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Fixture check for fixup-rider-check.sh — run after ANY edit to the hook.
+# Asserts the fire/silent table: only a `git commit` carrying `--fixup` fires
+# the rider checklist; plain commits, non-git Bash, other tools, and malformed
+# stdin all stay silent.
+#
+# Like the empty-result-stderr-guard probe, this hook never exits nonzero, so
+# the harness asserts BOTH the exit code and whether the banner reached stdout
+# — exit code alone cannot distinguish fire from silent here.
+#
+# Colocated with the hook — it IS the hook's verification mechanism, a bash
+# harness over a bash hook, run manually on hook edits.
+#
+# Usage: .claude/hooks/fixup-rider-check.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/fixup-rider-check.sh"
+
+fail=0
+check() { # $1=expected_exit  $2=fire|silent  $3=label  $4=json
+    local out got fired
+    out=$(echo "$4" | "$HOOK" 2>/dev/null)
+    got=$?
+    if grep -q 'FIXUP RIDER CHECK' <<<"$out"; then
+        fired="fire"
+    elif [ -z "${out//[[:space:]]/}" ]; then
+        fired="silent"
+    else
+        fired="unexpected-output"
+    fi
+    if [ "$got" != "$1" ] || [ "$fired" != "$2" ]; then
+        echo "FAIL [exit=$got want=$1 | $fired want=$2]: $3"
+        fail=1
+    else
+        echo "ok   [exit=$got | $fired]: $3"
+    fi
+}
+
+check 0 fire "fixup commit, --fixup=<sha> form" \
+    '{"tool_name":"Bash","tool_input":{"command":"git commit --fixup=abc1234"}}'
+check 0 fire "fixup commit, --fixup <sha> space form" \
+    '{"tool_name":"Bash","tool_input":{"command":"git add -A && git commit --fixup abc1234"}}'
+check 0 fire "fixup commit behind a git global flag" \
+    '{"tool_name":"Bash","tool_input":{"command":"git -C /repo commit --fixup=abc1234"}}'
+check 0 silent "plain commit with a message" \
+    '{"tool_name":"Bash","tool_input":{"command":"git add -A && git commit -m \"fix: thing\""}}'
+check 0 silent "amend commit (not a fixup)" \
+    '{"tool_name":"Bash","tool_input":{"command":"git commit --amend --no-edit"}}'
+check 0 silent "non-git Bash command" \
+    '{"tool_name":"Bash","tool_input":{"command":"pnpm test"}}'
+check 0 silent "--fixup token without a git commit (rebase autosquash)" \
+    '{"tool_name":"Bash","tool_input":{"command":"echo --fixup is a commit flag"}}'
+check 0 silent "non-Bash tool" \
+    '{"tool_name":"Read","tool_input":{"file_path":"x"}}'
+check 0 silent "malformed stdin" \
+    '{"tool_name":"Bash", not json'
+check 0 silent "empty stdin" \
+    ''
+
+[ "$fail" = 0 ] && echo "ALL PASS" || {
+    echo "FAILURES"
+    exit 1
+}

--- a/.claude/hooks/fixup-rider-check.sh
+++ b/.claude/hooks/fixup-rider-check.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# PostToolUse hook: after a `git commit --fixup` lands, surface the rider
+# checklist from /tzurot-review-response rule 3.
+#
+# Review-response riders systematically get less scrutiny than planned work —
+# "one clause" / "~10 lines" is exactly the size that skips the checks a
+# planned change gets. The three questions below are the authoring-time
+# complement to rule 3's test gate: the test gate catches breakage, this
+# catches absence.
+#
+# Advisory only: never blocks, always exits 0. Fires on every matching commit
+# (the banner is short) — no dedup state file, because a rider committed twice
+# deserves the checklist twice. Known limitation (accepted, same class as
+# claim-shape-guard's): detection is command-text only, so a commit whose
+# MESSAGE merely mentions `--fixup` also fires — spurious banner, no harm.
+#
+# Fixture check: run .claude/hooks/fixup-rider-check.probe.sh after ANY edit.
+
+set -uo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$COMMAND" ] && exit 0
+
+# Cheap bash-native short-circuit: the overwhelming majority of Bash calls
+# carry no fixup token at all and exit here (sibling hooks set the same
+# do-cheap-checks-first precedent).
+case "$COMMAND" in
+*--fixup*) ;;
+*) exit 0 ;;
+esac
+
+# Both `git commit` and the fixup flag in either form (`--fixup=<sha>` /
+# `--fixup <sha>`) must be present.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/git-command.sh
+. "$SCRIPT_DIR/lib/git-command.sh" 2>/dev/null || exit 0
+is_git_commit_command "$COMMAND" || exit 0
+if ! grep -qE '(^|[[:space:]])--fixup([=[:space:]]|$)' <<<"$COMMAND"; then
+    exit 0
+fi
+
+cat <<'EOF'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FIXUP RIDER CHECK
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Per /tzurot-review-response rule 3 — a rider that ADDS or MOVES code
+answers the same three questions a planned change answers:
+  (a) Does the addition need its own test? ("it's small" is not an exemption)
+  (b) Does it stale a comment or doc elsewhere — including files this fix
+      did not touch (schema.prisma doc comments, rules, skills)?
+  (c) Does moving code between files change what a coverage or mutation
+      gate measures?
+If any answer is yes and unhandled, amend before pushing.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/.claude/hooks/lib/git-command.sh
+++ b/.claude/hooks/lib/git-command.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Shared detection: does a Bash tool command string invoke `git commit`?
+# Sourced by claim-shape-guard.sh and fixup-rider-check.sh — the regex lives
+# here so a future tweak (new global-flag shape, new commit variant) lands in
+# one place. (develop-code-commit-guard.sh and git-commit-filter-guard.sh
+# carry equivalent Python-side logic — sync manually if the shape changes.)
+
+# is_git_commit_command <command-string> → exit 0 when the string invokes
+# `git commit`, tolerating global flags (`git -C path commit`, `git -c k=v
+# commit`) and every commit variant (--fixup, --amend, heredoc bodies). The
+# trailing ([^-a-zA-Z0-9_]|$) keeps plumbing subcommands (commit-tree,
+# commit-graph) from matching — a bare \b treats the hyphen as a boundary.
+# Scope is literal `git commit` only: revert/cherry-pick/merge also advance
+# HEAD without firing (accepted — the guarded pattern is authored commits).
+# The \b in the git anchor is a GNU-grep extension; fine on this project's
+# Linux environment, would need rework under BSD/macOS grep.
+is_git_commit_command() {
+    grep -qE '\bgit([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+commit([^-a-zA-Z0-9_]|$)' <<<"$1"
+}

--- a/.claude/hooks/skill-eval.sh
+++ b/.claude/hooks/skill-eval.sh
@@ -102,6 +102,13 @@ if echo "$PROMPT" | grep -qiE 'review (feedback|finding|comment)|claude.?review|
     RELEVANT_SKILLS="$RELEVANT_SKILLS tzurot-review-response"
 fi
 
+# Orchestrator mode → tzurot-orchestration skill. The primary trigger is
+# agent-internal (invoke before the first src edit of a delegated unit); this
+# hook is the second path, for the owner asking about delegation directly.
+if echo "$PROMPT" | grep -qiE 'delegate|delegation|orchestrat|implementer|worker spec|spawn.*(agent|worker|implementer)'; then
+    RELEVANT_SKILLS="$RELEVANT_SKILLS tzurot-orchestration"
+fi
+
 # Trim whitespace
 RELEVANT_SKILLS=$(echo "$RELEVANT_SKILLS" | xargs)
 

--- a/.claude/rules/10-working-posture.md
+++ b/.claude/rules/10-working-posture.md
@@ -104,6 +104,14 @@ posture is applying it to YOURSELF mid-session, at the moment of the miss —
 and choosing the surface by who needs it: every contributor → rules; every
 session of you on this machine → memory.
 
+## Scope contract: deliver what was asked, at the scope intended
+
+Trigger: interpreting any task or review finding. Make routine judgment calls
+yourself; check in only when different readings of the request would lead to
+materially different work. Never quietly narrow, widen, or transform the
+request — a scope change is announced before it happens, not discovered in
+the diff.
+
 ## Report shape
 
 Lead with the outcome. Keep an honest ledger — the day's summary includes your

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,6 +77,14 @@
           {
             "type": "command",
             "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/empty-result-stderr-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/fixup-rider-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/claim-shape-guard.sh"
           }
         ]
       }

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -7,21 +7,22 @@
 
 ## Available Skills (Procedures)
 
-| Skill                                                       | Purpose                                                        | Invoke With               |
-| ----------------------------------------------------------- | -------------------------------------------------------------- | ------------------------- |
-| [tzurot-git-workflow](./tzurot-git-workflow/SKILL.md)       | Commit, PR, rebase, release procedures                         | `/tzurot-git-workflow`    |
-| [tzurot-deployment](./tzurot-deployment/SKILL.md)           | Railway deployment & troubleshooting                           | `/tzurot-deployment`      |
-| [tzurot-docs](./tzurot-docs/SKILL.md)                       | Session start/end, CURRENT.md workflow                         | `/tzurot-docs`            |
-| [tzurot-db-vector](./tzurot-db-vector/SKILL.md)             | Prisma migrations, drift fixes, pgvector                       | `/tzurot-db-vector`       |
-| [tzurot-testing](./tzurot-testing/SKILL.md)                 | Test execution, coverage audits, tier verification             | `/tzurot-testing`         |
-| [tzurot-council-mcp](./tzurot-council-mcp/SKILL.md)         | Multi-perspective AI consultation                              | `/tzurot-council-mcp`     |
-| [tzurot-doc-audit](./tzurot-doc-audit/SKILL.md)             | Documentation + auto-memory freshness audit                    | `/tzurot-doc-audit`       |
-| [tzurot-arch-audit](./tzurot-arch-audit/SKILL.md)           | Architecture health audit                                      | `/tzurot-arch-audit`      |
-| [tzurot-bug-remediation](./tzurot-bug-remediation/SKILL.md) | Recurring-bug protocol: evidence → class sweep → guard         | `/tzurot-bug-remediation` |
-| [tzurot-reuse-scout](./tzurot-reuse-scout/SKILL.md)         | Pre-write reuse scouting, drifted-duplicate consolidation      | `/tzurot-reuse-scout`     |
-| [tzurot-review-response](./tzurot-review-response/SKILL.md) | PR review-response: edit-shape triage, auto-apply vs ASK       | `/tzurot-review-response` |
-| [tzurot-design-boulder](./tzurot-design-boulder/SKILL.md)   | Grounded, council-reviewed design sessions → ACCEPTED artifact | `/tzurot-design-boulder`  |
-| [tzurot-session-mining](./tzurot-session-mining/SKILL.md)   | Mine session logs for recurring friction → structural fixes    | `/tzurot-session-mining`  |
+| Skill                                                       | Purpose                                                         | Invoke With               |
+| ----------------------------------------------------------- | --------------------------------------------------------------- | ------------------------- |
+| [tzurot-git-workflow](./tzurot-git-workflow/SKILL.md)       | Commit, PR, rebase, release procedures                          | `/tzurot-git-workflow`    |
+| [tzurot-deployment](./tzurot-deployment/SKILL.md)           | Railway deployment & troubleshooting                            | `/tzurot-deployment`      |
+| [tzurot-docs](./tzurot-docs/SKILL.md)                       | Session start/end, CURRENT.md workflow                          | `/tzurot-docs`            |
+| [tzurot-db-vector](./tzurot-db-vector/SKILL.md)             | Prisma migrations, drift fixes, pgvector                        | `/tzurot-db-vector`       |
+| [tzurot-testing](./tzurot-testing/SKILL.md)                 | Test execution, coverage audits, tier verification              | `/tzurot-testing`         |
+| [tzurot-council-mcp](./tzurot-council-mcp/SKILL.md)         | Multi-perspective AI consultation                               | `/tzurot-council-mcp`     |
+| [tzurot-doc-audit](./tzurot-doc-audit/SKILL.md)             | Documentation + auto-memory freshness audit                     | `/tzurot-doc-audit`       |
+| [tzurot-arch-audit](./tzurot-arch-audit/SKILL.md)           | Architecture health audit                                       | `/tzurot-arch-audit`      |
+| [tzurot-bug-remediation](./tzurot-bug-remediation/SKILL.md) | Recurring-bug protocol: evidence → class sweep → guard          | `/tzurot-bug-remediation` |
+| [tzurot-reuse-scout](./tzurot-reuse-scout/SKILL.md)         | Pre-write reuse scouting, drifted-duplicate consolidation       | `/tzurot-reuse-scout`     |
+| [tzurot-review-response](./tzurot-review-response/SKILL.md) | PR review-response: edit-shape triage, auto-apply vs ASK        | `/tzurot-review-response` |
+| [tzurot-design-boulder](./tzurot-design-boulder/SKILL.md)   | Grounded, council-reviewed design sessions → ACCEPTED artifact  | `/tzurot-design-boulder`  |
+| [tzurot-session-mining](./tzurot-session-mining/SKILL.md)   | Mine session logs for recurring friction → structural fixes     | `/tzurot-session-mining`  |
+| [tzurot-orchestration](./tzurot-orchestration/SKILL.md)     | Delegation posture, worker spec template, full-diff review gate | `/tzurot-orchestration`   |
 
 ## Rules (Auto-Loaded)
 

--- a/.claude/skills/tzurot-orchestration/SKILL.md
+++ b/.claude/skills/tzurot-orchestration/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: tzurot-orchestration
+description: 'Orchestrator mode: when to delegate implementation to a worker agent, the spec template every worker gets, and the full-diff review gate before any commit. Invoke with /tzurot-orchestration at the start of any implementation unit run in orchestrator mode — the moment a task fix shape is known, before the first src Edit/Write.'
+lastUpdated: '2026-08-05'
+---
+
+# Orchestrator Mode
+
+**Invoke with /tzurot-orchestration** at the start of any implementation unit
+run in orchestrator mode — the moment a task's fix shape is known, BEFORE the
+first src Edit/Write.
+
+## Why this procedure exists
+
+Separating the drafting context from the judging context is what catches
+confident-but-wrong work: the context that wrote a diff cannot see its own
+assumptions, and a fresh reader can. The orchestrator's full-diff read is the
+gate that stops worker defects before CI does.
+
+## Mode decision table
+
+Who drives the main loop determines the delegation posture. The mechanism is
+quality — fresh context plus an independent diff review — not budget.
+
+| Driver                       | Posture                                                                                                                                                                                                                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fable main loop**          | Delegate implementation to `opus-implementer` by DEFAULT. "It's small" is not an inline justification. Inline only for: trivial mechanical edits (~a few lines), fixes discovered mid-review of a worker's diff, or work where writing the spec costs more than the edit.   |
+| **Opus main loop**           | Delegate substantive units — the fresh-context worker plus a separate diff review is the quality mechanism. But do NOT delegate work finishable in a handful of tool calls: Opus 5 over-delegates by documented tendency (prompting guide § controlling subagent spawning). |
+| **Bulk reading/exploration** | Explore/Plan agents, either driver. Reading fan-out is delegation's cheapest and least risky use.                                                                                                                                                                           |
+
+## The spec template
+
+Every implementation spec carries these sections, by name. A missing section is
+a gap the worker will fill by guessing.
+
+1. **Task** — the design decisions already made. The worker executes; it never
+   designs.
+2. **Files in scope.**
+3. **Landmines** — enumerated known traps: formatters that rewrite the file,
+   gated baselines, hook behavior, fixture shapes.
+4. **Authorized routine decisions** — name the 2–3 calls the worker may make
+   solo. Everything material not listed is a stop condition.
+5. **Stop conditions** — the task-specific ones, on top of the agent contract's
+   defaults.
+6. **Verification gates — enumerate the exact commands.** Name every gate CI
+   will run for the touched packages; in particular BOTH `typecheck` AND
+   `typecheck:spec` where the package defines it (separate tsconfig — plain
+   `typecheck` misses test-file errors). Sequential, long timeouts, never in
+   parallel (`05-tooling.md` § Resource Constraints).
+7. **Branch setup** — as a separate first step. The develop-code-commit-guard
+   evaluates the current branch before compound commands run, so branch
+   creation has to land on its own before any edit.
+8. **Report requirements** — deviations flagged, verbatim verification tails,
+   survivor-grep results.
+
+## Worktree spawns
+
+Before trusting any code-grounded output from a worktree-isolated worker,
+verify the worktree's base against the intended SHA:
+
+```bash
+git -C <worktree-path> log -1 --format='%H %s'
+```
+
+A stale base is the failure mode that reads as competence: the worker behaves
+correctly against the code it can see, and confidently "corrects" a spec that
+was right about the code it cannot.
+
+## While the worker runs
+
+Pre-stage the next unit's grounding — read the files, profile the data, draft
+the next spec. Never touch the worker's files while it holds them. Monitors
+exist so waiting is never the activity (`10-working-posture.md` § Momentum).
+
+## When the worker reports
+
+**Read the FULL diff before any commit.** This gate is the reason the split
+works; skipping it collapses orchestration back into a single context that
+reviewed nothing. Then:
+
+- A flagged stop or ambiguity is a good outcome — resolve it and re-dispatch,
+  not a worker failure to work around.
+- Check every reported deviation against the spec's intent, not just its
+  letter.
+- Re-run the gates yourself when the worker's verification tails are absent or
+  truncated; a claim without command output is unverified.
+- Then the normal commit → PR → monitor cycle per `/tzurot-git-workflow`.
+
+## Opus-main-loop posture
+
+Three habits that matter more when Opus 5 drives the main loop than when it
+works behind a spec.
+
+- **Compact at unit boundaries, proactively.** Error quality degrades as the
+  context window fills, and the degradation is invisible from inside it. Close
+  the unit out to `CURRENT.md` / the tracker first, then compact — a boundary
+  compaction loses nothing, while a mid-unit one loses the work-stack pointer.
+- **Escalate as one named question plus a recommendation**
+  (`09-interaction-style.md`). A menu without a pick is not an escalation; it
+  moves the decision to the user without the analysis that would let them make
+  it cheaply.
+- **Cite the read that proved it.** Before stating any factual claim about the
+  code, name the tool result from THIS session that establishes it
+  (`00-critical.md` § Don't Present Speculation as Fact). When challenged on a
+  claim, re-verify at the source rather than defending it — the pull to defend
+  is strongest exactly when the claim came from memory rather than a read.
+
+## Relationship to the rules
+
+- **`.claude/agents/opus-implementer.md`** is the worker's own contract — the
+  spec template above supplies what that contract expects to receive.
+- **`00-critical.md`** § Merge Approval and § Never Merge PRs Without Completed
+  CI govern the merge gate; the diff-read gate here sits before it, not instead
+  of it.
+- **`10-working-posture.md`** § Momentum and § Scope contract govern what the
+  orchestrator does between dispatches.
+- **`/tzurot-review-response`** owns what happens when the reviewer, rather
+  than the orchestrator, finds the defect.

--- a/.claude/skills/tzurot-session-mining/SKILL.md
+++ b/.claude/skills/tzurot-session-mining/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-session-mining
 description: 'Mine Claude session logs for recurring friction and convert findings into structural fixes (rules/skills/hooks). Invoke with /tzurot-session-mining periodically or when a failure pattern feels recurrent but unquantified.'
-lastUpdated: '2026-08-02'
+lastUpdated: '2026-08-05'
 ---
 
 # Session Friction Mining
@@ -92,6 +92,24 @@ alongside direct user messages. Do not pre-filter — compaction summaries
 preserve verbatim user quotes from compacted-away turns (the "All user
 messages" sections), and several of the highest-signal findings in the
 original audit survived ONLY there. The miner agent sorts signal from noise.
+
+**Mid-turn messages are NOT `type=="user"`.** Messages typed while a turn is
+running land as `type=="queue-operation"` entries (`operation=="enqueue"`,
+plain-string `.content`) — a user-only extraction drops exactly the
+corrections issued while the user watched something go wrong. Union them in:
+
+    jq -r 'select(.type == "queue-operation" and .operation == "enqueue")
+      | select((.content // "") | length > 0)
+      | "=== \(.timestamp) [mid-turn] ===\n\(.content)\n"' \
+      ~/.claude/projects/-home-deck-Projects-tzurot/$f.jsonl >> $CORPUS/$f.txt
+
+Blocks are appended out of chronological order; the timestamps let the miner
+interleave. Verify non-zero yield with a bare count first when the session had
+any mid-turn traffic. The stream is not only human messages — Monitor output
+and task-notification blocks enqueue the same way, so the extract will carry
+harness dumps beside the human corrections. That is consistent with the
+deliberately-raw posture above: the miner sorts them, the `[mid-turn]` marker
+tells it where to look.
 
 ## Step 2 — Mine (parallel reader agents, one per corpus file)
 

--- a/.claude/skills/tzurot-testing/SKILL.md
+++ b/.claude/skills/tzurot-testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-testing
 description: 'Testing procedures. Invoke with /tzurot-testing for test execution, coverage audits, and debugging test failures.'
-lastUpdated: '2026-08-02'
+lastUpdated: '2026-08-05'
 ---
 
 # Testing Procedures
@@ -146,6 +146,17 @@ it('should call service', () => {
   expect(getMyServiceMock().someMethod).toHaveBeenCalled();
 });
 ```
+
+## Mock-reachability check (before writing assertions)
+
+Before asserting on a subject that sits behind a mocked collaborator, answer
+two questions: (a) which mock makes this code path reachable, and (b) what
+would a wiring bug at that seam look like in this test's output? If the
+answer to (b) is "the test can't see it," the test asserts through the seam
+it mocked — add the seam assertion per `02-code-standards.md` § Assert what
+crosses a mocked seam before writing more cases. This is the coverage-illusion
+class: a mock missing one property leaves the dependent branch green and
+untested; a feature flag can no-op silently under a fully green suite.
 
 ## Integration Tests with PGLite
 


### PR DESCRIPTION
## Summary

Hardens the harness for sessions where Claude Opus 5 drives — as the main loop or as `opus-implementer` workers. Grounded in two inputs: Anthropic's Opus 5 prompting guide, and a model-attributed friction analysis of recent session history (Opus-driven windows measured 3.00 CI cycles/PR vs 1.77 under Fable, with the defects concentrated in classes no existing gate watches: unverified claims hardened under challenge, riders under-scrutinized relative to planned work, and coverage illusions behind mocked seams).

## Changes

- **NEW `/tzurot-orchestration` skill** — promotes the orchestrator working mode into a first-class procedure: delegation posture *per driving model* (Fable delegates by default; Opus delegates substantive units but not handful-of-tool-call work, per the guide's over-delegation warning), the 8-part worker spec template (verification gates must enumerate exact commands, including `typecheck:spec`), worktree base verification, the full-diff review gate, and an Opus-main-loop posture section (compact at unit boundaries; escalate with a recommendation; cite the read behind every claim).
- **`opus-implementer.md`** — replaces the blanket stop-on-ambiguity with a materiality contract (routine calls allowed + listed in the report; observable-behavior/API/schema/gate divergence stops), adds a verification floor (`test` + `typecheck` + `typecheck:spec` for touched packages even when the spec omits them), and a Report-contract bullet for routine calls.
- **`10-working-posture.md`** — scope contract, near-verbatim from the prompting guide's task-scope section (deliver what was asked at the scope intended; scope changes are announced, not discovered in the diff).
- **`tzurot-testing`** — mock-reachability check: name the mock that makes the subject reachable and what a wiring bug would look like, before writing assertions.
- **`tzurot-session-mining`** — extraction fix: mid-turn messages land as `queue-operation` entries, not `type=="user"`; the recipe now unions both (a real run found 17 dropped human messages).
- **Two advisory PostToolUse hooks** (+ probe harnesses): `fixup-rider-check` surfaces the rider checklist after any `--fixup` commit; `claim-shape-guard` flags claim-shaped assertions ("always populated", "never null") in committed added lines and asks for a producer citation, with meta-path exclusions. Shared commit-detection regex lives in `lib/git-command.sh`.

## Verification

- Both probe harnesses run green — 10 + 19 cases after review-round fixture additions (fire/silent asserted per case, throwaway-repo fixtures for the HEAD-scanning hook).
- `pnpm quality` fully green (all 28 checks, including both typechecks and `lines:check`).
- `pnpm test` not run: the diff contains zero `.ts` files (md/sh/json only); the unit suite's inputs are unchanged from the release-green state, and `typecheck`/`typecheck:spec` ran over the tree in the quality gate.
- `settings.json` validated as JSON; `skill-eval.sh` smoke shows the new keyword block firing without affecting existing blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)