### PR TITLE
fix(tooling): six audit follow-ups — gate hardening, a release gate, and lint

### DIFF
--- a/.claude/rules/06-backlog.md
+++ b/.claude/rules/06-backlog.md
@@ -53,6 +53,8 @@ the task file directly. Either way **read the file back after creating a task
 with a multi-paragraph description** — `pnpm ops backlog` gates on frontmatter
 parsing and cannot see a mangled body.
 
+**Repeated `-l` flags do not accumulate on `task create`** — only the last survives, so `-l area:x -l size:S -l state:ready` files a task labelled `state:ready` alone. Use the comma form: `-l area:x,size:S,state:ready`. (Repeated `-l` on `task list` DOES intersect — measured; the drain query below is fine as written.)
+
 - **A task description carries why, what, and acceptance** — same bar as any backlog entry. `Promote when: <event>` is an optional annotation (see the admission bar).
 - **Labels**: `area:<package-or-domain>` (db, redis, voice, bot-client, …). Label at filing; the digest's per-area counts are the jump-around index.
 - **Size + priority** (set at filing; every existing task carries them): `size:S` (<~1hr, one file) / `size:M` (a PR) / `size:L` (multi-PR or needs design) labels, plus the CLI priority field — `high` (prod-correctness / data-rights adjacent) · `medium` (real improvement, no urgency) · `low` (gated, speculative, or watch items).

--- a/.claude/rules/10-working-posture.md
+++ b/.claude/rules/10-working-posture.md
@@ -93,7 +93,10 @@ total — a subtotal is a well-formed number, so nothing looks off. Neither has 
 tell, so this half triggers at CLAIM time rather than at result time. Before
 stating what a file says or does not say, read it whole or state the window you
 read. Before stating a count, sum, or ranking as complete, derive it from the
-whole result set rather than the part on screen. An exit code read through a
+whole result set rather than the part on screen — and RE-derive it whenever the
+thing it counts changes, not only when first written: a correctly-derived count
+carried through later edits (a rebase, a trim, more cases) is still a
+well-formed number, so nothing flags it. An exit code read through a
 pipeline is the same seam: `PIPESTATUS` is indexed per stage, so `[0]` is the
 FIRST command's status, not the one whose result you want — index the stage you
 mean, or do not pipe.

--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -235,8 +235,9 @@ Cover the full release lifecycle: bump versions before the release PR, draft and
 
 | Command                                                              | Description                                                                                                       |
 | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `pnpm ops release:bump 3.0.0-beta.49`                                | Bump version in all package.json files                                                                            |
-| `pnpm ops release:bump 3.0.0 --dry-run`                              | Preview bump without writing                                                                                      |
+| `pnpm ops release:bump 3.0.0-beta.49`                                | Bump version in all package.json files (refuses when CURRENT.md still declares the previous release)              |
+| `pnpm ops release:bump 3.0.0 --dry-run`                              | Preview bump without writing (the CURRENT.md check still applies)                                                 |
+| `pnpm ops release:bump 3.0.0 --allow-stale-current`                  | Bump anyway when CURRENT.md was deliberately not reset                                                            |
 | `pnpm ops release:draft-notes`                                       | Draft release-notes skeleton from PRs merged since the previous tag                                               |
 | `pnpm ops release:draft-notes --from v3.0.0-beta.103`                | Draft starting from a specific tag (else auto-discovered via `git describe`)                                      |
 | `cat /tmp/notes.md \| pnpm ops release:verify-notes`                 | Verify a notes draft references every merged PR in range exactly once (exits 1 on missing/extra/duplicate refs)   |
@@ -249,7 +250,7 @@ Cover the full release lifecycle: bump versions before the release PR, draft and
 
 **Use cases:**
 
-- `release:bump` — before cutting the release PR, bump the monorepo version so it ships tagged correctly.
+- `release:bump` — before cutting the release PR, bump the monorepo version so it ships tagged correctly. It also gates the PREVIOUS release's close-out: CURRENT.md's `> **Version**: vX` header must equal package.json's current version, which is exactly what a skipped CURRENT.md reset looks like. The reset itself stays human judgment; `--allow-stale-current` bypasses the check for a deliberate exception.
 - `release:draft-notes` — generate the skeleton for the release PR body; edit as needed before submitting.
 - `release:verify-notes` — CI/pre-publish gate: confirms every merged PR in the tag-to-HEAD range appears in the notes exactly once.
 - `release:premigrate` — run BEFORE merging the release PR so auto-deploy lands into a ready schema; destructive shapes need `--allow-destructive` inside a maintenance window (see `.claude/rules/03-database.md` § Deployment).

--- a/packages/tooling/src/commands/release.ts
+++ b/packages/tooling/src/commands/release.ts
@@ -13,9 +13,13 @@ export function registerReleaseCommands(cli: CAC): void {
   cli
     .command('release:bump <version>', 'Bump version in all package.json files')
     .option('--dry-run', 'Preview changes without applying')
+    .option(
+      '--allow-stale-current',
+      'Bump even when CURRENT.md still declares the previous release (skips the reset gate)'
+    )
     .example('pnpm ops release:bump 3.0.0-beta.49')
     .example('pnpm ops release:bump 3.0.0 --dry-run')
-    .action(async (version: string, options: { dryRun?: boolean }) => {
+    .action(async (version: string, options: { dryRun?: boolean; allowStaleCurrent?: boolean }) => {
       const { bumpVersion } = await import('../release/bump-version.js');
       await bumpVersion(version, options);
     });

--- a/packages/tooling/src/dev/backlogLint.test.ts
+++ b/packages/tooling/src/dev/backlogLint.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import {
+  ALLOW_ORIGIN_ID_COLLISION_ENV,
+  checkDuplicateTaskIds,
+  checkOriginIdCollisions,
   checkTaskTriage,
   extractQueueDocRefs,
   parseSectionCaps,
   runBacklogLint,
+  type OriginTaskListing,
 } from './backlogLint.js';
 import type { TrackerTask } from './trackerTasks.js';
 
@@ -77,21 +81,118 @@ const VALID_TASK = [
   'Body.',
 ].join('\n');
 
-describe('checkTaskTriage', () => {
-  function task(overrides: Partial<TrackerTask> = {}): TrackerTask {
-    return {
-      id: 'TASK-1',
-      title: 'A task',
-      status: 'To Do',
-      createdDate: '2026-05-16',
-      labels: ['area:db', 'size:S', 'state:ready'],
-      priority: 'medium',
-      body: '',
-      file: 'tracker/tasks/task-1 - a-task.md',
-      ...overrides,
-    };
-  }
+function task(overrides: Partial<TrackerTask> = {}): TrackerTask {
+  return {
+    id: 'TASK-1',
+    title: 'A task',
+    status: 'To Do',
+    createdDate: '2026-05-16',
+    labels: ['area:db', 'size:S', 'state:ready'],
+    priority: 'medium',
+    body: '',
+    file: 'tracker/tasks/task-1 - a-task.md',
+    ...overrides,
+  };
+}
 
+describe('checkDuplicateTaskIds', () => {
+  it('passes a tree where every id appears once', () => {
+    expect(
+      checkDuplicateTaskIds([
+        task(),
+        task({ id: 'TASK-2', file: 'tracker/tasks/task-2 - other.md' }),
+      ])
+    ).toEqual([]);
+  });
+
+  it('flags two files carrying the same id, naming both', () => {
+    // The post-merge union shape: each file parses cleanly on its own branch,
+    // and only the merged tree has the ambiguity.
+    const [problem] = checkDuplicateTaskIds([
+      task({ id: 'TASK-451', file: 'tracker/tasks/task-451 - one.md' }),
+      task({ id: 'TASK-451', file: 'tracker/tasks/task-451 - two.md' }),
+    ]);
+
+    expect(problem).toContain('duplicate task id TASK-451');
+    expect(problem).toContain('task-451 - one.md');
+    expect(problem).toContain('task-451 - two.md');
+  });
+});
+
+describe('checkOriginIdCollisions', () => {
+  const resolvable = (files: string[]): OriginTaskListing => ({ resolvable: true, files });
+
+  it('flags a NEW local file reusing an id origin already has under another name', () => {
+    const problems = checkOriginIdCollisions(
+      [task({ id: 'TASK-451', file: 'tracker/tasks/task-451 - filed-here.md' })],
+      resolvable(['tracker/tasks/task-451 - filed-on-develop.md'])
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('id TASK-451 is already used on origin/develop');
+    expect(problems[0]).toContain('task-451 - filed-on-develop.md');
+  });
+
+  it('passes a file that already exists on origin under the same path', () => {
+    expect(
+      checkOriginIdCollisions(
+        [task({ id: 'TASK-451', file: 'tracker/tasks/task-451 - same.md' })],
+        resolvable(['tracker/tasks/task-451 - same.md'])
+      )
+    ).toEqual([]);
+  });
+
+  it('passes a new file whose id origin does not carry', () => {
+    expect(
+      checkOriginIdCollisions(
+        [task({ id: 'TASK-452', file: 'tracker/tasks/task-452 - new.md' })],
+        resolvable(['tracker/tasks/task-451 - old.md'])
+      )
+    ).toEqual([]);
+  });
+
+  it('skips entirely when origin/develop is not resolvable', () => {
+    // Fail-open: a CI shallow clone legitimately lacks the ref, and the
+    // in-tree duplicate check still covers the merged case.
+    expect(
+      checkOriginIdCollisions(
+        [task({ id: 'TASK-451', file: 'tracker/tasks/task-451 - filed-here.md' })],
+        { resolvable: false, files: [] }
+      )
+    ).toEqual([]);
+  });
+
+  it('matches a title-less origin filename (task-N.md, no separator) by its id', () => {
+    // fileIdToken strips the .md so `task-451.md` yields `task-451`, not
+    // `task-451.md` — otherwise a real collision against a title-less origin
+    // file would silently go undetected.
+    const problems = checkOriginIdCollisions(
+      [task({ id: 'TASK-451', file: 'tracker/tasks/task-451 - filed-here.md' })],
+      resolvable(['tracker/tasks/task-451.md'])
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('task-451.md');
+  });
+
+  it('names every origin file when origin/develop itself carries a duplicate id', () => {
+    // A pre-existing upstream dup is invisible to checkDuplicateTaskIds (local
+    // tree only); the message must not understate it to a single file.
+    const problems = checkOriginIdCollisions(
+      [task({ id: 'TASK-451', file: 'tracker/tasks/task-451 - filed-here.md' })],
+      resolvable([
+        'tracker/tasks/task-451 - one-on-develop.md',
+        'tracker/tasks/task-451 - two-on-develop.md',
+      ])
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('one-on-develop.md');
+    expect(problems[0]).toContain('two-on-develop.md');
+  });
+});
+
+describe('checkTaskTriage', () => {
   it('passes a fully triaged open task', () => {
     expect(checkTaskTriage([task()])).toEqual([]);
   });
@@ -202,6 +303,14 @@ describe('checkTaskTriage', () => {
 describe('runBacklogLint', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
 
+  /**
+   * A resolvable origin/develop with no task files on it. Injected so the suite
+   * never shells out to git: the default path reads the real repo, which would
+   * make these results depend on whatever the checkout's origin happens to
+   * carry. The id-collision cases below inject their own listings.
+   */
+  const NO_ORIGIN_FILES: OriginTaskListing = { resolvable: true, files: [] };
+
   beforeEach(() => {
     vi.resetAllMocks();
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -250,7 +359,7 @@ describe('runBacklogLint', () => {
       ['doc-1 - Foo.md']
     );
 
-    await runBacklogLint({ rootDir: '/repo' });
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
     const out = logSpy.mock.calls.flat().join('\n');
     expect(out).toContain('Backlog layout in sync');
@@ -260,7 +369,7 @@ describe('runBacklogLint', () => {
   it('flags a cap violation and sets a non-zero exit code', async () => {
     mockFs({ 'backlog/now.md': '### ⚡ Quick Wins (max 2)\n- a\n- b\n- c\n' }, []);
 
-    await runBacklogLint({ rootDir: '/repo' });
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
     expect(logSpy.mock.calls.flat().join('\n')).toContain('has 3 items (cap 2)');
     expect(process.exitCode).toBe(1);
@@ -277,7 +386,7 @@ describe('runBacklogLint', () => {
       ['doc-14 - Other.md']
     );
 
-    await runBacklogLint({ rootDir: '/repo' });
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
     expect(logSpy.mock.calls.flat().join('\n')).toContain('dangling doc reference → doc-1');
     expect(process.exitCode).toBe(1);
@@ -286,7 +395,7 @@ describe('runBacklogLint', () => {
   it('passes silently when queue.md is absent (cold/queue.md is optional)', async () => {
     mockFs({ 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' }, []);
 
-    await runBacklogLint({ rootDir: '/repo' });
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
     expect(logSpy.mock.calls.flat().join('\n')).toContain('Backlog layout in sync');
     expect(process.exitCode).not.toBe(1);
@@ -301,7 +410,7 @@ describe('runBacklogLint', () => {
       'task-2 - broken.md': 'no frontmatter here, just prose',
     });
 
-    await runBacklogLint({ rootDir: '/repo' });
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
     const out = logSpy.mock.calls.flat().join('\n');
     expect(out).toContain('Backlog structural problems');
@@ -313,9 +422,131 @@ describe('runBacklogLint', () => {
     vi.mocked(existsSync).mockImplementation(p => String(p).endsWith('backlog/now.md'));
     vi.mocked(readFileSync).mockReturnValue('### 🎯 Current Focus (max 3)\n1. a\n');
 
-    await runBacklogLint({ rootDir: '/repo' });
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
     expect(logSpy.mock.calls.flat().join('\n')).toContain('tracker/tasks/ not found');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('flags two working-tree tasks sharing an id and sets a non-zero exit code', async () => {
+    // Same id, different file and title — what two branches each filing a task
+    // produce once they merge.
+    const duplicate = VALID_TASK.replace("title: 'A valid task'", "title: 'The other one'");
+    mockFs({ 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' }, [], {
+      'task-1 - valid.md': VALID_TASK,
+      'task-1 - other.md': duplicate,
+    });
+
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('duplicate task id TASK-1');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('flags a new local task reusing an id origin/develop already carries', async () => {
+    mockFs({ 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' }, [], {
+      'task-1 - valid.md': VALID_TASK,
+    });
+
+    await runBacklogLint({
+      rootDir: '/repo',
+      origin: { resolvable: true, files: ['tracker/tasks/task-1 - filed-on-develop.md'] },
+    });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('id TASK-1 is already used on origin/develop');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('notes the skip and stays clean when origin/develop is unresolvable', async () => {
+    mockFs({ 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' }, [], {
+      'task-1 - valid.md': VALID_TASK,
+    });
+
+    await runBacklogLint({ rootDir: '/repo', origin: { resolvable: false, files: [] } });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('origin/develop not resolvable');
+    expect(out).toContain('Backlog layout in sync');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('bypasses the origin-collision check (only) when the env var is set', async () => {
+    // The rename escape hatch: the same colliding setup as above must NOT block
+    // once the bypass is set, so a legitimate rename branch is not deadlocked.
+    mockFs({ 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' }, [], {
+      'task-1 - valid.md': VALID_TASK,
+    });
+    process.env[ALLOW_ORIGIN_ID_COLLISION_ENV] = '1';
+    try {
+      await runBacklogLint({
+        rootDir: '/repo',
+        origin: { resolvable: true, files: ['tracker/tasks/task-1 - filed-on-develop.md'] },
+      });
+    } finally {
+      delete process.env[ALLOW_ORIGIN_ID_COLLISION_ENV];
+    }
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain(`${ALLOW_ORIGIN_ID_COLLISION_ENV}=1`);
+    expect(out).not.toContain('already used on origin/develop');
+    expect(process.exitCode).not.toBe(1);
+  });
+});
+
+// The one real git/OS seam this module introduces. A parse bug here fails
+// toward a false positive that sets process.exitCode = 1, tripping everyone's
+// quality gate — so the shell-out is mocked and its parse/trim/filter exercised
+// directly, the way ci-gate.test.ts covers fetchRuns' execFileSync.
+describe('readOriginTaskFiles', () => {
+  // Reset BEFORE each test, not only after: the top-level static import already
+  // cached this module with the real child_process, so without a reset the
+  // FIRST test's doMock would not apply and it would shell out to real git.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+  });
+
+  it('parses ls-tree output into repo-relative .md paths, dropping blanks and non-md', async () => {
+    vi.doMock('node:child_process', () => ({
+      execFileSync: (_cmd: string, args: string[]) =>
+        args[0] === 'rev-parse'
+          ? ''
+          : 'tracker/tasks/task-1 - a.md\ntracker/tasks/task-2 - b.md\n\ntracker/tasks/README.txt\n',
+    }));
+    const { readOriginTaskFiles } = await import('./backlogLint.js');
+
+    expect(readOriginTaskFiles('/repo')).toEqual({
+      resolvable: true,
+      files: ['tracker/tasks/task-1 - a.md', 'tracker/tasks/task-2 - b.md'],
+    });
+  });
+
+  it('reports unresolvable (fail-open) when rev-parse cannot verify origin/develop', async () => {
+    vi.doMock('node:child_process', () => ({
+      execFileSync: (_cmd: string, args: string[]) => {
+        if (args[0] === 'rev-parse') throw new Error('unknown revision or path');
+        return '';
+      },
+    }));
+    const { readOriginTaskFiles } = await import('./backlogLint.js');
+
+    expect(readOriginTaskFiles('/repo')).toEqual({ resolvable: false, files: [] });
+  });
+
+  it('reports unresolvable when ls-tree fails even though rev-parse succeeded', async () => {
+    vi.doMock('node:child_process', () => ({
+      execFileSync: (_cmd: string, args: string[]) => {
+        if (args[0] === 'rev-parse') return '';
+        throw new Error('ls-tree failed');
+      },
+    }));
+    const { readOriginTaskFiles } = await import('./backlogLint.js');
+
+    expect(readOriginTaskFiles('/repo')).toEqual({ resolvable: false, files: [] });
   });
 });

--- a/packages/tooling/src/dev/backlogLint.ts
+++ b/packages/tooling/src/dev/backlogLint.ts
@@ -30,6 +30,7 @@
  * informational nudge printed into a CI log surfaced nothing.
  */
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import chalk from 'chalk';
@@ -97,6 +98,11 @@ export function extractQueueDocRefs(queueMd: string): string[] {
 interface LintOptions {
   /** Repo root (defaults to cwd) */
   rootDir?: string;
+  /**
+   * The origin/develop task listing for the id-collision check. Injected by
+   * tests; read from git when absent.
+   */
+  origin?: OriginTaskListing;
 }
 
 /** Structural problems from now.md section caps. */
@@ -228,6 +234,155 @@ export function checkTaskTriage(tasks: TrackerTask[]): string[] {
   return problems;
 }
 
+/* -------------------------------------------------------------------------- */
+/* Task-id collisions                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `tracker/tasks/` as it exists on `origin/develop`, or the fact that the ref
+ * could not be resolved.
+ *
+ * The CLI allocates the next task id by scanning the CURRENT working tree, so a
+ * task filed on an unmerged sibling branch is invisible and the same id gets
+ * handed out twice. Neither branch's own lint can see that — the collision only
+ * exists in the union — so the comparison has to reach outside the working tree.
+ */
+export interface OriginTaskListing {
+  /** False when `origin/develop` could not be resolved (e.g. a shallow clone). */
+  resolvable: boolean;
+  /** Repo-root-relative task file paths on origin/develop. */
+  files: string[];
+}
+
+/**
+ * The id token a task filename starts with, e.g. `task-453 - Foo.md` → `task-453`.
+ *
+ * The trailing `.md` is stripped so a title-less filename (`task-453.md`, no
+ * ` - Title` suffix) still yields `task-453` rather than `task-453.md` — which
+ * would silently never match a frontmatter id and turn a real collision into a
+ * false negative. The convention is CLI-enforced, so this is belt-and-braces,
+ * but it fails LOUD rather than toward silence.
+ */
+function fileIdToken(path: string): string {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  return name.split(' ')[0].replace(/\.md$/i, '').toLowerCase();
+}
+
+/** Read the origin listing via git; unresolvable is a normal, non-fatal answer. */
+export function readOriginTaskFiles(rootDir: string): OriginTaskListing {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', 'origin/develop'], {
+      cwd: rootDir,
+      stdio: 'ignore',
+    });
+  } catch {
+    return { resolvable: false, files: [] };
+  }
+  try {
+    const raw = execFileSync(
+      'git',
+      ['ls-tree', '-r', '--name-only', 'origin/develop', '--', 'tracker/tasks/'],
+      { cwd: rootDir, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    return {
+      resolvable: true,
+      files: raw
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.endsWith('.md')),
+    };
+  } catch {
+    return { resolvable: false, files: [] };
+  }
+}
+
+/**
+ * Two task files in the WORKING TREE carrying the same `id:`.
+ *
+ * This is the post-merge shape: two branches each filed a task, each parsed
+ * cleanly in isolation, and the union has a duplicated id under which every
+ * id-based query (`task edit`, `task view`, cross-references) is ambiguous.
+ * @internal Exported for testing
+ */
+export function checkDuplicateTaskIds(tasks: TrackerTask[]): string[] {
+  const byId = new Map<string, string[]>();
+  for (const task of tasks) {
+    const files = byId.get(task.id) ?? [];
+    files.push(task.file);
+    byId.set(task.id, files);
+  }
+  return [...byId.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(
+      ([id, files]) => `duplicate task id ${id} across ${files.length} files: ${files.join(', ')}`
+    );
+}
+
+/** Escape hatch for the legitimate-rename false positive; mirrors `--allow-stale-current`. */
+export const ALLOW_ORIGIN_ID_COLLISION_ENV = 'TZUROT_ALLOW_ORIGIN_ID_COLLISION';
+
+/**
+ * A NEW local task file reusing an id that already exists on `origin/develop`
+ * under a different filename — the collision caught at push time, before the
+ * union ever lands.
+ *
+ * Asymmetric on purpose: the local id comes from frontmatter (authoritative,
+ * already parsed), the origin id from the FILENAME prefix, because reading the
+ * frontmatter of every origin file would cost one `git show` each.
+ *
+ * A deliberate RENAME of an existing task file lands in this same shape (the new
+ * path is absent from origin while the id is present under the old name), and it
+ * CANNOT be distinguished from a real collision by filenames alone. Because this
+ * runs in `pnpm quality` locally and the CI lint job, an un-escapable hard-fail
+ * would deadlock a rename branch (it can't merge until CI is green, and CI is
+ * red because of the rename). So `runBacklogLint` honours the
+ * `TZUROT_ALLOW_ORIGIN_ID_COLLISION` env var as the bypass, and the message
+ * names it.
+ *
+ * COVERAGE VARIES WITH FETCH RECENCY: this compares against the local
+ * `origin/develop` ref, not the true remote head. A same-id collision a teammate
+ * pushed since the last `git fetch` is invisible until the next fetch — a
+ * best-effort catch, not an authoritative gate (which is why the in-tree
+ * `checkDuplicateTaskIds` stays the unconditional backstop for the merged case).
+ * @internal Exported for testing
+ */
+export function checkOriginIdCollisions(tasks: TrackerTask[], origin: OriginTaskListing): string[] {
+  if (!origin.resolvable) {
+    return [];
+  }
+  const originPaths = new Set(origin.files);
+  // Accumulate ALL origin paths per id, not last-write-wins: if origin/develop
+  // already carries a pre-existing duplicate id (which checkDuplicateTaskIds
+  // cannot see — it scans only the local tree), the message should name every
+  // colliding origin file rather than silently understating the upstream state.
+  const originById = new Map<string, string[]>();
+  for (const path of origin.files) {
+    const id = fileIdToken(path);
+    const paths = originById.get(id) ?? [];
+    paths.push(path);
+    originById.set(id, paths);
+  }
+
+  return tasks
+    .filter(task => !originPaths.has(task.file))
+    .flatMap(task => {
+      // onOrigin is drawn from origin.files; the filter above dropped every
+      // task whose file is on origin, so a lookup hit here names a
+      // different origin file, not this task's own path — which is why the
+      // check does not re-compare against task.file.
+      const onOrigin = originById.get(task.id.toLowerCase());
+      if (onOrigin === undefined) {
+        return [];
+      }
+      return [
+        `${task.file}: id ${task.id} is already used on origin/develop by ${onOrigin.join(', ')} — ` +
+          'the CLI allocates ids from the working tree, so a sibling branch can hand out the ' +
+          'same one. Renumber this task (file, `id:`, and `ordinal:`), or — if the file was ' +
+          `simply renamed — re-run with ${ALLOW_ORIGIN_ID_COLLISION_ENV}=1 to bypass.`,
+      ];
+    });
+}
+
 function reportProblems(problems: string[]): void {
   if (problems.length === 0) {
     console.log(
@@ -246,7 +401,7 @@ function reportProblems(problems: string[]): void {
 /**
  * CLI entry point. Sets a non-zero exit code on any structural problem (cap
  * exceeded, dangling doc reference, unreadable tracker task, untriaged open
- * task).
+ * task, duplicated or origin-colliding task id).
  */
 export async function runBacklogLint(options: LintOptions = {}): Promise<void> {
   const rootDir = options.rootDir ?? process.cwd();
@@ -254,12 +409,35 @@ export async function runBacklogLint(options: LintOptions = {}): Promise<void> {
   // A task that failed to parse is already in `problems` and absent from
   // `tasks`, so the triage check never double-reports it.
   const { tasks, problems: trackerProblems } = loadTrackerTasks(rootDir);
+  const origin = options.origin ?? readOriginTaskFiles(rootDir);
+  // The bypass is honoured here, not inside the pure check, so the check stays
+  // testable and the skip is announced. The in-tree duplicate check is NOT
+  // bypassed — two local files sharing an id is unambiguous, never a rename.
+  const bypassOriginCollision = process.env[ALLOW_ORIGIN_ID_COLLISION_ENV] === '1';
   const problems = [
     ...checkNowCaps(rootDir),
     ...checkQueueDocRefs(rootDir),
     ...trackerProblems,
     ...checkTaskTriage(tasks),
+    ...checkDuplicateTaskIds(tasks),
+    ...(bypassOriginCollision ? [] : checkOriginIdCollisions(tasks, origin)),
   ];
+  if (bypassOriginCollision) {
+    console.log(
+      chalk.dim(
+        `ℹ ${ALLOW_ORIGIN_ID_COLLISION_ENV}=1 — skipped the origin/develop id-collision check`
+      )
+    );
+  }
+  if (!origin.resolvable) {
+    // Fail-open, and say so: a CI shallow clone legitimately lacks the ref, and
+    // the in-tree duplicate check above still covers the merged case.
+    console.log(
+      chalk.dim(
+        'ℹ origin/develop not resolvable — skipped the cross-branch task-id collision check'
+      )
+    );
+  }
   reportProblems(problems);
 
   if (problems.length > 0) {

--- a/packages/tooling/src/dev/check-repo-settings.test.ts
+++ b/packages/tooling/src/dev/check-repo-settings.test.ts
@@ -593,6 +593,13 @@ describe('formatRepoSettingsReport', () => {
     expect(text).toContain('not a proof of sufficiency');
     expect(text).not.toContain('deletion is unreachable');
     expect(text).not.toContain('deletion is impossible');
+    // This fixture IS the clean-but-bypassable state (delete_branch_on_merge
+    // off, develop's deletion rule fully bypassable — the repo's live shape), so
+    // a headline generalising over branches would contradict the state line two
+    // rows below it. Zero findings is all the headline gets to claim.
+    expect(text).not.toContain('every long-lived branch');
+    expect(text).toContain('✓ No deletion-safety findings. What each branch actually carries');
+    expect(text).toContain('probe-verified');
     expect(text).toContain('delete_branch_on_merge: false');
     expect(text).toContain('main: deletion rule present, not bypassable');
     expect(text).toContain('develop: deletion rule present but fully bypassable');

--- a/packages/tooling/src/dev/check-repo-settings.ts
+++ b/packages/tooling/src/dev/check-repo-settings.ts
@@ -510,10 +510,19 @@ export function formatRepoSettingsReport(surface: RepoSettingsSurface): string {
   });
 
   if (surface.findings.length === 0) {
+    // The headline claims only what zero findings establish. It does NOT claim
+    // every branch carries an un-bypassable deletion rule: the clean state is
+    // reachable with delete_branch_on_merge off and develop's deletion rule
+    // fully bypassable, which is what the per-branch lines below would then say
+    // — a headline asserting otherwise contradicts its own report. The
+    // probe-verified note is scoped to the one thing the probe established: a
+    // deletion rule with NO bypass actors holds against the admin-privileged
+    // path (see `isDeletionReachable` for the measurement).
     return [
-      '✓ No deletion-safety findings — every long-lived branch carries an un-bypassable',
-      '  deletion rule, and that rule is known to hold against the admin-privileged',
-      '  path (probe-verified). Still CONFIGURATION, not a proof of sufficiency —',
+      '✓ No deletion-safety findings. What each branch actually carries is in the',
+      '  per-branch state below: a deletion rule with no bypass actors is probe-verified',
+      '  to hold against the admin-privileged path; a fully bypassable rule carries no',
+      '  such guarantee. Still CONFIGURATION, not a proof of sufficiency —',
       '  delete_branch_on_merge below is the protection that assumes nothing.',
       `  delete_branch_on_merge: ${String(surface.deleteBranchOnMerge)}`,
       ...stateLines,

--- a/packages/tooling/src/dev/ghReadPartsAgreement.test.ts
+++ b/packages/tooling/src/dev/ghReadPartsAgreement.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Agreement guard between `lossy-pipe-guard.sh`'s protected `gh:` read list and
+ * the `gh:*` command registry.
+ *
+ * Rule 2 of the hook blocks a TRUNCATED read of a `gh:` wrapper whose rows can
+ * hide a failure, and the protected list is hand-enumerated. The enumeration is
+ * deliberate — a `gh:[a-z-]+` glob was tried and swept in `gh:pr-edit`, a WRITE
+ * command whose output is a confirmation line rather than rows, which produced
+ * pure friction. What the enumeration lacks is any tie to the registry in
+ * `commands/gh.ts`: renaming or deleting a read wrapper leaves the hook naming a
+ * command that no longer exists, and nothing goes red.
+ *
+ * So this test pins what is already DECIDED, not what should be decided.
+ * Read-vs-write for a NEW command stays a human call: a wrapper added to the
+ * registry and left out of the hook list is not a failure here.
+ *
+ * Both lists are EXTRACTED from their sources at run time. An extraction that
+ * stops matching is a hard failure rather than a silent pass — the same posture
+ * as `gitCommitPatternAgreement.test.ts`, which this file is modelled on.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const repoPath = (rel: string): string =>
+  fileURLToPath(new URL(`../../../../${rel}`, import.meta.url));
+
+const HOOK_FILE = '.claude/hooks/lossy-pipe-guard.sh';
+const REGISTRY_FILE = 'packages/tooling/src/commands/gh.ts';
+
+/**
+ * The alternation inside the hook's `\bgh:(…)` part — the enumerated names.
+ * Anchored on `gh:(` so an unrelated alternation elsewhere in the hook cannot
+ * be picked up instead.
+ */
+const HOOK_LIST = /\\bgh:\(([a-z0-9|-]+)\)/;
+
+/**
+ * Every `gh:` command the CLI registers. `.command(` may be followed by the
+ * string on the same line or the next one (the ci-gate registration wraps), so
+ * this matches across the whitespace rather than line by line.
+ */
+const REGISTERED = /\.command\(\s*'gh:([a-z0-9-]+)/g;
+
+/** Extraction failure is a test failure — a silent skip would disarm the guard. */
+function extractHookNames(): string[] {
+  const text = readFileSync(repoPath(HOOK_FILE), 'utf-8');
+  const match = HOOK_LIST.exec(text);
+  if (match === null) {
+    throw new Error(
+      `${HOOK_FILE}: no \\bgh:(…) alternation found by ${String(HOOK_LIST)}. ` +
+        'The hook was reformatted — update the extractor here rather than deleting this guard.'
+    );
+  }
+  return match[1].split('|').filter(name => name.length > 0);
+}
+
+/** Same posture: a registry whose shape changed must fail loudly, not silently. */
+function extractRegisteredNames(): string[] {
+  const text = readFileSync(repoPath(REGISTRY_FILE), 'utf-8');
+  const names = [...text.matchAll(REGISTERED)].map(m => m[1]);
+  if (names.length === 0) {
+    throw new Error(
+      `${REGISTRY_FILE}: no gh: command registrations found by ${String(REGISTERED)}. ` +
+        'The registry was reformatted — update the extractor here rather than deleting this guard.'
+    );
+  }
+  return names;
+}
+
+const hookNames = extractHookNames();
+const registeredNames = extractRegisteredNames();
+
+describe('lossy-pipe-guard gh: read list agrees with the gh command registry', () => {
+  it('extracts a non-empty list from each source', () => {
+    expect(hookNames.length, `${HOOK_FILE} yielded no names`).toBeGreaterThan(0);
+    expect(registeredNames.length, `${REGISTRY_FILE} yielded no commands`).toBeGreaterThan(0);
+  });
+
+  for (const name of hookNames) {
+    it(`protects a command that still exists: gh:${name}`, () => {
+      expect(
+        registeredNames,
+        `lossy-pipe-guard protects gh:${name}, which is no longer registered in ${REGISTRY_FILE}. ` +
+          'Rename or remove it in the hook too — rule 2 is now naming nothing.'
+      ).toContain(name);
+    });
+  }
+
+  it('excludes the write command gh:pr-edit', () => {
+    // The exclusion is the decision that killed the `gh:[a-z-]+` glob: pr-edit's
+    // output is a confirmation line, so truncating it loses nothing, and
+    // blocking it blocked `gh:pr-edit --help | tail` during authoring.
+    expect(registeredNames, 'gh:pr-edit is gone from the registry').toContain('pr-edit');
+    expect(hookNames, 'gh:pr-edit is a WRITE command and must stay out of rule 2').not.toContain(
+      'pr-edit'
+    );
+  });
+});

--- a/packages/tooling/src/gh/ci-gate.test.ts
+++ b/packages/tooling/src/gh/ci-gate.test.ts
@@ -731,4 +731,56 @@ describe('fetchRuns', () => {
     vi.doUnmock('node:child_process');
     vi.resetModules();
   });
+
+  it('bounds the call so a hang cannot block the poll loop', async () => {
+    // The catch below reports a timeout the same way it reports any other gh
+    // failure, so the error path alone cannot tell a bounded call from an
+    // unbounded one — only the options object can.
+    vi.resetModules();
+    let opts: { timeout?: number } = {};
+    vi.doMock('node:child_process', () => ({
+      execFileSync: (_c: string, _a: string[], o: { timeout?: number }) => {
+        opts = o;
+        return '[]';
+      },
+    }));
+    const mod = await import('./ci-gate.js');
+    mod.fetchRuns('a'.repeat(40));
+    expect(opts.timeout).toBe(mod.RUNS_FETCH_TIMEOUT_MS);
+    expect(typeof opts.timeout).toBe('number');
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+  });
+
+  it('reports a timeout kill with a non-empty detail naming the signal', async () => {
+    // The shape execFileSync produces on timeout: no stderr, a bare "Command
+    // failed" message, and the signal it was killed with. Reported blank, this
+    // failure would be indistinguishable from the silence the gate removes.
+    vi.resetModules();
+    vi.doMock('node:child_process', () => ({
+      execFileSync: () => {
+        const err = new Error('Command failed: gh api repos/...') as Error & {
+          stderr: string;
+          status: null;
+          signal: string;
+        };
+        err.stderr = '';
+        err.status = null;
+        err.signal = 'SIGTERM';
+        throw err;
+      },
+    }));
+    const { fetchRuns } = await import('./ci-gate.js');
+    let thrown: unknown;
+    try {
+      fetchRuns('a'.repeat(40));
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toEqual(expect.objectContaining({ name: 'GhApiError' }));
+    expect((thrown as Error).message).not.toBe('');
+    expect((thrown as Error).message).toContain('killed by SIGTERM');
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+  });
 });

--- a/packages/tooling/src/gh/ci-gate.ts
+++ b/packages/tooling/src/gh/ci-gate.ts
@@ -281,6 +281,17 @@ export class GhApiError extends Error {
  */
 export const RUNS_PAGE_SIZE = 100;
 
+/**
+ * Bound on each poll's runs lookup, matching `HEAD_FETCH_TIMEOUT_MS`.
+ *
+ * This call is synchronous and sits inside the poll loop, so a HUNG `gh api`
+ * (as opposed to a failing one) blocks the loop entirely: no further polls, and
+ * no heartbeat — the "a broken gate must not look like a slow one" promise fails
+ * for exactly the hang shape. Bounded, a hang becomes an ordinary `GhApiError`
+ * that the loop's failure reporting already prints.
+ */
+export const RUNS_FETCH_TIMEOUT_MS = 15_000;
+
 export function fetchRuns(
   sha: string,
   warn: (message: string) => void = console.warn
@@ -295,12 +306,20 @@ export function fetchRuns(
         '--jq',
         '.workflow_runs',
       ],
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: RUNS_FETCH_TIMEOUT_MS }
     );
   } catch (error) {
-    const stderr = (error as { stderr?: string }).stderr ?? '';
-    const detail = (stderr || (error as Error).message).trim().split('\n')[0];
-    throw new GhApiError(detail);
+    const { stderr, signal } = error as { stderr?: string; signal?: string | null };
+    const reported = (stderr ?? '') || (error as Error).message || '';
+    const first = reported.trim().split('\n')[0] ?? '';
+    // A timeout kill carries no stderr and only a bare "Command failed" message,
+    // which reads as an unexplained failure. Name the signal, the way
+    // `runChecks` separates "killed by SIGTERM" from a spawn failure — and keep
+    // the detail non-empty either way, because a blank failure line is the
+    // silence this gate exists to remove.
+    const killed = signal !== undefined && signal !== null ? `killed by ${signal}` : '';
+    const detail = [first, killed].filter(part => part !== '').join(' — ');
+    throw new GhApiError(detail === '' ? 'gh api failed with no output' : detail);
   }
   let runs: WorkflowRun[];
   try {

--- a/packages/tooling/src/release/bump-version.test.ts
+++ b/packages/tooling/src/release/bump-version.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock chalk
@@ -22,6 +23,39 @@ vi.mock('node:fs', () => ({
   writeFileSync: mockWriteFileSync,
 }));
 
+/**
+ * Every bump now runs the CURRENT.md reset gate first (see current-md-gate.ts),
+ * so a fixture tree needs a CURRENT.md whose header agrees with the root
+ * package.json — otherwise the bump refuses before it discovers a single file.
+ * The gate's own cases live in current-md-gate.test.ts; the block at the bottom
+ * of this file covers its wiring into bumpVersion.
+ */
+const currentMdText = (version: string): string =>
+  `# Current\n\n> **Version**: v${version} — session notes\n`;
+
+/** `readFileSync` over a tree: package.json content per path, plus CURRENT.md. */
+function mockTree(pkgFor: (path: string) => unknown, currentVersion: string): void {
+  mockReadFileSync.mockImplementation((path: string) =>
+    String(path).endsWith('CURRENT.md')
+      ? currentMdText(currentVersion)
+      : JSON.stringify(pkgFor(String(path)))
+  );
+}
+
+/** The common shape: every package.json at `version`, CURRENT.md agreeing. */
+function mockPackages(version: string, currentVersion = version): void {
+  mockTree(() => ({ version }), currentVersion);
+}
+
+/** Distinct package.json paths that were read, gate reads and all. */
+function packageJsonPathsRead(): Set<string> {
+  return new Set(
+    mockReadFileSync.mock.calls
+      .map(call => String(call[0]))
+      .filter(path => path.endsWith('package.json'))
+  );
+}
+
 describe('bumpVersion', () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
@@ -34,8 +68,10 @@ describe('bumpVersion', () => {
     originalExitCode = process.exitCode;
     process.exitCode = undefined;
 
-    // Default: empty directory
+    // Default: empty directory, and a tree whose CURRENT.md is already reset —
+    // every test below is about the bump, not about the gate in front of it.
     mockReaddirSync.mockReturnValue([]);
+    mockPackages('0.0.1');
   });
 
   afterEach(() => {
@@ -105,13 +141,16 @@ describe('bumpVersion', () => {
         return [];
       });
 
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.0.1' }));
+      mockPackages('0.0.1');
 
       const { bumpVersion } = await import('./bump-version.js');
       await bumpVersion('1.0.0');
 
-      // Should only read the root package.json, not anything in node_modules
-      expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+      // Should only read the root package.json, not anything in node_modules.
+      // Asserted over the PATHS rather than the call count: the reset gate reads
+      // CURRENT.md and the root package.json before discovery starts, so a count
+      // no longer isolates what discovery touched.
+      expect(packageJsonPathsRead()).toEqual(new Set([join(process.cwd(), 'package.json')]));
     });
 
     it('should recursively find package.json files', async () => {
@@ -128,12 +167,17 @@ describe('bumpVersion', () => {
         return [];
       });
 
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.0.1' }));
+      mockPackages('0.0.1');
 
       const { bumpVersion } = await import('./bump-version.js');
       await bumpVersion('1.0.0');
 
-      expect(mockReadFileSync).toHaveBeenCalledTimes(2);
+      expect(packageJsonPathsRead()).toEqual(
+        new Set([
+          join(process.cwd(), 'package.json'),
+          join(process.cwd(), 'packages', 'package.json'),
+        ])
+      );
     });
   });
 
@@ -148,7 +192,7 @@ describe('bumpVersion', () => {
     });
 
     it('should update version in package.json', async () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.0.1' }));
+      mockPackages('0.0.1');
 
       const { bumpVersion } = await import('./bump-version.js');
       await bumpVersion('1.0.0');
@@ -159,7 +203,7 @@ describe('bumpVersion', () => {
     });
 
     it('should skip packages already at target version', async () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '1.0.0' }));
+      mockPackages('1.0.0');
 
       const { bumpVersion } = await import('./bump-version.js');
       await bumpVersion('1.0.0');
@@ -170,7 +214,25 @@ describe('bumpVersion', () => {
     });
 
     it('should skip packages without version field', async () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'no-version-pkg' }));
+      // The versionless package is a NESTED one: the root package.json is what
+      // the reset gate compares CURRENT.md against, so a versionless root would
+      // be testing the gate's fail-closed path instead of this skip.
+      mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir === process.cwd()) {
+          return [{ name: 'packages', isDirectory: () => true, isFile: () => false }];
+        }
+        if (dir.endsWith('packages')) {
+          return [{ name: 'package.json', isDirectory: () => false, isFile: () => true }];
+        }
+        return [];
+      });
+      mockTree(
+        path =>
+          path === join(process.cwd(), 'package.json')
+            ? { version: '0.0.1' }
+            : { name: 'no-version-pkg' },
+        '0.0.1'
+      );
 
       const { bumpVersion } = await import('./bump-version.js');
       await bumpVersion('1.0.0');
@@ -181,7 +243,7 @@ describe('bumpVersion', () => {
     });
 
     it('should not write in dry-run mode', async () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.0.1' }));
+      mockPackages('0.0.1');
 
       const { bumpVersion } = await import('./bump-version.js');
       await bumpVersion('1.0.0', { dryRun: true });
@@ -192,7 +254,7 @@ describe('bumpVersion', () => {
     });
 
     it('should show count of updated files', async () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: '0.0.1' }));
+      mockPackages('0.0.1');
 
       const { bumpVersion } = await import('./bump-version.js');
       await bumpVersion('1.0.0');
@@ -200,6 +262,79 @@ describe('bumpVersion', () => {
       const output = consoleLogSpy.mock.calls.flat().join(' ');
       expect(output).toContain('Updated');
       expect(output).toContain('package.json');
+    });
+  });
+
+  describe('CURRENT.md reset gate', () => {
+    beforeEach(() => {
+      mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir === process.cwd()) {
+          return [{ name: 'package.json', isDirectory: () => false, isFile: () => true }];
+        }
+        return [];
+      });
+    });
+
+    it('refuses to bump when CURRENT.md still declares the previous release', async () => {
+      // The exact signature of a skipped reset: the file names the release
+      // before last while package.json has already moved on.
+      mockPackages('3.0.0-beta.196', '3.0.0-beta.195');
+
+      const { bumpVersion } = await import('./bump-version.js');
+      await bumpVersion('3.0.0-beta.197');
+
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      const output = consoleErrorSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('release step 9');
+      expect(output).toContain('--allow-stale-current');
+    });
+
+    it('refuses when CURRENT.md has no parseable version header', async () => {
+      // Fail-closed. An unparseable header cannot establish that the reset
+      // happened, and reading it as a pass would silently disarm the gate.
+      mockReadFileSync.mockImplementation((path: string) =>
+        String(path).endsWith('CURRENT.md')
+          ? '# Current\n\nsomebody reformatted the header\n'
+          : JSON.stringify({ version: '3.0.0-beta.196' })
+      );
+
+      const { bumpVersion } = await import('./bump-version.js');
+      await bumpVersion('3.0.0-beta.197');
+
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('proceeds when CURRENT.md agrees with package.json', async () => {
+      mockPackages('3.0.0-beta.196');
+
+      const { bumpVersion } = await import('./bump-version.js');
+      await bumpVersion('3.0.0-beta.197');
+
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('proceeds on a stale CURRENT.md when the bypass flag is passed', async () => {
+      mockPackages('3.0.0-beta.196', '3.0.0-beta.195');
+
+      const { bumpVersion } = await import('./bump-version.js');
+      await bumpVersion('3.0.0-beta.197', { allowStaleCurrent: true });
+
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('refuses in dry-run too, rather than previewing a bump it would refuse', async () => {
+      mockPackages('3.0.0-beta.196', '3.0.0-beta.195');
+
+      const { bumpVersion } = await import('./bump-version.js');
+      await bumpVersion('3.0.0-beta.197', { dryRun: true });
+
+      expect(process.exitCode).toBe(1);
+      const output = consoleErrorSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('release step 9');
     });
   });
 });

--- a/packages/tooling/src/release/bump-version.ts
+++ b/packages/tooling/src/release/bump-version.ts
@@ -8,6 +8,7 @@
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import chalk from 'chalk';
+import { ALLOW_STALE_CURRENT_FLAG, checkCurrentMdReset } from './current-md-gate.js';
 
 /** Semver with optional pre-release pattern */
 const SEMVER_REGEX = /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$/;
@@ -17,6 +18,8 @@ const EXCLUDED_DIRS = new Set(['node_modules', '.pnpm-store', 'tzurot-legacy', '
 
 interface BumpVersionOptions {
   dryRun?: boolean;
+  /** Skip the CURRENT.md-reset gate for a deliberate exceptional flow. */
+  allowStaleCurrent?: boolean;
 }
 
 interface BumpResult {
@@ -52,6 +55,24 @@ function findPackageJsonFiles(dir: string): string[] {
 }
 
 /**
+ * Run the CURRENT.md reset gate, reporting and marking failure. Returns whether
+ * the bump may proceed.
+ */
+function enforceCurrentMdReset(rootDir: string, allowStaleCurrent: boolean): boolean {
+  if (allowStaleCurrent) {
+    return true;
+  }
+  const verdict = checkCurrentMdReset(rootDir);
+  if (verdict.ok) {
+    return true;
+  }
+  console.error(chalk.red(`Error: ${verdict.reason}`));
+  console.error(chalk.dim(`Bypass with ${ALLOW_STALE_CURRENT_FLAG} if that is intended.`));
+  process.exitCode = 1;
+  return false;
+}
+
+/**
  * Bump version in all package.json files
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity -- CLI orchestrator: validation → file discovery → JSON parsing → version replacement → confirmation → write
@@ -59,7 +80,7 @@ export async function bumpVersion(
   newVersion: string,
   options: BumpVersionOptions = {}
 ): Promise<void> {
-  const { dryRun = false } = options;
+  const { dryRun = false, allowStaleCurrent = false } = options;
 
   // Validate version format
   if (!SEMVER_REGEX.test(newVersion)) {
@@ -73,6 +94,14 @@ export async function bumpVersion(
 
   // Find project root (where we're running from)
   const rootDir = process.cwd();
+
+  // The bump is where the PREVIOUS release's close-out is still checkable — see
+  // current-md-gate.ts. Runs before file discovery so a refusal writes nothing,
+  // and in dry-run too: a preview that hides the refusal would report the bump
+  // as clear when it is not.
+  if (!enforceCurrentMdReset(rootDir, allowStaleCurrent)) {
+    return;
+  }
 
   // Find all package.json files
   const packageFiles = findPackageJsonFiles(rootDir);

--- a/packages/tooling/src/release/current-md-gate.test.ts
+++ b/packages/tooling/src/release/current-md-gate.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALLOW_STALE_CURRENT_FLAG,
+  checkCurrentMdReset,
+  parseCurrentMdVersion,
+} from './current-md-gate.js';
+
+const ROOT = '/repo';
+
+const currentMd = (version: string): string =>
+  `# Current\n\n> **Version**: v${version} — a summary that changes every release\n\n---\n`;
+
+/** A reader over an in-memory tree; a missing path throws, as `readFileSync` does. */
+function reader(files: Record<string, string>): (path: string) => string {
+  return (path: string) => {
+    const content = files[path];
+    if (content === undefined) throw new Error(`ENOENT: ${path}`);
+    return content;
+  };
+}
+
+const tree = (
+  currentMdText: string | undefined,
+  packageJsonText: string
+): Record<string, string> =>
+  currentMdText === undefined
+    ? { '/repo/package.json': packageJsonText }
+    : { '/repo/CURRENT.md': currentMdText, '/repo/package.json': packageJsonText };
+
+describe('parseCurrentMdVersion', () => {
+  it('reads the version out of the header, ignoring the trailing summary', () => {
+    expect(parseCurrentMdVersion(currentMd('3.0.0-beta.196'))).toBe('3.0.0-beta.196');
+  });
+
+  it('returns undefined when no header is present', () => {
+    expect(parseCurrentMdVersion('# Current\n\nno header here\n')).toBeUndefined();
+  });
+});
+
+describe('checkCurrentMdReset', () => {
+  it('passes when CURRENT.md declares the version package.json is at', () => {
+    const verdict = checkCurrentMdReset(ROOT, {
+      readFile: reader(tree(currentMd('3.0.0-beta.196'), '{"version":"3.0.0-beta.196"}')),
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('refuses on a mismatch, naming the skipped release step and the bypass', () => {
+    const verdict = checkCurrentMdReset(ROOT, {
+      readFile: reader(tree(currentMd('3.0.0-beta.195'), '{"version":"3.0.0-beta.196"}')),
+    });
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain('v3.0.0-beta.195');
+    expect(verdict.reason).toContain('v3.0.0-beta.196');
+    expect(verdict.reason).toContain('release step 9');
+    expect(verdict.reason).toContain(ALLOW_STALE_CURRENT_FLAG);
+  });
+
+  it('refuses loudly on an unparseable header rather than reading it as a pass', () => {
+    // Fail-closed: a header nobody can parse establishes nothing about whether
+    // the reset happened, and a gate that passes on unreadable data is not one.
+    const verdict = checkCurrentMdReset(ROOT, {
+      readFile: reader(tree('# Current\n\nsomebody reformatted this\n', '{"version":"1.0.0"}')),
+    });
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain('no parseable');
+  });
+
+  it('refuses when CURRENT.md cannot be read at all', () => {
+    const verdict = checkCurrentMdReset(ROOT, {
+      readFile: reader(tree(undefined, '{"version":"1.0.0"}')),
+    });
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain('CURRENT.md could not be read');
+  });
+
+  it('refuses when package.json carries no string version', () => {
+    const verdict = checkCurrentMdReset(ROOT, {
+      readFile: reader(tree(currentMd('1.0.0'), '{"name":"root"}')),
+    });
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.reason).toContain('no string version field');
+  });
+
+  it('refuses when package.json is unparseable', () => {
+    const verdict = checkCurrentMdReset(ROOT, {
+      readFile: reader(tree(currentMd('1.0.0'), 'not json')),
+    });
+
+    expect(verdict.ok).toBe(false);
+  });
+});

--- a/packages/tooling/src/release/current-md-gate.ts
+++ b/packages/tooling/src/release/current-md-gate.ts
@@ -1,0 +1,114 @@
+/**
+ * Pre-bump gate: CURRENT.md must already have been reset for the PREVIOUS release.
+ *
+ * Every release starts with `pnpm bump-version`, which makes the bump the one
+ * deterministic moment where the previous release's close-out can still be
+ * checked. "CURRENT.md's version header ≠ package.json's current version" is
+ * exactly the signature of a skipped reset step: the file still declares the
+ * release before last and carries two releases of content, which surfaces later
+ * as a context-budget breach rather than as the missed release step it is.
+ *
+ * Only the "did it happen" half is mechanical. Deciding WHAT outlives a release
+ * is human judgment, and this gate does not touch the file — it refuses, names
+ * the step, and gets out of the way.
+ *
+ * Fail-CLOSED by construction: an unreadable file or an unparseable header
+ * refuses. A gate that passes on data it could not read is not a gate, and the
+ * bypass flag exists for the legitimate exceptional flow.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Escape hatch for a legitimate exceptional flow; named in every refusal. */
+export const ALLOW_STALE_CURRENT_FLAG = '--allow-stale-current';
+
+/** The release step whose omission this gate detects. Named in the refusal. */
+const RESET_STEP = 'release step 9 (CURRENT.md reset)';
+
+/**
+ * CURRENT.md's version header, e.g.
+ * `> **Version**: v3.0.0-beta.196 — summary…`
+ *
+ * The version is captured up to the first space, so the trailing summary (which
+ * is free prose and changes every release) is not part of the comparison.
+ */
+const CURRENT_MD_HEADER = /^>\s*\*\*Version\*\*:\s*v([^\s]+)/m;
+
+export type CurrentMdVerdict = { ok: true } | { ok: false; reason: string };
+
+/** The version CURRENT.md declares, or undefined when no header parses. */
+export function parseCurrentMdVersion(text: string): string | undefined {
+  return CURRENT_MD_HEADER.exec(text)?.[1];
+}
+
+export interface CurrentMdGateDeps {
+  /** Injectable file read; defaults to a UTF-8 `readFileSync`. */
+  readonly readFile?: (path: string) => string;
+}
+
+/** Read a file, or undefined when it cannot be read at all. */
+function tryRead(readFile: (path: string) => string, path: string): string | undefined {
+  try {
+    return readFile(path);
+  } catch {
+    return undefined;
+  }
+}
+
+/** The root package.json's `version`, or undefined when it cannot be established. */
+function readPackageVersion(
+  readFile: (path: string) => string,
+  rootDir: string
+): string | undefined {
+  const raw = tryRead(readFile, join(rootDir, 'package.json'));
+  if (raw === undefined) return undefined;
+  try {
+    const version = (JSON.parse(raw) as { version?: unknown }).version;
+    return typeof version === 'string' ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Compare CURRENT.md's declared version against package.json's CURRENT version
+ * (i.e. before the bump this call precedes).
+ */
+export function checkCurrentMdReset(
+  rootDir: string,
+  deps: CurrentMdGateDeps = {}
+): CurrentMdVerdict {
+  const readFile = deps.readFile ?? ((path: string) => readFileSync(path, 'utf-8'));
+
+  const currentMd = tryRead(readFile, join(rootDir, 'CURRENT.md'));
+  if (currentMd === undefined) {
+    return { ok: false, reason: `CURRENT.md could not be read from ${rootDir}` };
+  }
+  const declared = parseCurrentMdVersion(currentMd);
+  if (declared === undefined) {
+    return {
+      ok: false,
+      reason:
+        'CURRENT.md has no parseable `> **Version**: vX.Y.Z` header, so whether ' +
+        `${RESET_STEP} happened cannot be established`,
+    };
+  }
+
+  const version = readPackageVersion(readFile, rootDir);
+  if (typeof version !== 'string') {
+    return { ok: false, reason: `no string version field in ${join(rootDir, 'package.json')}` };
+  }
+
+  if (declared !== version) {
+    return {
+      ok: false,
+      reason:
+        `CURRENT.md still says v${declared} but package.json is at v${version} — ` +
+        `${RESET_STEP} was skipped for the previous release. Reset CURRENT.md first ` +
+        `(deciding what outlives the release is yours to make), or pass ` +
+        `${ALLOW_STALE_CURRENT_FLAG} if this bump is a deliberate exception.`,
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## What

Six items surfaced by the independent post-merge review of the Opus-window tooling PRs (#1985–#2022). Each is one logical unit; none ship to prod.

## Items

1. **TASK-481 — ci-gate `fetchRuns` timeout.** A *hung* `gh api` (not a failing one) blocked the synchronous poll loop and muted the heartbeat, so a broken gate looked like a slow one. Adds `RUNS_FETCH_TIMEOUT_MS = 15s` (matching sibling `HEAD_FETCH_TIMEOUT_MS`); the catch now names the kill signal and never emits a blank detail.
2. **TASK-480 — repo-settings clean headline.** No longer claims "every long-lived branch carries an un-bypassable deletion rule" — false in the reachable clean state where develop's rule is fully bypassable, and it contradicted its own per-branch lines. Scoped to what zero findings + the probe actually establish.
3. **TASK-478 — GH_READ_PARTS agreement test.** New `ghReadPartsAgreement.test.ts` ties `lossy-pipe-guard`'s protected gh-read list to the `commands/gh.ts` registry: renaming/removing a protected `gh:` read wrapper without updating the guard now fails; `pr-edit` staying *unprotected* (a write command) is pinned.
4. **TASK-476 — CURRENT.md-reset gate.** `release:bump` refuses when CURRENT.md's `> **Version**: vX` header ≠ package.json (the signature of a skipped step 9). Fail-closed (unreadable/unparseable refuses); `--allow-stale-current` for the deliberate exception. The reset *itself* stays human judgment — only the "did it happen" check is mechanical. Live-verified: `release:bump 3.0.0-beta.197 --dry-run` passes against the real tree.
5. **TASK-453 — duplicate task-id lint.** `backlogLint` gains an in-tree duplicate-id check (hard fail — the post-merge union shape) plus an origin/develop id-collision check (a new local file reusing an id already on origin under a different name — the push-time catch). Fail-open with a printed note when `origin/develop` is unresolvable (CI shallow clone).
6. **TASK-477 + a recorded note — two rules clauses.** Re-derive a count when the thing it counts changes, not only when first written (the stale-count class from the Opus window); and repeated `-l` on `task create` does not accumulate — comma form — with the measured note that `task list` *does* intersect.

## Verification
- `packages/tooling` unit suite: 2293 passed; lint clean; `tsc --noEmit` exit 0.
- **Canary-confirmed load-bearing** (each reverted → its test goes red): the fetchRuns timeout, the headline, the GH_READ_PARTS rename guard, the CURRENT.md gate wiring, both backlogLint checks.
- Real-git seam checked by hand: `task.file` (`tracker/tasks/${name}`) is byte-identical to `git ls-tree` output, so the origin-collision comparison the injected-origin tests mock is format-correct against real git.
- `pnpm ops lines:check`, `pnpm ops backlog`, `pnpm ops guard:ops-doc` all green.

Closes TASK-476, TASK-477, TASK-478, TASK-480, TASK-481; advances TASK-453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)