### PR TITLE
feat(bot-client): log Discord gateway shard lifecycle events

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -47,6 +47,7 @@ import { DenylistCache } from './services/DenylistCache.js';
 import { DMCacheWarmer } from './services/DMCacheWarmer.js';
 import { StartupDMPrewarmer } from './services/StartupDMPrewarmer.js';
 import { registerServices } from './services/serviceRegistry.js';
+import { registerShardLifecycleLogging } from './services/ShardLifecycleLogger.js';
 
 // Processors
 import {
@@ -504,6 +505,9 @@ client.once(Events.ClientReady, () => {
 client.on(Events.Error, error => {
   logger.error({ err: error }, 'Discord client error');
 });
+
+// Gateway shard lifecycle — without these, a dead websocket looks like a healthy, silent process.
+registerShardLifecycleLogging(client, logger);
 
 // unhandledRejection handling is registered by registerProcessLifecycle below
 // (rejectionPolicy: 'log-and-live').

--- a/services/bot-client/src/services/ShardLifecycleLogger.test.ts
+++ b/services/bot-client/src/services/ShardLifecycleLogger.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { type Client, Events } from 'discord.js';
+import { registerShardLifecycleLogging } from './ShardLifecycleLogger.js';
+
+type Handler = (...args: unknown[]) => void;
+
+describe('registerShardLifecycleLogging', () => {
+  let handlers: Map<string, Handler>;
+  let client: Client;
+  let logger: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  /** Invokes the handler registered for `event`, failing loudly if none was registered. */
+  function emit(event: string, ...args: unknown[]): void {
+    const handler = handlers.get(event);
+    if (handler === undefined) {
+      throw new Error(`No handler registered for ${event}`);
+    }
+    handler(...args);
+  }
+
+  beforeEach(() => {
+    handlers = new Map();
+    const on = vi.fn((event: string, handler: Handler) => {
+      handlers.set(event, handler);
+    });
+    client = { on } as unknown as Client;
+    logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    registerShardLifecycleLogging(
+      client,
+      logger as unknown as Parameters<typeof registerShardLifecycleLogging>[1]
+    );
+  });
+
+  it('registers a handler for every shard-lifecycle event', () => {
+    expect([...handlers.keys()].sort()).toEqual(
+      [
+        Events.ShardDisconnect,
+        Events.ShardReconnecting,
+        Events.ShardResume,
+        Events.ShardReady,
+        Events.ShardError,
+        Events.Invalidated,
+      ].sort()
+    );
+  });
+
+  it('logs a warning with shardId and close code on shard disconnect', () => {
+    emit(Events.ShardDisconnect, { code: 4004, reason: 'auth failed', wasClean: false }, 3);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      { shardId: 3, code: 4004 },
+      'Shard disconnected from gateway'
+    );
+  });
+
+  it('logs an info with shardId on shard reconnecting', () => {
+    emit(Events.ShardReconnecting, 1);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith({ shardId: 1 }, 'Shard reconnecting');
+  });
+
+  it('logs an info with shardId and replayedEvents on shard resume', () => {
+    emit(Events.ShardResume, 2, 17);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith({ shardId: 2, replayedEvents: 17 }, 'Shard resumed');
+  });
+
+  it('logs an info with the unavailable-guild COUNT (never ids) on shard ready', () => {
+    emit(Events.ShardReady, 0, new Set(['111111111111111111', '222222222222222222']));
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      { shardId: 0, unavailableGuildCount: 2 },
+      'Shard ready'
+    );
+    // The guild ids themselves must never reach the log payload.
+    expect(JSON.stringify(logger.info.mock.calls[0])).not.toContain('111111111111111111');
+  });
+
+  it('logs unavailableGuildCount 0 when shard ready reports no unavailable guilds', () => {
+    emit(Events.ShardReady, 4, undefined);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      { shardId: 4, unavailableGuildCount: 0 },
+      'Shard ready'
+    );
+  });
+
+  it('logs an error with the error under `err` on shard error', () => {
+    const error = new Error('websocket exploded');
+
+    emit(Events.ShardError, error, 5);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith({ err: error, shardId: 5 }, 'Shard websocket error');
+  });
+
+  it('logs an error stating the client will not reconnect on session invalidation', () => {
+    emit(Events.Invalidated);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      {},
+      'Discord session invalidated — the client will not reconnect'
+    );
+  });
+});

--- a/services/bot-client/src/services/ShardLifecycleLogger.ts
+++ b/services/bot-client/src/services/ShardLifecycleLogger.ts
@@ -1,0 +1,52 @@
+/**
+ * Structured logging for Discord gateway shard lifecycle events.
+ *
+ * Without these listeners a dead or zombied gateway websocket is invisible: the process stays
+ * up, the logs go quiet, and every interaction silently vanishes. Each handler below is a
+ * synchronous log call — no async work, so nothing here can delay the gateway event loop.
+ *
+ * Fields are deliberately non-identifying: shard ids, websocket close codes, and counts only.
+ *
+ * Payload order is NOT uniform across these events: shardDisconnect and shardError pass their
+ * close-event / error object FIRST and the shard id second, while the other four lead with the
+ * shard id. Check the discord.js ClientEvents typings before adding an event here. Swapping the
+ * two is only caught by the compiler where a property is read off the payload (closeEvent.code
+ * on a number errors); where the value is merely forwarded into the log object it type-checks
+ * fine, and the result is an Error silently logged as a shard id.
+ */
+import { type Client, Events } from 'discord.js';
+import type { createLogger } from '@tzurot/common-types/utils/logger';
+
+type Logger = ReturnType<typeof createLogger>;
+
+/**
+ * Registers structured logging for every shard-lifecycle event the client emits.
+ *
+ * Call once from the composition root, alongside the other client-event registrations.
+ */
+export function registerShardLifecycleLogging(client: Client, logger: Logger): void {
+  client.on(Events.ShardDisconnect, (closeEvent, shardId) => {
+    logger.warn({ shardId, code: closeEvent.code }, 'Shard disconnected from gateway');
+  });
+
+  client.on(Events.ShardReconnecting, shardId => {
+    logger.info({ shardId }, 'Shard reconnecting');
+  });
+
+  client.on(Events.ShardResume, (shardId, replayedEvents) => {
+    logger.info({ shardId, replayedEvents }, 'Shard resumed');
+  });
+
+  client.on(Events.ShardReady, (shardId, unavailableGuilds) => {
+    // Log only the SIZE — the set holds guild ids, which don't belong in logs.
+    logger.info({ shardId, unavailableGuildCount: unavailableGuilds?.size ?? 0 }, 'Shard ready');
+  });
+
+  client.on(Events.ShardError, (error, shardId) => {
+    logger.error({ err: error, shardId }, 'Shard websocket error');
+  });
+
+  client.on(Events.Invalidated, () => {
+    logger.error({}, 'Discord session invalidated — the client will not reconnect');
+  });
+}


### PR DESCRIPTION
Closes TASK-291.

## Why

bot-client registered **zero** shard-lifecycle listeners — grep-verified at HEAD, no `shardDisconnect` / `shardResume` / `shardError` / `shardReady` / `invalidated` anywhere under `services/bot-client/src`. A dead or zombied gateway websocket was therefore invisible: the process stays up, the logs go quiet, and every interaction vanishes without a trace.

The runtime evidence is a dev outage on 2026-07-18, roughly 02:33–04:25Z. The bot booted clean, emitted nothing for about two hours while the owner was actively retrying autocomplete, and a redeploy cured it. The mechanism was never pinned down precisely — and the missing listeners are exactly why it couldn't be.

## What

New `ShardLifecycleLogger` with one exported `registerShardLifecycleLogging(client, logger)`, called once from the composition root next to the existing `Events.Error` registration.

| Event | Level | Fields |
| --- | --- | --- |
| `shardDisconnect` | warn | `shardId`, `code` (websocket close code) |
| `shardReconnecting` | info | `shardId` |
| `shardResume` | info | `shardId`, `replayedEvents` |
| `shardReady` | info | `shardId`, `unavailableGuildCount` |
| `shardError` | error | `err`, `shardId` |
| `invalidated` | error | — |

`invalidated` logs at error level and says outright that the client will not reconnect, because that string is what a future incident search will land on.

Handler signatures were read from the installed discord.js 14.27.0 typings rather than assumed — `shardDisconnect` and `shardError` pass their payload **first** and `shardId` second, which is the opposite of what the field table above might suggest.

## Privacy

Fields are non-identifying by construction: shard ids, close codes, counts. `shardReady` receives a `Set` of unavailable guild ids and logs only its **size**; a test asserts the ids cannot reach the payload at all, rather than merely asserting the count is right.

Every handler is a synchronous log call, so nothing here can delay the gateway event loop.

## Verification

8 tests, each asserting the **full** logger call — level, exact structured-field object, and message string — plus `toHaveBeenCalledTimes(1)` so a stray log at the wrong level fails. Includes the `shardReady`-with-`undefined` case. Asserting only that "a log happened" would prove nothing here, since the module's entire output *is* its log calls.

`pnpm --filter @tzurot/bot-client test` (6090 passed), `typecheck`, `typecheck:spec`, `lint`, and `pnpm quality` (28/28) all green, run sequentially.

## Not in scope

The liveness watchdog TASK-291 also mentions ("no gateway event in N min while guilds > 0"). It needs these listeners to run first — its whole value is catching the case where *no* shard event fires, and until we can see the events we can't tell a silent-zombie socket from an upstream problem. Its scheduling mechanism is also a real decision rather than a detail: the state to check is in-process, so a BullMQ repeatable job would have to round-trip a timestamp through Redis and then disambiguate which replica's socket is dead. That deserves its own PR. **TASK-291 stays open for it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)