### PR TITLE
docs: three deferred doc/skill gotchas

### DIFF
--- a/.claude/rules/04-discord.md
+++ b/.claude/rules/04-discord.md
@@ -180,28 +180,37 @@ MUST go through CommandHandler.
 
 **ALWAYS check for existing utilities before implementing:**
 
-| Pattern                 | Shared Utility                  | Location                                      |
-| ----------------------- | ------------------------------- | --------------------------------------------- |
-| Browse pagination       | `createBrowseCustomIdHelpers`   | `utils/browse/customIdFactory.ts`             |
-| Browse buttons          | `buildBrowseButtons`            | `utils/browse/buttonBuilder.ts`               |
-| Browse truncation       | `truncateForSelect`             | `utils/browse/truncation.ts`                  |
-| Dashboard builder       | `buildDashboardEmbed`           | `utils/dashboard/DashboardBuilder.ts`         |
-| Dashboard modals        | `buildSectionModal`             | `utils/dashboard/ModalFactory.ts`             |
-| Dashboard sessions      | `initSessionManager`            | `utils/dashboard/SessionManager.ts`           |
-| Dashboard messages      | `DASHBOARD_MESSAGES`            | `utils/dashboard/messages.ts`                 |
-| Dashboard close         | `handleDashboardClose`          | `utils/dashboard/closeHandler.ts`             |
-| Dashboard refresh       | `createRefreshHandler`          | `utils/dashboard/refreshHandler.ts`           |
-| Dashboard delete        | `buildDeleteConfirmation`       | `utils/dashboard/deleteConfirmation.ts`       |
-| Dashboard perms         | `checkEditPermission`           | `utils/dashboard/permissionChecks.ts`         |
-| Session helpers         | `fetchOrCreateSession`          | `utils/dashboard/sessionHelpers.ts`           |
-| Dashboard select menu   | `handleDashboardSectionSelect`  | `utils/dashboard/genericSelectMenuHandler.ts` |
-| Dashboard modal merge   | `extractAndMergeSectionValues`  | `utils/dashboard/modalHelpers.ts`             |
-| Interaction error reply | `replyError`                    | `utils/dashboard/replyError.ts`               |
-| Personality autocomp    | `handlePersonalityAutocomplete` | `utils/autocomplete/`                         |
-| Persona autocomplete    | `handlePersonaAutocomplete`     | `utils/autocomplete/`                         |
-| List sorting            | `createListComparator`          | `utils/listSorting.ts`                        |
+| Pattern                 | Shared Utility                  | Location                                        |
+| ----------------------- | ------------------------------- | ----------------------------------------------- |
+| Browse pagination       | `createBrowseCustomIdHelpers`   | `utils/browse/customIdFactory.ts`               |
+| Browse buttons          | `buildBrowseButtons`            | `utils/browse/buttonBuilder.ts`                 |
+| Browse truncation       | `truncateForSelect`             | `utils/browse/truncation.ts`                    |
+| Dashboard builder       | `buildDashboardEmbed`           | `utils/dashboard/DashboardBuilder.ts`           |
+| Dashboard modals        | `buildSectionModal`             | `utils/dashboard/ModalFactory.ts`               |
+| Dashboard sessions      | `initSessionManager`            | `utils/dashboard/SessionManager.ts`             |
+| Dashboard messages      | `DASHBOARD_MESSAGES`            | `utils/dashboard/messages.ts`                   |
+| Dashboard close         | `handleDashboardClose`          | `utils/dashboard/closeHandler.ts`               |
+| Dashboard refresh       | `createRefreshHandler`          | `utils/dashboard/refreshHandler.ts`             |
+| Dashboard delete        | `buildDeleteConfirmation`       | `utils/dashboard/deleteConfirmation.ts`         |
+| Dashboard perms         | `checkEditPermission`           | `utils/dashboard/permissionChecks.ts`           |
+| Session helpers         | `fetchOrCreateSession`          | `utils/dashboard/sessionHelpers.ts`             |
+| Dashboard select menu   | `handleDashboardSectionSelect`  | `utils/dashboard/genericSelectMenuHandler.ts`   |
+| Dashboard modal merge   | `extractAndMergeSectionValues`  | `utils/dashboard/modalHelpers.ts`               |
+| Interaction error reply | `replyError`                    | `utils/dashboard/replyError.ts`                 |
+| Personality autocomp    | `handlePersonalityAutocomplete` | `utils/autocomplete/`                           |
+| Persona autocomplete    | `handlePersonaAutocomplete`     | `utils/autocomplete/`                           |
+| List sorting            | `createListComparator`          | `utils/listSorting.ts`                          |
+| Round-trip contract     | `DASHBOARDS` registry           | `utils/dashboard/updateSchemaRoundTrip.test.ts` |
 
 **Never reimplement these patterns locally.**
+
+**A new fetch-edit-PUT dashboard MUST add itself to the `DASHBOARDS` registry.**
+That guard runs a null-bearing fetched object through the dashboard's real payload
+builder and asserts the result validates against the gateway's update schema — it
+catches the class where a dashboard PUTs back a field it fetched as `null` against
+an update schema declaring it `.optional()` (which accepts `undefined` but rejects
+`null`), 400ing every save. Registration can't be auto-discovered, so an unregistered
+dashboard is simply unguarded; this table is where that requirement is visible.
 
 ## Autocomplete Formatting
 

--- a/.claude/skills/tzurot-deployment/SKILL.md
+++ b/.claude/skills/tzurot-deployment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-deployment
 description: 'Railway deployment procedures. Invoke with /tzurot-deployment for deploying, checking logs, and troubleshooting.'
-lastUpdated: '2026-08-02'
+lastUpdated: '2026-08-06'
 ---
 
 # Deployment Procedures
@@ -63,13 +63,22 @@ Additive migrations are safe to premigrate; destructive ones (drop/rename/tighte
 
 ```bash
 pnpm ops maintenance on --env prod      # bot replies 🔧, gateway 503s (health stays green), BullMQ drains
+pnpm ops maintenance status --env prod  # REQUIRED: confirm ON before migrating (see below)
 pnpm ops release:premigrate --allow-destructive
 gh pr merge <release-PR> --rebase       # Railway auto-deploys into the ready schema
 # verify /health + bot boot, then:
 pnpm ops maintenance off --env prod     # traffic resumes within the 5s flag-cache window
 ```
 
-`pnpm ops maintenance status --env prod` shows the flag + queue depth. The flag lives in Redis (not an env var — env changes trigger Railway redeploys, and Postgres is the thing in flux). Note: the maintenance CHECK must already be deployed in prod for the gate to work — it protects releases after the one that ships it. See `.claude/rules/03-database.md` § Deployment.
+**Verify `status` shows ON before premigrating — do not proceed if Redis is down.**
+It reports the flag state plus queue depth. `MaintenanceFlag` fails OPEN on Redis
+errors, which is right for normal operation (a Redis blip must not 503 the whole
+API) but inverts here: if Redis is unreachable during the window, traffic is NOT
+quiesced precisely when quiescing is what protects the still-live old code from the
+changed schema. `maintenance on` returning success is not proof the gate is active —
+read the status.
+
+The flag lives in Redis (not an env var — env changes trigger Railway redeploys, and Postgres is the thing in flux). Note: the maintenance CHECK must already be deployed in prod for the gate to work — it protects releases after the one that ships it. See `.claude/rules/03-database.md` § Deployment.
 
 ### 3. Monitor deployment
 
@@ -220,10 +229,22 @@ pnpm ops run --env dev npx prisma studio
 
 ## Service Restart
 
+**`railway redeploy` has no `--environment` flag** — it acts on whatever environment
+the CLI is currently LINKED to, which is not necessarily the one you were just
+working in. A blind `redeploy --service <name> --yes` has come within one keystroke of
+bouncing PROD because the link happened to be production. Always check the link,
+switch explicitly, then restore it:
+
 ```bash
 # Note: 'railway restart' doesn't exist, use redeploy
+railway status                          # shows the currently LINKED environment — note it
+railway environment <target>            # switch explicitly — never assume the link
 railway redeploy --service bot-client --yes
+railway environment <the one status showed>   # restore the link you found, not a guess
 ```
+
+Same hazard class as any env-implicit CLI command against shared infra: the command
+looks identical whether it is about to touch dev or prod.
 
 ## Cost Impact in Infra Recommendations
 


### PR DESCRIPTION
Three one-paragraph doc/skill items. Closes TASK-59, TASK-214, TASK-264.

All three had been filed with triggers of the shape `06-backlog.md` now classifies as never-firing on their own ("next time someone touches the deployment skill"), which is why they sat. Rules and skills are review-gated, so they ride a PR rather than the direct-doc-commit exception.

## TASK-59 — surface the round-trip `DASHBOARDS` registry (`04-discord.md`)

`updateSchemaRoundTrip.test.ts` guards a real, confirmed bug class: a dashboard fetches an object, lets the user edit one section, then PUTs back fields it never changed — including nullable ones fetched as `null`. If the gateway's update schema declares such a field `.optional()` (accepts `undefined`, **rejects** `null`), every save 400s. The confirmed instance was personality `avatarData`, which the dashboard force-nulls, so every no-avatar character's section save was rejected behind a generic "Failed to update character."

The guard only covers dashboards listed in its `DASHBOARDS` array — and that "every fetch-edit-PUT dashboard MUST register" requirement lived **only in that file's own docstring**. A developer adding a dashboard has no reason to open it, so the new dashboard is silently unguarded.

Registration intent genuinely cannot be auto-discovered (a structural test enumerating update schemas would produce false negatives), so the honest fix is visibility, not automation: a row in the Shared Utilities table — where the "check for existing utilities before implementing" habit already sends you — plus the requirement stated in prose beneath it.

The table's column widths shift in the diff; that is prettier realigning around the longer path, not a content change.

## TASK-214 — verify maintenance is actually ON before a destructive premigrate (`/tzurot-deployment`)

`MaintenanceFlag` fails **open** on Redis errors. That is the right default for normal operation — a Redis blip must not 503 the whole API — but it inverts during the destructive-migration window, which is the one moment quiescing is load-bearing: it is what keeps the still-live old code from reading the changed schema. If Redis is down then, traffic is not quiesced precisely when that matters most.

`maintenance on` returning success is therefore not proof the gate is active. Adds the `status` check as a required step inside the sequence block, plus the reasoning, and the instruction not to proceed if Redis is down.

Reviewer-flagged at the beta.149 release review and accepted as a narrow known edge; this documents the operator-side mitigation rather than changing the fail-open behavior (which is correct where it is).

## TASK-264 — `railway redeploy` acts on the LINKED environment (`/tzurot-deployment`)

`railway redeploy` has **no `--environment` flag**. It targets whatever environment the CLI happens to be linked to, which is not necessarily the one you were just working in. A blind `redeploy -s <service> -y` came within one keystroke of bouncing PROD because the link happened to be production at the time.

The § Service Restart block previously showed exactly that bare command. Now documents the safe sequence: `railway status` to read the current link → `railway environment <target>` to switch explicitly → redeploy → restore the link **to what status showed**, not to an assumed default. (Hardcoding `production` as the restore target would reproduce the same assume-the-link mistake the warning is about.)

Same hazard class as any env-implicit CLI command against shared infra: the command looks identical whether it is about to touch dev or prod.

## Verification

Docs-only. `pnpm ops lines:check` green — the always-loaded rules surface grew 9 lines to 2047, against a 2270 limit. `pnpm ops backlog` and `guard:workflow-sync` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
