### PR TITLE
fix(tooling): make an unknown ops command fail loudly instead of exiting 0

### DIFF
--- a/packages/tooling/src/cli.ts
+++ b/packages/tooling/src/cli.ts
@@ -37,7 +37,8 @@ import { registerCpdCommands } from './commands/cpd.js';
 import { registerCodegenCommands } from './commands/codegen.js';
 import { registerTopologyCommands } from './commands/topology.js';
 import { registerPromptCommands } from './commands/prompt.js';
-import { reportUsageError } from './utils/errors.js';
+import { UsageError, reportUsageError } from './utils/errors.js';
+import { classifyNoMatch, unknownCommandMessage } from './utils/unknown-command.js';
 
 // Read version from package.json dynamically
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -85,7 +86,12 @@ cli.version(packageJson.version);
 cli.parse(process.argv, { run: false });
 
 try {
-  await cli.runMatchedCommand();
+  // cac no-ops when nothing matched, so an unknown command name would otherwise
+  // print nothing and exit 0 — a typo indistinguishable from success.
+  const action = classifyNoMatch(cli);
+  if (action.kind === 'unknown') throw new UsageError(unknownCommandMessage(action.name));
+  if (action.kind === 'help') cli.outputHelp();
+  else await cli.runMatchedCommand();
 } catch (error) {
   if (!reportUsageError(error)) throw error;
 }

--- a/packages/tooling/src/memory/backfill-facts.ts
+++ b/packages/tooling/src/memory/backfill-facts.ts
@@ -19,6 +19,7 @@
  */
 
 import chalk from 'chalk';
+import { UsageError } from '../utils/errors.js';
 import { FACT_EXTRACTION_QUEUE_NAME, JobType } from '@tzurot/common-types/constants/queue';
 import { generateFactExtractionJobUuid } from '@tzurot/common-types/utils/deterministicUuid';
 import type { FactExtractionJobData } from '@tzurot/common-types/types/jobs';
@@ -82,7 +83,9 @@ export function buildWindows(rows: EligibleMemoryRow[], windowSize: number): Bac
   // Number.isInteger rejects NaN (a mistyped CLI value) — a bare `< 1` check
   // would let NaN through and crash confusingly in the chunking loop.
   if (!Number.isInteger(windowSize) || windowSize < 1 || windowSize > MAX_WINDOW_SIZE) {
-    throw new Error(`windowSize must be an integer in 1..${MAX_WINDOW_SIZE} (got ${windowSize})`);
+    throw new UsageError(
+      `windowSize must be an integer in 1..${MAX_WINDOW_SIZE} (got ${windowSize})`
+    );
   }
   const groups = new Map<string, EligibleMemoryRow[]>();
   for (const row of rows) {
@@ -200,7 +203,7 @@ export async function backfillFacts(options: BackfillFactsOptions): Promise<void
   // UNCAP the run (NaN comparisons are false), turning a mistyped 5-window
   // canary into the full budget-exempt backfill.
   if (options.limit !== undefined && (!Number.isInteger(options.limit) || options.limit < 1)) {
-    throw new Error(`--limit must be a positive integer (got ${options.limit})`);
+    throw new UsageError(`--limit must be a positive integer (got ${options.limit})`);
   }
 
   validateEnvironment(env);

--- a/packages/tooling/src/utils/unknown-command.test.ts
+++ b/packages/tooling/src/utils/unknown-command.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { cac } from 'cac';
+import { classifyNoMatch, unknownCommandMessage } from './unknown-command.js';
+
+const state = (over: Partial<Parameters<typeof classifyNoMatch>[0]> = {}) => ({
+  matchedCommand: undefined,
+  args: [] as (string | number)[],
+  options: {} as Record<string, unknown>,
+  ...over,
+});
+
+describe('classifyNoMatch', () => {
+  it('runs when a command matched', () => {
+    expect(classifyNoMatch(state({ matchedCommand: {}, args: ['db:status'] }))).toEqual({
+      kind: 'run',
+    });
+  });
+
+  it('reports an unmatched name as unknown', () => {
+    expect(classifyNoMatch(state({ args: ['no:such:command'] }))).toEqual({
+      kind: 'unknown',
+      name: 'no:such:command',
+    });
+  });
+
+  it('shows help for a bare invocation rather than exiting silently', () => {
+    expect(classifyNoMatch(state())).toEqual({ kind: 'help' });
+  });
+
+  it('leaves --help alone — cac already printed it and unset the match', () => {
+    // Without this, `pnpm ops db:status --help` would print help and then
+    // error out on the very command name it just documented.
+    expect(classifyNoMatch(state({ args: ['db:status'], options: { help: true } }))).toEqual({
+      kind: 'run',
+    });
+  });
+
+  it('leaves --version alone for the same reason', () => {
+    expect(classifyNoMatch(state({ options: { version: true } }))).toEqual({ kind: 'run' });
+  });
+
+  it('treats an empty first arg as no command given', () => {
+    expect(classifyNoMatch(state({ args: [''] }))).toEqual({ kind: 'help' });
+  });
+
+  it('still reports a non-string first arg as unknown rather than showing help', () => {
+    // cac gives us strings today, so this is defensive — but it has to fail
+    // toward "unknown": routing a coerced positional to help would silently
+    // restore the exit-0-on-a-typo bug this module removes.
+    expect(classifyNoMatch(state({ args: [42] }))).toEqual({ kind: 'unknown', name: '42' });
+  });
+});
+
+describe('classifyNoMatch against a real cac instance', () => {
+  // The unit tests above hand-build the state object, which cannot catch a cac
+  // upgrade changing the shape or semantics of .args/.options/.matchedCommand —
+  // none of which are documented public API. This is the seam test for that.
+  const build = () => {
+    const cli = cac('test');
+    cli.command('db:status', 'a registered command').action(() => {});
+    cli.help();
+    cli.version('1.0.0');
+    return cli;
+  };
+
+  it('classifies a registered command as run', () => {
+    const cli = build();
+    cli.parse(['node', 'test', 'db:status'], { run: false });
+    expect(classifyNoMatch(cli)).toEqual({ kind: 'run' });
+  });
+
+  it('classifies an unmatched name as unknown, carrying the name cac parsed', () => {
+    const cli = build();
+    cli.parse(['node', 'test', 'no:such:command'], { run: false });
+    expect(classifyNoMatch(cli)).toEqual({ kind: 'unknown', name: 'no:such:command' });
+  });
+
+  it('keeps a digit-only positional a string — cac does not coerce positionals', () => {
+    // Distinct from `--flag` VALUES, which mri does coerce (see cli-args.ts).
+    const cli = build();
+    cli.parse(['node', 'test', '123'], { run: false });
+    expect(classifyNoMatch(cli)).toEqual({ kind: 'unknown', name: '123' });
+  });
+
+  it('classifies a bare invocation as help', () => {
+    const cli = build();
+    cli.parse(['node', 'test'], { run: false });
+    expect(classifyNoMatch(cli)).toEqual({ kind: 'help' });
+  });
+});
+
+describe('unknownCommandMessage', () => {
+  it('names the command and points at --help', () => {
+    const message = unknownCommandMessage('no:such:command');
+    expect(message).toContain('no:such:command');
+    expect(message).toContain('pnpm ops --help');
+  });
+});

--- a/packages/tooling/src/utils/unknown-command.ts
+++ b/packages/tooling/src/utils/unknown-command.ts
@@ -1,0 +1,54 @@
+/**
+ * What to do when cac matched no command.
+ *
+ * cac dispatches to a registered command, a default command, or nothing. This
+ * CLI registers no default, so an unmatched name falls through
+ * `runMatchedCommand()` as a silent no-op: `pnpm ops no:such:command` printed
+ * nothing and exited 0, making an operator typo indistinguishable from success.
+ * Nothing throws, so the top-level UsageError handler never saw it.
+ *
+ * Two distinct no-match cases, and they want different outcomes:
+ *
+ * - **A name was given and matched nothing** — a mistake the operator can fix by
+ *   retyping, which is exactly what `UsageError` is for: one line, exit 1.
+ * - **No name was given at all** (`pnpm ops`) — not a mistake, just an
+ *   incomplete invocation. Print help and exit 0, the way every other CLI does.
+ *
+ * `--help` and `--version` also leave `matchedCommand` unset (cac unsets it
+ * after printing), so both are excluded — otherwise `pnpm ops db:status --help`
+ * would print help and then error.
+ */
+
+export type NoMatchAction = { kind: 'run' } | { kind: 'help' } | { kind: 'unknown'; name: string };
+
+/**
+ * Structural subset of cac's `CAC`. `matchedCommand` is optional there too, and
+ * `args` is typed `string[]` — widened to allow a number here only because mri
+ * coerces digit-only values in some positions, never to anything `String()`
+ * would render as `[object Object]`.
+ */
+export interface ParsedCliState {
+  matchedCommand?: unknown;
+  args: readonly (string | number)[];
+  options: Record<string, unknown>;
+}
+
+export function classifyNoMatch(state: ParsedCliState): NoMatchAction {
+  if (state.matchedCommand !== undefined) return { kind: 'run' };
+  // cac has already printed help/version and unset the match; nothing to add.
+  if (state.options.help === true || state.options.version === true) return { kind: 'run' };
+
+  const [first] = state.args;
+  if (first === undefined || first === '') return { kind: 'help' };
+  // Stringify rather than requiring a string. cac hands us strings today
+  // (verified: `pnpm ops 123` reports an unknown command, it does not coerce the
+  // positional to a number the way `cli-args.ts` documents for --flag VALUES).
+  // The coercion is defensive against that changing — and it must fail toward
+  // "unknown", because routing a coerced positional to help would silently
+  // restore the exit-0-on-a-typo bug this module exists to remove.
+  return { kind: 'unknown', name: String(first) };
+}
+
+export function unknownCommandMessage(name: string): string {
+  return `Unknown command "${name}". Run \`pnpm ops --help\` to list the available commands.`;
+}


### PR DESCRIPTION
Closes TASK-454.

## Problem

```
$ pnpm ops no:such:command
$ echo $?
0
```

No message, no help, no nonzero exit. An operator typo in a subcommand name was **indistinguishable from success** — the same class the `UsageError` work in #1990 exists to fix, verified there as pre-existing rather than introduced.

Mechanism: cac dispatches to a registered command, a default command, or nothing. `cli.ts` registers no default and no `command:*` handler, so an unmatched name falls through `runMatchedCommand()` as a silent no-op. Nothing throws, so #1990's top-level handler never sees it.

Bare `pnpm ops` was equally silent — same symptom, different cause.

## What this does

Classifies the no-match case, because the two variants want **opposite** outcomes:

| Invocation | Before | After |
| --- | --- | --- |
| `pnpm ops no:such:command` | silent, exit 0 | one-line `Unknown command "…"`, exit 1 |
| `pnpm ops` | silent, exit 0 | prints help, exit 0 |
| `pnpm ops db:status --help` | help, exit 0 | unchanged |

A given-but-unmatched name is a mistake the operator fixes by retyping — exactly what `UsageError` is for. No name at all is not a mistake, just an incomplete invocation, so it gets help and a clean exit like every other CLI.

`--help`/`--version` are excluded explicitly: cac unsets `matchedCommand` after printing them, so without that guard `pnpm ops db:status --help` would print help and then error on the very command it just documented. There's a test pinning that.

I read cac's dispatch path rather than working from its docs — `CAC extends EventTarget` and emits `command:*` with the unknown name, but only *after* the help/version unset, so a post-parse classification is both simpler and unit-testable without touching the event API.

## Also in this PR

`backfill-facts.ts`'s two remaining operator-facing `throw new Error` sites (`windowSize`, `--limit`) become `UsageError`, per TASK-454's MEMBER note. They're defense-in-depth today — `memory.ts` validates both flags with `parseIntFlag` before calling — but the shape should be uniform.

Deliberately **not** converted: `Could not resolve a Redis URL for ${env}` in the same file. That's an environment/config failure, not a usage error the operator fixes by retyping, so the stack trace is arguably the more useful output.

## Verification

Runtime-verified all three paths after the change (not just unit-tested):

```
$ pnpm ops no:such:command
Unknown command "no:such:command". Run `pnpm ops --help` to list the available commands.
exit=1

$ pnpm ops            → full command list, exit 0
$ pnpm ops db:status --help  → command help, exit 0, no spurious error
```

Unit tests cover all six classification branches. `pnpm test` and `pnpm quality` green, sequential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)