### PR TITLE
chore(rules): first economy pass — trim 10.7 kB from the always-loaded corpus

### DIFF
--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -242,9 +242,9 @@ No branch, no PR, no CI re-run. Pre-push hooks still fire because they run on an
 2. **Complete**: a CI cycle that's still running on the most recent commit is not "green" — it's incomplete. Wait for `claude-review` and every other check to finish before any merge proposal, even if the only remaining commit is a "trivial" fixup (one-line comment, test rename, etc.). Trivial-shape edits per `/tzurot-review-response` are still gated by tests; the analog at the merge step is "still gated by CI."
 3. **Read**: `claude-review` turning green only means it finished posting — it does NOT mean its content was read. Always fetch the latest review (`pnpm ops gh:pr-comments <N>`) and read its findings before any merge proposal. A "LGTM" verdict is fine; non-blocking observations may or may not warrant a fixup, but you can't decide without reading. Skipping this step is how reviewer feedback gets silently dropped.
 
-**Structural backstop**: `.claude/hooks/pr-merge-review-check.sh` is a `PreToolUse` hook on `gh pr merge` that fetches the most recent claude[bot] comment for the PR and injects its body into stderr (which lands in agent context), then blocks the merge once per (PR, review-comment-id). The agent must retry the merge after engaging — at which point the same comment-id is acked and the merge proceeds. This makes the "read the review" step structurally enforced rather than memory-dependent. A fresh review (e.g., the post-autosquash re-run that often surfaces findings invisible at pre-autosquash time) re-arms the gate because its comment-id is new. Do not bypass by editing the ack file.
+**Structural backstop**: `pr-merge-review-check.sh` blocks `gh pr merge` once per review, injecting the review body into context; retry after engaging with it. A fresh review re-arms it. Do not bypass by editing the ack file.
 
-**Scope of the structural backstop**: the hook covers `claude[bot]` issue-level comments (where claude-review posts via `gh pr comment`). It does NOT enforce reading formal `/pulls/{N}/reviews` summaries or human reviewer line-comments — those remain attention-dependent and you should fetch them via `pnpm ops gh:pr-reviews <N>` and `pnpm ops gh:pr-comments <N>` per the PR-monitoring rule in `05-tooling.md`.
+The hook covers only `claude[bot]` issue-level comments — formal review summaries and human line-comments stay attention-dependent, so fetch them per `05-tooling.md` § PR Monitoring.
 
 If post-merge feedback surfaces from claude-review on a tiny fixup, it can always be fixed on develop afterwards via the doc-commit exception (for docs) or a tiny follow-up PR (for code). The cost of one more CI cycle (~5 min) is far smaller than the cost of merging through an unreviewed change.
 
@@ -259,8 +259,6 @@ If post-merge feedback surfaces from claude-review on a tiny fixup, it can alway
 | Real code failure (test red, lint error, type error)                                             | Fix the code. Do not skip the check.                                                                                                                                                |
 
 **Bypassing CI is forbidden** even when the user has approved the merge in principle — approval is contingent on the merge happening through a green pipeline. If the user explicitly says "merge it anyway despite the red check," confirm once that they understand which check is red and what signal is being skipped before proceeding.
-
-**Observed**: release PR #892 — an infra-red claude-review was merged through; the correction is rerun-then-merge, never merge-through.
 
 ## Testing
 

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -160,7 +160,7 @@ pnpm ops lines:check                 # always-loaded surfaces (.claude/rules tot
 pnpm ops lines:update-baseline       # make budget growth explicit (same --update contract as cpd/test:audit); --surface <name> scopes the write
 ```
 
-`lines:check` gates two dimensions independently, because lines is not what these surfaces cost: density across the rules files runs 44–130 chars/line and `CURRENT.md` sits near 367, so a line-only ratchet called it comfortable at 96/97 while it carried a fifth of the rules corpus's bytes. Reach for `--surface <name>` whenever a refresh is wanted for one surface only — the unscoped write ratchets a trimmed surface DOWN and a grown one UP in the same commit, which is why the last post-trim refresh was skipped entirely.
+`lines:check` gates two dimensions independently, because lines is not what these surfaces cost: density varies several-fold across the corpus, so a line-only ratchet rated `CURRENT.md` comfortable while it carried a fifth of the rules corpus's bytes. `--breakdown` ranks every file worst-first by bytes — that ranking is the trim order, and the economy pass in `/tzurot-doc-audit` is the procedure that consumes it. Reach for `--surface <name>` whenever a refresh is wanted for one surface only — the unscoped write ratchets a trimmed surface DOWN and a grown one UP in the same commit.
 
 The first five run in the CI `lint` job; all guards hard-fail on findings. `guard:workflow-sync` runs in `pnpm quality`, `.husky/pre-push`, AND the CI `lint` job; it skips itself on main-cut branches (detected by topology — no develop-exclusive history — with `--base main` as the explicit override), because main-cut workflow PRs are the sanctioned path. It covers ONLY the self-validating claude workflow files (`claude-code-review.yml`, `claude.yml`): a develop-first change to those silently disables claude-review on every PR (green ~15s no-op) until the next release, because the review's skip-validation compares the action's OWN workflow file against main — empirically file-scoped (a PR carrying ci.yml drift still received a real review). Other workflow files (e.g. `ci.yml`) execute from the PR branch and may land via develop like any code change. `guard:boundaries`, `guard:proposal-links`, and `guard:audit-tool-docs` also support `--summary` for the future aggregator. `guard:audit-tool-docs` self-registers and runs the bidirectional check (every registered tool has a WHY.md AND every `*.WHY.md` is either registered or on `UNREGISTERED_WHY_PATHS`).
 
@@ -221,94 +221,76 @@ Enforced by `commitlint.config.cjs` (`type-enum`) and the `.husky/pre-push` bran
 
 ### PR Monitoring (automatic — do not wait to be asked)
 
-**Whenever you create a PR or push commits to an open PR, arm a `Monitor` that waits for CI to finish and then reports on new reviewer comments.** Don't wait for the user to ask whether CI passed or whether a review landed.
+**Whenever you create a PR or push commits to an open PR, arm a `Monitor` that waits for CI to finish and then reports on new reviewer comments.** Don't wait for the user to ask whether CI passed or whether a review landed. There is no hook behind this — `pr-monitor-reminder.sh` fires but its output never reaches the agent, so this text is the mechanism.
 
-**First verify the push actually landed.** Backgrounded pushes reporting "exit 0" AND foreground pushes with `| tail`/`| grep`-filtered output can both hide a failed transfer. Confirm the `-> branch` ref-update line or `git status -sb` in-sync before arming the Monitor — a monitor watching a push that never landed reports a stale CI run as fresh.
+**First verify the push actually landed.** Backgrounded pushes reporting "exit 0" and foreground pushes with filtered output can both hide a failed transfer. Confirm the `-> branch` ref-update line or `git status -sb` in-sync — a monitor watching a push that never landed reports a stale CI run as fresh.
 
-**One monitor per PR: `TaskStop` this PR's previous monitor before arming a new one** (scoped per-PR — a session tracking a release PR alongside a feature PR keeps one monitor for each). Re-arming on every push without stopping the prior monitor stacks watchers on the same PR (three accumulated across three fixup pushes in one review cycle). Its reporting half is not SHA-pinned — `gh pr checks N` reports whatever the PR's state is when it fires — so a stale watcher released by an OLDER push's completed run reports the current PR state under that older push's label, which reads identically to a finished run. Keep the task id returned by `Monitor` and stop it as the first step of the next arm — `TaskStop({ task_id: "<the id Monitor returned>" })`. Without `persistent: true` a forgotten watcher does self-terminate at its `timeout_ms`, so the exposure is bounded to that window rather than open-ended — bounded, not harmless.
+**One monitor per PR: `TaskStop` this PR's previous monitor before arming a new one** (scoped per-PR — a release PR alongside a feature PR keeps one each). The reporting half is not SHA-pinned, so a stale watcher reports the PR's current state under an older push's label, which reads identically to a finished run. Keep the id `Monitor` returns and stop it as the first step of the next arm.
 
-**If the id is gone** (compaction, session restart, a side-quest between pushes), you cannot look it up: `TaskList` enumerates the TaskCreate/TaskUpdate list and does NOT show background `Monitor` tasks — probed directly, it returns "No tasks found" with a monitor confirmed live, so treating it as a check reads as "nothing stale" and re-stacks. The recovery is the notification itself: every monitor event carries its own `task-id`, so when one fires for a PR you have already reported on at this SHA, `TaskStop` that id from the event rather than re-reporting it. That dedupes, it does not validate freshness — a stale watcher firing FIRST for a SHA has no "already reported" tell — so the safeguard against acting on it stays the mandatory SHA-pinned `actions/runs?head_sha=…` query in step 1 below, which is what distinguishes a finished run from a partially-registered one. Preserving live monitor task ids across compaction is listed in `CLAUDE.md` § Compaction Instructions for this reason.
+**If the id is gone** (compaction, session restart), you cannot look it up — `TaskList` does not enumerate background monitors, so it returns "No tasks found" with one live. Recover from the notification itself: every monitor event carries its own `task-id`, so when one fires for a PR you already reported on at this SHA, `TaskStop` that id instead of re-reporting. That dedupes but does not prove freshness; the SHA-pinned query in step 1 is what does. Preserving live ids across compaction is in `CLAUDE.md` § Compaction Instructions for this reason.
 
-**This rule text is the enforcement mechanism — there is no hook behind it.** `.claude/hooks/pr-monitor-reminder.sh` does fire after every `git push` / `gh pr create`, but its banner never reaches the agent: non-blocking post-hoc hook output is dropped, probed and confirmed. Arming the Monitor has always been driven by this rule, so read it as load-bearing rather than as a reminder of something a hook will catch. (The hook stays registered for its one effect that does work without delivery: backfilling the PR author as assignee via the API.)
-
-Arm the Monitor with this as its `command`, **substitution included** — copy it verbatim and only replace `N` with the PR number. Do not resolve the SHA yourself: hand-transcribing it failed four times in one session, twice by completing an abbreviated SHA with invented characters, and every such SHA spins silently rather than erroring. The gate rejects both shapes, but the substitution leaves nothing to get wrong:
+Arm the Monitor with this as its `command`, **substitution included** — copy it verbatim and only replace `N` with the PR number. Never transcribe the SHA by hand; a hand-completed SHA passes any format check, and the gate refuses it (`git cat-file`) rather than watching it:
 
 ```bash
 pnpm ops gh:ci-gate N --sha $(git rev-parse HEAD)
 ```
 
-**The substitution resolves when the Monitor executes, not when you pushed.** Arm it immediately after confirming the push landed — that is when `HEAD` still names the pushed commit. Anything that moves `HEAD` in between makes the gate silently watch a different SHA instead of erroring, and **checking out another branch is the likelier trigger than making another commit** — this same section describes multi-PR sessions as normal, and filing a tracker task between pushes means a hop to `develop`. **The gate's `git cat-file` check does not help here**: a moved `HEAD` still names a real commit, so it passes validation and the gate watches the wrong SHA's CI in silence. That check exists for the transcription failure it replaced, which was loud; this one is quiet, and only the arm-immediately discipline prevents it. This is a deliberate trade: the hook used to bake the pushed SHA into its reminder, which had no such window, but transcribing a SHA by hand failed four times in one session while a delayed arm has never happened. The window is small and the workflow already closes it; the transcription risk was live.
+**The substitution resolves when the Monitor executes, not when you pushed — so arm it immediately.** Anything that moves `HEAD` in between makes the gate watch a different SHA in silence, and **a branch hop is the likelier trigger than another commit** (filing a tracker task means a hop to `develop`). A moved `HEAD` still names a real commit, so no local check objects.
 
-**This invocation is duplicated in three places on purpose** — here, the hook heredoc, and `/tzurot-git-workflow` — because a pointer would hide it exactly where a reader needs to read it. `pnpm ops guard:monitor-command` normalizes the PR/SHA placeholders and fails CI if the copies differ in anything else, so **change all three or CI stops you**. The hook's heredoc is the guard's reference copy by position only — it is built on every push but never delivered, so the copy you actually arm from is this one.
+**This invocation is duplicated in three places on purpose** — here, the hook heredoc, and `/tzurot-git-workflow` — because a pointer would hide it where it needs reading. `pnpm ops guard:monitor-command` fails CI if the copies diverge, so change all three.
 
-The gate waits until the `CI` workflow RUN has completed **and** no other run on that SHA is still in flight, then hands off to `gh pr checks --watch`, prints a sentinel, and prints the final check list. It always prints **exactly one of three** sentinels — see the outcome table below; `CI_COMPLETE` means "the wait ended," not "all checks passed." Five behaviors worth knowing, each covered by tests in `packages/tooling/src/gh/ci-gate.test.ts`:
+Pass `timeout_ms: 1800000` (30 min) and `persistent: false`. **The `false` is a deliberate departure from the Monitor tool's own guidance — don't "correct" it back**: a forgotten session-length watcher cannot be cleaned up, since `TaskList` cannot see it, so its own timeout is the only thing bounding it. If it expires, re-arm.
 
-- **A bad `--sha` is rejected before the first poll — including a well-formed one.** An abbreviated SHA matches nothing in `actions/runs?head_sha=`, which the old bash gate read as "keep waiting" and spun to the timeout on; so does a SHA whose remaining characters were completed by hand from an abbreviated `git commit` line, which passes any format check. The gate resolves the SHA locally (`git cat-file`) and refuses one that names no commit. Pass `$(git rev-parse HEAD)`, never a transcribed value.
-- **A SHA that is not the PR's head is refused too**, which is what closes the arm-delay window described above. A moved `HEAD` still names a real commit, so no local check objects — the gate asks GitHub what the PR points at and names both SHAs on a mismatch. It **re-reads once after 3s before believing one**, because `pulls/N.head.sha` measurably trails a push (old SHA at 680ms, current at 1379ms), so a first-read refusal could reject a monitor armed immediately after pushing; real drift survives the re-read. It fails OPEN when the answer is unreadable — a `gh` blip arms the monitor anyway and says so — because not watching CI at all is worse than the rare drift this catches.
-- **`gh api` failures are reported, not swallowed** — first failure immediately, then every 10th, plus a recovery line — and a `⏳` heartbeat every 10 min proves liveness. A broken gate must never look like a slow one.
-- **A `startup_failure` run ends the wait immediately** rather than burning the timeout: it is terminal the instant it appears and creates zero jobs, so it is invisible in `gh pr checks` and needs a rerun.
-- **The gate gives up at 25 min** with a stated reason, just under the Monitor's 30-min timeout, so you get a message instead of a silent kill.
+The gate waits for the `CI` run to complete and for nothing else on that SHA to be in flight, then hands off to `gh pr checks --watch`. It prints exactly one sentinel (table below) and then the final check list. Its behaviour is covered by `packages/tooling/src/gh/ci-gate.test.ts`; read that rather than restating it here.
 
-**Gate on the RUN, not a `sleep`, because run creation is what lags.** `gh pr checks --watch` snapshots the check list at start time — it does NOT wait for checks that register after polling begins, so if it starts early it watches only the fast-registering checks (GitGuardian passes in ~1s) and exits with everything else still pending. A workflow run can be **created minutes after the push lands** — measured at 4m14s on a normal docs push — so `sleep 60` and `sleep 120` both expired early on consecutive pushes and both emitted a `CI_COMPLETE` over a one-entry check list. No constant bounds a queue. **Custom `until` loops parsing `gh pr checks --json bucket` are equally wrong** — they race partial check lists that momentarily read "all non-pending."
+**Exit-code semantics — "Monitor script failed (exit 1)" can be cosmetic.** The final `gh pr checks` exits non-zero whenever ANY check is red, and `fixup-check` is intentionally red on a fixup-bearing branch until autosquash. **Read the event stream for the outcome; treat the exit code as informational.**
 
-**Exit-code semantics — "Monitor script failed (exit 1)" can be cosmetic.** The final `gh pr checks` exits non-zero whenever ANY check is red, and `fixup-check` is intentionally red on a fixup-bearing branch until autosquash. **Read the event stream for the actual outcome; treat the exit code as informational only.** The gate also exits 1 on its own timeout or a `startup_failure` — and says which, so those are distinguishable from a merely-red check list.
+When the monitor fires, **all four** of the following must happen — do not stop after step 1 even if every check passed:
 
-The gate does not make the whole invocation SHA-pinned: the trailing `gh pr checks` reports the PR's CURRENT state, which is why one-monitor-per-PR above still holds.
+1. Note the final CI state from `gh pr checks N`, **and run the SHA-pinned run-list query below** — a green check list is not proof CI ran.
+2. Fetch new reviewer feedback. GitHub splits it across **three** endpoints that `gh api /issues/N/comments` does not cover together:
+   - `pnpm ops gh:pr-comments N` — conversation + inline line-level review comments
+   - `pnpm ops gh:pr-reviews N` — review summaries (Approve / Request Changes / Comment)
+   - `pnpm ops gh:pr-info N` — PR-level state
 
-**A green `gh pr checks` list is not proof CI ran — confirm the RUN list for the head SHA.** Check-runs are a derived view: a workflow run that dies before dispatch (`startup_failure`, typically a GitHub Actions incident) creates **zero jobs and therefore zero check-runs**, so it is absent from `gh pr checks` entirely and the surviving workflows print as a clean green list. Verified against a real `startup_failure` run — `actions/runs/<id>/jobs` returned `total_count: 0` while the same commit's check-run list showed 22 green entries. Both times this fired, the monitor reported a short all-green list (1 of ~27 checks) that read as success.
+   Inline line comments are where human reviewers leave blocking feedback. Track the last reported comment's timestamp so a later push doesn't re-report it, and **include human reviewers** alongside the bots.
+
+   **Never pipe review fetches through `| tail` / `| head`** — truncating the fetch is how body findings get silently dropped.
+
+   **claude-review health**: a green check means the action _completed_, not that a body was posted. If no new `claude[bot]` comment exists after a green run, `gh run rerun <run-id>` before proceeding.
+
+3. In one concise message, report CI pass/fail **and** any new review findings (blocking vs. non-blocking). If there are no new reviews, say so explicitly — silence isn't a substitute for "no new comments."
+
+   **Read every `###` section of each review body — do not rely on the trailing Summary.** Reviewer output is tiered, and the summary routinely under-reports what the body flags; treat a 100+ line review as a skimming risk. If multiple `claude[bot]` entries exist, read every one.
+
+4. **Apply review feedback — INVOKE `/tzurot-review-response` first, before touching anything.** That skill carries the full procedure. Loading it is not optional politeness — applying feedback from memory is how the rubber-stamping this procedure prevents creeps back in.
+
+Two failure modes, both observed:
+
+- **Step 1 without step 2**: all-green CI feels complete, so the comment fetch gets skipped. All-CI-green does not discharge it.
+- **Step 2 without a full-body read**: extracting only the summary section. A review ending "two actionable items" usually has more in the body.
+
+If CI fails or CodeQL flags a new alert, surface it via `PushNotification` — that class of feedback changes what the user does next.
+
+**A green `gh pr checks` list is not proof CI ran.** A run that dies before dispatch (`startup_failure`) creates zero jobs and therefore zero check-runs, so it is absent from the check list entirely while the surviving workflows print clean green. Confirm the run list for the head SHA:
 
 ```bash
 gh api "repos/{owner}/{repo}/actions/runs?head_sha=$(git rev-parse HEAD)" \
   --jq '.workflow_runs[] | "\(.status) \(.conclusion // "-") \(.name)"'
 ```
 
-`head_sha` filters **server-side**, so the result is exhaustive for that commit with no `--limit` window to outgrow. Don't substitute `gh run list --limit N | jq 'select(.headSha==…)'`: that lists runs repo-wide and filters client-side _after_ the window is applied, so other branches, dependabot, and cron runs share the budget — worst during an incident, when reruns spike repo activity and this check matters most.
+`head_sha` filters server-side, so the result is exhaustive with no `--limit` window to outgrow — don't substitute a client-side filter over `gh run list`. **An empty result minutes after a push means "not indexed yet", not "no run dispatched"**: re-query before concluding anything. Anything not `completed success` (or `skipped`) is a finding, and **pin on the SHA, never a timestamp window** — a window silently spans two pushes.
 
-**The index lags, so an empty result minutes after a push means "not indexed yet", not "no run dispatched".** Observed on a fresh push: zero runs for a commit that provably had two (the run object's own `head_sha` matched), then `total_count: 2` on the identical query two minutes later. Re-query before concluding anything, and cross-check `?branch=<name>` — same server-side filter, different index. Note this lag and the `--watch` snapshot race above share one cause (GitHub has not finished registering the push), so the fallback is least trustworthy exactly when a premature `CI_COMPLETE` makes you reach for it.
-
-**A red check with zero steps never ran — that's infrastructure, not your diff.** Read the job's step count, not just its conclusion:
+**A red check with zero steps never ran — that's infrastructure, not your diff**, and is rerun-eligible per `00-critical.md`'s failure-shape table. `gh pr checks` renders it identically to a real failure, so read the step count when a job fails without an obvious cause:
 
 ```bash
 gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs?per_page=100" \
   --jq '.jobs[] | "\(.conclusion // "-") steps=\(.steps | length) \(.name)"'
 ```
 
-A `cancelled` job with `steps=0` after a long queue waited for a runner it never got — rerun-eligible per `00-critical.md`'s failure-shape table. A cancel or timeout with steps behind it is a real failure. Observed: 5 of 19 jobs cancelled at 15–17 minutes with `steps=0`, beside 14 that succeeded with 5–19 steps each — indistinguishable in `gh pr checks`, which renders both as plain `fail`.
+**Wait on the gate, never on a `sleep` or a hand-written poll loop.** A fixed sleep expires before run creation (which can lag the push by minutes) and `gh pr checks --watch` then snapshots a near-empty check list; custom loops over `gh pr checks --json` race a partial list that momentarily reads all-non-pending. Both were measured emitting a premature `CI_COMPLETE`.
 
-Anything not `completed success` (or `skipped`) is a finding. **The died-before-dispatch case is the one `gh pr checks` structurally cannot show you** — a run `cancelled` or `timed_out` _after_ its jobs started still emits check-runs carrying that conclusion, so those DO surface in the check list; it is the zero-job run that vanishes from it. **Pin on the SHA, never a timestamp window**: a window silently spans two pushes and will report an older push's completion under the newer one's label. This is a verification step after the monitor fires, not a replacement watch loop — the run-gated `--watch` above is still how you wait.
-
-Pass to `Monitor` with `timeout_ms: 1800000` (30 min) and `persistent: false`. **The `false` is a deliberate departure from the Monitor tool's own guidance**, which names PR monitoring as its canonical `persistent: true` case — don't "correct" it back. The reason: a session-length watcher that gets forgotten cannot be cleaned up, because `TaskList` does not enumerate background monitors (see above), so the only thing bounding a stale watcher's lifetime is its own `timeout_ms`. A CI run also has a definite end, so nothing here needs session-length watching. The old 15-min budget assumed the clock started when CI did; it has to cover queue time plus the whole check suite, and 15 min no longer clears that. If it still expires, re-arm.
-
-**Measured durations (2026-08-06, 7 consecutive runs)** — the gate waits for ALL of them, so budget against the slowest, not against `CI`: the `CI` workflow itself is **3–4 min**, and the long pole is **`claude-review` at 4m31s–9m44s**, which scales with diff size. Add the run-creation lag (measured once at 4m14s) and the realistic worst case is ~14 min against the gate's 25-min give-up. Re-measure before trusting this if the check suite grows — an earlier "~20 min CI" figure here was stale enough to make a reviewer conclude the margin was 5 minutes when it was closer to 11.
-
-When the monitor fires, **all four** of the following must happen before the cycle is complete — do not stop after step 1 even if every check passed:
-
-1. Note the final CI state from the `gh pr checks N` output, **and run the SHA-pinned run-list query above** — a check list can be green because a whole run never dispatched.
-2. Fetch new reviewer feedback. GitHub splits it across **three** endpoints that the raw `gh api /issues/N/comments` call does **not** cover together:
-   - `pnpm ops gh:pr-comments N` — conversation comments + inline line-level review comments
-   - `pnpm ops gh:pr-reviews N` — review summaries (Approve / Request Changes / Comment)
-   - `pnpm ops gh:pr-info N` — PR-level state (status, mergeable, etc.)
-
-   Inline line comments are where human reviewers typically leave blocking feedback; if you only check `/issues/N/comments` you'll silently miss them. Track the most recently reported comment's timestamp in working memory so a subsequent push doesn't re-report already-surfaced feedback. **Include human reviewer comments** alongside `claude[bot]` / `github-advanced-security[bot]`.
-
-   **Never pipe review fetches through `| tail` / `| head`** — truncating the fetch is how body findings get silently dropped; pull the full output and read it.
-
-   **claude-review health**: the check turning green means the action _completed_ — it does NOT guarantee a review body was posted. If no new `claude[bot]` comment exists after a green run, re-run the workflow (`gh run rerun <run-id>`) before proceeding (observed twice: a placeholder post and a completed-but-posted-nothing run).
-
-3. In a single concise user-facing message, report: CI pass/fail summary **and** any new review findings (grouped as blocking vs. non-blocking). If there are no new reviews since the last push, say so explicitly — silence isn't a substitute for "no new comments."
-
-   **Read every `###` section of each review body — do not rely on the trailing "Summary" / "Actionable items" section.** Reviewer output is tiered (verdict → strengths → major → minor → observations → summary), and the summary is a shortcut that commonly under-reports items the body flags. When a review is 100+ lines, treat length itself as a skimming red flag. Cross-check correlated signals: if codecov flags missing lines, grep the review body for a corresponding test-gap call-out. If multiple `claude[bot]` entries exist (e.g., one per push cycle), read every one — don't assume only the latest matters.
-
-4. **Apply review feedback — INVOKE `/tzurot-review-response` first, before touching anything.** That skill carries the full procedure: classify each finding by edit shape (trivial → auto-apply as a test-gated `--fixup` commit; semantic → ASK), check for reviewer-vs-agent signal conflict, batch-present the four sections, and step back at ~3 automated rounds (a rule of thumb, not a hard stop). Loading it is not optional politeness — applying review feedback from memory is how the rubber-stamping fatigue this procedure exists to prevent creeps back in.
-
-Two failure modes to guard against — both matter:
-
-- **Step 1 without step 2**: all-green CI feels complete, so the comment-fetch step gets skipped. Steps 1 and 2 are both part of the Monitor-fire response contract; all-CI-green does not discharge the comment-fetch obligation.
-- **Step 2 without full-body read**: fetching comments but only extracting items from the trailing summary section. A review that ends "Summary: two actionable items" almost always has a body listing more (observed: body-only items, including a codecov-confirmed coverage gap, missed on three consecutive PRs).
-
-If CI fails or CodeQL flags a new alert, surface it via `PushNotification` — that class of feedback changes what the user does next.
-
-**Outcome handling — read WHICH sentinel printed, not just whether one did.** The gate always prints exactly one, and only the first means CI actually finished:
+**Outcome handling — read WHICH sentinel printed, not just whether one did.** Only the first means CI finished:
 
 | Sentinel                  | Meaning                                                             | Action                               |
 | ------------------------- | ------------------------------------------------------------------- | ------------------------------------ |
@@ -317,9 +299,7 @@ If CI fails or CodeQL flags a new alert, surface it via `PushNotification` — t
 | `CI_GATE_STARTUP_FAILURE` | a run died before dispatch (zero jobs, invisible in `gh pr checks`) | `gh run rerun <run-id>`, then re-arm |
 | _none of them_            | the Monitor's own 30-min `timeout_ms` killed the process            | re-arm                               |
 
-The bash gate this replaced had no internal timeout, so "no `CI_COMPLETE`" was a clean binary for "the Monitor killed it." That is no longer the only failure signal — the gate now gives up first and says why, so treat a give-up sentinel as seriously as an absent one. The final check list prints after every outcome.
-
-**Working-memory caveat**: the `created_at` dedup lives in conversation state, which is lost when the session restarts. After a session restart, re-fetching may surface previously-reported comments once. That's acceptable — re-reporting a known comment once is strictly preferable to silently missing a new one.
+**Working-memory caveat**: the dedup timestamp lives in conversation state, so after a session restart a re-fetch may surface previously-reported comments once. Acceptable — re-reporting a known comment beats silently missing a new one.
 
 ### Release Notes Format
 

--- a/.github/baselines/lines-baseline.json
+++ b/.github/baselines/lines-baseline.json
@@ -1,9 +1,9 @@
 {
   "surfaces": {
     "rules": {
-      "lines": 2088,
+      "lines": 2068,
       "graceMargin": 150,
-      "bytes": 172579,
+      "bytes": 162450,
       "bytesGraceMargin": 12000
     },
     "current": {
@@ -17,7 +17,7 @@
     "toolVersion": "lines-check/2",
     "configHash": "038ea0a31198",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "d574f178a1d44049dba20068e557e3f2e154fbc9",
-    "generatedAt": "2026-08-08T15:39:40.916Z"
+    "generatedFromSha": "731c4699788ddbc38fc32a15581d6ac0080b14f7",
+    "generatedAt": "2026-08-08T19:50:08.647Z"
   }
 }


### PR DESCRIPTION
The first run of the economy pass added to `/tzurot-doc-audit` in #2008 — worst-first by bytes, using `lines:check --breakdown`.

## Result

| Surface | Before | After | |
|---|---|---|---|
| `05-tooling.md` | 40,460 B | 30,540 B | **−24.5%** |
| `00-critical.md` | 31,110 B | 30,277 B | −3% |
| **rules corpus** | **173,204 B** | **162,450 B** | **−6.2%, ≈2.7k tokens per session** |

Every session on this repo now starts ~2.7k tokens lighter, forever. (Figures re-measured against the merged HEAD after review findings were applied — they match `lines-baseline.json` exactly.)

## `05-tooling.md` — where the weight actually was

Its **PR Monitoring section was 47% of the file** and 11% of the entire rules corpus by itself. Almost all of the excess was the CI gate's *internals*: how it polls, why a fixed `sleep` doesn't work, what its exit code means, per-run duration measurements from one afternoon, the index-lag observation, the bash gate it replaced. None of that changes what a reader does — and the gate's behaviour is covered by `packages/tooling/src/gh/ci-gate.test.ts`, which cannot go stale the way prose does (cut-test question 4).

**Every constraint survives.** Checked one by one: arm a Monitor on every push and PR creation · verify the push landed first · one monitor per PR with `TaskStop` on the previous · `TaskList` cannot see monitors, recover the id from the event · the verbatim gate invocation · arm immediately because a branch hop moves `HEAD` · `timeout_ms`/`persistent: false` and don't "correct" it · the four-step fire response · never truncate a review fetch · claude-review green ≠ body posted · read every `###` section · the two failure modes · `PushNotification` on failure · the sentinel table · the SHA-pinned run query · zero-step jobs are infrastructure · the working-memory dedup caveat.

`guard:monitor-command` (the three-copy byte-compare) and `guard:claude-content-refs` both still pass.

## `00-critical.md` — the honest result

Only 833 bytes came out, and that's the finding rather than a shortfall: **this file is genuinely constraint-dense and resists trimming.** What went was archaeology — a PR number whose lesson the surrounding constraint already states, and the merge-gate hook's comment-id lifecycle, which lives in the hook and its own probe.

I deliberately did *not* touch its largest section ("Don't Present Speculation as Fact", 21% of the file). Its worked examples are what make an abstract rule concrete, and cut-test question 2 — would a reader act differently without it — comes back *yes* for them. Worth noting I failed that particular rule three times today, which is not an argument for making it shorter.

## A fifth copy of the same stale numbers

The per-file density figures were quoted here too, and were stale. #2008 scrubbed them from three other surfaces on the grounds that a second stale copy is worse than none; this was the fifth, and the one the cut test names first. Replaced with a pointer to `--breakdown`, which prints them from measurement.

## Baseline

Ratcheted **down** to 162,450 B with `--surface rules`, which is exactly the flag's purpose: `CURRENT.md` currently sits *above* its own baseline, so an unscoped write would have loosened it in the same commit that tightened `rules` — the failure that caused a previous post-trim refresh to be skipped entirely.

## Not done in this pass

`06-backlog.md` (#3 at 14%) is untouched. The procedure says work the ranking and **stop after the top 3** — that's a cap, not a quota, and the second file already showed diminishing returns. It stays at the top of the next pass's ranking, which is how the procedure is meant to resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
