### PR TITLE
fix: exclude git plumbing subcommands from the python-side commit guards

### DIFF
--- a/.claude/hooks/claim-shape-guard.sh
+++ b/.claude/hooks/claim-shape-guard.sh
@@ -24,13 +24,24 @@
 set -uo pipefail
 
 INPUT=$(cat)
+
+# Cheapest possible short-circuit, on the RAW stdin, before jq is even
+# forked: a payload carrying no git+commit tokens anywhere cannot decode to
+# a command that carries them, so the overwhelming majority of Bash calls
+# (and every non-Bash tool call) leave without spawning a process.
+case "$INPUT" in
+*git*commit*) ;;
+*) exit 0 ;;
+esac
+
 TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 
 COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
 [ -z "$COMMAND" ] && exit 0
 
-# Cheap bash-native short-circuit before any git work.
+# Same short-circuit against the DECODED command — the raw-stdin pass above
+# can be satisfied by tokens living in some other JSON field.
 case "$COMMAND" in
 *git*commit*) ;;
 *) exit 0 ;;

--- a/.claude/hooks/develop-code-commit-guard.probe.sh
+++ b/.claude/hooks/develop-code-commit-guard.probe.sh
@@ -101,6 +101,11 @@ run 2 "dirty .mts module"                         'git commit -m "x"'           
 run 2 "dirty .cts module"                         'git commit -m "x"'                                      'services/probe.cts'
 run 2 "dirty yaml config"                         'git commit -m "x"'                                      'services/probe/config.yaml'
 run 2 "dirty Dockerfile"                          'git commit -m "x"'                                      'services/probe/Dockerfile'
+# Plumbing subcommands are not `git commit`: `-` is a non-word character, so
+# a bare `commit\b` matched them and blocked a tree-writing plumbing call.
+run 0 "plumbing: git commit-tree stays silent"    'git commit-tree abc1234 -m x'                           'services/probe.ts'
+run 0 "plumbing: git commit-graph stays silent"   'git commit-graph write'                                 'services/probe.ts'
+run 0 "plumbing: commit-tree behind -C flag"      'git -C /some/path commit-tree abc1234'                  'services/probe.ts'
 run 0 "escape hatch in command position"          'TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 git commit -m "x"'   'services/probe.ts'
 run 0 "escape hatch, canonical heredoc form"      "TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 $CANONICAL_HEREDOC"  'services/probe.ts'
 run 0 "non-git command"                           'echo hello'                                             'services/probe.ts'

--- a/.claude/hooks/develop-code-commit-guard.sh
+++ b/.claude/hooks/develop-code-commit-guard.sh
@@ -76,7 +76,18 @@ cmd = re.sub(r"'[^']*'", "S", cmd)
 cmd = re.sub(r'"[^"]*"', "S", cmd)
 
 # `git commit` with optional global flags (-C <path>, --git-dir=…, etc.).
-if not re.search(r"\bgit(\s+-{1,2}\S+(\s+\S+)?)*\s+commit\b", cmd):
+# The trailing (?![-\w]) is load-bearing: a plain \b would also match the
+# plumbing subcommands `git commit-tree` / `git commit-graph`, because `-`
+# is a non-word character and so a word boundary exists right before it.
+# Those write no commit and must never be treated as one.
+#
+# Python's \w is Unicode-aware, so this is equivalent to the bash side's
+# ASCII-only ([^-a-zA-Z0-9_]|$) for every real git invocation but not for
+# a non-ASCII suffix (`git commit日本語`). Deliberately NOT re.ASCII: that
+# flag narrows \s in the same pattern too, so a non-breaking space between
+# `git` and `commit` would stop matching and the guard would MISS a real
+# commit — failing open on a pasteable input to close a hypothetical one.
+if not re.search(r"\bgit(\s+-{1,2}\S+(\s+\S+)?)*\s+commit(?![-\w])", cmd):
     print("ok")
     raise SystemExit
 

--- a/.claude/hooks/fixup-rider-check.sh
+++ b/.claude/hooks/fixup-rider-check.sh
@@ -19,15 +19,24 @@
 set -uo pipefail
 
 INPUT=$(cat)
+
+# Cheapest possible short-circuit, on the RAW stdin, before jq is even
+# forked: firing requires a `git commit`, so a payload carrying no git+commit
+# tokens anywhere cannot decode to one — the overwhelming majority of Bash
+# calls (and every non-Bash tool call) leave without spawning a process.
+case "$INPUT" in
+*git*commit*) ;;
+*) exit 0 ;;
+esac
+
 TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 
 COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
 [ -z "$COMMAND" ] && exit 0
 
-# Cheap bash-native short-circuit: the overwhelming majority of Bash calls
-# carry no fixup token at all and exit here (sibling hooks set the same
-# do-cheap-checks-first precedent).
+# Cheap bash-native short-circuit: a commit carrying no fixup token at all
+# exits here (sibling hooks set the same do-cheap-checks-first precedent).
 case "$COMMAND" in
 *--fixup*) ;;
 *) exit 0 ;;

--- a/.claude/hooks/git-commit-filter-guard.probe.sh
+++ b/.claude/hooks/git-commit-filter-guard.probe.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Fixture check for git-commit-filter-guard.sh — run after ANY edit to the
+# hook. Asserts the exit-code table over the shapes that matter: a git
+# commit/push whose output feeds a filter blocks (exit 2); the same command
+# unpiped or feeding a pure pass-through passes; a filter on some OTHER
+# pipeline passes; and the plumbing subcommands (`git commit-tree`,
+# `git commit-graph`) are not commits and must never block.
+#
+# This hook reads no git state — it decides purely from the command text —
+# so the harness needs no fixture repo, only the JSON payload shape the
+# PreToolUse hook receives on stdin.
+#
+# Colocated with the hook (not packages/tooling) because it IS the hook's
+# verification mechanism — a bash exit-code harness over a bash hook, run
+# manually on hook edits, with no ops-CLI surface.
+#
+# Usage: .claude/hooks/git-commit-filter-guard.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/git-commit-filter-guard.sh"
+
+FAILURES=0
+
+# run <expected-exit> <label> <command>
+run() {
+  local expected="$1" label="$2" cmd="$3"
+  jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}' \
+    | "$HOOK" >/dev/null 2>&1
+  local actual=$?
+  if [ "$actual" -eq "$expected" ]; then
+    printf 'PASS  (exit %d)  %s\n' "$actual" "$label"
+  else
+    printf 'FAIL  (exit %d, expected %d)  %s\n' "$actual" "$expected" "$label"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# --- blocking shapes: a filter downstream of a commit/push -----------------
+run 2 "commit piped to tail"                  'git commit -m "x" | tail'
+run 2 "commit piped to grep"                  'git commit -m "x" | grep -i error'
+run 2 "push piped to tail"                    'git push | tail'
+run 2 "push piped to head"                    'git push origin develop | head -5'
+run 2 "git -C global-flag commit piped"       'git -C /some/path commit -m "x" | tail'
+run 2 "filter behind a pass-through stage"    'git commit -m "x" | cat | tail'
+run 2 "commit piped via |& shorthand"         'git commit -m "x" |& grep fatal'
+
+# --- plumbing subcommands are NOT `git commit` ----------------------------
+# `-` is a non-word character, so a bare `commit\b` matched these and blocked
+# a tree-writing plumbing call that this guard has no business touching.
+run 0 "plumbing: commit-tree piped to tail"   'git commit-tree abc1234 | tail'
+run 0 "plumbing: commit-graph piped to tail"  'git commit-graph write | tail'
+run 0 "plumbing: commit-tree behind -C flag"  'git -C /some/path commit-tree abc1234 | head -1'
+# The lookahead sits outside the (commit|push) alternation, so it guards the
+# push branch too — `push-all` was a false positive under the bare \b form.
+run 0 "plumbing: push-all piped to tail"      'git push-all origin | tail'
+
+# --- non-blocking shapes --------------------------------------------------
+run 0 "unpiped commit"                        'git commit -m "x"'
+run 0 "unpiped push"                          'git push origin develop'
+run 0 "commit into a pure pass-through"       'git commit -m "x" | cat'
+run 0 "filter on an unrelated pipeline"       'git status | grep ts && git commit -m "x"'
+run 0 "non-git command with a filter"         'pnpm test | tail -20'
+run 0 "git log piped to a filter"             'git log --oneline | head -5'
+run 0 "commit message merely mentions a pipe" 'git commit -m "fix: stop piping git push | tail"'
+
+# --- malformed / non-Bash input fails OPEN --------------------------------
+printf '{"tool_name":"Read","tool_input":{"file_path":"x"}}' | "$HOOK" >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  printf 'PASS  (exit 0)  non-Bash tool passes\n'
+else
+  printf 'FAIL  non-Bash tool should pass\n'
+  FAILURES=$((FAILURES + 1))
+fi
+
+printf 'not json at all' | "$HOOK" >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  printf 'PASS  (exit 0)  malformed tool-input fails open\n'
+else
+  printf 'FAIL  malformed tool-input should fail open\n'
+  FAILURES=$((FAILURES + 1))
+fi
+
+printf '' | "$HOOK" >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  printf 'PASS  (exit 0)  empty stdin fails open\n'
+else
+  printf 'FAIL  empty stdin should fail open\n'
+  FAILURES=$((FAILURES + 1))
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+  printf '\n%d probe(s) FAILED\n' "$FAILURES" >&2
+  exit 1
+fi
+printf '\nAll probes passed\n'

--- a/.claude/hooks/git-commit-filter-guard.sh
+++ b/.claude/hooks/git-commit-filter-guard.sh
@@ -61,7 +61,20 @@ cmd = cmd.replace("|&", "|")
 FILTERS = re.compile(r"^\s*(tail|head|grep|sed|awk)\b")
 # Tolerate git global flags between `git` and the subcommand:
 # -C <path>, -c k=v, --no-pager, --git-dir=..., etc.
-GIT_TARGET = re.compile(r"\bgit(\s+-{1,2}\S+(\s+\S+)?)*\s+(commit|push)\b")
+# The trailing (?![-\w]) sits OUTSIDE the alternation so it guards both
+# branches: a plain \b would also match the plumbing subcommands
+# `git commit-tree` / `git commit-graph`, because `-` is a non-word
+# character and so a word boundary exists right before it. Piping those
+# through a filter swallows nothing this guard cares about. Guarding the
+# push branch also kills a `git push-all` false positive.
+#
+# Python's \w is Unicode-aware, so this is equivalent to the bash side's
+# ASCII-only ([^-a-zA-Z0-9_]|$) for every real git invocation but not for
+# a non-ASCII suffix (`git commit日本語`). Deliberately NOT re.ASCII: that
+# flag narrows \s in the same pattern too, so a non-breaking space between
+# `git` and `commit` would stop matching and the guard would MISS a real
+# commit — failing open on a pasteable input to close a hypothetical one.
+GIT_TARGET = re.compile(r"\bgit(\s+-{1,2}\S+(\s+\S+)?)*\s+(commit|push)(?![-\w])")
 for segment in re.split(r"&&|\|\||;|\n", cmd):
     stages = segment.split("|")
     for i, stage in enumerate(stages[:-1]):

--- a/.claude/skills/tzurot-session-mining/SKILL.md
+++ b/.claude/skills/tzurot-session-mining/SKILL.md
@@ -98,10 +98,14 @@ running land as `type=="queue-operation"` entries (`operation=="enqueue"`,
 plain-string `.content`) — a user-only extraction drops exactly the
 corrections issued while the user watched something go wrong. Union them in:
 
-    jq -r 'select(.type == "queue-operation" and .operation == "enqueue")
-      | select((.content // "") | length > 0)
-      | "=== \(.timestamp) [mid-turn] ===\n\(.content)\n"' \
-      ~/.claude/projects/-home-deck-Projects-tzurot/$f.jsonl >> $CORPUS/$f.txt
+    # same shell, same $CORPUS and same session list as the block above —
+    # $f and $CORPUS are loop-scoped, so this must run inside the loop too
+    for f in <session-uuid-1> <session-uuid-2>; do
+      jq -r 'select(.type == "queue-operation" and .operation == "enqueue")
+        | select((.content // "") | length > 0)
+        | "=== \(.timestamp) [mid-turn] ===\n\(.content)\n"' \
+        ~/.claude/projects/-home-deck-Projects-tzurot/$f.jsonl >> $CORPUS/$f.txt
+    done
 
 Blocks are appended out of chronological order; the timestamps let the miner
 interleave. Verify non-zero yield with a bare count first when the session had


### PR DESCRIPTION
Substantially addresses TASK-441 — member (d) is deliberately deferred, so **the task stays open**. See "Not in scope" below.

## The bug

`\bcommit\b` matches `git commit-tree` and `git commit-graph` as well as `git commit` — `-` is a non-word character, so a word boundary exists right before it. #1980 fixed this in the bash-side `lib/git-command.sh` but left the two python-side guards on the old pattern, and `develop-code-commit-guard` **blocks**: a legitimate plumbing call on develop with dirty review-gated files in the tree was rejected as an on-long-lived-branch code commit.

Verified rather than assumed — the old and new patterns evaluated side by side:

```
git commit-tree abc123 -m x      old=True  new=False
git commit-graph write           old=True  new=False
git push-all origin              old=True  new=False
git commit -m S                  old=True  new=True
git -C /p commit -m S            old=True  new=True
```

## The fix

Both regexes now end in a `(?![-\w])` lookahead — the exact Python equivalent of the bash `([^-a-zA-Z0-9_]|$)` form. In `git-commit-filter-guard` the lookahead sits **outside** the alternation so it guards `push` too, which also kills a `git push-all` false positive.

## Rides along (same touch, from #1980's round-5 review)

- `claim-shape-guard` and `fixup-rider-check` now short-circuit on raw stdin before forking `jq`, so their cheap-first comments are accurate. The decoded-`$COMMAND` pass is retained — the raw pass can be satisfied by tokens in another JSON field, and dropping it would widen the hooks.
- `git-commit-filter-guard` gains a probe harness. It had none; the other three guards did.
- The session-mining mid-turn `jq` snippet is shown inside its `for` loop, so the loop-scoped `$f`/`$CORPUS` bindings are visible and it runs as printed.

## Verification

80 probe cases green across the four harnesses, re-run independently of the implementer's report:

```
develop-code-commit-guard -> exit=0 | 29 pass, 0 fail
git-commit-filter-guard   -> exit=0 | 21 pass, 0 fail
claim-shape-guard         -> exit=0 | 20 pass, 0 fail
fixup-rider-check         -> exit=0 | 10 pass, 0 fail
```

Every plumbing pin was checked against the OLD pattern first, so none of them is trivially true. `pnpm quality` green (28/28 checks). `pnpm test` not run and not applicable — the diff contains no `.ts`.

## Not in scope

TASK-441 member (d) — reusing the guards' heredoc/quote-stripping in `is_git_commit_command` to kill message-text false-fires — is deliberately left out. It needs a runtime-confirmed false-fire first, and the bash-vs-Python tradeoff (bash can't express the delimiter backreference; forking Python centralizes it at one process per call) deserves its own PR. **TASK-441 remains open for it and must not be marked Done by this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)