### PR TITLE
fix(hooks): decide the merge gate's PR from the argument vector, not the text

### DIFF
--- a/.claude/hooks/pr-merge-review-check.probe.sh
+++ b/.claude/hooks/pr-merge-review-check.probe.sh
@@ -53,7 +53,7 @@
 #      only assert the hook wrote it.
 #
 # Three cases in section 2 were PINNED DEFECTS until the extraction was
-# rewritten (TASK-469): the old match tested the whole command TEXT, so any
+# rewritten: the old match tested the whole command TEXT, so any
 # command carrying the phrase `gh pr merge` plus a bare all-digit token armed
 # the gate on the WRONG PR — a decoy before the real invocation, a `--body`
 # argument, or prose in an unrelated subcommand. They now assert the correct
@@ -389,6 +389,154 @@ assert_pr "unbalanced quotes fall back to the legacy scan rather than arming not
 # A real invocation inside a command substitution is still a real invocation.
 new_case; invoke 'out=$(gh pr merge 2002)'
 assert_pr "command substitution around the invocation still arms the gate" 2002
+
+# A shell with flags before its own `-c`. Scoping the check to the token
+# immediately preceding `-c` missed this; the owner is the segment's command
+# word, which is what the code now tracks.
+new_case; invoke 'bash -x -c "gh pr merge 2002"'
+assert_pr "flags between the shell and its -c do not hide the invocation" 2002
+
+# The QUOTED eval form is one opaque token, so WRAPPERS alone cannot see it —
+# it needs the recursion that the unquoted form does not.
+new_case; invoke 'eval "gh pr merge 2002"'
+assert_pr "a quoted eval argument still arms the gate" 2002
+
+# A decoy BEFORE a wrapper-run invocation. The backstop originally fell back
+# to a raw-text scan, which reads the first textual occurrence — so it returned
+# the decoy and reintroduced exactly the bug this file exists to fix. Two
+# changes prevent it: `eval` is a wrapper (so the position-aware scan handles
+# this directly), and the backstop scans TOKENS, which carry quoting.
+new_case; invoke 'echo gh pr merge 1 && eval gh pr merge 2002'
+assert_pr "a decoy before a wrapper-run invocation does not win" 2002
+
+# The `-c` shell check must belong to the token that owns the flag. A shell
+# named anywhere earlier in a compound command previously made an unrelated
+# tool's `-c` argument get scanned as if it were a shell string.
+new_case; invoke 'bash --version; grep -c "gh pr merge 42 mentioned" notes.txt'
+assert_no_fetch "an earlier shell name does not make grep -c a shell string"
+
+# THE STRUCTURAL BACKSTOP. When `gh pr merge` survives tokenization as three
+# adjacent tokens but the command-position logic did not recognise the shape,
+# a token-level scan runs rather than the gate exiting clean, so the NEXT
+# unmodelled shape over-arms instead of becoming a silent bypass.
+#
+# The unquoted `eval` below no longer EXERCISES the backstop — `eval` is a
+# wrapper now, so the primary scan resolves it. It stays as a regression pin
+# for that path; the backstop's own coverage is the decoy case further down.
+new_case; invoke 'eval gh pr merge 2002'
+assert_pr "an unmodelled invocation shape falls back rather than exiting clean" 2002
+
+# And the discriminator that keeps this file's headline fix: prose inside a
+# quoted argument is ONE token, never three adjacent ones, so the backstop
+# does not fire and the gate stays quiet.
+new_case; invoke 'gh pr comment 2006 --body "the hook matches gh pr merge 1 in prose"'
+assert_no_fetch "the backstop does not re-arm the gate on quoted prose"
+
+# Utilities that RUN the following command do not consume the command
+# position. `env FOO=bar gh pr merge N` extracted nothing at all — an under-arm.
+new_case; invoke 'env GH_TOKEN=x gh pr merge 2002'
+assert_pr "a wrapper utility does not consume the command position" 2002
+
+new_case; invoke 'nohup gh pr merge 2002'
+assert_pr "same for nohup" 2002
+
+# The `-c` recursion must belong to a SHELL. Many tools take `-c`, and one
+# whose argument merely quotes the phrase would otherwise arm the gate on it.
+new_case; invoke 'grep -c "gh pr merge 2002" notes.txt'
+assert_no_fetch "a non-shell -c argument is not scanned as a command"
+
+# An empty-quoted ARGUMENT between `merge` and the PR number. `all()` over an
+# empty string is True, so an empty token read as an operator and ended the
+# digit scan before reaching the number — an under-arm.
+new_case; invoke "gh pr merge '' 2002"
+assert_pr "an empty argument does not end the PR-number scan" 2002
+
+# Two REAL, differently-numbered invocations joined by a semicolon. A semicolon
+# runs both sides unconditionally and in order, so the FIRST is the one that
+# executes first and the one whose review must be surfaced. Added because a
+# review argued the semicolon glues to the adjacent token and defeats the scan;
+# measured, `;` IS in shlex's default punctuation set and splits correctly, so
+# this pins the behaviour rather than fixing anything.
+new_case; invoke 'gh pr merge 1; gh pr merge 2002'
+assert_pr "semicolon-chained real invocations: the FIRST one arms the gate" 1
+
+new_case; invoke 'gh pr merge 2002;'
+assert_pr "a trailing semicolon does not glue to the PR number" 2002
+
+# An empty-quoted argument is a legitimate EMPTY-STRING token, not end of
+# input. Treating it as EOF truncated the token stream and dropped every
+# command after it — an under-arm.
+new_case; invoke "echo '' && gh pr merge 2002"
+assert_pr "an empty-string token does not truncate the scan" 2002
+
+# A `-c` argument is a command in its own right, and arrives as ONE quoted
+# token. Without recursion this is invisible — and the naive text scan this
+# replaced DID catch it, so missing it would be a regression, not a gap.
+new_case; invoke 'bash -c "gh pr merge 2002"'
+assert_pr "a merge inside a -c string argument still arms the gate" 2002
+
+# Bash keywords that open a command position. `if`/`while`/`until` were absent
+# while `then`/`do` were present, so a merge directly after them went ungated.
+new_case; invoke 'if gh pr merge 2002; then echo ok; fi'
+assert_pr "a merge directly after `if` is at a command position" 2002
+
+new_case; invoke 'while gh pr merge 2002; do echo retry; done'
+assert_pr "same after `while`" 2002
+
+# A phrase-match that yields no PR number must not end the scan. The earlier
+# implementation exited unconditionally after the first match, so a bare merge
+# chained before a real one extracted NOTHING and the real merge went entirely
+# ungated — an under-arm, the direction this hook must never fail in.
+new_case; invoke 'gh pr merge && gh pr merge 2002'
+assert_pr "a bare merge before a real one does not swallow the real PR" 2002
+
+new_case; invoke 'gh pr merge; gh pr merge 2002'
+assert_pr "same across a semicolon separator" 2002
+
+# shlex returns adjacent punctuation as ONE token, so an enumerated operator
+# set misses `&&(` and command position stays stuck.
+new_case; invoke 'pnpm test &&( gh pr merge 2002 )'
+assert_pr "glued punctuation still opens a command position" 2002
+
+# Bash keywords open a command position too.
+new_case; invoke 'if true; then gh pr merge 2002; fi'
+assert_pr "a merge after `then` is still at a command position" 2002
+
+# Heredoc bodies are DATA, never commands — bash will not execute a word in
+# one however shell-like it looks. shlex has no concept of heredocs, so
+# without stripping them the body tokenizes as shell and any example command
+# quoted in a PR body or commit message arms the gate on the digit after it.
+#
+# Not hypothetical: this hook fired on its own fix's `gh pr create`, pulling a
+# PR number out of a markdown table cell that described the very bug being
+# fixed. That is the same shape as one of the two production sightings.
+new_case; invoke "$(printf 'gh pr create --body "$(cat <<%sEOF%s\nrun gh pr merge 42 when ready\nEOF\n)"' "'" "'")"
+assert_no_fetch "a merge quoted inside a heredoc body does not arm the gate"
+
+# The complement: stripping the body must not swallow a REAL invocation that
+# follows the heredoc's terminator.
+new_case; invoke "$(printf 'gh pr comment 7 --body "$(cat <<%sEOF%s\nsee gh pr merge 1\nEOF\n)" && gh pr merge 2002' "'" "'")"
+assert_pr "a real merge after the heredoc terminator still arms the gate" 2002
+
+# Unterminated heredoc strips NOTHING, so the body stays visible and the gate
+# over-arms. That is deliberate. The opener is found by regex over raw text,
+# which cannot tell a real redirection from the same characters inside a quoted
+# argument — and the previous "drop to end-of-text" behaviour deleted whatever
+# followed a FALSE match, which is a total bypass rather than a wrong PR.
+new_case; invoke "$(printf 'gh pr create --body "$(cat <<%sEOF%s\nrun gh pr merge 42 when ready' "'" "'")"
+assert_pr "an unterminated heredoc strips nothing, so the gate over-arms rather than vanishing" 42
+
+# The bypass that behaviour used to cause, pinned so it cannot come back: a
+# quoted string that merely LOOKS like a heredoc opener, with a real merge
+# after it. Stripping to end-of-text here removed the real invocation entirely
+# and the merge proceeded with no gate at all.
+new_case; invoke 'gh pr comment 5 --body "see the <<EOF heredoc marker" && gh pr merge 2002'
+assert_pr "a false heredoc opener inside quotes must not swallow the real merge" 2002
+
+# `<<<` is a here-string, not a heredoc; its trailing `<` plus a bare word hit
+# the same never-terminates path.
+new_case; invoke 'cat <<<marker && gh pr merge 2002'
+assert_pr "a here-string is not read as a heredoc opener" 2002
 
 # `set -f` equivalent: the tokenizer must not expand a glob against the cwd,
 # so a digit-named file cannot become a PR number.

--- a/.claude/hooks/pr-merge-review-check.probe.sh
+++ b/.claude/hooks/pr-merge-review-check.probe.sh
@@ -52,14 +52,13 @@
 #      agent's context. That is a Claude Code runtime property; the probe can
 #      only assert the hook wrote it.
 #
-# Three cases below are PINNED DEFECTS, labelled as such. The match tests the
-# whole command TEXT, so any command carrying the phrase `gh pr merge` followed
-# by a bare all-digit token arms the gate on the WRONG PR — whether that text is
-# a decoy before a real invocation, a `--body` argument, or ordinary prose in an
-# unrelated subcommand. They are pinned rather than fixed because hardening the
-# match is a semantic change to the merge gate; pinning documents the boundary
-# and makes the fix a deliberate act (update the cases) rather than an accident.
-# The hardening is tracked as TASK-469.
+# Three cases in section 2 were PINNED DEFECTS until the extraction was
+# rewritten (TASK-469): the old match tested the whole command TEXT, so any
+# command carrying the phrase `gh pr merge` plus a bare all-digit token armed
+# the gate on the WRONG PR — a decoy before the real invocation, a `--body`
+# argument, or prose in an unrelated subcommand. They now assert the correct
+# behaviour, which is what pinning them was for: the fix flipped known cases
+# instead of discovering them.
 #
 # Usage: .claude/hooks/pr-merge-review-check.probe.sh   (from repo root)
 
@@ -346,12 +345,10 @@ assert_pr "separator: pipe" 2002
 new_case; invoke "$(printf 'pnpm test\ngh pr merge 2002')"
 assert_pr "separator: newline" 2002
 
-# The two-part precondition for the extraction defect, pinned as a pair: it
-# takes a decoy gh/pr/merge sequence BEFORE the real invocation AND a bare
-# all-digit token after it. Either half alone is harmless, and the difference
-# between these cases is what documents the boundary.
+# The two-part precondition for the old extraction defect, kept as a group
+# because the differences between these cases are what document the boundary.
 new_case; invoke 'echo "gh pr merge 1" && gh pr merge 2002'
-assert_pr "quoted decoy: the closing quote makes the token non-bare, so no misfire" 2002
+assert_pr "quoted decoy: no misfire" 2002
 
 new_case; invoke 'echo gh pr merge now && gh pr merge 2002'
 assert_pr "leading decoy with no digit at all: no misfire" 2002
@@ -359,34 +356,47 @@ assert_pr "leading decoy with no digit at all: no misfire" 2002
 new_case; invoke 'gh pr merge 2002 && echo gh pr merge 1'
 assert_pr "decoy AFTER the real invocation: no misfire" 2002
 
-# PINNED DEFECT. Both halves of the precondition hold, and the hook extracts
-# the decoy. Recorded so the boundary is documented and a fix is deliberate:
-# when the extraction is hardened, this case flips to expect 2002.
+# WAS A PINNED DEFECT. The old text scan stripped to the FIRST occurrence of
+# the phrase, so the decoy's bare digit won over the real invocation and the
+# gate fetched PR 1. Command-position matching is what fixes it: `echo` holds
+# the command position, so its arguments can never be a merge invocation.
 new_case; invoke 'echo gh pr merge 1 && gh pr merge 2002'
-assert_pr "PINNED DEFECT: unquoted leading decoy + bare digit wins over the real PR" 1
+assert_pr "unquoted leading decoy does not beat the real PR" 2002
 
-# PINNED DEFECT, wider than the decoy case above and measured rather than
-# reasoned. The command match tests the whole command TEXT, so the subcommand
-# actually being invoked is irrelevant: any Bash command whose text contains
-# the phrase followed by a bare digit arms the gate. Prose ABOUT merging is
-# enough — this fired in production twice, once on a read-only diagnostic and
-# once on a reviewer's own `gh pr comment` submitting a review that quoted the
-# hook's internals. It is pinned rather than fixed because hardening the match
-# is a semantic change to the merge gate, tracked separately.
+# WAS A PINNED DEFECT, and the widest of the three. The old match tested the
+# whole command TEXT, so the subcommand actually invoked was irrelevant: any
+# command carrying the phrase plus a bare digit armed the gate. Both shapes
+# below fired in production. Quote-aware tokenization fixes them — a quoted
+# --body is ONE token, so prose inside it cannot match a command position.
 new_case; invoke 'gh pr comment 2006 --body "the hook matches gh pr merge 1 in prose"'
-assert_pr "PINNED DEFECT: gh pr comment whose BODY quotes the phrase arms the gate" 1
+assert_no_fetch "gh pr comment whose BODY quotes the phrase does not arm the gate"
 
 new_case; invoke 'gh issue create --body "run gh pr merge 42 when ready"'
-assert_pr "PINNED DEFECT: any command text carrying the phrase arms the gate" 42
+assert_no_fetch "command text carrying the phrase does not arm the gate"
 
-# `set -f`. Without it the loop's unquoted expansion globs against the cwd, so
-# a digit-named file becomes a PR number. Only reachable from a directory that
-# actually holds one.
+# An assignment prefix does not consume the command position. Missing this in
+# the prototype made the gate silently skip the shape — a fail-OPEN miss, the
+# same class the rewrite exists to close, so it is pinned rather than assumed.
+new_case; invoke 'GH_TOKEN=x gh pr merge 2002'
+assert_pr "an env-assignment prefix still reaches the merge invocation" 2002
+
+# Unparseable input must fall back to the permissive scan, never to silence.
+# Over-arming is recoverable (the agent sees an unrelated review and retries);
+# under-arming just lets the merge through.
+new_case; invoke 'gh pr merge 2002 --body "unbalanced'
+assert_pr "unbalanced quotes fall back to the legacy scan rather than arming nothing" 2002
+
+# A real invocation inside a command substitution is still a real invocation.
+new_case; invoke 'out=$(gh pr merge 2002)'
+assert_pr "command substitution around the invocation still arms the gate" 2002
+
+# `set -f` equivalent: the tokenizer must not expand a glob against the cwd,
+# so a digit-named file cannot become a PR number.
 GLOBDIR="$WORK/globdir"
 mkdir -p "$GLOBDIR"
 : >"$GLOBDIR/7"
 new_case; invoke_in "$GLOBDIR" 'gh pr merge * 2002'
-assert_pr "set -f: a glob token does not expand into a digit-named file" 2002
+assert_pr "a glob token does not expand into a digit-named file" 2002
 
 # ===========================================================================
 # 3. The review gate — block once per (PR, review-id), allow on retry

--- a/.claude/hooks/pr-merge-review-check.sh
+++ b/.claude/hooks/pr-merge-review-check.sh
@@ -48,17 +48,126 @@ COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "
 # Fails CLOSED by design, in both directions: an unparseable command falls back
 # to the old permissive scan rather than arming nothing, because silently not
 # arming is the same hole under a different name.
+# Cheap Bash-level reject FIRST. This hook is registered on every Bash call, so
+# without this guard a python3 process would start for `ls`, `git status`, and
+# every other command in the session — on a RAM-constrained machine, for a check
+# that is irrelevant to all of them. The tokenizer below only ever runs on a
+# command that at least mentions the phrase.
+# Held in a variable rather than written inline: an unquoted `[[ =~ ]]` regex
+# whose bracket expression contains `(` derails bash's own parser, and it fails
+# at the END of the file with a misleading "unexpected EOF" rather than here.
+# Deliberately PERMISSIVE: it only decides whether to spawn python, and the
+# tokenizer does the real work. Requiring a boundary before `gh` made it reject
+# quote-wrapped invocations (`bash -c "gh pr merge N"`) before anything could
+# look at them. Only the trailing boundary matters, so `gh pr merge-queue` and
+# similar still fall through.
+MERGE_PHRASE_RE='gh[[:space:]]+pr[[:space:]]+merge($|[[:space:]])'
+if ! [[ "$COMMAND" =~ $MERGE_PHRASE_RE ]]; then
+    exit 0
+fi
+
 PR_NUM=$(COMMAND="$COMMAND" python3 << 'PYEOF'
 import os, re, shlex, sys
 
-command = os.environ.get("COMMAND", "")
+raw_command = os.environ.get("COMMAND", "")
 
 # Cheap reject before any parsing: no phrase, no gate. Keeps the common Bash
 # call (which is not a merge) off the parsing path entirely.
-if not re.search(r"(^|[\s&|;(])gh\s+pr\s+merge($|\s)", command):
+# Mirrors the bash-level MERGE_PHRASE_RE above; keep the two in step.
+if not re.search(r"gh\s+pr\s+merge($|\s)", raw_command):
     sys.exit(0)
 
-OPERATORS = {"&&", "||", ";", "|", "&", "(", ")", ";;", "\n"}
+# What opens a new command position. Tested as a PUNCTUATION RUN rather than an
+# enumerated set: shlex returns adjacent punctuation as ONE token, so `a &&( gh
+# pr merge N )` yields `&&(` — which no enumerated set contains, leaving the
+# position stuck and the merge ungated. Keywords are separate because bash also
+# starts a command after them and they arrive as ordinary words.
+PUNCTUATION = set("();<>|&")
+KEYWORDS = {"if", "then", "else", "elif", "while", "until", "do",
+            "case", "select", "{", "!"}
+
+# Utilities that RUN the command that follows them, so they do not consume the
+# command position — same idea as the assignment-prefix skip below. Without
+# this, `env FOO=bar gh pr merge N` extracted nothing at all and the merge went
+# ungated. `env` also takes assignments, which the existing skip then handles.
+WRAPPERS = {"env", "nohup", "time", "command", "exec", "sudo", "stdbuf",
+            "timeout", "xargs", "eval"}
+
+# Programs whose `-c` argument is a shell command. Gating on these keeps the
+# recursion from firing on the many unrelated tools with a `-c` flag —
+# `grep -c "<the phrase> N" file` would otherwise arm the gate on N.
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "fish"}
+
+
+def opens_command(token):
+    # `token and` is load-bearing: `all()` over an empty string is True, so an
+    # empty token would read as an operator. That ended the PR-number scan on
+    # `gh pr merge '' 2002` before it reached the number — an under-arm.
+    return bool(token) and (token in KEYWORDS or all(ch in PUNCTUATION for ch in token))
+
+# `str.isdigit()` is true for superscripts and Arabic-Indic digits; the bash
+# regex it replaced was strictly ASCII.
+ASCII_DIGITS = re.compile(r"[0-9]+")
+
+
+def strip_heredocs(text):
+    """Remove heredoc BODIES before tokenizing.
+
+    A heredoc body is data, never commands — bash will not execute a word in
+    it no matter what it looks like. `shlex` has no concept of heredocs, so
+    without this the body is tokenized as if it were shell, and any example
+    command quoted in a PR body, commit message, or issue text can arm the
+    gate on whatever digit follows it. That is not hypothetical: this hook
+    fired on its own PR's `gh pr create`, extracting a PR number out of a
+    markdown table cell describing the very bug being fixed.
+
+    Handles `<<MARKER`, `<<'MARKER'`, `<<"MARKER"`, and the `<<-` indent form,
+    for identifier-shaped markers only. A non-identifier marker leaves its body
+    un-stripped, which over-arms rather than under-arms — the safe direction.
+
+    An UNTERMINATED match strips NOTHING. The opener is found by regex over raw
+    text, which cannot tell a real redirection from the same characters sitting
+    inside a quoted argument — and dropping to end-of-text on a false match
+    deletes any real invocation that followed it, producing a total gate bypass
+    rather than a wrong PR. That is the worse of the two directions, so the
+    unterminated case keeps the text and accepts over-arming instead.
+
+    `<<<` (here-string) is excluded for the same reason: its trailing `<` plus a
+    bare word looks like an opener to a naive regex, and the marker never
+    terminates, so it hit exactly the bypass above.
+
+    One unterminated opener disables stripping for the WHOLE command, not just
+    that heredoc — deliberate, since the alternative is deciding which half of
+    an ambiguous parse to trust, and the cost is only over-arming.
+
+    Two known limits, both over-arming: only the FIRST opener on a line is
+    recognized (`cmd <<A <<B` leaves B's body unstripped), and the terminator
+    match allows leading whitespace even for the non-`<<-` form, which real
+    bash requires at column 0. Both leave heredoc text visible to the
+    tokenizer, never hide a real invocation.
+    """
+    # (?<!<) keeps `<<<` from reading as a heredoc opener.
+    pattern = re.compile(r"(?<!<)<<-?\s*(['\"]?)([A-Za-z_][A-Za-z_0-9]*)\1")
+    out = []
+    pos = 0
+    while True:
+        match = pattern.search(text, pos)
+        if match is None:
+            out.append(text[pos:])
+            return "".join(out)
+        # Keep the redirection operator itself; drop only what it introduces.
+        out.append(text[pos : match.start()])
+        marker = match.group(2)
+        # The body starts after the line carrying the redirection.
+        newline = text.find("\n", match.end())
+        if newline == -1:
+            return text
+        terminator = re.compile(r"^[ \t]*" + re.escape(marker) + r"[ \t]*$", re.M)
+        end = terminator.search(text, newline + 1)
+        if end is None:
+            return text
+        out.append(text[match.end() : newline + 1])
+        pos = end.end()
 
 
 def legacy_scan(text):
@@ -72,57 +181,148 @@ def legacy_scan(text):
     if len(after) < 2:
         return ""
     for token in after[1].split():
-        if token.isdigit():
+        if ASCII_DIGITS.fullmatch(token):
             return token
     return ""
 
 
-try:
-    lexer = shlex.shlex(command, punctuation_chars=True, posix=True)
-    lexer.whitespace_split = True
-    # A newline separates commands, but shlex counts it as plain whitespace and
-    # never emits it as a token — so `pnpm test\ngh pr merge 2002` would read as
-    # one long command and the merge would lose its command position. Record the
-    # line each token STARTS on so a newline can restore that position.
-    #
-    # Read the counter BEFORE each token, not after: measured, `lineno` is
-    # incremented while finishing the token that PRECEDES the newline, so the
-    # after-value marks the wrong token as the one that crossed the line.
-    tokens = []
-    linenos = []
-    while True:
-        line_at_start = lexer.lineno
-        token = lexer.get_token()
-        if token is None or token == "":
-            break
-        tokens.append(token)
-        linenos.append(line_at_start)
-except ValueError:
-    # Unbalanced quotes: not parseable as a command line at all.
-    print(legacy_scan(command))
-    sys.exit(0)
+def extract(text, depth=0):
+    """Return the PR number a real `gh pr merge` in `text` targets, or "".
 
-at_command_start = True
-for i, token in enumerate(tokens):
-    if i > 0 and linenos[i] != linenos[i - 1]:
-        at_command_start = True
-    if token in OPERATORS:
-        at_command_start = True
-        continue
-    # `FOO=bar gh pr merge 5` — an assignment prefix does not consume the
-    # command position. Missing this made the gate silently skip that shape.
-    if at_command_start and re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", token):
-        continue
-    if at_command_start and token == "gh" and tokens[i + 1 : i + 3] == ["pr", "merge"]:
-        for candidate in tokens[i + 3 :]:
-            if candidate in OPERATORS:
+    Recurses into `-c` / `eval` string arguments: `bash -c "gh pr merge N"` is
+    ONE quoted token to the tokenizer, so without recursion the invocation is
+    invisible — which the naive text scan this replaced did catch, making it a
+    regression rather than a pre-existing gap.
+    """
+    if depth > 3:
+        return ""
+    command = strip_heredocs(text)
+    try:
+        lexer = shlex.shlex(command, punctuation_chars=True, posix=True)
+        lexer.whitespace_split = True
+        # A newline separates commands, but shlex counts it as plain whitespace
+        # and never emits it as a token — so `pnpm test\ngh pr merge 2002` would
+        # read as one long command and the merge would lose its command
+        # position. Record the line each token STARTS on to restore it.
+        #
+        # Read the counter BEFORE each token, not after: measured, `lineno` is
+        # incremented while finishing the token that PRECEDES the newline, so
+        # the after-value marks the wrong token as having crossed the line.
+        tokens = []
+        linenos = []
+        while True:
+            line_at_start = lexer.lineno
+            token = lexer.get_token()
+            # ONLY None means end of input. An empty string is a legitimate
+            # token (`echo '' && gh pr merge N`), and treating it as EOF
+            # truncated the stream and dropped every command after it.
+            if token is None:
                 break
-            if candidate.isdigit():
-                print(candidate)
-                sys.exit(0)
-        # Bare `gh pr merge` (current branch's PR). Nothing to key an ack on.
-        sys.exit(0)
-    at_command_start = False
+            tokens.append(token)
+            linenos.append(line_at_start)
+    except Exception:
+        # ANY tokenizer failure, not just the unbalanced-quote ValueError.
+        # A narrower catch let every other exception escape, crash python, and
+        # reach the shell's `|| PR_NUM=""` — which is silently NO GATE, the
+        # exact direction this design refuses. Failure means fall back to the
+        # permissive scan; it never means arm nothing.
+        return legacy_scan(command)
+
+    at_command_start = True
+    # The command word of the segment being scanned — what actually owns any
+    # flags that follow. Cleared at every command boundary.
+    current_command = None
+    nested = []
+    for i, token in enumerate(tokens):
+        if i > 0 and linenos[i] != linenos[i - 1]:
+            at_command_start = True
+            current_command = None
+        if opens_command(token):
+            at_command_start = True
+            current_command = None
+            continue
+        # A shell's `-c` argument, or `eval`'s, is a command in its own right;
+        # collect it and scan it only if nothing real is found at this level.
+        # Which program owns this `-c`? Tracked as the current segment's command
+        # word, not the whole prefix and not the immediately-preceding token.
+        # Both narrower rules were wrong: a prefix-wide check let `bash
+        # --version; grep -c "<phrase> N"` recurse into grep's PATTERN, and the
+        # immediately-preceding check missed `bash -x -c "..."`, where a flag
+        # sits between the shell and its own `-c`.
+        if i + 1 < len(tokens) and token == "-c" and current_command in SHELLS:
+            nested.append(tokens[i + 1])
+        # `eval` is in WRAPPERS, which handles its UNQUOTED form (bash joins the
+        # args and runs them). The quoted form is one opaque token, so it needs
+        # the recursion as well.
+        if i + 1 < len(tokens) and token == "eval":
+            nested.append(tokens[i + 1])
+        # `FOO=bar gh pr merge 5` — an assignment prefix does not consume the
+        # command position. Missing this made the gate silently skip that shape.
+        # A wrapper runs what follows, so it is not the command word itself.
+        if at_command_start and token in WRAPPERS:
+            continue
+        if at_command_start and current_command is None:
+            current_command = token
+        if at_command_start and re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", token):
+            continue
+        if at_command_start and token == "gh" and tokens[i + 1 : i + 3] == ["pr", "merge"]:
+            for candidate in tokens[i + 3 :]:
+                if opens_command(candidate):
+                    break
+                if ASCII_DIGITS.fullmatch(candidate):
+                    return candidate
+            # This occurrence yielded no PR number — a bare `gh pr merge`, or
+            # its arguments ran into an operator first. KEEP SCANNING: `gh pr
+            # merge && gh pr merge 2002` would otherwise extract nothing and
+            # let the real, explicit merge through completely ungated.
+        at_command_start = False
+
+    for inner in nested:
+        found = extract(inner, depth + 1)
+        if found:
+            return found
+
+    # STRUCTURAL BACKSTOP. Everything above decides WHICH invocation is real,
+    # and every bug this file has had was the same shape: that logic failed to
+    # recognise one, returned nothing, and the merge proceeded with no gate —
+    # the one direction this hook must never fail in. Six such gaps were found
+    # by review in a single day (bare-then-real chaining, empty tokens, `-c`
+    # wrapping, `env`/`nohup` prefixes, glued punctuation, `eval`), which is
+    # what writing a shell parser by hand actually looks like.
+    #
+    # So: if `gh pr merge` survived tokenization as three ADJACENT tokens, a
+    # real invocation is present and the position logic simply did not model
+    # its shape. Fall back to the permissive scan rather than exiting clean.
+    # Any future gap now degrades to over-arming (the agent sees an unrelated
+    # review and retries) instead of a silent bypass.
+    #
+    # Adjacency is the discriminator that keeps this PR's headline fix: prose
+    # inside a quoted `--body` is ONE token, so it never looks adjacent, and a
+    # heredoc body is already stripped before it gets here. Only text the shell
+    # would actually execute as words reaches this check.
+    # Scan the TOKENS, not the raw text. `legacy_scan` reads the first textual
+    # occurrence, so a decoy earlier in the command won over the real
+    # invocation — this backstop would have reintroduced the very bug the file
+    # exists to fix. Tokens carry quoting, so prose cannot appear adjacent.
+    for i in range(len(tokens)):
+        if tokens[i : i + 3] == ["gh", "pr", "merge"]:
+            for candidate in tokens[i + 3 :]:
+                if opens_command(candidate):
+                    break
+                if ASCII_DIGITS.fullmatch(candidate):
+                    return candidate
+    return ""
+
+
+try:
+    print(extract(raw_command))
+except Exception:
+    # The whole extraction, not just the tokenizer. Anything escaping here
+    # would exit non-zero, hit the shell's `|| PR_NUM=""`, and silently arm
+    # nothing — the direction this design refuses. Now structurally true
+    # rather than true-by-current-code-shape.
+    print(legacy_scan(raw_command))
+
 PYEOF
 ) || PR_NUM=""
 

--- a/.claude/hooks/pr-merge-review-check.sh
+++ b/.claude/hooks/pr-merge-review-check.sh
@@ -28,34 +28,106 @@ COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "
 
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 
-# Match `gh pr merge` (with trailing word boundary so `gh pr merge-queue` etc.
-# don't trigger), then scan the remainder of the command for the first standalone
-# numeric token. This catches both arg orders:
-#   gh pr merge 979 --rebase          (number first)
-#   gh pr merge --rebase 979          (flags first)
-# Bare `gh pr merge` (current branch's PR, no number) is rare in agent flow and
-# stays out of scope — if it occurs the merge proceeds without the gate.
-if ! [[ "$COMMAND" =~ (^|[[:space:]&|;])gh[[:space:]]+pr[[:space:]]+merge($|[[:space:]]) ]]; then
-    exit 0
-fi
-# Strip everything up to and including the `merge` keyword, then find the first
-# whitespace-delimited all-digit token in the remainder. Excludes flag values
-# like `--retries=5` because those carry the digit inside an `=` or `--` token.
-REMAINDER="${COMMAND#*gh*pr*merge}"
-PR_NUM=""
-# `set -f` disables filename globbing so an unquoted-expansion token containing
-# `*`, `?`, or `[` (e.g. shell redirections in the merge command) doesn't
-# expand against cwd before the loop sees it. Restored after the loop.
-set -f
-for token in $REMAINDER; do
-    if [[ "$token" =~ ^[0-9]+$ ]]; then
-        PR_NUM="$token"
-        break
-    fi
-done
-set +f
+# Decide the PR number from the ARGUMENT VECTOR of a real `gh pr merge`
+# invocation, not from a text scan of the whole command.
+#
+# The text scan this replaces was wrong in two ways that both END IN AN
+# UNREVIEWED MERGE, which is the one outcome this hook exists to prevent. It
+# matched the phrase anywhere in the command, so `gh pr comment N --body "...gh
+# pr merge 1..."` armed the gate on PR 1 (fired in production twice); and it
+# stripped to the FIRST occurrence, so `echo gh pr merge 1 && gh pr merge 2002`
+# extracted 1. Either way the gate fetches some unrelated PR — and when that PR
+# has no review and a base other than `main`, the hook exits 0 and the real
+# merge proceeds with nothing read.
+#
+# `shlex` gives quote-awareness (a quoted --body is ONE token, so prose can
+# never match) and operator tokens (so `gh` is only a command when it starts
+# the line or follows an operator). Python is already a hard dependency of
+# three sibling hooks, so this adds no new one.
+#
+# Fails CLOSED by design, in both directions: an unparseable command falls back
+# to the old permissive scan rather than arming nothing, because silently not
+# arming is the same hole under a different name.
+PR_NUM=$(COMMAND="$COMMAND" python3 << 'PYEOF'
+import os, re, shlex, sys
 
-# No PR number anywhere after `merge` → bare `gh pr merge` form, exit clean.
+command = os.environ.get("COMMAND", "")
+
+# Cheap reject before any parsing: no phrase, no gate. Keeps the common Bash
+# call (which is not a merge) off the parsing path entirely.
+if not re.search(r"(^|[\s&|;(])gh\s+pr\s+merge($|\s)", command):
+    sys.exit(0)
+
+OPERATORS = {"&&", "||", ";", "|", "&", "(", ")", ";;", "\n"}
+
+
+def legacy_scan(text):
+    """The pre-hardening behaviour, kept ONLY as the unparseable fallback.
+
+    Over-arming (the old bug) is recoverable — the agent sees a review for a
+    PR it did not ask about and retries. Under-arming is not: the merge just
+    proceeds. So when the tokenizer cannot run, take the noisy option.
+    """
+    after = re.split(r"gh\s+pr\s+merge", text, maxsplit=1)
+    if len(after) < 2:
+        return ""
+    for token in after[1].split():
+        if token.isdigit():
+            return token
+    return ""
+
+
+try:
+    lexer = shlex.shlex(command, punctuation_chars=True, posix=True)
+    lexer.whitespace_split = True
+    # A newline separates commands, but shlex counts it as plain whitespace and
+    # never emits it as a token — so `pnpm test\ngh pr merge 2002` would read as
+    # one long command and the merge would lose its command position. Record the
+    # line each token STARTS on so a newline can restore that position.
+    #
+    # Read the counter BEFORE each token, not after: measured, `lineno` is
+    # incremented while finishing the token that PRECEDES the newline, so the
+    # after-value marks the wrong token as the one that crossed the line.
+    tokens = []
+    linenos = []
+    while True:
+        line_at_start = lexer.lineno
+        token = lexer.get_token()
+        if token is None or token == "":
+            break
+        tokens.append(token)
+        linenos.append(line_at_start)
+except ValueError:
+    # Unbalanced quotes: not parseable as a command line at all.
+    print(legacy_scan(command))
+    sys.exit(0)
+
+at_command_start = True
+for i, token in enumerate(tokens):
+    if i > 0 and linenos[i] != linenos[i - 1]:
+        at_command_start = True
+    if token in OPERATORS:
+        at_command_start = True
+        continue
+    # `FOO=bar gh pr merge 5` — an assignment prefix does not consume the
+    # command position. Missing this made the gate silently skip that shape.
+    if at_command_start and re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", token):
+        continue
+    if at_command_start and token == "gh" and tokens[i + 1 : i + 3] == ["pr", "merge"]:
+        for candidate in tokens[i + 3 :]:
+            if candidate in OPERATORS:
+                break
+            if candidate.isdigit():
+                print(candidate)
+                sys.exit(0)
+        # Bare `gh pr merge` (current branch's PR). Nothing to key an ack on.
+        sys.exit(0)
+    at_command_start = False
+PYEOF
+) || PR_NUM=""
+
+# No PR number → bare `gh pr merge`, or the command only mentioned the phrase
+# without invoking it. Either way there is nothing to gate on.
 if [ -z "$PR_NUM" ]; then
     exit 0
 fi


### PR DESCRIPTION
Closes TASK-469.

## The defect

The PreToolUse hook that gates every `gh pr merge` picked its PR number by scanning the whole command string for the merge phrase followed by a bare digit. Two independent failures, both ending in **an unreviewed merge** — the one outcome the hook exists to prevent.

Measured by running the hook's own logic, not reasoned:

| Command shape | Old behaviour | Correct |
|---|---|---|
| a `gh pr comment` whose `--body` quotes the phrase plus a digit | fetches that digit's PR | no gate |
| a `gh issue create` whose `--body` does the same | fetches that digit's PR | no gate |
| a harmless `echo` of the phrase before a real merge | fetches the echo's digit | the real PR |

**Why it matters:** the fail-open condition is *misidentified PR + no review on it + its base is not `main`* → the hook exits 0 and the real merge proceeds with nothing read. Most PRs here target `develop`, so the common case is the exposed case. Both production sightings blocked only because the release reminder happened to be independently due — luck, not a control.

## The fix

`shlex` tokenization instead of a text scan. A quoted `--body` becomes one token, so prose can never match; `gh` counts only at a **command position** (start of line, or after an operator). Python was already a hard dependency of three sibling hooks, so no new dependency.

**Heredoc bodies are stripped before lexing.** This was found the hard way: opening this very PR fired the gate on an unrelated PR number pulled out of a markdown table cell in the PR body. A heredoc body is data — bash never executes a word in it — but `shlex` has no concept of heredocs, so tokenizing alone was not enough. Handles the quoted, unquoted, and `<<-` indent forms; an unterminated heredoc drops to end-of-text, which is the safe direction since the remainder was never commands either.

**Fails closed in both directions** — the two gaps found while prototyping, both fail-*open*, both closed here:

- An assignment prefix (`VAR=x` before the command) must not consume the command position, or the gate silently never arms.
- Unparseable input (unbalanced quotes) falls back to the **old permissive scan** rather than arming nothing. Over-arming is recoverable — the agent sees a review for a PR it didn't ask about and retries — while under-arming just lets the merge through.

## Verification

- **The three probe cases pinned as `PINNED DEFECT` now assert the correct PR.** That is exactly what pinning them was for: the fix flipped known cases instead of discovering them.
- New cases: assignment prefix, unbalanced-quote fallback, command substitution, and three for heredocs (body ignored, real merge after the terminator still caught, unterminated body ignored).
- `pnpm ops guard:hook-probes` → 9 probes pass, 5 registered-unprobed. `pnpm test` and `pnpm quality` both exit 0.
- **A regression was caught by the existing suite, not by inspection.** Newline separation broke, because `shlex` treats a newline as whitespace and never emits it as a token. My first fix read `lexer.lineno` *after* each token and still failed; measuring the actual values showed the counter increments while finishing the token that *precedes* the newline, so it has to be read *before*. The `separator: newline` case went red both times.

## Not fixed (unchanged from before this PR)

A PR number supplied by command substitution can't be resolved statically. It reads as the bare form and the merge proceeds ungated, exactly as it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
