### PR TITLE
chore: session-mining operationalizations — two UserPromptSubmit hooks + drain-net skill step

### DIFF
--- a/.claude/hooks/bare-token-binding-reminder.probe.sh
+++ b/.claude/hooks/bare-token-binding-reminder.probe.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Fixture check for bare-token-binding-reminder.sh — run after ANY edit to the
+# hook. Asserts the fire/silent table over the shapes that matter: a whole-message
+# approval / decline / selection token fires; the same token used as the OPENING
+# of a real sentence stays silent, as do slash commands, multi-line messages, and
+# anything past the 60-character ceiling.
+#
+# The hook takes its payload on stdin as the UserPromptSubmit JSON envelope, so
+# each fixture is one `{"prompt": …}` object built with jq (the same tool the
+# hook parses with — without it the hook is inert and no case here is meaningful,
+# hence the FATAL rather than a skip).
+#
+# The hook never exits nonzero, so the harness asserts BOTH the exit code and
+# whether the banner reached stdout — exit code alone cannot distinguish fire
+# from silent here.
+#
+# Usage: .claude/hooks/bare-token-binding-reminder.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/bare-token-binding-reminder.sh"
+
+command -v jq >/dev/null 2>&1 || {
+    echo "FATAL: jq is required — the hook parses its stdin envelope with it" >&2
+    exit 1
+}
+
+fail=0
+
+check() { # $1=fire|silent  $2=prompt  $3=label
+    local out got fired json
+    json=$(jq -nc --arg p "$2" '{prompt: $p}')
+    out=$(printf '%s' "$json" | "$HOOK" 2>/dev/null)
+    got=$?
+    if grep -q 'BARE-TOKEN APPROVAL' <<<"$out"; then
+        fired="fire"
+    elif [ -z "${out//[[:space:]]/}" ]; then
+        fired="silent"
+    else
+        fired="unexpected-output"
+    fi
+    if [ "$got" != 0 ] || [ "$fired" != "$1" ]; then
+        echo "FAIL [exit=$got want=0 | $fired want=$1]: $3"
+        fail=1
+    else
+        echo "ok   [exit=$got | $fired]: $3"
+    fi
+}
+
+# --- MUST TRIGGER -----------------------------------------------------------
+
+check fire 'sure' "single approval token"
+check fire 'A' "bare option letter (uppercase — matching is case-insensitive)"
+check fire 'okay' "approval token spelled out"
+check fire 'yes and yes' "compound token chain"
+check fire 'I approve your recommendation' "content-free recommendation approval"
+check fire "let's go with your recommendations" "let's-go-with form (apostrophe)"
+check fire 'approve both' "approve-both selector"
+check fire 'yes please' "courtesy suffix: please"
+check fire '1' "bare option digit"
+check fire 'the second one' "ordinal option selector"
+check fire 'sounds good' "multi-word approval token"
+check fire 'Sounds good, thanks!' "punctuation + courtesy suffix + punctuation"
+check fire 'no' "bare decline token"
+
+# --- MUST NOT TRIGGER -------------------------------------------------------
+
+# The whole point of the anchoring: every one of these OPENS with a token the
+# fire table above matches, and then carries real content.
+check silent 'sure we can work on 444' "token as the opening of a real sentence"
+check silent 'yes and yes but hold the second until tomorrow' "chain followed by content"
+check silent 'can you merge the PR?' "question containing an approval word"
+check silent '/compact' "slash command"
+check silent 'approved the design doc needs one tweak' "approval word opening a directive"
+
+# 72 characters — over the ceiling. Belt-and-braces: it would not match anyway.
+check silent 'yes let us proceed with the plan you outlined and then run the gates now' \
+    "long sentence starting with yes (over the 60-char ceiling)"
+
+# 67 characters, and it DOES full-match the compound-chain shape — so this is
+# the case that actually pins the length guard rather than the pattern.
+check silent 'yes and yes and yes and yes and yes and yes and yes and yes and yes' \
+    "matching chain past the 60-char ceiling (pins the length guard)"
+
+check silent $'yes\nand also please check the migration ordering' \
+    "two-line message whose first line is a bare token"
+
+check silent '' "empty prompt"
+
+check silent "1. yes, 2. discretionary. it's only really a rule of thumb" \
+    "enumerated answer opening with a digit selector"
+
+[ "$fail" = 0 ] && echo "ALL PASS" || {
+    echo "FAILURES"
+    exit 1
+}

--- a/.claude/hooks/bare-token-binding-reminder.sh
+++ b/.claude/hooks/bare-token-binding-reminder.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Bare-token approval reminder (UserPromptSubmit).
+#
+# Fires when the user's whole message is a short approval / decline / selection
+# token — "sure", "A", "yes and yes", "approve both". Those replies carry a
+# decision whose BINDING lives only in the assistant's preceding menu, so a
+# later reader (or a post-compaction session) sees an unreadable "sure" with no
+# record of what it chose. 09-interaction-style.md § "An Escalation Is One Named
+# Question Plus a Recommendation" requires restating the binding; this hook is
+# the mechanical trigger for it.
+#
+# Deliberately narrow: anything with a newline, anything over 60 characters, and
+# anything starting with `/` is left alone. A reminder that fires on ordinary
+# prose trains the reader to skim past it.
+#
+# Patterns are plain POSIX ERE (no PCRE-only constructs) because some dev
+# machines have ugrep standing in for grep — see the note at skill-eval.sh:81-90.
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Fail open when jq is missing — checked BEFORE the jq invocation it guards.
+command -v jq >/dev/null 2>&1 || exit 0
+
+PROMPT=$(jq -r '.prompt // empty' <<<"$INPUT" 2>/dev/null || echo "")
+
+[ -n "$PROMPT" ] || exit 0
+
+# Trim leading and trailing whitespace.
+PROMPT="${PROMPT#"${PROMPT%%[![:space:]]*}"}"
+PROMPT="${PROMPT%"${PROMPT##*[![:space:]]}"}"
+
+[ -z "$PROMPT" ] && exit 0
+
+# Slash command — the harness owns it, not a reply to anything we asked.
+case "$PROMPT" in
+    /*) exit 0 ;;
+esac
+
+# Multi-line means the message carries its own content; a bare token does not.
+case "$PROMPT" in
+    *$'\n'*) exit 0 ;;
+esac
+
+# Length ceiling. A token plus courtesy fits easily; a sentence does not.
+if [ "${#PROMPT}" -gt 60 ]; then
+    exit 0
+fi
+
+# --- Shapes -----------------------------------------------------------------
+# (a) single approval / decline token
+TOKENS='yes|yep|yeah|sure|ok|okay|approved|approve|confirmed|confirm|proceed|lgtm|go ahead|do it|ship it|sounds good|works for me|no|nope|skip|decline|either|both|neither'
+
+# (b) compound token chains — "yes and yes", "yes and no"
+CHAIN='(yes|no|sure)( and (yes|no|sure))+'
+
+# (c) bare option selectors — "A", "1", "the second one". Ceiling is a scope
+# choice, not an oversight: menus here run 2-4 options (AskUserQuestion's max),
+# so A-D / 1-9 / first-fourth covers the real shapes; a wider range would start
+# matching prose fragments.
+SELECTOR='[a-d]|[1-9]|(option |the )?(first|second|third|fourth)( one)?'
+
+# (d) content-free recommendation approvals. Single-quoted strings can't hold an
+# apostrophe, so `let's` is assembled around $APOS.
+APOS="'"
+RECS="(i )?(approve|go with|follow)( your| the)? recommendations?|let${APOS}?s go with (your|the) recommendations?|your recommendation sounds good( to me)?|approve both|you can merge|(merge )?approval granted"
+
+# Trailing punctuation and one courtesy suffix are allowed on every shape, in
+# either order around the courtesy word ("Sounds good, thanks!").
+SUFFIX='[.!,]*( (please|thanks|thank you))?[.!,]*'
+
+PATTERN="^(${TOKENS}|${CHAIN}|${SELECTOR}|${RECS})${SUFFIX}\$"
+
+# printf, not echo: a prompt that IS a flag-shaped token ("-n") would vanish
+# into bash's builtin echo as an option rather than data.
+if ! printf '%s\n' "$PROMPT" | grep -qiE "$PATTERN"; then
+    exit 0
+fi
+
+cat << 'EOF'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+BARE-TOKEN APPROVAL: the user's reply is a short approval/selection token.
+Per 09-interaction-style.md, restate what it binds at the top of your reply
+("<token> = <the specific choice>") and record the decision to a durable
+surface if it outlives this session. A bare token with no recorded menu is
+an unreadable decision after compaction.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/.claude/hooks/queued-message-receipt.probe.sh
+++ b/.claude/hooks/queued-message-receipt.probe.sh
@@ -1,0 +1,358 @@
+#!/bin/bash
+# Fixture check for queued-message-receipt.sh — run after ANY edit to the hook.
+#
+# The hook decides from two inputs: a transcript JSONL tail and a per-session
+# state file holding the highest enqueue timestamp already reported. So each
+# case here builds a fixture transcript, points a crafted UserPromptSubmit
+# envelope at it, and asserts BOTH the banner (fire/silent) and — where it is
+# the actual subject — the state file's contents afterwards.
+#
+# Session ids are unique per case so the state files cannot collide; they are
+# removed on exit along with the fixture directory.
+#
+# The hook never exits nonzero, so exit code alone cannot distinguish fire from
+# silent — every assertion checks stdout too.
+#
+# Usage: .claude/hooks/queued-message-receipt.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/queued-message-receipt.sh"
+
+command -v jq >/dev/null 2>&1 || {
+    echo "FATAL: jq is required — the hook parses its stdin envelope with it" >&2
+    exit 1
+}
+
+TMPDIR_PROBE=$(mktemp -d)
+STATE_DIR="/tmp/claude-$(id -u)"
+SESSION_PREFIX="probe-queued-$$"
+
+cleanup() {
+    rm -rf "$TMPDIR_PROBE"
+    rm -f "$STATE_DIR/queued-receipt-state-$SESSION_PREFIX"-* 2>/dev/null
+    rm -f "$STATE_DIR/queued-receipt-state-.._.._$SESSION_PREFIX-traversal" 2>/dev/null
+}
+trap cleanup EXIT
+
+fail=0
+OUT=""
+RC=0
+
+state_file() { # $1 = session suffix
+    printf '%s/queued-receipt-state-%s-%s' "$STATE_DIR" "$SESSION_PREFIX" "$1"
+}
+
+# One transcript line for an enqueue. $1 = timestamp, $2 = content.
+enqueue_line() {
+    jq -nc --arg ts "$1" --arg c "$2" \
+        '{type: "queue-operation", operation: "enqueue", timestamp: $ts, content: $c}'
+}
+
+# A queue-operation that is NOT an enqueue.
+dequeue_line() {
+    jq -nc --arg ts "$1" '{type: "queue-operation", operation: "dequeue", timestamp: $ts}'
+}
+
+# Run the hook. $1 = session suffix, $2 = transcript path ("" omits the field),
+# $3 = the stdin prompt (defaults to something no fixture's content matches —
+# the hook excludes any enqueue equal to the current prompt, so a case that
+# wants that exclusion passes $3 explicitly).
+run_hook() {
+    local session="$SESSION_PREFIX-$1" json prompt="${3:-next message}"
+    if [ -z "$2" ]; then
+        json=$(jq -nc --arg s "$session" --arg p "$prompt" \
+            '{prompt: $p, session_id: $s}')
+    else
+        json=$(jq -nc --arg s "$session" --arg t "$2" --arg p "$prompt" \
+            '{prompt: $p, session_id: $s, transcript_path: $t}')
+    fi
+    OUT=$(printf '%s' "$json" | "$HOOK" 2>/dev/null)
+    RC=$?
+}
+
+assert_silent() { # $1 = label
+    if [ "$RC" != 0 ] || [ -n "${OUT//[[:space:]]/}" ]; then
+        echo "FAIL [exit=$RC want=0 | output=$([ -n "${OUT//[[:space:]]/}" ] && echo present || echo empty) want=empty]: $1"
+        [ -n "$OUT" ] && printf '     got: %s\n' "$OUT"
+        fail=1
+    else
+        echo "ok   [exit=$RC | silent]: $1"
+    fi
+}
+
+assert_fires() { # $1 = label, rest = substrings that must appear
+    local label="$1"
+    shift
+    local missing=""
+    if ! grep -q 'MID-TURN MESSAGES' <<<"$OUT"; then
+        missing="banner"
+    fi
+    local needle
+    for needle in "$@"; do
+        grep -qF -- "$needle" <<<"$OUT" || missing="$missing [$needle]"
+    done
+    if [ "$RC" != 0 ] || [ -n "$missing" ]; then
+        echo "FAIL [exit=$RC want=0 | missing:$missing]: $label"
+        printf '     got: %s\n' "$OUT"
+        fail=1
+    else
+        echo "ok   [exit=$RC | fired]: $label"
+    fi
+}
+
+assert_absent() { # $1 = label, $2 = substring that must NOT appear
+    if grep -qF -- "$2" <<<"$OUT"; then
+        echo "FAIL [unexpected substring '$2']: $1"
+        printf '     got: %s\n' "$OUT"
+        fail=1
+    else
+        echo "ok   [absent '$2']: $1"
+    fi
+}
+
+assert_state() { # $1 = label, $2 = session suffix, $3 = expected contents
+    local path got
+    path=$(state_file "$2")
+    if [ ! -f "$path" ]; then
+        echo "FAIL [state file missing: $path]: $1"
+        fail=1
+        return
+    fi
+    got=$(head -n 1 "$path")
+    if [ "$got" != "$3" ]; then
+        echo "FAIL [state='$got' want='$3']: $1"
+        fail=1
+    else
+        echo "ok   [state=$got]: $1"
+    fi
+}
+
+OLD_TS='2026-01-01T00:00:00.000Z'
+
+# --- 1. Fresh session baselines silently -----------------------------------
+
+T1="$TMPDIR_PROBE/case1.jsonl"
+{
+    enqueue_line '2026-08-01T10:00:00.000Z' 'first queued message'
+    enqueue_line '2026-08-01T11:00:00.000Z' 'second queued message'
+} >"$T1"
+
+run_hook 1 "$T1"
+assert_silent "fresh session with 2 enqueues stays silent (baseline run)"
+assert_state "baseline run records the max enqueue timestamp" 1 '2026-08-01T11:00:00.000Z'
+
+# --- 2. Same session, transcript unchanged ----------------------------------
+
+run_hook 1 "$T1"
+assert_silent "unchanged transcript on a baselined session stays silent"
+
+# --- 3. Same session, a NEWER enqueue arrives -------------------------------
+
+enqueue_line '2026-08-01T12:00:00.000Z' 'can you answer the webhook question first' >>"$T1"
+
+run_hook 1 "$T1"
+assert_fires "newer enqueue fires the banner" \
+    'MID-TURN MESSAGES: 1' \
+    'can you answer the webhook question first'
+assert_state "state advances to the new max timestamp" 1 '2026-08-01T12:00:00.000Z'
+
+# --- 4. Five new enqueues → 3 excerpts + "and 2 more" -----------------------
+
+T4="$TMPDIR_PROBE/case4.jsonl"
+{
+    enqueue_line '2026-08-02T10:00:00.000Z' 'message one'
+    enqueue_line '2026-08-02T10:00:01.000Z' 'message two'
+    enqueue_line '2026-08-02T10:00:02.000Z' 'message three'
+    enqueue_line '2026-08-02T10:00:03.000Z' 'message four'
+    enqueue_line '2026-08-02T10:00:04.000Z' 'message five'
+} >"$T4"
+printf '%s\n' "$OLD_TS" >"$(state_file 4)"
+
+run_hook 4 "$T4"
+assert_fires "five new enqueues: count, first three excerpts, overflow line" \
+    'MID-TURN MESSAGES: 5' \
+    'message one' 'message two' 'message three' \
+    '…and 2 more'
+assert_absent "the fourth message is not excerpted" 'message four'
+
+# --- 5. Transcript with no queue-operations ---------------------------------
+
+T5="$TMPDIR_PROBE/case5.jsonl"
+{
+    jq -nc '{type: "user", message: {role: "user", content: "hello"}}'
+    jq -nc '{type: "assistant", message: {role: "assistant", content: "hi"}}'
+} >"$T5"
+printf '%s\n' "$OLD_TS" >"$(state_file 5)"
+
+run_hook 5 "$T5"
+assert_silent "transcript with no queue-operations stays silent"
+assert_state "state is left untouched when there is nothing to report" 5 "$OLD_TS"
+
+# --- 6/7. Missing and nonexistent transcript --------------------------------
+
+run_hook 6 ""
+assert_silent "missing transcript_path exits silently"
+
+run_hook 7 "$TMPDIR_PROBE/does-not-exist.jsonl"
+assert_silent "nonexistent transcript path exits silently"
+
+# --- 8. Truncated first line (the `tail -c` byte cut) -----------------------
+
+T8="$TMPDIR_PROBE/case8.jsonl"
+{
+    printf '%s\n' 'ration":"enqueue","timestamp":"2026-08-03T09:00:00.000Z","content":"half a line"}'
+    enqueue_line '2026-08-03T10:00:00.000Z' 'survived the byte cut'
+    enqueue_line '2026-08-03T10:00:01.000Z' 'and so did this one'
+} >"$T8"
+printf '%s\n' "$OLD_TS" >"$(state_file 8)"
+
+run_hook 8 "$T8"
+assert_fires "truncated leading line is skipped, valid enqueues still counted" \
+    'MID-TURN MESSAGES: 2' \
+    'survived the byte cut' 'and so did this one'
+
+# --- 9. Content longer than 80 characters -----------------------------------
+
+LONG='0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789 TAIL_MARKER'
+T9="$TMPDIR_PROBE/case9.jsonl"
+enqueue_line '2026-08-04T10:00:00.000Z' "$LONG" >"$T9"
+printf '%s\n' "$OLD_TS" >"$(state_file 9)"
+
+run_hook 9 "$T9"
+assert_fires "over-long content is excerpted with an ellipsis" \
+    'MID-TURN MESSAGES: 1' \
+    '01234567890123456789012345678901234567890123456789012345678901234567890123456789…'
+assert_absent "the excerpt drops everything past the 80-char ceiling" 'TAIL_MARKER'
+
+# --- 10. queue-operation with operation != enqueue --------------------------
+
+T10="$TMPDIR_PROBE/case10.jsonl"
+{
+    dequeue_line '2026-08-05T10:00:00.000Z'
+    dequeue_line '2026-08-05T10:00:01.000Z'
+} >"$T10"
+printf '%s\n' "$OLD_TS" >"$(state_file 10)"
+
+run_hook 10 "$T10"
+assert_silent "dequeue operations are ignored"
+
+# --- 11. Monitor task-notifications are not user messages -------------------
+#
+# The dominant real-world shape: 57 of 62 enqueues in a measured window were
+# `<task-notification>` blocks. They carry a string .content like a user
+# message does, so only the prefix separates them.
+
+T11="$TMPDIR_PROBE/case11.jsonl"
+{
+    enqueue_line '2026-08-06T10:00:00.000Z' '<task-notification>
+<task-id>abc123</task-id>
+<summary>Monitor event: CI checks on PR #1892</summary>
+</task-notification>'
+    enqueue_line '2026-08-06T10:00:01.000Z' '<task-notification>
+<task-id>def456</task-id>
+</task-notification>'
+    enqueue_line '2026-08-06T10:00:02.000Z' 'REAL_USER_ASK did you see my earlier question'
+    enqueue_line '2026-08-06T10:00:03.000Z' '<task-notification>
+<task-id>ghi789</task-id>
+</task-notification>'
+} >"$T11"
+printf '%s\n' "$OLD_TS" >"$(state_file 11)"
+
+run_hook 11 "$T11"
+assert_fires "three task-notifications + one real message: only the real one counts" \
+    'MID-TURN MESSAGES: 1' \
+    'REAL_USER_ASK did you see my earlier question'
+assert_absent "no task-notification markup reaches the banner" 'task-notification'
+assert_absent "no Monitor task id reaches the banner" 'abc123'
+assert_state "skipped task-notifications still advance the state" 11 '2026-08-06T10:00:03.000Z'
+
+# --- 12. Slash commands need no receipt -------------------------------------
+
+T12="$TMPDIR_PROBE/case12.jsonl"
+{
+    enqueue_line '2026-08-07T10:00:00.000Z' '/compact'
+    enqueue_line '2026-08-07T10:00:01.000Z' 'SLASH_SIBLING a genuine ask'
+} >"$T12"
+printf '%s\n' "$OLD_TS" >"$(state_file 12)"
+
+run_hook 12 "$T12"
+assert_fires "a slash command alongside a real message: only the real one counts" \
+    'MID-TURN MESSAGES: 1' \
+    'SLASH_SIBLING a genuine ask'
+assert_absent "the slash command is not excerpted" '/compact'
+
+# --- 13. The message being submitted right now ------------------------------
+#
+# An ordinary, non-mid-turn message is ALSO written as an enqueue, so whenever
+# that write lands before the hook runs the current message would otherwise
+# report itself. It is excluded by content — but it must still advance the
+# state, or it would be re-evaluated on every subsequent message forever.
+
+CURRENT='this is the message I am submitting right now'
+T13="$TMPDIR_PROBE/case13.jsonl"
+enqueue_line '2026-08-08T10:00:00.000Z' "$CURRENT" >"$T13"
+printf '%s\n' "$OLD_TS" >"$(state_file 13)"
+
+run_hook 13 "$T13" "$CURRENT"
+assert_silent "an enqueue equal to the current prompt does not report itself"
+assert_state "the current message still advances the state" 13 '2026-08-08T10:00:00.000Z'
+
+# The same content with surrounding whitespace on ONE side only — both sides are
+# trimmed by the same expression, so it must still match.
+T13B="$TMPDIR_PROBE/case13b.jsonl"
+enqueue_line '2026-08-08T11:00:00.000Z' "  $CURRENT  " >"$T13B"
+printf '%s\n' "$OLD_TS" >"$(state_file 14)"
+
+run_hook 14 "$T13B" "$CURRENT"
+assert_silent "prompt matching is whitespace-insensitive on both sides"
+
+# --- 15. Path-traversal-shaped session id is sanitized ----------------------
+#
+# The session id reaches a filesystem path; anything outside [A-Za-z0-9._-]
+# folds to `_`, so a traversal-shaped id lands as a plain filename INSIDE
+# STATE_DIR rather than escaping it. Pins the sanitization as a tested
+# property instead of a correct-by-inspection one.
+
+T15="$TMPDIR_PROBE/case15.jsonl"
+enqueue_line '2026-08-09T10:00:00.000Z' 'traversal fixture message' >"$T15"
+
+EVIL_SESSION="../../$SESSION_PREFIX-traversal"
+SAFE_NAME="queued-receipt-state-.._.._$SESSION_PREFIX-traversal"
+json=$(jq -nc --arg s "$EVIL_SESSION" --arg t "$T15" --arg p 'next message' \
+    '{prompt: $p, session_id: $s, transcript_path: $t}')
+OUT=$(printf '%s' "$json" | "$HOOK" 2>/dev/null)
+RC=$?
+assert_silent "a traversal-shaped session id baselines silently"
+if [ -f "$STATE_DIR/$SAFE_NAME" ]; then
+    echo "ok   [state at sanitized path]: traversal id folds to a filename inside STATE_DIR"
+else
+    echo "FAIL [no state file at $STATE_DIR/$SAFE_NAME]: traversal id escaped or was dropped"
+    fail=1
+fi
+
+# --- 16. A VERBATIM captured production transcript line parses ---------------
+#
+# Every other fixture is synthetic JSON this probe authored itself, so a real
+# schema drift (a renamed field, a shape change) would sail past them. This
+# line was captured verbatim from a live session transcript (harness-generated
+# task-notification content — no user text). It pins the REAL field set
+# (sessionId alongside the fields the hook reads); if the harness changes the
+# enqueue shape, this case is the one that goes red. Live-verified 2026-08-09:
+# 1,991 of 1,991 enqueue lines in the capture session carried string content.
+
+T16="$TMPDIR_PROBE/case16.jsonl"
+cat >"$T16" <<'REALLINE'
+{"type":"queue-operation","operation":"enqueue","timestamp":"2026-08-01T17:44:16.516Z","sessionId":"3f50da50-2ed0-4de4-9829-b38a45f944f3","content":"<task-notification>\n<task-id>btdowilck</task-id>\n<summary>Monitor event: \"CI checks on PR #1892 (code-span discriminator family)\"</summary>"}
+REALLINE
+printf '%s\n' "$OLD_TS" >"$(state_file 16)"
+
+run_hook 16 "$T16"
+assert_silent "a verbatim real transcript enqueue parses and classifies (task-notification → skip)"
+assert_state "the real line's timestamp advances the state (schema fields all read)" 16 '2026-08-01T17:44:16.516Z'
+
+[ "$fail" = 0 ] && echo "ALL PASS" || {
+    echo "FAILURES"
+    exit 1
+}

--- a/.claude/hooks/queued-message-receipt.sh
+++ b/.claude/hooks/queued-message-receipt.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+# Mid-turn message receipt reminder (UserPromptSubmit).
+#
+# Fires when the user typed one or more messages WHILE the assistant's previous
+# turn was still in flight. 09-interaction-style.md § "Answer the User's
+# Questions First" checkpoint (a) requires a one-line receipt at the top of the
+# next reply for exactly those messages — the rule alone kept being violated
+# under monitor-notification interleave, so this is its mechanical trigger.
+#
+# Detection is via the session TRANSCRIPT, because the hook's stdin envelope
+# carries no origin flag: a mid-turn arrival is written to the transcript JSONL
+# as a line with `"type":"queue-operation"` and `"operation":"enqueue"`, each
+# carrying `.timestamp` (ISO8601, Z) and a string `.content`.
+#
+# State: one file per session holding the highest enqueue timestamp already
+# reported. The FIRST run of a session only baselines that file and stays
+# silent, so pre-existing history never spams. The transcript is written
+# ASYNCHRONOUSLY and may lag the hook, which is why catch-up is the design: an
+# enqueue that had not been flushed at this firing is simply picked up at the
+# next one. Do NOT add sleeps or retries here — the state file is what makes
+# lag harmless.
+#
+# Fail-open everywhere (exit 0, no output): no jq, no/unreadable transcript, no
+# session id. A missed reminder is a missed reminder; a hook that errors on a
+# UserPromptSubmit is in the way of every message.
+
+set -uo pipefail
+
+# Bash 4.4+ required: `mapfile` is a 4.0 builtin, but the empty-array `set -u`
+# quirk (`"${arr[@]}"` on an empty array reads as unbound) was only FIXED in
+# 4.4 — on 4.0-4.3 (RHEL 7 ships 4.2) an empty scan window would error on
+# every prompt, and macOS stock bash is 3.2. Older bash fails open instead.
+[ "${BASH_VERSINFO[0]:-0}" -gt 4 ] ||
+    { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 4 ]; } ||
+    exit 0
+
+# Byte-collation only, so ISO8601 timestamps compare as plain strings regardless
+# of the ambient locale's collation rules. LC_CTYPE is deliberately left alone —
+# ${#s} must keep counting CHARACTERS for the 80-char excerpt ceiling. Known
+# accepted gap: under a non-UTF-8 LC_CTYPE (LC_ALL=C containers), ${s:0:80}
+# counts bytes and can split a multi-byte character — cosmetic-only, fails open.
+export LC_COLLATE=C
+
+# How much of the transcript tail to scan — bounds runtime to milliseconds on
+# a multi-hundred-megabyte transcript. Known accepted gap: if a single turn
+# writes more than this window AFTER an enqueue lands, that enqueue scrolls
+# out before the next firing and its receipt is silently lost (a later
+# enqueue still advances state past it). Fail-open by design — widening the
+# window only trades runtime for a rarer miss.
+TAIL_BYTES=4000000
+
+INPUT=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Load-bearing: the message being submitted RIGHT NOW is itself written to the
+# transcript as an enqueue (measured — an ordinary, non-mid-turn message
+# enqueues and dequeues ~13ms later), so whenever that write lands before this
+# hook runs, the current message would report itself as mid-turn. Matching it by
+# content is what excludes it. Known accepted gap, the flush-order mirror image:
+# when the current message's enqueue flushes AFTER this hook ran, the NEXT
+# firing sees it as new and reports an already-answered ordinary message one
+# turn late. No discriminator exists (dequeues carry no content to correlate);
+# the banner's own wording bounds the cost — it instructs "confirm instead of
+# re-answering" for already-handled messages.
+PROMPT=$(jq -r '.prompt // empty' <<<"$INPUT" 2>/dev/null || echo "")
+
+TRANSCRIPT=$(jq -r '.transcript_path // empty' <<<"$INPUT" 2>/dev/null || echo "")
+SESSION=$(jq -r '.session_id // empty' <<<"$INPUT" 2>/dev/null || echo "")
+
+[ -n "$TRANSCRIPT" ] || exit 0
+[ -f "$TRANSCRIPT" ] && [ -r "$TRANSCRIPT" ] || exit 0
+[ -n "$SESSION" ] || exit 0
+
+# The session id reaches a filesystem path, so anything outside the safe set is
+# folded to `_` rather than trusted. Real ids are UUIDs; this only matters for
+# a malformed envelope.
+SAFE_SESSION=$(printf '%s' "$SESSION" | tr -c 'A-Za-z0-9._-' '_')
+
+STATE_DIR="/tmp/claude-$(id -u)"
+STATE_FILE="$STATE_DIR/queued-receipt-state-$SAFE_SESSION"
+
+# Mode is set atomically at creation (-m), and a pre-existing directory is
+# trusted only if this user owns it: the path is predictable, so on a shared
+# /tmp another user could pre-create it (dir squat / symlink plant, CWE-377) —
+# chmod on a dir we don't own would fail silently and the write would proceed
+# into hostile territory. Fail open instead.
+mkdir -p -m 700 "$STATE_DIR" 2>/dev/null || exit 0
+[ ! -L "$STATE_DIR" ] || exit 0
+[ -O "$STATE_DIR" ] || exit 0
+chmod 700 "$STATE_DIR" 2>/dev/null || true
+
+# One record per enqueue as `timestamp<TAB>report|skip<TAB>content`.
+#
+# `jq -R 'fromjson?'` is required rather than a plain `jq -c` stream: `tail -c`
+# cuts on a byte boundary, so the first line of the window is usually half a
+# JSON object, and a streaming parser aborts the whole read on it. The `?`
+# discards unparseable lines instead.
+#
+# @tsv escapes tabs, newlines and backslashes inside the content, so one enqueue
+# is always exactly one output line no matter what the user typed.
+#
+# The three non-reportable shapes are CLASSIFIED here rather than filtered out,
+# because a skipped entry must still advance the state timestamp: it was seen,
+# it is just not worth a receipt. Dropping it instead would pin state below the
+# newest enqueue forever and force a full re-evaluation on every message.
+#
+#   <task-notification>  — Monitor events, not the user typing. They dominate:
+#                          57 of 62 enqueues in a measured window.
+#   /…                   — a slash command; the harness owns it, nothing to ack.
+#   == the current prompt — the message being submitted right now (see $PROMPT).
+#
+# The prompt exclusion matches by CONTENT, not entry identity, so an earlier,
+# genuinely mid-turn message whose text happens to equal the current prompt is
+# also excluded — accepted: the assistant still sees and acts on the current
+# copy, only the earlier occurrence's mid-turn timing signal is lost.
+#
+# Both sides of the prompt comparison are trimmed by the SAME jq expression, so
+# the two can't drift the way a bash-trim-vs-jq-trim split would.
+JQ_FILTER='
+  def trim: sub("^[[:space:]]+"; "") | sub("[[:space:]]+$"; "");
+  ($prompt | trim) as $now
+  | fromjson?
+  | select(type == "object")
+  | select(.type == "queue-operation" and .operation == "enqueue")
+  | select((.timestamp | type) == "string" and (.content | type) == "string")
+  | . as $entry
+  | ($entry.content | trim) as $body
+  | [ $entry.timestamp,
+      (if ($body | startswith("<task-notification>")) then "skip"
+       elif ($body | startswith("/")) then "skip"
+       elif $body == $now then "skip"
+       else "report" end),
+      $entry.content ]
+  | @tsv
+'
+
+mapfile -t ENTRIES < <(
+    tail -c "$TAIL_BYTES" "$TRANSCRIPT" 2>/dev/null |
+        jq -Rr --arg prompt "$PROMPT" "$JQ_FILTER" 2>/dev/null
+)
+
+# Every entry advances the max, skipped ones included.
+MAX_TS=""
+for entry in "${ENTRIES[@]}"; do
+    ts=${entry%%$'\t'*}
+    [ -n "$ts" ] || continue
+    if [ -z "$MAX_TS" ] || [[ "$ts" > "$MAX_TS" ]]; then
+        MAX_TS="$ts"
+    fi
+done
+
+write_state() { # $1 = timestamp to record
+    # Never move the high-water mark backward: if a transcript were ever
+    # rewritten non-monotonically (no observed trigger — defensive only), a
+    # lower scan max must not re-open already-reported entries.
+    local current=""
+    [ -f "$STATE_FILE" ] && current=$(head -n 1 "$STATE_FILE" 2>/dev/null || echo "")
+    if [ -n "$current" ] && [[ "$current" > "$1" ]]; then
+        return 0
+    fi
+    printf '%s\n' "$1" >"$STATE_FILE" 2>/dev/null || return 0
+    chmod 600 "$STATE_FILE" 2>/dev/null || true
+}
+
+# First run of this session: baseline and say nothing. Epoch when the tail holds
+# no enqueue at all, so the next run compares against something rather than
+# re-baselining.
+if [ ! -f "$STATE_FILE" ]; then
+    write_state "${MAX_TS:-1970-01-01T00:00:00.000Z}"
+    exit 0
+fi
+
+STATE_TS=$(head -n 1 "$STATE_FILE" 2>/dev/null || echo "")
+[ -n "$STATE_TS" ] || STATE_TS="1970-01-01T00:00:00.000Z"
+
+# One display line for a message: unescape what @tsv escaped, flatten to a
+# single line, and cap at 80 characters.
+excerpt() { # $1 = @tsv-escaped content
+    local s="$1"
+    s=${s//\\n/ }
+    s=${s//\\r/ }
+    s=${s//\\t/ }
+    s=${s//\\\\/\\}
+    # Cap BEFORE the collapse loop so a pathological whitespace-heavy paste
+    # costs O(cap), not O(message). 400 leaves ample slack to collapse down
+    # to the 80-char display ceiling.
+    s="${s:0:400}"
+    while [[ "$s" == *"  "* ]]; do s=${s//  / }; done
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    if [ "${#s}" -gt 80 ]; then
+        s="${s:0:80}…"
+    fi
+    printf '%s' "$s"
+}
+
+NEW_COUNT=0
+EXCERPTS=()
+# Known accepted gap: strictly-greater-than means an enqueue whose millisecond
+# timestamp EXACTLY equals the recorded high-water mark (written by a prior
+# firing) is treated as already-seen and silently never reported. Closing it
+# needs a tie-broken identity (timestamp+content) in the state file; a
+# same-millisecond straddle across two separate firings is rare enough that
+# the fail-open posture (a missed reminder is a missed reminder) covers it.
+# >= is not the fix — it would re-report the boundary entry on every firing.
+for entry in "${ENTRIES[@]}"; do
+    ts=${entry%%$'\t'*}
+    [ -n "$ts" ] || continue
+    [[ "$ts" > "$STATE_TS" ]] || continue
+    rest=${entry#*$'\t'}
+    flag=${rest%%$'\t'*}
+    [ "$flag" = "report" ] || continue
+    content=${rest#*$'\t'}
+    NEW_COUNT=$((NEW_COUNT + 1))
+    if [ "${#EXCERPTS[@]}" -lt 3 ]; then
+        EXCERPTS+=("$(excerpt "$content")")
+    fi
+done
+
+if [ "$NEW_COUNT" -eq 0 ]; then
+    # Advance anyway. Everything newer than the old state was seen and
+    # classified as not worth a receipt; leaving state behind would re-evaluate
+    # those same entries on every subsequent message, and one permanently
+    # skipped entry (a Monitor notification, say) would pin it forever.
+    # `:-$STATE_TS` keeps the value unchanged when the tail held no enqueue at
+    # all, so an empty scan never rewinds the baseline.
+    write_state "${MAX_TS:-$STATE_TS}"
+    exit 0
+fi
+
+RULE='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+
+printf '%s\n' "$RULE"
+printf 'MID-TURN MESSAGES: %s user message(s) arrived while a turn was in flight.\n' "$NEW_COUNT"
+printf 'Per 09-interaction-style.md checkpoint (a), give EACH a one-line receipt\n'
+printf 'at the top of your reply (restate the ask); if one was already answered\n'
+printf 'mid-turn, confirm that instead of re-answering.\n'
+for ex in "${EXCERPTS[@]}"; do
+    printf '  - %s\n' "$ex"
+done
+if [ "$NEW_COUNT" -gt 3 ]; then
+    printf '  …and %s more\n' "$((NEW_COUNT - 3))"
+fi
+printf '%s\n' "$RULE"
+
+write_state "${MAX_TS:-$STATE_TS}"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,14 @@
           {
             "type": "command",
             "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/skill-eval.sh"
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/bare-token-binding-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/queued-message-receipt.sh"
           }
         ]
       }

--- a/.claude/skills/tzurot-docs/SKILL.md
+++ b/.claude/skills/tzurot-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-docs
 description: 'Session workflow procedures. Invoke with /tzurot-docs for session start/end, CURRENT.md and backlog management.'
-lastUpdated: '2026-07-28'
+lastUpdated: '2026-08-09'
 ---
 
 # Documentation & Session Workflow
@@ -124,3 +124,9 @@ procedure, don't wait to be walked through it:
    removed (verify by grep, not by date); umbrella entries get sub-items struck.
 4. **Measure net shrink**: the success metric is the backlog getting SMALLER —
    report entries removed vs. added at the end of the sweep.
+5. **Standing drain directive = running net at every batch.** While a
+   drain/shrink directive is in force, every batch report states the running
+   session net (tasks closed vs tasks filed). Any task the assistant itself
+   generates (process/meta work — audits, gates, skill/hook improvements) is
+   named as such at filing time and counts visibly against the net — growth
+   must be visible at the moment it happens, not discovered by the owner later.

--- a/packages/tooling/src/dev/check-hook-probes-registry.ts
+++ b/packages/tooling/src/dev/check-hook-probes-registry.ts
@@ -45,6 +45,10 @@ export interface HookProbeEntry {
  */
 export const HOOK_PROBES: HookProbeEntry[] = [
   {
+    hook: '.claude/hooks/bare-token-binding-reminder.sh',
+    probe: '.claude/hooks/bare-token-binding-reminder.probe.sh',
+  },
+  {
     hook: '.claude/hooks/claim-shape-guard.sh',
     probe: '.claude/hooks/claim-shape-guard.probe.sh',
   },
@@ -76,6 +80,10 @@ export const HOOK_PROBES: HookProbeEntry[] = [
   {
     hook: '.claude/hooks/pr-monitor-reminder.sh',
     probe: '.claude/hooks/pr-monitor-reminder.probe.sh',
+  },
+  {
+    hook: '.claude/hooks/queued-message-receipt.sh',
+    probe: '.claude/hooks/queued-message-receipt.probe.sh',
   },
   {
     hook: '.claude/hooks/eslint-on-edit.sh',


### PR DESCRIPTION
## What

Operationalizes the two hook-eligible findings from the 2026-08-09 session-mining run, plus one skill amendment:

1. **`bare-token-binding-reminder.sh`** (UserPromptSubmit) — fires when the user's whole message is a short approval/decline/selection token ("sure", "A", "yes and yes", "I approve your recommendation") and injects a reminder to restate the token's binding per `09-interaction-style.md`. Deliberately narrow: slash commands, multi-line messages, and anything over 60 chars stay silent, so the reminder doesn't train skimming.
2. **`queued-message-receipt.sh`** (UserPromptSubmit) — detects user messages typed mid-turn via a transcript-tail scan (`queue-operation`/`enqueue` entries) against a per-session state file, and injects a receipt reminder per `09-interaction-style.md` checkpoint (a). First run baselines silently; excluded shapes (Monitor task-notifications, slash commands, the current prompt itself) still advance state so they never pin it.
3. **`tzurot-docs` skill, net-shrink sweep step 5** — while a drain directive is in force, every batch report states the running closed-vs-filed net, and assistant-generated meta/process tasks name themselves as such at filing.

## Why

The mined window showed the bare-token rule violated 12+ times (the exact phrase "yes and yes" bound to two different menus in one day, with the cost surfacing live post-compaction), a queued question buried ~6h ("I think you got stuck"), and the backlog grown with meta-tasks under an explicit shrink directive. All three are compliance findings on existing rules — the fix tier is mechanism, not more rule text.

## Verified, and how

- Both hooks have exit-code probe harnesses (23 and 26 assertions); `pnpm ops guard:hook-probes` green at 10 probed / 5 unprobed.
- The receipt hook was demoed against the live 146MB session transcript: a rewound window that naively reported 62 "messages" reports exactly the 5 genuine user messages, with per-rule attribution (56 task-notifications, 1 slash command excluded). Runtime 0.2s via a 4MB tail bound.
- The receipt probe caught a real state-advance bug during development (state written only on the fire path → a Monitor-only window would rescan forever) — fixed and pinned.
- Review-round hardening: the receipt hook fails open on bash < **4.4** (the empty-array `set -u` quirk was only fixed in 4.4, so 4.0–4.3 — RHEL 7's 4.2 — would otherwise error on an empty scan window; macOS stock 3.2 additionally lacks `mapfile`), state-dir creation is squat-hardened (`mkdir -m 700` atomic mode + `-O` ownership check), the session-id sanitization is probe-pinned with a path-traversal case, and the bare-token match uses `printf` over builtin-`echo`.
- Tooling suite 155 files / 2329 tests green; full `pnpm quality` chain green.

## Design notes

- Mid-turn detection has no documented origin flag in the hook input (verified against current docs), so the transcript scan + state-file catch-up is the design; transcript write lag makes a reminder late, never wrong.
- Known accepted gaps, each documented at the code site — all fail-open (worst case: a missed or garbled reminder banner, never a blocked prompt): same-millisecond timestamp tie (strictly-greater-than state comparison); content-equality self-exclusion masking an identical earlier message; the 4MB tail-window blind spot (a single turn writing >4MB after an enqueue scrolls it out); byte-vs-character truncation under a non-UTF-8 locale; the cosmetic excerpt unescape of a literal backslash-n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)