### PR TITLE
docs(rules): a comment that asserts behavior is a claim

### DIFF
--- a/.claude/rules/02-code-standards.md
+++ b/.claude/rules/02-code-standards.md
@@ -59,6 +59,42 @@ This applies to all comment shapes: full-line `//`, JSDoc `*` body, block `/* */
 
 **Enforcement**: `.husky/pre-commit` scans newly-added comment lines in `*.ts`/`*.tsx`/`*.js`/`*.jsx` for date stamps, PR refs, and round/review markers. Override with `TZUROT_SKIP_TEMPORAL_CHECK=1` for the rare intentional case (post-mortem references where the date is the point).
 
+## A Comment That Asserts Behavior Is a Claim
+
+A comment stating what the code _does_ under some condition — "it never
+bypasses", "this cannot backtrack", "the retry is idempotent" — gets the same
+treatment as a claim in a PR body: **pin it with a test, or say in the comment
+that it is unverified.** This applies to the same comment shapes the section
+above enumerates.
+
+Both failure directions are silent, which is why this is a rule and not care. A
+_wrong_ claim reads as documentation and is trusted — a comment described a
+ReDoS as fixed for a whole PR while the pattern still ran for minutes. A claim
+that is _right but unpinned_ invites the change that breaks it: an exact-case
+escape token, argued at length and tested nowhere, sits one plausible
+"consistency cleanup" away from unlocking a blocking guard.
+
+Trigger: any comment asserting RUNTIME behavior. The certainty words — _never_,
+_always_, _cannot_, _is safe_ — are the usual tell but not the whole set: a bare
+property name claims just as much ("the retry is idempotent"), and so does a
+named mechanism's EFFECT ("the lookahead prevents backtracking"), which asserts
+something with no certainty word in it at all. Naming a mechanism alone does not
+("uses a lookahead to skip whitespace" asserts nothing), and neither does
+design-structure prose ("cannot be extracted", "cannot be collapsed into one") —
+`claim-shape-guard.sh` was narrowed for exactly that reason, because a trigger
+that fires on structure trains readers to skim past the real ones. Name the
+test, or hedge in the comment itself (`// not verified: assumes the caller
+already acked`) — an honest hedge invites the correction that a confident wrong
+claim deters.
+
+Scope: in CODE files the VALUE half is already caught mechanically by
+`claim-shape-guard.sh` (`never null`, `always populated`, `cannot be <value>`) —
+it skips `*.md` and the `.claude/` tree entirely, so a value claim in prose is
+this rule's too. Otherwise this rule is the judgment half — behavioral,
+algorithmic, security. `00-critical.md`
+§ "Code-reading is not runtime verification" holds the same standard for a claim
+made in conversation; a comment differs by persisting.
+
 ## TypeScript Strict Rules
 
 - TypeScript `strict: true`, no `any` types


### PR DESCRIPTION
**36 lines** added to `.claude/rules/02-code-standards.md`, beside the existing comment rules. Budget after: **2127/2218 lines, 166278/174450 bytes** — both figures from `git diff develop --numstat` and `lines:check` against the pushed commit, not from reading.

> The body said 17 for two rounds while the diff was 30, then 24 after the trim. That is the **fourth** count I have gotten wrong in this session's PRs, shipped in the description of the PR arguing that unverified claims get trusted. The number now comes from a command, and the section below records why the pattern deserves more than an apology.

## Three sightings, one class

Each is a comment asserting a behavioral property that nothing verified, and **each was caught by a reviewer rather than by me**:

| the comment claimed | what was true |
|---|---|
| a ReDoS was fixed | it wasn't — the proof measured an input shape that could not reach the ambiguity |
| a regex lookahead was load-bearing | inert at every scale from 60 to 1000 flags, in both directions |
| an exact-case escape token "BLOCKS, never bypasses" | true, and pinned by nothing — in a change whose stated bar was that every claim gets canaried |

## Why a rule and not care

Both failure directions are silent, and they fail differently:

- A **wrong** claim reads as documentation and gets trusted. The ReDoS comment sat in a merged PR describing a fix that did not work, and the next reader had no reason to doubt it.
- A **right but unpinned** claim invites the change that breaks it. The escape token is exact-case on purpose (bash env var names are case-sensitive), and that asymmetry looks like an oversight — it sat one plausible "consistency cleanup" away from letting `tzurot_allow_...=1` unlock a blocking guard. The cleanup would have looked like an improvement in review.

Neither is caught by trying harder, because in both cases the author believed the sentence while typing it. What catches them is a test named next to the claim, or an honest hedge.

## Why it isn't covered already

The two neighbouring rules cover adjacent halves and stop short of this one:

- **`10-working-posture` § claim-time trigger** governs what you say to the *user* — read the file whole, derive a count from the whole result set. It says nothing about a sentence in a comment.
- **`/tzurot-bug-remediation` § canary the existing tests** governs whether a *test* measures anything. It presumes a test exists; the failure here is a claim with no test at all.

## Scope

Rule-only for the half it covers — and **round 1 corrected my framing here**, which claimed flatly that "there is no mechanical form." There is a narrower one, already in this repo: `claim-shape-guard.sh` fires on `never null` / `always populated` / `cannot be <value>`. That it exists and I did not mention it is this PR's own class, committed in this PR's own body.

The split is now stated in the rule and it is **empirical, not asserted** — run the rule's two example comments through the guard's vocabulary and neither matches, while `this value is never null here` does. The guard owns value/field claims; this rule owns the behavioral, algorithmic, and security ones it structurally cannot reach. `00-critical.md` § code-reading is not runtime verification is also now cross-referenced: it holds the same standard for a claim made in conversation, and the reason this is separate is persistence — a comment outlives the exchange and is read as settled by people who were not there.

The residual judgment is real: whether a comment asserts behavior is a judgment (`// bump the counter` doesn't, `// this can never be null` does), and whether a named test actually holds the claim up needs the canary's result, which exists only after running it. The trigger words (*never*, *always*, *cannot*, *is safe*) are the attention hook, deliberately not a grep — a lint rule on those tokens would fire constantly on prose that makes no claim at all.

Sizing was checked against `07-documentation.md`'s "constraint plus at most a one-sentence why": the two examples are one clause each and carry the two distinct failure directions, which is the part that would not survive compression without losing the reason the rule exists.

## Round 2 — the Scope paragraph had become the thing it warns about

Round 1 asked for cross-references and I wrote a paragraph of derivation instead of the one-clause pointer that was requested. Round 2 correctly measured it against `07-documentation.md` — *"a rule states the constraint plus at most a one-sentence why; council-derivation notes don't belong in always-loaded surfaces"* — and against the budget, where `.claude/rules` had ~97 lines of headroom left.

It is now two clauses: `claim-shape-guard.sh` owns the value half, this rule owns the judgment half, and `00-critical.md` § code-reading-is-not-runtime-verification holds the same standard for conversation. The reasoning behind the split stays here in the PR body, which is where it belongs and where it already was.

Also fixed: **"those two example comments above" was ambiguous** — by that point the section had three quoted examples plus two narrative ones, so "two" picked out nothing. The reviewer verified the underlying claim anyway (neither `never bypasses` nor `cannot backtrack` matches the guard's vocabulary; `never null` does), which is generous, but a rule whose thesis is *make the claim checkable* should not need a reader to guess which claim. The self-check sentence is gone; the split is now stated flatly and is verifiable against the guard's source in one grep.

And the rule now states its comment shapes, matching the sibling Temporal Markers section directly above it rather than leaving it implicit.

## Round 3 — one taken, one dismissed with evidence

**Taken:** the mechanical half is narrower than I wrote. `claim-shape-guard.sh` skips `*.md` and the whole `.claude/` tree, so "already caught mechanically" was true only for code files — a reader could reasonably have assumed a value claim in prose was covered. Now scoped explicitly, with the consequence stated: a value claim in prose is this rule's too.

**Dismissed:** that `§` should name a real heading, since the `00-critical.md` target is a bold lead sentence rather than a `###`. The corpus already does exactly this — `10-working-posture.md:80` writes ``§ "An empty or sparse tool result"``, pointing at a bold lead in the same file. My usage matches existing practice, so the asserted convention isn't one. (Checked before dismissing; if the corpus had been consistent the other way I'd have changed it.)

## Round 4 — the trigger reintroduced a false-positive class its sibling already paid to remove

The substantive finding: `claim-shape-guard.sh`'s own commentary documents that bare `cannot`/`always` fire heavily on **design-structure** prose — "cannot be extracted", "cannot be collapsed into one" — which asserts nothing about what executes. That guard was deliberately narrowed for exactly that reason, and its comments say why: a trigger that fires on ordinary structural prose trains readers to skim past the real hits.

My trigger list reintroduced the bare tokens with no such caveat, in the same file, one section below a rule that cites that guard. It now scopes to RUNTIME behavior and names the excluded class explicitly.

Also taken: the `00-critical.md` citation ran its section title straight into the sentence's predicate (`§ code-reading is not runtime verification holds the same standard`), which parses as two competing claims on first read — now quoted, matching the corpus precedent this PR's own body cited a round earlier. And the rule now shows one concrete hedge form (`// not verified: assumes the caller already acked`), since "hedge" was otherwise left to taste; the reviewer asked for a ❌/✅ table like the neighbouring sections, which I did not add — the section has been trimmed once already under budget pressure, and one inline example buys most of the clarity for none of the lines.

Grew 26 → 31 lines. That is the right direction for this particular change: every added line removes an ambiguity a reviewer actually tripped on.

## Round 5 — the trigger list contained the failure it warns about, two sentences later

"or a named mechanism" was a category mismatch. The other four triggers are certainty words — the lexical tell that a claim is being made. Naming a mechanism is not one: `// uses a regex lookahead to skip whitespace` names a mechanism and asserts nothing. Read literally, that clause over-fires on ordinary descriptive comments, which is the exact false-positive class round 4 added a caveat about.

What I meant was the *effect* claim — the lookahead sighting from this PR's own evidence, where the assertion is implicit in saying the mechanism DOES something. Now stated that way, with both sides shown so the boundary is checkable rather than inferred:

> or asserting a named mechanism's EFFECT ("the lookahead prevents backtracking"), which is a claim even with no certainty word in it. Naming a mechanism is not ("uses a lookahead to skip whitespace" asserts nothing).

Five rounds, and each one found the rule failing its own standard in a different place: an unpinned mechanical claim, a derivation paragraph in an always-loaded surface, an ambiguous referent, a trigger that reintroduced a narrowing its sibling had already paid for, and now a trigger term that wasn't a trigger. That is a reasonable argument that the rule is worth having.

## Round 6 — two sentence fragments, shipped by patching a paragraph instead of rereading it

Round 5's fix inserted a clause and left behind `Naming a mechanism is not (...)` — no predicate — and `All of it about RUNTIME behavior.` — no verb. Both in an always-loaded rules file. I wrote them and did not read the paragraph back, which is how a run-on Trigger paragraph accumulated across three separate patch-in edits.

Rewritten as a whole rather than patched again, and this time read back sentence by sentence with each one checked for a predicate before pushing.

The third finding is the substantive one and the same class as round 5's: the section's own opening example, **"the retry is idempotent"**, matched none of the trigger vocabulary it later lists. A reader following the Trigger paragraph would not have flagged the rule's own example. The caveat that the words are an attention hook and not an exhaustive grep existed — in the PR body, which a future session reading `02-code-standards.md` never sees. Now in the rule: the certainty words are "the usual tell but not the whole set", with a bare property name named explicitly as claiming just as much.

That is three rounds running where this section failed its own standard by asserting something its reader could not check from the text alone. The rule is being written by exactly the process it describes.

## Round 7 — my round-6 verification had a blind spot, and I reported it as complete

Round 6 fixed two fragments and I said I had read the section back "sentence by sentence with each one checked for a predicate." Round 7 found a third fragment — "Same comment shapes as the section above." — that had been there the whole time.

The claim was not a lie but it was overstated, and the mechanism is worth naming: my splitter broke on `". "`, so that sentence got merged into the preceding paragraph line and was never isolated. The check could not see it, and I reported the check's output as if it covered the section. That is the same shape as everything else this PR is about — a verification whose blind spot is invisible from inside it.

Re-verified this round with a splitter that does not merge across the bold marker. It flagged one further candidate, `Trigger: any comment asserting RUNTIME behavior.`, which I checked against the corpus rather than "fixing": `10-working-posture.md:134` uses exactly that labelled-noun-phrase construction. The checker over-flagged; no change made.

**This is the last edit.** The bar I set at round 7 was "would this be wrong in the merged file", and a verb-less sentence in an always-loaded rule meets it. Nothing else raised does — the remaining item is explicitly informational, matches existing precedent in this same file, and the reviewer said so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
