### PR TITLE
test(tooling): guard that the three git-commit-detection patterns agree

### DIFF
--- a/.claude/hooks/develop-code-commit-guard.sh
+++ b/.claude/hooks/develop-code-commit-guard.sh
@@ -75,6 +75,11 @@ cmd = re.sub(r"<<[-~]?\s*'?\"?(\w+)'?\"?.*?\n\1(?=\s|$)", "HEREDOC", cmd, flags=
 cmd = re.sub(r"'[^']*'", "S", cmd)
 cmd = re.sub(r'"[^"]*"', "S", cmd)
 
+# Kept in agreement with the other two copies (lib/git-command.sh and
+# git-commit-filter-guard.sh) by
+# packages/tooling/src/dev/gitCommitPatternAgreement.test.ts, which extracts all
+# three patterns and runs them over a shared case table.
+#
 # `git commit` with optional global flags (-C <path>, --git-dir=…, etc.).
 # The trailing (?![-\w]) is load-bearing: a plain \b would also match the
 # plumbing subcommands `git commit-tree` / `git commit-graph`, because `-`

--- a/.claude/hooks/git-commit-filter-guard.sh
+++ b/.claude/hooks/git-commit-filter-guard.sh
@@ -59,6 +59,12 @@ cmd = cmd.replace("|&", "|")
 # the same pipeline blocks — `| cat | tail` must not defeat the guard, while
 # pure pass-throughs (cat/tee) on their own stay allowed.
 FILTERS = re.compile(r"^\s*(tail|head|grep|sed|awk)\b")
+# Kept in agreement with the other two copies (lib/git-command.sh and
+# develop-code-commit-guard.sh) by
+# packages/tooling/src/dev/gitCommitPatternAgreement.test.ts, which extracts all
+# three patterns and runs them over a shared case table. Note this copy detects
+# (commit|push); the agreement table is push-free so the alternation is inert.
+#
 # Tolerate git global flags between `git` and the subcommand:
 # -C <path>, -c k=v, --no-pager, --git-dir=..., etc.
 # The trailing (?![-\w]) sits OUTSIDE the alternation so it guards both

--- a/.claude/hooks/lib/git-command.sh
+++ b/.claude/hooks/lib/git-command.sh
@@ -3,7 +3,10 @@
 # Sourced by claim-shape-guard.sh and fixup-rider-check.sh — the regex lives
 # here so a future tweak (new global-flag shape, new commit variant) lands in
 # one place. (develop-code-commit-guard.sh and git-commit-filter-guard.sh
-# carry equivalent Python-side logic — sync manually if the shape changes.)
+# carry equivalent Python-side logic. The three are kept in agreement by
+# packages/tooling/src/dev/gitCommitPatternAgreement.test.ts, which extracts
+# all three patterns and runs them over a shared case table — change one
+# without the others and it names the copy that drifted.)
 
 # is_git_commit_command <command-string> → exit 0 when the string invokes
 # `git commit`, tolerating global flags (`git -C path commit`, `git -c k=v

--- a/packages/tooling/src/dev/gitCommitPatternAgreement.test.ts
+++ b/packages/tooling/src/dev/gitCommitPatternAgreement.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Agreement guard for the three git-commit-detection patterns.
+ *
+ * The same "does this command string invoke `git commit`" decision is encoded
+ * three times, in two languages:
+ *
+ *   1. `.claude/hooks/lib/git-command.sh`         — `is_git_commit_command`, a
+ *      GNU-grep ERE, sourced by claim-shape-guard.sh and fixup-rider-check.sh
+ *   2. `.claude/hooks/develop-code-commit-guard.sh` — a Python regex (BLOCKING)
+ *   3. `.claude/hooks/git-commit-filter-guard.sh`   — a Python regex (BLOCKING)
+ *
+ * They cannot be collapsed into one: the two blocking hooks need Python for
+ * their heredoc/quote stripping, and the lib exists so the two bash consumers
+ * don't fork Python on every Bash call. So the coupling is real, hand-managed,
+ * and documented only in a comment ("sync manually if the shape changes") —
+ * the unenforced-invariant shape. It has already opened once: the commit-tree
+ * false positive was fixed in the bash copy one PR before the two Python ones.
+ *
+ * This test asserts the three agree on a shared CASE TABLE, not that they are
+ * textually identical — they deliberately aren't (see DIVERGENCES below). The
+ * patterns are EXTRACTED from the hook sources at run time, so editing any one
+ * of them without the others fails here; an extraction that stops matching is
+ * a hard failure, never a silent pass.
+ *
+ * Copy 3 detects `(commit|push)` rather than `commit`. Every case below is
+ * free of the token `push` (asserted), which makes that alternation inert and
+ * lets all three be compared directly with no rewriting of the extracted text.
+ *
+ * EXTERNAL BINARIES: this file shells out to `grep` and `python3`, because the
+ * only honest way to evaluate a hook's pattern is to run it through the same
+ * engine the hook does. `python3` was already required to RUN the two blocking
+ * hooks and their .probe.sh scripts; this makes it a prerequisite of the
+ * tooling unit-test cell too. Both are present on ubuntu-latest, which is where
+ * CI runs. If a future minimal image drops either, the failure surfaces here as
+ * an ENOENT at collection time — that is this note's reason for existing.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const repoPath = (rel: string): string =>
+  fileURLToPath(new URL(`../../../../${rel}`, import.meta.url));
+
+interface PatternSource {
+  /** Human label used in failure messages. */
+  readonly label: string;
+  readonly file: string;
+  /** Must capture the pattern in group 1 and match EXACTLY once in the file. */
+  readonly extract: RegExp;
+}
+
+const SOURCES: readonly PatternSource[] = [
+  {
+    label: 'bash lib/git-command.sh',
+    file: '.claude/hooks/lib/git-command.sh',
+    extract: /grep -qE '(.+)' <<</,
+  },
+  {
+    label: 'python develop-code-commit-guard.sh',
+    file: '.claude/hooks/develop-code-commit-guard.sh',
+    extract: /re\.search\(r"(.+)", cmd\)/,
+  },
+  {
+    label: 'python git-commit-filter-guard.sh',
+    file: '.claude/hooks/git-commit-filter-guard.sh',
+    extract: /GIT_TARGET = re\.compile\(r"(.+)"\)/,
+  },
+];
+
+/**
+ * Extraction failure is a TEST failure, not a skip. A reformatted hook line
+ * that stops matching would otherwise silently disarm this guard — the exact
+ * failure mode it exists to prevent, one level up.
+ */
+function extractPattern(source: PatternSource): string {
+  const text = readFileSync(repoPath(source.file), 'utf-8');
+  const occurrences = text.split('\n').filter(line => source.extract.test(line));
+  if (occurrences.length !== 1) {
+    throw new Error(
+      `${source.label}: expected exactly 1 line matching ${String(source.extract)}, found ${occurrences.length}. ` +
+        `The hook was reformatted — update the extractor here rather than deleting this guard.`
+    );
+  }
+  const match = source.extract.exec(occurrences[0]);
+  return match![1];
+}
+
+/**
+ * Cases every implementation must agree on. Single-line only: the bash copy is
+ * evaluated through `grep`, which is line-oriented.
+ */
+const AGREEMENT_CASES: readonly (readonly [expected: boolean, input: string])[] = [
+  // --- is a commit ---
+  [true, 'git commit'],
+  [true, 'git commit -m "x"'],
+  [true, 'git commit --amend --no-edit'],
+  [true, 'git commit --fixup=abc1234'],
+  [true, 'git -C /some/path commit -m "x"'],
+  [true, 'git -c user.name=x commit -m "y"'],
+  [true, 'git --git-dir=/tmp/x commit'],
+  [true, 'git --no-pager commit -m "x"'],
+  [true, 'cd foo && git commit -m "x"'],
+  [true, 'git add . && git commit -m "x" && git status'],
+
+  // --- is NOT a commit ---
+  // The plumbing subcommands: `-` is a non-word character, so a bare \b matched
+  // these. They write no commit; treating one as a commit wrongly BLOCKS.
+  [false, 'git commit-tree abc1234'],
+  [false, 'git commit-graph write'],
+  [false, 'git -C /some/path commit-tree abc1234'],
+  [false, 'git commit_backup'],
+  [false, 'git commitfoo'],
+  [false, 'gitcommit -m "x"'],
+  [false, 'git status'],
+  [false, 'git add .'],
+  [false, 'git log --grep=commit'],
+  [false, 'echo committing now'],
+];
+
+/**
+ * The cases where the implementations legitimately differ, pinned so each
+ * divergence stays deliberate rather than becoming an unnoticed drift. Both
+ * come from the same root: the bash copy's character classes are ASCII-only
+ * while Python's \w and \s are Unicode-aware. Neither side is wrong — see the
+ * re.ASCII discussion in both Python hooks, which argues exactly this trade —
+ * but a change to either side shows up here first.
+ *
+ * Verified against /usr/bin/grep (GNU). A grep whose [[:space:]] accepts
+ * U+00A0 — ugrep does — flips the second row's bash column, so re-confirm which
+ * binary is on PATH before treating a failure here as pattern drift.
+ */
+const DIVERGENCE_CASES: readonly (readonly [input: string, expectedByLabel: readonly boolean[]])[] =
+  [
+    // Non-ASCII suffix: Python's (?![-\w]) rejects it, bash's [^-a-zA-Z0-9_] accepts.
+    ['git commit日本語', [true, false, false]],
+    // Non-breaking space as the separator: Python's \s matches U+00A0, GNU grep's
+    // [[:space:]] does not. This row is what makes adding re.ASCII to either
+    // Python copy fail here — the flag would narrow \s and MISS a real commit.
+    ['git commit -m "x"', [false, true, true]],
+  ];
+
+/**
+ * The bash copy's verdicts are only meaningful under the engine the hooks
+ * actually run on. `grep` on PATH is not reliably GNU grep: ugrep ships as a
+ * drop-in `/usr/bin/grep` on some systems (including at least one sandbox this
+ * project's own agent sessions run in), and its `[[:space:]]` ACCEPTS U+00A0
+ * where GNU's does not — which flips the NBSP divergence row below.
+ *
+ * Without this check that mismatch surfaces as a per-case assertion failure,
+ * i.e. as "the pattern drifted" — the one message this guard must never emit
+ * falsely. Fail loudly, and name the cause, so the reader is not sent to
+ * re-audit three correct regexes.
+ *
+ * BSD/macOS grep is out of scope for the same reason it is in lib/git-command.sh:
+ * the shared pattern uses `\b`, a GNU extension, so the hook itself is already
+ * GNU-scoped.
+ */
+function assertGnuGrep(): void {
+  let version: string;
+  try {
+    version = execFileSync('grep', ['--version'], { encoding: 'utf-8' });
+  } catch (error) {
+    throw new Error('Could not run `grep --version`, so the bash copy cannot be evaluated', {
+      cause: error,
+    });
+  }
+  const firstLine = version.split('\n')[0];
+  if (!/GNU grep/.test(firstLine)) {
+    throw new Error(
+      `This guard compares the hooks' patterns under the engine they run on, and \`grep\` ` +
+        `on PATH is not GNU grep — it reports: "${firstLine}". A non-GNU grep (ugrep ships as ` +
+        `a drop-in /usr/bin/grep on some systems) differs on U+00A0 in [[:space:]], which would ` +
+        `fail the NBSP divergence row below as if a pattern had drifted. This is an ENVIRONMENT ` +
+        `mismatch, not a hook change: put GNU grep on PATH before reading the result.`
+    );
+  }
+}
+
+/** grep exits 0 on match, 1 on no-match; anything else is a real error. */
+function bashVerdict(pattern: string, input: string): boolean {
+  try {
+    execFileSync('grep', ['-qE', pattern], { input });
+    return true;
+  } catch (error) {
+    const status = (error as { status?: number | null }).status;
+    if (status === 1) return false;
+    throw error;
+  }
+}
+
+/** One python3 spawn evaluates both Python patterns over every case. */
+function pythonVerdicts(patterns: readonly string[], inputs: readonly string[]): boolean[][] {
+  const script = [
+    'import json, re, sys',
+    'req = json.load(sys.stdin)',
+    'pats = [re.compile(p) for p in req["patterns"]]',
+    'json.dump([[bool(p.search(c)) for c in req["cases"]] for p in pats], sys.stdout)',
+  ].join('\n');
+  const out = execFileSync('python3', ['-c', script], {
+    input: JSON.stringify({ patterns, cases: inputs }),
+    encoding: 'utf-8',
+  });
+  return JSON.parse(out) as boolean[][];
+}
+
+assertGnuGrep();
+
+const patterns = SOURCES.map(extractPattern);
+const allInputs = [
+  ...AGREEMENT_CASES.map(([, input]) => input),
+  ...DIVERGENCE_CASES.map(([input]) => input),
+];
+const pythonResults = pythonVerdicts(patterns.slice(1), allInputs);
+
+/** verdicts[sourceIndex][caseIndex] */
+const verdicts: boolean[][] = [
+  allInputs.map(input => bashVerdict(patterns[0], input)),
+  ...pythonResults,
+];
+
+describe('git-commit detection patterns agree across all three copies', () => {
+  it('extracts a distinct, non-empty pattern from each hook', () => {
+    for (const [i, pattern] of patterns.entries()) {
+      expect(pattern.length, `${SOURCES[i].label} extracted an empty pattern`).toBeGreaterThan(10);
+    }
+
+    // Distinctness is not cosmetic: if an extractor were edited to capture the
+    // same substring from two files, every case below would compare a pattern
+    // against ITSELF and pass unconditionally — the guard would read green while
+    // enforcing nothing, which is the exact failure it exists to prevent. The
+    // three patterns genuinely differ today (bash character classes vs Python
+    // lookahead vs the (commit|push) alternation), so equality means a broken
+    // extractor, never a legitimate convergence.
+    expect(new Set(patterns).size, 'two extractors captured the same pattern').toBe(
+      patterns.length
+    );
+  });
+
+  it('uses only push-free cases, so copy 3’s (commit|push) alternation is inert', () => {
+    for (const input of allInputs) {
+      expect(
+        input,
+        'a case containing "push" would compare copy 3 against a different decision'
+      ).not.toContain('push');
+    }
+  });
+
+  for (const [caseIndex, [expected, input]] of AGREEMENT_CASES.entries()) {
+    it(`${expected ? 'detects' : 'ignores'}: ${JSON.stringify(input)}`, () => {
+      for (const [sourceIndex, source] of SOURCES.entries()) {
+        expect.soft(verdicts[sourceIndex][caseIndex], source.label).toBe(expected);
+      }
+    });
+  }
+
+  for (const [offset, [input, expectedByLabel]] of DIVERGENCE_CASES.entries()) {
+    it(`pinned divergence: ${JSON.stringify(input)}`, () => {
+      const caseIndex = AGREEMENT_CASES.length + offset;
+      for (const [sourceIndex, source] of SOURCES.entries()) {
+        expect
+          .soft(
+            verdicts[sourceIndex][caseIndex],
+            `${source.label} (deliberate ASCII-vs-Unicode divergence)`
+          )
+          .toBe(expectedByLabel[sourceIndex]);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes TASK-442.

## The drift class

The same "does this command string invoke \`git commit\`" decision is encoded **three times, in two languages**:

| # | Copy | Role |
|---|------|------|
| 1 | `.claude/hooks/lib/git-command.sh` | GNU-grep ERE, sourced by `claim-shape-guard.sh` + `fixup-rider-check.sh` |
| 2 | `.claude/hooks/develop-code-commit-guard.sh` | Python regex — **blocking** |
| 3 | `.claude/hooks/git-commit-filter-guard.sh` | Python regex — **blocking** |

They can't be collapsed into one: the blocking hooks need Python for their heredoc/quote stripping, and the lib exists precisely so the two bash consumers don't fork Python on every Bash call. So the coupling is real, hand-managed, and was documented only in a comment — "sync manually if the shape changes."

**It had already opened once.** The `commit-tree` false positive was fixed in copy 1 (#1980) one PR before copies 2 and 3 (#1981). During that window a legitimate `git commit-tree` on develop with dirty review-gated files would have been wrongly **blocked** by copy 2.

## What the guard does

`packages/tooling/src/dev/gitCommitPatternAgreement.test.ts` extracts all three patterns **from the hook sources at run time** and runs them over a shared case table (plumbing subcommands, the `-C`/`-c`/`--git-dir` global-flag forms, chained commands, `git log --grep=commit`, real commits).

It asserts **agreement on verdicts, not textual identity** — per TASK-442, the copies deliberately differ. Two divergences are pinned rather than papered over, both from the same root (bash character classes are ASCII-only; Python's `\w`/`\s` are Unicode-aware):

- `git commit日本語` — bash matches, Python doesn't
- a **U+00A0 separator** — Python matches, GNU grep doesn't

The second row is load-bearing: it is what makes adding `re.ASCII` to either Python copy fail here, which is exactly the change both hooks' comments argue against (the flag would narrow `\s` and make the guard **miss a real commit**).

Copy 3 detects `(commit|push)`; every case is asserted push-free, which makes that alternation inert and lets all three be compared with no rewriting of the extracted text.

## Verified

Canaried in **all three directions**, each confirmed to turn the suite red and name the offending copy:

1. Reverting copy 1's trailing `([^-a-zA-Z0-9_]|$)` to a bare `\b` → 4 failures, labelled `bash lib/git-command.sh`
2. Reverting copy 2's `(?![-\w])` to a bare `\b` → 3 failures, labelled `python develop-code-commit-guard.sh`
3. Reformatting copy 3's `re.compile(` line so the extractor no longer matches → **hard error**, not a silent pass: `expected exactly 1 line matching …, found 0. The hook was reformatted — update the extractor here rather than deleting this guard.`

That third canary is the one that matters most — an extraction that quietly stops matching would disarm the guard while staying green, reproducing the failure mode one level up.

Also run green: all four affected hook probes (`develop-code-commit-guard`, `git-commit-filter-guard`, `claim-shape-guard`, `fixup-rider-check`), `pnpm test`, `pnpm quality`.

## Correction worth recording

My first pass had the NBSP case as an *agreement* row, because a shell probe showed GNU grep matching U+00A0. That probe was wrong: this shell's `grep` is a **ugrep-backed shim**, and ugrep's `[[:space:]]` accepts U+00A0 where `/usr/bin/grep`'s does not. The test spawns `grep` directly (no shell function in the way), which is also what the hooks get — so the divergence is real and the hooks' comments were accurate all along. The test header notes this so a future failure on that row gets checked against *which grep is on PATH* before being treated as pattern drift.

## Also in this PR

The three "sync manually" comments now name the guard that enforces them — an unenforced-invariant comment that still reads as unenforced is the thing this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)