### PR TITLE
fix(bot-client): five more items whose only trigger was "next time we touch this"

### DIFF
--- a/services/bot-client/src/commands/character/avatar.ts
+++ b/services/bot-client/src/commands/character/avatar.ts
@@ -9,6 +9,10 @@
 
 import { escapeMarkdown } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
+import {
+  characterAvatarSetOptions,
+  characterAvatarClearOptions,
+} from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
@@ -64,13 +68,13 @@ async function handleAvatarUpload(
   context: DeferredCommandContext,
   config: EnvConfig
 ): Promise<void> {
-  const interaction = context.interaction;
-  const slug = interaction.options.getString('character', true);
+  const options = characterAvatarSetOptions(context.interaction);
+  const slug = options.character();
   if (isAutocompleteErrorSentinel(slug)) {
     await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
     return;
   }
-  const attachment = interaction.options.getAttachment('image', true);
+  const attachment = options.image();
   const userId = context.user.id;
 
   const validationError = validateImageAttachment(attachment);
@@ -163,8 +167,7 @@ async function handleAvatarClear(
   context: DeferredCommandContext,
   config: EnvConfig
 ): Promise<void> {
-  const interaction = context.interaction;
-  const slug = interaction.options.getString('character', true);
+  const slug = characterAvatarClearOptions(context.interaction).character();
   if (isAutocompleteErrorSentinel(slug)) {
     await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
     return;

--- a/services/bot-client/src/commands/character/view.test.ts
+++ b/services/bot-client/src/commands/character/view.test.ts
@@ -671,9 +671,21 @@ describe('handleExpandField', () => {
   });
 
   function expandInteraction() {
-    return { deferReply, editReply, deferred: true, replied: false } as unknown as Parameters<
-      typeof handleExpandField
-    >[0];
+    const interaction: Record<string, unknown> = {
+      deferReply,
+      editReply,
+      deferred: false,
+      replied: false,
+    };
+    // deferReply flips the ack state like Discord, so an error path picks editReply
+    // (deferred) over reply (fresh) — matching the runtime path. A statically
+    // pre-set `deferred: true` would silently exercise the deferred branch even if
+    // a future pre-defer error path took the fresh one.
+    deferReply.mockImplementation(() => {
+      interaction.deferred = true;
+      return Promise.resolve(undefined);
+    });
+    return interaction as unknown as Parameters<typeof handleExpandField>[0];
   }
 
   it('defers ephemerally and sends the full field content via chunked reply', async () => {

--- a/services/bot-client/src/commands/character/voice.ts
+++ b/services/bot-client/src/commands/character/voice.ts
@@ -10,6 +10,10 @@
 
 import { escapeMarkdown } from 'discord.js';
 import { type EnvConfig } from '@tzurot/common-types/config/config';
+import {
+  characterVoiceSetOptions,
+  characterVoiceClearOptions,
+} from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
@@ -64,13 +68,13 @@ async function handleVoiceUpload(
   context: DeferredCommandContext,
   config: EnvConfig
 ): Promise<void> {
-  const interaction = context.interaction;
-  const slug = interaction.options.getString('character', true);
+  const options = characterVoiceSetOptions(context.interaction);
+  const slug = options.character();
   if (isAutocompleteErrorSentinel(slug)) {
     await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
     return;
   }
-  const attachment = interaction.options.getAttachment('audio', true);
+  const attachment = options.audio();
   const userId = context.user.id;
   const { contentType } = attachment;
 
@@ -164,8 +168,7 @@ async function handleVoiceUpload(
  * Handle /character voice clear
  */
 async function handleVoiceClear(context: DeferredCommandContext, config: EnvConfig): Promise<void> {
-  const interaction = context.interaction;
-  const slug = interaction.options.getString('character', true);
+  const slug = characterVoiceClearOptions(context.interaction).character();
   if (isAutocompleteErrorSentinel(slug)) {
     await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
     return;

--- a/services/bot-client/src/commands/memory/detail.test.ts
+++ b/services/bot-client/src/commands/memory/detail.test.ts
@@ -522,19 +522,28 @@ describe('Memory Detail', () => {
     it('should show error if memory not found', async () => {
       stub.getMemory.mockResolvedValue(makeErr(404, 'Not found'));
 
-      const mockDeferReply = vi.fn();
       const mockEditReply = vi.fn();
 
-      const interaction = {
+      const interaction: Record<string, unknown> = {
         user: { id: 'user-123', username: 'testuser' },
-        deferReply: mockDeferReply,
         editReply: mockEditReply,
-        deferred: true,
+        reply: vi.fn(),
+        deferred: false,
         replied: false,
-      } as unknown as ButtonInteraction;
+      };
+      // deferReply flips the ack state like Discord, so the error path picks
+      // editReply (deferred) over reply (fresh) — matching the runtime path. A
+      // statically pre-set `deferred: true` would silently exercise the deferred
+      // branch even if a future pre-defer error path took the fresh one.
+      const mockDeferReply = vi.fn().mockImplementation(() => {
+        interaction.deferred = true;
+        return Promise.resolve(undefined);
+      });
+      interaction.deferReply = mockDeferReply;
 
-      await handleViewFullButton(interaction, 'memory-123');
+      await handleViewFullButton(interaction as unknown as ButtonInteraction, 'memory-123');
 
+      expect(mockDeferReply).toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith(
         expect.objectContaining({
           content: expect.stringContaining('Memory not found'),

--- a/services/bot-client/src/commands/persona/view.test.ts
+++ b/services/bot-client/src/commands/persona/view.test.ts
@@ -206,14 +206,23 @@ describe('handleExpandContent', () => {
   });
 
   function createMockButtonInteraction() {
-    return {
+    const interaction: Record<string, unknown> = {
       user: { id: '123456789' },
       deferReply: mockDeferReply,
       editReply: mockEditReply,
       followUp: mockFollowUp,
-      deferred: true,
+      deferred: false,
       replied: false,
-    } as unknown as Parameters<typeof handleExpandContent>[0];
+    };
+    // deferReply flips the ack state like Discord, so an error path picks editReply
+    // (deferred) over reply (fresh) — matching the runtime path. A statically
+    // pre-set `deferred: true` would silently exercise the deferred branch even if
+    // a future pre-defer error path took the fresh one.
+    mockDeferReply.mockImplementation(() => {
+      interaction.deferred = true;
+      return Promise.resolve(undefined);
+    });
+    return interaction as unknown as Parameters<typeof handleExpandContent>[0];
   }
 
   it('should show full content when short', async () => {

--- a/services/bot-client/src/commands/preset/create.test.ts
+++ b/services/bot-client/src/commands/preset/create.test.ts
@@ -130,19 +130,28 @@ describe('Preset Create', () => {
   });
 
   describe('handleSeedModalSubmit', () => {
-    const createMockModalInteraction = (values: Record<string, string>) =>
-      ({
+    const createMockModalInteraction = (values: Record<string, string>) => {
+      const interaction: Record<string, unknown> = {
         user: { id: 'user-123' },
         channelId: 'channel-123',
-        deferReply: vi.fn(),
         editReply: vi.fn().mockResolvedValue({ id: 'message-123' }),
         followUp: vi.fn().mockResolvedValue(undefined),
-        deferred: true,
+        deferred: false,
         replied: false,
         fields: {
           getTextInputValue: vi.fn((id: string) => values[id] ?? ''),
         },
-      }) as unknown as ModalSubmitInteraction;
+      };
+      // deferReply flips the ack state like Discord, so an error path picks editReply
+      // (deferred) over reply (fresh) — matching the runtime path. A statically
+      // pre-set `deferred: true` would silently exercise the deferred branch even if
+      // a future pre-defer error path took the fresh one.
+      interaction.deferReply = vi.fn().mockImplementation(() => {
+        interaction.deferred = true;
+        return Promise.resolve(undefined);
+      });
+      return interaction as unknown as ModalSubmitInteraction;
+    };
 
     beforeEach(() => {
       vi.clearAllMocks();

--- a/services/bot-client/src/services/HttpPersonalityLoader.test.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.test.ts
@@ -11,21 +11,14 @@ vi.mock('../utils/gatewayClients.js', () => ({
 import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import { InfraError, GatewayClientError } from '@tzurot/clients';
 import { HttpPersonalityLoader, NEGATIVE_TTL_MS } from './HttpPersonalityLoader.js';
+// `makeErr` derives `kind` from the real GatewayResult invariant (status>0 ⟺ 'http')
+// so the strict helpers classify correctly: a 5xx / non-http → InfraError, a non-404
+// 4xx → GatewayClientError.
+import { makeErr } from '../test/gatewayClientStubs.js';
 
 const PERSONALITY = { id: 'pers-1', name: 'Lila', slug: 'lila' };
 
 const ok = <T>(data: T): { ok: true; data: T } => ({ ok: true, data });
-// `kind` mirrors the real GatewayResult invariant (status>0 ⟺ 'http') so the
-// strict helpers classify correctly: a 5xx / non-http → InfraError, a non-404
-// 4xx → GatewayClientError.
-const err = (
-  status: number
-): { ok: false; kind: 'http' | 'network'; error: string; status: number } => ({
-  ok: false,
-  kind: status > 0 ? 'http' : 'network',
-  error: 'boom',
-  status,
-});
 
 describe('HttpPersonalityLoader', () => {
   let loader: HttpPersonalityLoader;
@@ -93,7 +86,7 @@ describe('HttpPersonalityLoader', () => {
   });
 
   it('does NOT negative-cache transport errors (a gateway blip must not blind routing)', async () => {
-    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(err(503));
+    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(makeErr(503, 'boom'));
     expect(await loader.loadPersonality('lila', 'user-1')).toBeNull();
 
     mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(
@@ -106,12 +99,12 @@ describe('HttpPersonalityLoader', () => {
   });
 
   it('loadPersonalityStrict throws InfraError on an infra failure (5xx) — not a silent null', async () => {
-    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(503));
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(makeErr(503, 'boom'));
     await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(InfraError);
   });
 
   it('loadPersonalityStrict throws GatewayClientError on a non-404 4xx', async () => {
-    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(403));
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(makeErr(403, 'boom'));
     await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(
       GatewayClientError
     );
@@ -123,7 +116,7 @@ describe('HttpPersonalityLoader', () => {
   });
 
   it('loadPersonalityStrict does NOT negative-cache an infra failure (throw happens first)', async () => {
-    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(err(503));
+    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(makeErr(503, 'boom'));
     await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(InfraError);
     mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(
       ok({ personality: PERSONALITY })
@@ -135,12 +128,12 @@ describe('HttpPersonalityLoader', () => {
   it('loadPersonalityStrict throws InfraError on a NETWORK failure (status 0, kind network)', async () => {
     // A network/timeout failure carries status 0 / kind!=='http' — still infra,
     // never a 404. Documents that "network failure ≠ not found" like the 5xx case.
-    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(0));
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(makeErr(0, 'boom'));
     await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(InfraError);
   });
 
   it('loadPersonality (lenient wrapper) collapses an infra failure to null for routing', async () => {
-    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(503));
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(makeErr(503, 'boom'));
     expect(await loader.loadPersonality('lila', 'user-1')).toBeNull();
   });
 

--- a/services/bot-client/src/services/MultiTagPersistence.test.ts
+++ b/services/bot-client/src/services/MultiTagPersistence.test.ts
@@ -410,8 +410,33 @@ describe('MultiTagPersistence', () => {
       expect(await persistence.getSyntheticTimeout('job-1')).toBeNull();
     });
 
+    it('getSyntheticTimeout round-trips a DM context (null guildId, absent clientId)', async () => {
+      // `JSON.stringify` drops an undefined clientId, so the stored marker has no
+      // such key at all — the shape guard must still accept it.
+      const dmCtx = { ...ctx, guildId: null, clientId: undefined };
+      mockRedis.get.mockResolvedValue(JSON.stringify(dmCtx));
+      expect(await persistence.getSyntheticTimeout('job-1')).toEqual({
+        ...ctx,
+        guildId: null,
+        clientId: undefined,
+      });
+    });
+
     it('getSyntheticTimeout fails soft (null) on malformed JSON', async () => {
       mockRedis.get.mockResolvedValue('not-json{');
+      expect(await persistence.getSyntheticTimeout('job-1')).toBeNull();
+    });
+
+    it('getSyntheticTimeout returns null (not a half-populated object) on a wrong-shaped marker', async () => {
+      // Structurally valid JSON missing a required field — what a marker written
+      // by an older deploy looks like once the shape gains a field.
+      const { personalitySlug: _dropped, ...missingField } = ctx;
+      mockRedis.get.mockResolvedValue(JSON.stringify(missingField));
+      expect(await persistence.getSyntheticTimeout('job-1')).toBeNull();
+    });
+
+    it('getSyntheticTimeout returns null on a marker whose field has the wrong type', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify({ ...ctx, isAutoResponse: 'yes' }));
       expect(await persistence.getSyntheticTimeout('job-1')).toBeNull();
     });
 

--- a/services/bot-client/src/services/MultiTagPersistence.ts
+++ b/services/bot-client/src/services/MultiTagPersistence.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Redis } from 'ioredis';
+import { z } from 'zod';
 import { MULTI_TAG } from '@tzurot/common-types/constants/message';
 import { REDIS_KEY_PREFIXES } from '@tzurot/common-types/constants/queue';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -92,6 +93,23 @@ export interface SyntheticTimeoutContext {
   recipientUserId: string;
   isAutoResponse: boolean;
 }
+
+/**
+ * Runtime shape guard for a persisted `SyntheticTimeoutContext`. Mirrors the
+ * interface above field-for-field — keep the two in sync. A cast alone would
+ * accept a structurally-valid-but-wrong-shaped marker (one written by an older
+ * deploy that predates a newly-required field), handing the consumer an
+ * `undefined` it never guards against; parsing turns that into a clean skip.
+ * `clientId` is optional here because `JSON.stringify` drops an undefined key.
+ */
+const SyntheticTimeoutContextSchema = z.object({
+  channelId: z.string(),
+  guildId: z.string().nullable(),
+  clientId: z.string().optional(),
+  personalitySlug: z.string(),
+  recipientUserId: z.string(),
+  isAutoResponse: z.boolean(),
+});
 
 /**
  * Serializable snapshot of a single slot. Strips runtime-only fields
@@ -337,17 +355,33 @@ export class MultiTagPersistence {
 
   /**
    * Read the synthetic-timeout recovery context for a jobId, or null if none
-   * (not a synthetic-timeout job, or marker expired). Fails soft → null.
+   * (not a synthetic-timeout job, marker expired, or the stored value no longer
+   * matches the current shape). Fails soft → null.
    */
   async getSyntheticTimeout(jobId: string): Promise<SyntheticTimeoutContext | null> {
     const key = `${REDIS_KEY_PREFIXES.MULTI_TAG_SYNTHETIC_TIMEOUT}${jobId}`;
     try {
       const raw = await this.redis.get(key);
-      // No deep schema validation: we wrote this marker ourselves minutes earlier and
-      // the 30-min TTL keeps any cross-deploy shape drift transient. A structurally
-      // valid but wrong-shaped marker would surface downstream (e.g. sendResponse),
-      // not here — acceptable for a best-effort recovery path.
-      return raw === null ? null : (JSON.parse(raw) as SyntheticTimeoutContext);
+      if (raw === null) {
+        return null;
+      }
+      // Validate rather than cast: the `catch` below covers malformed JSON, this
+      // covers structurally-valid-but-wrong-shape (a marker written by an older
+      // deploy). A half-populated context would otherwise surface downstream as a
+      // surprising send or a Discord API error instead of a clean skip.
+      const parsed = SyntheticTimeoutContextSchema.safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        logger.warn(
+          { jobId },
+          'getSyntheticTimeout marker failed shape validation — treating as no recovery marker'
+        );
+        return null;
+      }
+      // The trailing `clientId` is not redundant with the spread: zod's
+      // `.optional()` omits the KEY entirely when unset, while the interface
+      // declares it required-but-possibly-undefined. Re-assigning forces the
+      // key to exist so the return structurally satisfies the type.
+      return { ...parsed.data, clientId: parsed.data.clientId };
     } catch (err) {
       logger.warn(
         { err, jobId },

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -229,6 +229,106 @@ describe('VoiceTranscriptionService', () => {
 
       expect(service.hasVoiceAttachment(message)).toBe(false);
     });
+
+    // The forwarded branch delegates to `hasForwardedVoiceAttachment`, which reads a
+    // precomputed `isVoiceMessage` flag rather than re-running the predicate over raw
+    // snapshot attachments. These pin the inputs where the two mechanisms could
+    // plausibly disagree.
+
+    it('detects a forwarded voice snapshot with an OMITTED content-type (duration fallback)', () => {
+      // The one case the two mechanisms most plausibly diverge on: with no
+      // content-type there is no audio/* discriminator, so detection rests entirely
+      // on the duration fallback. It survives only because the flag is computed from
+      // the RAW attachment, before a null content-type is normalized to octet-stream.
+      const message = createMockMessage({
+        attachments: [],
+        messageSnapshots: [
+          {
+            attachments: [
+              {
+                url: 'https://cdn.discord.com/voice/forwarded-no-ct.ogg',
+                contentType: null,
+                name: 'voice.ogg',
+                size: 50000,
+                duration: 5.2,
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(service.hasVoiceAttachment(message)).toBe(true);
+    });
+
+    it('does NOT treat a forwarded content-type-less snapshot attachment WITHOUT duration as voice', () => {
+      const message = createMockMessage({
+        attachments: [],
+        messageSnapshots: [
+          {
+            attachments: [
+              {
+                url: 'https://cdn.discord.com/forwarded-no-ct.bin',
+                contentType: null,
+                name: 'file.bin',
+                size: 50000,
+                duration: null,
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(service.hasVoiceAttachment(message)).toBe(false);
+    });
+
+    it('detects voice in a LATER snapshot, not just the first (multi-snapshot walk)', () => {
+      const message = createMockMessage({
+        attachments: [],
+        messageSnapshots: [
+          {
+            attachments: [
+              {
+                url: 'https://cdn.discord.com/image.png',
+                contentType: 'image/png',
+                name: 'image.png',
+                size: 50000,
+                duration: null,
+              },
+            ],
+          },
+          {
+            attachments: [
+              {
+                url: 'https://cdn.discord.com/voice/second.ogg',
+                contentType: 'audio/ogg',
+                name: 'voice.ogg',
+                size: 50000,
+                duration: 5.2,
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(service.hasVoiceAttachment(message)).toBe(true);
+    });
+
+    it('returns false for a forward whose snapshots Discord did not populate', () => {
+      // `reference.type === Forward` with no snapshots: the old walk bailed on
+      // `hasForwardedSnapshots`, the shared detector instead falls back to the MAIN
+      // message's attachments — which the direct check above has already cleared.
+      const message = createMockMessage({
+        attachments: [
+          {
+            contentType: 'image/png',
+            duration: null,
+          },
+        ],
+        forwardReferenceWithoutSnapshots: true,
+      });
+
+      expect(service.hasVoiceAttachment(message)).toBe(false);
+    });
   });
 
   describe('transcribe', () => {
@@ -1421,6 +1521,13 @@ interface MockMessageOptions {
   authorId?: string;
   /** Give the mock channel a `send` method (the taking-longer notice path). */
   channelSend?: boolean;
+  /**
+   * Mark the message as a forward (`reference.type === Forward`) while leaving
+   * `messageSnapshots` absent — the shape Discord produces when it declines to
+   * populate snapshots. The two forwarded-voice detectors guard this case with
+   * different predicates, so it needs its own fixture.
+   */
+  forwardReferenceWithoutSnapshots?: boolean;
 }
 
 function createMockAttachmentsMap(attachmentsList: MockSnapshotAttachment[] | null): Map<
@@ -1486,6 +1593,12 @@ function createMockMessage(options: MockMessageOptions = {}): Message {
         attachments: createMockAttachmentsMap(snapshot.attachments),
       });
     });
+    // Discord.js hands back a `Collection`, not a bare `Map` — the shared
+    // forwarded-message helpers use `first()`. Stub it so the fixture matches the
+    // real shape instead of only the subset one caller happened to touch.
+    (messageSnapshots as any).first = function () {
+      return this.values().next().value;
+    };
   }
 
   const channel: any = options.noTypingSupport
@@ -1503,7 +1616,10 @@ function createMockMessage(options: MockMessageOptions = {}): Message {
 
   // If messageSnapshots is provided, include forward reference type
   // This is required by the centralized forwardedMessageUtils detection
-  const reference = messageSnapshots !== undefined ? { type: MessageReferenceType.Forward } : null;
+  const reference =
+    messageSnapshots !== undefined || options.forwardReferenceWithoutSnapshots === true
+      ? { type: MessageReferenceType.Forward }
+      : null;
 
   return {
     attachments,

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -22,7 +22,11 @@ import {
 } from '@tzurot/common-types/utils/errors';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { voiceTranscriptCache } from '../redis.js';
-import { hasForwardedSnapshots, getSnapshots } from '../utils/forwardedMessageUtils.js';
+import {
+  hasForwardedSnapshots,
+  getSnapshots,
+  hasForwardedVoiceAttachment,
+} from '../utils/forwardedMessageUtils.js';
 import { isVoiceAttachment } from '../utils/voiceAttachment.js';
 import { sendTypingIndicator } from '../utils/typingErrorClassifier.js';
 import { classifyBotAudio } from '../utils/botAudioClassifier.js';
@@ -249,26 +253,6 @@ function extractAudioFromSnapshot(snapshot: {
 }
 
 /**
- * Check if a snapshot has any audio attachments
- * @internal
- */
-function snapshotHasAudio(snapshot: {
-  attachments?: ReadonlyMap<
-    string,
-    {
-      contentType: string | null;
-      duration: number | null;
-    }
-  > | null;
-}): boolean {
-  if (!snapshot.attachments || snapshot.attachments.size === 0) {
-    return false;
-  }
-
-  return Array.from(snapshot.attachments.values()).some(isVoiceAttachment);
-}
-
-/**
  * Extract audio attachments from forwarded message snapshots
  * @internal
  */
@@ -314,23 +298,12 @@ export class VoiceTranscriptionService {
       return true;
     }
 
-    // Check forwarded message snapshots using centralized utility
-    if (!hasForwardedSnapshots(message)) {
-      return false;
-    }
-
-    const snapshots = getSnapshots(message);
-    if (snapshots === undefined) {
-      return false;
-    }
-
-    for (const snapshot of snapshots.values()) {
-      if (snapshotHasAudio(snapshot)) {
-        return true;
-      }
-    }
-
-    return false;
+    // Forwarded snapshots: delegate to the shared detector rather than re-walking
+    // the snapshots here. It reads the `isVoiceMessage` flag that
+    // `extractAttachments` computed from the RAW snapshot attachment, i.e. the same
+    // `isVoiceAttachment` predicate over the same object — including the
+    // duration fallback for content-type-less snapshots.
+    return hasForwardedVoiceAttachment(message);
   }
 
   /**

--- a/services/bot-client/src/utils/gatewayServiceCalls.test.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.test.ts
@@ -53,13 +53,9 @@ import {
   clearAllChannelSettingsCache,
   _clearAdminSettingsCacheForTesting,
 } from './gatewayServiceCalls.js';
+import { makeErr } from '../test/gatewayClientStubs.js';
 
 const ok = <T>(data: T): { ok: true; data: T } => ({ ok: true, data });
-const err = (status: number): { ok: false; error: string; status: number } => ({
-  ok: false,
-  error: 'boom',
-  status,
-});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -87,7 +83,7 @@ describe('getChannelSettingsCached', () => {
   });
 
   it('returns null (no throw) on a gateway error and does not cache it', async () => {
-    mockServiceClient.getChannelSettings.mockResolvedValue(err(500));
+    mockServiceClient.getChannelSettings.mockResolvedValue(makeErr(500, 'boom'));
 
     expect(await getChannelSettingsCached('chan-err')).toBeNull();
     // A subsequent call still tries again (error was not cached).
@@ -120,7 +116,7 @@ describe('getAdminSettingsCached', () => {
   });
 
   it('returns null on error', async () => {
-    mockServiceClient.getAdminSettingsInternal.mockResolvedValue(err(503));
+    mockServiceClient.getAdminSettingsInternal.mockResolvedValue(makeErr(503, 'boom'));
     expect(await getAdminSettingsCached()).toBeNull();
   });
 });
@@ -145,7 +141,7 @@ describe('setDmSessionPersonality', () => {
 
   it('does not throw and does not invalidate on failure', async () => {
     mockServiceClient.getChannelSettings.mockResolvedValue(ok({ hasSettings: true }));
-    mockServiceClient.setDmSession.mockResolvedValue(err(500));
+    mockServiceClient.setDmSession.mockResolvedValue(makeErr(500, 'boom'));
 
     await getChannelSettingsCached('dm-2');
     await expect(setDmSessionPersonality('dm-2', 'lila')).resolves.toBeUndefined();
@@ -165,14 +161,14 @@ describe('lookupPersonalityFromMessage', () => {
   });
 
   it('returns null on a 404 / error', async () => {
-    mockServiceClient.lookupPersonalityFromMessage.mockResolvedValue(err(404));
+    mockServiceClient.lookupPersonalityFromMessage.mockResolvedValue(makeErr(404, 'boom'));
     expect(await lookupPersonalityFromMessage('msg-x')).toBeNull();
   });
 });
 
 describe('fire-and-forget helpers', () => {
   it('updateDiagnosticResponseIds passes the ids and never throws on failure', async () => {
-    mockServiceClient.updateDiagnosticResponseIds.mockResolvedValue(err(500));
+    mockServiceClient.updateDiagnosticResponseIds.mockResolvedValue(makeErr(500, 'boom'));
     await expect(updateDiagnosticResponseIds('req-1', ['m1', 'm2'])).resolves.toBeUndefined();
     expect(mockServiceClient.updateDiagnosticResponseIds).toHaveBeenCalledWith('req-1', {
       responseMessageIds: ['m1', 'm2'],
@@ -180,7 +176,7 @@ describe('fire-and-forget helpers', () => {
   });
 
   it('stampUserActivity forwards the discordId as { discordId } and never throws on failure', async () => {
-    mockServiceClient.stampUserActivity.mockResolvedValue(err(500));
+    mockServiceClient.stampUserActivity.mockResolvedValue(makeErr(500, 'boom'));
     // Seam assertion: the wrapper must forward the raw snowflake as the request
     // body shape the endpoint expects, and a failed stamp must not surface to
     // the fire-and-forget caller.
@@ -191,7 +187,7 @@ describe('fire-and-forget helpers', () => {
   });
 
   it('filterNotifyEligible THROWS on gateway failure (pre-send: BullMQ must retry)', async () => {
-    mockServiceClient.retentionNotifyFilter.mockResolvedValue(err(503));
+    mockServiceClient.retentionNotifyFilter.mockResolvedValue(makeErr(503, 'boom'));
     await expect(filterNotifyEligible(['u-1'])).rejects.toThrow('Notify-eligibility filter failed');
   });
 
@@ -241,7 +237,7 @@ describe('fire-and-forget helpers', () => {
   });
 
   it('filterPendingDeliveries THROWS on gateway failure (pre-send: BullMQ must retry)', async () => {
-    mockServiceClient.releaseBroadcastPending.mockResolvedValue(err(503));
+    mockServiceClient.releaseBroadcastPending.mockResolvedValue(makeErr(503, 'boom'));
     await expect(filterPendingDeliveries('release-1', ['a'])).rejects.toThrow(
       'Pending-delivery filter failed'
     );
@@ -324,7 +320,7 @@ describe('fire-and-forget helpers', () => {
   });
 
   it('confirmDelivery never throws on failure', async () => {
-    mockServiceClient.aiConfirmDelivery.mockResolvedValue(err(404));
+    mockServiceClient.aiConfirmDelivery.mockResolvedValue(makeErr(404, 'boom'));
     await expect(confirmDelivery('job-1')).resolves.toBeUndefined();
     expect(mockServiceClient.aiConfirmDelivery).toHaveBeenCalledWith('job-1');
   });
@@ -354,7 +350,7 @@ describe('generate', () => {
   });
 
   it('throws on submission failure', async () => {
-    mockServiceClient.aiGenerate.mockResolvedValue(err(500));
+    mockServiceClient.aiGenerate.mockResolvedValue(makeErr(500, 'boom'));
     await expect(
       generate({ slug: 'lila' } as never, { messageContent: 'hi' } as never)
     ).rejects.toThrow('Gateway request failed');

--- a/services/bot-client/src/utils/gatewayWriteHelpers.test.ts
+++ b/services/bot-client/src/utils/gatewayWriteHelpers.test.ts
@@ -16,13 +16,9 @@ import {
   persistUserMessageViaGateway,
   syncConversationViaGateway,
 } from './gatewayWriteHelpers.js';
+import { makeErr } from '../test/gatewayClientStubs.js';
 
 const ok = <T>(data: T): { ok: true; data: T } => ({ ok: true, data });
-const err = (status: number): { ok: false; error: string; status: number } => ({
-  ok: false,
-  error: 'boom',
-  status,
-});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -56,7 +52,7 @@ describe('persistAssistantMessageViaGateway', () => {
   });
 
   it('THROWS on a request failure (authoritative write, caller owns the catch)', async () => {
-    mockServiceClient.persistAssistantMessage.mockResolvedValue(err(503));
+    mockServiceClient.persistAssistantMessage.mockResolvedValue(makeErr(503, 'boom'));
 
     await expect(persistAssistantMessageViaGateway(PARAMS)).rejects.toThrow(
       'Assistant-message persist failed via gateway: 503'
@@ -104,7 +100,7 @@ describe('syncConversationViaGateway', () => {
   });
 
   it('never throws: zero counts on request failure and on client error', async () => {
-    mockServiceClient.syncConversation.mockResolvedValue(err(503));
+    mockServiceClient.syncConversation.mockResolvedValue(makeErr(503, 'boom'));
     await expect(syncConversationViaGateway('chan-1', 'pers-1', OBSERVED)).resolves.toEqual({
       updated: 0,
       deleted: 0,
@@ -157,7 +153,7 @@ describe('persistUserMessageViaGateway', () => {
   });
 
   it('THROWS on a request failure (authoritative write, caller owns the catch)', async () => {
-    mockServiceClient.persistUserMessage.mockResolvedValue(err(503));
+    mockServiceClient.persistUserMessage.mockResolvedValue(makeErr(503, 'boom'));
 
     await expect(persistUserMessageViaGateway(PARAMS)).rejects.toThrow(
       'User-message persist failed via gateway: 503'


### PR DESCRIPTION
Closes TASK-121, TASK-128, TASK-152, TASK-156, TASK-229.

Second batch off the `state:unreachable` shelf from the triage pass, grouped by service so the diff stays readable. Each was filed with a "next time someone touches this file" trigger — one `06-backlog.md` already classifies as never firing.

| Task | Change |
| --- | --- |
| 121 | Three test files kept local `err()` builders with shapes differing from the shared `makeErr`. 19 call sites migrated. |
| 128 | `getSyntheticTimeout` cast parsed JSON straight to its type; now `safeParse`s against a mirroring schema. |
| 152 | Four test factories statically pre-set `deferred: true`; converted to the state-flipping pattern. |
| 156 | `hasVoiceAttachment` walked forwarded snapshots itself; deleted in favour of `hasForwardedVoiceAttachment`. |
| 229 | `/character avatar` and `voice` read options raw; converged on the generated typed accessor. |

## TASK-156 — the one that needed verifying rather than trusting

The task asserted the two detection paths agree. They use genuinely different mechanisms — a raw `some(isVoiceAttachment)` over snapshot attachments versus a precomputed `isVoiceMessage` flag — so that was checked at the producer rather than taken from the task text:

- **The flag is the same predicate over the same object.** `extractAttachments` sets `isVoiceMessage: isVoiceAttachment(attachment)` on the **raw** attachment, before `contentType ?? BINARY` normalization — so the duration fallback for content-type-less voice notes survives the delegation. Pinned with a test.
- **The guard is genuinely asymmetric, and that's the subtle part.** The old path required a forward *and* snapshots present. `hasForwardedVoiceAttachment` requires only a forward, then falls through to a branch that reads the **main message's** attachments — a different input set. It is safe *solely because* the delegation sits after the direct check, which already ran the identical predicate over that same collection, so the fall-through can only be reached when every main attachment is non-voice. A test pins it.
- Extra sources folded in by `extractAllForwardedContent` (embed images, snapshot stickers) never set `isVoiceMessage`, so they can't produce a false positive.
- Multi-snapshot and empty/null-snapshot cases covered.

Five tests pin these. **If any of that reasoning is wrong, this is the change that breaks voice transcription on forwarded messages** — so it's spelled out rather than summarised.

## A test-fixture edit that deserves scrutiny

Six pre-existing snapshot tests failed immediately after the delegation with `messageSnapshots?.first is not a function`. That shape — "test failed after my change, so I edited the test" — is exactly what shouldn't be taken on trust, so: discord.js types `messageSnapshots` as a **`Collection`**, verified in 14.27.0's typings (`public messageSnapshots: Collection<Snowflake, MessageSnapshot>`), and the fixture built a bare `Map` that happened to satisfy only the `.values()` walk the old code used. The shared helper chain calls `.first()`. Adding it to the fixture makes the mock match the real shape. **No assertion was changed.**

## Observed, not done

`forwardedMessageUtils.hasVoiceAttachments` appears to be an exact equivalent of the *whole* `hasVoiceAttachment` method (direct `||` forwarded), which would collapse it to a one-line delegation. Left alone because it exceeds "have the forwarded branch delegate", and because the guard-asymmetry analysis above means the two are only equivalent given the current ordering — worth a reviewer's eye before anyone collapses it.

## Verification

`pnpm --filter @tzurot/bot-client test` (6097 passed), `typecheck`, `typecheck:spec`, `lint`, `pnpm test:component` (624 passed), `pnpm quality` (28/28). Sequential.

Survivor greps: no `err(` left in the three migrated files, no `snapshotHasAudio` anywhere outside `dist/`, and the only surviving raw `interaction.options` calls in avatar/voice are `getSubcommand()` — which the generated accessor has no concept of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)