### PR TITLE
perf(hooks): skip the jq forks on every Bash call the guards cannot block

### DIFF
--- a/.claude/hooks/develop-code-commit-guard.probe.sh
+++ b/.claude/hooks/develop-code-commit-guard.probe.sh
@@ -109,6 +109,14 @@ run 0 "plumbing: commit-tree behind -C flag"      'git -C /some/path commit-tree
 run 0 "escape hatch in command position"          'TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 git commit -m "x"'   'services/probe.ts'
 run 0 "escape hatch, canonical heredoc form"      "TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 $CANONICAL_HEREDOC"  'services/probe.ts'
 run 0 "non-git command"                           'echo hello'                                             'services/probe.ts'
+# Raw-payload pre-check boundary: the hook exits before forking jq when the RAW
+# stdin has no git…commit token pair. `git status` has no `commit` at all;
+# `echo commit && git status` has the tokens in the WRONG ORDER, and the glob
+# needs git BEFORE commit — matching the decoded check it replaces. Both must
+# stay silent, and a commit whose tokens sit behind a chain must still block
+# (covered by the blocking cases above).
+run 0 "pre-check: git verb with no commit token"  'git status --porcelain'                                 'services/probe.ts'
+run 0 "pre-check: tokens in the wrong order"      'echo commit && git status'                              'services/probe.ts'
 run 0 "clean tree commit"                         'git add -A && git commit -m "x"'
 run 0 "docs-only dirty file"                      'git commit -m "x"'                                      'docs/probe-notes.md'
 # Accepted-tradeoff pin: dirty-tree (not staged-set) design means an

--- a/.claude/hooks/develop-code-commit-guard.sh
+++ b/.claude/hooks/develop-code-commit-guard.sh
@@ -44,6 +44,28 @@
 set -uo pipefail
 
 INPUT=$(cat)
+
+# Raw-payload pre-check, BEFORE the two jq forks. This hook is PreToolUse on
+# every Bash call, and the jq pair dominates the cost — 22.25ms -> 9.07ms per
+# call (measured, 100 runs against a non-git payload) — so the decoded
+# short-circuit below was saving the python spawn but not the forks.
+#
+# Safe on a BLOCKING guard because it can only OVER-match, never under-match:
+# JSON escaping inserts backslashes at `"`, `\`, and control characters, and
+# leaves ASCII letters alone, so a decoded command containing `git`…`commit`
+# implies the raw payload carries those tokens too, in that order (the JSON
+# envelope contains no `git` ahead of the command field). Confirmed against a
+# REAL harness payload, not just jq-built probe fixtures: the sibling
+# filter-guard blocked a live `git push … | tail` through this same pre-check,
+# which requires the tokens to have been literal in the raw stdin.
+#
+# A false positive costs exactly what today already costs; a false negative is
+# the only dangerous direction and this shape cannot produce one.
+case "$INPUT" in
+  *git*commit*) ;;
+  *) exit 0 ;;
+esac
+
 TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 

--- a/.claude/hooks/git-commit-filter-guard.probe.sh
+++ b/.claude/hooks/git-commit-filter-guard.probe.sh
@@ -65,6 +65,15 @@ run 0 "non-git command with a filter"         'pnpm test | tail -20'
 run 0 "git log piped to a filter"             'git log --oneline | head -5'
 run 0 "commit message merely mentions a pipe" 'git commit -m "fix: stop piping git push | tail"'
 
+# --- raw-payload pre-check boundary ---------------------------------------
+# The hook exits before forking jq when the RAW stdin lacks a pipe, or lacks
+# the git+commit / git+push token pair. These pin that the fast path never
+# swallows a command the decoded checks would have caught, and that the slow
+# path is still reached when it must be.
+run 0 "pre-check: pipe but no git token"      'ls -la | tail'
+run 0 "pre-check: git commit but no pipe"     'git commit --amend --no-edit'
+run 2 "pre-check: tokens split across a &&"   'echo commit && git push | tail'
+
 # --- malformed / non-Bash input fails OPEN --------------------------------
 printf '{"tool_name":"Read","tool_input":{"file_path":"x"}}' | "$HOOK" >/dev/null 2>&1
 if [ $? -eq 0 ]; then

--- a/.claude/hooks/git-commit-filter-guard.sh
+++ b/.claude/hooks/git-commit-filter-guard.sh
@@ -17,6 +17,32 @@
 set -uo pipefail
 
 INPUT=$(cat)
+
+# Raw-payload pre-check, BEFORE the two jq forks — same reasoning as the
+# sibling develop-code-commit-guard.sh: this runs PreToolUse on every Bash
+# call, and the jq pair dominates the cost — 22.35ms -> 9.02ms per call
+# (measured, 100 runs against a non-git payload) — so the decoded short-circuit
+# below was saving the python spawn but not the forks.
+#
+# It can only OVER-match: JSON escaping leaves ASCII letters alone and `|` is
+# not an escaped character, so anything the decoded checks would accept is still
+# present in the raw payload. Verified against a REAL harness payload rather
+# than only jq-built fixtures — a live `git push … | tail` was blocked through
+# this pre-check, which requires both the pipe and the git/push tokens to have
+# been literal in the raw stdin.
+#
+# The `|` pattern is quoted — unquoted it would be read as case-alternation
+# rather than a literal pipe, matching everything and silently deleting the
+# speedup while leaving every verdict unchanged.
+case "$INPUT" in
+  *"|"*) ;;
+  *) exit 0 ;;
+esac
+case "$INPUT" in
+  *git*commit*|*git*push*) ;;
+  *) exit 0 ;;
+esac
+
 TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 


### PR DESCRIPTION
TASK-441 member (e).

## The problem

Both **blocking** PreToolUse guards forked `jq` twice before reaching their cheap decoded short-circuit:

```bash
INPUT=$(cat)
TOOL_NAME=$(jq …)          # fork 1
COMMAND=$(jq …)            # fork 2
case "$COMMAND" in         # ← the cheap check, AFTER both forks
  *git*commit*) ;;
  *) exit 0 ;;
esac
```

So the short-circuit saved the *python* spawn but not the forks — and the forks dominate. These run on **every Bash call**, which is the whole reason a cheap-first pass pays here.

## Measured, 100 runs each, non-git payload (`ls -la`)

| Hook | Before | After | |
|---|---|---|---|
| `develop-code-commit-guard` | 22.25 ms | **9.07 ms** | −59% |
| `git-commit-filter-guard` | 22.35 ms | **9.02 ms** | −60% |

Both fire per Bash call, so that is **~26 ms returned on every tool call**.

Paired measurement — the "before" side is the actual pre-change file from `origin/develop`, run through the identical harness, not a number carried over from an earlier session.

## Why this is safe on a BLOCKING guard

This is the reason #1981 deferred it: an early exit added to a guard that *blocks* fails dangerously if it can ever exit early on a command that should have been caught. This shape cannot.

**It can only OVER-match, never under-match.** JSON escaping inserts backslashes at `"`, `\`, and control characters and leaves ASCII letters alone.

> **Runtime-verified (round 1).** The review correctly flagged that I stated this as fact about the harness's serializer without capturing a real payload — the probes build fixtures with `jq -n --arg`, which is a stand-in, not evidence. So I ran the cheapest falsifying probe: a live `git push --dry-run … | tail` on this branch. The filter-guard **blocked it**, which it can only do by passing the raw pre-check first — so the harness's own JSON carried `|`, `git` and `push` as literal ASCII. Observation, not inference. (The guard demonstrating its own safety argument by blocking me is a fitting way to close the loop.) So a decoded command containing `git`…`commit` implies those tokens are present in the raw payload too. A false positive costs exactly what today already costs (the full path runs); a false negative is the only dangerous direction, and the substring relation rules it out.

**Token order is preserved too** — the JSON envelope (`{"tool_name":…,"tool_input":{"command":…}}`) carries no `git` before the command field, so `git`-before-`commit` holds in the raw payload exactly when it holds in the decoded one. That matters because the glob is ordered: `echo commit && git status` fails the pre-check, and it failed the decoded check before this PR for the same reason.

The `|` pattern in the filter-guard is **quoted** (`*"|"*`) — unquoted, bash reads it as case-alternation rather than a literal pipe, which would match everything and silently delete the speedup.

## Verified

- **The 50 existing probe assertions are the regression evidence** — every verdict across both hooks is unchanged. That is the claim that matters: this PR must alter performance and nothing else.
- **5 new cases pin the pre-check boundary directly**: pipe without a git token, git commit without a pipe, tokens split across a `&&` chain (must still block), a git verb with no commit token, and tokens in the wrong order.
- **Canaried**: making the pre-check too strict fails **18** assertions — so the suite genuinely guards the fast path rather than passing regardless of it.
- All four related probes green (`develop-code-commit-guard` 31, `git-commit-filter-guard` 24, `claim-shape-guard` 20, `fixup-rider-check` 10).
- The new `gitCommitPatternAgreement` guard from #1996 passes — confirming these edits introduce no second match for any of its three extraction regexes.
- `pnpm test` and `pnpm quality` sequentially, both green.

## What stays open

TASK-441 member **(d)** — reusing the heredoc/quote stripping inside `is_git_commit_command` to kill message-text false-fires — remains open deliberately. It needs a runtime-confirmed false-fire first; building it on a code-read mechanism is exactly what `00-critical.md` forbids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
