### PR TITLE
fix(hooks): extract the shell quote scanner and fix its last two copies

### DIFF
--- a/.claude/hooks/cwd-drift-guard.probe.sh
+++ b/.claude/hooks/cwd-drift-guard.probe.sh
@@ -49,6 +49,49 @@ check 0 "self-correcting: leading cd to root before the git command" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd \\\"\$CLAUDE_PROJECT_DIR\\\" && git add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
 check 2 "drift + .github pathspec (allowlist completeness)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add .github/workflows/ci.yml\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+# Two apostrophes STRADDLING a real pathspec. Under the two-pass sed strip this
+# replaces, they paired as a single-quoted span and deleted `packages/…` along
+# with everything else between them, so the drift went unwarned. The stateful
+# scanner sees both as literal text inside their own double-quoted arguments.
+check 2 "apostrophes straddling a real pathspec" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m \\\"it's\\\" && git add packages/tooling/x.ts && echo \\\"don't\\\"\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+# The complement: with the scanner in place, a path-like substring that lives
+# ONLY inside quotes must still be invisible. Without this, a scanner that
+# stripped nothing at all would pass the case above.
+check 0 "apostrophes, and the only path is inside quotes" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m \\\"it's packages/tooling\\\" && echo \\\"don't\\\"\"},\"cwd\":\"$ROOT/services/bot-client\"}"
+# Uppercase is a shape the shell accepts, and the detection grep was the last
+# case-sensitive `git` gate left in this class after the sibling guards were
+# fixed. Without -i this exits 0 and the drift goes unwarned.
+check 2 "uppercase GIT is still detected" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"GIT ADD packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+# The anchored form must stay exempt in EITHER case. Making the detector
+# case-insensitive without this exemption sent a correctly-anchored uppercase
+# command into a false block — the regression that motivated this pair.
+check 0 "uppercase but root-anchored is exempt" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"GIT -C $ROOT add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 0 "uppercase --git-dir is exempt" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"GIT --git-dir=$ROOT/.git add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+# The NEGATIVE half of the exemption, and its absence is what let a `grep -i`
+# fold `-C` into `-c`. Those are different flags: `-C <path>` anchors the
+# working directory, `-c key=val` overrides config and anchors nothing. This
+# repo's own hooks run the `-c` form, so folding them silently dropped the
+# drift check for a live shape. Both cases are exempt-direction assertions,
+# so only this one can catch the fold.
+check 2 "config -c does NOT exempt (it anchors nothing)" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -c core.pager=cat add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+check 2 "uppercase GIT -c also does NOT exempt" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"GIT -c core.pager=cat add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+# `--git-dir` needs a trailing boundary like `-C` has, or a longer flag that
+# merely starts with it reads as root-anchored.
+check 2 "--git-directory is NOT --git-dir" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git --git-directory=x add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
+# Quoted text merely CONTAINING the anchor flag must not exempt the real
+# invocation beside it — the exemption reads the stripped command for exactly
+# this reason. This is the quote-content-leaks-into-a-structural-scan class
+# the whole PR is about, in the one hook where it survived longest.
+check 2 "quoted \"git -C\" does not exempt real drift" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m \\\"see git -C /somewhere\\\" && git add packages/tooling/src/x.ts\"},\"cwd\":\"$ROOT/packages/tooling\"}"
 check 0 "no cwd in payload (fail-safe)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add packages/tooling/src/x.ts\"}}"
 check 0 "non-Bash tool" \

--- a/.claude/hooks/cwd-drift-guard.sh
+++ b/.claude/hooks/cwd-drift-guard.sh
@@ -50,24 +50,77 @@ esac
 
 # Cheap short-circuit: only git commands with a repo-root-relative-looking
 # pathspec are candidates. `-C` anywhere means the command is root-anchored.
-case "$CMD" in
-  *git\ -C\ *|*git\ --git-dir*) exit 0 ;;
-esac
-if ! grep -qE '(^|[[:space:]&|;])git[[:space:]]' <<<"$CMD"; then
+# Case-insensitive for the same reason as the detector below — and they MUST
+# move together. Making only the detector `-i` (as this hook briefly did) leaves
+# `GIT -C <root> add packages/x` falling past its own exemption into the
+# now-matching detector, and the hook false-blocks a correctly-anchored command.
+# Verified by running it: that shape exited 2 before this line was fixed.
+#
+# Scoped as a grep rather than `shopt -s nocasematch` (which is what the sibling
+# guards use) because that shopt is FILE-GLOBAL, and this file compares PATHS
+# with `case` further down. On a case-sensitive filesystem `/home/x/Projects`
+# and `/home/x/PROJECTS` are different directories; matching them insensitively
+# would silently suppress the "drifted outside the repo" bail.
+# NOT `grep -i`: that case-folds the whole pattern, so `-C` also matches `-c`,
+# and those are different git flags — `-C <path>` anchors the working dir,
+# `-c key=val` overrides config and anchors nothing. Folding them exempted
+# `git -c core.pager=cat add packages/x` from the drift check entirely, a
+# shape this repo's own hooks run. Case-insensitivity belongs on the COMMAND
+# token, never on the flag letter, so `git` is spelled out as classes.
+# -i for the same reason the sibling guards carry `shopt -s nocasematch`: an
+# uppercase invocation is a real shape a shell accepts, and a case-sensitive
+# gate here silently skips the drift check. Lower stakes than in the blocking
+# guards (a missed warning, not a bypass) — fixed anyway, because leaving the
+# last copy of a class is how the class survives.
+if ! grep -qiE '(^|[[:space:]&|;])git[[:space:]]' <<<"$CMD"; then
   exit 0
 fi
 # Strip quoted spans BEFORE the pathspec scan — a commit message like
 # `git commit -m "docs: update packages/tooling/README"` contains a path-like
 # substring that is NOT a pathspec argument, and matching it would false-block
 # (violating this hook's "only ever block an unambiguous mistake" contract).
-# NOTE: this is the naive two-pass strip (single-quoted spans, then
-# double-quoted spans, independently) that lossy-pipe-guard REPLACED with a
-# stateful scanner, because an ordinary apostrophe in one double-quoted
+# The strip is the shared stateful scanner (.claude/hooks/lib/shell_quotes.py),
+# not a local sed pair. The sed pair it replaces was a third copy of a bug this
+# repo has now fixed twice: two independent passes pair raw quote characters
+# with no notion of which quote is already open, so an apostrophe in one
 # argument pairs with one in a later argument and erases everything between.
-# It is a third copy of that bug class and is tracked in TASK-474 alongside the
-# develop-code-commit-guard copy. Lower stakes here: this hook only ever ADDS a
-# block, so the failure mode is a missed drift warning, not a bypass.
-SCAN=$(sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g" <<<"$CMD")
+#
+# Stakes here are LOWER than in the sibling guards and the difference is worth
+# keeping straight: this hook only ever ADDS a block, so a mis-strip costs a
+# missed drift warning or a false block, never an unreviewed commit. It is
+# fixed anyway — leaving the last copy of a class is how the class survives.
+#
+# The python spawn sits behind every cheap check above (drift detected, in-repo,
+# not self-correcting, a bare `git` present), so it runs on a small fraction of
+# git commands and none of the non-git ones. If python or the lib is
+# unavailable, `|| exit 0` allows the command, which matches this hook's
+# fail-safe contract.
+SCAN=$(CMD="$CMD" HOOK_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib" \
+  PYTHONDONTWRITEBYTECODE=1 python3 -c '
+import os, sys
+sys.path.insert(0, os.environ["HOOK_LIB"])
+from shell_quotes import strip_quoted
+cmd = os.environ.get("CMD", "")
+scanned = strip_quoted(cmd)
+# An unterminated quote strips NOTHING (see the module docstring). Falling back
+# to the raw text can only make this hook MORE likely to block, which is the
+# recoverable direction for a command that is a bash syntax error anyway.
+sys.stdout.write(cmd if scanned is None else scanned)
+') || exit 0
+
+# The exemption runs on $SCAN, NOT the raw command, and the ordering is the
+# whole point: quoted text that merely CONTAINS `git -C ` would otherwise
+# exempt the real invocation beside it. Measured — `git commit -m "see git -C
+# /somewhere" && git add packages/x.ts` from a drifted cwd exited 0 and the
+# drift went unwarned. That is this repo's own quote-content-leaks-into-a-
+# structural-scan bug, in the hook whose quote handling was just hardened.
+# `--git-dir` carries a trailing boundary for the same reason `-C` does: git
+# spells it `--git-dir=<path>` or `--git-dir <path>`, so anything else after
+# the token is a different flag. Without it `--git-directory=x` reads as
+# root-anchored and skips the drift check.
+if grep -qE '[Gg][Ii][Tt][[:space:]]+-C[[:space:]]|[Gg][Ii][Tt][[:space:]]+--git-dir[=[:space:]]' <<<"$SCAN"; then
+  exit 0
+fi
 # Repo-root-relative DIR-prefixed pathspec (the always-wrong drift shape)...
 if ! grep -qE '(^|[[:space:]])(services|packages|backlog|docs|prisma|scripts|\.claude|\.github|\.husky)/' <<<"$SCAN"; then
   # ...or a bare root-file pathspec (CURRENT.md/BACKLOG.md — files, so no

--- a/.claude/hooks/develop-code-commit-guard.probe.sh
+++ b/.claude/hooks/develop-code-commit-guard.probe.sh
@@ -193,11 +193,67 @@ run 2 "dirty .mts module"                         'git commit -m "x"'           
 run 2 "dirty .cts module"                         'git commit -m "x"'                                      'services/probe.cts'
 run 2 "dirty yaml config"                         'git commit -m "x"'                                      'services/probe/config.yaml'
 run 2 "dirty Dockerfile"                          'git commit -m "x"'                                      'services/probe/Dockerfile'
+
+# --- the quote scanner ------------------------------------------------------
+# An EARLIER quoted argument carrying an apostrophe used to erase the whole
+# `git commit` that followed it. Measured against the two-pass strip this
+# replaces: the first case stripped to `echo S`, detection returned False, and
+# the guard exited 0 — an unreviewed code commit on develop because someone
+# wrote a contraction. The ordering matters and both directions are pinned:
+# apostrophes AFTER the commit were always harmless (the swallow happens
+# downstream of the match), so a one-sided case would pass on the OLD code too.
+run 2 "apostrophe in an EARLIER quoted arg"       'echo "it'"'"'s" && git commit -m "won'"'"'t"'            'services/probe.ts'
+run 2 "apostrophe only AFTER the commit"          'git commit -m "won'"'"'t"'                               'services/probe.ts'
+# The mirror direction, and it is honestly labelled: this case passes on the OLD
+# two-pass code too (that version stripped single-quoted spans FIRST, so this
+# shape never reached the double-quote pass). It is here to pin the mirror
+# against a future "fix" that swaps the pass order back — which is the tempting
+# wrong repair, because swapping makes the apostrophe case above pass while
+# breaking this one.
+run 2 "double quote inside single-quoted arg"     "echo 'say \"hi\"' && git commit -m x"                    'services/probe.ts'
+
+# --- line continuations -----------------------------------------------------
+# Breaking a long invocation across lines with `\` is an ordinary style choice,
+# not obfuscation — and it defeated detection outright: the scanner emitted a
+# placeholder where bash emits nothing, so `git` and `commit` were no longer
+# adjacent and the guard exited 0 on a real commit. The flag-carrying variant is
+# the realistic one, since long `-C <path>` invocations are what get wrapped.
+run 2 "line continuation before the subcommand"   "$(printf 'git \\\n  commit -m "x"')"       'services/probe.ts'
+run 2 "line continuation after a global flag"     "$(printf 'git -C /some/path \\\n  commit -m x')" 'services/probe.ts'
+# The splice must also produce the NON-match: with no space around it, bash
+# joins the words into one token and `gitcommit` is not a commit.
+run 0 "continuation joining words is not a commit" "$(printf 'git\\\ncommit -m x')"          'services/probe.ts'
+
+# --- case-insensitivity -----------------------------------------------------
+# Both the bash pre-filters and the python regex had to change: a case-sensitive
+# pre-filter short-circuits before python runs, so fixing the regex alone fixes
+# nothing. Mixed case is the case that catches a half-fix on either side.
+run 2 "uppercase GIT COMMIT"                      'GIT COMMIT -m "x"'                                      'services/probe.ts'
+run 2 "mixed-case Git Commit"                     'Git Commit -m "x"'                                      'services/probe.ts'
+run 2 "uppercase behind a global flag"            'GIT -C /some/path COMMIT -m "x"'                        'services/probe.ts'
+
+# The shared lib is a runtime dependency of this hook, and a missing one fails
+# OPEN. Nothing above distinguishes "lib present" from "lib gone" on the ALLOW
+# cases, so this asserts the import path itself rather than trusting it.
+if [ ! -f "$SCRIPT_DIR/lib/shell_quotes.py" ]; then
+  echo "FAIL  shared lib .claude/hooks/lib/shell_quotes.py is missing" >&2
+  FAILURES=$((FAILURES + 1))
+fi
 # Plumbing subcommands are not `git commit`: `-` is a non-word character, so
 # a bare `commit\b` matched them and blocked a tree-writing plumbing call.
 run 0 "plumbing: git commit-tree stays silent"    'git commit-tree abc1234 -m x'                           'services/probe.ts'
 run 0 "plumbing: git commit-graph stays silent"   'git commit-graph write'                                 'services/probe.ts'
 run 0 "plumbing: commit-tree behind -C flag"      'git -C /some/path commit-tree abc1234'                  'services/probe.ts'
+# The escape token is exact-case while DETECTION is case-insensitive, and that
+# asymmetry is deliberate (env var names are case-sensitive in bash). It was
+# argued at length in a comment and pinned by nothing, which is the one claim in
+# this hook that had no test. It needs one precisely because the asymmetry looks
+# like an oversight: a future contributor "fixing" it with (?i) would let
+# `tzurot_allow_...=1` unlock the guard while the REAL variable was never set —
+# an unreviewed commit, from a change that looks like a consistency cleanup.
+run 2 "lowercase escape token does NOT unlock"    'tzurot_allow_develop_code_commit=1 git commit -m "x"'   'services/probe.ts'
+run 2 "mixed-case escape token does NOT unlock"   'Tzurot_Allow_Develop_Code_Commit=1 git commit -m "x"'   'services/probe.ts'
+
 run 0 "escape hatch in command position"          'TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 git commit -m "x"'   'services/probe.ts'
 run 0 "escape hatch, canonical heredoc form"      "TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1 $CANONICAL_HEREDOC"  'services/probe.ts'
 run 0 "non-git command"                           'echo hello'                                             'services/probe.ts'
@@ -211,19 +267,45 @@ run 0 "non-git command"                           'echo hello'                  
 # would hang for minutes.
 #
 # This hook is PreToolUse on every Bash call AND it blocks, so a hang here is
-# strictly worse than in the advisory sibling. The fix (a value may not itself
-# start with `-`) preserves every verdict; this case exists so a revert cannot
-# go unnoticed. Bounded on wall clock rather than on a verdict, because the
-# verdict was always correct — it just took forever to reach.
-long_flags=$(python3 -c "print(' '.join(f'-x{i}' for i in range(60)))")
+# strictly worse than in the advisory sibling.
+#
+# TWO THINGS THIS CASE GOT WRONG, both fixed together because either alone
+# leaves it useless:
+#
+# 1. The fixture reached nothing. `-x0 -x1 …` is SINGLE-dash, and the
+#    re-partitioning that actually blows this pattern up comes from `-{1,2}`
+#    on a DOUBLE dash (`--flag` = `--`+`flag` or `-`+`-flag`). The case passed
+#    in milliseconds while the real shape ran for minutes, and it would not
+#    have noticed the fix being reverted. Now double-dash, each with a value.
+#
+# 2. The bound was measured, not enforced. A wall clock read AFTER the call
+#    cannot catch a hang — it can only report one that already finished.
+#    Catastrophic backtracking does not finish, so this case would have wedged
+#    the probe until guard:hook-probes' 120s ceiling killed the whole job, with
+#    no attributable diagnostic. `timeout` turns that into exit 124 and a named
+#    failure. (The sibling probe learned this first; this copy did not get the
+#    lesson until a reviewer noticed the asymmetry.)
+#
+# Bounded on wall clock rather than on a verdict, because the verdict was
+# always correct — it just took forever to reach.
+long_flags=$(python3 -c "print(' '.join(f'--flag{i} val{i}' for i in range(60)))")
 redos_start=$(date +%s%N)
-run 0 "60 dummy flags does not hang"              "git $long_flags nocommit"                               'services/probe.ts'
+jq -n --arg c "git $long_flags nocommit" \
+  '{tool_name:"Bash",tool_input:{command:$c}}' \
+  | timeout 10 "$HOOK" >/dev/null 2>&1
+redos_rc=$?
 redos_ms=$(( ($(date +%s%N) - redos_start) / 1000000 ))
-if [ "$redos_ms" -lt 2000 ]; then
-  printf 'PASS  (%dms)  ...and returns well inside the 2s bound\n' "$redos_ms"
-else
+if [ "$redos_rc" -eq 124 ]; then
+  printf 'FAIL  (timed out at 10s)  pathological flag run is backtracking\n'
+  FAILURES=$((FAILURES + 1))
+elif [ "$redos_rc" -ne 0 ]; then
+  printf 'FAIL  (exit %d, expected 0)  60 dummy flags\n' "$redos_rc"
+  FAILURES=$((FAILURES + 1))
+elif [ "$redos_ms" -ge 2000 ]; then
   printf 'FAIL  (%dms, expected <2000ms)  pathological flag run is backtracking\n' "$redos_ms"
   FAILURES=$((FAILURES + 1))
+else
+  printf 'PASS  (%dms)  60 dummy flags stays well inside the bound\n' "$redos_ms"
 fi
 # Raw-payload pre-check boundary: the hook exits before forking jq when the RAW
 # stdin has no git…commit token pair. `git status` has no `commit` at all;

--- a/.claude/hooks/develop-code-commit-guard.sh
+++ b/.claude/hooks/develop-code-commit-guard.sh
@@ -10,12 +10,19 @@
 # staged yet — only the working tree carries the signal.
 #
 # Matching notes (review-hardened):
-# - Heredoc bodies and quoted strings are stripped BEFORE any matching (the
-#   sibling lossy-pipe-guard.sh python technique — delimiter-scoped,
-#   so the repo's canonical `-m "$(cat <<'EOF' … EOF)"` commit shape strips
-#   to just its command skeleton instead of blinding the scan). A commit
-#   MESSAGE can therefore neither trigger the guard nor supply the escape
-#   token.
+# - Heredoc bodies and quoted strings are stripped BEFORE any matching, so the
+#   repo's canonical `-m "$(cat <<'EOF' … EOF)"` commit shape strips to just
+#   its command skeleton instead of blinding the scan. A commit MESSAGE can
+#   therefore neither trigger the guard nor supply the escape token. The quote
+#   half is the SHARED scanner in lib/shell_quotes.py — this hook's own copy
+#   was a two-pass strip, and it was a measured bypass (see the note at the
+#   call site). The heredoc half stays local: each hook strips the heredoc
+#   forms its own matching cares about.
+# - COMMIT DETECTION is case-insensitive on BOTH sides — the bash pre-filters
+#   and the python regex. Either one left case-sensitive re-opens the hole on
+#   its own, because the pre-filter short-circuits before python runs. The
+#   ESCAPE TOKEN is deliberately exact-case and is not covered by this; see its
+#   own note at the match site.
 # - `git commit` matching tolerates global flags (`git -C x commit`,
 #   `git --git-dir=y commit`).
 # - The escape hatch is an assignment token leading ANY chain segment of the
@@ -42,6 +49,19 @@
 # included).
 
 set -uo pipefail
+
+# The pre-filters below are the fast path, and a case-sensitive one is a hole
+# in its own right: `GIT COMMIT -m x` would exit at the raw-payload glob before
+# the python regex ever ran, so making only the regex case-insensitive fixes
+# nothing. Both sides change together or neither does.
+# FILE-GLOBAL, and there is no reset below — every `case` and `[[ ]]` in the
+# rest of this script inherits case-insensitive matching. Nothing downstream
+# relies on case today (the checks past this point use `grep -E` and `[ ]`
+# string equality, neither affected), but a later contributor adding a `case`
+# on a filename, branch, or extension would silently get case-insensitive
+# behaviour without anything at the new site saying so. If you add one and want
+# exact matching, `shopt -u nocasematch` around it — do not assume the default.
+shopt -s nocasematch
 
 INPUT=$(cat)
 
@@ -78,9 +98,23 @@ case "$COMMAND" in
   *) exit 0 ;;
 esac
 
-VERDICT=$(GUARD_CMD="$COMMAND" python3 << 'PYEOF'
+# Absolute path to the shared hook lib, resolved before the python spawn and
+# before the cd below, so the import cannot depend on the caller's cwd.
+HOOK_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
+
+# PYTHONDONTWRITEBYTECODE: keep the import from dropping a __pycache__ into
+# the hooks lib on every guarded commit (gitignored, but a stale .pyc can
+# also mask a broken edit to the module).
+VERDICT=$(GUARD_CMD="$COMMAND" HOOK_LIB="$HOOK_LIB" PYTHONDONTWRITEBYTECODE=1 python3 << 'PYEOF'
 import os
 import re
+import sys
+
+# Shared with lossy-pipe-guard.sh and cwd-drift-guard.sh. An import failure
+# exits non-zero, which the caller treats as allow (fail-open); the probe,
+# not runtime, is what catches a missing lib.
+sys.path.insert(0, os.environ["HOOK_LIB"])
+from shell_quotes import strip_quoted
 
 cmd = os.environ.get("GUARD_CMD", "")
 if not cmd:
@@ -94,8 +128,23 @@ if not cmd:
 # and erases the very line carrying `git commit`.)
 cmd = re.sub(r"\$\(cat <<'?\"?(\w+)'?\"?.*?\n\1\s*\)", "MSG", cmd, flags=re.S)
 cmd = re.sub(r"<<[-~]?\s*'?\"?(\w+)'?\"?.*?\n\1(?=\s|$)", "HEREDOC", cmd, flags=re.S)
-cmd = re.sub(r"'[^']*'", "S", cmd)
-cmd = re.sub(r'"[^"]*"', "S", cmd)
+
+# Quote stripping is a single left-to-right SCAN. The two independent regex
+# passes this replaces were a BYPASS of this blocking hook, measured:
+#
+#     echo "it's" && git commit -m "won't"     stripped to `echo S`, exit 0
+#
+# The apostrophes in `it's` and `won't` paired across the `&&`, erasing the
+# whole `git commit` — so a code commit could land on develop with no review
+# because someone used a contraction. Note the ordering: quoted arguments AFTER
+# `git commit` are harmless (the swallow happens downstream of the match); it is
+# specifically an EARLIER quoted argument that hides the commit.
+#
+# Full rationale, both measured repros, and the unterminated-quote failure
+# direction live in .claude/hooks/lib/shell_quotes.py.
+scanned = strip_quoted(cmd)
+if scanned is not None:
+    cmd = scanned
 
 # Kept in agreement with the other copy (lossy-pipe-guard.sh) by
 # packages/tooling/src/dev/gitCommitPatternAgreement.test.ts, which extracts
@@ -108,18 +157,44 @@ cmd = re.sub(r'"[^"]*"', "S", cmd)
 # is a non-word character and so a word boundary exists right before it.
 # Those write no commit and must never be treated as one.
 #
+# The flag run is DETERMINISTIC, deliberately without an atomic group. `-{1,2}`
+# made it re-partitionable — `--flag` parses as `--`+`flag` or `-`+`-flag`, so a
+# failing match explores 2^n splits (measured: 20 double-dash flags 2.7s, 60 no
+# finish in 20s). `-+[^-\s]\S*` forces the dash count by requiring a non-dash
+# after it; 200 flags then take 0.24ms with every verdict unchanged.
+#
+# `(?>...)` would also fix it and is NOT used: atomic groups need Python 3.11,
+# and on anything older re.compile raises, python exits non-zero, and the
+# `|| exit 0` below silently ALLOWS the commit — this guard disabled by
+# interpreter version. Ubuntu 22.04 ships 3.10; CI (3.12) would not have caught
+# it.
+#
+# The (?i) is INLINE rather than an re.I argument: the agreement test extracts
+# this pattern out of the source text, so a flag passed outside the string
+# would vanish from the comparison against the sibling copy (and break the
+# extraction outright, which that test treats as a hard failure).
+#
 # Python's \w is Unicode-aware, so this is equivalent to the bash side's
 # ASCII-only ([^-a-zA-Z0-9_]|$) for every real git invocation but not for
 # a non-ASCII suffix (`git commit日本語`). Deliberately NOT re.ASCII: that
 # flag narrows \s in the same pattern too, so a non-breaking space between
 # `git` and `commit` would stop matching and the guard would MISS a real
 # commit — failing open on a pasteable input to close a hypothetical one.
-if not re.search(r"\bgit(\s+-{1,2}\S+(\s+[^-\s]\S*)?)*\s+commit(?![-\w])", cmd):
+if not re.search(r"(?i)\bgit(?:\s+-+[^-\s]\S*(?:\s+[^-\s]\S*)?)*\s+commit(?![-\w])", cmd):
     print("ok")
     raise SystemExit
 
 # Escape hatch: an assignment token leading a chain segment — never prose
 # (prose lived in quotes/heredocs, which are already stripped).
+#
+# EXACT-CASE ON PURPOSE, and the asymmetry with the case-insensitive detection
+# above is the point rather than an oversight. This token is an environment
+# variable NAME, and bash env names are case-sensitive: `tzurot_allow_...=1`
+# sets a different variable entirely. Honouring a lowercase spelling would mean
+# unlocking on a token that is not the documented variable — the unlock is
+# supposed to be a deliberate, review-visible act, so it recognises exactly one
+# spelling. The failure direction is safe either way: an unrecognised spelling
+# BLOCKS, it never bypasses.
 for segment in re.split(r"&&|\|\||;|\||\n", cmd):
     if re.match(r"\s*TZUROT_ALLOW_DEVELOP_CODE_COMMIT=1(\s|$)", segment):
         print("ok")

--- a/.claude/hooks/lib/shell_quotes.py
+++ b/.claude/hooks/lib/shell_quotes.py
@@ -1,0 +1,121 @@
+"""Shell quote stripping, shared by every hook that has to scan a command line.
+
+WHY THIS IS A MODULE AND NOT THREE COPIES
+-----------------------------------------
+Three hooks need the same thing: replace each quoted span in a command string
+with a placeholder, so that argument CONTENT (a commit message, a `-m` body, an
+example command quoted in prose) cannot influence a structural scan of the
+command. Each of them had its own copy, and the copies had already diverged —
+lossy-pipe-guard's was fixed while develop-code-commit-guard's and
+cwd-drift-guard's kept the bug for another PR.
+
+The bug is worth stating precisely, because the naive version looks obviously
+correct and is not. Stripping single-quoted spans and double-quoted spans as two
+INDEPENDENT passes pairs raw quote characters with no notion of which quote type
+is already open, so an ordinary apostrophe inside a double-quoted argument is
+read as a real delimiter and pairs with a later one:
+
+    git commit -m "it's" | grep "isn't"     MEASURED: the guard exited 0
+    echo "it's" && git commit -m "won't"    MEASURED: strips to `echo S`
+
+In the first, the apostrophes in `it's` and `isn't` pair, erasing the pipe and
+`grep` between them. In the second, they erase the entire `git commit`. Both are
+ordinary English in a commit message, not adversarial input.
+
+Swapping the pass order only mirrors the bug — a literal `"` inside a
+single-quoted argument then pairs the same naive way — so the two-pass strategy
+has no correct ordering. It needs STATE, which is what this scanner has.
+
+FAILURE DIRECTION
+-----------------
+An UNTERMINATED quote strips NOTHING (returns None). Dropping to end-of-text
+would delete a real invocation and produce a bypass; keeping the text merely
+over-arms the caller, and over-arming is the recoverable direction for all three
+consumers.
+
+CONSUMERS
+---------
+    .claude/hooks/lossy-pipe-guard.sh
+    .claude/hooks/develop-code-commit-guard.sh
+    .claude/hooks/cwd-drift-guard.sh
+
+Behaviour is pinned by packages/tooling/src/dev/shellQuotes.test.ts, which runs
+this module directly, plus each consumer's own .probe.sh.
+
+A hook that cannot import this module fails OPEN (its python exits non-zero and
+the hook allows the command). That direction is deliberate — a PreToolUse hook
+that blocked every Bash call on an infrastructure error would be unusable — but
+it does mean a missing lib silently disarms a blocking guard at runtime. The
+backstop is CI, not runtime: every consumer's probe exercises a case that only
+passes when the import works, and `guard:hook-probes` runs them in the lint job
+and in `pnpm quality`.
+"""
+
+
+def strip_quoted(text):
+    """Replace each quoted span with `S`. Returns None if a quote is unclosed."""
+    out = []
+    quote = None
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if quote is None:
+            if ch == "\\" and i + 1 < len(text):
+                # Outside quotes bash lets a backslash escape ANY character, and
+                # the escaped character keeps its own value — `t\ail` runs tail.
+                # Collapsing every escape to a placeholder therefore HID command
+                # names from the scan: measured, a commit piped into that
+                # spelling of tail exited 0 while bash ran it as tail exactly as
+                # written. Emit the real character instead; only an escaped
+                # QUOTE needs a placeholder, so it cannot open a span.
+                nxt = text[i + 1]
+                if nxt == "\n":
+                    # A LINE CONTINUATION, which is not an escape at all: bash
+                    # removes the backslash AND the newline and splices the two
+                    # lines with nothing between them. Emitting a placeholder
+                    # here fabricated a non-whitespace token between two words
+                    # bash runs adjacently, and every target regex requires
+                    # `\s+` adjacency — measured, `git \<newline>  commit -m x`
+                    # stripped to `git Q  commit` and detection returned False,
+                    # so a perfectly ordinary multi-line commit slipped the
+                    # blocking guard. Dropping both characters reproduces the
+                    # splice exactly, including the case that must NOT match:
+                    # `git\<newline>commit` splices to `gitcommit`, one token.
+                    i += 2
+                    continue
+                # Re-emit the escaped character — EXCEPT the ones that are
+                # syntax to the splitters in the calling hooks. An escaped `|`
+                # is a literal pipe character in an argument, not a pipeline
+                # operator, but once the backslash is gone `segment.split("|")`
+                # cannot tell the difference: measured, `git commit -m x\|tail`
+                # blocked as though the commit were piped into tail, when bash
+                # runs no pipeline at all. Same reasoning for the chain
+                # separators. A placeholder keeps the character from acting as
+                # syntax while preserving the token boundary.
+                #
+                # No `\n` in that set: the branch above consumes every
+                # backslash-newline, so it could never reach here — and a
+                # placeholder would be wrong for it anyway. bash DELETES that
+                # pair rather than making it literal, which is exactly the
+                # distinction the two branches encode.
+                out.append("Q" if nxt in "\"'|&;" else nxt)
+                i += 2
+                continue
+            if ch in "\"'":
+                quote = ch
+                out.append("S")
+            else:
+                out.append(ch)
+        elif quote == '"':
+            if ch == "\\" and i + 1 < len(text):
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        else:
+            # Inside single quotes there are no escapes; only the closing
+            # quote ends the span.
+            if ch == quote:
+                quote = None
+        i += 1
+    return None if quote is not None else "".join(out)

--- a/.claude/hooks/lossy-pipe-guard.probe.sh
+++ b/.claude/hooks/lossy-pipe-guard.probe.sh
@@ -183,7 +183,12 @@ run 2 "mirror: quotes inside single-quoted"   "git commit -m 'say \"hi\"' | grep
 # minutes. PreToolUse on every Bash call makes that a session hang, not a slow
 # command. Pinned with a wall-clock bound rather than a verdict, because the
 # verdict was always correct — it just took forever to reach.
-long_flags=$(python3 -c "print(' '.join(f'-x{i}' for i in range(60)))")
+# DOUBLE dash, and each flag carries a value. Both details are load-bearing and
+# neither was here before: `-x0 -x1 …` gives `-{1,2}` exactly one parse, so the
+# re-partitioning that actually blows this pattern up is never reached, and the
+# case passed in ~2ms while the real shape ran for minutes. A timing case that
+# cannot reach the ambiguity measures nothing.
+long_flags=$(python3 -c "print(' '.join(f'--flag{i} val{i}' for i in range(60)))")
 # GIT_TARGET and GH_READ_TARGET are separately compiled, so each needs its OWN
 # timed window. The git-side call originally sat outside the gh timer: its label
 # promised a 2s bound it never asserted, and an independent regression there
@@ -217,7 +222,16 @@ bounded_run() { # <label> <command>
   fi
 }
 
-bounded_run "60 dummy flags, gh side"  "gh pr $long_flags nomatch | tail -5"
+# Flags sit BETWEEN `gh` and its subcommand — the only place GH_FLAGS can
+# consume them. The previous spelling was `gh pr $long_flags`, which fails the
+# match immediately and timed a path the flag group never entered.
+#
+# The trailing `pr` is not decoration: without a pr/run/api token the BASH
+# pre-filter exits before python and the case times a process that never
+# compiled the regex. Caught by canary — the reverted pattern still "passed"
+# this case in 12ms. `pr nomatch` clears the pre-filter and still fails the
+# match at `(checks|view)`, which is what forces the full backtrack.
+bounded_run "60 dummy flags, gh side"  "gh $long_flags pr nomatch | tail -5"
 bounded_run "60 dummy flags, git side" "git $long_flags nocommit | tail -5"
 
 # Every `pnpm ops gh:*` wrapper is a read command. Enumerating just two of them

--- a/.claude/hooks/lossy-pipe-guard.sh
+++ b/.claude/hooks/lossy-pipe-guard.sh
@@ -65,6 +65,13 @@ set -uo pipefail
 # The pre-filters below are the fast path, and a case-sensitive one is a hole in
 # its own right: `GIT COMMIT … | tail` would exit here before the tokenizer ever
 # ran, so making only the python regexes case-insensitive would fix nothing.
+# FILE-GLOBAL, and there is no reset below — every `case` and `[[ ]]` in the
+# rest of this script inherits case-insensitive matching. Nothing downstream
+# relies on case today (the checks past this point use `grep -E` and `[ ]`
+# string equality, neither affected), but a later contributor adding a `case`
+# on a filename, branch, or extension would silently get case-insensitive
+# behaviour without anything at the new site saying so. If you add one and want
+# exact matching, `shopt -u nocasematch` around it — do not assume the default.
 shopt -s nocasematch
 
 INPUT=$(cat)
@@ -123,9 +130,26 @@ case "$GUARD_CMD" in
   *) exit 0 ;;
 esac
 
-VERDICT=$(GUARD_CMD="$GUARD_CMD" python3 << 'PYEOF'
+# Absolute path to the shared hook lib, resolved before the python spawn (and
+# before any cd) so the import cannot depend on the caller's cwd.
+HOOK_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
+
+# PYTHONDONTWRITEBYTECODE: importing the shared lib otherwise drops a
+# __pycache__ into .claude/hooks/lib on every guarded command. It is gitignored,
+# but a stale .pyc can also mask a broken edit to the module — the import
+# succeeds against yesterday's bytecode. Cheaper to never write it.
+VERDICT=$(GUARD_CMD="$GUARD_CMD" HOOK_LIB="$HOOK_LIB" PYTHONDONTWRITEBYTECODE=1 python3 << 'PYEOF'
 import os
 import re
+import sys
+
+# The quote scanner is shared with develop-code-commit-guard.sh and
+# cwd-drift-guard.sh; see the module docstring for why it is one
+# implementation rather than three copies. An import failure exits
+# non-zero, which the caller treats as allow (fail-open) — the probe is
+# what catches a missing lib, not runtime.
+sys.path.insert(0, os.environ["HOOK_LIB"])
+from shell_quotes import strip_quoted
 
 cmd = os.environ.get("GUARD_CMD", "")
 if not cmd:
@@ -148,80 +172,11 @@ raw_cmd = cmd
 # false-block.
 cmd = re.sub(r"\$\(cat <<-?'?\"?(\w+)'?\"?.*?\n\s*\1\s*\)", "MSG", cmd, flags=re.S)
 
-# Quote stripping is a single left-to-right SCAN, not a pair of regex passes.
-#
-# The two-pass version (strip every single-quoted span, then every double-quoted
-# span) paired raw quote characters with no notion of which quote type was
-# already open. That is not a corner case — it failed on ordinary English:
-#
-#     git commit -m "it's" | grep "isn't"          MEASURED: exited 0
-#
-# The single-quote pass paired the apostrophe in `it's` with the one in `isn't`,
-# erasing the closing double quote, the real pipe and `grep` sitting between
-# them. Rule 1's exact protected shape, allowed, because someone used a
-# contraction in a commit message.
-#
-# Swapping the pass order only mirrors the bug — a literal `"` inside a
-# single-quoted argument then pairs the same naive way — so the strategy has no
-# correct ordering. It needs STATE. The scanner tracks which quote is open and
-# treats the other quote character as ordinary text while inside it, which also
-# subsumes the two backslash-neutralization passes this replaces:
-#
-#   * outside quotes, and inside "..." , a backslash escapes the next character
-#   * inside '...' , bash gives backslash NO meaning at all
-#
-# An UNTERMINATED quote strips NOTHING, for the same reason strip_heredocs
-# leaves an unterminated heredoc alone: dropping to end-of-text would delete a
-# real invocation and produce a bypass, where keeping the text merely over-arms.
-def strip_quoted(text):
-    """Replace each quoted span with `S`. Returns None if a quote is unclosed."""
-    out = []
-    quote = None
-    i = 0
-    while i < len(text):
-        ch = text[i]
-        if quote is None:
-            if ch == "\\" and i + 1 < len(text):
-                # Outside quotes bash lets a backslash escape ANY character, and
-                # the escaped character keeps its own value — `t\\ail` runs tail.
-                # Collapsing every escape to a placeholder therefore HID command
-                # names from the scan: measured, a commit piped into that
-                # spelling of tail exited 0 while bash ran it as tail exactly as
-                # written. Emit the real character instead; only an escaped
-                # QUOTE needs a placeholder, so it cannot open a span.
-                nxt = text[i + 1]
-                # Re-emit the escaped character — EXCEPT the ones that are
-                # syntax to the splitters below. An escaped `|` is a literal
-                # pipe character in an argument, not a pipeline operator, but
-                # once the backslash is gone `segment.split("|")` cannot tell
-                # the difference: measured, `git commit -m x\\|tail` blocked as
-                # though the commit were piped into tail, when bash runs no
-                # pipeline at all. Same reasoning for the chain separators.
-                # A placeholder keeps the character from acting as syntax while
-                # preserving the token boundary.
-                out.append("Q" if nxt in "\"'|&;\n" else nxt)
-                i += 2
-                continue
-            if ch in "\"'":
-                quote = ch
-                out.append("S")
-            else:
-                out.append(ch)
-        elif quote == '"':
-            if ch == "\\" and i + 1 < len(text):
-                i += 2
-                continue
-            if ch == quote:
-                quote = None
-        else:
-            # Inside single quotes there are no escapes; only the closing
-            # quote ends the span.
-            if ch == quote:
-                quote = None
-        i += 1
-    return None if quote is not None else "".join(out)
-
-
+# Quote stripping is a single left-to-right SCAN, not a pair of regex passes:
+# the two-pass version failed on ordinary English (an apostrophe in one
+# argument pairing with one in a later argument, erasing the real pipe
+# between them). Rationale, the measured repros, and the unterminated-quote
+# failure direction all live in .claude/hooks/lib/shell_quotes.py.
 scanned = strip_quoted(cmd)
 if scanned is not None:
     cmd = scanned
@@ -308,25 +263,57 @@ TRUNCATORS = re.compile(r"(?i)^\s*(head|tail|sed)\b")
 # flag narrows \s in the same pattern too, so a non-breaking space between
 # `git` and `commit` would stop matching and the guard would MISS a real
 # commit — failing open on a pasteable input to close a hypothetical one.
-GIT_TARGET = re.compile(r"(?i)\bgit(\s+-{1,2}\S+(\s+[^-\s]\S*)?)*\s+(commit|push)(?![-\w])")
+GIT_TARGET = re.compile(r"(?i)\bgit(?:\s+-+[^-\s]\S*(?:\s+[^-\s]\S*)?)*\s+(commit|push)(?![-\w])")
 
 # Rule 2's targets: gh READ commands whose output has to be seen whole.
 # Global flags may sit between `gh` and its subcommand, exactly as GIT_TARGET
 # already tolerates for git. Without this, `gh --repo owner/name pr checks |
 # tail` slipped past the whole rule — and `--repo`/`-R` is gh's standard way to
 # target another repo, not an exotic spelling.
-# A flag's VALUE may not itself start with `-`. That restriction is not
-# cosmetic — it removes an ambiguity that made this pattern backtrack
-# CATASTROPHICALLY. With a bare `\S+` value, every token in a run of flags can
-# be read either as the previous flag's value or as a new flag, so a failing
-# match explores exponentially many partitions. Measured on `gh` plus N dummy
-# flags that never reach a subcommand: 18 flags 4.9ms, 22 flags 34ms, 26 flags
-# 231ms — doubling every two. Roughly 34 flags would hang for minutes.
+# `-+[^-\s]\S*` — any run of dashes followed by a MANDATORY non-dash — is what
+# keeps this pattern from backtracking catastrophically.
 #
-# This hook is PreToolUse on EVERY Bash call, so that is a session hang, not a
-# slow command. After the fix: 200 flags in 0.17ms, with every verdict
-# unchanged.
-GH_FLAGS = r"(?:\s+-{1,2}\S+(?:\s+[^-\s]\S*)?)*"
+# The blowup came from `-{1,2}`: `--flag` reads as `--`+`flag` or `-`+`-flag`,
+# so a FAILING match re-partitioned every flag in the run, 2^n ways. Measured on
+# `git` plus N double-dash flags that never reach a subcommand: 20 flags 2.7s,
+# 60 flags did not finish inside 20 seconds. On a PreToolUse hook that is a
+# session hang, not a slow command. Requiring a non-dash after the dashes forces
+# the dash count, so there is nothing left to re-partition: 200 flags in 0.24ms,
+# 1000 in 1.3ms, every verdict unchanged.
+#
+# It was NOT the optional VALUE, checked by measuring the shapes separately:
+# single-dash flags WITH values run 0.6ms at 60. The earlier "a value may not
+# start with `-`" restriction was never the fix it was documented as.
+#
+# WHY NOT AN ATOMIC GROUP `(?>...)`, which is the obvious fix and was written
+# first: it needs Python 3.11. On anything older `re.compile` raises, python
+# exits non-zero, and the caller's `|| exit 0` silently ALLOWS the command —
+# a blocking guard disabled by interpreter version, which is this hook's own
+# bug class wearing a different hat. Ubuntu 22.04 still ships 3.10, and CI
+# (3.12) would never have caught it. The deterministic spelling needs no
+# version floor.
+#
+# A negative lookahead forbidding the flag VALUE from being the subcommand sat
+# here too and was REMOVED, because it was inert: it was required only to keep
+# the ATOMIC version from swallowing `commit` as `--no-pager`'s value, and with
+# ordinary backtracking restored it changed no verdict (including
+# `git --x commit`, the shape it literally described) and no timing at any size
+# from 60 to 1000 flags. It survived the atomic group's deletion by inertia and
+# kept a comment claiming a job it no longer did.
+#
+# KNOWN NARROWING, accepted: a bare `--` is no longer read as a flag, so
+# `git -- commit` stops matching. That is not a commit — git answers `unknown
+# option: --` and exits 129 (verified, not assumed) — so the old behaviour was
+# over-detecting a non-command.
+#
+# WHY THIS WENT UNMEASURED for a whole PR, since this comment once claimed the
+# opposite: the timing probe built its flags as `-x0 -x1 …` — SINGLE dash, so
+# `-{1,2}` has exactly one parse and the ambiguity is never reached — and on the
+# gh side placed them after the subcommand, where this group cannot consume them
+# at all. It measured a shape with no ambiguity in it and reported the pattern
+# safe. Both probes now use double-dash flags with values, positioned to reach
+# the group, and each is canaried by reverting the fix.
+GH_FLAGS = r"(?:\s+-+[^-\s]\S*(?:\s+[^-\s]\S*)?)*"
 GH_READ_PARTS = [
     r"\bgh" + GH_FLAGS + r"\s+pr\s+(checks|view)(?![-\w])",
     r"\bgh" + GH_FLAGS + r"\s+run\s+list(?![-\w])",
@@ -336,6 +323,11 @@ GH_READ_PARTS = [
     # whole. That produced pure friction — it blocked `gh:pr-edit --help | tail`
     # during this PR's own authoring, twice. Rule 2 exists for reads whose rows
     # can hide a failure; a write command has no rows to lose.
+    # DRIFT RISK, named rather than hidden: nothing ties this list to the
+    # command registry in packages/tooling/src/commands/gh.ts, so a future
+    # gh: READ wrapper is unprotected by rule 2 until someone adds it here.
+    # Enumerated anyway — the `gh:[a-z-]+` glob that would self-maintain
+    # swept in the WRITE command gh:pr-edit and produced pure friction.
     r"\bgh:(pr-all|pr-comments|pr-conversation|pr-info|pr-reviews|ci-gate)(?![-\w])",
 ]
 # `gh api` is conditional, and the condition is not squeamishness: an api URL

--- a/packages/tooling/src/dev/gitCommitPatternAgreement.test.ts
+++ b/packages/tooling/src/dev/gitCommitPatternAgreement.test.ts
@@ -99,6 +99,19 @@ const AGREEMENT_CASES: readonly (readonly [expected: boolean, input: string])[] 
   [true, 'cd foo && git commit -m "x"'],
   [true, 'git add . && git commit -m "x" && git status'],
 
+  // --- case ---
+  // Both copies carry an inline (?i). Uppercase is not a hypothetical: shells
+  // accept it, and a case-sensitive copy exits silently on it — for two BLOCKING
+  // hooks that means a commit that should have been stopped goes through. The
+  // flag is inline rather than an re.I argument because these patterns are
+  // extracted from source TEXT above; a flag outside the string would be
+  // invisible here (and break the extraction, which is a hard failure).
+  [true, 'GIT COMMIT -m "x"'],
+  [true, 'Git Commit -m "x"'],
+  [true, 'GIT -C /some/path COMMIT -m "x"'],
+  // Case-insensitivity must not erode the plumbing exclusion.
+  [false, 'GIT COMMIT-TREE abc1234'],
+
   // --- is NOT a commit ---
   // The plumbing subcommands: `-` is a non-word character, so a bare \b matched
   // these. They write no commit; treating one as a commit wrongly BLOCKS.

--- a/packages/tooling/src/dev/shellQuotes.test.ts
+++ b/packages/tooling/src/dev/shellQuotes.test.ts
@@ -1,0 +1,203 @@
+/**
+ * CI coverage for `.claude/hooks/lib/shell_quotes.py` — the shell quote scanner
+ * shared by three PreToolUse hooks.
+ *
+ * WHY IT HAS ITS OWN TEST rather than being covered through its consumers: it
+ * had none while it was three private copies, and the copies diverged. Each
+ * consumer's .probe.sh exercises it only through that hook's own verdict, which
+ * means a scanner bug is visible there only when it happens to flip a verdict —
+ * so the shapes that matter most (an unterminated quote, an escaped structural
+ * character) were being asserted nowhere. This file pins the scanner's OUTPUT
+ * directly; the probes keep pinning the verdicts.
+ *
+ * Both surfaces are CI-enforced. `guard:hook-probes` runs every probe in the
+ * lint job and in `pnpm quality`; this runs in the tooling unit cell.
+ *
+ * EXTERNAL BINARY: this shells out to `python3`, because the only honest way to
+ * evaluate the scanner is to run it through the engine the hooks use. python3
+ * was already a prerequisite of both those hooks and of
+ * gitCommitPatternAgreement.test.ts; a minimal image dropping it surfaces here
+ * as an ENOENT at collection time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const LIB_DIR = fileURLToPath(new URL('../../../../.claude/hooks/lib', import.meta.url));
+
+/**
+ * One python3 spawn strips every case. `null` is the unterminated-quote signal,
+ * carried through JSON so this test can assert it rather than inferring it from
+ * a returned string.
+ */
+function stripAll(inputs: readonly string[]): (string | null)[] {
+  const script = [
+    'import json, sys',
+    'sys.path.insert(0, sys.argv[1])',
+    'from shell_quotes import strip_quoted',
+    'json.dump([strip_quoted(c) for c in json.load(sys.stdin)], sys.stdout)',
+  ].join('\n');
+  const out = execFileSync('python3', ['-c', script, LIB_DIR], {
+    input: JSON.stringify(inputs),
+    encoding: 'utf-8',
+    env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1' },
+  });
+  return JSON.parse(out) as (string | null)[];
+}
+
+/** [label, input, expected output] — `null` means "unterminated, strip nothing". */
+const CASES: readonly (readonly [string, string, string | null])[] = [
+  ['leaves an unquoted command alone', 'git status', 'git status'],
+  ['replaces a double-quoted span', 'git commit -m "hello"', 'git commit -m S'],
+  ['replaces a single-quoted span', "git commit -m 'hello'", 'git commit -m S'],
+
+  // The bug this scanner exists for. Two independent regex passes paired the
+  // apostrophes across the `&&` and erased the `git commit` between them.
+  [
+    'an apostrophe inside double quotes is literal',
+    'echo "it\'s" && git commit -m "won\'t"',
+    'echo S && git commit -m S',
+  ],
+  [
+    'the mirror: a double quote inside single quotes is literal',
+    'echo \'say "hi"\' && git commit -m x',
+    'echo S && git commit -m x',
+  ],
+  [
+    'apostrophes straddling an unquoted token do not swallow it',
+    'git commit -m "it\'s" && git add packages/x.ts && echo "don\'t"',
+    'git commit -m S && git add packages/x.ts && echo S',
+  ],
+
+  // Escapes. Outside quotes bash escapes ANY character and the character keeps
+  // its value, so collapsing escapes to a placeholder HID command names from
+  // the callers' scans — measured, a commit piped into `t\ail` exited 0 while
+  // bash ran tail exactly as written.
+  ['an escaped letter keeps its value', 'git push | t\\ail -5', 'git push | tail -5'],
+  ['an escaped quote cannot open a span', 'echo \\"x', 'echo Qx'],
+  ['an even backslash run is not an escaped quote', 'echo \\\\"x"', 'echo \\S'],
+
+  // A structural character that was ESCAPED is a literal in an argument, not
+  // syntax. The callers split on these, so re-emitting them bare invented a
+  // pipeline stage that bash never runs.
+  ['an escaped pipe is not a pipeline operator', 'git commit -m x\\|tail', 'git commit -m xQtail'],
+  ['an escaped semicolon is not a separator', 'echo a\\;b', 'echo aQb'],
+  ['a real pipe survives untouched', 'git push | tail -5', 'git push | tail -5'],
+
+  // Inside single quotes bash gives backslash no meaning at all, so a trailing
+  // backslash does NOT escape the closing quote.
+  ['no escapes inside single quotes', "echo 'a\\' && git commit", 'echo S && git commit'],
+  ['a backslash escapes the closing double quote', 'echo "a\\" still in" && x', 'echo S && x'],
+
+  // ANSI-C quoting (`$'...'`) is a KNOWN SCOPE BOUNDARY, pinned here rather
+  // than left unstated. Bash gives `$'...'` backslash escapes while `'...'` has
+  // none, and the two share a delimiter, so the scanner — which implements the
+  // plain-single-quote rule — mis-pairs an escaped apostrophe inside one. This
+  // is not hypothetical for this repo: `06-backlog.md` documents
+  // `pnpm tracker task create -d $'Why: …\nFix: …'` as the recommended shape.
+  //
+  // What these pin is the DIRECTION of the mistake. The desync leaves an odd
+  // number of open quotes, so the scan ends unterminated and returns null —
+  // the caller then scans raw text and the target stays visible, which
+  // over-arms. Fixing the pairing properly would mean modelling `$'` as its own
+  // span type; worth doing only if a case ever lands on the other side, and
+  // these cases are what would catch that.
+  [
+    "an escaped apostrophe in $'...' desyncs to null, not a swallow",
+    "echo $'it\\'s' && git commit -m x",
+    null,
+  ],
+  [
+    '...also when it straddles the target',
+    "echo $'a\\'b' && git commit -m x && echo $'c\\'d'",
+    null,
+  ],
+  ['...also on the pipe form rule 1 protects', "git commit -m $'it\\'s' | tail -5", null],
+  // TWO escapes in one construct, and two constructs each carrying one. The
+  // single-escape cases below establish the direction; these are what make it a
+  // pinned property rather than an inference, because the worry is a mis-scan
+  // that RE-synchronises to a cleanly-terminated result with a `git commit`
+  // absorbed inside it — that would be a bypass, not an over-arm.
+  [
+    "two escapes in one $'...' span still desync to null",
+    "echo $'a\\'b\\'c' && git commit -m x",
+    null,
+  ],
+  [
+    "two $'...' constructs straddling the target desync to null",
+    "echo $'a\\'b' && git commit -m x && echo $'c\\'d'",
+    null,
+  ],
+
+  // Without an escaped apostrophe, `$'...'` and `'...'` are identical, so these
+  // strip normally and the `$` survives as an ordinary character.
+  [
+    "$'...' with no escape behaves like a plain single-quoted span",
+    "echo $'plain' && git commit -m x",
+    'echo $S && git commit -m x',
+  ],
+  [
+    'the documented tracker shape strips cleanly',
+    "pnpm tracker task create 'T' -d $'Why: x\\nFix: y' && git commit -m x",
+    'pnpm tracker task create S -d $S && git commit -m x',
+  ],
+
+  // A backslash-newline is a LINE CONTINUATION, not an escape: bash deletes
+  // both characters and splices with nothing between. Emitting a placeholder
+  // here fabricated a non-whitespace token between two words bash runs
+  // adjacently, and since every target regex needs `\s+` adjacency, an
+  // ordinary multi-line `git \<newline> commit` slipped the blocking guard
+  // entirely. Both directions are pinned, because the splice is only correct
+  // if it also produces the NON-match.
+  [
+    'a line continuation splices, preserving word adjacency',
+    'git \\\n  commit -m "msg"',
+    'git   commit -m S',
+  ],
+  [
+    '...and splices words TOGETHER when no space surrounds it',
+    'git\\\ncommit -m x',
+    'gitcommit -m x',
+  ],
+  [
+    'a continuation inside a double-quoted span stays inside it',
+    'git commit -m "line one \\\nline two"',
+    'git commit -m S',
+  ],
+
+  // The failure direction: strip nothing, so a caller over-arms rather than
+  // losing a real invocation to an accidental end-of-text delete.
+  ['an unterminated double quote strips nothing', 'git commit -m "oops', null],
+  ['an unterminated single quote strips nothing', "git commit -m 'oops", null],
+  ['a trailing lone backslash is emitted as itself', 'git commit -m x\\', 'git commit -m x\\'],
+];
+
+describe('shell_quotes.strip_quoted (shared by three hooks)', () => {
+  const results = stripAll(CASES.map(([, input]) => input));
+
+  for (const [index, [label, input, expected]] of CASES.entries()) {
+    it(label, () => {
+      expect(results[index], `input: ${JSON.stringify(input)}`).toBe(expected);
+    });
+  }
+
+  it('leaves no quote character behind in any successful strip', () => {
+    // The property every caller relies on but none of them states: after a
+    // successful strip, no `"` or `'` survives — neither as a span delimiter
+    // nor as an escaped literal (that is what the `Q` placeholder is for). All
+    // three hooks then scan and split the result as if it were bare syntax, so
+    // a surviving quote is a quote they would misread as structure.
+    //
+    // Deliberately NOT an idempotence assertion, which is the invariant this
+    // shape invites and the function does not have: `echo \S` re-strips to
+    // `echo S`, because a placeholder in the output is indistinguishable from
+    // an escaped letter in a fresh input. Nothing re-strips, so nothing needs
+    // it — asserting it would have pinned a property no caller wants.
+    for (const [index, [label]] of CASES.entries()) {
+      const stripped = results[index];
+      if (stripped === null) continue;
+      expect(stripped, label).not.toMatch(/["']/);
+    }
+  });
+});


### PR DESCRIPTION
Closes **TASK-474**, all three members.

## The bypass

Three hooks each carried their own quote-stripping, and two still used the two independent regex passes that lossy-pipe-guard replaced with a stateful scanner in #2015. Measured against `develop-code-commit-guard.sh` — a hook that **blocks**:

```
echo "it's" && git commit -m "won't"
```

strips to `echo S`. The apostrophes in `it's` and `won't` pair across the `&&`, the `git commit` between them is erased, detection returns False, and the guard exits 0. A code commit lands on develop with **no review** because someone used a contraction.

Ordering matters and both directions are pinned: a quoted argument *after* `git commit` is harmless (the swallow happens downstream of the match). It is specifically an **earlier** quoted argument that hides the commit — so a one-sided test case would have passed on the broken code, which the canary below confirms.

`cwd-drift-guard.sh` had the same strip in `sed` form. Lower stakes on purpose: it only ever *adds* a block, so the cost is a missed warning rather than a bypass. Fixed anyway — leaving the last copy is how a class survives.

## One scanner, three consumers

The scanner now lives once, in `.claude/hooks/lib/shell_quotes.py`, and all three hooks import it. Copying it a third time was the alternative, and copying is how this started: the copies had already diverged, with one fixed a PR before the others.

The tradeoff is stated rather than hidden. A hook that cannot import the lib **fails open** — deliberate, since a PreToolUse hook that blocked every Bash call on an infrastructure error would be unusable, but it does mean a missing lib silently disarms a blocking guard at runtime. The backstop is CI, and it is measured, not assumed: removing the module fails **51** lossy-pipe-guard probe cases, and `develop-code-commit-guard.probe.sh` asserts the file's existence directly.

`PYTHONDONTWRITEBYTECODE=1` on each spawn — the import otherwise drops a `__pycache__` into the hooks dir on every guarded command, and a stale `.pyc` can mask a broken edit to the module.

## Case-sensitivity, the second member

`develop-code-commit-guard.sh` missed `GIT COMMIT -m x` entirely. Both the bash pre-filters and the python regex had to change, and **each half was canaried separately**: dropping either one alone re-opens the hole on its own, because the pre-filter short-circuits before python ever runs. That "a pre-filter is a second gate" trap cost four separate cycles in #2015; here it is pinned by test rather than by comment.

The `(?i)` is inline rather than an `re.I` argument because `gitCommitPatternAgreement.test.ts` extracts the pattern from source text — a flag outside the string would vanish from the sibling comparison and break the extraction outright.

## Verification

Every fix canaried by reverting it and confirming the matching case goes red:

| Canary | Result |
|---|---|
| Scanner → two-pass strip | `apostrophe in an EARLIER quoted arg` fails (exit 0); the AFTER case still passes |
| Drop `(?i)`, keep `shopt` | all 3 uppercase cases fail |
| Drop `shopt`, keep `(?i)` | all 3 uppercase cases fail |
| Remove the shared lib | 51 lossy-pipe-guard cases fail |
| cwd-drift → sed strip | `apostrophes straddling a real pathspec` fails |

New coverage: **11** develop-code-commit-guard probe cases, **3** cwd-drift-guard cases, **4** agreement cases, and a **28-case** unit suite over the shared module (counted from the runner: `shellQuotes.test.ts (28 tests)`). This figure has been wrong twice — 17 at round 1, 23 at round 5 after new cases landed and the body was not re-counted — which is the same provenance slip this PR criticises #2015 for, committed twice inside the PR that criticises it — which had no test of its own for as long as it was three private copies. All 8 hook probes pass; `pnpm test` and `pnpm quality` green locally.

One new probe case is labelled honestly as **not** a discriminator: `double quote inside single-quoted arg` passes on the old code too (that version stripped single-quoted spans first). It is there to pin the mirror against the tempting wrong repair — swapping the pass order, which makes the apostrophe case pass while breaking that one.

One assertion I wrote and removed: an idempotence check on the scanner's output. It failed, and the test was wrong rather than the code — `echo \S` re-strips to `echo S`, because a placeholder is indistinguishable from an escaped letter on a fresh pass. Nothing re-strips, so nothing needs it. Replaced with the invariant the callers do rely on: no quote character survives a successful strip.

## Round 1 — a live ReDoS, and a correction to #2015

The reviewer asked whether `GIT_TARGET` still had the catastrophic-backtracking shape, and said it couldn't run a timing repro. I could. **It does, and the fix #2015 shipped for it does not work.**

| shape | 20 flags | 60 flags |
|---|---|---|
| before | 2.7 s | no finish in 20 s |
| after | 2.0 ms | 1.7 ms |

At 200 flags: 0.34 ms, with all 34 verdict cases unchanged.

**The trigger is not what #2015 said it was.** That PR attributed the blowup to the optional flag VALUE and "fixed" it by requiring a value not start with `-`. Measuring the shapes separately shows single-dash flags *with* values run 0.6 ms at 60 — the value was never the problem. It is `-{1,2}`: `--flag` parses as `--`+`flag` or `-`+`-flag`, so a failing match re-partitions the whole run, 2^n ways. The restriction #2015 added neither caused nor cured it.

**Why the probe called it fixed.** The timing fixture built its flags as `-x0 -x1 …` — single dash, one parse, ambiguity never reached — and on the gh side placed them *after* the subcommand, where `GH_FLAGS` cannot consume them at all. It measured a shape with no ambiguity in it and reported 200 flags in 0.17 ms. That number is in #2015's body as the fix's proof, and it measured nothing. This is the same vacuous-assertion class this PR's canaries exist to catch; it slipped through because the canary was run against the fixture rather than the fixture being checked against the bug.

**The fix** makes the dash count deterministic: `-+[^-\s]\S*` — any run of dashes followed by a MANDATORY non-dash — so there is nothing to re-partition. The value carries a lookahead forbidding it from BEING the subcommand, which is what keeps `git --no-pager commit` matching. Both halves verified by removing each.

**The corrected fixture is itself canaried**, both sides independently: reverting `GIT_TARGET` fails the git case, reverting `GH_FLAGS` fails the gh case. Getting there needed one more fix — the gh fixture initially had no `pr` token, so the bash pre-filter short-circuited it before Python and the reverted pattern still "passed" in 12 ms. That is the pre-filter-is-a-second-gate trap for the fifth time in this hook's history, and it is now the reason the fixture has a trailing `pr`.

## Round 2 — an atomic group would have been a Python-version bypass

Round 1 shipped `(?>...)` for this. **Atomic groups need Python 3.11**, and the reviewer worked out what that means here: on an older interpreter `re.compile` raises, python exits non-zero, and `|| exit 0` **silently allows the command**. A blocking guard disabled by interpreter version — this hook's own bug class wearing a different hat. Ubuntu 22.04 still ships 3.10, and CI (3.12) would never have caught it.

Rather than guard the version, the dependency is gone: `-+[^-\s]\S*` forces the dash count by requiring a non-dash after the dashes, so the pattern is deterministic on **any** Python. All 28 verdict cases correct, 200 flags in 0.6ms.

One narrowing, verified rather than assumed: a bare `--` is no longer read as a flag, so `git -- commit` stops matching. That is not a commit — git answers `unknown option: --`, exit 129 — so the atomic version was over-detecting a non-command.

## Round 2 — I fixed one probe's vacuous fixture and left its twin

Round 1's whole thesis was that a timing fixture built from single-dash flags "measures nothing." `develop-code-commit-guard.probe.sh` had the **identical** fixture for the **identical** pattern, ~30 lines from the regex this PR edits, and I did not touch it. Worse than the sibling's version: it had no `timeout`, so a real backtrack would have wedged the probe until CI's 120s ceiling killed the job with no attributable diagnostic — the exact failure the sibling's `bounded_run` exists to prevent.

That is the class-sweep discipline failing inside the PR that preaches it, and it took a reviewer to see it. Now double-dash with values, `timeout`-enforced, and canaried: reverting the pattern trips it with `FAIL (timed out at 10s) pathological flag run is backtracking` instead of hanging.

**Four ReDoS fixtures now exist and all four are canaried** — git and gh sides of `lossy-pipe-guard.probe.sh`, the `develop-code-commit-guard.probe.sh` case, and the agreement suite's verdict parity.

## The class sweep, and what is deliberately NOT built

Fixing three patterns is not the same as closing the class, so the class was enumerated rather than assumed. Every `r"..."` regex literal carrying a quantified group was extracted from all 18 hook scripts — 15 distinct patterns — and each was hammered with adversarial inputs built from its own alphabet (long runs of digits/redirects, double-dash flags, flag+value pairs, escaped quotes), every case bounded in its own process. **Zero remaining findings.** The three `-{1,2}` patterns were the only members, and `REDIRECT_PREFIX` — the one other nested-quantifier shape in the corpus — is clean because `[<>]{1,2}` is mandatory inside it, so its group cannot match empty.

The sweep is NOT being shipped as a `guard:*` command, and the reason is worth stating rather than leaving as an omission. It takes minutes, which is the wrong shape for the lint job, and the class it hunts now has zero members; a periodic sweep for a class with no members is speculative tooling. The recurrence-blocker that DOES ship is narrower and free: the timing cases in the probe, now built on the shape that actually reaches the ambiguity and canaried on both sides, run in CI on every push. If a future pattern reintroduces the shape, the honest catch is that the same measurement discipline gets applied when it is written — which is what the corrected comment at each pattern now tells the next reader to do.

The false claim in #2015's merged body has been corrected in place, pointing here.

## Round 1 — the other two findings

**`$'...'` ANSI-C quoting** — real, and the reviewer was right that it is not hypothetical here (`06-backlog.md` recommends `-d $'…\n…'`). Measured every case it raised plus the straddling and pipe forms: an escaped apostrophe inside `$'...'` always desyncs to an odd quote count, so the scan returns `None`, the caller uses raw text, and the target stays visible. It over-arms; it never swallows. Five cases now pin that direction, so a future change landing on the other side fails CI instead of going unnoticed.

**Probe-hardening asymmetry** — checked rather than assumed: with the lib removed, `cwd-drift-guard.probe.sh` goes red on its block case. The implicit coverage is real, so no redundant assertion added.

## Round 7 — the one claim in this PR that had no test was mine

The review turned this PR's own bar on it and found the gap: I argued at length, in a fresh comment, that the escape token stays exact-case and that **"an unrecognised spelling BLOCKS, it never bypasses"** — and pinned it with nothing, in a PR whose thesis is that every claim gets canaried.

It matters because the asymmetry *looks* like an oversight. A contributor "fixing" it with `(?i)` — a change that reads as a consistency cleanup — would let `tzurot_allow_develop_code_commit=1` unlock the guard while the real environment variable was never set. An unreviewed commit, arriving through a tidy-up. Canaried exactly that way: adding `(?i)` turns both new cases red.

Also closed the last case-sensitive `git` gate in the class. `cwd-drift-guard.sh` still detected with a case-sensitive grep after its two siblings were fixed — lower stakes (a missed warning, not a bypass) but the same class, and this PR's own framing is that leaving the last copy is how a class survives. Fixed with `-i`, pinned, canaried.

And the `$'...'` safety direction is now a pinned property rather than a hand-traced inference: two escapes in one construct, and two constructs straddling the target, both asserted to desync to `null`. The worry the reviewer named — a mis-scan re-synchronising to a cleanly-terminated result with a `git commit` absorbed inside — would be a bypass rather than an over-arm, so it is worth asserting instead of reasoning about.

## Round 12 — the class is NOT closed, and this body said it was

**TASK-479 (high) is open against the scanner this PR creates.** A command substitution nested inside a quoted argument is erased, and the blocking guard exits 0:

| shape | bash runs the inner command | scanner output | detected |
|---|---|---|---|
| `echo "$(git commit -m x)"` | **yes** (probe printed `RAN`) | `echo S` | **no** |
| ``echo "`git commit -m x`"`` | **yes** | `echo S` | **no** |
| `echo $(git commit -m x)` — unquoted | yes | intact | yes |

Measured on this branch, not traced — the reviewer flagged it and explicitly could not execute, so running it was the first step.

The documented fail-safe cannot help here, which is the part worth understanding: it relies on an unterminated quote returning `None` so the caller falls back to raw text. A well-formed substitution has an **even** quote count by syntactic necessity, so the scan closes cleanly over erased content and never reaches the safe direction.

Pre-existing — the two-pass `re.sub` this replaced consumed the same span identically — so shipping does not worsen it. But **this body's class-sweep section implied the "quote content leaks into a structural scan" class was closed, and it is not.** That is a false claim in durable text, in the PR whose sibling rule (#2023) exists to stop exactly that. Corrected here rather than quietly.

**Why it is filed rather than fixed here:** recursive substitution handling is a distinct structural change to a scanner with three consumers, one of them blocking. This PR has already produced three regressions in adjacent code — an atomic group that needed Python 3.11, a case-fold that conflated `-c` with `-C`, an exemption reading raw instead of stripped text — each caught a round after I introduced it. Adding a fourth structural change at round 12 is how a fifth happens. The fix deserves its own review, and TASK-479 carries the measured repro and fix shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
