### PR TITLE
docs(rules): add the claim-time trigger for lossy READS

### DIFF
--- a/.claude/rules/10-working-posture.md
+++ b/.claude/rules/10-working-posture.md
@@ -86,6 +86,18 @@ needed the command's RESULT, which exists only post-hoc, and non-blocking
 post-hoc hook output never reaches the agent. No channel can carry it, so for
 everything the guard does not name, the rule is the mechanism.
 
+That tell only fires on a result that LOOKS wrong, and the costlier half of
+this class produces a plausible one: a window that hides the section deciding
+the question, or an aggregate summed from the visible rows and reported as the
+total — a subtotal is a well-formed number, so nothing looks off. Neither has a
+tell, so this half triggers at CLAIM time rather than at result time. Before
+stating what a file says or does not say, read it whole or state the window you
+read. Before stating a count, sum, or ranking as complete, derive it from the
+whole result set rather than the part on screen. An exit code read through a
+pipeline is the same seam: `PIPESTATUS` is indexed per stage, so `[0]` is the
+FIRST command's status, not the one whose result you want — index the stage you
+mean, or do not pipe.
+
 ## Reviews are collaborators, not gates to survive
 
 Procedure in `/tzurot-review-response`; two postures on top. When a reviewer


### PR DESCRIPTION
Closes **TASK-465**. Twelve lines added to an existing section of `10-working-posture.md`; rules budget **2091/2218 lines, 164085/174450 bytes** — re-measured after round 2's trim, which round 3 correctly flagged as unverified in the body (it still carried round 1's 2093/164236).

## Why the existing rule didn't catch these

`## Lossy steps are for known output shapes` already covers this class conceptually. But its read-side tell is **"an empty or oddly short result"** — and all five misses that motivated this produced results that looked complete and plausible. There was no trigger for the case where the window itself is the lie.

Per the session-mining guidance, a rule that exists and is still violated is a **compliance** finding: another rule restating it is worthless. So this is a decision-point trigger inside the section that already owns the class, moving the check from *result* time to **claim** time.

## The two sub-shapes

**A window that hides the deciding section.** A `sed -n` range read of a task file cut off the STATUS block at line 77; a commit was built on the wrong conclusion and the owner was told a member was live work when it had already shipped. A staleness sweep grepped two named files, declared itself done, and left the identical false claim live in a third — in the error output a reader hits at the moment they act on it.

**An aggregate summed from the visible rows.** A ranking read through a truncated view was published as "second-most by lines, three places below by bytes" (third-most, one place). A test count summed from the four package rows that happened to be on screen was reported as the repo total — 12020 against a real 19183 across 13 packages. This half is the more dangerous one, because *a subtotal is a well-formed number*: there is no odd-looking output for the existing tell to fire on.

Four of the five were published before anyone noticed, caught by accident or by a reviewer, never by me; the fifth (a `PIPESTATUS[0]` misread that nearly recorded a working blocking gate as broken) was caught pre-publication. Round 1 caught the rule text overclaiming that split as "five shipped" — an overclaimed count inside the rule against overclaiming counts, now exact. Two happened inside a measurement-reporting tool while the subject matter was measurement — so proximity to the topic provided no protection, which rules out any fix that relies on the author being alert to it. That's the argument for a trigger tied to the *act of claiming* rather than to the topic.

The `PIPESTATUS` note is that fifth incident rather than an unrelated rider, and the text now says so — round 1 flagged that "the same move" oversold the connection. It is the same seam one layer down: the signal you can see is not the one you think you are reading.

## Scope

Rule-only, deliberately. The task asked whether a hook could catch the file-read shape mechanically — a `sed -n`/`head`/`tail` on a path under `tracker/` or `.claude/` is a deterministic trigger, but the correction is not mechanical (sometimes a window is exactly right), and the guard would need the command's *result* to tell the two apart. That's the same post-hoc problem that retired an earlier hook in this space, recorded in the paragraph directly above this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
