### PR TITLE
fix(hooks): narrow claim-shape-guard's cannot-be arm to runtime value claims

### DIFF
--- a/.claude/hooks/claim-shape-guard.probe.sh
+++ b/.claude/hooks/claim-shape-guard.probe.sh
@@ -118,6 +118,114 @@ check 0 fire "cannot-<verb> phrasing in a code file"
 stage_fixture 'src/isalways.ts' 'seed(map); // the map is always seeded before first read'
 check 0 fire "is-always phrasing in a code file"
 
+# `cannot be` is narrowed to a following VALUE token. Both directions are
+# pinned, because the allow side is the whole point of the narrowing: bare
+# `cannot be` fired on ordinary design prose about code structure, and a guard
+# that mostly cries wolf trains the reader to skim past its true positives.
+stage_fixture 'src/cannotnull.ts' 'assert(id); // the id cannot be null once queued'
+check 0 fire "cannot-be with a value token is still a runtime claim"
+
+stage_fixture 'src/cannotempty.ts' 'use(rows); // the batch cannot be empty here'
+check 0 fire "cannot-be-empty is still a runtime claim"
+
+# The exact line that false-fired in practice, on a comment about why two
+# regex copies stay separate.
+stage_fixture 'src/collapse.ts' '// They cannot be collapsed into one: each needs its own stripping'
+check 0 silent "cannot-be-collapsed is design prose, not a runtime claim"
+
+stage_fixture 'src/extract.ts' '// this helper cannot be extracted without three callbacks'
+check 0 silent "cannot-be-extracted is design prose"
+
+stage_fixture 'src/reuse.ts' '// the adapter cannot be reused across implementors'
+check 0 silent "cannot-be-reused is design prose"
+
+# One fixture per value token. The alternation is 13 branches wide and the
+# probe is the only verification this hook gets, so a typo in any single branch
+# must fail here rather than silently stop catching that claim shape.
+stage_fixture 'src/tok0.ts' '// the value cannot be null at this point'
+check 0 fire "value token: cannot be null"
+
+stage_fixture 'src/tok1.ts' '// the value cannot be empty at this point'
+check 0 fire "value token: cannot be empty"
+
+stage_fixture 'src/tok2.ts' '// the value cannot be undefined at this point'
+check 0 fire "value token: cannot be undefined"
+
+stage_fixture 'src/tok3.ts' '// the value cannot be unset at this point'
+check 0 fire "value token: cannot be unset"
+
+stage_fixture 'src/tok4.ts' '// the value cannot be set at this point'
+check 0 fire "value token: cannot be set"
+
+stage_fixture 'src/tok5.ts' '// the value cannot be present at this point'
+check 0 fire "value token: cannot be present"
+
+stage_fixture 'src/tok6.ts' '// the value cannot be absent at this point'
+check 0 fire "value token: cannot be absent"
+
+stage_fixture 'src/tok7.ts' '// the value cannot be missing at this point'
+check 0 fire "value token: cannot be missing"
+
+stage_fixture 'src/tok8.ts' '// the value cannot be zero at this point'
+check 0 fire "value token: cannot be zero"
+
+stage_fixture 'src/tok9.ts' '// the value cannot be negative at this point'
+check 0 fire "value token: cannot be negative"
+
+stage_fixture 'src/tok10.ts' '// the value cannot be false at this point'
+check 0 fire "value token: cannot be false"
+
+stage_fixture 'src/tok11.ts' '// the value cannot be true at this point'
+check 0 fire "value token: cannot be true"
+
+stage_fixture 'src/tok12.ts' '// the value cannot be populated at this point'
+check 0 fire "value token: cannot be populated"
+
+# The `$` half of the boundary. Every fire fixture above has trailing text, so
+# a typo shrinking ([^a-z]|$) to ([^a-z]) would pass all of them while silently
+# dropping every claim that ENDS at the token — a completely ordinary shape for
+# a short inline comment.
+stage_fixture 'src/tokeol.ts' '// the id cannot be null'
+check 0 fire "value token at end of line (the \$ half of the boundary)"
+
+# The `reached` exclusion is a reasoned decision, so it gets a pin like every
+# other one. Under the old bare arm this fired; it must now stay silent, and an
+# accidental re-addition of the token to the list has to fail here.
+stage_fixture 'src/reached.ts' '// this branch cannot be reached'
+check 0 silent "reached is out of scope by design (control flow, not a value)"
+
+# The accepted recall loss, pinned so it reads as chosen rather than missed: an
+# inflected form no longer fires. If a future edit decides to catch these, this
+# case is where that intent gets stated.
+stage_fixture 'src/nulled.ts' '// the config cannot be nulled once persisted'
+check 0 silent "inflected forms fall outside the narrowed pattern (accepted)"
+
+# `unset` gets its own collision pin because English is unusually rich in words
+# that start with it — "unsettled", "unsettling" — making it the token most
+# likely to meet a real collision, alongside the five already pinned below.
+stage_fixture 'src/unsettled.ts' '// this precedent cannot be unsettled by one case'
+check 0 silent "collision: 'unsettled' must not match the 'unset' token"
+
+# SUBSTRING COLLISIONS. awk's `~` is a substring match with no \b support,
+# so an unanchored alternation fired on ordinary English whose next word
+# merely STARTS with a value token — reintroducing the exact false-positive
+# class this narrowing exists to remove. The trailing ([^a-z]|$) is what
+# stops it, and these pin it per colliding token.
+stage_fixture 'src/coll0.ts' '// this cannot be settled without more data'
+check 0 silent "collision: 'settled' must not match the 'set' token"
+
+stage_fixture 'src/coll1.ts' '// this cannot be negatively impacted'
+check 0 silent "collision: 'negatively' must not match the 'negative' token"
+
+stage_fixture 'src/coll2.ts' '// the count cannot be zeroed out'
+check 0 silent "collision: 'zeroed' must not match the 'zero' token"
+
+stage_fixture 'src/coll3.ts' '// this cannot be falsely triggered'
+check 0 silent "collision: 'falsely' must not match the 'false' token"
+
+stage_fixture 'src/coll4.ts' '// this cannot be presently disabled'
+check 0 silent "collision: 'presently' must not match the 'present' token"
+
 stage_fixture 'src/onlyever.ts' 'const job = queue[0]; // this queue only ever holds one job'
 check 0 fire "only-ever phrasing in a code file"
 

--- a/.claude/hooks/claim-shape-guard.sh
+++ b/.claude/hooks/claim-shape-guard.sh
@@ -9,6 +9,49 @@
 # author's intent at writing time and drifts silently; near-identical sibling
 # interfaces make a plausible-looking declaration weak evidence.
 #
+# `cannot be` is NARROWED to a following value token (null/empty/set/…) rather
+# than matching bare. Unqualified, it fired on ordinary design prose about code
+# STRUCTURE — "cannot be collapsed into one", "cannot be extracted", "cannot be
+# reused" — which asserts nothing about runtime and has no producer to cite.
+# That noise is not free: a guard whose output is mostly false positives trains
+# the reader to skim past the true ones. The other arms (`always populated`,
+# `never null`, `cannot happen`) are already runtime-claim-shaped and are left
+# alone.
+#
+# The trailing ([^a-z]|$) is LOAD-BEARING, not tidiness. awk's `~` is a
+# substring match with no \b, so an unanchored alternation matched whenever the
+# next word merely STARTS with a token: "cannot be settled" hit `set`, "cannot
+# be negatively impacted" hit `negative`, "cannot be zeroed out" hit `zero`.
+# That is the same design-prose false positive the narrowing exists to remove,
+# reintroduced through the back door.
+#
+# `[^a-z]` is a broad boundary, not a true word break — awk ERE has no \b — so
+# ANY hyphenated compound built on a token still fires: "cannot be
+# false-positive", "cannot be zero-indexed", "cannot be null-terminated". The
+# limitation is not specific to one token, and a reader who assumes otherwise
+# will be surprised by the second one. Left as is: the constructions are rare,
+# and over-firing on an advisory guard costs a glance where under-firing costs
+# the signal entirely.
+#
+# `reached` was considered for the token list and left OUT: "this branch cannot
+# be reached" is a control-flow claim, not a claim about what a value holds, so
+# it sits outside this guard's stated scope and reads like the design prose
+# above. If reachability claims ever deserve a guard, that is its own decision
+# with its own evidence. Pinned silent in the probe so the decision cannot be
+# reverted by accident.
+#
+# ACCEPTED RECALL LOSS: only the exact token form fires, so inflected ones no
+# longer do — "cannot be nulled / emptied / populating" are real value claims
+# that now pass unflagged, where the bare arm caught them. This is a deliberate
+# trade of recall for precision, not an oversight, and it is not free.
+#
+# Not fixed by adding the inflections, because the ambiguity is genuine rather
+# than a vocabulary gap: "the count cannot be zeroed out" is pinned SILENT here
+# as design prose, yet it is defensible as a value claim. Deciding that sentence
+# either way requires the reader's context, which is exactly the judgement the
+# bare arm made badly and noisily. A guard that fires on the unambiguous forms
+# and stays quiet on the arguable ones is the version people keep reading.
+#
 # Channel: this runs from `.husky/pre-commit`, NOT as a Claude Code hook.
 # Non-blocking PostToolUse output never reaches the agent — probed directly and
 # confirmed for every matcher — so the PostToolUse registration this guard used
@@ -62,7 +105,7 @@ MATCHES=$(git -c diff.mnemonicprefix=false -c core.quotepath=false diff --cached
 /^\+/{
     if (skip || n >= 3) next
     line = substr($0, 2)
-    if (tolower(line) ~ /always (populated|set|non-null|present|returns)|never (null|empty|undefined|happens|fires)|cannot (be|happen|match|occur)|guaranteed to|(is|are) always|only ever/) {
+    if (tolower(line) ~ /always (populated|set|non-null|present|returns)|never (null|empty|undefined|happens|fires)|cannot be (null|empty|undefined|unset|set|present|absent|missing|zero|negative|false|true|populated)([^a-z]|$)|cannot (happen|match|occur)|guaranteed to|(is|are) always|only ever/) {
         print substr(line, 1, 100)
         n++
     }

--- a/tracker/tasks/task-464 - claim-shape-guard-cannot-verb-pattern-false-fires-on-ordinary-prose.md
+++ b/tracker/tasks/task-464 - claim-shape-guard-cannot-verb-pattern-false-fires-on-ordinary-prose.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-464
 title: claim-shape-guard cannot-<verb> pattern false-fires on ordinary prose
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-07 23:50'
-updated_date: '2026-08-09 00:48'
+updated_date: '2026-08-09 01:31'
 labels:
   - 'area:process'
   - 'area:tooling'


### PR DESCRIPTION
Closes **TASK-464**.

## The false positive

`claim-shape-guard` catches claims about what a field **holds at runtime** — the class `00-critical.md § "the producer is authoritative"` says must be verified at the assignment site. Its `cannot (be|happen|match|occur)` alternative matched far more: the bare `be` fires on design prose about code **structure**.

Real hits, all false:

- `They cannot be collapsed into one: each needs its own stripping`
- `this helper cannot be extracted without three callbacks`
- `the adapter cannot be reused across implementors`

None asserts anything about runtime. None has a producer to cite. That noise isn't free — a guard whose output is mostly false positives trains the reader to skim past the true ones.

## Why it surfaced now

The arm has been wrong since it was written, but nobody could tell: the hook was a non-blocking PostToolUse hook whose output never reached the agent. TASK-458 moved it to `.husky/pre-commit`, where it's part of `git commit`'s own stdout — so its noise became observable for the first time. It fired again on the exact `cannot be collapsed into one` shape.

## The fix

`cannot be` now requires a following **value token**, with a trailing boundary — 13 tokens:

```
null | empty | undefined | unset | set | present | absent | missing
zero | negative | false | true | populated
```

### The boundary is load-bearing

Review round 1 caught that my first attempt **reintroduced the exact class it was fixing**. awk's `~` is substring matching with no `\b`, so an unanchored alternation matched whenever the next word merely *started* with a token. Verified against awk directly:

```
"this cannot be settled without more data"   → FIRE  (set)
"this cannot be negatively impacted"         → FIRE  (negative)
"the count cannot be zeroed out"             → FIRE  (zero)
"this cannot be falsely triggered"           → FIRE  (false)
```

`([^a-z]|$)` fixes it.

## Three deliberate limits

| Limit | Disposition |
|---|---|
| **`reached` excluded** — "this branch cannot be reached" is control-flow, not value-holds | Left out; **pinned silent** so it can't be re-added by accident |
| **Inflected forms no longer fire** — `cannot be nulled / emptied / populating` | **Accepted recall loss**, recorded and pinned. Not fixed by adding inflections: `the count cannot be zeroed out` is pinned silent as prose yet is defensible as a claim, and deciding that needs the reader's context — the judgement the bare arm made badly |
| **`[^a-z]` is a broad boundary** — any hyphenated compound (`false-positive`, `zero-indexed`, `null-terminated`) still fires | Left as is; rare, and over-firing on an advisory guard costs a glance where under-firing costs the signal. **Deliberately not pinned** — a fixture asserting these FIRE would make a future real word-boundary implementation fail the probe, pinning a wart as required behaviour |

## Verification

**27 fixtures added — 16 fire, 11 silent** (counted from the diff): 13 per-token, 6 substring-collision, 1 end-of-line, the `reached` exclusion, the inflection limit, and the 3 motivating false positives.

| Canary | Result |
|---|---|
| revert to the bare `cannot (be\|…)` arm | 3 design-prose cases fail |
| drop the boundary entirely | 8 cases fail |
| shrink `([^a-z]\|$)` → `([^a-z])` | the end-of-line case fails |

The last exists because every other fire fixture has trailing text — a typo dropping `$` would pass all of them while missing every claim that ends at the token.

`guard:hook-probes` 8/5 green · `pnpm quality` green.

*(This description's fixture count was wrong twice — 19, then 26. Both caught by review; 27/16/11 is counted from the diff.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)