### PR TITLE
fix(tooling): give collectRepoSettings one aggregate timeout budget

### DIFF
--- a/packages/tooling/src/dev/check-repo-settings.test.ts
+++ b/packages/tooling/src/dev/check-repo-settings.test.ts
@@ -12,6 +12,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { execFileSync } from 'node:child_process';
+import { GH_TIMEOUT_MS } from '../audits/health-extras.js';
 import {
   LONG_LIVED_BRANCHES,
   isDeletionReachable,
@@ -335,6 +336,109 @@ describe('collectRepoSettings', () => {
       return detail;
     });
   }
+
+  it('spends one aggregate budget across the whole sweep, not one per call', () => {
+    // Ruleset 1 needs a real detail fixture: it is the third fetch, which the
+    // budget still permits. Ruleset 2 deliberately has none — the budget must
+    // stop the sweep BEFORE that fetch, so a shim error there would mean the
+    // deadline failed to fire.
+    mockGh({
+      list: [1, 2],
+      details: { 'repos/{owner}/{repo}/rulesets/1': rulesetDetail({ refs: ['~ALL'] }) },
+    });
+    // Half a per-call timeout per read. budget() is consulted four times —
+    // repo settings, the ruleset list, then one per id — and the elapsed time
+    // at each is 0.5T / 1.0T / 1.5T / 2.0T against a 2T budget. So the first
+    // three fetches run and the FOURTH finds nothing left.
+    //
+    // The tick size is load-bearing: a full-T tick exhausts the budget on the
+    // second consultation, so only one gh call would ever run and the sweep
+    // would never demonstrate accumulation across calls at all.
+    let ticks = 0;
+    const now = (): number => GH_TIMEOUT_MS * 0.5 * ticks++;
+
+    const surface = collectRepoSettings({ now });
+
+    expect(surface.available).toBe(false);
+    // Exactly the calls that fit: budget exhaustion happened DURING the sweep,
+    // not before it. Without this the test would also pass if the very first
+    // call threw, which is a different bug.
+    expect(vi.mocked(execFileSync).mock.calls).toHaveLength(3);
+    // The reason must name the BUDGET, not the last gh error — otherwise the
+    // reader chases a network problem that is not there.
+    expect(surface.available === false && surface.reason).toContain('budget');
+  });
+
+  it('shrinks each call timeout to the REMAINING budget', () => {
+    mockGh({ list: [1] });
+    let ticks = 0;
+    // 0.6 of a per-call timeout per read, against a 2T budget. Elapsed at each
+    // consultation is 0.6T / 1.2T / 1.8T, so remaining is 1.4T / 0.8T / 0.2T —
+    // only the FIRST call is clamped by the ceiling; the other two are already
+    // below it.
+    const now = (): number => GH_TIMEOUT_MS * 0.6 * ticks++;
+
+    collectRepoSettings({ now });
+
+    const timeouts = vi
+      .mocked(execFileSync)
+      .mock.calls.map(call => (call[2] as { timeout: number }).timeout);
+    // Asserted as a literal sequence rather than as properties: a property
+    // check ("non-increasing, never above the ceiling") is satisfied by more
+    // than one implementation, and the prose explaining WHY drifted from the
+    // arithmetic once already. The sequence cannot drift from itself.
+    expect(timeouts).toEqual([
+      GH_TIMEOUT_MS, // 1.4T remaining, clamped to the ceiling
+      GH_TIMEOUT_MS * 0.8,
+      GH_TIMEOUT_MS * 0.2,
+    ]);
+  });
+
+  it('never hands execFileSync a fractional timeout', () => {
+    mockGh({ list: [] });
+    // The tick has to be chosen so the REMAINING budget is fractional AND below
+    // the per-call ceiling — the clamp returns an integer whenever remaining
+    // exceeds the ceiling, so a naive fractional clock never reaches the branch
+    // at all. (Learned by canary: a half-millisecond tick left this test green
+    // with Math.floor removed.) At 20000.25 per tick the two consultations see
+    // 39999.75 (clamped to 30000) and 19999.5 (fractional, unclamped).
+    //
+    // Node rejects a non-integer `timeout` with ERR_OUT_OF_RANGE — verified by
+    // running it — which the catch would swallow into a misleading
+    // "unavailable" naming a gh problem rather than a clock one.
+    let ticks = 0;
+    const now = (): number => ticks++ * 20000.25;
+
+    const surface = collectRepoSettings({ now });
+
+    expect(surface.available).toBe(true);
+    for (const call of vi.mocked(execFileSync).mock.calls) {
+      expect(Number.isInteger((call[2] as { timeout: number }).timeout)).toBe(true);
+    }
+  });
+
+  it('never hands execFileSync a zero timeout', () => {
+    mockGh({ list: [] });
+    // A tick that leaves the remaining budget fractional and strictly between
+    // 0 and 1 on the second consultation: 2T - 59999.5 = 0.5. The `left <= 0`
+    // throw does not catch that, and Math.floor alone would turn it into 0 —
+    // which Node reads as NO TIMEOUT rather than expire-now, handing that call
+    // an unbounded wait.
+    let ticks = 0;
+    const now = (): number => ticks++ * 59999.5;
+
+    collectRepoSettings({ now });
+
+    for (const call of vi.mocked(execFileSync).mock.calls) {
+      expect((call[2] as { timeout: number }).timeout).toBeGreaterThan(0);
+    }
+  });
+
+  it('completes normally when the sweep fits inside the budget', () => {
+    mockGh({ list: [] });
+    const surface = collectRepoSettings({ now: () => 0 });
+    expect(surface.available).toBe(true);
+  });
 
   it('passes gh arguments as an array (never an interpolated shell string)', () => {
     mockGh({ list: [] });

--- a/packages/tooling/src/dev/check-repo-settings.ts
+++ b/packages/tooling/src/dev/check-repo-settings.ts
@@ -117,12 +117,34 @@ export function isDeletionReachable(state: BranchDeletionState): boolean {
 /* gh fetch + parsing                                                          */
 /* -------------------------------------------------------------------------- */
 
-/** Run one `gh api` call and return its raw stdout. Throws on any gh failure. */
-function ghApi(path: string, ...extraArgs: string[]): string {
+/**
+ * Overall budget for ONE `collectRepoSettings()` sweep.
+ *
+ * Without it the sweep is `1 + 1 + N` sequential `gh` calls, each carrying its
+ * own independent `GH_TIMEOUT_MS` — so a repo with many rulesets plus a slow or
+ * flaky `gh` compounds into MINUTES of waiting before the surface degrades to
+ * "unavailable". Both call sites (release preflight, weekly ops health) are
+ * latency-tolerant today and this repo has two rulesets, but a per-call timeout
+ * with no aggregate is a budget only in the single-call case, and the ruleset
+ * count is not ours to bound.
+ *
+ * 60s = two full per-call timeouts: one slow call plus its successor, past
+ * which an informational surface has stopped being worth waiting for.
+ */
+export const REPO_SETTINGS_BUDGET_MS = 2 * GH_TIMEOUT_MS;
+
+/**
+ * Run one `gh api` call and return its raw stdout. Throws on any gh failure.
+ *
+ * `timeoutMs` is the REMAINING budget, not a fresh allowance — the caller
+ * shrinks it as the sweep proceeds, so one slow call cannot overrun the whole
+ * budget by itself.
+ */
+function ghApi(path: string, timeoutMs: number, ...extraArgs: string[]): string {
   return execFileSync('gh', ['api', path, ...extraArgs], {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: GH_TIMEOUT_MS,
+    timeout: timeoutMs,
   });
 }
 
@@ -140,13 +162,13 @@ function ghApi(path: string, ...extraArgs: string[]): string {
  * class of endpoint (see `audits/advisories.ts`) — one value per line across
  * every page, with no array framing to reassemble.
  */
-function fetchRulesetIdsNdjson(): string {
-  return ghApi('repos/{owner}/{repo}/rulesets', '--paginate', '--jq', '.[].id');
+function fetchRulesetIdsNdjson(timeoutMs: number): string {
+  return ghApi('repos/{owner}/{repo}/rulesets', timeoutMs, '--paginate', '--jq', '.[].id');
 }
 
 /** Fetch `delete_branch_on_merge`; throws when the field is missing or not a boolean. */
-export function fetchDeleteBranchOnMerge(): boolean {
-  const parsed = safeParse(ghApi('repos/{owner}/{repo}'), 'repository');
+export function fetchDeleteBranchOnMerge(timeoutMs: number = GH_TIMEOUT_MS): boolean {
+  const parsed = safeParse(ghApi('repos/{owner}/{repo}', timeoutMs), 'repository');
   const value = asRecord(parsed)?.delete_branch_on_merge;
   if (typeof value !== 'boolean') {
     throw new Error('repository response has no boolean delete_branch_on_merge');
@@ -398,21 +420,61 @@ export function evaluateRepoSettings(
 /* Collection + report                                                         */
 /* -------------------------------------------------------------------------- */
 
+/** Options for {@link collectRepoSettings}. */
+export interface CollectRepoSettingsOptions {
+  /**
+   * Injectable clock, defaulting to `Date.now`. The sweep is synchronous, so a
+   * fake clock is the only way to advance time across calls in a test.
+   */
+  readonly now?: () => number;
+}
+
 /**
  * Read the repo setting + every active branch ruleset and evaluate the
  * invariant. Never throws: `gh` is legitimately unavailable (missing binary,
  * no auth, no network, a CI token without the rulesets scope), and a guard
  * must degrade rather than block on a query it cannot run.
  */
-export function collectRepoSettings(): RepoSettingsSurface {
+export function collectRepoSettings(options: CollectRepoSettingsOptions = {}): RepoSettingsSurface {
   try {
-    const deleteBranchOnMerge = fetchDeleteBranchOnMerge();
+    const now = options.now ?? Date.now;
+    // Inside the try so "never throws" holds unconditionally, not merely for
+    // well-behaved clocks. Date.now cannot throw; an injected one could.
+    const startedAt = now();
+
+    // Remaining budget, clamped to the per-call ceiling. Throws once spent, so
+    // expiry lands in the same catch as any gh failure and degrades the surface
+    // to "unavailable" with a reason naming the BUDGET — not the last gh error,
+    // which would send a reader chasing a network problem that is not there.
+    //
+    // Math.floor is not cosmetic: execFileSync rejects a FRACTIONAL timeout
+    // with ERR_OUT_OF_RANGE (verified by running it, not recalled). Date.now
+    // yields integers so production never reaches it, but every clock this
+    // function accepts is a chance to, and the tests inject clocks by design.
+    const budget = (): number => {
+      const left = REPO_SETTINGS_BUDGET_MS - (now() - startedAt);
+      if (left <= 0) {
+        throw new Error(
+          `repo-settings budget of ${REPO_SETTINGS_BUDGET_MS}ms exhausted before the sweep finished`
+        );
+      }
+      // Math.max(1, …) guards a floor to ZERO. `left` can be fractional and
+      // strictly between 0 and 1 — the `left <= 0` throw above lets it through
+      // — and Node reads `timeout: 0` as NO TIMEOUT, not as expire-now
+      // (verified by running it: a `sleep 1` under `timeout: 0` ran to
+      // completion). Flooring to 0 would therefore hand the last gh call an
+      // UNBOUNDED wait, which is the exact failure this budget exists to
+      // prevent, arriving through the fix for it.
+      return Math.max(1, Math.floor(Math.min(left, GH_TIMEOUT_MS)));
+    };
+
+    const deleteBranchOnMerge = fetchDeleteBranchOnMerge(budget());
     const rulesets: ActiveBranchRuleset[] = [];
-    for (const id of parseRulesetIds(fetchRulesetIdsNdjson())) {
+    for (const id of parseRulesetIds(fetchRulesetIdsNdjson(budget()))) {
       // The id came from GitHub's own list response and is narrowed to a
       // finite number above; it is passed as an ARRAY argument, never as part
       // of a shell command string.
-      const detail = parseRulesetDetail(ghApi(`repos/{owner}/{repo}/rulesets/${id}`));
+      const detail = parseRulesetDetail(ghApi(`repos/{owner}/{repo}/rulesets/${id}`, budget()));
       if (detail !== undefined) {
         rulesets.push(detail);
       }

--- a/tracker/tasks/task-463 - collectRepoSettings-has-no-aggregate-timeout-budget-across-its-per-ruleset-fetches.md
+++ b/tracker/tasks/task-463 - collectRepoSettings-has-no-aggregate-timeout-budget-across-its-per-ruleset-fetches.md
@@ -3,10 +3,10 @@ id: TASK-463
 title: >-
   collectRepoSettings has no aggregate timeout budget across its per-ruleset
   fetches
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-07 22:30'
-updated_date: '2026-08-07 22:30'
+updated_date: '2026-08-09 01:52'
 labels:
   - 'area:tooling'
   - 'size:S'


### PR DESCRIPTION
Closes **TASK-463** (surfaced LOW/non-blocking by the #2001 review).

## The problem

`collectRepoSettings()` is `1 + 1 + N` sequential `gh` calls — repo settings, the ruleset list, then one per ruleset id — each carrying its own independent `GH_TIMEOUT_MS`. A repo with many rulesets plus a slow or flaky `gh` compounds into **minutes** of sequential waiting before the surface degrades to "unavailable."

A per-call timeout with no aggregate is a budget only in the single-call case.

## The fix

One deadline computed at entry. Each call is handed the **remaining** budget, clamped to the per-call ceiling, so no single slow call can overrun the whole budget. On expiry the error names the **budget** rather than the last `gh` error — otherwise the degradation line sends a reader chasing a network problem that isn't there.

`REPO_SETTINGS_BUDGET_MS = 2 × GH_TIMEOUT_MS` (60s): one slow call plus its successor, past which an informational surface has stopped being worth waiting for.

The clock is injectable (defaulting to `Date.now`) because the sweep is synchronous — a fake clock is the only way to advance time across calls in a test.

**Honest scope**: low impact today. Both call sites (release preflight, weekly ops health) are latency-tolerant and this repo has two rulesets. Worth the deadline rather than a comment because the ruleset count isn't ours to bound.

## Two arithmetic hazards, both found by review, both verified by running Node

Neither is reachable via the default `Date.now` (integer ms) — but `now` is a public option, so both are real rather than theoretical:

| Hazard | Verified behaviour | Guard |
|---|---|---|
| A **fractional** timeout | `execFileSync` throws `ERR_OUT_OF_RANGE` | `Math.floor` |
| A timeout **floored to 0** | `sleep 1` under `timeout: 0` **ran to completion** — Node reads 0 as *no timeout*, not expire-now | `Math.max(1, …)` |

The second is the sharper one: `left` can be fractional and strictly between 0 and 1 (the `left <= 0` throw doesn't catch it), so flooring alone would hand the final `gh` call an **unbounded** wait — the exact failure this budget exists to prevent, arriving through the fix for it.

## Verification

**5 new `it()` blocks** (44 tests in the file, up from 39): aggregate exhaustion mid-sweep with a budget-named reason; the literal timeout sequence; no fractional timeout; no zero timeout; and a sweep inside budget completing normally.

| Canary | Result |
|---|---|
| remove the remaining-budget clamp | shrink test fails |
| widen `REPO_SETTINGS_BUDGET_MS` | both budget tests fail |
| remove `Math.floor` | fractional test fails |
| remove `Math.max(1, …)` | zero-timeout test fails |

### Two tests that earned their keep by failing first

- The shrink test initially asserted *strictly decreasing* timeouts — false by construction, since the ceiling holds early calls equal. It now asserts the **literal sequence**, which can't drift from its own prose.
- The fractional test initially passed **with `Math.floor` removed**: the clamp returns an integer whenever remaining exceeds the ceiling, so the fraction never reached `execFileSync`. It needed a tick size (20000.25) leaving the remainder both fractional *and* below the ceiling. That reasoning is in the test comment.

`pnpm --filter @tzurot/tooling test` green · `pnpm quality` green · typecheck clean.

*(Earlier revisions said "42 tests (3 new)"; recounted from the diff — 5 new blocks, 44 in the file.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)