### PR TITLE
fix(ai-worker): five small items whose only trigger was "next time we touch this"

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.test.ts
@@ -803,9 +803,10 @@ describe('GenerationStep', () => {
         const result = await step.process(context);
 
         expect(result.result?.success).toBe(false);
-        // The error message should be from the RetryError (outer), but the
-        // errorInfo.category should be based on the underlying authError
-        expect(result.result?.error).toBe('All retries failed');
+        // Both the diagnostic message and the category come from the UNWRAPPED
+        // error: the RetryError's own text is a generic wrapper that buries the
+        // provider detail, so `result.error` leads with the root cause.
+        expect(result.result?.error).toBe('Invalid API key');
         // The underlying error contains 'Invalid API key' which matches authentication pattern
         expect(result.result?.errorInfo?.category).toBe('authentication');
       });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
@@ -290,13 +290,25 @@ export function getAttemptedFallbackProvider(error: unknown): string | undefined
 }
 
 /**
- * Compose the user-facing error string: the pristine original message plus the
+ * Compose the diagnostic error string: the pristine original message plus the
  * fallback-failure summary when one was attached. MUST be called only after
  * classification (`parseApiError`) has run — that's the whole point of keeping
  * the summary off the message.
+ *
+ * The base is the UNWRAPPED error, mirroring what the fallback summary and the
+ * classifier both do: a `RetryError`'s own message is the generic wrapper
+ * ("LLM invocation (<model>) failed with non-retryable error"), which buries
+ * the provider detail that makes the log line useful. Unwrapping keeps this
+ * string's root cause consistent with `errorInfo.technicalMessage`, which is
+ * derived from the same unwrapped error.
  */
 export function composeFallbackAwareErrorMessage(error: unknown): string {
-  const base = error instanceof Error ? error.message : 'Unknown error';
+  // `RetryError.lastError` is `unknown` — when it isn't an Error there is no
+  // root-cause message to lead with, so keep the wrapper's own text rather
+  // than degrading to the placeholder.
+  const unwrapped = error instanceof RetryError ? error.lastError : error;
+  const baseError = unwrapped instanceof Error ? unwrapped : error;
+  const base = baseError instanceof Error ? baseError.message : 'Unknown error';
   const summary = getFallbackFailureSummary(error);
   return summary !== undefined ? `${base} — fallback via OpenRouter also failed: ${summary}` : base;
 }

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/generationFailureResult.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/generationFailureResult.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { DiagnosticCollector } from '../../../../services/DiagnosticCollector.js';
 import type { GenerationContext } from '../types.js';
+import { RetryError } from '../../../../utils/retry.js';
 import {
   composeGenerationFailureResult,
   type GenerationFailureOptions,
@@ -108,6 +109,36 @@ describe('composeGenerationFailureResult', () => {
     // Footer seam: both routes named so the chain can render.
     expect(result.result?.metadata?.providerUsed).toBe('zai-coding');
     expect(result.result?.metadata?.fallbackProviderAttempted).toBe('openrouter');
+  });
+
+  it('leads with the root cause, not the wrapper text, when the error is RetryError-wrapped', () => {
+    const rootCause = new Error('OpenRouter 402: requires more credits');
+    const wrapped = new RetryError(
+      'LLM invocation (glm-4.7) failed with non-retryable error',
+      1,
+      rootCause
+    );
+    const options = buildOptions(wrapped);
+
+    const result = composeGenerationFailureResult(options);
+
+    // result.error is a diagnostic string; it must name the provider detail
+    // rather than the generic retry wrapper, matching what technicalMessage
+    // (derived from the same unwrapped error) already says.
+    expect(result.result?.error).toBe('OpenRouter 402: requires more credits');
+    expect(result.result?.error).not.toContain('non-retryable error');
+    expect(options.diagnosticCollector.recordError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'OpenRouter 402: requires more credits' })
+    );
+  });
+
+  it('keeps the wrapper text when a RetryError carries a non-Error cause', () => {
+    const wrapped = new RetryError('LLM invocation (glm-4.7) failed', 1, 'not-an-error');
+    const options = buildOptions(wrapped);
+
+    const result = composeGenerationFailureResult(options);
+
+    expect(result.result?.error).toBe('LLM invocation (glm-4.7) failed');
   });
 
   it('records the failure in the diagnostic collector and stores the log', () => {

--- a/services/ai-worker/src/jobs/utils/participantUtils.ts
+++ b/services/ai-worker/src/jobs/utils/participantUtils.ts
@@ -79,9 +79,13 @@ export function resolveSpeakerInfo(
     // store `personality.name` (same vocabulary as the parameter), but the
     // extended-context fetch's registry-miss fallback stores the webhook
     // DISPLAY name (`${displayName}${botSuffix}`) — a strict compare would
-    // demote the persona's OWN rows whenever name !== displayName. Cost: a
-    // sibling whose name is an exact prefix of the responder's reads as self
-    // (same accepted bounded edge as referenceRole.ts's self-variant skip).
+    // demote the persona's OWN rows whenever name !== displayName. Cost: the
+    // check is symmetric, so BOTH prefix directions collide. A sibling whose
+    // name is a prefix of the responder's reads as self ("Alex" sibling under
+    // an "Alexandra" responder), and so does the reverse — an unrelated
+    // sibling "Alexandra" under an "Alex" responder reads as self by the same
+    // rule. (Same accepted bounded edge as referenceRole.ts's self-variant
+    // skip.)
     const speakerLower = speakerName.toLowerCase();
     const personalityLower = personalityName.toLowerCase();
     const isSelf =

--- a/services/ai-worker/src/services/MultimodalProcessor.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.ts
@@ -297,7 +297,15 @@ export async function processAttachments(
     'Processing attachments in parallel'
   );
 
-  // Use retryService for consistent retry behavior
+  // Use retryService for consistent retry behavior.
+  //
+  // Scope note: this outer retry cannot fire for an image on the fallback path.
+  // `describeImageWithFallback` retries INTERNALLY across vision tiers and never
+  // throws by contract — it degrades to a null/marker description instead — so a
+  // failure there returns normally and the wrapper sees success. What the wrapper
+  // is actually live for: non-vision attachment types (audio/STT, documents) and
+  // the legacy single-model `describeImage` branch taken when no `visionAuth`
+  // bundle was supplied, both of which can still throw.
   const results = await withParallelRetry(
     attachments,
     attachment =>

--- a/services/ai-worker/src/services/context/ContextAssembler.component.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.component.test.ts
@@ -293,8 +293,14 @@ describe('ContextAssembler.assembleCore — PGLite component', () => {
     // Decoration: B uses the env-map entry; C (no entry) uses the shared fallback.
     const byChannel = (id: string): DiscordEnvironment | undefined =>
       groups.find(g => g.channelEnvironment.channel.id === id)?.channelEnvironment;
-    expect(byChannel(CHANNEL_ID_B)?.channel.name).toBe('other-channel');
-    expect(byChannel(CHANNEL_ID_C)?.channel.name).toBe('unknown-channel');
+    // Presence first, so a MISSING group fails as "expected undefined to be
+    // defined" rather than as an ambiguous wrong-name mismatch below.
+    const envB = byChannel(CHANNEL_ID_B);
+    const envC = byChannel(CHANNEL_ID_C);
+    expect(envB).toBeDefined();
+    expect(envC).toBeDefined();
+    expect(envB?.channel.name).toBe('other-channel');
+    expect(envC?.channel.name).toBe('unknown-channel');
   });
 
   // ── Content rewriting via real DB-fallback mention resolution (step 6) ──────

--- a/services/ai-worker/src/services/eval/factPoolScoring.test.ts
+++ b/services/ai-worker/src/services/eval/factPoolScoring.test.ts
@@ -14,7 +14,7 @@ import {
   type FactPooledCandidate,
 } from './factPoolScoring.js';
 import { reconcile } from './qrelsReconciliation.js';
-import { scoreArm } from './poolScoring.js';
+import { rankedIds, scoreArm } from './poolScoring.js';
 
 const NOW = 1_800_000_000_000;
 const DAY_MS = 86_400_000;
@@ -150,6 +150,41 @@ describe('policyRanks / withPolicyArm', () => {
     expect(pool.candidates[0].ranks.balanced).toBeUndefined();
     // Re-adding the same arm does not duplicate the name
     expect(withPolicyArm(withArm, 'balanced', c => c.salience).arms).toEqual(['prod', 'balanced']);
+  });
+
+  it('never emits 0 as a rank — the unranked sentinel is null, which sorts OUT', () => {
+    const pool = makePool([
+      makeCandidate({ corpusId: 'a', similarity: 0.9 }),
+      makeCandidate({ corpusId: 'b', similarity: 0.5 }),
+      makeCandidate({ corpusId: 'c', similarity: 0.1 }),
+    ]);
+    const withArm = withPolicyArm(pool, 'partial', c => c.similarity);
+
+    // 0 is a REAL rank to `rankedIds` and sorts ahead of rank 1, so an arm that
+    // ever dropped a candidate would put its rejects at the head of the list.
+    // Every emitted value must therefore be a genuine 1-based rank.
+    for (const candidate of withArm.candidates) {
+      expect(candidate.ranks.partial).not.toBe(0);
+      expect(candidate.ranks.partial ?? 1).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('leaves a candidate an arm did not surface OUT of that arm ordering, not at its head', () => {
+    // The shape a partially-ranking arm produces: `null` for the candidate it
+    // dropped. Pinned through the real consumer chain (reconcile → rankedIds)
+    // because that is where a `0` placeholder would misorder — a dropped
+    // candidate would lead the arm's list instead of being absent from it.
+    const pool = makePool(
+      [
+        makeCandidate({ corpusId: 'kept-1', ranks: { prod: 1, partial: 1 } }),
+        makeCandidate({ corpusId: 'kept-2', ranks: { prod: 2, partial: 2 } }),
+        makeCandidate({ corpusId: 'dropped', ranks: { prod: 3, partial: null } }),
+      ],
+      { arms: ['prod', 'partial'] }
+    );
+    const { queries } = reconcile([pool], {});
+
+    expect(rankedIds(queries[0].candidates, 'partial')).toEqual(['kept-1', 'kept-2']);
   });
 });
 

--- a/services/ai-worker/src/services/eval/factPoolScoring.ts
+++ b/services/ai-worker/src/services/eval/factPoolScoring.ts
@@ -151,7 +151,12 @@ export function withPolicyArm(
     arms: pool.arms.includes(armName) ? pool.arms : [...pool.arms, armName],
     candidates: pool.candidates.map(candidate => ({
       ...candidate,
-      ranks: { ...candidate.ranks, [armName]: ranks.get(candidate.corpusId) ?? 0 },
+      // `null`, never `0`: null is the documented "arm did not surface this"
+      // value. `rankedIds` includes any non-null rank and sorts ascending, so a
+      // `0` placeholder would put an arm's DROPPED candidates ahead of its real
+      // rank-1 pick. Today's arms rank every candidate, so the difference is
+      // latent — which is exactly why the wrong value must not sit here.
+      ranks: { ...candidate.ranks, [armName]: ranks.get(candidate.corpusId) ?? null },
     })),
   };
 }
@@ -180,7 +185,8 @@ export function repetitionOverlap(
       pool.candidates
         .filter(candidate => {
           const rank = candidate.ranks[arm];
-          return rank !== undefined && rank >= 1 && rank <= k;
+          // Absent AND null both mean "this arm did not surface it".
+          return rank !== undefined && rank !== null && rank >= 1 && rank <= k;
         })
         .map(candidate => candidate.corpusId)
     ),
@@ -230,7 +236,8 @@ export function tierRankLift(pools: readonly FactGoldenPool[], arm: string): Tie
         continue;
       }
       const rank = candidate.ranks[arm];
-      if (rank === undefined || rank < 1) {
+      // Absent AND null both mean "this arm did not surface it".
+      if (rank === undefined || rank === null || rank < 1) {
         continue;
       }
       count += 1;

--- a/services/ai-worker/src/services/eval/factPooling.eval.test.ts
+++ b/services/ai-worker/src/services/eval/factPooling.eval.test.ts
@@ -287,7 +287,9 @@ function buildFactJudgmentSheets(pools: FactGoldenPool[]): string {
       ''
     );
     const display = pool.candidates
-      .filter(candidate => Object.values(candidate.ranks).some(rank => rank >= 1 && rank <= POOL_K))
+      .filter(candidate =>
+        Object.values(candidate.ranks).some(rank => rank !== null && rank >= 1 && rank <= POOL_K)
+      )
       .sort((a, b) => bestRank(a) - bestRank(b));
     for (const candidate of display) {
       const badges = [
@@ -330,11 +332,15 @@ function buildMechanicalReport(pools: FactGoldenPool[]): string {
 }
 
 function bestRank(candidate: FactPooledCandidate): number {
-  const ranks = Object.values(candidate.ranks).filter(rank => rank >= 1);
+  const ranks = Object.values(candidate.ranks).filter(
+    (rank): rank is number => rank !== null && rank >= 1
+  );
   return ranks.length === 0 ? 99 : Math.min(...ranks);
 }
 
 function rankBadge(candidate: FactPooledCandidate, arm: string, label: string): string | null {
   const rank = candidate.ranks[arm];
-  return rank === undefined || rank < 1 || rank > POOL_K ? null : `${label}#${rank}`;
+  return rank === undefined || rank === null || rank < 1 || rank > POOL_K
+    ? null
+    : `${label}#${rank}`;
 }

--- a/services/ai-worker/src/services/eval/poolingArms.ts
+++ b/services/ai-worker/src/services/eval/poolingArms.ts
@@ -138,12 +138,16 @@ export function oldestHistoryMs(priorHistory: { createdAt: string }[]): number {
 
 /** Sort candidates by best (lowest) rank across all arms for sheet readability. */
 export function armSortKey(candidate: PooledCandidate): number {
-  const ranks = Object.values(candidate.ranks);
+  // Null ranks are "arm did not surface it" — dropping them keeps a
+  // non-surfacing arm from sorting the candidate to the top (null would
+  // coerce to 0 through Math.min).
+  const ranks = Object.values(candidate.ranks).filter((rank): rank is number => rank !== null);
   return ranks.length === 0 ? 99 : Math.min(...ranks);
 }
 
 /** `label#rank` badge for the judgment sheet, or null when the arm missed the candidate. */
 export function rankBadge(candidate: PooledCandidate, arm: string, label: string): string | null {
   const rank = candidate.ranks[arm];
-  return rank === undefined ? null : `${label}#${rank}`;
+  // Absent AND null both mean the arm missed this candidate.
+  return rank === undefined || rank === null ? null : `${label}#${rank}`;
 }

--- a/services/ai-worker/src/services/eval/qrelsReconciliation.ts
+++ b/services/ai-worker/src/services/eval/qrelsReconciliation.ts
@@ -22,7 +22,14 @@ export interface PooledCandidate {
   corpusId: string;
   createdAtMs: number;
   contentPreview: string;
-  ranks: Record<string, number>;
+  /**
+   * Arm name → 1-based rank. Absent OR null = the arm did not surface this
+   * candidate — same vocabulary `ScoredCandidate.ranks` uses downstream, and
+   * the reason a derived arm must never write `0` for an unranked candidate:
+   * `rankedIds` accepts any non-null number, so a `0` would sort AHEAD of the
+   * arm's genuine rank-1 pick.
+   */
+  ranks: Record<string, number | null>;
   verdict: GuardVerdict;
 }
 

--- a/services/ai-worker/src/services/prompt/referenceRole.ts
+++ b/services/ai-worker/src/services/prompt/referenceRole.ts
@@ -60,9 +60,12 @@ function matchesPersonality(authorName: string, personalityName: string): boolea
  * Whether a set entry is the SAME persona as the responder under a different
  * name vocabulary — stored rows carry `personality.name` ("Yeshua") while the
  * live path matches against `displayName` ("Yeshua ben Yosef"). Either prefix
- * direction counts. The cost: a sibling whose name is an exact prefix of the
- * responder's reads as a self-variant (accepted bounded edge, same class as
- * the documented name-collision edge on the fallback).
+ * direction counts. The cost: because the check is symmetric, BOTH prefix
+ * directions collide. A sibling whose name is a prefix of the responder's
+ * reads as a self-variant ("Alex" under an "Alexandra" responder), and so
+ * does the reverse — an unrelated sibling "Alexandra" under an "Alex"
+ * responder reads as a self-variant by the same rule. (Accepted bounded edge,
+ * same class as the documented name-collision edge on the fallback.)
  */
 function isSelfVariant(name: string, personalityName: string): boolean {
   return matchesPersonality(personalityName, name) || matchesPersonality(name, personalityName);


### PR DESCRIPTION
Closes TASK-29, TASK-33, TASK-179, TASK-266. Closes TASK-13 as obsolete (see below).

First batch off the `state:unreachable` shelf from the triage pass. Each of these was filed with a trigger of the form "next time someone touches this file" — a trigger `06-backlog.md` already classifies as one that never fires, because nobody greps a 300-row pool before unrelated work. Each is smaller than the task row describing it. Batched by service so the diff stays reviewable.

## The four that landed

- **TASK-29** — comment the `withParallelRetry` wrap site. The outer retry can't fire for the never-throwing fallback path. Refined from the task's framing: it's live for non-vision attachment types **and** for the legacy single-model `describeImage` branch, which can still throw.
- **TASK-33** — compose `result.error` from the *unwrapped* error. A `RetryError`'s own message is a generic wrapper that buries the provider detail, so the log line now leads with the root cause and agrees with `errorInfo.technicalMessage`, which was already unwrapped.
- **TASK-179** — pre-assert group presence so a missing cross-channel group fails as "not found" rather than "wrong name".
- **TASK-266** — `withPolicyArm` writes `null`, the documented not-surfaced value, instead of `0`. `rankedIds` accepts any non-null rank and sorts ascending, so a `0` would place an arm's **dropped** candidates ahead of its genuine rank-1 pick.

## Two disclosures that matter more than the diff

**TASK-266 is latent and I could not write a test that fails against the old code.** `policyRanks` assigns a rank to every candidate, and `withPolicyArm` maps that same array — so `ranks.get()` never misses and the `??` branch is unreachable through the public API. This was checked empirically, not reasoned about: reverting to `?? 0` leaves all 15 tests passing. Reaching the branch needs an injectable rank source, which is a signature change this PR deliberately doesn't make. The sentinel is corrected because the wrong value must not sit there, not because it fires today — and the new tests pin the *consequence* (a null-ranked candidate stays out of the ordering via the real `reconcile` → `rankedIds` chain) rather than pretending to be a regression test.

**The `poolingArms` changes are not separate bug fixes.** They are what introducing `null` *requires*: without them `armSortKey` would coerce `null` to 0 through `Math.min` and sort a non-surfaced candidate to the top, and `rankBadge` would render `label#null` on the judgment sheet. Calling them independent finds would be overclaiming.

**One existing assertion was changed.** `GenerationStep.test.ts` pinned `result.error === 'All retries failed'` — the exact wrapper text TASK-33 exists to remove. It now pins the root cause, with the comment rewritten to state the new invariant. Flagging it explicitly because "never modify tests to make them pass" is a standing rule; this is a test tracking a deliberate behavior change, not a gate weakened.

**Impact of TASK-33 is diagnostic-only, verified rather than assumed.** `composeFallbackAwareErrorMessage` has exactly one consumer, and `generationFailureResult.ts:59` documents in-source that `result.error` is log-only while bot-client renders `errorInfo.technicalMessage`. The change makes those two agree instead of diverge.

## TASK-13 closed as obsolete

Its first half described drift in `resolveSpeakerForEstimation` / `getFormattedMessageCharLength`. Neither symbol exists any more — grep-verified — and the replacement `measureHistoryEntryTokens` already threads `allPersonalityNames` at all three call sites, so there is no overclaiming docstring left to correct. The surviving half is here: the accepted-edge comments on `isSelf` / `isSelfVariant` described one direction of a symmetric check, so the reverse edge (responder "Alex" reading as self against an unrelated sibling "Alexandra") is now written down.

## Verification

`pnpm --filter @tzurot/ai-worker test` (4532 passed), `typecheck`, `typecheck:spec`, `lint`, `pnpm test:component` (624 passed — TASK-179 edits a `.component.test.ts`, which `pnpm test` excludes and would have "passed" by not running), and `pnpm quality` (28/28). All sequential.

Survivor greps: no rank-sentinel `?? 0` remains in eval; the three surviving `ranks: Record<string, number>` are test-local *producers* that write full rankings and stay assignable to the widened consumer type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)