### PR TITLE
fix(tooling): the deletion-rule premise is verified, so stop hedging on it

### DIFF
--- a/packages/tooling/src/dev/check-repo-settings.test.ts
+++ b/packages/tooling/src/dev/check-repo-settings.test.ts
@@ -582,12 +582,17 @@ describe('formatRepoSettingsReport', () => {
     });
 
     expect(text).toContain('✓ No deletion-safety findings');
-    // The clean report must describe observed CONFIGURATION, never promise an
-    // outcome: that a bypass-actor-free deletion rule actually stops GitHub's
-    // admin-privileged auto-delete is an unverified premise, so the wording
-    // must not read as a settled guarantee.
-    expect(text).toContain('not a proven guarantee');
+    // The clean report must describe observed CONFIGURATION and never promise
+    // an outcome. The premise underneath it — that a bypass-actor-free deletion
+    // rule stops GitHub's admin-privileged auto-delete — is now probe-verified,
+    // so the wording may say so; what it still must NOT do is claim the ruleset
+    // is SUFFICIENT. One branch on one repo is not a guarantee, and
+    // `delete_branch_on_merge: false` remains the protection that assumes
+    // nothing. These two assertions pin both halves of that: the verified claim
+    // is present, the sufficiency claim is absent.
+    expect(text).toContain('not a proof of sufficiency');
     expect(text).not.toContain('deletion is unreachable');
+    expect(text).not.toContain('deletion is impossible');
     expect(text).toContain('delete_branch_on_merge: false');
     expect(text).toContain('main: deletion rule present, not bypassable');
     expect(text).toContain('develop: deletion rule present but fully bypassable');

--- a/packages/tooling/src/dev/check-repo-settings.ts
+++ b/packages/tooling/src/dev/check-repo-settings.ts
@@ -93,21 +93,18 @@ export interface ActiveBranchRuleset {
  * admin-privileged delete: either no active ruleset carries a `deletion` rule,
  * or every ruleset that does can be bypassed.
  *
- * UNVERIFIED PREMISE — read before trusting a clean report. The converse (a
- * deletion rule with ZERO bypass actors actually blocks the admin-privileged
- * auto-delete) has never been observed. The incident that motivated this guard
- * demonstrates only the FAILURE case: a bypassable rule on `develop`, deleted.
- * `main` survived because `main` is never the head branch of any merge here —
- * feature PRs merge into `develop`, and the release PR's head is `develop` —
- * NOT because its bypass-actor-free rule was exercised and held.
+ * The premise this rests on is VERIFIED, not assumed. A bypass-actor-free
+ * `deletion` rule does stop the admin-privileged path, measured on a disposable
+ * repo carrying that rule with `delete_branch_on_merge: true`: a direct ref
+ * DELETE issued as the repository OWNER was refused 422, and a PR whose HEAD
+ * was that branch merged with the branch surviving. Both directions of the
+ * guard have now been exercised — the incident supplied the failure case (a
+ * bypassable rule on `develop`, deleted), the probe supplied the success case.
  *
- * So a "safe" verdict rests on how GitHub is assumed to treat bypass actors on
- * that path. If the auto-delete ignores rulesets entirely, this reports safe
- * for a branch that is still deletable — the silent direction. The falsifying
- * probe is cheap and has not been run: a disposable repo with a no-bypass
- * deletion rule and `delete_branch_on_merge: true`, merge a PR whose head is
- * that branch, see whether it survives. Until then the primary protection is
- * `delete_branch_on_merge: false`, which needs no assumption about rulesets.
+ * What that does NOT establish is sufficiency: one branch, one ruleset, one
+ * merge, on a repo nobody else touches. `delete_branch_on_merge: false` stays
+ * the primary protection precisely because it needs no assumption about
+ * rulesets at all, and this guard asserts both.
  */
 export function isDeletionReachable(state: BranchDeletionState): boolean {
   return !state.hasDeletionRule || state.deletionRuleFullyBypassable;
@@ -515,8 +512,9 @@ export function formatRepoSettingsReport(surface: RepoSettingsSurface): string {
   if (surface.findings.length === 0) {
     return [
       '✓ No deletion-safety findings — every long-lived branch carries an un-bypassable',
-      '  deletion rule. (Reports observed CONFIGURATION, not a proven guarantee — see',
-      '  the unverified-premise note in check-repo-settings.ts.)',
+      '  deletion rule, and that rule is known to hold against the admin-privileged',
+      '  path (probe-verified). Still CONFIGURATION, not a proof of sufficiency —',
+      '  delete_branch_on_merge below is the protection that assumes nothing.',
       `  delete_branch_on_merge: ${String(surface.deleteBranchOnMerge)}`,
       ...stateLines,
     ].join('\n');


### PR DESCRIPTION
Closes **TASK-461's second half**.

The probe ran during the beta.196 cycle and its result is recorded in the task. What did not happen is the acceptance criterion that result unlocked — *drop the unverified-premise caveat* — which was parked in a task note as "a separate small PR". That is precisely where work goes to sit, so it is being done rather than left.

## What was measured

On a disposable repo (owner-approved, since deleted) carrying `delete_branch_on_merge: true` and a branch with an ACTIVE ruleset whose `deletion` rule had **zero** bypass actors:

1. A direct `DELETE` of the ref, issued as the **repository owner**, was refused — `422 Repository rule violations found / Cannot delete this branch`.
2. A PR whose **HEAD was that branch** was merged, with auto-delete still enabled. The branch **survived**.

So a bypass-actor-free deletion rule does stop the admin-privileged path. Both directions of the guard have now been exercised: the beta.195 incident supplied the failure case (a bypassable rule on `develop`, deleted), the probe supplied the success case that `isDeletionReachable` had only ever assumed.

## The report changes claim, it does not drop one

The old footer said the clean report was "not a proven guarantee", pointing at a note explaining the premise had never been observed. That reads as doubt about whether the rule works at all — which is now answered.

The new footer says the rule is **known to hold** against the admin-privileged path, and that this is still configuration rather than a proof of **sufficiency**. Those are different claims and the second one still stands: one branch, one ruleset, one merge, on a repo nobody else touches. `delete_branch_on_merge: false` remains the primary protection precisely because it assumes nothing about rulesets, and the guard asserts both.

## Verification

The test moved with the wording and **gained** an assertion rather than being loosened — it now pins both halves: the verified claim present (`not a proof of sufficiency`), the over-claim absent (`deletion is unreachable`, `deletion is impossible`). Canaried per the discipline in #2021: reverting the footer fails it, so the assertion is measuring something.

`pnpm test` 26/26 tasks, `pnpm quality` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
