### PR TITLE
refactor(bot-client): collapse hasVoiceAttachment onto the shared detector

### DIFF
--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -1524,28 +1524,31 @@ interface MockMessageOptions {
   /**
    * Mark the message as a forward (`reference.type === Forward`) while leaving
    * `messageSnapshots` absent — the shape Discord produces when it declines to
-   * populate snapshots. The two forwarded-voice detectors guard this case with
-   * different predicates, so it needs its own fixture.
+   * populate snapshots. `isForwardedMessage` says yes on the reference alone, so
+   * this reaches the snapshot walk with nothing to walk; it needs its own fixture
+   * to pin that the empty walk yields false rather than throwing.
    */
   forwardReferenceWithoutSnapshots?: boolean;
 }
 
-function createMockAttachmentsMap(attachmentsList: MockSnapshotAttachment[] | null): Map<
-  string,
-  MockSnapshotAttachment
-> & {
-  some: (predicate: (a: MockSnapshotAttachment) => boolean) => boolean;
-} {
-  const map = new Map<string, MockSnapshotAttachment>();
+/**
+ * Discord.js hands back a `Collection`, which extends Map with helpers the shared
+ * forwarded-message utilities call — `some` on attachment collections, `first` on
+ * snapshot collections. A bare Map silently lacks both, so each fixture used to
+ * monkey-patch only the subset its own caller happened to touch. Building one
+ * shape that carries both keeps a fixture honest to the real Collection instead
+ * of to one call path, which is what let a detector reach a fixture missing the
+ * very method it needed.
+ */
+type MockCollection<V> = Map<string, V> & {
+  some: (predicate: (value: V) => boolean) => boolean;
+  first: () => V | undefined;
+};
 
-  if (attachmentsList) {
-    attachmentsList.forEach((att, index) => {
-      map.set(`snapshot-att-${index}`, att);
-    });
-  }
+function createMockCollection<V>(entries: Iterable<readonly [string, V]>): MockCollection<V> {
+  const collection = new Map<string, V>(entries) as MockCollection<V>;
 
-  // Add Collection-like methods
-  (map as any).some = function (predicate: (a: MockSnapshotAttachment) => boolean) {
+  collection.some = function (predicate: (value: V) => boolean): boolean {
     for (const value of this.values()) {
       if (predicate(value)) {
         return true;
@@ -1554,51 +1557,53 @@ function createMockAttachmentsMap(attachmentsList: MockSnapshotAttachment[] | nu
     return false;
   };
 
-  return map as Map<string, MockSnapshotAttachment> & {
-    some: (predicate: (a: MockSnapshotAttachment) => boolean) => boolean;
+  collection.first = function (): V | undefined {
+    return this.values().next().value;
   };
+
+  return collection;
+}
+
+function createMockAttachmentsMap(
+  attachmentsList: MockSnapshotAttachment[] | null
+): MockCollection<MockSnapshotAttachment> {
+  return createMockCollection(
+    (attachmentsList ?? []).map((att, index) => [`snapshot-att-${index}`, att] as const)
+  );
 }
 
 function createMockMessage(options: MockMessageOptions = {}): Message {
-  const attachments = new Map();
-
-  (options.attachments || []).forEach((att, index) => {
-    attachments.set(`attachment-${index}`, {
-      url: att.url || `https://cdn.discord.com/file-${index}`,
-      contentType: att.contentType === undefined ? 'application/octet-stream' : att.contentType,
-      name: att.name || `file-${index}`,
-      size: att.size || 1000,
-      duration: att.duration === undefined ? null : att.duration,
-      waveform: att.waveform,
-    });
-  });
-
-  // Add Collection-like methods to Map (Discord.js Collection extends Map)
-  (attachments as any).some = function (predicate: any) {
-    for (const value of this.values()) {
-      if (predicate(value)) {
-        return true;
-      }
-    }
-    return false;
-  };
+  const attachments = createMockCollection(
+    (options.attachments || []).map(
+      (att, index) =>
+        [
+          `attachment-${index}`,
+          {
+            url: att.url || `https://cdn.discord.com/file-${index}`,
+            contentType:
+              att.contentType === undefined ? 'application/octet-stream' : att.contentType,
+            name: att.name || `file-${index}`,
+            size: att.size || 1000,
+            duration: att.duration === undefined ? null : att.duration,
+            waveform: att.waveform,
+          },
+        ] as const
+    )
+  );
 
   // Create messageSnapshots if provided
   let messageSnapshots:
-    Map<string, { attachments: ReturnType<typeof createMockAttachmentsMap> }> | undefined;
+    MockCollection<{ attachments: MockCollection<MockSnapshotAttachment> }> | undefined;
   if (options.messageSnapshots && options.messageSnapshots.length > 0) {
-    messageSnapshots = new Map();
-    options.messageSnapshots.forEach((snapshot, index) => {
-      messageSnapshots!.set(`snapshot-${index}`, {
-        attachments: createMockAttachmentsMap(snapshot.attachments),
-      });
-    });
-    // Discord.js hands back a `Collection`, not a bare `Map` — the shared
-    // forwarded-message helpers use `first()`. Stub it so the fixture matches the
-    // real shape instead of only the subset one caller happened to touch.
-    (messageSnapshots as any).first = function () {
-      return this.values().next().value;
-    };
+    messageSnapshots = createMockCollection(
+      options.messageSnapshots.map(
+        (snapshot, index) =>
+          [
+            `snapshot-${index}`,
+            { attachments: createMockAttachmentsMap(snapshot.attachments) },
+          ] as const
+      )
+    );
   }
 
   const channel: any = options.noTypingSupport

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -25,7 +25,7 @@ import { voiceTranscriptCache } from '../redis.js';
 import {
   hasForwardedSnapshots,
   getSnapshots,
-  hasForwardedVoiceAttachment,
+  hasVoiceAttachments,
 } from '../utils/forwardedMessageUtils.js';
 import { isVoiceAttachment } from '../utils/voiceAttachment.js';
 import { sendTypingIndicator } from '../utils/typingErrorClassifier.js';
@@ -287,23 +287,17 @@ interface VoiceTranscriptionResult {
  */
 export class VoiceTranscriptionService {
   /**
-   * Check if message contains voice attachment (in direct attachments or forwarded message snapshots)
-   * Uses centralized utilities from forwardedMessageUtils.ts for consistent forwarded message handling.
+   * Check if message contains voice attachment (in direct attachments or forwarded
+   * message snapshots).
+   *
+   * Kept as a method rather than an import at the call site so VoiceMessageProcessor
+   * retains an injectable seam over this service; the detection itself is the shared
+   * one — direct attachments first, then the forwarded-snapshot detector, which reads
+   * the `isVoiceMessage` flag `extractAttachments` computed from the RAW snapshot
+   * attachment (including the duration fallback for content-type-less snapshots).
    */
   hasVoiceAttachment(message: Message): boolean {
-    // Direct attachments (forwarded snapshots handled below).
-    const hasDirectAudio = message.attachments.some(isVoiceAttachment);
-
-    if (hasDirectAudio) {
-      return true;
-    }
-
-    // Forwarded snapshots: delegate to the shared detector rather than re-walking
-    // the snapshots here. It reads the `isVoiceMessage` flag that
-    // `extractAttachments` computed from the RAW snapshot attachment, i.e. the same
-    // `isVoiceAttachment` predicate over the same object — including the
-    // duration fallback for content-type-less snapshots.
-    return hasForwardedVoiceAttachment(message);
+    return hasVoiceAttachments(message);
   }
 
   /**


### PR DESCRIPTION
Closes TASK-443.

## The duplication finally became exact

After #1984 delegated the forwarded branch, the two implementations converged to *literally* the same logic:

```ts
// VoiceTranscriptionService.hasVoiceAttachment    // forwardedMessageUtils.hasVoiceAttachments
const d = message.attachments.some(isVoiceAttachment);   const d = message.attachments.some(isVoiceAttachment);
if (d) return true;                                       return d || hasForwardedVoiceAttachment(message);
return hasForwardedVoiceAttachment(message);
```

Same predicate, same operand order, and `||` short-circuits exactly like the early return. This is the last piece of the parallel implementation #1309 and #1984 had been chipping at.

## The ordering concern, resolved

TASK-443 recorded a reason this wasn't ridden along in #1984: the equivalence "depends on ordering" — `hasForwardedVoiceAttachment` guards on the weaker `isForwardedMessage`, so it is only harmless once the direct check has already cleared.

That holds, and it is **preserved by construction**: both versions call it in the same position, after the direct check. The delegation doesn't remove the ordering guarantee, it inherits it. The two existing `hasVoiceAttachments` consumers (`ReferenceExtractor`, `MessageContextBuilder`) are untouched by this change — they already used the shared helper.

## Why it stays a method

`VoiceMessageProcessor` mocks `voiceService.hasVoiceAttachment` as an injectable service seam across 16 touch points (14 `mockReturnValue` setups + 2 `toHaveBeenCalledWith` assertions, 19 references in all). Deleting the method would churn that mock surface for no gain, so the method survives as a one-line delegation — what goes away is the duplicated *implementation*, not the seam.

## Member (b): one mock-Collection helper

The fixture carried three near-duplicate `as any` monkey-patches, each stubbing only the Collection method its own caller happened to touch (`some` twice, `first` once). They collapse onto a single `createMockCollection<V>` carrying both, which also drops every `as any` on that path in favour of one typed cast at construction.

That "stub only what my call path touches" habit is the shape that lets a detector reach a fixture missing the very method it needs — worth removing on its own, not just for the line count.

## Stale comment fixed

The `forwardReferenceWithoutSnapshots` fixture comment said *"the two forwarded-voice detectors guard this case with different predicates"* — that was describing the duplication this PR removes. Rewritten to state what the case actually pins now: `isForwardedMessage` says yes on the reference alone, so the case reaches the snapshot walk with nothing to walk, and pins that the empty walk yields `false` rather than throwing.

## Verified

- `pnpm --filter @tzurot/bot-client test` — 393 files / 6097 tests green, including the 15-case `hasVoiceAttachment` block that exercises both arms (direct voice, forwarded snapshot, duration-fallback, MP4 false-positive, null/empty snapshot attachments, forward-reference-without-snapshots)
- `pnpm --filter @tzurot/bot-client typecheck` **and** `typecheck:spec` — both clean
- `pnpm test` and `pnpm quality`, sequentially — both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
