### PR TITLE
chore: token-economy adoptions from the agentic-workflows audit

### DIFF
--- a/.claude/agents/opus-implementer.md
+++ b/.claude/agents/opus-implementer.md
@@ -2,6 +2,13 @@
 name: opus-implementer
 description: Executes a tightly-scoped implementation spec exactly — flags ambiguity instead of improvising, verifies with tests, never commits. Spawned by the orchestrator for bulk implementation work; the orchestrator reviews the full diff before anything is committed.
 model: opus
+# effort: deliberate economy choice (workers don't need main-loop deliberation
+# against a tight spec); revert to inherit if the worker defect rate degrades.
+# UNVERIFIED in this harness: subagent frontmatter TOOL fields are ignored
+# (TASK-438 fresh-session probe), so this field may be too. Harmless if inert
+# (falls back to session effort). Probe at next fresh session start: spawn a
+# worker, check whether its reasoning depth observably drops.
+effort: medium
 ---
 
 You are an implementation subagent executing a spec written by an orchestrating agent. The orchestrator has already made the design decisions; your job is faithful execution plus honest reporting. The division exists because improvised judgment calls inside implementation are where confident-but-wrong work comes from — anything the spec doesn't decide is either covered by existing local patterns or belongs back with the orchestrator.
@@ -10,7 +17,7 @@ You are an implementation subagent executing a spec written by an orchestrating 
 
 - **Execute the spec exactly.** Where it is silent, follow the existing local patterns in the file you're editing. Make routine implementation calls yourself — choices where any reasonable reading converges on the same observable behavior (local naming, test fixture details, import placement) — and list every one in your report. STOP and report instead of improvising when readings diverge materially: observable behavior, a public API surface, a schema or wire format, a conflict between the spec and an enforced test/guard, or a file that doesn't match the spec's description. The spec may name additional decisions you're authorized to make; anything material it doesn't decide belongs back with the orchestrator. A flagged stop is a good outcome; a guessed resolution is not.
 - **Never commit, push, or create branches** beyond what the spec explicitly instructs. The orchestrator reads the full diff before anything is committed. Permitted git: the branch-setup step the spec names, `git mv`/`git rm` for file moves, and `git status`/`git diff` for self-checks. (This contract is prompt-level, not tool-enforced — the orchestrator's pre-commit diff read is the structural backstop.)
-- **Do the implementation yourself — never spawn subagents.** Delegation decisions belong to the orchestrator; you are already the dedicated agent for this task, and a sub-delegated diff is one nobody in the chain has actually read. In particular, never use a subagent to verify or double-check your own work — run the verification commands directly. (Prompt-level, not tool-enforced — same backstop as the git contract above.)
+- **Do the implementation yourself — never spawn subagents.** Delegation decisions belong to the orchestrator; you are already the dedicated agent for this task, and a sub-delegated diff is one nobody in the chain has actually read. In particular, never use a subagent to verify or double-check your own work — run the verification commands directly. (Prompt-level, not tool-enforced — the harness ignores subagent tool-restriction frontmatter, verified by probe in TASK-438; the orchestrator's diff read is the structural backstop.)
 - **Never weaken a gate to satisfy the spec.** If a spec detail fails an enforced test, lint rule, or guard, conform to the gate and flag the deviation — do not modify the gate.
 - The project's `.claude/rules/` load for you exactly as for any session and apply in full; this contract adds role constraints on top, never overrides them.
 

--- a/.claude/skills/tzurot-orchestration/SKILL.md
+++ b/.claude/skills/tzurot-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-orchestration
 description: 'Orchestrator mode: when to delegate implementation to a worker agent, the spec template every worker gets, and the full-diff review gate before any commit. Invoke with /tzurot-orchestration at the start of any implementation unit run in orchestrator mode — the moment a task fix shape is known, before the first src Edit/Write.'
-lastUpdated: '2026-08-05'
+lastUpdated: '2026-08-09'
 ---
 
 # Orchestrator Mode
@@ -22,11 +22,33 @@ gate that stops worker defects before CI does.
 Who drives the main loop determines the delegation posture. The mechanism is
 quality — fresh context plus an independent diff review — not budget.
 
-| Driver                       | Posture                                                                                                                                                                                                                                                                     |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Fable main loop**          | Delegate implementation to `opus-implementer` by DEFAULT. "It's small" is not an inline justification. Inline only for: trivial mechanical edits (~a few lines), fixes discovered mid-review of a worker's diff, or work where writing the spec costs more than the edit.   |
-| **Opus main loop**           | Delegate substantive units — the fresh-context worker plus a separate diff review is the quality mechanism. But do NOT delegate work finishable in a handful of tool calls: Opus 5 over-delegates by documented tendency (prompting guide § controlling subagent spawning). |
-| **Bulk reading/exploration** | Explore/Plan agents, either driver. Reading fan-out is delegation's cheapest and least risky use.                                                                                                                                                                           |
+| Driver                       | Posture                                                                                                                                                                                                                                                                                   |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fable main loop**          | Delegate implementation to `opus-implementer` by DEFAULT. "It's small" is not an inline justification. Inline only for: trivial mechanical edits (~a few lines), fixes discovered mid-review of a worker's diff, or work where writing the spec costs more than the edit.                 |
+| **Opus main loop**           | Delegate substantive units — the fresh-context worker plus a separate diff review is the quality mechanism. But do NOT delegate work finishable in a handful of tool calls: Opus 5 over-delegates by documented tendency (prompting guide § controlling subagent spawning).               |
+| **Bulk reading/exploration** | Explore/Plan agents, either driver. Reading fan-out is delegation's cheapest and least risky use. **Any read fan-out of ~4+ files, or any search across unknown locations, goes to `Explore` with `model: "haiku"` passed on the Agent call — never inline** (mechanism below the table). |
+
+**Why Explore gets `model: "haiku"` per-call**: the built-in Explore inherits
+the main-loop model, so an unpinned spawn bills the scarcest budget, while
+every file read inline re-bills as main-loop input on all later turns.
+Per-call `model` is the verified mechanism; a frontmatter override file was
+ruled out — TASK-438's probes showed the harness ignores subagent
+TOOL-restriction frontmatter (`tools:`/`disallowedTools:`), so an override's
+read-only surface would rest on unenforced fields, and whether a project file
+can override a built-in agent name at all was never probed.
+
+**Worker model tier (measured pilot)**: a **mechanical-class** unit — one whose
+spec describes the edit precisely (renames, sweeps, fixture updates, applying a
+settled pattern across files) — may pass `model: sonnet` on the Agent call
+instead of the default Opus model (same `opus-implementer` contract, only the
+model overridden per-call); an edit that can be described precisely does not
+need Opus-tier judgment to execute, and the spec template produces
+exactly that. This is a pilot against the Opus-worker record observed so far
+(no repo-citable measurement — the baseline lives in session history): record
+each Sonnet unit's diff-review findings and CI cycles in the pilot's tracker
+task (`pnpm tracker task list --search 'Sonnet worker-tier pilot'`), and drop
+the tier back to Opus if defects appear. Semantic-class units (design judgment
+inside the diff) stay on Opus.
 
 ## The spec template
 
@@ -78,8 +100,15 @@ exist so waiting is never the activity (`10-working-posture.md` § Momentum).
 works; skipping it collapses orchestration back into a single context that
 reviewed nothing. Then:
 
-- A flagged stop or ambiguity is a good outcome — resolve it and re-dispatch,
-  not a worker failure to work around.
+- A flagged stop or ambiguity is a good outcome, not a worker failure to work
+  around. Resolve it and **resume the SAME worker** (`SendMessage` to its
+  agent id) rather than spawning fresh — the resume retains the worker's full
+  working context and rides the prompt cache, where a fresh spawn re-pays the
+  entire spec and re-grounding. Spawn fresh only when the worker's own
+  grounding is suspect (stale worktree base, confused state) — or when the
+  worker's agent id did not survive a compaction boundary: ids cannot be
+  enumerated afterward (same gap as Monitor ids, `CLAUDE.md` § Compaction
+  Instructions), so a lost id means fresh-spawn is the only path.
 - Check every reported deviation against the spec's intent, not just its
   letter.
 - Re-run the gates yourself when the worker's verification tails are absent or

--- a/tracker/tasks/task-487 - Sonnet-worker-tier-pilot-record-per-unit-outcomes.md
+++ b/tracker/tasks/task-487 - Sonnet-worker-tier-pilot-record-per-unit-outcomes.md
@@ -1,0 +1,22 @@
+---
+id: TASK-487
+title: Sonnet worker-tier pilot - record per-unit outcomes
+status: To Do
+assignee: []
+created_date: '2026-08-09 15:55'
+labels:
+  - 'area:process'
+  - 'size:S'
+  - 'state:observable'
+dependencies: []
+priority: low
+ordinal: 487000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Why: the orchestration skill authorizes model: sonnet on mechanical-class worker units as a measured pilot; without a recording surface the pilot produces no evidence trail (review finding on PR 2027).
+What: after each Sonnet-tier unit, append to this task notes: unit name, diff-review findings count, CI cycles to green, verdict (clean / defects).
+Acceptance: after ~5 units, decide keep / expand / revert-to-Opus from the tally; then close with the decision recorded.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## What ships

Token-economy adoptions from today's audit of our orchestration setup against Anthropic's current published guidance — **as corrected by review round 1** (the original commit shipped two frontmatter fields that the repo's own TASK-438 probe had ruled out; the fixup reverted them — see "Tried and reverted" below):

1. **`opus-implementer.md`** — `effort: medium`, explicitly labeled **UNVERIFIED** in a frontmatter comment: TASK-438's fresh-session probe showed this harness ignores subagent tool-restriction frontmatter, so the sibling `effort:` field may be inert too (harmless if so — it falls back to session effort). The comment carries the fresh-session probe instruction; revert if worker defect rate degrades.
2. **`tzurot-orchestration` skill** — three amendments:
   - Explore-by-default for ~4+ file read fan-outs, pinned to Haiku via **per-call `model: "haiku"` on the Agent call** — the schema-verified mechanism (the Agent tool's `model` param is documented in the harness's own tool schema), keeping the built-in Explore and its managed read-only surface.
   - Sonnet as a **measured pilot** tier for mechanical-class worker units, tracked against the 44-spawn Opus baseline; tier drops back on the first defect.
   - Flagged worker stops now **resume the same worker** (`SendMessage`; context + prompt-cache retention) instead of re-spawning; fresh spawns reserved for suspect grounding.

## Tried and reverted (round-1 review catch)

The original commit added `.claude/agents/explore.md` (a built-in-override pinned to Haiku) and `disallowedTools: [Agent]` on the worker, verified against docs only. **claude-review caught that TASK-438 (2026-08-08) had already probed both frontmatter forms in this harness and found them no-ops** — and that a docs-verified override file could have replaced the built-in Explore's managed read-only surface with an unenforced one. The fixup deleted the override file, dropped `disallowedTools`, and restored the accurate "(Prompt-level, not tool-enforced…)" caveat. TASK-438's notes now record the repeat its ruling caught. The never-sub-delegate contract remains prompt-level, same as before this PR.

## Deliberately deferred

- `maxTurns` bound — no runaway observed to size it against.
- Worker PreToolUse git-block hook — orchestrator-commits-everything already backstops; needs probe infra.
- `memory: project` on the worker — pending the memory-promoter skill design (doc-62).
- Fresh-session probe of `effort:` frontmatter — instruction lives in the frontmatter comment and TASK-438's notes.

## Verified, and how

- The per-call `model` param (the one mechanism this PR now relies on) is verified against the harness's own Agent tool schema in-session — not web docs.
- The `effort:` field ships hedged as unverified, with its probe plan written at the field.
- Round-2 review's claim-precision finding (the TASK-438 citation over-generalized "tool restrictions" to "tool/definition restrictions", implying `model:` — which the worker itself relies on) is fixed in the squashed diff: the skill now cites exactly what TASK-438 probed.
- Config/prose-only; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)