### PR TITLE
refactor(tooling): render ops CLI usage errors as one line, not a stack trace

### DIFF
--- a/packages/tooling/src/cli.ts
+++ b/packages/tooling/src/cli.ts
@@ -37,6 +37,7 @@ import { registerCpdCommands } from './commands/cpd.js';
 import { registerCodegenCommands } from './commands/codegen.js';
 import { registerTopologyCommands } from './commands/topology.js';
 import { registerPromptCommands } from './commands/prompt.js';
+import { reportUsageError } from './utils/errors.js';
 
 // Read version from package.json dynamically
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -72,5 +73,19 @@ registerPromptCommands(cli);
 cli.help();
 cli.version(packageJson.version);
 
-// Parse and run
-cli.parse();
+// Parse and run.
+//
+// `cli.parse()` runs the matched command but DISCARDS the promise its action
+// returns, so a rejected async action surfaces as an unhandled rejection — a
+// stack trace and a Node version banner where a one-line usage error belongs.
+// Parsing with `{ run: false }` and awaiting `runMatchedCommand()` ourselves
+// is cac's documented seam for owning that error path. `--help` and
+// `--version` are still handled inside `parse()`, which unsets the matched
+// command afterwards, so `runMatchedCommand()` correctly no-ops for them.
+cli.parse(process.argv, { run: false });
+
+try {
+  await cli.runMatchedCommand();
+} catch (error) {
+  if (!reportUsageError(error)) throw error;
+}

--- a/packages/tooling/src/commands/cache.ts
+++ b/packages/tooling/src/commands/cache.ts
@@ -8,6 +8,7 @@ import type { CAC } from 'cac';
 
 import { validateEnvironment, type Environment } from '../utils/env-runner.js';
 import { rawOptionValue, parseIntFlag } from '../utils/cli-args.js';
+import { UsageError } from '../utils/errors.js';
 
 /**
  * Upper bound on `cache:prefix-diff --limit` (pair count).
@@ -60,7 +61,7 @@ export function registerCacheCommands(cli: CAC): void {
       // values and a snowflake exceeds MAX_SAFE_INTEGER (see utils/cli-args.ts).
       const channelId = rawOptionValue(process.argv, '--channel');
       if (channelId === undefined || channelId.length === 0) {
-        throw new Error('--channel is required (Discord channel snowflake)');
+        throw new UsageError('--channel is required (Discord channel snowflake)');
       }
       const limit =
         parseIntFlag(options.limit, '--limit', { min: 1, max: PREFIX_DIFF_MAX_PAIRS }) ??

--- a/packages/tooling/src/commands/deploy.ts
+++ b/packages/tooling/src/commands/deploy.ts
@@ -5,6 +5,7 @@
 import type { CAC } from 'cac';
 
 import { parseIntFlag } from '../utils/cli-args.js';
+import { UsageError } from '../utils/errors.js';
 
 const ENV_OPTION = '--env <env>';
 
@@ -33,12 +34,10 @@ function registerMaintenanceCommand(cli: CAC): void {
         options: { env: string; skipDrain: boolean; drainTimeout: number }
       ) => {
         if (action !== 'on' && action !== 'off' && action !== 'status') {
-          console.error('Error: action must be "on", "off", or "status"');
-          process.exit(1);
+          throw new UsageError('action must be "on", "off", or "status"');
         }
         if (options.env !== 'local' && options.env !== 'dev' && options.env !== 'prod') {
-          console.error('Error: --env must be "local", "dev", or "prod"');
-          process.exit(1);
+          throw new UsageError('--env must be "local", "dev", or "prod"');
         }
 
         const { runMaintenance } = await import('../deployment/maintenance.js');
@@ -81,8 +80,7 @@ export function registerDeployCommands(cli: CAC): void {
     .option('--yes, -y', 'Skip confirmation prompts', { default: false })
     .action(async (options: { env: string; dryRun: boolean; yes: boolean }) => {
       if (options.env !== 'dev' && options.env !== 'prod') {
-        console.error('Error: --env must be "dev" or "prod"');
-        process.exit(1);
+        throw new UsageError('--env must be "dev" or "prod"');
       }
 
       const { setupRailwayVariables } = await import('../deployment/setup-railway-variables.js');
@@ -127,8 +125,7 @@ export function registerDeployCommands(cli: CAC): void {
         follow?: boolean;
       }) => {
         if (options.env !== 'dev' && options.env !== 'prod') {
-          console.error('Error: --env must be "dev" or "prod"');
-          process.exit(1);
+          throw new UsageError('--env must be "dev" or "prod"');
         }
 
         const { fetchLogs } = await import('../deployment/logs.js');

--- a/packages/tooling/src/commands/gh.test.ts
+++ b/packages/tooling/src/commands/gh.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { cac } from 'cac';
 
 import { registerGhCommands } from './gh.js';
+import { UsageError } from '../utils/errors.js';
 
 // Every gh command dynamically imports this module and hits the GitHub API
 // through it; stubbing it lets the positional validation run offline, and
@@ -23,14 +24,12 @@ describe('gh command PR-number validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'log').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
     cli = cac('test');
     registerGhCommands(cli);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    process.exitCode = undefined;
   });
 
   async function run(command: string, number: string): Promise<void> {
@@ -38,26 +37,29 @@ describe('gh command PR-number validation', () => {
     await (cli.runMatchedCommand() as Promise<void>);
   }
 
-  // The early-return is the load-bearing half: without it a NaN would reach
-  // the API as a literal `/pulls/NaN` path and fail with an opaque 404 rather
-  // than a usage error.
-  it('returns before the API call when the PR number is not a number', async () => {
+  // Aborting before the call is the load-bearing half: without it a NaN would
+  // reach the API as a literal `/pulls/NaN` path and fail with an opaque 404
+  // rather than a usage error. The throw is what cli.ts renders as one line.
+  it('throws a UsageError before the API call when the PR number is not a number', async () => {
     const { getPrInfo } = await import('../gh/github-api.js');
 
-    await run('gh:pr-info', 'abc');
+    await expect(run('gh:pr-info', 'abc')).rejects.toThrow(UsageError);
 
     expect(getPrInfo).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
-    expect(console.error).toHaveBeenCalledWith('<number> must be an integer, got: "abc"');
   });
 
-  it('returns before the API call when the PR number is zero', async () => {
+  it('names the offending positional in the message', async () => {
+    await expect(run('gh:pr-info', 'abc')).rejects.toThrow(
+      '<number> must be an integer, got: "abc"'
+    );
+  });
+
+  it('throws before the API call when the PR number is zero', async () => {
     const { getPrReviews } = await import('../gh/github-api.js');
 
-    await run('gh:pr-reviews', '0');
+    await expect(run('gh:pr-reviews', '0')).rejects.toThrow('<number> must be at least 1, got: 0');
 
     expect(getPrReviews).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
   });
 
   // The absent-value case never reaches the action: cac rejects a missing
@@ -80,7 +82,6 @@ describe('gh command PR-number validation', () => {
     await run('gh:pr-info', '1985');
 
     expect(getPrInfo).toHaveBeenCalledWith(1985);
-    expect(process.exitCode).toBeUndefined();
   });
 
   // The guard was applied to six call sites by a scripted replace; this pins
@@ -88,7 +89,7 @@ describe('gh command PR-number validation', () => {
   it('guards the multi-call gh:pr-all command as well', async () => {
     const api = await import('../gh/github-api.js');
 
-    await run('gh:pr-all', 'abc');
+    await expect(run('gh:pr-all', 'abc')).rejects.toThrow(UsageError);
 
     expect(api.getPrInfo).not.toHaveBeenCalled();
     expect(api.getPrReviews).not.toHaveBeenCalled();

--- a/packages/tooling/src/commands/gh.ts
+++ b/packages/tooling/src/commands/gh.ts
@@ -11,31 +11,31 @@
 
 import type { CAC } from 'cac';
 
-import { parseIntFlagOrReport } from '../utils/cli-args.js';
+import { parseIntFlag } from '../utils/cli-args.js';
+import { UsageError } from '../utils/errors.js';
 
 /**
- * Parse the `<number>` positional every gh command takes. Returns the PR
- * number, or `null` if it isn't one (having already printed the error and set
- * `exitCode` — the caller returns on null).
+ * Parse the `<number>` positional every gh command takes, throwing a
+ * `UsageError` when it isn't a usable PR number.
  *
  * `parseInt('abc', 10)` is NaN, which would reach the GitHub API as a literal
  * `/pulls/NaN` path and fail with an opaque 404 rather than a usage error.
  *
- * An ABSENT value is reported here rather than passed through: `parseIntFlag`
+ * An ABSENT value throws here rather than being passed through: `parseIntFlag`
  * treats `undefined` as "flag omitted, use the default" and returns silently,
- * which is right for an optional flag and wrong for a required positional —
- * collapsing it with `?? null` would exit 0 printing nothing, the one failure
- * shape a caller checking `=== null` could not distinguish from success. cac
- * enforces the positional before the action runs, so this is belt-and-braces;
- * it exists so every `null` this returns has a printed reason.
+ * which is right for an optional flag and wrong for a required positional. cac
+ * enforces the positional before the action runs, so that branch is
+ * belt-and-braces; it exists so a missing number can never be read as a
+ * successful parse.
  */
-function parsePrNumber(raw: string | undefined): number | null {
-  if (raw === undefined) {
-    console.error('<number> is required');
-    process.exitCode = 1;
-    return null;
+function parsePrNumber(raw: string | undefined): number {
+  // `parseIntFlag` throws on a present-but-invalid value and returns undefined
+  // only for an absent one, so the single guard below covers the absent case.
+  const parsed = parseIntFlag(raw, '<number>', { min: 1 });
+  if (parsed === undefined) {
+    throw new UsageError('<number> is required');
   }
-  return parseIntFlagOrReport(raw, '<number>', { min: 1 }) ?? null;
+  return parsed;
 }
 
 function registerPrInfoCommands(cli: CAC): void {
@@ -45,7 +45,6 @@ function registerPrInfoCommands(cli: CAC): void {
     .action(async (number: string) => {
       const { getPrInfo } = await import('../gh/github-api.js');
       const prNumber = parsePrNumber(number);
-      if (prNumber === null) return;
       const pr = getPrInfo(prNumber);
       console.log(`# PR #${pr.number}: ${pr.title}\n`);
       console.log(`State: ${pr.state}`);
@@ -60,7 +59,6 @@ function registerPrInfoCommands(cli: CAC): void {
     .action(async (number: string) => {
       const { getPrReviews, formatReviews } = await import('../gh/github-api.js');
       const prNumber = parsePrNumber(number);
-      if (prNumber === null) return;
       const reviews = getPrReviews(prNumber);
       console.log(`# Reviews for PR #${prNumber}\n`);
       console.log(formatReviews(reviews));
@@ -75,7 +73,6 @@ function registerPrInfoCommands(cli: CAC): void {
     .action(async (number: string) => {
       const { getPrAllComments, formatComments } = await import('../gh/github-api.js');
       const prNumber = parsePrNumber(number);
-      if (prNumber === null) return;
       const comments = getPrAllComments(prNumber);
 
       console.log(`# Comments for PR #${prNumber}\n`);
@@ -104,7 +101,6 @@ function registerPrInfoCommands(cli: CAC): void {
     .action(async (number: string) => {
       const { getPrIssueComments, formatComments } = await import('../gh/github-api.js');
       const prNumber = parsePrNumber(number);
-      if (prNumber === null) return;
       const comments = getPrIssueComments(prNumber);
       console.log(`# Conversation for PR #${prNumber}\n`);
       console.log(formatComments(comments));
@@ -123,7 +119,6 @@ function registerPrEditCommand(cli: CAC): void {
       async (number: string, options: { title?: string; body?: string; bodyFile?: string }) => {
         const { editPr } = await import('../gh/github-api.js');
         const prNumber = parsePrNumber(number);
-        if (prNumber === null) return;
 
         let body = options.body;
         if (options.bodyFile) {
@@ -132,11 +127,7 @@ function registerPrEditCommand(cli: CAC): void {
         }
 
         if (!options.title && !body) {
-          // Soft exit, matching parsePrNumber above: process.exit() kills the
-          // process mid-event-loop, so any pending stdout write can be lost.
-          console.error('Error: Must provide --title, --body, or --body-file');
-          process.exitCode = 1;
-          return;
+          throw new UsageError('Must provide --title, --body, or --body-file');
         }
 
         const updates: { title?: string; body?: string } = {};
@@ -165,7 +156,6 @@ function registerPrAllCommand(cli: CAC): void {
         formatComments,
       } = await import('../gh/github-api.js');
       const prNumber = parsePrNumber(number);
-      if (prNumber === null) return;
 
       const pr = getPrInfo(prNumber);
       const reviews = getPrReviews(prNumber);

--- a/packages/tooling/src/commands/memory.ts
+++ b/packages/tooling/src/commands/memory.ts
@@ -6,7 +6,8 @@
 
 import type { CAC } from 'cac';
 import type { Environment } from '../utils/env-runner.js';
-import { parseIntFlagOrReport } from '../utils/cli-args.js';
+import { parseIntFlag } from '../utils/cli-args.js';
+import { UsageError } from '../utils/errors.js';
 
 const ENV_OPTION = '--env <env>';
 const ENV_OPTION_DESC = 'Environment: local, dev, or prod';
@@ -23,38 +24,34 @@ const OUT_OPTION = '--out <dir>';
 const OUT_OPTION_DESC = 'Output dir (default reports/goldens-mining — gitignored)';
 
 /**
- * Parse an optional positive-integer CLI flag. Returns the number, `undefined`
- * if the flag is absent, or `null` if it's present-but-invalid (having already
- * printed the error + set exitCode — the caller returns on null).
+ * Parse an optional positive-integer CLI flag. Returns the number, or
+ * `undefined` when the flag is absent so the caller's default still applies;
+ * throws a `UsageError` when the flag is present but not a positive integer.
  *
- * Names the `{ min: 1 }` range this file's flags all share, over the shared
- * `parseIntFlagOrReport`.
+ * Exists to name the `{ min: 1 }` range every numeric flag in this file
+ * shares, over the shared `parseIntFlag`.
  */
 function parsePositiveIntOption(
   raw: string | number | undefined,
   flag: string
-): number | undefined | null {
-  return parseIntFlagOrReport(raw, flag, { min: 1 });
+): number | undefined {
+  return parseIntFlag(raw, flag, { min: 1 });
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * Validate a required `--persona-id` UUID. Returns the id, or `null` when it's
- * absent or malformed (error printed + exitCode set — the caller returns on null).
- * Catches a bad id before it hits a raw `::uuid` cast, which would otherwise
- * surface as a raw Postgres error instead of a clean CLI message.
+ * Validate a required `--persona-id` UUID, throwing a `UsageError` when it is
+ * absent or malformed. Catches a bad id before it hits a raw `::uuid` cast,
+ * which would otherwise surface as a raw Postgres error instead of a clean
+ * CLI message.
  */
-function requirePersonaId(raw: string | undefined): string | null {
+function requirePersonaId(raw: string | undefined): string {
   if (raw === undefined) {
-    console.error('--persona-id is required');
-    process.exitCode = 1;
-    return null;
+    throw new UsageError('--persona-id is required');
   }
   if (!UUID_RE.test(raw)) {
-    console.error(`--persona-id must be a UUID (got '${raw}')`);
-    process.exitCode = 1;
-    return null;
+    throw new UsageError(`--persona-id must be a UUID (got '${raw}')`);
   }
   return raw;
 }
@@ -87,9 +84,7 @@ function registerBackfillFactsCommand(cli: CAC): void {
         // exists to keep canary runs bounded, and `enqueued >= NaN` is always
         // false — the run would proceed uncapped over the whole backlog.
         const limit = parsePositiveIntOption(options.limit, '--limit');
-        if (limit === null) return;
         const windowSize = parsePositiveIntOption(options.windowSize, '--window-size');
-        if (windowSize === null) return;
 
         const { backfillFacts } = await import('../memory/backfill-facts.js');
         await backfillFacts({
@@ -146,15 +141,9 @@ function registerGoldensCommands(cli: CAC): void {
         out?: string;
       }) => {
         const personaId = requirePersonaId(options.personaId);
-        if (personaId === null) {
-          return;
-        }
         // Fail loudly on a garbage --sample: NaN comparisons are all false, so
         // it would otherwise degrade into nonsense quota math silently.
         const sampleSize = parsePositiveIntOption(options.sample, '--sample');
-        if (sampleSize === null) {
-          return;
-        }
         const { mineGoldens } = await import('../memory/mine-goldens.js');
         await mineGoldens({
           env: options.env ?? 'dev',
@@ -211,17 +200,8 @@ function registerAttachmentGoldensCommand(cli: CAC): void {
         out?: string;
       }) => {
         const personaId = requirePersonaId(options.personaId);
-        if (personaId === null) {
-          return;
-        }
         const sampleSize = parsePositiveIntOption(options.sample, '--sample');
-        if (sampleSize === null) {
-          return;
-        }
         const historyWindow = parsePositiveIntOption(options.historyWindow, '--history-window');
-        if (historyWindow === null) {
-          return;
-        }
         const { mineAttachmentGoldens } = await import('../memory/mine-attachment-goldens.js');
         await mineAttachmentGoldens({
           env: options.env ?? 'dev',
@@ -255,17 +235,8 @@ function registerConversationGoldensCommand(cli: CAC): void {
         out?: string;
       }) => {
         const personaId = requirePersonaId(options.personaId);
-        if (personaId === null) {
-          return;
-        }
         const sampleSize = parsePositiveIntOption(options.sample, '--sample');
-        if (sampleSize === null) {
-          return;
-        }
         const historyWindow = parsePositiveIntOption(options.historyWindow, '--history-window');
-        if (historyWindow === null) {
-          return;
-        }
         const { mineConversationGoldens } = await import('../memory/mine-conversation-goldens.js');
         await mineConversationGoldens({
           env: options.env ?? 'dev',
@@ -311,8 +282,7 @@ export function registerMemoryCommands(cli: CAC): void {
         force?: boolean;
       }) => {
         if (!options.from || !options.to) {
-          console.error('Error: --from and --to are required');
-          process.exit(1);
+          throw new UsageError('--from and --to are required');
         }
         const { backfillLongTermMemories } = await import('../memory/backfill-ltm.js');
         await backfillLongTermMemories({

--- a/packages/tooling/src/commands/prompt.ts
+++ b/packages/tooling/src/commands/prompt.ts
@@ -8,6 +8,7 @@ import type { CAC } from 'cac';
 
 import { validateEnvironment, type Environment } from '../utils/env-runner.js';
 import { rawOptionValue, parseIntFlag } from '../utils/cli-args.js';
+import { UsageError } from '../utils/errors.js';
 
 export function registerPromptCommands(cli: CAC): void {
   cli
@@ -42,7 +43,7 @@ export function registerPromptCommands(cli: CAC): void {
         // values and a snowflake exceeds MAX_SAFE_INTEGER (see utils/cli-args.ts).
         const ownerDiscordId = rawOptionValue(process.argv, '--owner');
         if (ownerDiscordId === undefined || ownerDiscordId.length === 0) {
-          throw new Error(
+          throw new UsageError(
             '--owner is required (operator Discord snowflake) — the privacy scope is explicit, never implied.'
           );
         }

--- a/packages/tooling/src/commands/release.ts
+++ b/packages/tooling/src/commands/release.ts
@@ -6,6 +6,7 @@
 
 import type { CAC } from 'cac';
 import type { Environment } from '../utils/env-runner.js';
+import { UsageError } from '../utils/errors.js';
 
 export function registerReleaseCommands(cli: CAC): void {
   // Bump version across all package.json files
@@ -125,7 +126,7 @@ function registerPublishCommand(cli: CAC): void {
         options: { notesFile?: string; target?: string; dryRun?: boolean }
       ) => {
         if (options.notesFile === undefined || options.notesFile.length === 0) {
-          throw new Error(
+          throw new UsageError(
             '--notes-file <path> is required (prepare notes first, e.g. release:draft-notes).'
           );
         }

--- a/packages/tooling/src/commands/secrets.ts
+++ b/packages/tooling/src/commands/secrets.ts
@@ -7,6 +7,7 @@
 import type { CAC } from 'cac';
 import type { SecretsEnv } from '../secrets/rotation.js';
 import { parseIntFlag } from '../utils/cli-args.js';
+import { UsageError } from '../utils/errors.js';
 
 const ENV_OPTION_FLAG = '--env <env>';
 const ENV_OPTION_HELP = 'Target environment: dev | prod';
@@ -53,7 +54,7 @@ export function registerSecretsCommands(cli: CAC): void {
     .example('ops secrets:rotate-byok --env prod --stage 1')
     .action(async (options: { env: SecretsEnv; stage?: string }) => {
       if (options.stage === undefined) {
-        throw new Error('--stage is required (1|stage, 2|reencrypt, 3|finalize)');
+        throw new UsageError('--stage is required (1|stage, 2|reencrypt, 3|finalize)');
       }
       const { rotateByokKey } = await loadRotation();
       await rotateByokKey({ env: options.env, stage: options.stage });

--- a/packages/tooling/src/memory/backfill-cli-helpers.test.ts
+++ b/packages/tooling/src/memory/backfill-cli-helpers.test.ts
@@ -1,16 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { parseDateRange, printDryRunPreview } from './backfill-cli-helpers.js';
+import { UsageError } from '../utils/errors.js';
 
 describe('backfill-cli-helpers', () => {
   describe('parseDateRange', () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-    const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    beforeEach(() => {
-      mockExit.mockClear();
-      mockConsoleError.mockClear();
-    });
-
     it('should parse valid YYYY-MM-DD dates', () => {
       const result = parseDateRange('2026-02-09', '2026-02-17');
       expect(result.fromDate).toEqual(new Date('2026-02-09'));
@@ -23,24 +16,28 @@ describe('backfill-cli-helpers', () => {
       expect(result.toDate).toEqual(new Date('2026-02-17T00:00:00Z'));
     });
 
-    it('should exit on invalid from date', () => {
-      parseDateRange('not-a-date', '2026-02-17');
-      expect(mockExit).toHaveBeenCalledWith(1);
+    // These throw rather than exit so cli.ts's top-level handler renders them
+    // as a one-line usage error. The CLASS is load-bearing, not just the
+    // message: a bare Error would fall through to the raw stack-trace path.
+    it('throws a UsageError on an invalid from date', () => {
+      expect(() => parseDateRange('not-a-date', '2026-02-17')).toThrow(UsageError);
+      expect(() => parseDateRange('not-a-date', '2026-02-17')).toThrow(
+        'Invalid date format. Use YYYY-MM-DD.'
+      );
     });
 
-    it('should exit on invalid to date', () => {
-      parseDateRange('2026-02-09', 'garbage');
-      expect(mockExit).toHaveBeenCalledWith(1);
+    it('throws a UsageError on an invalid to date', () => {
+      expect(() => parseDateRange('2026-02-09', 'garbage')).toThrow(UsageError);
     });
 
-    it('should exit when from equals to', () => {
-      parseDateRange('2026-02-09', '2026-02-09');
-      expect(mockExit).toHaveBeenCalledWith(1);
+    it('throws a UsageError when from equals to', () => {
+      expect(() => parseDateRange('2026-02-09', '2026-02-09')).toThrow(
+        '--from must be before --to'
+      );
     });
 
-    it('should exit when from is after to', () => {
-      parseDateRange('2026-02-17', '2026-02-09');
-      expect(mockExit).toHaveBeenCalledWith(1);
+    it('throws a UsageError when from is after to', () => {
+      expect(() => parseDateRange('2026-02-17', '2026-02-09')).toThrow(UsageError);
     });
   });
 

--- a/packages/tooling/src/memory/backfill-cli-helpers.ts
+++ b/packages/tooling/src/memory/backfill-cli-helpers.ts
@@ -5,18 +5,18 @@
 
 import chalk from 'chalk';
 
+import { UsageError } from '../utils/errors.js';
+
 /** Validate and parse date range options */
 export function parseDateRange(from: string, to: string): { fromDate: Date; toDate: Date } {
   const fromDate = new Date(from);
   const toDate = new Date(to);
 
   if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
-    console.error(chalk.red('Invalid date format. Use YYYY-MM-DD.'));
-    process.exit(1);
+    throw new UsageError('Invalid date format. Use YYYY-MM-DD.');
   }
   if (fromDate >= toDate) {
-    console.error(chalk.red('--from must be before --to'));
-    process.exit(1);
+    throw new UsageError('--from must be before --to');
   }
 
   return { fromDate, toDate };

--- a/packages/tooling/src/utils/cli-args.test.ts
+++ b/packages/tooling/src/utils/cli-args.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { rawOptionValue, parseIntFlag, parseIntFlagOrReport } from './cli-args.js';
+import { describe, it, expect } from 'vitest';
+import { rawOptionValue, parseIntFlag } from './cli-args.js';
+import { UsageError } from './errors.js';
 
 describe('rawOptionValue', () => {
   it('reads a space-separated flag value verbatim (no numeric coercion)', () => {
@@ -128,44 +129,16 @@ describe('parseIntFlag', () => {
     // shape check has to pass for a real `number` arrival, not just a string.
     expect(parseIntFlag(42, '--limit', { min: 1 })).toBe(42);
   });
-});
 
-describe('parseIntFlagOrReport', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-    process.exitCode = undefined;
-  });
-
-  it('returns the parsed value and leaves exitCode alone when valid', () => {
-    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(parseIntFlagOrReport('42', '--limit', { min: 1 })).toBe(42);
-    expect(err).not.toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
-  });
-
-  it('distinguishes an absent flag (undefined) from an invalid one (null)', () => {
-    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // The distinction callers depend on: undefined means "fall back to the
-    // default", null means "abort" — collapsing them would run an invalid
-    // flag under the default.
-    expect(parseIntFlagOrReport(undefined, '--limit', { min: 1 })).toBeUndefined();
-    expect(err).not.toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
-
-    expect(parseIntFlagOrReport('abc', '--limit', { min: 1 })).toBeNull();
-    expect(process.exitCode).toBe(1);
-  });
-
-  it('prints the flag-named message and sets exitCode on an invalid value', () => {
-    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(parseIntFlagOrReport('0', '--count', { min: 1 })).toBeNull();
-    expect(err).toHaveBeenCalledWith('--count must be at least 1, got: 0');
-    expect(process.exitCode).toBe(1);
-  });
-
-  it('reports an out-of-range value against a ceiling', () => {
-    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(parseIntFlagOrReport('101', '--limit', { min: 1, max: 100 })).toBeNull();
-    expect(err).toHaveBeenCalledWith('--limit must be at most 100, got: 101');
+  // The CLASS is load-bearing, not just the message text: cli.ts's top-level
+  // handler keys on `UsageError` to print one line instead of a stack trace
+  // and a Node version banner, so a bare `Error` here would regress the
+  // operator-facing output while every message assertion above still passed.
+  // One case per throw branch.
+  it('throws UsageError, the tag the top-level handler renders as one line', () => {
+    expect(() => parseIntFlag('abc', '--limit', { min: 1 })).toThrow(UsageError);
+    expect(() => parseIntFlag('0', '--limit', { min: 1 })).toThrow(UsageError);
+    expect(() => parseIntFlag('101', '--limit', { min: 1, max: 100 })).toThrow(UsageError);
+    expect(() => parseIntFlag('99999999999999999999', '--limit', { min: 1 })).toThrow(UsageError);
   });
 });

--- a/packages/tooling/src/utils/cli-args.ts
+++ b/packages/tooling/src/utils/cli-args.ts
@@ -14,6 +14,8 @@
  * with this helper instead of the parsed options object.
  */
 
+import { UsageError } from './errors.js';
+
 /**
  * Read `--flag value` or `--flag=value` verbatim from an argv array.
  * Returns undefined when the flag is absent or has no value token.
@@ -57,7 +59,7 @@ export interface IntFlagRange {
  *
  * Returns `undefined` for an absent flag, so an optional flag stays optional.
  *
- * @throws Error naming the flag when the value is present but not an integer
+ * @throws UsageError naming the flag when the value is present but not an integer
  *   within `range`.
  */
 export function parseIntFlag(
@@ -79,14 +81,14 @@ export function parseIntFlag(
   const value = /^-?\d+$/.test(text) ? Number(text) : Number.NaN;
 
   if (!Number.isInteger(value)) {
-    throw new Error(`${flag} must be an integer, got: "${String(raw)}"`);
+    throw new UsageError(`${flag} must be an integer, got: "${String(raw)}"`);
   }
   // The shape check above guarantees a decimal integer STRING, but a long
   // enough one still lands on an imprecise float — `Number.isInteger` reports
   // true for it, so the value would be silently rounded. This is the shared
   // choke point for numeric CLI parsing, so it rejects rather than rounds.
   if (!Number.isSafeInteger(value)) {
-    throw new Error(
+    throw new UsageError(
       `${flag} is too large to represent exactly, got: "${String(raw)}" (max ${String(Number.MAX_SAFE_INTEGER)})`
     );
   }
@@ -94,38 +96,10 @@ export function parseIntFlag(
   // echo back what was typed, so the operator can spot the typo in their own
   // command line rather than in a normalized form they never wrote.
   if (value < range.min) {
-    throw new Error(`${flag} must be at least ${range.min}, got: ${String(raw)}`);
+    throw new UsageError(`${flag} must be at least ${range.min}, got: ${String(raw)}`);
   }
   if (range.max !== undefined && value > range.max) {
-    throw new Error(`${flag} must be at most ${range.max}, got: ${String(raw)}`);
+    throw new UsageError(`${flag} must be at most ${range.max}, got: ${String(raw)}`);
   }
   return value;
-}
-
-/**
- * `parseIntFlag` for commands that report usage errors by printing and
- * setting `exitCode` rather than throwing — the dominant convention among the
- * `ops` commands that take numeric input.
- *
- * Returns the parsed integer, `undefined` for an absent optional flag, or
- * `null` when the value was present but invalid (having already printed the
- * error and set `exitCode`). The caller returns on `null`.
- *
- * The three-way return is what lets a caller distinguish "flag omitted, use
- * the default" from "flag given but unusable, abort" — collapsing them would
- * silently run an invalid flag under the default, which is the failure this
- * whole helper exists to prevent.
- */
-export function parseIntFlagOrReport(
-  raw: string | number | undefined,
-  flag: string,
-  range: IntFlagRange
-): number | undefined | null {
-  try {
-    return parseIntFlag(raw, flag, range);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-    return null;
-  }
 }

--- a/packages/tooling/src/utils/env-runner.ts
+++ b/packages/tooling/src/utils/env-runner.ts
@@ -10,6 +10,8 @@
 import { spawn, execFileSync } from 'node:child_process';
 import chalk from 'chalk';
 
+import { UsageError } from './errors.js';
+
 export type Environment = 'local' | 'dev' | 'prod';
 
 const VALID_ENVIRONMENTS = new Set<string>(['local', 'dev', 'prod']);
@@ -261,10 +263,14 @@ export async function runPrismaCommand(
  * 3. For 'dev'/'prod': Railway CLI is authenticated
  */
 export function validateEnvironment(env: string): void {
+  // A bad --env is an operator typo, so it throws for the top-level handler to
+  // render as one line. The two checks below are NOT: a missing DATABASE_URL or
+  // an unauthenticated Railway CLI are operational preconditions, which keep
+  // their own reporting (see utils/errors.ts on the distinction).
   if (!isValidEnvironment(env)) {
-    console.error(chalk.red(`❌ Invalid environment: "${String(env)}"`));
-    console.error(chalk.dim(`   Valid values: ${[...VALID_ENVIRONMENTS].join(', ')}`));
-    process.exit(1);
+    throw new UsageError(
+      `Invalid environment: "${String(env)}" — valid values: ${[...VALID_ENVIRONMENTS].join(', ')}`
+    );
   }
 
   if (env === 'local') {

--- a/packages/tooling/src/utils/errors.test.ts
+++ b/packages/tooling/src/utils/errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { UsageError, reportUsageError } from './errors.js';
+
+describe('reportUsageError', () => {
+  let originalExitCode: typeof process.exitCode;
+  let err: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // `process.exitCode` is global state shared with the vitest run itself:
+    // leaving it at 1 would make an all-green run exit nonzero.
+    originalExitCode = process.exitCode;
+    err = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = originalExitCode;
+  });
+
+  it('reports a UsageError: prints the message, sets exitCode, claims the error', () => {
+    expect(reportUsageError(new UsageError('--limit must be an integer, got: "abc"'))).toBe(true);
+    expect(err).toHaveBeenCalledWith('--limit must be an integer, got: "abc"');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports cac's own CACError, which it throws for an unknown option", () => {
+    // cac does not export the class, so the handler matches on `name` — this
+    // stand-in reproduces exactly what the handler can observe.
+    const cacError = new Error('Unknown option `--nope`');
+    cacError.name = 'CACError';
+
+    expect(reportUsageError(cacError)).toBe(true);
+    expect(err).toHaveBeenCalledWith('Unknown option `--nope`');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('leaves a plain Error alone so a genuine bug keeps its stack trace', () => {
+    expect(reportUsageError(new Error('Cannot read properties of undefined'))).toBe(false);
+    expect(err).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(originalExitCode);
+  });
+
+  it('leaves a subclass that is not a usage error alone', () => {
+    class OperationalError extends Error {}
+    const operational = new OperationalError('database unreachable');
+    operational.name = 'OperationalError';
+
+    expect(reportUsageError(operational)).toBe(false);
+    expect(err).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(originalExitCode);
+  });
+
+  it('leaves a non-Error thrown value alone', () => {
+    expect(reportUsageError('just a string')).toBe(false);
+    expect(reportUsageError(undefined)).toBe(false);
+    expect(reportUsageError({ name: 'CACError', message: 'not a real Error' })).toBe(false);
+    expect(err).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(originalExitCode);
+  });
+});
+
+describe('UsageError', () => {
+  it('is an Error named UsageError, so it survives an instanceof check', () => {
+    const error = new UsageError('--channel is required');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(UsageError);
+    expect(error.name).toBe('UsageError');
+    expect(error.message).toBe('--channel is required');
+  });
+});

--- a/packages/tooling/src/utils/errors.ts
+++ b/packages/tooling/src/utils/errors.ts
@@ -1,0 +1,60 @@
+/**
+ * Usage-error typing for the `ops` CLI, and the single place that decides how
+ * one is rendered.
+ *
+ * The distinction this module draws is between an error the OPERATOR caused
+ * (a bad flag value, a missing required option) and one the CODE caused (a
+ * bug, or an operational failure like an unreachable database). Only the first
+ * kind deserves a one-line message: a stack trace tells the operator nothing
+ * about their own typo, while stripping the stack from a genuine bug would
+ * throw away the only thing that makes it debuggable. Tagging the operator's
+ * mistakes lets the top-level handler in `cli.ts` print one line for them and
+ * leave everything else to Node's default reporting.
+ */
+
+/**
+ * An error caused by how the command was invoked: an invalid flag value, a
+ * missing required option, an argument that fails validation.
+ *
+ * Throw this — never a bare `Error` — for anything an operator can fix by
+ * retyping their command.
+ */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UsageError';
+  }
+}
+
+/**
+ * Render `error` as a usage error if it is one.
+ *
+ * Returns `true` when it handled the error (message printed to stderr,
+ * `process.exitCode` set to 1) and `false` otherwise, so the caller can
+ * rethrow anything else and let a genuine bug keep its stack trace.
+ */
+export function reportUsageError(error: unknown): boolean {
+  if (!isUsageError(error)) {
+    return false;
+  }
+  console.error(error.message);
+  process.exitCode = 1;
+  return true;
+}
+
+/**
+ * Usage errors are our own `UsageError` plus cac's `CACError`, which cac
+ * throws for an unknown option, a missing required arg, or an option given
+ * without its value — all operator mistakes by the same definition.
+ *
+ * The cac half is matched on `error.name`, not `instanceof`, because cac does
+ * not export the `CACError` class (its only export line is
+ * `export { CAC, Command, cac, cac as default }`). Do not "fix" this to an
+ * `instanceof` check — there is nothing importable to check against.
+ */
+function isUsageError(error: unknown): error is Error {
+  if (error instanceof UsageError) {
+    return true;
+  }
+  return error instanceof Error && error.name === 'CACError';
+}


### PR DESCRIPTION
Closes TASK-444.

## The defect

`packages/tooling` carried two conventions for CLI **usage** errors (bad or missing flag values):

- **throwing** — `parseIntFlag`, used by `cache.ts`, `deploy.ts`, `dev.ts`, `prompt.ts`, `secrets.ts`
- **print-and-set-exitCode** — `parseIntFlagOrReport`, used by `gh.ts` and `memory.ts`

cac's `parse()` runs the matched command's action but **discards the promise it returns**, and `cli.ts` registered no top-level handler. So the throwing half surfaced in a real run as an unhandled-rejection stack trace and a Node version banner wrapped around an otherwise correct one-line message:

```
$ pnpm ops dev:stale-debug --max-age-days abc
/home/deck/Projects/tzurot/packages/tooling/src/utils/cli-args.ts:82
    throw new Error(...)
          ^
Error: --max-age-days must be an integer, got: "abc"
    at parseIntFlag (.../cli-args.ts:82:11)
Node.js v24.11.1
```

Exit code was already 1, so this was UX, not correctness.

## The change

Unify on **throwing**, and own the error path at the top level.

- **New `utils/errors.ts`** — `UsageError` (the operator caused it: bad flag, missing required option) plus `reportUsageError`, which prints one line and sets `exitCode` for a `UsageError` **or cac's own `CACError`**, and returns `false` for everything else so a genuine bug keeps its stack trace. That split is the point: a stack trace tells an operator nothing about their own typo, and stripping the stack from a real bug throws away the only thing that makes it debuggable.
- **`cli.ts`** parses with `{ run: false }` and awaits `runMatchedCommand()` itself — cac's documented seam for owning this. `--help`/`--version` are still handled inside `parse()`, which calls `unsetMatchedCommand()`, so `runMatchedCommand()` correctly no-ops for them.
- **`parseIntFlagOrReport` deleted.** With the handler in place its output is identical to a throw, and its three-way `number | undefined | null` return was what forced **16 null-guards** across `gh.ts` and `memory.ts`. Those are gone; net −163/+219 including the new module and its tests.
- **`memory:backfill`'s required `--from`/`--to` guard** joins the same convention, replacing a `process.exit(1)` that can truncate pending stdout — the exact hazard `gh.ts` had a comment warning about.

`CACError` is matched by `name`, not `instanceof`, because **cac does not export the class** — verified against `cac@7.0.0`'s dist, whose only export line is `export { CAC, Command, cac, cac as default }`. There's a comment at the check saying so, since it otherwise reads like something to "fix."

## Verification

`pnpm test` (26 packages), `pnpm quality`, and the tooling package's build/lint/typecheck all green. The acceptance criterion is runtime behavior, so it was checked by running the CLI, not by reading it — every case below prints exactly one line, no stack, no Node banner, exit 1:

| Command | Output |
|---|---|
| `pnpm ops dev:stale-debug --max-age-days abc` | `--max-age-days must be an integer, got: "abc"` |
| `pnpm ops gh:pr-info notanumber` | `<number> must be an integer, got: "notanumber"` |
| `pnpm ops memory:backfill` | `--from and --to are required` |
| `pnpm ops cache:prefix-diff --env dev` | `--channel is required (Discord channel snowflake)` |
| `pnpm ops gh:pr-info --bogus 5` | ``Unknown option `--bogus` `` (the CACError path) |

`pnpm ops --help` and `--version` still work and exit 0.

The `cli.ts` wiring itself has no unit test — it's a thin entry point, and the five runtime checks above exercise the real seam end to end rather than a mocked one. `errors.test.ts` covers the classification (UsageError, a `CACError` stand-in, a plain `Error`, a non-usage subclass, and non-`Error` thrown values), saving and restoring `process.exitCode` so a green run can't exit nonzero.

### Pre-existing, unchanged

`pnpm ops no:such:command` exits 0 silently. Verified against the unmodified `cli.ts` at `HEAD` before this branch — not a regression here, and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)