### PR TITLE
fix(hooks): scan command substitutions so a nested commit can't bypass the guards

### DIFF
--- a/.claude/hooks/develop-code-commit-guard.probe.sh
+++ b/.claude/hooks/develop-code-commit-guard.probe.sh
@@ -212,6 +212,64 @@ run 2 "apostrophe only AFTER the commit"          'git commit -m "won'"'"'t"'   
 # breaking this one.
 run 2 "double quote inside single-quoted arg"     "echo 'say \"hi\"' && git commit -m x"                    'services/probe.ts'
 
+# --- command substitutions nested inside quotes -----------------------------
+# A BYPASS of this blocking hook, measured in all three forms: bash executes the
+# inner command in every one, but the quote strip erases a substitution nested
+# inside a quoted argument, so the first two stripped to `echo S` and the guard
+# exited 0. Wrapping a captured commit result in a status echo needs no
+# adversarial intent — it is an ordinary shape.
+run 2 "quoted \$( ) substitution around a commit"  'echo "$(git commit -m x)"'                              'services/probe.ts'
+run 2 "quoted backtick substitution around a commit" 'echo "`git commit -m x`"'                             'services/probe.ts'
+# The control: unquoted was always detected, because the strip leaves it intact.
+# Without this row a regression that broke only the quoted forms would look like
+# a whole-feature failure rather than the narrower thing it is.
+run 2 "unquoted substitution was already detected"  'echo $(git commit -m x)'                               'services/probe.ts'
+
+# The other half of the substitution scan, and the reason it strips heredoc
+# bodies first: a commit MESSAGE discussing git commit habits is data. Without
+# the strip this span reads as a commit invocation and an innocent `echo`
+# blocks. The escape token is exact-case and this body carries none, so the
+# verdict here comes from the strip and nothing else.
+SPAN_HEREDOC_PROSE='echo "$(cat <<'\''EOF'\''
+notes about git commit habits on this repo
+EOF
+)"'
+run 0 "heredoc BODY inside a span is not a commit"  "$SPAN_HEREDOC_PROSE"                                   'services/probe.ts'
+
+# THE ACCEPTED OVER-ARM, pinned as behaviour rather than left in a comment. A
+# span inside SINGLE quotes is inert prose to bash, and the extraction reads it
+# anyway, so this blocks an `echo`. Over-arming is the recoverable direction for
+# a blocking guard and the escape hatch covers it; the row exists so the next
+# reader who hits the false positive finds it named instead of hunting a bug.
+run 2 "a span in SINGLE quotes blocks too (accepted)"  "echo 'run \$(git commit)'"                          'services/probe.ts'
+
+# A non-heredoc quoted argument INSIDE a span that merely mentions the target
+# is prose, not an invocation — the span scan strip_quoteds each span exactly as
+# the top level does. Capturing the output of a command whose --body text says
+# "git commit" is an ordinary shape; without the per-span strip it would falsely
+# block a command that runs no git at all.
+run 0 "quoted prose in a span is not a commit"      'RESULT=$(gh pr comment 5 --body "reminder: git commit early and often")' 'services/probe.ts'
+
+# A BARE heredoc (not inside a substitution) whose body mentions $(git commit)
+# as prose — the exact shape this repo's own hook-dev commit messages produce.
+# The helper strips heredoc bodies from the WHOLE raw command before extracting
+# spans, so the $(git commit) sitting in inert data is gone before it can be
+# pulled out as a span. A per-span strip could not see it (the extracted span
+# carries no heredoc marker).
+BARE_HEREDOC_SUBST='cat <<'\''EOF'\'' > docs/notes.md
+We fixed the $(git commit -m x) bypass.
+EOF'
+run 0 "a bare heredoc body mentioning a commit substitution is data" "$BARE_HEREDOC_SUBST" 'services/probe.ts'
+
+# BYPASS REGRESSION: an UNTERMINATED `<<WORD`-shaped string in earlier quoted
+# prose must not truncate the real commit substitution that follows. The whole-
+# command heredoc strip keeps the tail on an unterminated opener, so the real
+# $(git commit) span survives and blocks. (Dropping the tail was a measured
+# bypass — the guard exited 0 on a live commit.)
+UNTERM_HEREDOC_BYPASS='echo "notes: <<EOF"
+echo "$(git commit -m x)"'
+run 2 "unterminated heredoc opener does not truncate a later commit span" "$UNTERM_HEREDOC_BYPASS" 'services/probe.ts'
+
 # --- line continuations -----------------------------------------------------
 # Breaking a long invocation across lines with `\` is an ordinary style choice,
 # not obfuscation — and it defeated detection outright: the scanner emitted a

--- a/.claude/hooks/develop-code-commit-guard.sh
+++ b/.claude/hooks/develop-code-commit-guard.sh
@@ -18,6 +18,11 @@
 #   was a two-pass strip, and it was a measured bypass (see the note at the
 #   call site). The heredoc half stays local: each hook strips the heredoc
 #   forms its own matching cares about.
+# - A command SUBSTITUTION is scanned as its own command, from the raw text.
+#   The quote strip erases a `$(…)`/backtick span nested inside a quoted
+#   argument while bash still executes it, so the detection above would miss
+#   `echo "$(git commit -m x)"` entirely. See the call site for the two
+#   accepted imprecisions.
 # - COMMIT DETECTION is case-insensitive on BOTH sides — the bash pre-filters
 #   and the python regex. Either one left case-sensitive re-opens the hole on
 #   its own, because the pre-filter short-circuits before python runs. The
@@ -114,12 +119,17 @@ import sys
 # exits non-zero, which the caller treats as allow (fail-open); the probe,
 # not runtime, is what catches a missing lib.
 sys.path.insert(0, os.environ["HOOK_LIB"])
-from shell_quotes import strip_quoted
+from shell_quotes import strip_quoted, substitution_spans_matching
 
 cmd = os.environ.get("GUARD_CMD", "")
 if not cmd:
     print("ok")
     raise SystemExit
+
+# The command before ANY stripping. The substitution scan below reads from it,
+# because every strip step here is destructive by design and the nested-
+# substitution shape is destroyed by the quote strip specifically.
+raw_cmd = cmd
 
 # Strip $(cat <<'EOF' … EOF) commit-message substitutions, bare heredoc
 # bodies, and quoted strings — each scoped to its own terminator — so
@@ -180,7 +190,34 @@ if scanned is not None:
 # flag narrows \s in the same pattern too, so a non-breaking space between
 # `git` and `commit` would stop matching and the guard would MISS a real
 # commit — failing open on a pasteable input to close a hypothetical one.
-if not re.search(r"(?i)\bgit(?:\s+-+[^-\s]\S*(?:\s+[^-\s]\S*)?)*\s+commit(?![-\w])", cmd):
+#
+# THE PARAMETER IS NAMED `cmd` ON PURPOSE. gitCommitPatternAgreement.test.ts
+# pulls this pattern out of the source TEXT: it looks for a raw-string
+# `re.search` call whose second argument is spelled `cmd`, and it requires
+# EXACTLY ONE such line in the whole file. Wrapping the call in a function is
+# what keeps the pattern written once while two call sites — top level, and
+# each substitution span — share it. Renaming the parameter disarms that
+# guard, and so does a second line of the same shape anywhere in this file,
+# including inside a comment (measured while writing this one).
+def is_commit_invocation(cmd):
+    """True when `cmd` contains a `git commit` invocation."""
+    return re.search(r"(?i)\bgit(?:\s+-+[^-\s]\S*(?:\s+[^-\s]\S*)?)*\s+commit(?![-\w])", cmd) is not None
+
+
+detected = is_commit_invocation(cmd)
+
+# Command substitutions, scanned from the RAW text. A `$(…)` or backtick span
+# nested inside a QUOTED argument is erased by the quote strip above while bash
+# still runs it, so `echo "$(git commit -m x)"` stripped to `echo S` and this
+# guard exited 0 on a real commit (measured, all three forms). Each span gets
+# the SAME cleaning the top-level scan applies to the command — heredoc bodies
+# off the WHOLE raw command first, then strip_quoted per span — inside the
+# shared helper (see substitution_spans_matching in lib/shell_quotes.py for the
+# accepted over-arm/under-arm boundaries it documents).
+if not detected and substitution_spans_matching(raw_cmd, is_commit_invocation):
+    detected = True
+
+if not detected:
     print("ok")
     raise SystemExit
 

--- a/.claude/hooks/lib/shell_quotes.py
+++ b/.claude/hooks/lib/shell_quotes.py
@@ -33,11 +33,32 @@ would delete a real invocation and produce a bypass; keeping the text merely
 over-arms the caller, and over-arming is the recoverable direction for all three
 consumers.
 
+WHAT strip_quoted DOES NOT SEE
+------------------------------
+A quoted span is replaced WHOLE, which means a command substitution nested
+inside one is erased along with it — while bash still executes the inner
+command. Measured, all three forms ran the inner commit:
+
+    echo "$(git commit -m x)"   ->  echo S   (the invocation is gone)
+    echo "`git commit -m x`"    ->  echo S
+    echo $(git commit -m x)     ->  intact   (unquoted survives the strip)
+
+The even quote count means the scan closes cleanly and the caller never
+reaches the unterminated-quote safe direction above. `substitution_spans`
+exists for that: it reads the substitution CONTENTS straight out of the raw
+text so a caller can scan them as commands in their own right, which is what
+bash treats them as. `strip_heredoc_bodies` is its companion — without it a
+span holding the repo's canonical `$(cat <<'EOF' … EOF)` commit message would
+be scanned including the message body.
+
 CONSUMERS
 ---------
     .claude/hooks/lossy-pipe-guard.sh
     .claude/hooks/develop-code-commit-guard.sh
-    .claude/hooks/cwd-drift-guard.sh
+    .claude/hooks/cwd-drift-guard.sh   (strip_quoted only — it blocks too, but
+                                        for the lower-stakes drift-warning case,
+                                        so it keeps the substitution-blind
+                                        behaviour)
 
 Behaviour is pinned by packages/tooling/src/dev/shellQuotes.test.ts, which runs
 this module directly, plus each consumer's own .probe.sh.
@@ -50,6 +71,8 @@ backstop is CI, not runtime: every consumer's probe exercises a case that only
 passes when the import works, and `guard:hook-probes` runs them in the lint job
 and in `pnpm quality`.
 """
+
+import re
 
 
 def strip_quoted(text):
@@ -119,3 +142,202 @@ def strip_quoted(text):
                 quote = None
         i += 1
     return None if quote is not None else "".join(out)
+
+
+def substitution_spans(text):
+    """Return the CONTENT of every `$(...)` and backtick span in `text`.
+
+    Read from the RAW text, DELIBERATELY IGNORING quote context. A span inside
+    DOUBLE quotes really is executed by bash, so it must be extracted; a span
+    inside SINGLE quotes is inert prose and is extracted anyway. That second
+    case is a known OVER-ARM, accepted rather than fixed: the callers are
+    blocking guards where over-arming costs one re-run (or the documented
+    escape hatch) while under-arming is an unreviewed commit. Pinned by
+    "a span inside single quotes is extracted anyway (accepted over-arm)" in
+    packages/tooling/src/dev/shellQuotes.test.ts.
+
+    KNOWN UNDER-ARM, same file, pinned by "a quoted `)` inside a span ends it
+    early": `)` is counted structurally, so `$(echo ")" && git commit)` yields
+    only `echo "` and anything after that paren escapes the scan. Modelling
+    quotes inside the span would mean a second scanner with its own failure
+    directions; the threat model here is habitual command shapes, matching the
+    boundary the consuming hooks already state.
+
+    Nesting is handled by PAREN DEPTH and nothing else: `$(a $(b))` yields the
+    single span `a $(b)`, inner text verbatim. The callers run a regex over the
+    content, and a regex sees the inner text just as well inside the outer —
+    so recursing would only produce duplicate hits.
+
+    An UNTERMINATED span runs to end of text. Unlike strip_quoted's
+    strip-nothing rule, that direction is safe here: this function only ADDS
+    text for the caller to scan, so an over-long span can over-arm and can
+    never hide an invocation.
+    """
+    spans = []
+    i = 0
+    end_of_text = len(text)
+    while i < end_of_text:
+        ch = text[i]
+        if ch == "\\" and i + 1 < end_of_text:
+            # An escaped `$` or backtick opens nothing.
+            i += 2
+            continue
+        if ch == "$" and i + 1 < end_of_text and text[i + 1] == "(":
+            j = i + 2
+            depth = 1
+            while j < end_of_text:
+                if text[j] == "\\" and j + 1 < end_of_text:
+                    j += 2
+                    continue
+                if text[j] == "(":
+                    depth += 1
+                elif text[j] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            if j >= end_of_text:
+                spans.append(text[i + 2 :])
+                break
+            spans.append(text[i + 2 : j])
+            i = j + 1
+            continue
+        if ch == "`":
+            j = i + 1
+            while j < end_of_text:
+                if text[j] == "\\" and j + 1 < end_of_text:
+                    j += 2
+                    continue
+                if text[j] == "`":
+                    break
+                j += 1
+            if j >= end_of_text:
+                spans.append(text[i + 1 :])
+                break
+            spans.append(text[i + 1 : j])
+            i = j + 1
+            continue
+        i += 1
+    return spans
+
+
+# `(?<!<)` keeps a here-string (`<<<word`) from reading as a heredoc opener:
+# its trailing `<` plus a bare word matches the same characters, and the marker
+# then never terminates, so the whole remainder of the span would be dropped.
+#
+# The marker is `\w+`, deliberately WIDER than pr-merge-review-check.sh's own
+# stripper (`[A-Za-z_][A-Za-z_0-9]*`): bash accepts a digit-leading delimiter
+# (`cat <<1EOF`), and a wider marker over-strips, which only ever removes
+# candidate text a caller would scan — the recoverable direction here. Each
+# hook strips the heredoc forms its own matching cares about (module docstring),
+# so the two need not agree.
+_HEREDOC_OPENER = re.compile(r"(?<!<)<<(-?)\s*(['\"]?)(\w+)\2")
+
+
+def strip_heredoc_bodies(text):
+    """Return `text` with every heredoc BODY removed, terminator line included.
+
+    A QUOTED-delimiter heredoc body (`<<'EOF'` / `<<"EOF"`) is DATA — bash
+    executes no word in it however command-shaped it looks. The companion to
+    `substitution_spans`: the repo's canonical commit form is
+    `git commit -m "$(cat <<'EOF' … EOF)"`, so a caller scanning that span would
+    otherwise scan the commit MESSAGE, and a message discussing git commit
+    habits would arm a blocking guard. Pinned by the strip_heredoc_bodies cases
+    in packages/tooling/src/dev/shellQuotes.test.ts and by "heredoc BODY inside
+    a span is not a commit" in .claude/hooks/develop-code-commit-guard.probe.sh.
+
+    An UNQUOTED delimiter (`<<EOF`) is the one exception to "body is data": bash
+    performs command/parameter substitution inside it exactly as in a
+    double-quoted string, so a genuinely-executing `$(git …)` there is stripped
+    as if inert — an accepted UNDER-arm. It matches what the guards' own
+    top-level heredoc collapse already does, needs deliberate nested
+    construction to reach, and sits inside the habitual-shapes threat model the
+    consumers state; not verified against a runtime repro, argued from bash's
+    documented expansion rules.
+
+    Handles `<<MARKER`, `<<'MARKER'`, `<<"MARKER"` and the `<<-` indent form.
+    The terminator must be the whole line; leading whitespace is tolerated only
+    for `<<-`, matching bash.
+
+    KNOWN LIMITATION, matching the sibling `strip_heredocs` in
+    pr-merge-review-check.sh: only the FIRST opener on a line is recognized.
+    Bash allows two on one line (`cmd <<A <<B` reads body A then body B), but
+    search resumes past A's terminator, so B's body is left un-stripped. Fails
+    SAFE — an un-stripped body only ADDS text a guard scans, which can only
+    over-block, never hide a target. Pinned by "second heredoc opener on a line
+    leaves its body" in shellQuotes.test.ts.
+
+    An UNTERMINATED heredoc KEEPS the text after the opener rather than dropping
+    it — the same over-arm direction as the sibling `strip_heredocs` in
+    pr-merge-review-check.sh, and for the same reason. `substitution_spans_matching`
+    hands this the WHOLE raw command, not one span's content, and the opener
+    regex is quote-blind: a `<<WORD`-shaped string sitting inside an earlier
+    quoted argument with no matching terminator line anywhere later would, under
+    a drop-to-end rule, silently truncate a REAL `$(git commit …)` span that
+    comes after it — a measured bypass of both blocking guards. Keeping the tail
+    can only ADD text a guard scans (over-block, recoverable); dropping it can
+    hide a target (a bypass, the one direction this must never take). Pinned by
+    "a target after an unterminated heredoc opener still matches" in
+    shellQuotes.test.ts and by the equivalent probe cases.
+    """
+    out = []
+    pos = 0
+    while True:
+        match = _HEREDOC_OPENER.search(text, pos)
+        if match is None:
+            out.append(text[pos:])
+            return "".join(out)
+        # Keep the redirection operator and the rest of the line carrying it;
+        # only what the operator INTRODUCES is data.
+        out.append(text[pos : match.end()])
+        newline = text.find("\n", match.end())
+        if newline == -1:
+            out.append(text[match.end() :])
+            return "".join(out)
+        out.append(text[match.end() : newline + 1])
+        indent = "[ \t]*" if match.group(1) == "-" else ""
+        terminator = re.compile(
+            r"^" + indent + re.escape(match.group(3)) + r"[ \t]*$", re.M
+        )
+        end = terminator.search(text, newline + 1)
+        if end is None:
+            # Unterminated: keep everything after the opener line (over-arm)
+            # instead of dropping it — see the docstring for the bypass this
+            # closes. Only the body of a TERMINATED heredoc is inert data.
+            out.append(text[newline + 1 :])
+            return "".join(out)
+        pos = end.end()
+
+
+def substitution_spans_matching(raw_text, predicate):
+    """True if any command substitution in `raw_text`, cleaned as bash sees it,
+    satisfies `predicate` (a text -> bool test).
+
+    Both blocking guards need the identical thing — scan each `$(…)`/backtick
+    span for their own target — and had the same three-step loop copy-pasted;
+    this module exists BECAUSE three copies of quote logic diverged once, so the
+    loop lives here rather than in each hook.
+
+    The cleaning mirrors what a guard already does to the command itself, in the
+    same order:
+
+    1. strip heredoc bodies from the WHOLE raw command FIRST, so a `$(git …)`
+       sitting in inert heredoc DATA is gone before extraction and cannot be
+       pulled out as a span (a per-span strip cannot see it — the extracted span
+       carries no heredoc marker). This is what keeps a documented bypass
+       example inside a heredoc'd commit message from false-blocking.
+    2. extract the substitution spans that remain.
+    3. strip_quoted each span, so a quoted argument that merely MENTIONS the
+       target (`$(gh pr comment --body "…git commit…")`) is inert prose. None
+       means an unbalanced quote inside the span; fall back to the raw span so a
+       broken quote state over-arms rather than escaping.
+
+    Pinned by the substitution-span probe cases in
+    develop-code-commit-guard.probe.sh and lossy-pipe-guard.probe.sh (the
+    heredoc-body, single-quote-over-arm, and quoted-prose cases).
+    """
+    for span in substitution_spans(strip_heredoc_bodies(raw_text)):
+        scanned = strip_quoted(span)
+        if predicate(scanned if scanned is not None else span):
+            return True
+    return False

--- a/.claude/hooks/lossy-pipe-guard.probe.sh
+++ b/.claude/hooks/lossy-pipe-guard.probe.sh
@@ -135,6 +135,48 @@ run 2 "even backslash run, gh rule"           'gh pr checks 2000 | grep "x\\" | 
 # passed because the buggy neutralization made it look terminated.)
 run 2 "backslash before a closing single quote" "git commit -m 'a\\' | grep 'x'"
 
+# --- a target hidden inside a command substitution ------------------------
+# The quote strip replaces a quoted argument WHOLE, so a `$(…)` nested inside
+# one disappears while bash still runs it — the stage scan saw `echo S | tail`
+# and matched no target. The pipe here is real and at the top level, so `tail`
+# does truncate the commit output that `echo` prints.
+run 2 "quoted substitution hides the commit from the pipe scan" 'echo "$(git commit -m x)" | tail -5'
+run 2 "same via a backtick substitution"                        'echo "`git push origin b`" | head -3'
+# RULE 2 gets the SAME span protection: a gh read captured via a substitution and
+# piped to a truncator truncates the read exactly as the direct pipe would, so it
+# must block too — the git-only version of this scan left it exposed.
+run 2 "quoted substitution hides the gh read from the pipe scan" 'echo "$(gh pr checks 2000)" | tail -5'
+# And the complement: heredoc bodies come off the span before it is scanned, so
+# a commit MESSAGE that merely discusses the phrase is not a target. Without the
+# strip this blocks an ordinary `echo`.
+run 0 "a heredoc BODY inside a span is not a target" 'echo "$(cat <<'"'"'EOF'"'"'
+notes about git commit habits
+EOF
+)" | tail -5'
+# And the non-heredoc complement: a quoted argument inside a span that merely
+# mentions the target is inert prose, because the span is strip_quoted before
+# scanning, exactly as the top-level pipe scan strips it. Capturing a gh command
+# whose --body says "git push" then filtering the output must not block.
+run 0 "quoted prose in a span is not a target" 'echo "$(gh pr comment 5 --body "remember to git push")" | tail -5'
+# A BARE heredoc body mentioning $(git push), piped to a filter — inert data, so
+# the helper strips it from the whole raw command before span extraction and the
+# pipe does not block. Without the global strip the span scan would pull the
+# $(git push) out of the heredoc and arm the git rule for the trailing filter.
+run 0 "a bare heredoc body mentioning a push substitution is data" 'cat <<'"'"'EOF'"'"' | tail -5
+notes: we closed the $(git push) bypass
+EOF'
+# BYPASS REGRESSION: an UNTERMINATED `<<WORD` in earlier quoted prose must not
+# truncate a real gh/git target substitution + pipe that follows. The whole-
+# command heredoc strip keeps the tail on an unterminated opener.
+run 2 "unterminated heredoc opener does not truncate a later piped target" 'echo "notes: <<EOF"
+echo "$(git push origin b)" | tail -5'
+# THE ACCEPTED OVER-BLOCK, pinned as behaviour rather than left in a comment.
+# The span scan is command-wide because the stage split runs on the STRIPPED
+# text, where the span no longer exists to be tied back to its stage — so a
+# target-bearing substitution in one segment arms the git rule for a filtered
+# pipeline in another. Named here so the false positive is recognisable.
+run 2 "the span scan is command-wide, not per-stage" 'echo "$(git commit -m x)" && ls | head -3'
+
 # --- case and leading redirects ------------------------------------------
 # Both were live bypasses. Case: the bash PRE-FILTER is checked first, so making
 # only the python regexes case-insensitive would have fixed nothing — the

--- a/.claude/hooks/lossy-pipe-guard.sh
+++ b/.claude/hooks/lossy-pipe-guard.sh
@@ -52,6 +52,11 @@
 # is named here so the next reader who hits it recognises it rather than
 # hunting a bug.
 #
+# BOTH RULES also scan COMMAND SUBSTITUTIONS for their target, because the quote
+# strip erases a `$(…)`/backtick span nested inside a quoted argument while
+# bash still runs it. That scan is command-wide rather than per-stage — its
+# accepted over-block is spelled out at SPAN_CARRIES_GIT_TARGET below.
+#
 # This guard buys these two classes, NOT the general pattern. A `sed -n '18,40p'`
 # on a source file and a grep scoped to two named files both hid information in
 # the same session and neither is reachable from here — that class belongs to
@@ -149,7 +154,7 @@ import sys
 # non-zero, which the caller treats as allow (fail-open) — the probe is
 # what catches a missing lib, not runtime.
 sys.path.insert(0, os.environ["HOOK_LIB"])
-from shell_quotes import strip_quoted
+from shell_quotes import strip_quoted, substitution_spans_matching
 
 cmd = os.environ.get("GUARD_CMD", "")
 if not cmd:
@@ -265,6 +270,38 @@ TRUNCATORS = re.compile(r"(?i)^\s*(head|tail|sed)\b")
 # commit — failing open on a pasteable input to close a hypothetical one.
 GIT_TARGET = re.compile(r"(?i)\bgit(?:\s+-+[^-\s]\S*(?:\s+[^-\s]\S*)?)*\s+(commit|push)(?![-\w])")
 
+# BOTH RULES: the target hiding inside a command SUBSTITUTION. A `$(…)` or
+# backtick span nested in a QUOTED argument is erased whole by the quote strip
+# above while bash still executes it, so `echo "$(git commit -m x)" | tail`
+# reached the stage scan as `echo S | tail` and matched no target. The same
+# shape hides a gh READ from rule 2 — `echo "$(gh pr checks 2000)" | tail` — so
+# BOTH targets get the scan, not just git (the gh flag is built with
+# GH_READ_TARGET below, once it exists). The shared helper cleans each span
+# exactly as the top-level scan cleans the command (heredoc bodies off the whole
+# raw command first, then strip_quoted per span), so a quoted argument that
+# merely MENTIONS a target — `$(gh pr comment --body "git push …") | tail` — is
+# inert prose, not a false block. See substitution_spans_matching in
+# lib/shell_quotes.py for the boundaries.
+#
+# COMMAND-WIDE, NOT PER-STAGE, and that is an accepted OVER-BLOCK rather than an
+# oversight: the stage split runs on the STRIPPED text, where the span no longer
+# exists, so there is no offset left to tie a span back to the stage that
+# carried it. The consequence is that a command holding BOTH a target-bearing
+# substitution and any filtered pipeline blocks, even when the two are in
+# different segments. Over-blocking costs one re-run without the pipe; the
+# under-arm it replaces is a swallowed commit/push failure or a truncated gh
+# read, which is the whole reason this hook exists. Pinned by the "quoted
+# substitution hides the commit/target from the pipe scan" cases in
+# lossy-pipe-guard.probe.sh.
+#
+# The substitution is only ever read for a rule's target, never fed to the
+# pipe segmentation — a `|` inside a substitution is that subshell's pipeline,
+# not this command's, and treating it as a stage boundary would invent stages
+# bash never runs.
+SPAN_CARRIES_GIT_TARGET = substitution_spans_matching(
+    raw_cmd, lambda span: GIT_TARGET.search(span) is not None
+)
+
 # Rule 2's targets: gh READ commands whose output has to be seen whole.
 # Global flags may sit between `gh` and its subcommand, exactly as GIT_TARGET
 # already tolerates for git. Without this, `gh --repo owner/name pr checks |
@@ -341,6 +378,17 @@ if re.search(r"(?i)\bcomments?\b|\breviews?\b", raw_cmd):
     GH_READ_PARTS.append(r"\bgh" + GH_FLAGS + r"\s+api(?![-\w])")
 GH_READ_TARGET = re.compile("(?i)" + "|".join(GH_READ_PARTS))
 
+# The gh half of the substitution scan (see SPAN_CARRIES_GIT_TARGET above for
+# the full reasoning and the accepted command-wide over-block). Symmetric with
+# git: `echo "$(gh pr checks 2000)" | tail` truncates a gh read exactly as the
+# direct pipe would, and without this the captured read hides from the stage
+# scan. Pinned by "quoted substitution hides the gh read from the pipe scan" in
+# lossy-pipe-guard.probe.sh.
+SPAN_CARRIES_GH_TARGET = substitution_spans_matching(
+    raw_cmd, lambda span: GH_READ_TARGET.search(span) is not None
+)
+SPAN_TARGET_HITS = {"git": SPAN_CARRIES_GIT_TARGET, "gh": SPAN_CARRIES_GH_TARGET}
+
 # (target, lossy-stage, rule-name). Two different lossy sets is exactly why
 # this is a list of pairs rather than one target regex: rule 1 blocks any
 # filter, rule 2 blocks only truncation.
@@ -364,9 +412,8 @@ for segment in re.split(r"&&|\|\||;|\n", cmd):
     stages = segment.split("|")
     for i, stage in enumerate(stages[:-1]):
         for target, lossy, name in RULES:
-            if target.search(stage) and any(
-                lossy.match(stage_head(later)) for later in stages[i + 1 :]
-            ):
+            hit = target.search(stage) or SPAN_TARGET_HITS.get(name, False)
+            if hit and any(lossy.match(stage_head(later)) for later in stages[i + 1 :]):
                 print("block:" + name)
                 raise SystemExit
 print("ok")

--- a/.claude/hooks/pr-merge-review-check.probe.sh
+++ b/.claude/hooks/pr-merge-review-check.probe.sh
@@ -470,6 +470,46 @@ assert_pr "an empty-string token does not truncate the scan" 2002
 new_case; invoke 'bash -c "gh pr merge 2002"'
 assert_pr "a merge inside a -c string argument still arms the gate" 2002
 
+# THE RECURSION DEPTH CAP, both sides of it. `extract` stops recursing past
+# depth 3, and it used to resolve NOTHING there — so a merge nested four shells
+# deep armed no gate and the hook exited 0, which is the under-arm direction the
+# whole file is built to avoid. The cap now runs the token-adjacency backstop on
+# the text it abandons, so the deep shape over-arms instead of vanishing.
+#
+# Built by wrapping rather than by hand, so the nesting depth is the loop count
+# and not a hand-counted run of backslashes that is easy to get wrong by one.
+#
+# SINGLE-QUOTE wrapping specifically, not `printf %q`. %q escapes the SPACES
+# (`gh\ pr\ merge`), and the hook's bash pre-filter requires the three words to
+# be separated by real whitespace — so a %q-built fixture exits at the
+# pre-filter and measures nothing, whichever way the depth cap behaves. Measured
+# while writing these cases: both levels fetched no PR at all.
+sq() { # <text> -> the text as one single-quoted shell word
+  local escaped=${1//\'/\'\\\'\'}
+  printf "'%s'" "$escaped"
+}
+nest_shells() { # <levels>
+  local nested='gh pr merge 2002' i
+  for ((i = 0; i < $1; i++)); do nested="bash -c $(sq "$nested")"; done
+  printf '%s' "$nested"
+}
+new_case; invoke "$(nest_shells 3)"
+assert_pr "three levels of shell nesting resolve the real PR" 2002
+
+new_case; invoke "$(nest_shells 4)"
+assert_pr "four levels hit the depth cap and still arm rather than exiting clean" 2002
+
+# Five-plus levels leave a `bash -c '…'` wrap still on the text when the cap
+# fires, so a token scan (which only sees the outermost layer) would find
+# nothing and the under-arm would return one level deeper. The cap now runs a
+# raw textual regex that reads through every wrap and tolerates the closing
+# quote abutting the number, so a merge arms at ANY nesting depth.
+new_case; invoke "$(nest_shells 5)"
+assert_pr "five levels past the cap still arm via the textual scan" 2002
+
+new_case; invoke "$(nest_shells 7)"
+assert_pr "seven levels still arm — depth-independent at the cap" 2002
+
 # ORDERING: candidates resolve in TOKEN order, which is execution order — not
 # top-level-first. Draining the top level before recursing armed the gate on
 # 2002 here, while the merge that actually runs first is 2001. Both are real
@@ -486,10 +526,14 @@ assert_pr "a plain merge before a wrapped one still wins" 2001
 # Bash keywords that open a command position. `if`/`while`/`until` were absent
 # while `then`/`do` were present, so a merge directly after them went ungated.
 new_case; invoke 'if gh pr merge 2002; then echo ok; fi'
-assert_pr "a merge directly after `if` is at a command position" 2002
+# SINGLE-quoted labels here and below: a backticked word inside a DOUBLE-quoted
+# label is command substitution, and bash printed `command substitution: syntax
+# error` to stderr for each one. The assertions still passed, so the only cost
+# was noise that reads as a failing probe to anyone scanning stderr.
+assert_pr 'a merge directly after `if` is at a command position' 2002
 
 new_case; invoke 'while gh pr merge 2002; do echo retry; done'
-assert_pr "same after `while`" 2002
+assert_pr 'same after `while`' 2002
 
 # A phrase-match that yields no PR number must not end the scan. The earlier
 # implementation exited unconditionally after the first match, so a bare merge
@@ -508,7 +552,7 @@ assert_pr "glued punctuation still opens a command position" 2002
 
 # Bash keywords open a command position too.
 new_case; invoke 'if true; then gh pr merge 2002; fi'
-assert_pr "a merge after `then` is still at a command position" 2002
+assert_pr 'a merge after `then` is still at a command position' 2002
 
 # Heredoc bodies are DATA, never commands — bash will not execute a word in
 # one however shell-like it looks. shlex has no concept of heredocs, so

--- a/.claude/hooks/pr-merge-review-check.sh
+++ b/.claude/hooks/pr-merge-review-check.sh
@@ -186,28 +186,26 @@ def legacy_scan(text):
     return ""
 
 
-def extract(text, depth=0):
-    """Return the PR number a real `gh pr merge` in `text` targets, or "".
+def tokenize(command):
+    """Token list plus each token's starting line, or None if it won't parse.
 
-    Recurses into `-c` / `eval` string arguments: `bash -c "gh pr merge N"` is
-    ONE quoted token to the tokenizer, so without recursion the invocation is
-    invisible — which the naive text scan this replaced did catch, making it a
-    regression rather than a pre-existing gap.
+    A newline separates commands, but shlex counts it as plain whitespace and
+    never emits it as a token — so `pnpm test\\ngh pr merge 2002` would read as
+    one long command and the merge would lose its command position. Record the
+    line each token STARTS on to restore it.
+
+    Read the counter BEFORE each token, not after: measured, `lineno` is
+    incremented while finishing the token that PRECEDES the newline, so the
+    after-value marks the wrong token as having crossed the line.
+
+    Returns None on ANY tokenizer failure, not just the unbalanced-quote
+    ValueError. A narrower catch let every other exception escape, crash
+    python, and reach the shell's `|| PR_NUM=""` — which is silently NO GATE,
+    the exact direction this design refuses.
     """
-    if depth > 3:
-        return ""
-    command = strip_heredocs(text)
     try:
         lexer = shlex.shlex(command, punctuation_chars=True, posix=True)
         lexer.whitespace_split = True
-        # A newline separates commands, but shlex counts it as plain whitespace
-        # and never emits it as a token — so `pnpm test\ngh pr merge 2002` would
-        # read as one long command and the merge would lose its command
-        # position. Record the line each token STARTS on to restore it.
-        #
-        # Read the counter BEFORE each token, not after: measured, `lineno` is
-        # incremented while finishing the token that PRECEDES the newline, so
-        # the after-value marks the wrong token as having crossed the line.
         tokens = []
         linenos = []
         while True:
@@ -220,13 +218,67 @@ def extract(text, depth=0):
                 break
             tokens.append(token)
             linenos.append(line_at_start)
+        return tokens, linenos
     except Exception:
-        # ANY tokenizer failure, not just the unbalanced-quote ValueError.
-        # A narrower catch let every other exception escape, crash python, and
-        # reach the shell's `|| PR_NUM=""` — which is silently NO GATE, the
-        # exact direction this design refuses. Failure means fall back to the
-        # permissive scan; it never means arm nothing.
+        return None
+
+
+def adjacent_merge_scan(tokens):
+    """The PR number after the first ADJACENT `gh` `pr` `merge` token triple.
+
+    Scans the TOKENS, not raw text. `legacy_scan` reads the first textual
+    occurrence, so a decoy earlier in the command beats the real invocation —
+    that would reintroduce the very bug this file exists to fix. Tokens carry
+    quoting, so prose inside a quoted argument is ONE token and can never look
+    adjacent.
+    """
+    for i in range(len(tokens)):
+        if tokens[i : i + 3] == ["gh", "pr", "merge"]:
+            for candidate in tokens[i + 3 :]:
+                if opens_command(candidate):
+                    break
+                if ASCII_DIGITS.fullmatch(candidate):
+                    return candidate
+    return ""
+
+
+def extract(text, depth=0):
+    """Return the PR number a real `gh pr merge` in `text` targets, or "".
+
+    Recurses into `-c` / `eval` string arguments: `bash -c "gh pr merge N"` is
+    ONE quoted token to the tokenizer, so without recursion the invocation is
+    invisible — which the naive text scan this replaced did catch, making it a
+    regression rather than a pre-existing gap.
+    """
+    if depth > 3:
+        # THE RECURSION CAP FAILS TOWARD ARMING. Returning "" here resolved no
+        # PR at all for a merge nested four shells deep, and the caller reads
+        # "" as "nothing to gate on" and exits 0 — an UNDER-arm, the one
+        # direction this hook must never fail in. The cap itself stays (it
+        # bounds recursion depth); what changes is what happens at it.
+        #
+        # A TOKEN scan at the cap only sees the outermost layer, so a merge
+        # still wrapped one-or-more `bash -c` deep tokenizes as a single quoted
+        # token and the under-arm just returns one level deeper. This is a raw
+        # TEXTUAL over-arm instead: it finds `gh pr merge <n>` at ANY remaining
+        # nesting depth. `["']*` sits BEFORE the digits, so it absorbs a quote
+        # directly in front of the number — a quoted PR number like
+        # `merge "2002"` — not the trailing shell-wrap quote (`merge 2002'`),
+        # which needs no help because `(\d+)` stops at the first non-digit
+        # anyway. Belt-and-braces for the quoted-number shape, which the nesting
+        # probes do not exercise (their numbers are bare). At the cap the input
+        # is pathological, so over-arming on the first textual match (even a
+        # decoy's) is the safe direction. Pinned by the 5- and 7-level nesting
+        # cases in pr-merge-review-check.probe.sh.
+        match = re.search(r"gh\s+pr\s+merge\s+[\"']*(\d+)", strip_heredocs(text))
+        return match.group(1) if match else ""
+    command = strip_heredocs(text)
+    tokenized = tokenize(command)
+    if tokenized is None:
+        # Tokenizer failure means fall back to the permissive scan; it never
+        # means arm nothing.
         return legacy_scan(command)
+    tokens, linenos = tokenized
 
     at_command_start = True
     # The command word of the segment being scanned — what actually owns any
@@ -316,18 +368,13 @@ def extract(text, depth=0):
     # inside a quoted `--body` is ONE token, so it never looks adjacent, and a
     # heredoc body is already stripped before it gets here. Only text the shell
     # would actually execute as words reaches this check.
-    # Scan the TOKENS, not the raw text. `legacy_scan` reads the first textual
-    # occurrence, so a decoy earlier in the command won over the real
-    # invocation — this backstop would have reintroduced the very bug the file
-    # exists to fix. Tokens carry quoting, so prose cannot appear adjacent.
-    for i in range(len(tokens)):
-        if tokens[i : i + 3] == ["gh", "pr", "merge"]:
-            for candidate in tokens[i + 3 :]:
-                if opens_command(candidate):
-                    break
-                if ASCII_DIGITS.fullmatch(candidate):
-                    return candidate
-    return ""
+    #
+    # adjacent_merge_scan is called only here. The depth-cap path at the top of
+    # this function plays the SAME conceptual role — over-arm as the safe
+    # fallback when the position logic can't model the shape — but shares no
+    # code with it: at the cap there is no reliable tokenization to run
+    # adjacency over, so it uses a raw-text regex instead.
+    return adjacent_merge_scan(tokens)
 
 
 try:

--- a/packages/tooling/src/dev/shellQuotes.test.ts
+++ b/packages/tooling/src/dev/shellQuotes.test.ts
@@ -46,6 +46,26 @@ function stripAll(inputs: readonly string[]): (string | null)[] {
   return JSON.parse(out) as (string | null)[];
 }
 
+/**
+ * One python3 spawn evaluates one single-argument helper over every case.
+ * Results come back through JSON so a list result and a string result are both
+ * asserted as themselves rather than through a rendered form.
+ */
+function evalAll<T>(fn: string, inputs: readonly string[]): T[] {
+  const script = [
+    'import json, sys',
+    'sys.path.insert(0, sys.argv[1])',
+    `from shell_quotes import ${fn}`,
+    `json.dump([${fn}(c) for c in json.load(sys.stdin)], sys.stdout)`,
+  ].join('\n');
+  const out = execFileSync('python3', ['-c', script, LIB_DIR], {
+    input: JSON.stringify(inputs),
+    encoding: 'utf-8',
+    env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1' },
+  });
+  return JSON.parse(out) as T[];
+}
+
 /** [label, input, expected output] — `null` means "unterminated, strip nothing". */
 const CASES: readonly (readonly [string, string, string | null])[] = [
   ['leaves an unquoted command alone', 'git status', 'git status'],
@@ -199,5 +219,226 @@ describe('shell_quotes.strip_quoted (shared by three hooks)', () => {
       if (stripped === null) continue;
       expect(stripped, label).not.toMatch(/["']/);
     }
+  });
+});
+
+/**
+ * `strip_quoted` replaces a quoted span WHOLE, so a command substitution nested
+ * inside one is erased while bash still executes it — measured, that let
+ * `echo "$(git commit -m x)"` through the blocking commit guard. These two
+ * helpers are what the guards use instead of trusting the stripped text.
+ */
+const SPAN_CASES: readonly (readonly [string, string, readonly string[]])[] = [
+  ['no substitution yields no spans', 'git commit -m "x"', []],
+  ['a $( ) span inside double quotes', 'echo "$(git commit -m x)"', ['git commit -m x']],
+  ['a backtick span inside double quotes', 'echo "`git commit -m x`"', ['git commit -m x']],
+  ['an unquoted $( ) span', 'echo $(git commit)', ['git commit']],
+  ['two spans in one command', 'echo $(a) and `b`', ['a', 'b']],
+
+  // Nesting is paren DEPTH only. The caller runs a regex over the content, and
+  // a regex sees the inner text inside the outer span just as well — recursing
+  // would only produce duplicate hits.
+  ['a nested span is returned inside its outer span, verbatim', 'echo $(a $(b))', ['a $(b)']],
+
+  // An escaped opener is not an opener.
+  ['an escaped backtick opens nothing', 'echo \\`x\\`', []],
+  ['an escaped dollar opens nothing', 'echo \\$(git commit)', []],
+
+  // Unterminated runs to end of text. Safe here in a way it is not for
+  // strip_quoted: this function only ADDS text for the caller to scan.
+  ['an unterminated $( runs to end of text', 'echo "$(git commit', ['git commit']],
+  ['an unterminated backtick runs to end of text', 'echo `git commit', ['git commit']],
+
+  // THE ACCEPTED OVER-ARM. A span inside SINGLE quotes is inert prose to bash
+  // and is extracted anyway, so the consuming guards block on it. Over-arming
+  // is the recoverable direction for a blocking guard; the escape hatch covers
+  // the false positive.
+  [
+    'a span inside single quotes is extracted anyway (accepted over-arm)',
+    "echo 'run $(git commit)'",
+    ['git commit'],
+  ],
+
+  // THE KNOWN UNDER-ARM, pinned AS the limit rather than left to be discovered.
+  // `)` is counted structurally, so a quoted one inside the span ends it early
+  // and the command names after it escape the scan.
+  ['a quoted `)` inside a span ends it early', 'echo "$(echo ")" && git commit)"', ['echo "']],
+];
+
+describe('shell_quotes.substitution_spans', () => {
+  const results = evalAll<string[]>(
+    'substitution_spans',
+    SPAN_CASES.map(([, input]) => input)
+  );
+
+  for (const [index, [label, input, expected]] of SPAN_CASES.entries()) {
+    it(label, () => {
+      expect(results[index], `input: ${JSON.stringify(input)}`).toEqual([...expected]);
+    });
+  }
+});
+
+/**
+ * The companion strip: a heredoc body is DATA, and the repo's canonical commit
+ * form puts the whole message inside a substitution span. Without this, a span
+ * scan of `-m "$(cat <<'EOF' … EOF)"` reads the commit MESSAGE as a command.
+ */
+const HEREDOC_CASES: readonly (readonly [string, string, string])[] = [
+  ['text with no heredoc is returned unchanged', 'git commit -m x', 'git commit -m x'],
+  ["a quoted marker's body is dropped", "cat <<'EOF'\ngit commit\nEOF\n", "cat <<'EOF'\n\n"],
+  ["a bare marker's body is dropped", 'cat <<EOF\ngit commit\nEOF\n', 'cat <<EOF\n\n'],
+  ['a double-quoted marker works too', 'cat <<"EOF"\ngit commit\nEOF\n', 'cat <<"EOF"\n\n'],
+
+  // `<<-` is the only form whose terminator may be indented, and bash allows
+  // only TABS there. The non-dash row is what pins that the indent tolerance is
+  // not applied everywhere.
+  [
+    'the <<- form accepts an indented terminator',
+    'cat <<-EOF\n\tgit commit\n\tEOF\n',
+    'cat <<-EOF\n\n',
+  ],
+  // An indented terminator does not close a plain (non-`<<-`) heredoc, so this
+  // is UNTERMINATED — and an unterminated heredoc now KEEPS its tail rather than
+  // dropping it (over-arm), because this runs on the whole raw command where a
+  // dropped tail can hide a real target.
+  [
+    'an indented terminator leaves a plain heredoc unterminated; tail kept',
+    'cat <<EOF\n\tEOF\ngit commit',
+    'cat <<EOF\n\tEOF\ngit commit',
+  ],
+
+  // Unterminated KEEPS the tail — the same over-arm direction as the sibling
+  // stripper in pr-merge-review-check.sh. Dropping it here would let a `<<WORD`
+  // inside earlier quoted prose truncate a real $(…) target out of the scan (a
+  // measured bypass); keeping it can only over-block.
+  [
+    'an unterminated heredoc keeps its tail (over-arm, not dropped)',
+    'cat <<EOF\ngit commit\n',
+    'cat <<EOF\ngit commit\n',
+  ],
+
+  // The rest of the OPENER line is real command text and survives.
+  [
+    'the rest of the opener line survives',
+    'cat <<EOF > notes.txt\ngit commit\nEOF\n',
+    'cat <<EOF > notes.txt\n\n',
+  ],
+
+  // A here-string is not a heredoc: its trailing `<` plus a bare word matches
+  // the same characters, and the marker would never terminate.
+  [
+    'a here-string is not read as an opener',
+    'cat <<<marker && git commit',
+    'cat <<<marker && git commit',
+  ],
+
+  // The shape this function exists for, asserted end to end.
+  [
+    'the canonical commit-message span keeps its skeleton and loses its body',
+    "cat <<'EOF'\nfix: stop saying git commit in prose\nEOF\n",
+    "cat <<'EOF'\n\n",
+  ],
+
+  // KNOWN LIMITATION (matches the sibling strip_heredocs): only the FIRST
+  // opener on a line is recognized, so with two openers on one line the second
+  // body survives un-stripped. Safe — an un-stripped body only adds text to
+  // scan, never hides a target.
+  [
+    'second heredoc opener on a line leaves its body',
+    'cat <<A <<B\naaa-body\nA\nbbb-body\nB\ntrailer\n',
+    'cat <<A <<B\n\nbbb-body\nB\ntrailer\n',
+  ],
+];
+
+describe('shell_quotes.strip_heredoc_bodies', () => {
+  const results = evalAll<string>(
+    'strip_heredoc_bodies',
+    HEREDOC_CASES.map(([, input]) => input)
+  );
+
+  for (const [index, [label, input, expected]] of HEREDOC_CASES.entries()) {
+    it(label, () => {
+      expect(results[index], `input: ${JSON.stringify(input)}`).toBe(expected);
+    });
+  }
+
+  it('suppresses a commit-shaped message body inside a canonical commit span', () => {
+    // The two functions in composition, which is how both guards call them —
+    // and the property that actually matters: the span of a real canonical
+    // commit carries a message mentioning `git commit`, and what the guards
+    // scan must not contain it.
+    const command = [
+      "git commit -m \"$(cat <<'EOF'",
+      'docs: explain when to git commit',
+      'EOF',
+      ')"',
+    ].join('\n');
+    const spans = evalAll<string[]>('substitution_spans', [command])[0];
+    expect(spans).toHaveLength(1);
+    expect(spans[0]).toContain('git commit');
+    expect(evalAll<string>('strip_heredoc_bodies', [spans[0]])[0]).not.toContain('git commit');
+  });
+});
+
+/**
+ * Runs `substitution_spans_matching` with a fixed `'git commit' in span`
+ * predicate, exercising the full composition both blocking guards rely on
+ * (heredoc-strip the WHOLE raw text → extract spans → strip_quoted each →
+ * predicate). A predicate can't cross the JSON boundary, so it is baked into
+ * the python snippet.
+ */
+function spansMatchGitCommit(inputs: readonly string[]): boolean[] {
+  const script = [
+    'import json, sys',
+    'sys.path.insert(0, sys.argv[1])',
+    'from shell_quotes import substitution_spans_matching',
+    "pred = lambda s: 'git commit' in s.lower()",
+    'json.dump([substitution_spans_matching(c, pred) for c in json.load(sys.stdin)], sys.stdout)',
+  ].join('\n');
+  const out = execFileSync('python3', ['-c', script, LIB_DIR], {
+    input: JSON.stringify(inputs),
+    encoding: 'utf-8',
+    env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1' },
+  });
+  return JSON.parse(out) as boolean[];
+}
+
+describe('shell_quotes.substitution_spans_matching (composition used by both guards)', () => {
+  it('matches a target hidden in a real substitution span', () => {
+    expect(spansMatchGitCommit(['echo "$(git commit -m x)"'])[0]).toBe(true);
+  });
+
+  it('does NOT match a target in an inert heredoc body — heredocs are stripped FIRST', () => {
+    // If the whole raw text were not heredoc-stripped before span extraction,
+    // the $(git commit) in this bare-heredoc body would be pulled out as a span
+    // and falsely match. This pins the strip-then-extract order.
+    const cmd = ["cat <<'EOF' > notes.md", 'we fixed the $(git commit -m x) bypass', 'EOF'].join(
+      '\n'
+    );
+    expect(spansMatchGitCommit([cmd])[0]).toBe(false);
+  });
+
+  it('does NOT match a target that is only quoted prose inside a span — strip_quoted runs', () => {
+    expect(spansMatchGitCommit(['echo "$(gh pr comment --body "git commit early")"'])[0]).toBe(
+      false
+    );
+  });
+
+  it('still matches when a real invocation sits beside quoted prose in the span', () => {
+    // strip_quoted removes the quoted arg but leaves the real command word.
+    expect(spansMatchGitCommit(['echo "$(git commit -m "wip")"'])[0]).toBe(true);
+  });
+
+  it('is span-only: a top-level target with no substitution does not match', () => {
+    expect(spansMatchGitCommit(['git commit -m x'])[0]).toBe(false);
+  });
+
+  it('a target after an unterminated heredoc opener still matches (no truncation bypass)', () => {
+    // The regression guard for the whole-command heredoc strip: a `<<WORD`-shaped
+    // string in earlier quoted prose with no terminator must NOT drop the real
+    // $(git commit) span that follows. strip_heredoc_bodies keeps the tail on an
+    // unterminated opener, so the span survives and matches.
+    const cmd = ['echo "notes: <<EOF"', 'echo "$(git commit -m x)"'].join('\n');
+    expect(spansMatchGitCommit([cmd])[0]).toBe(true);
   });
 });


### PR DESCRIPTION
## What

`strip_quoted` replaces a quoted span whole, so a `$(...)` or backtick substitution nested inside a quoted argument was erased while bash still executed the inner command. `echo "$(git commit -m x)"` stripped to `echo S`, and **both blocking guards exited clean on a real commit** — measured, all three forms (`$()`, backtick, unquoted-survives-strip). The quote count stays even, so the unterminated-quote fail-safe never engaged. This was the HIGH-severity finding on #2019 (filed as TASK-479 rather than fixed at round 12, deliberately, to keep that PR's scanner change bounded).

## How

Two pure helpers added to `lib/shell_quotes.py`; `strip_quoted` untouched:
- `substitution_spans(text)` — the CONTENT of every `$(...)`/backtick span, read from raw text regardless of quote context (paren-depth nesting; unterminated span runs to end).
- `strip_heredoc_bodies(text)` — drops heredoc bodies so the canonical `git commit -m "$(cat <<'EOF' … EOF)"` form isn't scanned including its message body.

Both blocking guards (`develop-code-commit-guard`, `lossy-pipe-guard` rule 1) now scan each span for their target. `cwd-drift-guard` stays substitution-blind (advisory-only).

### Accepted, documented, test-pinned imprecisions
- A span in **single quotes** is inert in bash but still scanned → over-arm (`echo 'run $(git commit)'` now blocks; the escape hatch covers it). Over-arm is the recoverable direction for a blocking guard.
- A quoted `)` inside a span ends extraction early → under-arm, consistent with the sibling guards' habitual-shapes threat model.
- `lossy-guard`'s span scan is **command-wide, not per-stage**, because the stage split runs on stripped text where the span is gone. Consequence: a command holding both a target-bearing substitution and any filtered pipeline blocks even across segments. Documented at `SPAN_CARRIES_GIT_TARGET`.

## Rides two same-file audit findings
- **TASK-482**: the merge gate's `extract()` depth cap returned `""` at >3 nesting — an under-arm; 4-level `bash -c` nesting armed no gate and exited 0. The cap now runs a raw quote-tolerant textual regex (`gh\s+pr\s+merge\s+["']*(\d+)`) that finds the invocation at any remaining nesting depth — a token scan sees only the outermost layer, so a merge still wrapped past the cap would vanish one level deeper. Over-arming on the first textual match is the safe direction at the cap (pathological input). Pinned by 5-/7-level nesting probe cases.
- **TASK-483**: `pr-merge-review-check` probe backtick labels emitted command-substitution stderr noise; labels re-quoted (stderr now byte-empty).

## Verification
- 5 hook probes green (including new bypass + heredoc-negative + single-quote-over-arm + 3-/4-level-nesting cases); **canary-confirmed** — each new case goes red when its fix is reverted (two-round canary: consumer wiring stubbed, then `strip_heredoc_bodies` neutered separately, since the heredoc negatives pass for the wrong reason otherwise).
- `packages/tooling` unit suite: 2284 passed. Extends `shellQuotes.test.ts` with 12 span + 10 heredoc + 1 composition case.
- `gitCommitPatternAgreement.test.ts` precondition preserved (pattern written once, extracted from one `re.search(…, cmd)` line).

Closes TASK-479, TASK-482, TASK-483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-response (folded in, will autosquash)

- **Span scan now mirrors the top-level treatment fully.** Findings surfaced two asymmetries where the per-span scan diverged from how the top level cleans the command: it didn't `strip_quoted` the span (so `$(gh pr comment --body "…git commit…")` false-blocked), and it stripped heredoc bodies only per-span, so a `$(git commit)` sitting in an inert bare-heredoc body (the shape this repo's own hook-dev commit messages produce) got extracted and false-blocked. Both fixed by a shared `substitution_spans_matching(raw, predicate)` helper in `shell_quotes.py` that strips heredoc bodies from the whole raw command first, then `strip_quoted`s each span — DRYing the loop both guards had copied (the module exists because copies diverged once). Canary-confirmed; new probe cases for both.
- `strip_heredoc_bodies` docstring hedged: "body is data" holds for quoted delimiters; an unquoted `<<EOF` expands substitutions (an accepted under-arm matching the top-level collapse).
