### PR TITLE
fix(tooling): four items whose only trigger was "next time we touch this"

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -114,10 +114,12 @@ if [ -n "$STAGED_CODE_FILES" ]; then
     #
     # Smoke-test after editing TEMPORAL_PATTERN (run in a shell where it's set):
     #   for s in 'Fixes #42' 'bug #1254' 'the #1254 drift' '(#1254)' \
-    #            'Phase 5b' 'Epic Phase 3' 'Post-Phase 4' 'Phase 6 made X'; do \
+    #            'Phase 5b' 'Epic Phase 3' 'Post-Phase 4' 'Phase 6 made X' \
+    #            'round 1 review' 'round-1 review' 'round-2 claude-review'; do \
     #     echo "$s" | grep -qEi "$TEMPORAL_PATTERN" && echo "catch: $s"; done
     #   for s in '#FF0000' '#123456' '#123' 'close the door' \
-    #            'Phase 1 (scan)' 'Phase 2 (flush)'; do \
+    #            'Phase 1 (scan)' 'Phase 2 (flush)' 'round-trip review' \
+    #            'round-trips through the encoder' 'a rounded-corner review panel'; do \
     #     echo "$s" | grep -qEi "$TEMPORAL_PATTERN" || echo "ignore: $s"; done
     #
     # Epic-phase archaeology: `Phase 5b` / `Epic Phase` / `Post-Phase` name WHICH
@@ -126,7 +128,7 @@ if [ -n "$STAGED_CODE_FILES" ]; then
     # `[a-z]`, not closed at `c`) + explicit "Epic/Post-Phase" + a bare `Phase N`
     # followed by a change-verb are caught; bare `Phase N (word)` is NOT
     # (algorithm phases like `Phase 1 (scan)` describe code, not archaeology).
-    TEMPORAL_PATTERN='PR #[0-9]+|PR-[0-9]+(\.[0-9a-z]+)*|GH-[0-9]+|[Bb]ug #[0-9]+|[Ii]ssue #[0-9]+|\(#[0-9]+\)|(fix(e[sd])?|close[sd]?|resolve[sd]?) #[0-9]+|#[0-9]{4,5}([^0-9]|$)|202[0-9]-[0-9]{2}-[0-9]{2}|Surfaced 202[0-9]|caught in (round|PR )|flagged by (review|PR)|round [0-9]+ (claude-review|review)|Epic Phase|[Pp]ost-[Pp]hase|Phase [0-9]+[a-z]|Phase [0-9]+ (made|added|introduced|landed|removed|renamed|dropped)'
+    TEMPORAL_PATTERN='PR #[0-9]+|PR-[0-9]+(\.[0-9a-z]+)*|GH-[0-9]+|[Bb]ug #[0-9]+|[Ii]ssue #[0-9]+|\(#[0-9]+\)|(fix(e[sd])?|close[sd]?|resolve[sd]?) #[0-9]+|#[0-9]{4,5}([^0-9]|$)|202[0-9]-[0-9]{2}-[0-9]{2}|Surfaced 202[0-9]|caught in (round|PR )|flagged by (review|PR)|round[- ][0-9]+ (claude-review|review)|Epic Phase|[Pp]ost-[Pp]hase|Phase [0-9]+[a-z]|Phase [0-9]+ (made|added|introduced|landed|removed|renamed|dropped)'
     HAS_VIOLATIONS=0
     VIOLATION_OUTPUT=""
     for file in $STAGED_CODE_FILES; do

--- a/packages/config-resolver/src/VisionConfigResolver.test.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.test.ts
@@ -110,10 +110,10 @@ describe('VisionConfigResolver', () => {
     });
 
     it("carries the row's explicitly-set params through the REAL mapper (tier 1)", async () => {
-      // The round-1 review of the vision-params feature found the resolver
-      // discarding every sampling field — this pins the real end-to-end path
-      // (DB row JSONB → mapper → ResolvedVisionConfig.params) so contract
-      // drift between the resolver and the gateway stamp can't recur silently.
+      // Runs the REAL mapper, not a stub, so the whole path is pinned:
+      // DB row JSONB → mapper → ResolvedVisionConfig.params. The resolver
+      // must carry every explicitly-set sampling field through; dropping one
+      // would leave the resolver and the gateway stamp silently disagreeing.
       mockPrisma.user.findFirst.mockResolvedValue({
         id: 'internal-x',
         defaultVisionConfigId: null,

--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -1112,18 +1112,18 @@ DECLARE
   personality_ids UUID[];
   pid UUID;
 BEGIN
-  
+  -- Determine which personalities are affected based on the table
   IF TG_TABLE_NAME = 'personalities' THEN
     personality_ids := ARRAY[COALESCE(NEW.id, OLD.id)];
 
   ELSIF TG_TABLE_NAME = 'llm_configs' THEN
-    
-    
+    -- When llm_configs change, send single "all" event instead of N individual events
+    -- This prevents notification storms when bulk operations occur
     PERFORM pg_notify(
       'cache_invalidation',
       json_build_object('type', 'all')::text
     );
-    RETURN NULL; 
+    RETURN NULL; -- Exit early - already sent notification
 
   ELSIF TG_TABLE_NAME = 'personality_default_configs' THEN
     personality_ids := ARRAY[COALESCE(NEW.personality_id, OLD.personality_id)];
@@ -1132,7 +1132,7 @@ BEGIN
     personality_ids := ARRAY[COALESCE(NEW.personality_id, OLD.personality_id)];
   END IF;
 
-  
+  -- Send NOTIFY for each affected personality
   IF personality_ids IS NOT NULL THEN
     FOREACH pid IN ARRAY personality_ids
     LOOP

--- a/packages/tooling/src/commands/cache.test.ts
+++ b/packages/tooling/src/commands/cache.test.ts
@@ -66,7 +66,14 @@ describe('cache:prefix-diff --limit bounds', () => {
   it('still rejects a non-positive limit (the lower bound is unchanged)', async () => {
     const { runPrefixDiff } = await import('../cache/prefix-diff.js');
 
-    await expect(runWithLimit('0')).rejects.toThrow('--limit must be a positive integer, got: 0');
+    await expect(runWithLimit('0')).rejects.toThrow('--limit must be at least 1, got: 0');
+    expect(runPrefixDiff).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric limit rather than letting NaN skip the cap check', async () => {
+    const { runPrefixDiff } = await import('../cache/prefix-diff.js');
+
+    await expect(runWithLimit('abc')).rejects.toThrow('--limit must be an integer, got: "abc"');
     expect(runPrefixDiff).not.toHaveBeenCalled();
   });
 });

--- a/packages/tooling/src/commands/cache.ts
+++ b/packages/tooling/src/commands/cache.ts
@@ -7,7 +7,7 @@
 import type { CAC } from 'cac';
 
 import { validateEnvironment, type Environment } from '../utils/env-runner.js';
-import { rawOptionValue } from '../utils/cli-args.js';
+import { rawOptionValue, parseIntFlag } from '../utils/cli-args.js';
 
 /**
  * Upper bound on `cache:prefix-diff --limit` (pair count).
@@ -19,6 +19,13 @@ import { rawOptionValue } from '../utils/cli-args.js';
  * and the run dies mid-transfer instead of producing a diff.
  */
 const PREFIX_DIFF_MAX_PAIRS = 100;
+
+/**
+ * Default `cache:prefix-diff --limit`. Named so the cac option default and
+ * the post-parse fallback cannot drift apart — cac always supplies the
+ * default, but `parseIntFlag` is typed to allow an absent flag.
+ */
+const PREFIX_DIFF_DEFAULT_PAIRS = 5;
 
 export function registerCacheCommands(cli: CAC): void {
   cli.command('cache:inspect', 'Inspect Turborepo cache size and status').action(async () => {
@@ -43,7 +50,7 @@ export function registerCacheCommands(cli: CAC): void {
     .option('--channel <channelId>', 'Discord channel to trace (snowflake)')
     .option('--personality <uuid>', 'Restrict to one personality')
     .option('--limit <pairs>', `Consecutive pairs to compare (max ${PREFIX_DIFF_MAX_PAIRS})`, {
-      default: 5,
+      default: PREFIX_DIFF_DEFAULT_PAIRS,
     })
     .example('ops cache:prefix-diff --env dev --channel 123456789012345678')
     .example('ops cache:prefix-diff --env prod --channel 123456789012345678 --limit 10')
@@ -55,15 +62,9 @@ export function registerCacheCommands(cli: CAC): void {
       if (channelId === undefined || channelId.length === 0) {
         throw new Error('--channel is required (Discord channel snowflake)');
       }
-      const limit = Number(options.limit);
-      if (!Number.isInteger(limit) || limit < 1) {
-        throw new Error(`--limit must be a positive integer, got: ${String(options.limit)}`);
-      }
-      if (limit > PREFIX_DIFF_MAX_PAIRS) {
-        throw new Error(
-          `--limit must be at most ${PREFIX_DIFF_MAX_PAIRS}, got: ${String(options.limit)}`
-        );
-      }
+      const limit =
+        parseIntFlag(options.limit, '--limit', { min: 1, max: PREFIX_DIFF_MAX_PAIRS }) ??
+        PREFIX_DIFF_DEFAULT_PAIRS;
       const { runPrefixDiff } = await import('../cache/prefix-diff.js');
       await runPrefixDiff({
         env: options.env as Environment,

--- a/packages/tooling/src/commands/deploy.test.ts
+++ b/packages/tooling/src/commands/deploy.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cac } from 'cac';
+
+import { registerDeployCommands } from './deploy.js';
+
+// The action dynamically imports the maintenance runner, which would talk to
+// Railway and Redis; stubbing it lets the flag validation run with no
+// external contact.
+vi.mock('../deployment/maintenance.js', () => ({
+  runMaintenance: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('../deployment/logs.js', () => ({
+  fetchLogs: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('maintenance --drain-timeout validation', () => {
+  let cli: ReturnType<typeof cac>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cli = cac('test');
+    registerDeployCommands(cli);
+  });
+
+  /**
+   * cac's parse() discards the action's returned promise; runMatchedCommand()
+   * returns it, which is what makes an async validation throw assertable.
+   */
+  async function runWithTimeout(timeout: string): Promise<void> {
+    cli.parse(
+      ['node', 'test', 'maintenance', 'status', '--env', 'dev', '--drain-timeout', timeout],
+      { run: false }
+    );
+    await (cli.runMatchedCommand() as Promise<void>);
+  }
+
+  // The behaviour change this pins: a malformed value used to fall back to the
+  // 120s default, which hid the fact that the operator's intended window was
+  // never applied — on the one command that runs during a destructive prod
+  // migration.
+  it('aborts on a non-numeric timeout instead of falling back to the default', async () => {
+    const { runMaintenance } = await import('../deployment/maintenance.js');
+
+    await expect(runWithTimeout('garbage')).rejects.toThrow(
+      '--drain-timeout must be an integer, got: "garbage"'
+    );
+    expect(runMaintenance).not.toHaveBeenCalled();
+  });
+
+  it('aborts on a zero timeout, which would make the drain wait meaningless', async () => {
+    const { runMaintenance } = await import('../deployment/maintenance.js');
+
+    await expect(runWithTimeout('0')).rejects.toThrow('--drain-timeout must be at least 1, got: 0');
+    expect(runMaintenance).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid timeout through to the runner', async () => {
+    const { runMaintenance } = await import('../deployment/maintenance.js');
+
+    await runWithTimeout('300');
+
+    expect(runMaintenance).toHaveBeenCalledWith(
+      'status',
+      expect.objectContaining({ drainTimeoutSec: 300 })
+    );
+  });
+
+  it('rejects a non-integer --lines on the logs command', async () => {
+    // Same coercion change as --drain-timeout, on the other deploy.ts flag.
+    const { fetchLogs } = await import('../deployment/logs.js');
+    cli.parse(['node', 'test', 'logs', '--env', 'dev', '--lines', 'abc'], { run: false });
+
+    await expect(cli.runMatchedCommand() as Promise<void>).rejects.toThrow(
+      '--lines must be an integer, got: "abc"'
+    );
+    expect(fetchLogs).not.toHaveBeenCalled();
+  });
+
+  it('applies the declared default when the flag is omitted', async () => {
+    const { runMaintenance } = await import('../deployment/maintenance.js');
+
+    cli.parse(['node', 'test', 'maintenance', 'status', '--env', 'dev'], { run: false });
+    await (cli.runMatchedCommand() as Promise<void>);
+
+    expect(runMaintenance).toHaveBeenCalledWith(
+      'status',
+      expect.objectContaining({ drainTimeoutSec: 120 })
+    );
+  });
+});

--- a/packages/tooling/src/commands/deploy.ts
+++ b/packages/tooling/src/commands/deploy.ts
@@ -4,7 +4,15 @@
 
 import type { CAC } from 'cac';
 
+import { parseIntFlag } from '../utils/cli-args.js';
+
 const ENV_OPTION = '--env <env>';
+
+/**
+ * Default `maintenance --drain-timeout`, in seconds. Named so the cac option
+ * default and the post-parse fallback cannot drift apart.
+ */
+const DRAIN_TIMEOUT_DEFAULT_SEC = 120;
 
 function registerMaintenanceCommand(cli: CAC): void {
   cli
@@ -14,7 +22,7 @@ function registerMaintenanceCommand(cli: CAC): void {
       default: false,
     })
     .option('--drain-timeout <seconds>', 'Max seconds to wait for the queue to drain', {
-      default: 120,
+      default: DRAIN_TIMEOUT_DEFAULT_SEC,
     })
     .example('pnpm ops maintenance status --env prod')
     .example('pnpm ops maintenance on --env prod')
@@ -34,14 +42,17 @@ function registerMaintenanceCommand(cli: CAC): void {
         }
 
         const { runMaintenance } = await import('../deployment/maintenance.js');
-        // NaN-guard: `Number('abc')` is NaN, and `waited >= NaN` is always
-        // false — an unfiltered NaN deadline would poll forever. Fall back to
-        // the command default instead.
-        const drainTimeout = Number(options.drainTimeout);
+        // A malformed timeout is a usage error, not a fall-back: `waited >=
+        // NaN` is always false, so an unfiltered NaN deadline polls forever,
+        // and silently substituting the default hides that the operator's
+        // intended (probably longer) window was never applied.
+        const drainTimeoutSec =
+          parseIntFlag(options.drainTimeout, '--drain-timeout', { min: 1 }) ??
+          DRAIN_TIMEOUT_DEFAULT_SEC;
         process.exitCode = await runMaintenance(action, {
           env: options.env,
           skipDrain: options.skipDrain,
-          drainTimeoutSec: Number.isFinite(drainTimeout) ? drainTimeout : undefined,
+          drainTimeoutSec,
         });
       }
     );
@@ -124,7 +135,10 @@ export function registerDeployCommands(cli: CAC): void {
         await fetchLogs({
           env: options.env,
           service: options.service,
-          lines: options.lines === undefined ? undefined : Number(options.lines),
+          // No ceiling here: logs.ts clamps an over-large window to the
+          // Railway CLI cap with a warning, which is friendlier than a hard
+          // usage error for a flag whose cap is an external tool's limit.
+          lines: parseIntFlag(options.lines, '--lines', { min: 1 }),
           filter: options.filter,
           // CAC auto-casts all-digit values to Number; an unstringed ID would
           // silently fail logs.ts's `typeof === 'string'` term filter.

--- a/packages/tooling/src/commands/dev.test.ts
+++ b/packages/tooling/src/commands/dev.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cac } from 'cac';
+
+import { registerDevCommands } from './dev.js';
+
+vi.mock('../dev/stale-debug-audit.js', () => ({
+  runStaleDebugAudit: vi.fn(),
+}));
+
+describe('dev:stale-debug --max-age-days validation', () => {
+  let cli: ReturnType<typeof cac>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cli = cac('test');
+    registerDevCommands(cli);
+  });
+
+  async function run(...args: string[]): Promise<void> {
+    cli.parse(['node', 'test', 'dev:stale-debug', ...args], { run: false });
+    await (cli.runMatchedCommand() as Promise<void>);
+  }
+
+  // Defense in depth rather than a gap-closer: runStaleDebugAudit already
+  // rejects a non-finite maxAgeDays. This pins that the CLI layer refuses
+  // first, so the operator gets a flag-named message instead of one about an
+  // internal argument.
+  it('rejects a non-integer max-age-days at the CLI layer', async () => {
+    const { runStaleDebugAudit } = await import('../dev/stale-debug-audit.js');
+
+    await expect(run('--max-age-days', 'abc')).rejects.toThrow(
+      '--max-age-days must be an integer, got: "abc"'
+    );
+    expect(runStaleDebugAudit).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid max-age-days to the audit', async () => {
+    const { runStaleDebugAudit } = await import('../dev/stale-debug-audit.js');
+
+    await run('--max-age-days', '30');
+
+    expect(runStaleDebugAudit).toHaveBeenCalledWith(expect.objectContaining({ maxAgeDays: 30 }));
+  });
+
+  it('leaves max-age-days undefined when omitted, so the audit default applies', async () => {
+    const { runStaleDebugAudit } = await import('../dev/stale-debug-audit.js');
+
+    await run();
+
+    expect(runStaleDebugAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ maxAgeDays: undefined })
+    );
+  });
+});

--- a/packages/tooling/src/commands/dev.ts
+++ b/packages/tooling/src/commands/dev.ts
@@ -6,6 +6,8 @@
 
 import type { CAC } from 'cac';
 
+import { parseIntFlag } from '../utils/cli-args.js';
+
 export function registerDevCommands(cli: CAC): void {
   cli
     .command('dev:focus <task>', 'Run turbo task only on packages with changes')
@@ -117,7 +119,7 @@ function registerStaleDebugCommand(cli: CAC): void {
       const { runStaleDebugAudit } = await import('../dev/stale-debug-audit.js');
       runStaleDebugAudit({
         summary: options.summary,
-        maxAgeDays: options.maxAgeDays !== undefined ? Number(options.maxAgeDays) : undefined,
+        maxAgeDays: parseIntFlag(options.maxAgeDays, '--max-age-days', { min: 1 }),
       });
     });
 }

--- a/packages/tooling/src/commands/gh.test.ts
+++ b/packages/tooling/src/commands/gh.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cac } from 'cac';
+
+import { registerGhCommands } from './gh.js';
+
+// Every gh command dynamically imports this module and hits the GitHub API
+// through it; stubbing it lets the positional validation run offline, and
+// makes "did the command return early?" directly assertable.
+vi.mock('../gh/github-api.js', () => ({
+  getPrInfo: vi.fn().mockReturnValue({ number: 1, title: 't', state: 'open', html_url: 'u' }),
+  getPrReviews: vi.fn().mockReturnValue([]),
+  getPrAllComments: vi.fn().mockReturnValue({ conversation: [], line: [] }),
+  getPrIssueComments: vi.fn().mockReturnValue([]),
+  getPrLineComments: vi.fn().mockReturnValue([]),
+  editPr: vi.fn(),
+  formatReviews: vi.fn().mockReturnValue(''),
+  formatComments: vi.fn().mockReturnValue(''),
+}));
+
+describe('gh command PR-number validation', () => {
+  let cli: ReturnType<typeof cac>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    cli = cac('test');
+    registerGhCommands(cli);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  async function run(command: string, number: string): Promise<void> {
+    cli.parse(['node', 'test', command, number], { run: false });
+    await (cli.runMatchedCommand() as Promise<void>);
+  }
+
+  // The early-return is the load-bearing half: without it a NaN would reach
+  // the API as a literal `/pulls/NaN` path and fail with an opaque 404 rather
+  // than a usage error.
+  it('returns before the API call when the PR number is not a number', async () => {
+    const { getPrInfo } = await import('../gh/github-api.js');
+
+    await run('gh:pr-info', 'abc');
+
+    expect(getPrInfo).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledWith('<number> must be an integer, got: "abc"');
+  });
+
+  it('returns before the API call when the PR number is zero', async () => {
+    const { getPrReviews } = await import('../gh/github-api.js');
+
+    await run('gh:pr-reviews', '0');
+
+    expect(getPrReviews).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  // The absent-value case never reaches the action: cac rejects a missing
+  // required positional first. This pins that upstream guarantee, because it
+  // is what makes `parsePrNumber`'s own absent-value branch unreachable — if
+  // `<number>` were ever loosened to the optional `[number]` form, this test
+  // fails and points at the branch that then starts carrying real weight.
+  it('is rejected by cac before the action runs when the number is missing', async () => {
+    const { getPrInfo } = await import('../gh/github-api.js');
+
+    cli.parse(['node', 'test', 'gh:pr-info'], { run: false });
+
+    expect(() => cli.runMatchedCommand()).toThrow('missing required args');
+    expect(getPrInfo).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid PR number to the API', async () => {
+    const { getPrInfo } = await import('../gh/github-api.js');
+
+    await run('gh:pr-info', '1985');
+
+    expect(getPrInfo).toHaveBeenCalledWith(1985);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  // The guard was applied to six call sites by a scripted replace; this pins
+  // that the multi-call command got it too, not just the single-call ones.
+  it('guards the multi-call gh:pr-all command as well', async () => {
+    const api = await import('../gh/github-api.js');
+
+    await run('gh:pr-all', 'abc');
+
+    expect(api.getPrInfo).not.toHaveBeenCalled();
+    expect(api.getPrReviews).not.toHaveBeenCalled();
+    expect(api.getPrLineComments).not.toHaveBeenCalled();
+    expect(api.getPrIssueComments).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tooling/src/commands/gh.ts
+++ b/packages/tooling/src/commands/gh.ts
@@ -11,13 +11,41 @@
 
 import type { CAC } from 'cac';
 
+import { parseIntFlagOrReport } from '../utils/cli-args.js';
+
+/**
+ * Parse the `<number>` positional every gh command takes. Returns the PR
+ * number, or `null` if it isn't one (having already printed the error and set
+ * `exitCode` — the caller returns on null).
+ *
+ * `parseInt('abc', 10)` is NaN, which would reach the GitHub API as a literal
+ * `/pulls/NaN` path and fail with an opaque 404 rather than a usage error.
+ *
+ * An ABSENT value is reported here rather than passed through: `parseIntFlag`
+ * treats `undefined` as "flag omitted, use the default" and returns silently,
+ * which is right for an optional flag and wrong for a required positional —
+ * collapsing it with `?? null` would exit 0 printing nothing, the one failure
+ * shape a caller checking `=== null` could not distinguish from success. cac
+ * enforces the positional before the action runs, so this is belt-and-braces;
+ * it exists so every `null` this returns has a printed reason.
+ */
+function parsePrNumber(raw: string | undefined): number | null {
+  if (raw === undefined) {
+    console.error('<number> is required');
+    process.exitCode = 1;
+    return null;
+  }
+  return parseIntFlagOrReport(raw, '<number>', { min: 1 }) ?? null;
+}
+
 function registerPrInfoCommands(cli: CAC): void {
   cli
     .command('gh:pr-info <number>', 'Get PR title, body, and state')
     .example('ops gh:pr-info 478')
     .action(async (number: string) => {
       const { getPrInfo } = await import('../gh/github-api.js');
-      const prNumber = parseInt(number, 10);
+      const prNumber = parsePrNumber(number);
+      if (prNumber === null) return;
       const pr = getPrInfo(prNumber);
       console.log(`# PR #${pr.number}: ${pr.title}\n`);
       console.log(`State: ${pr.state}`);
@@ -31,7 +59,8 @@ function registerPrInfoCommands(cli: CAC): void {
     .example('ops gh:pr-reviews 478')
     .action(async (number: string) => {
       const { getPrReviews, formatReviews } = await import('../gh/github-api.js');
-      const prNumber = parseInt(number, 10);
+      const prNumber = parsePrNumber(number);
+      if (prNumber === null) return;
       const reviews = getPrReviews(prNumber);
       console.log(`# Reviews for PR #${prNumber}\n`);
       console.log(formatReviews(reviews));
@@ -45,7 +74,8 @@ function registerPrInfoCommands(cli: CAC): void {
     .example('ops gh:pr-comments 478')
     .action(async (number: string) => {
       const { getPrAllComments, formatComments } = await import('../gh/github-api.js');
-      const prNumber = parseInt(number, 10);
+      const prNumber = parsePrNumber(number);
+      if (prNumber === null) return;
       const comments = getPrAllComments(prNumber);
 
       console.log(`# Comments for PR #${prNumber}\n`);
@@ -73,7 +103,8 @@ function registerPrInfoCommands(cli: CAC): void {
     .example('ops gh:pr-conversation 478')
     .action(async (number: string) => {
       const { getPrIssueComments, formatComments } = await import('../gh/github-api.js');
-      const prNumber = parseInt(number, 10);
+      const prNumber = parsePrNumber(number);
+      if (prNumber === null) return;
       const comments = getPrIssueComments(prNumber);
       console.log(`# Conversation for PR #${prNumber}\n`);
       console.log(formatComments(comments));
@@ -91,7 +122,8 @@ function registerPrEditCommand(cli: CAC): void {
     .action(
       async (number: string, options: { title?: string; body?: string; bodyFile?: string }) => {
         const { editPr } = await import('../gh/github-api.js');
-        const prNumber = parseInt(number, 10);
+        const prNumber = parsePrNumber(number);
+        if (prNumber === null) return;
 
         let body = options.body;
         if (options.bodyFile) {
@@ -100,8 +132,11 @@ function registerPrEditCommand(cli: CAC): void {
         }
 
         if (!options.title && !body) {
+          // Soft exit, matching parsePrNumber above: process.exit() kills the
+          // process mid-event-loop, so any pending stdout write can be lost.
           console.error('Error: Must provide --title, --body, or --body-file');
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
 
         const updates: { title?: string; body?: string } = {};
@@ -129,7 +164,8 @@ function registerPrAllCommand(cli: CAC): void {
         formatReviews,
         formatComments,
       } = await import('../gh/github-api.js');
-      const prNumber = parseInt(number, 10);
+      const prNumber = parsePrNumber(number);
+      if (prNumber === null) return;
 
       const pr = getPrInfo(prNumber);
       const reviews = getPrReviews(prNumber);

--- a/packages/tooling/src/commands/memory.ts
+++ b/packages/tooling/src/commands/memory.ts
@@ -6,6 +6,7 @@
 
 import type { CAC } from 'cac';
 import type { Environment } from '../utils/env-runner.js';
+import { parseIntFlagOrReport } from '../utils/cli-args.js';
 
 const ENV_OPTION = '--env <env>';
 const ENV_OPTION_DESC = 'Environment: local, dev, or prod';
@@ -24,20 +25,16 @@ const OUT_OPTION_DESC = 'Output dir (default reports/goldens-mining — gitignor
 /**
  * Parse an optional positive-integer CLI flag. Returns the number, `undefined`
  * if the flag is absent, or `null` if it's present-but-invalid (having already
- * printed the error + set exitCode — the caller returns on null). Shared by the
- * mining commands' `--sample` / `--history-window` validation.
+ * printed the error + set exitCode — the caller returns on null).
+ *
+ * Names the `{ min: 1 }` range this file's flags all share, over the shared
+ * `parseIntFlagOrReport`.
  */
-function parsePositiveIntOption(raw: string | undefined, flag: string): number | undefined | null {
-  if (raw === undefined) {
-    return undefined;
-  }
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value < 1) {
-    console.error(`${flag} must be a positive integer (got '${raw}')`);
-    process.exitCode = 1;
-    return null;
-  }
-  return value;
+function parsePositiveIntOption(
+  raw: string | number | undefined,
+  flag: string
+): number | undefined | null {
+  return parseIntFlagOrReport(raw, flag, { min: 1 });
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -86,13 +83,21 @@ function registerBackfillFactsCommand(cli: CAC): void {
         includeCovered?: boolean;
         force?: boolean;
       }) => {
+        // A typo'd --limit must not fall through as NaN: this command's cap
+        // exists to keep canary runs bounded, and `enqueued >= NaN` is always
+        // false — the run would proceed uncapped over the whole backlog.
+        const limit = parsePositiveIntOption(options.limit, '--limit');
+        if (limit === null) return;
+        const windowSize = parsePositiveIntOption(options.windowSize, '--window-size');
+        if (windowSize === null) return;
+
         const { backfillFacts } = await import('../memory/backfill-facts.js');
         await backfillFacts({
           env: options.env ?? 'dev',
           dryRun: options.dryRun,
-          limit: options.limit === undefined ? undefined : Number(options.limit),
+          limit,
           personalityId: options.personalityId,
-          windowSize: options.windowSize === undefined ? undefined : Number(options.windowSize),
+          windowSize,
           includeCovered: options.includeCovered,
           force: options.force,
         });

--- a/packages/tooling/src/commands/prompt.test.ts
+++ b/packages/tooling/src/commands/prompt.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cac } from 'cac';
+
+import { registerPromptCommands } from './prompt.js';
+
+vi.mock('../utils/env-runner.js', () => ({
+  validateEnvironment: vi.fn(),
+}));
+
+vi.mock('../prompt/voice-probes.js', () => ({
+  parseDepthsOption: vi.fn().mockReturnValue([5, 10]),
+}));
+
+vi.mock('../prompt/mine-voice-probes.js', () => ({
+  mineVoiceProbes: vi.fn().mockResolvedValue(undefined),
+}));
+
+// A real snowflake — the action reads --owner from raw argv (cac would lose
+// precision on a digit-only value), so it has to be present there.
+const OWNER = '278863839632818186';
+
+describe('prompt:mine-voice-probes --count validation', () => {
+  let cli: ReturnType<typeof cac>;
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalArgv = process.argv;
+    process.argv = ['node', 'ops', 'prompt:mine-voice-probes', '--owner', OWNER];
+    cli = cac('test');
+    registerPromptCommands(cli);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  async function runWithCount(count: string): Promise<void> {
+    cli.parse(
+      [
+        'node',
+        'test',
+        'prompt:mine-voice-probes',
+        '--env',
+        'dev',
+        '--owner',
+        OWNER,
+        '--count',
+        count,
+      ],
+      { run: false }
+    );
+    await (cli.runMatchedCommand() as Promise<void>);
+  }
+
+  // The defect this closes was silent, not loud: an unvalidated NaN reached
+  // pickPersonalities, whose `count < 1` guard is FALSE for NaN, so it fell
+  // through to `ranked.slice(0, NaN)` — mining zero personalities and
+  // reporting success. A mined run of nothing looks like a mined run.
+  it('rejects a non-numeric count instead of silently mining zero personalities', async () => {
+    const { mineVoiceProbes } = await import('../prompt/mine-voice-probes.js');
+
+    await expect(runWithCount('abc')).rejects.toThrow('--count must be an integer, got: "abc"');
+    expect(mineVoiceProbes).not.toHaveBeenCalled();
+  });
+
+  it('rejects a zero count, which would mine nothing by construction', async () => {
+    const { mineVoiceProbes } = await import('../prompt/mine-voice-probes.js');
+
+    await expect(runWithCount('0')).rejects.toThrow('--count must be at least 1, got: 0');
+    expect(mineVoiceProbes).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid count through to the miner', async () => {
+    const { mineVoiceProbes } = await import('../prompt/mine-voice-probes.js');
+
+    await runWithCount('6');
+
+    expect(mineVoiceProbes).toHaveBeenCalledWith(expect.objectContaining({ personalityCount: 6 }));
+  });
+
+  it('leaves count undefined when the flag is omitted, so the miner default applies', async () => {
+    const { mineVoiceProbes } = await import('../prompt/mine-voice-probes.js');
+
+    cli.parse(['node', 'test', 'prompt:mine-voice-probes', '--env', 'dev', '--owner', OWNER], {
+      run: false,
+    });
+    await (cli.runMatchedCommand() as Promise<void>);
+
+    expect(mineVoiceProbes).toHaveBeenCalledWith(
+      expect.objectContaining({ personalityCount: undefined })
+    );
+  });
+});

--- a/packages/tooling/src/commands/prompt.ts
+++ b/packages/tooling/src/commands/prompt.ts
@@ -7,7 +7,7 @@
 import type { CAC } from 'cac';
 
 import { validateEnvironment, type Environment } from '../utils/env-runner.js';
-import { rawOptionValue } from '../utils/cli-args.js';
+import { rawOptionValue, parseIntFlag } from '../utils/cli-args.js';
 
 export function registerPromptCommands(cli: CAC): void {
   cli
@@ -46,10 +46,7 @@ export function registerPromptCommands(cli: CAC): void {
             '--owner is required (operator Discord snowflake) — the privacy scope is explicit, never implied.'
           );
         }
-        const count = options.count === undefined ? undefined : Number(options.count);
-        if (count !== undefined && (!Number.isInteger(count) || count < 1)) {
-          throw new Error(`--count must be a positive integer, got: ${String(options.count)}`);
-        }
+        const count = parseIntFlag(options.count, '--count', { min: 1 });
         const { parseDepthsOption } = await import('../prompt/voice-probes.js');
         const { mineVoiceProbes } = await import('../prompt/mine-voice-probes.js');
         await mineVoiceProbes({

--- a/packages/tooling/src/commands/secrets.test.ts
+++ b/packages/tooling/src/commands/secrets.test.ts
@@ -42,4 +42,32 @@ describe('registerSecretsCommands', () => {
     const command = cli.commands.find(c => c.name === 'secrets:rotate-byok');
     expect(command?.options.find(option => option.name === 'stage')).toBeDefined();
   });
+
+  // The action validates --interval before the dynamic import, so a malformed
+  // value fails here rather than as a NaN at the Prisma write. This is the one
+  // action-level assertion in this file; the rest is registration shape per
+  // the convention above.
+  it('rejects a malformed --interval before loading the rotation module', async () => {
+    registerSecretsCommands(cli);
+
+    cli.parse(['node', 'test', 'secrets:mark-rotated', 'some-secret', '--interval', 'abc'], {
+      run: false,
+    });
+
+    await expect(cli.runMatchedCommand() as Promise<void>).rejects.toThrow(
+      '--interval must be an integer, got: "abc"'
+    );
+  });
+
+  it('rejects a zero --interval, which would mark every secret perpetually overdue', async () => {
+    registerSecretsCommands(cli);
+
+    cli.parse(['node', 'test', 'secrets:mark-rotated', 'some-secret', '--interval', '0'], {
+      run: false,
+    });
+
+    await expect(cli.runMatchedCommand() as Promise<void>).rejects.toThrow(
+      '--interval must be at least 1, got: 0'
+    );
+  });
 });

--- a/packages/tooling/src/commands/secrets.ts
+++ b/packages/tooling/src/commands/secrets.ts
@@ -6,6 +6,7 @@
 
 import type { CAC } from 'cac';
 import type { SecretsEnv } from '../secrets/rotation.js';
+import { parseIntFlag } from '../utils/cli-args.js';
 
 const ENV_OPTION_FLAG = '--env <env>';
 const ENV_OPTION_HELP = 'Target environment: dev | prod';
@@ -26,15 +27,9 @@ export function registerSecretsCommands(cli: CAC): void {
     .option('--interval <days>', 'Override the rotation interval in days')
     .example('ops secrets:mark-rotated internal-service-secret --env prod')
     .action(async (name: string, options: { env: SecretsEnv; interval?: string }) => {
-      let intervalDays: number | undefined;
-      if (options.interval !== undefined) {
-        // Strict parse: a malformed value must be a usage error here, not a
-        // NaN that only fails downstream at the Prisma write.
-        intervalDays = Number(options.interval);
-        if (!Number.isInteger(intervalDays) || intervalDays <= 0) {
-          throw new Error(`--interval must be a positive integer, got "${options.interval}"`);
-        }
-      }
+      // Strict parse: a malformed value must be a usage error here, not a
+      // NaN that only fails downstream at the Prisma write.
+      const intervalDays = parseIntFlag(options.interval, '--interval', { min: 1 });
       const { markSecretRotated } = await loadRotation();
       await markSecretRotated({ env: options.env, name, intervalDays });
     });

--- a/packages/tooling/src/secrets/rotation.test.ts
+++ b/packages/tooling/src/secrets/rotation.test.ts
@@ -176,7 +176,8 @@ describe('rotateByokKey', () => {
   it('stage 1 happy path: PREVIOUS has NEVER existed on Railway (first rotation ever)', async () => {
     // Regression pin: the variable is absent from `railway variables --json`
     // entirely before the first rotation — absent must read as unset, not
-    // throw. (The round-1 window-guard fix crashed here.)
+    // throw — the window guard must treat a missing key as "no previous key"
+    // rather than dereferencing it.
     stubRailwayVars({ API_KEY_ENCRYPTION_KEY: KEY_A_HEX });
 
     await expect(rotateByokKey({ env: 'dev', stage: '1' })).resolves.toBeUndefined();

--- a/packages/tooling/src/test/generate-schema.test.ts
+++ b/packages/tooling/src/test/generate-schema.test.ts
@@ -266,6 +266,52 @@ describe('generateSchema', () => {
       expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "c" CHECK ("n" > 0);');
     });
 
+    // A `$word$`-shaped run inside an ordinary string literal looks exactly
+    // like a dollar-quote tag to the scanner. Treating an unmatched one as a
+    // span running to end-of-file does not delete the tail — it is copied
+    // through verbatim — but it does stop comment-stripping for the rest of
+    // the file, and an unstripped comment containing a `;` then splits the
+    // statement after it, which IS how the constraint gets lost. The trailing
+    // comment below is therefore load-bearing: without it the bug is inert.
+    it('does not swallow the rest of the file on an unmatched dollar-tag', async () => {
+      mockMigrations({
+        '20251127110000_dollar_lookalike': `
+          ALTER TABLE "t" ADD CONSTRAINT "before_tag" CHECK ("a" > 0);
+          ALTER TABLE "t" ALTER COLUMN "note" SET DEFAULT '$money$';
+          /* retires the old one; a new one follows */
+          ALTER TABLE "t" ADD CONSTRAINT "after_tag" CHECK ("b" > 0);
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "before_tag" CHECK ("a" > 0);');
+      // The one that a swallow-to-EOF scanner loses.
+      expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "after_tag" CHECK ("b" > 0);');
+    });
+
+    // Postgres block comments NEST, so the whole `/* a /* b */ c */` span is
+    // one comment. Closing at the FIRST `*/` leaves ` c */` behind as live
+    // SQL, which then splits the following statement on the comment's own
+    // text and drops the constraint.
+    it('treats a nested block comment as one span', async () => {
+      mockMigrations({
+        '20251127110000_nested_block': `
+          /* outer prologue /* inner note; with a semicolon */ still commented; */
+          ALTER TABLE "t" ADD CONSTRAINT "nested_ok" CHECK ("n" > 0);
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "nested_ok" CHECK ("n" > 0);');
+      expect(content).not.toContain('still commented');
+    });
+
     // Realistic "same name appears twice" shape: migration B drops the
     // constraint, then re-adds it with a different expression. Without the
     // dedup, both ADDs would land in the output and PGLite would reject the
@@ -812,6 +858,268 @@ describe('generateSchema', () => {
 
       const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
       expect(content).not.toContain('doomed_trigger');
+    });
+
+    // Comment stripping must not reach inside a dollar-quoted body. A plpgsql
+    // body's own string literals are arbitrary text: a URL or example string
+    // containing `--` would otherwise have the rest of that line deleted,
+    // silently corrupting the harvested function — and a corrupted or missing
+    // trigger means component tests stop exercising production behaviour
+    // while still passing.
+    it('keeps a `--` inside a dollar-quoted string literal intact', async () => {
+      mockMigrations({
+        '20260101000000_url_in_body': `
+          CREATE FUNCTION note_source() RETURNS trigger AS $$
+          BEGIN
+            NEW.source := 'https://example.test/a--b';
+            RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql;
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain("NEW.source := 'https://example.test/a--b';");
+      // The statement after the truncated line must survive too — blind
+      // stripping eats it along with the rest of the line.
+      expect(content).toContain('RETURN NEW;');
+      expect(content).toContain('LANGUAGE plpgsql;');
+    });
+
+    it('keeps a `/*` inside a dollar-quoted body from swallowing later statements', async () => {
+      // A `/*` inside a body is not a comment opener at all — but a blind
+      // block-comment strip reads it as one and deletes everything up to the
+      // next `*/`, gutting the body in between.
+      mockMigrations({
+        '20260101000000_glob_in_body': `
+          CREATE FUNCTION glob_note() RETURNS trigger AS $$
+          BEGIN
+            NEW.pattern := 'src/*.ts';
+            NEW.other := 'a*/b';
+            RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql;
+          CREATE TRIGGER glob_note_trigger AFTER UPDATE ON "users" FOR EACH ROW EXECUTE FUNCTION glob_note();
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain("NEW.pattern := 'src/*.ts';");
+      expect(content).toContain("NEW.other := 'a*/b';");
+      expect(content).toContain('CREATE TRIGGER glob_note_trigger');
+    });
+
+    it('leaves a $tag$-quoted span alone when stripping comments around it', async () => {
+      // The custom-tag form ($tag$…$tag$) is equally valid plpgsql quoting.
+      // (CREATE_FUNCTION_REGEX itself only recognises the bare `$$` form, so
+      // this pins the STRIPPER's behaviour: a `/*` inside the tagged span
+      // must not pair with a real block comment further down the file and
+      // swallow the trigger between them.)
+      mockMigrations({
+        '20260101000000_tagged_body': `
+          CREATE FUNCTION tagged_note() RETURNS trigger AS $body$
+          BEGIN
+            NEW.pattern := 'src/*.ts';
+            RETURN NEW;
+          END;
+          $body$ LANGUAGE plpgsql;
+          CREATE TRIGGER tagged_note_trigger AFTER UPDATE ON "users" /* deferred */ FOR EACH ROW EXECUTE FUNCTION tagged_note();
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('CREATE TRIGGER tagged_note_trigger');
+    });
+
+    it('still strips a real `--` comment OUTSIDE any dollar-quoted body', async () => {
+      // The dollar-quote awareness must not turn the stripper off wholesale:
+      // a genuine comment mentioning CREATE TRIGGER would otherwise be
+      // harvested as if it were DDL.
+      mockMigrations({
+        '20260101000000_commented': `
+          -- CREATE TRIGGER commented_out AFTER DELETE ON "users" FOR EACH ROW EXECUTE FUNCTION f();
+          CREATE TRIGGER real_trigger AFTER DELETE ON "users" FOR EACH ROW EXECUTE FUNCTION f();
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('CREATE TRIGGER real_trigger');
+      expect(content).not.toContain('commented_out');
+    });
+  });
+
+  describe('dedup scoping (table + name)', () => {
+    function mockMigrations(migrations: Record<string, string>): void {
+      fsMock.existsSync.mockImplementation((path: string) => {
+        if (path.endsWith('prisma/migrations')) return true;
+        for (const name of Object.keys(migrations)) {
+          if (path.endsWith(`${name}/migration.sql`)) return true;
+        }
+        return false;
+      });
+      fsMock.readdirSync.mockImplementation(() =>
+        Object.keys(migrations).map(name => ({
+          name,
+          isDirectory: () => true,
+        }))
+      );
+      fsMock.readFileSync.mockImplementation((path: string) => {
+        for (const [name, sql] of Object.entries(migrations)) {
+          if (path.endsWith(`${name}/migration.sql`)) return sql;
+        }
+        return '';
+      });
+    }
+
+    // Postgres scopes constraint names to their table, so a hand-written
+    // migration may legitimately use the same bare name on two tables.
+    // Keying the dedup on the name alone collapses the pair to ONE statement
+    // and silently drops the other from the generated schema.
+    it('keeps same-named CHECK constraints on two different tables', async () => {
+      mockMigrations({
+        '20260101000000_two_tables': `
+          ALTER TABLE "a" ADD CONSTRAINT "valid_range" CHECK ("n" > 0);
+          ALTER TABLE "b" ADD CONSTRAINT "valid_range" CHECK ("m" > 10);
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('ALTER TABLE "a" ADD CONSTRAINT "valid_range" CHECK ("n" > 0);');
+      expect(content).toContain('ALTER TABLE "b" ADD CONSTRAINT "valid_range" CHECK ("m" > 10);');
+    });
+
+    it('drops a CHECK on one table without disturbing the same name on another', async () => {
+      mockMigrations({
+        '20260101000000_add': `
+          ALTER TABLE "a" ADD CONSTRAINT "valid_range" CHECK ("n" > 0);
+          ALTER TABLE "b" ADD CONSTRAINT "valid_range" CHECK ("m" > 10);
+        `,
+        '20260102000000_drop_a': 'ALTER TABLE "a" DROP CONSTRAINT "valid_range";',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).not.toContain('ALTER TABLE "a" ADD CONSTRAINT "valid_range"');
+      expect(content).toContain('ALTER TABLE "b" ADD CONSTRAINT "valid_range" CHECK ("m" > 10);');
+    });
+
+    it('keeps same-named DEFERRABLE constraints on two different tables', async () => {
+      mockMigrations({
+        '20260101000000_two_tables': `
+          ALTER TABLE "a" ALTER CONSTRAINT "shared_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+          ALTER TABLE "b" ALTER CONSTRAINT "shared_fkey" DEFERRABLE INITIALLY DEFERRED;
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain(
+        'ALTER TABLE "a" ALTER CONSTRAINT "shared_fkey" DEFERRABLE INITIALLY IMMEDIATE;'
+      );
+      expect(content).toContain(
+        'ALTER TABLE "b" ALTER CONSTRAINT "shared_fkey" DEFERRABLE INITIALLY DEFERRED;'
+      );
+    });
+
+    // Index names are unique per SCHEMA in Postgres (and `DROP INDEX` names no
+    // table at all), so the index harvest stays keyed on the name alone —
+    // last-wins across tables is the correct behaviour there, not a bug.
+    it('still last-wins partial-unique indexes by name alone across tables', async () => {
+      mockMigrations({
+        '20260101000000_first': 'CREATE UNIQUE INDEX "u" ON "a"("kind") WHERE "x" = true;',
+        '20260102000000_second': `
+          DROP INDEX "u";
+          CREATE UNIQUE INDEX "u" ON "b"("kind") WHERE "y" = true;
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      const matches = content.match(/CREATE UNIQUE INDEX "u"/g) ?? [];
+      expect(matches).toHaveLength(1);
+      expect(content).toContain('CREATE UNIQUE INDEX "u" ON "b"("kind") WHERE "y" = true;');
+    });
+
+    // Trigger names follow the CONSTRAINT rule, not the index rule: they are
+    // unique per table, so a repeated convention name on two tables must not
+    // collapse.
+    it('keeps same-named triggers on two different tables', async () => {
+      mockMigrations({
+        '20260101000000_two_tables': `
+          CREATE TRIGGER set_updated_at AFTER UPDATE ON "a" FOR EACH ROW EXECUTE FUNCTION f();
+          CREATE TRIGGER set_updated_at AFTER UPDATE ON "b" FOR EACH ROW EXECUTE FUNCTION f();
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('CREATE TRIGGER set_updated_at AFTER UPDATE ON "a"');
+      expect(content).toContain('CREATE TRIGGER set_updated_at AFTER UPDATE ON "b"');
+    });
+
+    // The table is quoted in Prisma-generated statements and bare in the
+    // hand-written cache-invalidation migrations — and the two forms are
+    // mixed across a single trigger's own DROP/CREATE pair. If the harvest
+    // keyed on the quoting rather than the identifier, this drop would no
+    // longer match its add and the retired trigger would survive.
+    it('pairs a bare-table DROP TRIGGER with a quoted-table CREATE TRIGGER', async () => {
+      mockMigrations({
+        '20260101000000_create': `
+          CREATE TRIGGER t_cache AFTER UPDATE ON "personalities" FOR EACH ROW EXECUTE FUNCTION f();
+        `,
+        '20260102000000_retire': 'DROP TRIGGER IF EXISTS t_cache ON personalities;',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).not.toContain('CREATE TRIGGER t_cache');
+    });
+
+    // The multi-line, unquoted-table shape the cache-invalidation migrations
+    // actually use — the timing clause spans lines and carries no `ON` of its
+    // own, so the first `ON` is the table's.
+    it('captures the table from a multi-line unquoted CREATE TRIGGER', async () => {
+      mockMigrations({
+        '20260101000000_multiline': `
+          CREATE TRIGGER t_multi
+            AFTER INSERT OR UPDATE OR DELETE ON personality_default_configs
+            FOR EACH ROW
+            EXECUTE FUNCTION notify();
+        `,
+        '20260102000000_retire_other_table': 'DROP TRIGGER IF EXISTS t_multi ON some_other_table;',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      // The drop targets a DIFFERENT table, so it must not retire this one.
+      expect(content).toContain('CREATE TRIGGER t_multi');
     });
   });
 

--- a/packages/tooling/src/test/generate-schema.ts
+++ b/packages/tooling/src/test/generate-schema.ts
@@ -85,13 +85,14 @@ interface GenerateSchemaOptions {
  * least one character inside the quotes, so a successful match guarantees
  * the name group is a non-empty string.
  */
-const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"([^"]+)"\s+CHECK\b/i;
+const CHECK_CONSTRAINT_REGEX =
+  /^ALTER\s+TABLE\s+"([^"]+)"\s+ADD\s+CONSTRAINT\s+"([^"]+)"\s+CHECK\b/i;
 // Matches both forms: `DROP CONSTRAINT "c"` and `DROP CONSTRAINT IF EXISTS "c"`.
 // Prisma migrate dev doesn't currently emit `IF EXISTS` for CHECK constraints,
 // but a hand-written migration may, and the IF-EXISTS form is semantically
 // equivalent for our extraction purposes.
 const DROP_CONSTRAINT_REGEX =
-  /^ALTER\s+TABLE\s+"[^"]+"\s+DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?"([^"]+)"/i;
+  /^ALTER\s+TABLE\s+"([^"]+)"\s+DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?"([^"]+)"/i;
 
 /**
  * Matches a `CREATE UNIQUE INDEX "<name>" ON ... WHERE ...` statement and
@@ -141,7 +142,7 @@ const DROP_INDEX_REGEX = /^DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?"([^"]+)"/i;
  * to DEFERRABLE_UNDO_REGEX below.
  */
 const DEFERRABLE_CONSTRAINT_REGEX =
-  /^ALTER\s+TABLE\s+"[^"]+"\s+ALTER\s+CONSTRAINT\s+"([^"]+)"\s+DEFERRABLE\b/i;
+  /^ALTER\s+TABLE\s+"([^"]+)"\s+ALTER\s+CONSTRAINT\s+"([^"]+)"\s+DEFERRABLE\b/i;
 /**
  * Undoes a harvested DEFERRABLE clause. Two forms retire deferrability:
  * an explicit `ALTER CONSTRAINT "c" NOT DEFERRABLE` revert, or dropping the
@@ -151,27 +152,197 @@ const DEFERRABLE_CONSTRAINT_REGEX =
  * must mirror that).
  */
 const DEFERRABLE_UNDO_REGEX =
-  /^ALTER\s+TABLE\s+"[^"]+"\s+(?:ALTER\s+CONSTRAINT\s+"([^"]+)"\s+NOT\s+DEFERRABLE\b|DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?"([^"]+)")/i;
+  /^ALTER\s+TABLE\s+"([^"]+)"\s+(?:ALTER\s+CONSTRAINT\s+"([^"]+)"\s+NOT\s+DEFERRABLE\b|DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?"([^"]+)")/i;
 
-type ExtractedOp =
-  { kind: 'add'; name: string; statement: string } | { kind: 'drop'; name: string };
+/**
+ * One harvest's regex pair plus how to build its dedup key.
+ *
+ * `tableScoped` encodes the identifier-uniqueness rule Postgres applies to
+ * the objects that harvest collects:
+ *
+ * - CONSTRAINT names are unique only WITHIN a table, so two tables may
+ *   legitimately carry the same constraint name (`"valid_range"` on both).
+ *   Those harvests capture the quoted table as group 1 and key on
+ *   `table + name` — keying on the name alone would last-wins-collapse the
+ *   pair into ONE statement and silently drop the other from the generated
+ *   schema.
+ * - INDEX names are unique per SCHEMA, not per table, so the name alone is
+ *   already a complete key — and `DROP INDEX "i"` names no table at all
+ *   (Postgres does not accept one), so a table-scoped key is not merely
+ *   unnecessary there but unrepresentable on the drop side.
+ */
+interface HarvestSpec {
+  addRegex: RegExp;
+  dropRegex: RegExp;
+  /** When true, group 1 of BOTH regexes is the quoted table name. */
+  tableScoped: boolean;
+}
+
+const CHECK_CONSTRAINT_SPEC: HarvestSpec = {
+  addRegex: CHECK_CONSTRAINT_REGEX,
+  dropRegex: DROP_CONSTRAINT_REGEX,
+  tableScoped: true,
+};
+
+const PARTIAL_UNIQUE_INDEX_SPEC: HarvestSpec = {
+  addRegex: PARTIAL_UNIQUE_INDEX_REGEX,
+  dropRegex: DROP_INDEX_REGEX,
+  tableScoped: false,
+};
+
+const DEFERRABLE_CONSTRAINT_SPEC: HarvestSpec = {
+  addRegex: DEFERRABLE_CONSTRAINT_REGEX,
+  dropRegex: DEFERRABLE_UNDO_REGEX,
+  tableScoped: true,
+};
+
+type ExtractedOp = { kind: 'add'; key: string; statement: string } | { kind: 'drop'; key: string };
 
 /** Collapse internal whitespace so each statement ends up on one line. */
 function normalizeStatement(stmt: string): string {
   return stmt.replace(/\s+/g, ' ').trim();
 }
 
-/** First defined capture group — undo regexes carry the name in one of two groups. */
-function capturedName(match: RegExpExecArray): string | undefined {
-  return match.slice(1).find(group => group !== undefined);
+/**
+ * Build the dedup key for a matched statement under the group convention
+ * described on `HarvestSpec`: when the harvest is table-scoped, group 1 is
+ * the quoted table and the object name is the first defined group after it
+ * (the undo regexes carry the name in one of two alternatives); otherwise
+ * the name is simply the first defined group.
+ *
+ * The separator is a double quote: every capture group here is `[^"]+`, so a
+ * quote can never appear inside either half and no pair of (table, name)
+ * values can collide with a different pair by concatenation.
+ */
+function dedupKeyFor(match: RegExpExecArray, tableScoped: boolean): string | undefined {
+  const groups = match.slice(1);
+  if (!tableScoped) {
+    return groups.find(group => group !== undefined);
+  }
+  const table = groups[0];
+  const name = groups.slice(1).find(group => group !== undefined);
+  if (table === undefined || name === undefined) return undefined;
+  return `${table}"${name}`;
+}
+
+/**
+ * Matches whichever comes first: a dollar-quote tag (`$$` or `$tag$`), the
+ * start of a line comment, or the start of a block comment.
+ */
+const SQL_COMMENT_OR_DOLLAR_TAG_REGEX = /\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$|--|\/\*/g;
+
+/**
+ * Index just past the block comment opening at `start`.
+ *
+ * Postgres block comments NEST: an inner open-comment token inside an outer
+ * one starts a second level, and BOTH must close before the comment ends.
+ * Closing at the first close-token instead would leave the outer comment's
+ * tail behind as live SQL, where its own text (a stray `;` especially) then
+ * splits the statement that follows and drops it from the harvest.
+ *
+ * An unterminated comment consumes the remainder, as Postgres itself would.
+ */
+function endOfBlockComment(sql: string, start: number): number {
+  let depth = 1;
+  let scan = start + 2;
+  while (depth > 0) {
+    const close = sql.indexOf('*/', scan);
+    if (close === -1) return sql.length;
+    const open = sql.indexOf('/*', scan);
+    if (open !== -1 && open < close) {
+      depth += 1;
+      scan = open + 2;
+    } else {
+      depth -= 1;
+      scan = close + 2;
+    }
+  }
+  return scan;
+}
+
+/**
+ * Strip SQL comments while leaving dollar-quoted spans (`$$…$$`,
+ * `$tag$…$tag$`) byte-for-byte intact.
+ *
+ * A blind whole-file comment regex is safe for the short ALTER/CREATE DDL the
+ * constraint harvests read, but plpgsql function bodies are arbitrary text: a
+ * body containing `--` or `/*` inside a string literal (a URL, example text)
+ * would have the rest of that line — or everything up to the next `*` + `/` —
+ * deleted, silently corrupting the harvested function or dropping it from the
+ * generated schema entirely. A missing trigger means component tests stop
+ * exercising production behaviour while still passing, so the corruption is
+ * invisible at exactly the layer meant to catch it.
+ *
+ * An unterminated BLOCK COMMENT consumes the remainder of the input, matching
+ * how Postgres itself would read the file. An unmatched dollar-tag does NOT —
+ * see the reasoning at the dollar-quote branch below.
+ *
+ * KNOWN LIMITATION — ordinary single-quoted string literals are NOT tracked,
+ * which has two consequences, both bounded:
+ *
+ * 1. A comment token inside one that sits OUTSIDE any dollar-quoted span (say
+ *    a `DEFAULT 'foo--bar'` on a plain `ALTER TABLE`) is read as a real
+ *    comment start, losing the rest of that line or block.
+ * 2. A `$word$`-shaped run inside such a literal is read as a dollar-tag. If
+ *    the same run appears again later it opens a bogus "span" and the text
+ *    between them survives un-stripped; if it does not appear again the tag is
+ *    treated as ordinary text (see the dollar-quote branch), so the damage
+ *    cannot extend past the second occurrence.
+ *
+ * Both predate this scanner — the blind regex it replaced mis-handled every
+ * comment in a literal — and the plpgsql bodies that motivated the rewrite are
+ * all dollar-quoted, which is why the fix stops here. Widening to full literal
+ * tracking means a real SQL tokenizer; do that only when a migration actually
+ * trips this, not preemptively.
+ */
+function stripSqlComments(sql: string): string {
+  const out: string[] = [];
+  let cursor = 0;
+  SQL_COMMENT_OR_DOLLAR_TAG_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = SQL_COMMENT_OR_DOLLAR_TAG_REGEX.exec(sql)) !== null) {
+    const token = match[0];
+    const start = match.index;
+    out.push(sql.slice(cursor, start));
+
+    if (token === '--') {
+      const newline = sql.indexOf('\n', start);
+      cursor = newline === -1 ? sql.length : newline;
+    } else if (token === '/*') {
+      cursor = endOfBlockComment(sql, start);
+    } else {
+      // Dollar-quoted span: copy it through verbatim, closing tag included.
+      //
+      // An UNMATCHED tag is treated as ordinary text (advance past it and
+      // keep scanning) rather than as a span running to end-of-file. Every
+      // migration under prisma/migrations has been applied by Postgres, so it
+      // is valid SQL — a tag with no closing partner was therefore never a
+      // real dollar-quote, but a `$word$`-shaped run of characters inside
+      // something else (a string literal, a regex in a CHECK expression).
+      // Consuming to end-of-file on that guess would silently discard every
+      // constraint, index, and trigger declared after it, and the harvest
+      // reports no error when it simply sees less input — the exact
+      // silent-under-collection failure this scanner exists to prevent.
+      const close = sql.indexOf(token, start + token.length);
+      cursor = close === -1 ? start + token.length : close + token.length;
+      out.push(sql.slice(start, cursor));
+    }
+
+    SQL_COMMENT_OR_DOLLAR_TAG_REGEX.lastIndex = cursor;
+  }
+
+  out.push(sql.slice(cursor));
+  return out.join('');
 }
 
 /**
  * Parse one migration.sql file and emit the add/drop operations matched by
- * the given regex pair. Strips both line-comments and block-comments before
- * splitting on `;` — block comments matter because a block-comment body can
- * contain a raw `;` that would split the surrounding statement in half and
- * silently drop the statement that followed.
+ * the spec's regex pair. Strips line-comments and block-comments (outside
+ * dollar-quoted spans — see `stripSqlComments`) before splitting on `;`:
+ * block comments matter because a block-comment body can contain a raw `;`
+ * that would split the surrounding statement in half and silently drop the
+ * statement that followed.
  *
  * Prisma migrations use `;` as the unambiguous statement terminator even
  * across line breaks. Harvested expressions can contain nested parens but
@@ -183,52 +354,53 @@ function capturedName(match: RegExpExecArray): string | undefined {
  * migration retires it without re-adding (else PGLite would enforce DDL that
  * prod Postgres no longer has, producing confusing test false positives).
  */
-function extractOpsFromFile(sqlPath: string, addRegex: RegExp, dropRegex: RegExp): ExtractedOp[] {
+function extractOpsFromFile(sqlPath: string, spec: HarvestSpec): ExtractedOp[] {
   const raw = readFileSync(sqlPath, 'utf-8');
-  const uncommented = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/--[^\n]*/g, '');
+  const uncommented = stripSqlComments(raw);
   const results: ExtractedOp[] = [];
 
   for (const stmt of uncommented.split(';')) {
     const trimmed = stmt.trim();
     if (trimmed.length === 0) continue;
 
-    const addMatch = addRegex.exec(trimmed);
+    const addMatch = spec.addRegex.exec(trimmed);
     if (addMatch !== null) {
-      const name = capturedName(addMatch);
+      const key = dedupKeyFor(addMatch, spec.tableScoped);
       // Unreachable per the regexes (`"[^"]+"` requires the capture), but TS
-      // sees the group as string | undefined.
-      if (name === undefined) continue;
+      // sees the groups as string | undefined.
+      if (key === undefined) continue;
       results.push({
         kind: 'add',
-        name,
+        key,
         statement: normalizeStatement(trimmed) + ';',
       });
       continue;
     }
 
-    const dropMatch = dropRegex.exec(trimmed);
+    const dropMatch = spec.dropRegex.exec(trimmed);
     if (dropMatch !== null) {
-      const name = capturedName(dropMatch);
-      // Unreachable per the regexes; guard satisfies TS's view of the group.
-      if (name === undefined) continue;
-      results.push({ kind: 'drop', name });
+      const key = dedupKeyFor(dropMatch, spec.tableScoped);
+      // Unreachable per the regexes; guard satisfies TS's view of the groups.
+      if (key === undefined) continue;
+      results.push({ kind: 'drop', key });
     }
   }
   return results;
 }
 
 /**
- * Extract all statements matching `addRegex` from every `migration.sql`
- * under `migrationsDir`, applying last-wins dedup by captured name. When the
- * same name appears in multiple migrations (drop + re-add across two files,
- * or a same-file drop-then-add pair), the **last** definition wins — this
- * matches Postgres's own semantics: after migration B drops and re-adds a
- * constraint, prod enforces migration B's definition, not migration A's.
- * First-wins would silently ship the stale definition into PGLite while prod
- * runs the latest one, re-introducing the fidelity gap the harvest exists to
- * eliminate. A drop without re-add removes the entry entirely.
+ * Extract all statements matching the spec's add regex from every
+ * `migration.sql` under `migrationsDir`, applying last-wins dedup by the
+ * spec's key (see `HarvestSpec`). When the same key appears in multiple
+ * migrations (drop + re-add across two files, or a same-file drop-then-add
+ * pair), the **last** definition wins — this matches Postgres's own
+ * semantics: after migration B drops and re-adds a constraint, prod enforces
+ * migration B's definition, not migration A's. First-wins would silently ship
+ * the stale definition into PGLite while prod runs the latest one,
+ * re-introducing the fidelity gap the harvest exists to eliminate. A drop
+ * without re-add removes the entry entirely.
  */
-function harvestLastWins(migrationsDir: string, addRegex: RegExp, dropRegex: RegExp): string[] {
+function harvestLastWins(migrationsDir: string, spec: HarvestSpec): string[] {
   if (!existsSync(migrationsDir)) {
     return [];
   }
@@ -242,42 +414,42 @@ function harvestLastWins(migrationsDir: string, addRegex: RegExp, dropRegex: Reg
 
   // Map.set overwrites existing entries while preserving insertion order.
   // Iterating chronologically means later migrations replace earlier ones
-  // by name while the overall emission order stays deterministic.
-  const byName = new Map<string, string>();
+  // by key while the overall emission order stays deterministic.
+  const byKey = new Map<string, string>();
 
   for (const folder of migrationFolders) {
     const sqlPath = join(migrationsDir, folder, 'migration.sql');
     if (!existsSync(sqlPath)) continue;
 
-    for (const op of extractOpsFromFile(sqlPath, addRegex, dropRegex)) {
+    for (const op of extractOpsFromFile(sqlPath, spec)) {
       if (op.kind === 'add') {
-        byName.set(op.name, op.statement);
+        byKey.set(op.key, op.statement);
       } else {
         // Drop without subsequent re-add must remove the prior definition.
         // A drop-then-re-add pair (across files or within one) is handled
         // correctly by the natural sequence: this delete fires, then the
         // following add repopulates with the new statement.
-        byName.delete(op.name);
+        byKey.delete(op.key);
       }
     }
   }
 
-  return Array.from(byName.values());
+  return Array.from(byKey.values());
 }
 
 /** All `ADD CONSTRAINT ... CHECK (...)` statements, last-wins deduped. */
 export function extractCheckConstraints(migrationsDir: string): string[] {
-  return harvestLastWins(migrationsDir, CHECK_CONSTRAINT_REGEX, DROP_CONSTRAINT_REGEX);
+  return harvestLastWins(migrationsDir, CHECK_CONSTRAINT_SPEC);
 }
 
 /** All partial `CREATE UNIQUE INDEX ... WHERE ...` statements, last-wins deduped. */
 export function extractPartialUniqueIndexes(migrationsDir: string): string[] {
-  return harvestLastWins(migrationsDir, PARTIAL_UNIQUE_INDEX_REGEX, DROP_INDEX_REGEX);
+  return harvestLastWins(migrationsDir, PARTIAL_UNIQUE_INDEX_SPEC);
 }
 
 /** All `ALTER CONSTRAINT ... DEFERRABLE ...` statements, last-wins deduped. */
 export function extractDeferrableConstraints(migrationsDir: string): string[] {
-  return harvestLastWins(migrationsDir, DEFERRABLE_CONSTRAINT_REGEX, DEFERRABLE_UNDO_REGEX);
+  return harvestLastWins(migrationsDir, DEFERRABLE_CONSTRAINT_SPEC);
 }
 
 /**
@@ -293,8 +465,33 @@ export function extractDeferrableConstraints(migrationsDir: string): string[] {
 const CREATE_FUNCTION_REGEX =
   /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)[^$]*\$\$(?:[^$]|\$(?!\$))*\$\$\s+LANGUAGE\s+plpgsql\s*;/gi;
 const DROP_FUNCTION_REGEX = /DROP\s+FUNCTION\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)/gi;
-const CREATE_TRIGGER_REGEX = /CREATE\s+TRIGGER\s+([A-Za-z_][A-Za-z0-9_]*)\b[^;]*;/gi;
-const DROP_TRIGGER_REGEX = /DROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)/gi;
+/**
+ * Trigger add/drop, each capturing (name, table) — trigger names are unique
+ * only WITHIN a table (the same rule as constraints, see `HarvestSpec`), so
+ * the harvest keys on both.
+ *
+ * The optional quotes around the table are OUTSIDE the capture group on
+ * purpose. Both forms appear in this repo's own migrations — Prisma emits
+ * `ON "conversation_history"` while the hand-written cache-invalidation
+ * migrations use `ON personalities` — and a `DROP TRIGGER x ON t` must key
+ * identically to the `CREATE TRIGGER x ... ON "t"` it retires. Capturing the
+ * quotes would make those two keys differ, so the drop would stop matching
+ * its add and the retired trigger would survive into the generated schema.
+ *
+ * `[^;]*?` before `ON` is non-greedy so the FIRST `ON` after the trigger name
+ * is taken as the table's — the timing clause (`AFTER INSERT OR UPDATE`,
+ * `AFTER UPDATE OF col`) never contains one, and `WHEN (...)` follows.
+ */
+// Linear-time by construction (regexp/no-super-linear-backtracking): each
+// identifier group is followed by `(?![A-Za-z0-9_])`, which forces it to
+// consume every word character it can. Without that, the group could give a
+// character back to the adjoining `[^;]*` gap and the two would exchange
+// characters — polynomial backtracking on a long statement. A bare `\b` does
+// not fix it: `\b` still holds at the shortened split point.
+const CREATE_TRIGGER_REGEX =
+  /CREATE\s+TRIGGER\s+([A-Za-z_][A-Za-z0-9_]*)(?![A-Za-z0-9_])[^;]*?\bON\s+"?([A-Za-z_][A-Za-z0-9_]*)(?![A-Za-z0-9_])"?[^;]*;/gi;
+const DROP_TRIGGER_REGEX =
+  /DROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)(?![A-Za-z0-9_])\s+ON\s+"?([A-Za-z_][A-Za-z0-9_]*)(?![A-Za-z0-9_])"?/gi;
 
 /**
  * Whole-file variant of the harvest: collects add/drop matches WITH their
@@ -307,7 +504,8 @@ const DROP_TRIGGER_REGEX = /DROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][A-Za-
 function harvestWholeFileLastWins(
   migrationsDir: string,
   addRegex: RegExp,
-  dropRegex: RegExp
+  dropRegex: RegExp,
+  tableScoped = false
 ): string[] {
   if (!existsSync(migrationsDir)) {
     return [];
@@ -317,35 +515,43 @@ function harvestWholeFileLastWins(
     .map(d => d.name)
     .sort();
 
-  const byName = new Map<string, string>();
+  // Same separator rationale as `dedupKeyFor`: every group here is an
+  // identifier charset that cannot contain a quote, so no two (table, name)
+  // pairs can collide by concatenation.
+  const keyOf = (match: RegExpMatchArray): string =>
+    tableScoped ? `${match[2]}"${match[1]}` : match[1];
+
+  const byKey = new Map<string, string>();
   for (const folder of migrationFolders) {
     const sqlPath = join(migrationsDir, folder, 'migration.sql');
     if (!existsSync(sqlPath)) continue;
     const raw = readFileSync(sqlPath, 'utf-8');
-    const uncommented = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/--[^\n]*/g, '');
+    // Dollar-quote-aware: a plpgsql body's own string literals may contain
+    // `--` or `/*`, and blind stripping would truncate the harvested body.
+    const uncommented = stripSqlComments(raw);
 
-    const ops: { index: number; kind: 'add' | 'drop'; name: string; statement?: string }[] = [];
+    const ops: { index: number; kind: 'add' | 'drop'; key: string; statement?: string }[] = [];
     for (const match of uncommented.matchAll(addRegex)) {
       ops.push({
         index: match.index ?? 0,
         kind: 'add',
-        name: match[1],
+        key: keyOf(match),
         statement: match[0].trim(),
       });
     }
     for (const match of uncommented.matchAll(dropRegex)) {
-      ops.push({ index: match.index ?? 0, kind: 'drop', name: match[1] });
+      ops.push({ index: match.index ?? 0, kind: 'drop', key: keyOf(match) });
     }
     ops.sort((a, b) => a.index - b.index);
     for (const op of ops) {
       if (op.kind === 'add' && op.statement !== undefined) {
-        byName.set(op.name, op.statement);
+        byKey.set(op.key, op.statement);
       } else {
-        byName.delete(op.name);
+        byKey.delete(op.key);
       }
     }
   }
-  return Array.from(byName.values());
+  return Array.from(byKey.values());
 }
 
 /** All plpgsql `CREATE FUNCTION` bodies, last-wins deduped by function name. */
@@ -355,7 +561,11 @@ export function extractPlpgsqlFunctions(migrationsDir: string): string[] {
 
 /** All `CREATE TRIGGER` statements, last-wins deduped by trigger name. */
 export function extractTriggers(migrationsDir: string): string[] {
-  return harvestWholeFileLastWins(migrationsDir, CREATE_TRIGGER_REGEX, DROP_TRIGGER_REGEX);
+  // Table-scoped: trigger names are unique per table, not per schema, so two
+  // tables may legitimately carry the same trigger name (a repeated
+  // `set_updated_at` convention). Functions above stay name-keyed — THEIR
+  // names are schema-scoped.
+  return harvestWholeFileLastWins(migrationsDir, CREATE_TRIGGER_REGEX, DROP_TRIGGER_REGEX, true);
 }
 
 /**

--- a/packages/tooling/src/utils/cli-args.test.ts
+++ b/packages/tooling/src/utils/cli-args.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { rawOptionValue } from './cli-args.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { rawOptionValue, parseIntFlag, parseIntFlagOrReport } from './cli-args.js';
 
 describe('rawOptionValue', () => {
   it('reads a space-separated flag value verbatim (no numeric coercion)', () => {
@@ -26,5 +26,146 @@ describe('rawOptionValue', () => {
 
   it('does not match a flag that only shares a prefix', () => {
     expect(rawOptionValue(['--channel-id', '123'], '--channel')).toBeUndefined();
+  });
+});
+
+describe('parseIntFlag', () => {
+  it('returns the integer for a valid string value', () => {
+    expect(parseIntFlag('7', '--limit', { min: 1 })).toBe(7);
+  });
+
+  it('accepts a number, since cac coerces digit-only values at tokenize time', () => {
+    expect(parseIntFlag(120, '--drain-timeout', { min: 1 })).toBe(120);
+  });
+
+  it('returns undefined for an absent flag, keeping optional flags optional', () => {
+    expect(parseIntFlag(undefined, '--limit', { min: 1 })).toBeUndefined();
+  });
+
+  it('rejects a non-numeric value, naming the flag', () => {
+    // The core failure this helper exists to stop: `Number('abc')` is NaN and
+    // every downstream comparison against it is false, so the typo'd flag
+    // would silently ignore itself instead of erroring.
+    expect(() => parseIntFlag('abc', '--limit', { min: 1 })).toThrow(
+      '--limit must be an integer, got: "abc"'
+    );
+  });
+
+  it('rejects a float', () => {
+    expect(() => parseIntFlag('2.5', '--window-size', { min: 1 })).toThrow(
+      '--window-size must be an integer, got: "2.5"'
+    );
+  });
+
+  it('rejects an empty value, which `Number("")` would otherwise read as 0', () => {
+    expect(() => parseIntFlag('', '--limit', { min: 1 })).toThrow('--limit must be an integer');
+    expect(() => parseIntFlag('   ', '--limit', { min: 1 })).toThrow('--limit must be an integer');
+  });
+
+  it('rejects Infinity, which is numeric but not an integer', () => {
+    expect(() => parseIntFlag('Infinity', '--limit', { min: 1 })).toThrow(
+      '--limit must be an integer'
+    );
+  });
+
+  it('rejects a negative value against a positive-integer floor', () => {
+    expect(() => parseIntFlag('-3', '--count', { min: 1 })).toThrow(
+      '--count must be at least 1, got: -3'
+    );
+  });
+
+  it('rejects zero against a positive-integer floor', () => {
+    expect(() => parseIntFlag('0', '--count', { min: 1 })).toThrow('--count must be at least 1');
+  });
+
+  it('rejects a value above the maximum, naming the cap', () => {
+    expect(() => parseIntFlag('101', '--limit', { min: 1, max: 100 })).toThrow(
+      '--limit must be at most 100, got: 101'
+    );
+  });
+
+  it('accepts the inclusive bounds themselves', () => {
+    expect(parseIntFlag('1', '--limit', { min: 1, max: 100 })).toBe(1);
+    expect(parseIntFlag('100', '--limit', { min: 1, max: 100 })).toBe(100);
+  });
+
+  // `Number` reads all of these as integers, so an isInteger-only check would
+  // accept them and quietly use a value the operator never typed.
+  it.each([
+    ['scientific notation', '1e2'],
+    ['hexadecimal', '0x10'],
+    ['binary', '0b11'],
+    ['octal', '0o17'],
+    ['a leading plus', '+5'],
+  ])('rejects %s, which Number() would silently coerce to an integer', (_label, input) => {
+    expect(() => parseIntFlag(input, '--limit', { min: 1 })).toThrow('--limit must be an integer');
+  });
+
+  it('echoes the verbatim input in a range message, not the coerced value', () => {
+    // `007` coerces to 7; reporting "got: 7" would show the operator a number
+    // they never typed, which is the harder thing to spot in a shell history.
+    expect(() => parseIntFlag('007', '--limit', { min: 10 })).toThrow(
+      '--limit must be at least 10, got: 007'
+    );
+  });
+
+  it('rejects a decimal integer too large to represent exactly', () => {
+    // Passes the shape check and `Number.isInteger`, but rounds on coercion —
+    // accepting it would silently use a different number than was typed.
+    expect(() => parseIntFlag('99999999999999999999', '--limit', { min: 1 })).toThrow(
+      '--limit is too large to represent exactly'
+    );
+  });
+
+  it('accepts MAX_SAFE_INTEGER itself', () => {
+    expect(parseIntFlag(String(Number.MAX_SAFE_INTEGER), '--limit', { min: 1 })).toBe(
+      Number.MAX_SAFE_INTEGER
+    );
+  });
+
+  it('still accepts a value cac already coerced to a number', () => {
+    // cac number-coerces digit-only option values at tokenize time, so the
+    // shape check has to pass for a real `number` arrival, not just a string.
+    expect(parseIntFlag(42, '--limit', { min: 1 })).toBe(42);
+  });
+});
+
+describe('parseIntFlagOrReport', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it('returns the parsed value and leaves exitCode alone when valid', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseIntFlagOrReport('42', '--limit', { min: 1 })).toBe(42);
+    expect(err).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('distinguishes an absent flag (undefined) from an invalid one (null)', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // The distinction callers depend on: undefined means "fall back to the
+    // default", null means "abort" — collapsing them would run an invalid
+    // flag under the default.
+    expect(parseIntFlagOrReport(undefined, '--limit', { min: 1 })).toBeUndefined();
+    expect(err).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+
+    expect(parseIntFlagOrReport('abc', '--limit', { min: 1 })).toBeNull();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('prints the flag-named message and sets exitCode on an invalid value', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseIntFlagOrReport('0', '--count', { min: 1 })).toBeNull();
+    expect(err).toHaveBeenCalledWith('--count must be at least 1, got: 0');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports an out-of-range value against a ceiling', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseIntFlagOrReport('101', '--limit', { min: 1, max: 100 })).toBeNull();
+    expect(err).toHaveBeenCalledWith('--limit must be at most 100, got: 101');
   });
 });

--- a/packages/tooling/src/utils/cli-args.ts
+++ b/packages/tooling/src/utils/cli-args.ts
@@ -1,5 +1,6 @@
 /**
- * Raw CLI argument extraction — the snowflake-precision escape hatch.
+ * CLI argument parsing helpers: raw-argv extraction (the snowflake-precision
+ * escape hatch) and validated numeric-flag coercion.
  *
  * cac (via mri) coerces digit-only option values to Number at TOKENIZE time,
  * before any type declaration applies. A Discord snowflake (17-20 digits)
@@ -29,4 +30,102 @@ export function rawOptionValue(argv: string[], flag: string): string | undefined
     }
   }
   return undefined;
+}
+
+/** Accepted range for a numeric flag. `max` is omitted when none applies. */
+export interface IntFlagRange {
+  /** Smallest accepted value, inclusive. */
+  min: number;
+  /** Largest accepted value, inclusive. */
+  max?: number;
+}
+
+/**
+ * Coerce a numeric CLI flag to an integer, throwing a flag-named error when
+ * the value is not one.
+ *
+ * Bare `Number(options.x)` is unsafe as a flag parser: `Number('abc')` is NaN
+ * and EVERY comparison against NaN is false, so a downstream `if (n > cap)`
+ * guard silently passes and the typo'd flag ignores itself instead of
+ * erroring — a run that was meant to be capped executes uncapped. `Number`
+ * also accepts floats and `Number('')` is 0, both of which read as valid to a
+ * later `> 0` check.
+ *
+ * `raw` is typed to accept `number` as well as `string` because cac (via mri)
+ * number-coerces digit-only option values at tokenize time, so a flag
+ * declared as a string can still arrive as a number.
+ *
+ * Returns `undefined` for an absent flag, so an optional flag stays optional.
+ *
+ * @throws Error naming the flag when the value is present but not an integer
+ *   within `range`.
+ */
+export function parseIntFlag(
+  raw: string | number | undefined,
+  flag: string,
+  range: IntFlagRange
+): number | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const text = String(raw).trim();
+  // Shape-check before coercing, because `Number` accepts several spellings
+  // that are integers by the time `Number.isInteger` sees them but are not
+  // what an operator typed on purpose: `1e2` → 100, `0x10` → 16, `0b11` → 3,
+  // and `''`/`'  '` → 0. Silently reading `--limit 1e2` as 100 is the same
+  // class of quiet misinterpretation this helper exists to end, so the
+  // literal decimal form is the only accepted one.
+  const value = /^-?\d+$/.test(text) ? Number(text) : Number.NaN;
+
+  if (!Number.isInteger(value)) {
+    throw new Error(`${flag} must be an integer, got: "${String(raw)}"`);
+  }
+  // The shape check above guarantees a decimal integer STRING, but a long
+  // enough one still lands on an imprecise float — `Number.isInteger` reports
+  // true for it, so the value would be silently rounded. This is the shared
+  // choke point for numeric CLI parsing, so it rejects rather than rounds.
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(
+      `${flag} is too large to represent exactly, got: "${String(raw)}" (max ${String(Number.MAX_SAFE_INTEGER)})`
+    );
+  }
+  // Range messages quote `raw`, not the coerced value: `--limit 007` should
+  // echo back what was typed, so the operator can spot the typo in their own
+  // command line rather than in a normalized form they never wrote.
+  if (value < range.min) {
+    throw new Error(`${flag} must be at least ${range.min}, got: ${String(raw)}`);
+  }
+  if (range.max !== undefined && value > range.max) {
+    throw new Error(`${flag} must be at most ${range.max}, got: ${String(raw)}`);
+  }
+  return value;
+}
+
+/**
+ * `parseIntFlag` for commands that report usage errors by printing and
+ * setting `exitCode` rather than throwing — the dominant convention among the
+ * `ops` commands that take numeric input.
+ *
+ * Returns the parsed integer, `undefined` for an absent optional flag, or
+ * `null` when the value was present but invalid (having already printed the
+ * error and set `exitCode`). The caller returns on `null`.
+ *
+ * The three-way return is what lets a caller distinguish "flag omitted, use
+ * the default" from "flag given but unusable, abort" — collapsing them would
+ * silently run an invalid flag under the default, which is the failure this
+ * whole helper exists to prevent.
+ */
+export function parseIntFlagOrReport(
+  raw: string | number | undefined,
+  flag: string,
+  range: IntFlagRange
+): number | undefined | null {
+  try {
+    return parseIntFlag(raw, flag, range);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+    return null;
+  }
 }

--- a/services/ai-worker/src/services/prompt/referenceRole.test.ts
+++ b/services/ai-worker/src/services/prompt/referenceRole.test.ts
@@ -69,8 +69,8 @@ describe('deriveRefRole', () => {
 
   it('fallback: own line under a stored-name variant resolves to assistant, not character', () => {
     // Mirror of the stamped self-variant pin with NO stamp — the fallback must
-    // route through the same self-variant guard (round-2 review catch: it
-    // previously matched the bare set entry and misread the persona's own line).
+    // route through the same self-variant guard. Matching the bare set entry
+    // instead misreads the persona's own line as a character line.
     expect(
       deriveRefRole(
         undefined,

--- a/services/api-gateway/src/utils/stampResolvedConfig.test.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.test.ts
@@ -22,8 +22,9 @@ const llmResolver = (
 
 // Mirrors the REAL ResolvedVisionConfig contract: explicit params arrive
 // NESTED on `params` (picked at resolution time by VisionConfigResolver via
-// pickVisionTierParams), never as flat sampling fields — the round-1 review
-// caught the double drifting from the real shape and hiding a dead feature.
+// pickVisionTierParams), never as flat sampling fields. A double that
+// flattens them diverges from the production shape, so every test built on it
+// keeps passing while the behaviour it claims to cover is dead.
 const visionResolver = (
   model: string,
   source: string,


### PR DESCRIPTION
Closes TASK-11, TASK-19, TASK-22, TASK-196. Batch 3 of the do-now shelf — items filed with a trigger that never fires on its own ("next time someone touches this file"), so each was cheaper to fix than to keep tracking.

## The one thing worth reviewing carefully

**The schema harvester was already corrupting a real function body.** `generate-schema.ts` stripped SQL comments with a blind whole-file regex — fine for short DDL, wrong for plpgsql bodies. Regenerating `pglite-schema.sql` after the fix restores five comment lines inside `notify_cache_invalidation()` that the stripper had been blanking:

```
-  
+  -- Determine which personalities are affected based on the table
...
-    RETURN NULL; 
+    RETURN NULL; -- Exit early - already sent notification
```

No SQL, identifier, or semantics changed — the deleted text happened to be comments rather than a string literal, which is why it was benign. The latent case (a `--` or `/*` inside a body's string literal) would have truncated the statement instead. CI's `pglite-schema.sql` drift gate makes regenerating mandatory, not optional.

## Verified, not just read

- **(A) dollar-quote stripping**: new tests confirmed to FAIL against the pre-fix implementation (reverted `stripSqlComments` only, ran, restored). The worker's first drafts of two of these tests passed pre-fix — the fixtures lacked a closing `*/`, so the blind regex never matched — and were strengthened before acceptance.
- **(B) (table, name) dedup**: same revert-and-confirm, 3 tests red pre-fix.
- **(D) tightened hook**: staged a scratch file containing `round-1 review` and ran `.husky/pre-commit` for real — exit 1, correct file cited. Control confirms the old pattern misses the same string. The hook's own smoke set still passes (8 must-catch, 9 must-ignore), plus three new negatives: `round-trip review`, `round-trips through the encoder`, `rounded-corner review panel`.

## Deviations from the plan, and why

**The spec's premise for (B) was wrong about one harvester.** It asserted the regexes already capture the table. True for CHECK and DEFERRABLE (both `ALTER TABLE "t" …`), **false for partial-unique indexes**: `DROP INDEX "i"` names no table because Postgres does not accept one. That is also not a bug — index names are unique per *schema*, so name-alone is already a complete key. Index harvesting stays name-keyed, with the reason documented on `HarvestSpec` and pinned by a test.

**`maintenance --drain-timeout` behavior change.** It previously fell back to the 120s default on a malformed value (documented as intentional). It now hard-errors. Quietly substituting the default hides that the operator's intended — probably longer — window was never applied, on the one command that runs during a destructive prod migration.

**Two adjacent findings ridden along rather than filed.** TASK-22's text says `Number(`, but the class is unvalidated numeric CLI input; `gh.ts` had six `parseInt(number, 10)` positionals with the same NaN defect (reaching the API as a literal `/pulls/NaN`). Closing the task with those left in the same package would have been an under-sweep. Also rewrote one archaeology comment in `rotation.test.ts` that the tightened pattern does *not* catch but the code standard does.

**One shared adapter, not two.** The print-and-set-exitCode wrapper existed in `memory.ts` and was about to be duplicated in `gh.ts`; both now route through `parseIntFlagOrReport` in the tested `cli-args.ts`. Its three-way return (value / `undefined` absent / `null` invalid) is what lets callers distinguish "use the default" from "abort" — collapsing them would run an invalid flag under the default, which is the whole defect.

## Verification

`pnpm --filter @tzurot/tooling test` (1915 passed) · `build` · `lint` · `pnpm test:component` (624 passed) · `pnpm quality` exit 0. Sequential, never parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)