### PR TITLE
docs: rules economy pass — first execution of the doc-audit 3b trim

### DIFF
--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -193,7 +193,7 @@ Arm the CI Monitor immediately after `gh pr create` per `05-tooling.md` § PR Mo
 
 **Apply the test, not just the file extension**: when in doubt about a doc change, ask "would `claude-bot`, codecov, or lint produce useful output on this diff?" If yes (e.g., a rule that affects every contributor's behavior, a runbook that prescribes a specific command sequence reviewer might want to second-guess), use a PR. If no (a status update, a typo fix, a stale-link replacement), direct commit is fine.
 
-**Workflow**: commit the doc files on `develop` and push — no branch, no PR, no CI re-run. Pre-push hooks still fire.
+**Workflow**: pull `develop` first, commit the doc files, push — no branch, no PR, no CI re-run. Pre-push hooks still fire.
 
 **This permission does NOT extend to:**
 

--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -6,7 +6,7 @@ These constraints MUST always be followed. Violations cause bugs, security issue
 
 ### Shell Command Safety
 
-**This vulnerability has occurred multiple times.** Never use string interpolation in shell commands.
+Never use string interpolation in shell commands.
 
 ```typescript
 // ❌ WRONG - Command injection vulnerable
@@ -72,7 +72,7 @@ const url = `${BASE_URL}/api/resource/${encodeURIComponent(apiResponseId)}/detai
 
 ### URL Substring Checks (CodeQL)
 
-**Never validate a URL or host with `.includes()`, `.indexOf()`, `.startsWith()`, or an unanchored regex.** CodeQL flags `url.includes('example.com')` as "Incomplete URL substring sanitization" (`js/incomplete-url-substring-sanitization`, high severity) — `evil-example.com.attacker.io` passes it. **This fires even on allowlist checks over trusted, build-time input** (a legal-doc content guard tripped it): CodeQL judges the code shape, not where the string came from, so "it's not attacker-controlled" is not a defense — the check will block the merge.
+**Never validate a URL or host with `.includes()`, `.indexOf()`, `.startsWith()`, or an unanchored regex.** CodeQL flags `url.includes('example.com')` as "Incomplete URL substring sanitization" (`js/incomplete-url-substring-sanitization`, high severity) — `evil-example.com.attacker.io` passes it. **This fires even on allowlist checks over trusted, build-time input** — CodeQL judges the code shape, not the string's origin, so "it's not attacker-controlled" won't unblock the merge.
 
 ```typescript
 // ❌ WRONG - substring host check (CodeQL high)
@@ -132,8 +132,6 @@ gh pr merge --rebase --delete-branch
 gh pr merge --rebase
 ```
 
-**To update main from develop**: Use GitHub PR with rebase merge, or ensure fast-forward is possible.
-
 ### Long-Lived Branch Protection (CRITICAL)
 
 **NEVER delete `main` or `develop`.** These are permanent branches.
@@ -150,7 +148,7 @@ gh pr merge 714 --rebase --delete-branch  # PR from develop → main
 gh pr merge 714 --rebase                  # develop survives
 ```
 
-**The flag is not the only deletion path — the repo setting is the other one.** `delete_branch_on_merge` deletes the head branch on EVERY merge regardless of the flag, and GitHub performs that delete with ADMIN privileges, so it passes straight through a ruleset whose `bypass_actors` is non-empty. `develop`'s ruleset carries bypass actors deliberately (`release:finalize`'s force-push, sanctioned direct doc-commits), which makes `develop` — and only `develop` — reachable that way. **`delete_branch_on_merge` must stay `false`**; feature branches are cleaned by passing `--delete-branch` explicitly, which the commands above already do. `pnpm ops guard:repo-settings` asserts the whole invariant; run it in the release preflight.
+**`delete_branch_on_merge` must stay `false`** — it deletes the head branch on EVERY merge regardless of the `--delete-branch` flag, with admin privileges, so it passes through `develop`'s deliberately-bypassable ruleset. `pnpm ops guard:repo-settings` asserts the invariant; run it in the release preflight.
 
 ### Destructive Commands - ASK FIRST
 
@@ -175,15 +173,13 @@ gh pr merge 714 --rebase                  # develop survives
 
 Routine `git add <files>` + `git commit` + `git push` + `gh pr create` to feature branches is **pre-authorized**. After implementation work passes its verification (tests + quality), proceed straight to: branch → stage specific files → commit → push → `gh pr create`. Don't ask "want me to commit?" or "should I open the PR now?" — the user reviews on the PR diff, not on a per-commit prompt.
 
-**`gh pr create` is part of the routine cycle, not a separate checkpoint.** Even though opening a PR is publicly visible (notifications fire, the URL appears in the GitHub UI), the user has chosen the PR diff as their review surface — the standing permission overrides the generic "confirm before user-visible actions" guidance for this specific action. Arm the CI Monitor immediately after `gh pr create` per `05-tooling.md`'s PR-monitoring rule; don't ask first.
+Arm the CI Monitor immediately after `gh pr create` per `05-tooling.md` § PR Monitoring; don't ask first.
 
 **Gate**: `pnpm test` and `pnpm quality` must be green before the commit-push-PR cycle runs. Don't commit to get CI to check for you — CI is a second line of defense, not a substitute for local verification. If either fails, fix the failure (or escalate to the user if the failure is unclear) before commit; do not commit a known-broken state with the intent to follow up.
 
 **This permission applies ONLY to feature branches.** Direct commits to `main` remain forbidden — open a PR instead.
 
 ### Direct doc commits to `develop` (narrow exception)
-
-The PR cycle's primary value on this project is **automated review** — `claude-bot` scrutinises diffs for bugs, codecov flags coverage gaps, lint catches style/complexity issues. When a change can't benefit from any of those, the PR adds friction without catching anything. For that class of change, direct commits to `develop` are permitted.
 
 | Allowed on `develop` directly                                                                                 | Still requires a PR                                                          |
 | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
@@ -197,40 +193,22 @@ The PR cycle's primary value on this project is **automated review** — `claude
 
 **Apply the test, not just the file extension**: when in doubt about a doc change, ask "would `claude-bot`, codecov, or lint produce useful output on this diff?" If yes (e.g., a rule that affects every contributor's behavior, a runbook that prescribes a specific command sequence reviewer might want to second-guess), use a PR. If no (a status update, a typo fix, a stale-link replacement), direct commit is fine.
 
-**Workflow for the exception**:
-
-```bash
-git checkout develop && git pull
-# edit BACKLOG.md / backlog/<section>.md / CURRENT.md / docs/...
-git add <doc-files>
-git commit -m "docs(<scope>): <message>"
-git push origin develop
-```
-
-No branch, no PR, no CI re-run. Pre-push hooks still fire because they run on any push.
-
-**Why**: doc housekeeping gets no useful signal from automated review; code diffs are where the review fires.
+**Workflow**: commit the doc files on `develop` and push — no branch, no PR, no CI re-run. Pre-push hooks still fire.
 
 **This permission does NOT extend to:**
 
-- Anything in the "Destructive Commands - ASK FIRST" table above (force-push, reset --hard, restore, clean, kill processes, rm -rf)
-- `gh pr merge` on the release PR (develop → main) — always needs explicit per-release approval; feature/fix merges follow "Merge Approval" below (standing authorization once truly ready)
-- Branch deletion (`git branch -D`, `--delete-branch` flag on `gh pr merge`) on long-lived branches (main/develop)
-- Skipping hooks (`--no-verify`, `--no-gpg-sign`)
-- Touching `.env` or files that may contain secrets
-
-**Why**: per-commit asks produced rubber-stamping noise; the PR diff is the review surface. Low cost for routine actions, high cost for irreversible ones.
+- Skipping hooks (`--no-verify`, `--no-gpg-sign`), plus everything already forbidden above: the ASK-FIRST table, long-lived-branch deletion, release-PR approval, `.env`/secrets.
 
 ### Before Code Changes
 
 1. Read the ENTIRE file first
 2. Never modify files you haven't read
 3. Make ONLY the requested change
-4. **For approved designs that touch schema or user-visible behavior: restate the user-visible semantics in plain terms and get confirmation before building.** Plan-mode plans must include a "what the user will see/do differently" section. An epic phase was once built on a `kind` param the owner understood as capability-filtering when it actually stored config-kind — the most expensive miscommunication on record; restating semantics up front is how that class dies.
+4. **For approved designs that touch schema or user-visible behavior: restate the user-visible semantics in plain terms and get confirmation before building.** Plan-mode plans must include a "what the user will see/do differently" section.
 
 ### Merge Approval
 
-**Standing authorization (explicit user grant, reconfirmed at codification): feature/fix PRs may be merged without a per-PR ask once they are truly ready** — every CI check green + complete + read (next section), the claude-review body read with no unresolved substantive findings, and any human feedback addressed. "Truly ready" is strict; when in doubt, ask.
+**Standing authorization: feature/fix PRs may be merged without a per-PR ask once they are truly ready** — every CI check green + complete + read (next section), the claude-review body read with no unresolved substantive findings, and any human feedback addressed. "Truly ready" is strict; when in doubt, ask.
 
 **The release PR (develop → main) ALWAYS requires explicit per-release user approval.** CI passing ≠ release approval — no exceptions.
 
@@ -245,8 +223,6 @@ No branch, no PR, no CI re-run. Pre-push hooks still fire because they run on an
 **Structural backstop**: `pr-merge-review-check.sh` blocks `gh pr merge` once per review, injecting the review body into context; retry after engaging with it. A fresh review re-arms it. Do not bypass by editing the ack file.
 
 The hook covers only `claude[bot]` issue-level comments — formal review summaries and human line-comments stay attention-dependent, so fetch them per `05-tooling.md` § PR Monitoring.
-
-If post-merge feedback surfaces from claude-review on a tiny fixup, it can always be fixed on develop afterwards via the doc-commit exception (for docs) or a tiny follow-up PR (for code). The cost of one more CI cycle (~5 min) is far smaller than the cost of merging through an unreviewed change.
 
 **Why:** CI green-by-omission is invisible by default. A failed `claude-review` (or any other check) sitting next to 14 green checks looks identical to "all green" at a glance, and skipping it silently sacrifices the signal it would have produced. Release PRs in particular benefit from a holistic second-look review even when the constituent code was reviewed PR-by-PR.
 
@@ -265,13 +241,11 @@ If post-merge feedback surfaces from claude-review on a tiny fixup, it can alway
 - **NEVER modify tests to make them pass** - fix the implementation
 - **Coverage required**: 80% minimum, Codecov blocks PRs below threshold
 - Run `pnpm test` before pushing - no exceptions
-- Run `pnpm test:component` when changes affect: slash command options/structure, command file discovery, or service integration points. The `CommandHandler.component.test.ts` has **snapshot tests** that break on any command option change.
+- Run `pnpm test:component` after slash-command structure changes (snapshot tests) — trigger table in `/tzurot-testing`.
 
 ### Test Coverage Baseline
 
 - **NEVER add NEW code to `knownGaps` baseline** - write proper tests instead
-- `knownGaps` is for pre-existing tech debt, not new features
-- When audit fails with "NEW gaps", fix by adding tests, not by updating baseline
 - File: `.github/baselines/test-coverage-baseline.json`
 
 ## Project Rules
@@ -284,28 +258,13 @@ One-person project. Make the cleanest change, even if breaking.
 
 **Never dismiss issues as "pre-existing" or "out of scope."** If you discover a problem while working in an area — missing tests, coverage gaps, code smells, unclear naming, stale comments — fix it. "Pre-existing" is not a reason to ignore something; it's an explanation of how it got there.
 
-This applies to:
-
-- **Missing test coverage** for modules you're modifying or extracting
-- **Code quality issues** adjacent to your changes (dead imports, unclear names)
-- **Coverage gaps** flagged in PR reviews — fix them, don't explain them away
-- **Documentation** that's stale or misleading in files you're touching
-
 The only exception: fixing it would significantly expand the PR's scope and risk unrelated bugs. Deferring requires a stated strong reason (different mechanism, no production evidence, risky breadth) — "pre-existing," "harmless," and "could be a follow-up" are non-reasons. If deferred, write the backlog entry immediately and fix it in a follow-up, not "someday." Declined ideas get NO tombstone in docs or backlog — the decline rationale lives in the PR/commit that declined them.
 
 ### Verify Before Accepting External Feedback
 
 Automated reviewers can be wrong. Check schema/source/tests before implementing suggestions.
 
-**Verifying the mechanism is not verifying the scenario.** A finding has two
-parts — the mechanism ("this gate doesn't check X") and the repro that motivates
-it ("so when a user does A, B, or C, it breaks"). Confirming the mechanism in the
-source says nothing about whether each listed trigger actually reaches it. Check
-every trigger condition separately, and drop the ones that don't hold before
-repeating the scenario in a PR body, commit message, or smoke item — a wrong
-trigger there sends the owner to verify a path that was never broken, and it
-passes, which reads as confirmation. Same standard applies to a repro you wrote
-yourself.
+**Verifying the mechanism is not verifying the scenario.** Confirming a finding's mechanism in the source says nothing about whether each listed trigger actually reaches it. Check every trigger separately and drop the ones that don't hold before repeating the scenario in a PR body, commit message, or smoke item — including a repro you wrote yourself.
 
 ### Don't Present Speculation as Fact
 
@@ -328,13 +287,13 @@ When making claims about causation, origin, intent, or history, distinguish betw
 
 **The producer is authoritative on what a field HOLDS — a declaration is not.** Any claim about a field's actual values ("this is a UUID", "that's always populated", "these two key spaces are disjoint", "a 0 here means it failed") must be verified by grepping where the field is ASSIGNED, not by reading a type, schema, or doc comment. Two failure modes drive this: a doc comment states the author's intent at writing time and drifts silently, and near-identical sibling interfaces coexist (`RawHistoryEntry` vs `ConversationHistoryEntry` vs an inline structural type — all three declare `id?: string` on the same conceptual row, with materially different semantics), so reading a plausible-looking declaration is not evidence you read the one in the path. Trace producer → wire → consumer and cite the assignment site. A second reviewer agreeing is not independent confirmation when it read the same declaration you did.
 
-**An empty or sparse tool result is not evidence that the data is gone.** When a query returns nothing — or less than you expected — the cause is almost always the _query_, not missing data: a wrong filter field, an out-of-range flag value, the wrong scope, or finicky query syntax. Do NOT explain it away with infrastructure-decay claims ("the logs rolled off", "it aged out of retention", "it expired", "it got GC'd") unless you have direct evidence that's literally true. That's the satisfying answer, and it's almost always wrong — stating it as fact sends the user looking for data that's sitting right there. Default to "my query is wrong": enumerate why it could be returning nothing, and fix the query before blaming the store. "The query" includes your own command shape — stderr you discarded and a search form you transformed fail identically (`10-working-posture.md` § "Lossy steps are for known output shapes" is the command side of this same seam). (Railway-log specifics — the `--lines` cap, filtering by the field the log actually carries, the ended-deploy lookup — live in the `/tzurot-deployment` skill.)
+**An empty or sparse tool result is not evidence that the data is gone.** Default to "my query is wrong" — wrong filter field, out-of-range flag, wrong scope, finicky syntax — and enumerate why it could be returning nothing before blaming the store. "The query" includes your own command shape (`10-working-posture.md` § "Lossy steps are for known output shapes"). Railway-log specifics live in the `/tzurot-deployment` skill.
 
-**Negative existence claims require an exhaustive search.** "We don't have X," "there's no way to do Y," and "that's not possible in this codebase" are claims about the ENTIRE codebase; a one-vocabulary grep cannot support them. Before stating one: search ≥3 vocabulary variants (your term, the domain's term, the library's term), sweep the generated declaration index (`pnpm ops xray --format md | grep -iE 'termA|termB|termC'` — regenerated from source, cannot be stale), and check for dormant scaffolding (`pnpm knip:dead`). If the sweep still finds nothing, state the claim WITH its evidence — "I searched A/B/C and found nothing" — which honestly invites correction. **The user's "I thought we had X" is a search order, not a debate prompt**: their vague memory has repeatedly beaten confident absence claims (webhook `applicationId`, the dormant `isProxyMessage` stub, the OpenRouter key that was "missing").
+**Negative existence claims require an exhaustive search.** "We don't have X," "there's no way to do Y," and "that's not possible in this codebase" are claims about the ENTIRE codebase; a one-vocabulary grep cannot support them. Before stating one: search ≥3 vocabulary variants (your term, the domain's term, the library's term), sweep the generated declaration index (`pnpm ops xray --format md | grep -iE 'termA|termB|termC'` — regenerated from source, cannot be stale), and check for dormant scaffolding (`pnpm knip:dead`). If the sweep still finds nothing, state the claim WITH its evidence — "I searched A/B/C and found nothing" — which honestly invites correction. **The user's "I thought we had X" is a search order, not a debate prompt**: their vague memory has repeatedly beaten confident absence claims.
 
-**Completion claims require re-reading the scope definition.** Before declaring a theme, epic, or multi-part task "done"/"complete," re-open its scope artifact (theme file, plan, epic roadmap) and enumerate remaining items by name. "The last PR merged" is not "done" — the definition's own checklist being empty is. An overclaimed completion silently removes work from the finishing-first queue, which is strictly worse than leaving it visibly unfinished (the Stryker theme was declared done with one of many packages piloted).
+**Completion claims require re-reading the scope definition.** Before declaring a theme, epic, or multi-part task "done"/"complete," re-open its scope artifact (theme file, plan, epic roadmap) and enumerate remaining items by name. "The last PR merged" is not "done" — the definition's own checklist being empty is. An overclaimed completion silently removes work from the finishing-first queue, which is strictly worse than leaving it visibly unfinished.
 
-**Why this matters:** Users rely on assertions to decide what to do next. Speculation-as-fact produces wasted work when the real cause turns out to be different, and erodes trust when the pattern repeats. Prefer "the evidence shows X; the remaining candidates for why Y are A / B / C — here's how to narrow it" over "it was Z."
+Prefer "the evidence shows X; the remaining candidates for why Y are A / B / C — here's how to narrow it" over "it was Z."
 
 ### Mandatory Global Discovery ("Grep Rule")
 
@@ -348,12 +307,8 @@ When a failure pattern surfaces — a missed verification step, a skimmed review
 2. **Can a skill capture this procedurally?** Add to `.claude/skills/<skill>/SKILL.md` if it's a workflow step the skill should own. Skills load on invocation.
 3. **Can a hook enforce it automatically?** Add to `.claude/hooks/` if the trigger is deterministic and the correction mechanical. Hooks fire without reliance on model attention.
 
-Claude's per-instance auto-memory at `~/.claude/projects/*/memory/` is a complement, not a substitute. Memory gives future-Claude the narrative ("this happened on date X during PR #Y"); rules/skills/hooks give the instruction. Memory is local to one machine and one Claude instance; rules and skills are source-controlled and apply to every contributor and every session.
+**Promotion is atomic with deletion**: promoting a memory into a rule/skill/hook deletes the memory file, its `MEMORY.md` line, and any inbound `[[links]]` in the same action.
 
-**When something is important enough to flag as feedback, it is usually important enough to make recurrence structurally harder.** If a failure mode belongs in memory, first ask whether it also belongs in a rule or skill. Don't let memory become a graveyard of "try harder" notes.
+**A tool without a named decision-point trigger goes unused.** When building or adopting a tool, write down the moment it must be reached for ("before asserting X", "after every push") in the relevant rule/skill — a tool that exists only in a command-reference table gathers dust.
 
-**Promotion is atomic with deletion.** When a memory's content is promoted into a rule/skill/hook, delete the memory file, its MEMORY.md index line, and any inbound `[[links]]` in the same action — never leave the draft behind. Redundant memories reload every session and drift out of sync with the promoted rule.
-
-**A tool without a named decision-point trigger goes unused.** When building or adopting a tool, write down the moment it must be reached for ("before asserting X", "after every push") in the relevant rule/skill — a tool that exists only in a command-reference table gathers dust (xray: 95 mentions while being built, near-zero use in the month after).
-
-Scope the structural fix to the **class** of failure, not just the exact symptom. And don't over-expand — a one-line rule addition or a paragraph in a skill is usually enough. Rules state constraints plus at most a one-sentence why; multi-paragraph incident narratives don't belong here — the operationalized outcome IS the record (git preserves the story).
+Scope the structural fix to the **class** of failure, not just the exact symptom. And don't over-expand — a one-line rule addition or a paragraph in a skill is usually enough.

--- a/.claude/rules/02-code-standards.md
+++ b/.claude/rules/02-code-standards.md
@@ -13,16 +13,12 @@
 | `max-statements`         | 50    | Warn  | Extract helpers        |
 
 **Note**: Test files (`*.test.ts`, `*.spec.ts`) are excluded from the
-size/complexity limits above (production blocks ignore them), but they are NOT
-lint-free: a dedicated test block in `eslint.config.js` still lints them
-(vitest correctness rules plus style rules like `import/no-duplicates` and
-`prefer-optional-chain`, without type-checking). The limits above apply to
-production code only. Do NOT split test files to satisfy max-lines — keep all
-tests for a module in one colocated file for discoverability.
+size/complexity limits above but are still linted (vitest correctness + style
+rules, no type-checking). Do NOT split test files to satisfy max-lines — keep
+all tests for a module in one colocated file.
 
 **To fix `max-lines`**: Extract code (functions, helpers, types) to a new module.
 **NEVER** trim, compact, or shorten comments/JSDoc to fit the line limit.
-Comments document intent — removing them to satisfy a linter is always wrong.
 
 ## Lint Suppression Standards
 
@@ -39,25 +35,21 @@ Rules:
 
 1. **Describe WHY the code needs the suppression**, not that it's old
 2. **If the reason is "this code is messy"** — refactor it instead of suppressing
-3. **"pre-existing" is not a justification** — it just means nobody bothered to explain
-4. Run `pnpm ops xray --suppressions` to audit; target 0 unjustified items
+3. Run `pnpm ops xray --suppressions` to audit; target 0 unjustified items
 
 ## Temporal Markers in Code Comments
 
-**Don't reference dates, PR numbers, or review-archaeology in code comments.** They rot meaninglessly the moment the surrounding context shifts — a `// Caught in PR #847 round 3` marker tells a future reader nothing useful once #847 is squashed into the history. Keep the _invariant explanation_ (why this constraint exists, what it protects against) and drop the _archaeology_ (when, who, which review).
+**No dates, PR numbers, or review-archaeology in code comments** (`//`, JSDoc
+`*`, block `/* */`) — keep the invariant, drop the journey: not
+`// Added 2026-05-06 to fix data loss` but
+`// Required for parity with API schema cap; UI silently truncated otherwise`.
+`backlog/**/*.md` is exempt. Archaeology belongs in commit messages, PR
+descriptions, post-mortems, and backlog entries.
 
-| ❌ Don't write                                 | ✅ Instead                                                                                |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `// Added 2026-05-06 to fix data loss`         | `// Required for parity with API schema cap; UI silently truncated otherwise`             |
-| `// Caught in PR #985 final round review`      | `// Async work before showModal blows the 3-second budget; must wrap in timeout helper`   |
-| `// Surfaced 2026-04-25 by claude-bot`         | `// guards against the empty-default leaking into ON CONFLICT path`                       |
-| `* Background: PR #983 raised the cap to 4000` | `* Cap mirrors API schema's SHORT_PARAGRAPH_MAX_LENGTH; do not raise without bumping API` |
-
-This applies to all comment shapes: full-line `//`, JSDoc `*` body, block `/* */`. Backlog markdown (`backlog/**/*.md`) is exempt — it intentionally tracks surfacing dates and PR origins.
-
-**Where archaeology _does_ belong**: commit messages (preserved by git), PR descriptions, post-mortems (`docs/incidents/`), and backlog entries with explicit "Surfaced 20YY-MM-DD" prefixes. Code comments document the _invariant_, not the _journey_.
-
-**Enforcement**: `.husky/pre-commit` scans newly-added comment lines in `*.ts`/`*.tsx`/`*.js`/`*.jsx` for date stamps, PR refs, and round/review markers. Override with `TZUROT_SKIP_TEMPORAL_CHECK=1` for the rare intentional case (post-mortem references where the date is the point).
+**Enforcement**: `.husky/pre-commit` scans newly-added comment lines in
+`*.ts`/`*.tsx`/`*.js`/`*.jsx` for date stamps, PR refs, and round/review
+markers. Override with `TZUROT_SKIP_TEMPORAL_CHECK=1` for the rare intentional
+case.
 
 ## A Comment That Asserts Behavior Is a Claim
 
@@ -67,33 +59,18 @@ treatment as a claim in a PR body: **pin it with a test, or say in the comment
 that it is unverified.** This applies to the same comment shapes the section
 above enumerates.
 
-Both failure directions are silent, which is why this is a rule and not care. A
-_wrong_ claim reads as documentation and is trusted — a comment described a
-ReDoS as fixed for a whole PR while the pattern still ran for minutes. A claim
-that is _right but unpinned_ invites the change that breaks it: an exact-case
-escape token, argued at length and tested nowhere, sits one plausible
-"consistency cleanup" away from unlocking a blocking guard.
+Trigger: any comment asserting RUNTIME behavior. Certainty words (_never_,
+_always_, _cannot_, _is safe_) are the usual tell but not the whole set — a bare
+property name ("the retry is idempotent") and a named mechanism's EFFECT ("the
+lookahead prevents backtracking") claim just as much. Naming a mechanism alone
+does not ("uses a lookahead to skip whitespace"), and neither does
+design-structure prose ("cannot be extracted"). Name the test, or hedge in the
+comment itself (`// not verified: assumes the caller already acked`).
 
-Trigger: any comment asserting RUNTIME behavior. The certainty words — _never_,
-_always_, _cannot_, _is safe_ — are the usual tell but not the whole set: a bare
-property name claims just as much ("the retry is idempotent"), and so does a
-named mechanism's EFFECT ("the lookahead prevents backtracking"), which asserts
-something with no certainty word in it at all. Naming a mechanism alone does not
-("uses a lookahead to skip whitespace" asserts nothing), and neither does
-design-structure prose ("cannot be extracted", "cannot be collapsed into one") —
-`claim-shape-guard.sh` was narrowed for exactly that reason, because a trigger
-that fires on structure trains readers to skim past the real ones. Name the
-test, or hedge in the comment itself (`// not verified: assumes the caller
-already acked`) — an honest hedge invites the correction that a confident wrong
-claim deters.
-
-Scope: in CODE files the VALUE half is already caught mechanically by
-`claim-shape-guard.sh` (`never null`, `always populated`, `cannot be <value>`) —
-it skips `*.md` and the `.claude/` tree entirely, so a value claim in prose is
-this rule's too. Otherwise this rule is the judgment half — behavioral,
-algorithmic, security. `00-critical.md`
-§ "Code-reading is not runtime verification" holds the same standard for a claim
-made in conversation; a comment differs by persisting.
+In CODE files the VALUE half (`never null`, `always populated`, `cannot be
+<value>`) is caught mechanically by `claim-shape-guard.sh`, which skips `*.md`
+and the `.claude/` tree — so a value claim in prose is this rule's too. The
+rest (behavioral, algorithmic, security) is judgment.
 
 ## TypeScript Strict Rules
 
@@ -105,27 +82,13 @@ made in conversation; a comment differs by persisting.
 
 ## Pino Logger Format
 
-```typescript
-// ✅ CORRECT - Error object in first argument
-logger.error({ err: error }, 'Failed to process request');
-logger.info({ requestId, duration }, 'Request completed');
-
-// ❌ WRONG - Will fail lint
-logger.error(error, 'Failed to process');
-```
+Error/fields object FIRST, static message second: `logger.error({ err: error }, 'Failed to process request')`. Single-argument and template-literal forms are ESLint errors.
 
 ## Testing Standards
 
 ### Test Tiers (canonical: see TESTING.md)
 
-Tzurot uses Toby Clemson's 5-tier model — **unit** (mocked logic) · **component**
-(one whole service over PGLite; our `*.component.test.ts`) · **integration** (a module
-against a real external dep; our `tests/e2e/*.integration.test.ts`) ·
-**contract** (provider↔consumer agreement; `tests/e2e/contracts/*.contract.test.ts`) · **e2e**
-(full system). The canonical definitions live in **one place** —
-[Test Tier Taxonomy](../../docs/reference/guides/TESTING.md#test-tier-taxonomy).
-Do not re-define the tiers here or in the skill; link there (the
-`pnpm ops guard:test-taxonomy` CI gate enforces this single-sourcing).
+Tzurot uses Toby Clemson's 5-tier model. **The canonical definitions live in one place** — [Test Tier Taxonomy](../../docs/reference/guides/TESTING.md#test-tier-taxonomy). Do not re-define the tiers here or in the skill; link there (`pnpm ops guard:test-taxonomy` enforces the single-sourcing).
 
 **Suffixes match tiers**: `*.component.test.ts` (component), `*.integration.test.ts`
 (integration), `*.contract.test.ts` (contract), plain `*.test.ts` (unit).
@@ -145,17 +108,41 @@ Don't file Zod schema tests under "contract."
 6. **Tests must be self-contained** - Each `it()` block sets up its own data; never depend on side effects from prior tests. Use `beforeAll`/`beforeEach` in a sub-describe for shared fixtures.
 7. **Assert what crosses a mocked seam** - When you `vi.mock` a downstream module/collaborator, at least one test MUST assert the arguments that cross that seam (`expect(mockX).toHaveBeenCalledWith(...)`), not only the orchestrator's return value. A test that mocks the seam it's meant to verify **cannot catch a wiring bug at that seam** — the mocked collaborator returns the same thing whether the caller forwarded the right data or silently dropped it. For a multi-module flow (A → B → C where each is unit-tested with the next mocked), also keep ONE **wiring/seam test** that runs the real chain end-to-end and mocks ONLY the external boundary (network/DB/Redis/model client). Reference: `services/ai-worker/src/services/multimodal/visionFallbackChain.test.ts`.
 
-   **Why this rule exists**: a feature shipped with green coverage but two real bugs (a dropped forwarded field between two functions, and a wrong output for an untested failure _sequence_) that every unit test missed — because they each mocked the seam. Line coverage marks the buggy lines "covered" (they executed); it has no concept of "this covered line forwarded the wrong thing." The only gate that catches a seam bug is a test that _asserts across the seam_ or runs the seam for real. Established 2026-07-01 after PR #1429's review caught the seam bugs by hand.
+   **Cover every render MODE, not just the default one.** A branching renderer
+   (full vs. deduped, live vs. stored, enabled vs. disabled) leaves its
+   non-default arms as untested forwarding paths — enumerate the modes and
+   assert the seam in each. When the forwarded value **cost money** (vision,
+   transcription, an external fetch), mock the paid boundary to return a
+   sentinel and assert the sentinel reaches the final output — a field-parity
+   allowlist only catches the field you already know about. Reference: the
+   (deduped × full) × (live × stored) matrix in
+   `services/ai-worker/src/services/ReferencedMessageFormatter.test.ts`.
 
-   **Cover every render MODE, not just the default one.** A branching renderer (full vs. deduped, live vs. stored, enabled vs. disabled) leaves its non-default arms as untested forwarding paths — which is where fields get dropped: the reference path silently lost `authorRole`, then image descriptions, both on the deduped arm, both under green line coverage. Enumerate the modes and assert the seam in each. When the forwarded value **cost money** (vision, transcription, an external fetch), make the assertion economic rather than structural — mock the paid boundary to return a sentinel and assert the sentinel reaches the final output, because **paid work must appear**. A field-parity allowlist only ever catches the field you already know about; a sentinel catches whichever goes next. Reference: the (deduped × full) × (live × stored) matrix in `services/ai-worker/src/services/ReferencedMessageFormatter.test.ts`.
+   **A shared mutable context is a seam too, with no mock to assert across.**
+   Pipeline steps, middleware, and anything handing data to a later stage by
+   writing a field on a shared object (`job.data.context`, `req`, an
+   accumulating result): each step's unit tests construct that object
+   themselves, so neither can observe what the other produced. Whenever a step
+   writes a field a later step reads, keep ONE test that runs those steps
+   **in order**.
 
-   **A shared mutable context is a seam too — and it has no mock to assert across.** Everything above assumes a CALL chain. Pipeline steps, middleware, and anything else that hands data to a later stage by writing a field on a shared object (`job.data.context`, `req`, an accumulating result) form a seam with no call and no mock in it: step A writes, step B reads, and each one's unit tests construct that object themselves — so neither can observe what the other actually produced. Whenever a step writes a field a later step reads, keep ONE test that runs those steps **in order**.
-
-   **The specific tell is a default-coalescing write-back**: `x = ctx.field ?? []`, `?? {}`, `|| fallback` — harmless as a local view, silently destructive when the normalized value is written BACK onto the shared object, because it erases the distinction the later step reads. Where absence carries meaning (a `?? derive(...)` sentinel, an "unset vs. explicitly empty" config), say so in a comment at the write site and pin BOTH states in the sequencing test — absent stays absent, empty stays empty. `??` falls through on `undefined`, never on `[]`. Reference: `services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionSeam.test.ts`.
+   **The specific tell is a default-coalescing write-back**: `x = ctx.field ??
+[]`, `?? {}`, `|| fallback` written BACK onto the shared object erases the
+   distinction the later step reads. Where absence carries meaning, say so in a
+   comment at the write site and pin BOTH states in the sequencing test —
+   absent stays absent, empty stays empty (`??` falls through on `undefined`,
+   never on `[]`). Reference:
+   `services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionSeam.test.ts`.
 
 8. **Interface changes must sweep UNTYPED fixtures — and new fixtures should be typed** - When a shared type's shape changes, grep by a distinctive FIELD name in addition to the type name: untyped mock payloads (`vi.fn().mockResolvedValue({...})`) never reference the type, so both a type-name grep AND the compiler miss them — and a fail-soft catch downstream can hide the breakage entirely (a PGLite suite's usage-log writes silently no-oped this way). Prevent the class at authoring time by typing fixture payloads: `mockResolvedValue({...} satisfies ExtractionModelResult)` makes the compiler break the test when the interface moves.
 
-   **The sweep must cover every test TIER, not just the ones a local `pnpm test` runs.** `tests/e2e/` (integration + contract, CI's component-integration-tests job) pins producer shapes too, and shape pins there have gone red in CI twice after locally-green sweeps. Before pushing any cross-service string-shape change (job ids, fixture fields, wire formats): (a) grep the OLD shape's distinctive tokens repo-wide _including `tests/`_, and (b) run the touched contract files — `npx vitest run --config vitest.integration.config.ts tests/e2e/contracts/` finishes in ~2s (the full-`test:integration` OOM ban covers the heavy integration suites, NOT this fixture+schema subset).
+   **The sweep must cover every test TIER, not just the ones a local
+   `pnpm test` runs** — `tests/e2e/` (integration + contract) pins producer
+   shapes too. Before pushing any cross-service string-shape change (job ids,
+   fixture fields, wire formats): (a) grep the OLD shape's distinctive tokens
+   repo-wide _including `tests/`_, and (b) run
+   `npx vitest run --config vitest.integration.config.ts tests/e2e/contracts/`
+   (~2s; the full-`test:integration` OOM ban does not cover this subset).
 
 **All packages are enforced by `structure.test.ts`** — services, common-types, embeddings, AND tooling. Adding a new `.ts` file without a colocated `.test.ts` will fail the test suite unless the file matches an exclusion pattern (types, constants, thin CLI wrappers, etc.).
 
@@ -188,12 +175,7 @@ await assertion;
 
 ### Schema Test Colocation
 
-Schema tests follow the same colocation rule as all other tests:
-
-- `schemas/api/persona.ts` → `schemas/api/persona.test.ts`
-- `types/jobs.ts` → `types/jobs.test.ts`
-
-Do NOT place schema tests in a separate directory.
+Schema tests colocate like everything else: `schemas/api/persona.ts` → `schemas/api/persona.test.ts`. Never a separate directory.
 
 ## Types & Constants
 
@@ -217,43 +199,21 @@ export const MY_CONFIG = {
 
 ## Module Organization
 
-**Import from source modules, not index files.** Re-exports create circular import issues.
+**Import from source modules, not index files** — `./utils/dateUtils.js`,
+never `./utils/index.js`. Re-exports create circular imports and break vitest
+mocking.
 
-```typescript
-// ✅ GOOD - Import from source
-import { formatDate } from './utils/dateUtils.js';
+**No wrapper re-export files.** Never create a local file that just re-exports
+from another package; import directly from the source package.
 
-// ❌ BAD - Re-exporting for convenience
-import { formatDate } from './utils/index.js';
-```
-
-**Exception**: Package entry points (e.g., `@tzurot/common-types`) are acceptable.
-
-**No wrapper re-export files.** Never create a local file that just re-exports from
-another package. Import directly from the source package instead.
-
-```typescript
-// ❌ BAD - Wrapper file that re-exports (slugUtils.ts just doing
-//   export { normalizeSlugForUser } from '@tzurot/common-types')
-import { normalizeSlugForUser } from '../../utils/slugUtils.js';
-
-// ✅ GOOD - Import directly from the package
-import { normalizeSlugForUser } from '@tzurot/common-types';
-```
-
-Re-export wrappers add indirection, break vitest mocking (the mock of the package
-doesn't intercept internal imports), and make dependency tracing harder.
+The `@tzurot/common-types` root barrel was REMOVED — a bare
+`from '@tzurot/common-types'` import is an ESLint error
+(`no-restricted-imports`). Use deep subpaths
+(`@tzurot/common-types/types/jobs`, `@tzurot/common-types/services/prisma`).
 
 ## Dependency Additions Land on Latest
 
-When adding a **new** dependency (not bumping an existing one), check the latest
-stable version first — `pnpm view <pkg> version` — and pin to it, rather than
-whatever version is top-of-mind or copied from a stale example. A dep added a
-major behind starts its life needing an upgrade (Astro was added at v5 with v6
-already shipped). This applies at the **add** moment; keeping deps current
-afterward is Dependabot's job. When the latest major is very new (days old) and
-the ecosystem around it may lag, that's a reason to _note_ the choice, not to
-default to the old major.
+When adding a **new** dependency (not bumping an existing one), check `pnpm view <pkg> version` and pin to latest stable — a dep added a major behind starts life needing an upgrade. Keeping deps current afterward is Dependabot's job.
 
 ## Python Standards (voice-engine)
 
@@ -261,39 +221,43 @@ Moved to [`services/voice-engine/CLAUDE.md`](../../services/voice-engine/CLAUDE.
 
 ## Duplication, Helpers, and the CPD Ratchet
 
-The CRUD config routes (admin/{llm,tts}-config, user/{llm,tts}-config) share extracted helpers; the raw-jscpd metric is paired with a post-filter that excludes call-expression-dominant fragments (the "standardized helper call site" false-positive class). The full close-out audit lives in [`docs/reference/CPD_CAMPAIGN_AUDIT.md`](../../docs/reference/CPD_CAMPAIGN_AUDIT.md).
+Raw jscpd output is paired with a post-filter that excludes call-expression-dominant fragments (the "standardized helper call site" false-positive class). Close-out audit: [`docs/reference/CPD_CAMPAIGN_AUDIT.md`](../../docs/reference/CPD_CAMPAIGN_AUDIT.md).
 
 ### Config-route helpers — scope and boundary
 
-The helpers in `services/api-gateway/src/utils/configRouteHelpers.ts` and `normalizeConfigNameOnPromote.ts` standardize the CRUD config-route shape:
-
-- `parseBodyOrSendError(res, schema, body)` — Zod parse + send error
-- `findConfigOrSendNotFound(res, fetchRow, resourceName)` — fetch + 404
-- `findGlobalConfigOrSendError(res, fetchRow, options)` — fetch + 404 + isGlobal guard (admin paths)
-- `findAdminUserOrSendError(res, prisma, discordUserId, logger)` — admin discordId → UUID
-- `ensureNoNameCollision<TScope>(res, service, options)` — generic name-collision check; supports `postIsGlobal` for cross-namespace promotion paths
-- `shapeDeleteResponse(warning, baseLogFields)` — conditional warning omission for delete
-- `applyOwnerNamePromotion<TBody>(body, config, user)` — generic promotion patch construction
+`services/api-gateway/src/utils/configRouteHelpers.ts` + `normalizeConfigNameOnPromote.ts` standardize the CRUD config-route shape: `parseBodyOrSendError`, `findConfigOrSendNotFound`, `findGlobalConfigOrSendError`, `findAdminUserOrSendError`, `ensureNoNameCollision`, `shapeDeleteResponse`, `applyOwnerNamePromotion` (signatures in the file).
 
 **Apply these helpers when:** the route follows the fetch-validate-respond shape over a top-level config row (LlmConfig, TtsConfig, similar future resources).
 
-**Do NOT apply these helpers when:** the route uses cascade-override semantics (`user/{tts,stt,model}-override.ts`). Cascade overrides set/clear values on a personality-scoped key — a fundamentally different domain shape than CRUD. Forcing CRUD helpers there is the Wrong Abstraction trap per Kimi K2.6 and GLM 5.1 council review during campaign close-out.
+**Do NOT apply these helpers when:** the route uses cascade-override semantics (`user/{tts,stt,model}-override.ts`). Cascade overrides set/clear values on a personality-scoped key — a fundamentally different domain shape than CRUD. Forcing CRUD helpers there is the Wrong Abstraction trap.
 
 ### The 2-callback ceiling rule (when considering new extractions)
 
 Before extracting a new shared helper from a duplicated route pattern, prototype the kernel signature. If the proposed shared function requires **more than 2 callback/predicate parameters** to handle observed divergences across the call sites, **the divergence is structural and the helper should NOT be extracted**. Leave the code inline; duplication is cheaper than the wrong abstraction.
 
-The rule's symmetry: when council reviewers (or your own instinct) warn "this looks like Wrong Abstraction," try the prototype. Don't pre-decide; let the signature size be the empirical answer.
-
-**The adapter-interface exception (council-ruled)**: a cohesive INTERFACE whose methods are authored together per implementor is ONE parameter, not N callbacks — even with 3+ methods. The test is cohesion: if removing one method makes the others meaningless (they produce/consume each other's outputs), it's an adapter seam; if the functions are independent degrees of freedom a caller could mix-and-match, it's callbacks and the ceiling applies. Precedents: `TtsProvider`, `EntitySectionAdapter` (findSection's sync bundle is what loadSectionData warms and resolveSectionContext composes — cohesive), vs. the rejected cascade-route "preamble helper" (schema + verify-access + pre-hook = independent knobs — ceiling). Constraint that keeps this honest: adapter IMPLEMENTATIONS live next to their implementor's code, never in the shared module.
+**The adapter-interface exception**: a cohesive INTERFACE whose methods are
+authored together per implementor is ONE parameter, not N callbacks — even
+with 3+ methods. The test is cohesion: if removing one method makes the others
+meaningless, it's an adapter seam; if the functions are independent degrees of
+freedom a caller could mix-and-match, the ceiling applies. Precedents:
+`TtsProvider`, `EntitySectionAdapter` (cohesive) vs. the rejected
+cascade-route "preamble helper" (schema + verify-access + pre-hook =
+independent knobs). Adapter IMPLEMENTATIONS live next to their implementor's
+code, never in the shared module.
 
 ### CPD measurement: raw vs filtered
 
-- **`pnpm cpd`** — runs jscpd. Output is informational. The raw clone count cannot reach zero in a well-abstracted TypeScript codebase because jscpd's token matcher treats standardized call sites of shared helpers as new clones across consumers.
-- **`pnpm ops cpd:filtered`** — runs the post-filter against jscpd's JSON output. Excludes fragments where ≥80% of classifiable lines are call-expression shape. This is the metric that reflects real duplication debt.
-- **`pnpm ops cpd:check`** — CI gate. Fails the build if filtered lines exceed the baseline ceiling (`baseline.filteredLines + baseline.graceMargin`) recorded in `.github/baselines/cpd-baseline.json`.
-- **`pnpm ops cpd:update-baseline`** — sanctioned path for updating the baseline. Writes the current filtered count to `cpd-baseline.json`, preserving existing `graceMargin` / `threshold` / `notes` / `version` fields. Includes `--dry-run` to preview the delta first (recommended). Use after applying one of the three legitimate paths below — never to "make CI pass" without doing the underlying work.
+Commands: `05-tooling.md` § CPD. `pnpm cpd` (raw jscpd) is informational — the
+raw count cannot reach zero in a well-abstracted TypeScript codebase;
+`pnpm ops cpd:filtered` is the metric that reflects real debt.
 
-**When a clone trips the ratchet, ask first**: is this a new call-site of a shared helper (likely OK, will be excluded by the filter — investigate why the filter missed it) or a new copy-paste of business logic (real debt, fix it)? `pnpm ops cpd:filtered --show-pairs 25` shows the top remaining pairs to help triage.
+**When a clone trips the ratchet, ask first**: new call-site of a shared
+helper (likely OK — investigate why the filter missed it) or new copy-paste of
+business logic (real debt, fix it)? `pnpm ops cpd:filtered --show-pairs 25`
+triages.
 
-**Do NOT bypass the ratchet by editing the baseline upward** without first either (a) extracting the duplication into a shared helper, (b) confirming the new clones are legitimate skeleton-shape uniformity not worth abstracting (apply the 2-callback rule), or (c) raising the threshold on `pnpm ops cpd:filtered` if the heuristic is misclassifying. Once one of (a)/(b)/(c) is done, `pnpm ops cpd:update-baseline --dry-run` to preview, then run without `--dry-run` to commit the change.
+**Never raise the baseline to make CI pass.** First do one of: (a) extract the
+duplication into a shared helper, (b) confirm the clones are legitimate
+skeleton-shape uniformity (2-callback rule), or (c) raise the `cpd:filtered`
+threshold if the heuristic is misclassifying. Then
+`pnpm ops cpd:update-baseline --dry-run` to preview, and again without it.

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -7,7 +7,7 @@
 pnpm dev              # Start all services
 pnpm test             # Run unit tests
 pnpm test:component   # Run component tests (snapshots, cross-service)
-pnpm quality          # the full static gate — composition lives in package.json scripts.quality (guard:gate-parity keeps it in sync with the CI lint job; don't enumerate it here, that's a third list to drift)
+pnpm quality          # full static gate (composition: package.json scripts.quality)
 pnpm lint             # Lint all packages
 pnpm lint:errors      # Show only errors
 
@@ -23,20 +23,9 @@ pnpm focus:test       # Test changed packages
 
 ## Resource Constraints (CRITICAL)
 
-**NEVER run `pnpm test` and `pnpm quality` in parallel.** The Steam Deck has
-limited RAM, and running both simultaneously causes OOM kills that crash the IDE
-and Claude Code. Always run them **sequentially**:
-
-```bash
-# ✅ CORRECT - Sequential
-pnpm test && pnpm quality
-
-# ❌ WRONG - Parallel (crashes Steam Deck)
-# Running both as background tasks simultaneously
-```
-
-This applies to all heavy commands: `pnpm test`, `pnpm test:component`, `pnpm quality`,
-`pnpm typecheck`. Run one at a time, wait for completion, then run the next.
+**NEVER run heavy commands in parallel** — `pnpm test`, `pnpm test:component`,
+`pnpm quality`, `pnpm typecheck`. The Steam Deck OOM-kills the IDE and Claude
+Code. Run sequentially: `pnpm test && pnpm quality`.
 
 ## Ops CLI (`pnpm ops`)
 
@@ -50,9 +39,7 @@ pnpm ops db:inspect                   # Inspect tables/indexes (local)
 pnpm ops db:check-drift               # Check for migration drift
 ```
 
-**Non-interactive note**: `db:safe-migrate` and `db:migrate` work in non-TTY
-environments (AI assistants, CI). `--name` is required for `db:safe-migrate`
-when stdin is not a TTY.
+**`db:safe-migrate` requires `--name` in non-TTY environments (AI assistants, CI).**
 
 ### GitHub (Use instead of broken `gh pr edit`)
 
@@ -71,7 +58,7 @@ pnpm ops run --env dev <command>     # Run any command with Railway creds
 pnpm ops maintenance on|off|status --env prod   # Maintenance mode (destructive migrations) — sequence in /tzurot-deployment
 ```
 
-**Migration-timing reminder:** Migrations are NOT auto-applied on Railway, and timing matters because every service auto-deploys in parallel. For a **prod release**, migrate BEFORE merging the release PR — `pnpm ops release:premigrate` (then merge; auto-deploy lands into the ready schema). For **dev**, apply promptly after the push — `pnpm ops db:migrate --env dev`. See `.claude/rules/03-database.md` § Deployment for the additive-vs-destructive distinction.
+**Migration timing:** prod — `pnpm ops release:premigrate` BEFORE merging the release PR; dev — `pnpm ops db:migrate --env dev` promptly after the push. Details: `03-database.md` § Deployment.
 
 ### Codebase Analysis (Xray)
 
@@ -89,8 +76,6 @@ pnpm ops xray --imports              # Include import analysis (auto for md/json
 
 **Use `--summary` for architectural overview.** Full mode lists every declaration.
 
-**Decision-point trigger**: xray is not just a periodic-audit tool — it is the required sweep before any negative existence claim ("we don't have X") per `00-critical.md` § Don't Present Speculation as Fact. `pnpm ops xray --format md | grep -iE 'termA|termB|termC'` searches every export in seconds and cannot be stale.
-
 ### Mutation-Score Ratchet (Stryker)
 
 ```bash
@@ -100,7 +85,7 @@ pnpm ops mutation:gate                      # CI skip gate: run=false when the d
 pnpm ops mutation:update-baseline           # sanctioned refresh (needs a fresh LOCAL report for EVERY tracked package)
 ```
 
-Tracked packages live in `MUTATED_PACKAGES` (`packages/tooling/src/test/mutation-check.ts`). Adding one: copy config-resolver's `stryker.config.mjs` + `logger-calls` ignorer (NOT cache-invalidation's copy — its `observability-options` rule is package-specific), add a `test:mutation` script + the `@stryker-mutator/*` devDeps, add to `MUTATED_PACKAGES` (fingerprint drift forces the baseline refresh), add its CI step before `mutation:check` (the gate + tracked-set intersection picks the new package up automatically). When the check fails on a genuine score drop: close the test gaps it names — never hand-edit the baseline. Services are adjudicated NOT per-PR viable (30-70min projected runs); don't re-attempt without new data. `ignoreStatic` stays OFF (owner decision — module-top-level mutants held the rollout's best real finds).
+Tracked set: `MUTATED_PACKAGES` (`packages/tooling/src/test/mutation-check.ts`). On a genuine score drop, close the test gaps — never hand-edit the baseline. `ignoreStatic` stays OFF. Services are not per-PR viable (30-70min); don't re-attempt without new data. Adding a package: copy config-resolver's `stryker.config.mjs` + `logger-calls` ignorer (NOT cache-invalidation's).
 
 ### Secret Rotation
 
@@ -110,7 +95,7 @@ pnpm ops secrets:mark-rotated <name> --env prod   # stamp a manual rotation
 pnpm ops secrets:rotate-byok --env prod --stage 1 # staged BYOK key rotation (1=stage, 2=reencrypt, 3=finalize)
 ```
 
-The ledger (`secret_rotations`, per-env, sync-excluded) drives a daily bot-client check that posts an owner-channel nag when a secret passes its interval (BYOK 180d, others 365d). BYOK rotation is breakage-free via the dual-key window in `common-types/utils/encryption.ts` — never rotate `API_KEY_ENCRYPTION_KEY` by hand-replacing the variable; always use the staged command.
+Never rotate `API_KEY_ENCRYPTION_KEY` by hand-replacing the variable — always the staged command (dual-key window in `common-types/utils/encryption.ts`). Intervals: BYOK 180d, others 365d; a daily bot-client check nags the owner channel when one lapses.
 
 ### Security Advisories
 
@@ -120,7 +105,7 @@ pnpm ops security:advisories --json     # machine-readable surface
 pnpm ops security:advisories --strict   # exit nonzero on an actionable (fix-available) high/critical
 ```
 
-Reads the GitHub Dependabot alerts API and prints each open advisory with its fix version and — the actionable bit — whether it's a **direct** dep (Dependabot auto-PRs the fix) or **transitive-only** (Dependabot _can't_ PR it; needs a manual `pnpm.overrides` bump and otherwise lingers open with no PR). **Decision-point trigger:** the release security-preflight (`/tzurot-git-workflow` § Release) — run it before cutting a release and ride any transitive-with-fix advisory into the release via an override. The same list also appears in `pnpm ops health`. Degrades to "unavailable" (never blocks) when the alerts API can't be read — CI tokens lack the `security-events` scope. Not an audit-class tool (a point-in-time report, no baseline/ratchet — see the exclusion note in `audit-tool-registry.ts`).
+Flags each advisory **direct** (Dependabot auto-PRs the fix) vs **transitive-only** (needs a manual `pnpm.overrides` bump — no PR will ever appear). **Decision-point trigger:** the release security-preflight (`/tzurot-git-workflow` § Release) — ride any transitive-with-fix advisory into the release via an override. Degrades to "unavailable", never blocks.
 
 ### Test Audits
 
@@ -129,7 +114,7 @@ pnpm ops test:audit                  # Run coverage ratchet (CI)
 pnpm ops test:audit --update         # Update baseline + refresh meta block (run after closing coverage gaps)
 ```
 
-**Drift detection (Layer 3):** `test:audit` hard-fails when the baseline's stored `configHash` doesn't match the current `getTestAuditConfigFingerprint()`. Bump `TEST_AUDIT_IMPL_VERSION` in `packages/tooling/src/test/audit-version.ts` whenever the measurement-affecting logic changes (Prisma-detection heuristic, service-file glob, etc.) — that bump invalidates baselines and forces an explicit `--update` refresh. The `--update` path is the only one that updates the meta block; hand-editing the baseline JSON is not the sanctioned path.
+Bump `TEST_AUDIT_IMPL_VERSION` (`packages/tooling/src/test/audit-version.ts`) whenever measurement-affecting logic changes; `--update` is the only sanctioned baseline refresh.
 
 ### CPD (Duplication Ratchet)
 
@@ -142,7 +127,7 @@ pnpm ops cpd:update-baseline         # Refresh baseline + meta block
 pnpm ops cpd:update-baseline --dry-run  # Preview without writing
 ```
 
-`cpd:check` hard-fails on either (a) `filteredLines > baseline + graceMargin` or (b) `configHash` drift. Same `--update`-refreshes-meta contract as `test:audit`. Bump `FILTER_IMPL_VERSION` in `packages/tooling/src/cpd/postFilter.ts` when the call-dominance heuristic changes.
+Bump `FILTER_IMPL_VERSION` (`packages/tooling/src/cpd/postFilter.ts`) when the call-dominance heuristic changes.
 
 ### Guards (Structural enforcement)
 
@@ -160,13 +145,11 @@ pnpm ops lines:check                 # always-loaded surfaces (.claude/rules tot
 pnpm ops lines:update-baseline       # make budget growth explicit (same --update contract as cpd/test:audit); --surface <name> scopes the write
 ```
 
-`lines:check` gates two dimensions independently, because lines is not what these surfaces cost: density varies several-fold across the corpus, so a line-only ratchet rated `CURRENT.md` comfortable while it carried a fifth of the rules corpus's bytes. `--breakdown` ranks every file worst-first by bytes — that ranking is the trim order, and the economy pass in `/tzurot-doc-audit` is the procedure that consumes it. Reach for `--surface <name>` whenever a refresh is wanted for one surface only — the unscoped write ratchets a trimmed surface DOWN and a grown one UP in the same commit.
+`--breakdown` ranks every file worst-first by bytes — that is the trim order the `/tzurot-doc-audit` economy pass consumes. `--surface <name>` scopes a refresh to one surface; the unscoped write ratchets a trimmed surface DOWN and a grown one UP in the same commit.
 
-The first five run in the CI `lint` job; all guards hard-fail on findings. `guard:workflow-sync` runs in `pnpm quality`, `.husky/pre-push`, AND the CI `lint` job; it skips itself on main-cut branches (detected by topology — no develop-exclusive history — with `--base main` as the explicit override), because main-cut workflow PRs are the sanctioned path. It covers ONLY the self-validating claude workflow files (`claude-code-review.yml`, `claude.yml`): a develop-first change to those silently disables claude-review on every PR (green ~15s no-op) until the next release, because the review's skip-validation compares the action's OWN workflow file against main — empirically file-scoped (a PR carrying ci.yml drift still received a real review). Other workflow files (e.g. `ci.yml`) execute from the PR branch and may land via develop like any code change. `guard:boundaries`, `guard:proposal-links`, and `guard:audit-tool-docs` also support `--summary` for the future aggregator. `guard:audit-tool-docs` self-registers and runs the bidirectional check (every registered tool has a WHY.md AND every `*.WHY.md` is either registered or on `UNREGISTERED_WHY_PATHS`).
+All guards hard-fail on findings. `guard:workflow-sync` covers ONLY `claude-code-review.yml` and `claude.yml` — those must land via a **main-cut** branch (a develop-first change silently disables claude-review on every PR until the next release); it self-skips on main-cut branches, `--base main` overrides. Other workflow files (`ci.yml`) may land via develop like any code change.
 
-`guard:hook-probes` is the only verification the hook scripts have — a bash hook has no unit-test tier, so its colocated `*.probe.sh` exit-code harness is it. **After editing any hook, run its probe**; the gate is the backstop, not the loop. It runs unconditionally (~18s) rather than keying off a hooks-dir diff, and its `HOOK_PROBES` registry in `packages/tooling/src/dev/check-hook-probes-registry.ts` is bidirectional over BOTH `.claude/hooks/*.sh` and the `.husky/` lifecycle scripts: a new hook in either place with no probe must carry a written reason, and an orphan probe fails too. **New local precondition:** because the probes now run on every `pnpm quality`, `develop-code-commit-guard.probe.sh` needs local branches named `develop` and `main` to exist (it puts a worktree on each to test the hook's branch check). A fresh clone has only `main` — `git fetch origin develop:develop` if the probe fails on it. Branches are fabricated automatically only on a real GitHub Actions runner (gated on `GITHUB_ACTIONS` set AND `ACT` unset — `act` sets `CI`, `GITHUB_ACTIONS` and `ACT` alike, so neither of the first two alone excludes a local run), never on a working repo.
-
-**Note on `guard:duplicate-exports`, `guard:dockerfile-dist`, `guard:hook-probes`, and `guard:gate-parity`**: all four are CI gates but intentionally NOT registered as audit-class tools (no WHY.md, no canary, no `--summary` mode). The criteria for "audit-class" require a measurement with a threshold — duplicate-exports and dockerfile-dist are binary "is this in sync?" checks, not measurements. Same framing as `memory:analyze` (one-shot remediation, not periodic audit). See [`docs/reference/audit-enforcement.md`](../../docs/reference/audit-enforcement.md) for the registry criteria.
+**After editing any hook, run its probe** — `guard:hook-probes` is the backstop, not the loop (a bash hook has no unit-test tier). Registry: `packages/tooling/src/dev/check-hook-probes-registry.ts`, bidirectional over `.claude/hooks/*.sh` AND `.husky/`. Local precondition: `develop-code-commit-guard.probe.sh` needs local `develop` and `main` branches — `git fetch origin develop:develop` if it fails on a fresh clone.
 
 ### Backlog lint + digest
 
@@ -177,11 +160,11 @@ pnpm ops backlog:digest              # Session-start briefing from tracker/: per
 pnpm tracker task list --search <t> --plain   # Query the small-item pool (Backlog.md CLI)
 ```
 
-The lint verifies the caps (Current Focus ≤ 3, Quick Wins ≤ 5, Untriaged ≤ 10), flags `cold/queue.md` doc references (`doc-N`) that don't resolve in `tracker/docs/`, fails on any `tracker/tasks/` file whose frontmatter won't parse (a broken task silently vanishes from every query surface), and enforces triage on every OPEN task — ≥1 `area:*` label, exactly one `size:S|M|L`, exactly one `state:*` (`ready` · `observable` · `dependent` · `owner` · `unreachable`), and a high/medium/low priority, the four axes every selection query filters on. A label carrying a known prefix but an unknown value (`state:blocked`, `size:XL`) is reported as unknown, never as missing — a present-but-invalid label must not read as an absent one. **Wired into `pnpm quality` AND the CI lint job** (they are separate lists — CI does not run `quality`; `guard:gate-parity` keeps the two in sync). Like the binary guards above, it's a layout sync-check, not an audit-class tool — no WHY.md / canary / `--summary`. The digest is informational (never gates) — the aging-escalation surface lives there, read at session start per `06-backlog.md`.
+Gate details and the triage axes live in `06-backlog.md`. The digest never gates — it's the session-start aging surface.
 
 ### Audit-tool infrastructure (Layers 1-3)
 
-`pnpm ops`-class commands that meet the audit criteria (measurement + threshold + periodic) are subject to three structural enforcement layers. **Before adding a new audit tool, read [`docs/reference/audit-enforcement.md`](../../docs/reference/audit-enforcement.md)** — it covers the WHY.md convention, the canary-fixture pattern, the JSONL summary line shape, and the baseline-meta drift contract. Skipping these checklist items will fail CI in non-obvious ways.
+**Before adding a new audit tool, read [`docs/reference/audit-enforcement.md`](../../docs/reference/audit-enforcement.md)** — skipping its checklist fails CI in non-obvious ways.
 
 ## Git Workflow
 
@@ -202,32 +185,34 @@ EOF
 )"
 ```
 
-**Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `debug`
+**Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `debug` (+ standard `build`, `ci`, `revert`, `style`; every valid type is also a valid branch prefix)
 **Scopes:** `ai-worker`, `api-gateway`, `bot-client`, `common-types`, `ci`, `deps`
 
 **Commitlint gotchas** (the hook catches these, but every trip costs a retry): the **full header must be ≤100 chars** (`header-max-length` — the most-tripped rule in practice; count before writing a long subject), the subject must start **lowercase** (`subject-case`), and the scope must be in the configured enum **or omitted entirely** — an unknown scope is rejected, no scope is fine.
 
-The list above is the project's primary set. `commitlint.config.cjs` also accepts the rest of the standard Conventional Commits types — `build`, `ci`, `revert`, `style` — and the `.husky/pre-push` branch-name allowlist permits all of them as branch prefixes too, so a valid commit type is always a valid branch prefix. Reach for the standard ones when they genuinely fit (`build:` for bundler/Docker changes, `revert:` for a clean revert); otherwise the primary set covers most work.
-
 #### The `debug` type
 
-`debug` is for **temporary diagnostic instrumentation** — logging (or similar probes) added to a production code path to confirm a bug's _runtime_ behaviour before fixing it, then removed in a cleanup PR once the bug is understood. It exists because such work fits none of the other types cleanly: it is not `feat` (nothing ships to users), not `fix` (it corrects no behaviour), and not `chore` (it is risky production-path code, not housekeeping). Use it for **both** adding and removing the scaffolding (`debug(bot-client): add forward-shape probes` … `debug(bot-client): remove forward-shape probes`) so an add/remove pair reads cleanly in the log.
+`debug` = temporary diagnostic instrumentation in a production path, added to
+confirm a bug's runtime behaviour and removed in a cleanup PR. Use it for BOTH
+the add and the remove so the pair reads cleanly. Permanent observability is
+`feat`, not `debug` — the distinction is lifecycle.
 
-The payoff is a built-in safety net: a `debug` commit is a high-signal "did I remove this?" marker. `git log --grep '^debug[:(]' origin/develop..HEAD` on a branch surfaces any instrumentation still live on it — empty output means the production code is clean. (The `[:(]` anchors to the conventional `debug:` / `debug(scope):` forms so a free-form subject like `debugged the parser` doesn't false-match.) The token grep is per-branch hygiene only; the structural catch for FORGOTTEN scaffolding is `pnpm ops dev:stale-debug` (weekly `ops health` roster) — blame-based, so it finds survivors whose lines don't contain any greppable marker word.
-
-Do **not** use `debug` for **permanent** observability (structured logs, metrics, traces that stay) — that is a real operational improvement and should be `feat`. The distinction is lifecycle: `debug` is scaffolding you intend to delete; `feat` observability is infrastructure you intend to keep.
-
-Enforced by `commitlint.config.cjs` (`type-enum`) and the `.husky/pre-push` branch-name allowlist (`debug/` branches permitted).
+`git log --grep '^debug[:(]' origin/develop..HEAD` surfaces instrumentation
+still live on a branch (empty = clean). Forgotten scaffolding older than that
+is caught by `pnpm ops dev:stale-debug` (blame-based, weekly `ops health`).
 
 ### PR Monitoring (automatic — do not wait to be asked)
 
-**Whenever you create a PR or push commits to an open PR, arm a `Monitor` that waits for CI to finish and then reports on new reviewer comments.** Don't wait for the user to ask whether CI passed or whether a review landed. There is no hook behind this — `pr-monitor-reminder.sh` fires but its output never reaches the agent, so this text is the mechanism.
+**Whenever you create a PR or push commits to an open PR, arm a `Monitor` that waits for CI to finish and then reports on new reviewer comments.** Don't wait for the user to ask whether CI passed or whether a review landed.
 
-**First verify the push actually landed.** Backgrounded pushes reporting "exit 0" and foreground pushes with filtered output can both hide a failed transfer. Confirm the `-> branch` ref-update line or `git status -sb` in-sync — a monitor watching a push that never landed reports a stale CI run as fresh.
+**Verify the push landed first** (the `-> branch` ref-update line, or `git status -sb` in-sync) — a monitor on a push that never landed reports a stale run as fresh.
 
-**One monitor per PR: `TaskStop` this PR's previous monitor before arming a new one** (scoped per-PR — a release PR alongside a feature PR keeps one each). The reporting half is not SHA-pinned, so a stale watcher reports the PR's current state under an older push's label, which reads identically to a finished run. Keep the id `Monitor` returns and stop it as the first step of the next arm.
-
-**If the id is gone** (compaction, session restart), you cannot look it up — `TaskList` does not enumerate background monitors, so it returns "No tasks found" with one live. Recover from the notification itself: every monitor event carries its own `task-id`, so when one fires for a PR you already reported on at this SHA, `TaskStop` that id instead of re-reporting. That dedupes but does not prove freshness; the SHA-pinned query in step 1 is what does. Preserving live ids across compaction is in `CLAUDE.md` § Compaction Instructions for this reason.
+**One monitor per PR: `TaskStop` this PR's previous monitor before arming a
+new one** (a release PR alongside a feature PR keeps one each). The reporting
+half is not SHA-pinned, so a stale watcher reports current state under an older
+push's label. **If the id is gone** (compaction): `TaskList` cannot enumerate
+monitors, so recover from the notification — every monitor event carries its own
+`task-id`; `TaskStop` that id when one fires for a PR already reported at this SHA.
 
 Arm the Monitor with this as its `command`, **substitution included** — copy it verbatim and only replace `N` with the PR number. Never transcribe the SHA by hand; a hand-completed SHA passes any format check, and the gate refuses it (`git cat-file`) rather than watching it:
 
@@ -255,8 +240,6 @@ When the monitor fires, **all four** of the following must happen — do not sto
 
    Inline line comments are where human reviewers leave blocking feedback. Track the last reported comment's timestamp so a later push doesn't re-report it, and **include human reviewers** alongside the bots.
 
-   **Never pipe review fetches through `| tail` / `| head`** — truncating the fetch is how body findings get silently dropped.
-
    **claude-review health**: a green check means the action _completed_, not that a body was posted. If no new `claude[bot]` comment exists after a green run, `gh run rerun <run-id>` before proceeding.
 
 3. In one concise message, report CI pass/fail **and** any new review findings (blocking vs. non-blocking). If there are no new reviews, say so explicitly — silence isn't a substitute for "no new comments."
@@ -264,11 +247,6 @@ When the monitor fires, **all four** of the following must happen — do not sto
    **Read every `###` section of each review body — do not rely on the trailing Summary.** Reviewer output is tiered, and the summary routinely under-reports what the body flags; treat a 100+ line review as a skimming risk. If multiple `claude[bot]` entries exist, read every one.
 
 4. **Apply review feedback — INVOKE `/tzurot-review-response` first, before touching anything.** That skill carries the full procedure. Loading it is not optional politeness — applying feedback from memory is how the rubber-stamping this procedure prevents creeps back in.
-
-Two failure modes, both observed:
-
-- **Step 1 without step 2**: all-green CI feels complete, so the comment fetch gets skipped. All-CI-green does not discharge it.
-- **Step 2 without a full-body read**: extracting only the summary section. A review ending "two actionable items" usually has more in the body.
 
 If CI fails or CodeQL flags a new alert, surface it via `PushNotification` — that class of feedback changes what the user does next.
 
@@ -288,7 +266,7 @@ gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs?per_page=100" \
   --jq '.jobs[] | "\(.conclusion // "-") steps=\(.steps | length) \(.name)"'
 ```
 
-**Wait on the gate, never on a `sleep` or a hand-written poll loop.** A fixed sleep expires before run creation (which can lag the push by minutes) and `gh pr checks --watch` then snapshots a near-empty check list; custom loops over `gh pr checks --json` race a partial list that momentarily reads all-non-pending. Both were measured emitting a premature `CI_COMPLETE`.
+**Wait on the gate, never on a `sleep` or a hand-written poll loop** — both were measured emitting a premature `CI_COMPLETE`.
 
 **Outcome handling — read WHICH sentinel printed, not just whether one did.** Only the first means CI finished:
 
@@ -299,11 +277,9 @@ gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs?per_page=100" \
 | `CI_GATE_STARTUP_FAILURE` | a run died before dispatch (zero jobs, invisible in `gh pr checks`) | `gh run rerun <run-id>`, then re-arm |
 | _none of them_            | the Monitor's own 30-min `timeout_ms` killed the process            | re-arm                               |
 
-**Working-memory caveat**: the dedup timestamp lives in conversation state, so after a session restart a re-fetch may surface previously-reported comments once. Acceptable — re-reporting a known comment beats silently missing a new one.
-
 ### Release Notes Format
 
-Release notes follow the Conventional Changelog format. This enables machine parsing for Discord release notifications.
+Release notes follow the Conventional Changelog format.
 
 - **Release title**: `v3.0.0-beta.XX` (version number only, no summary)
 - **Body** starts directly with category headings (no version line in body)
@@ -324,50 +300,20 @@ Release notes follow the Conventional Changelog format. This enables machine par
 **Full Changelog**: https://github.com/lbds137/tzurot/compare/vOLD...vNEW
 ```
 
-**Rules:**
-
-- Categories use H3: **Features**, **Bug Fixes**, **Improvements**, **Breaking Changes**, **Chores**, **Tests**, **Database Migrations**
-- Breaking Changes section always comes first when present
-- Only include categories that have entries
-- Line items: `- **scope:** description (#123)` — scope maps to commit scope, `#N` auto-links on GitHub (PR numbers optional)
-- End with: `**Full Changelog**: https://github.com/lbds137/tzurot/compare/vOLD...vNEW`
-
-## Project Structure
-
-```
-tzurot/
-├── .claude/
-│   ├── rules/              # Always-loaded constraints (THIS DIRECTORY)
-│   ├── hooks/              # Automation (skill-eval, merge/commit guards)
-│   └── skills/             # Procedural skills
-├── services/
-│   ├── bot-client/         # Discord interface (NO Prisma)
-│   ├── api-gateway/        # HTTP API + BullMQ
-│   └── ai-worker/          # AI processing + memory
-├── packages/
-│   ├── common-types/       # Shared types
-│   └── tooling/            # CLI commands (pnpm ops)
-└── prisma/                 # Database schema
-```
+**Rules:** H3 categories — **Breaking Changes** (always first when present),
+**Features**, **Bug Fixes**, **Improvements**, **Chores**, **Tests**,
+**Database Migrations**. Omit empty categories. Line items:
+`- **scope:** description (#123)`. End with the Full Changelog compare link.
 
 ## No Standalone Scripts
 
-**All tooling must live in `packages/tooling/`** as TypeScript, not as standalone
-bash/shell scripts. This ensures:
+**All tooling lives in `packages/tooling/`** as TypeScript, never as bash
+scripts — for options-object consistency, unit testability, and `pnpm ops --help`
+discoverability. New dev tool: `src/dev/<name>.ts` + colocated test + registration
+in `src/commands/dev.ts` (+ a root `package.json` shortcut if frequent).
 
-- Consistent patterns (options objects, typed interfaces)
-- Unit testability (colocated `.test.ts` files with mocked child_process)
-- Discoverability via `pnpm ops --help`
-
-When adding a new dev tool, follow the existing pattern:
-
-1. Implementation in `packages/tooling/src/dev/<name>.ts`
-2. Tests in `packages/tooling/src/dev/<name>.test.ts`
-3. Command registration in `packages/tooling/src/commands/dev.ts`
-4. Shortcut in root `package.json` if frequently used (e.g., `"knip:dead"`)
-
-**Exception:** `scripts/` may contain one-off data migration or codegen scripts
-that run once and are deleted. Persistent tooling goes in the tooling package.
+**Exception:** `scripts/` may hold one-off migration/codegen scripts that run
+once and are deleted.
 
 ## References
 

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -85,7 +85,7 @@ pnpm ops mutation:gate                      # CI skip gate: run=false when the d
 pnpm ops mutation:update-baseline           # sanctioned refresh (needs a fresh LOCAL report for EVERY tracked package)
 ```
 
-Tracked set: `MUTATED_PACKAGES` (`packages/tooling/src/test/mutation-check.ts`). On a genuine score drop, close the test gaps — never hand-edit the baseline. `ignoreStatic` stays OFF. Services are not per-PR viable (30-70min); don't re-attempt without new data. Adding a package: copy config-resolver's `stryker.config.mjs` + `logger-calls` ignorer (NOT cache-invalidation's).
+Tracked set: `MUTATED_PACKAGES` (`packages/tooling/src/test/mutation-check.ts`). On a genuine score drop, close the test gaps — never hand-edit the baseline. `ignoreStatic` stays OFF. Services are not per-PR viable (30-70min); don't re-attempt without new data. Adding a package: 4-step checklist in `packages/tooling/src/test/mutation-check.WHY.md` § Onboarding.
 
 ### Secret Rotation
 
@@ -276,6 +276,8 @@ gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs?per_page=100" \
 | `CI_GATE_TIMEOUT`         | the gate gave up at 25 min; CI never reached a releasable state     | re-arm; do NOT assume CI passed      |
 | `CI_GATE_STARTUP_FAILURE` | a run died before dispatch (zero jobs, invisible in `gh pr checks`) | `gh run rerun <run-id>`, then re-arm |
 | _none of them_            | the Monitor's own 30-min `timeout_ms` killed the process            | re-arm                               |
+
+After a session restart, a re-fetch may re-surface already-reported comments once (the dedup timestamp lives in conversation state) — expected, not a dedup bug.
 
 ### Release Notes Format
 

--- a/.claude/skills/tzurot-orchestration/SKILL.md
+++ b/.claude/skills/tzurot-orchestration/SKILL.md
@@ -29,8 +29,11 @@ quality — fresh context plus an independent diff review — not budget.
 | **Bulk reading/exploration** | Explore/Plan agents, either driver. Reading fan-out is delegation's cheapest and least risky use. **Any read fan-out of ~4+ files, or any search across unknown locations, goes to `Explore` with `model: "haiku"` passed on the Agent call — never inline** (mechanism below the table). |
 
 **Why Explore gets `model: "haiku"` per-call**: the built-in Explore inherits
-the main-loop model, so an unpinned spawn bills the scarcest budget, while
-every file read inline re-bills as main-loop input on all later turns.
+the main-loop model (per the Agent tool's own schema: an omitted `model` "uses
+the agent definition's model, or inherits from the parent" — inference from
+that schema line, not a live probe), so an unpinned spawn bills the scarcest
+budget, while every file read inline re-bills as main-loop input on all later
+turns.
 Per-call `model` is the verified mechanism; a frontmatter override file was
 ruled out — TASK-438's probes showed the harness ignores subagent
 TOOL-restriction frontmatter (`tools:`/`disallowedTools:`), so an override's
@@ -46,7 +49,9 @@ need Opus-tier judgment to execute, and the spec template produces
 exactly that. This is a pilot against the Opus-worker record observed so far
 (no repo-citable measurement — the baseline lives in session history): record
 each Sonnet unit's diff-review findings and CI cycles in the pilot's tracker
-task (`pnpm tracker task list --search 'Sonnet worker-tier pilot'`), and drop
+task (`pnpm tracker task list --search 'Sonnet worker-tier pilot'` to find it;
+append by editing the task file's notes section directly — the CLI's `--notes`
+flag REPLACES the whole section and has destroyed notes before), and drop
 the tier back to Opus if defects appear. Semantic-class units (design judgment
 inside the diff) stay on Opus.
 
@@ -76,6 +81,16 @@ a gap the worker will fill by guessing.
    survivor-grep results.
 
 ## Worktree spawns
+
+**Any worker that MUTATES files runs with `isolation: "worktree"` on the Agent
+call — no exceptions.** A same-tree file-mutating worker and an orchestrator
+that keeps using `git checkout` are fighting over one working tree: the
+orchestrator's branch hop silently carries the worker's uncommitted edits onto
+another branch (observed live — the first Sonnet-pilot unit had its branch
+yanked mid-edit). Same-tree spawns are for read-only analysis only. Should the
+rule nonetheless be violated and a file-mutating worker found sharing the tree,
+the damage-control posture is: the orchestrator FREEZES its own git operations
+(checkout, pull, rebase, merge) until the worker reports.
 
 Before trusting any code-grounded output from a worktree-isolated worker,
 verify the worktree's base against the intended SHA:

--- a/.github/baselines/lines-baseline.json
+++ b/.github/baselines/lines-baseline.json
@@ -1,9 +1,9 @@
 {
   "surfaces": {
     "rules": {
-      "lines": 2068,
+      "lines": 1997,
       "graceMargin": 150,
-      "bytes": 162450,
+      "bytes": 142502,
       "bytesGraceMargin": 12000
     },
     "current": {
@@ -17,7 +17,7 @@
     "toolVersion": "lines-check/2",
     "configHash": "038ea0a31198",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "731c4699788ddbc38fc32a15581d6ac0080b14f7",
-    "generatedAt": "2026-08-08T19:50:08.647Z"
+    "generatedFromSha": "85f1e5eac70dcb00337b868764d176ab8ab81e2b",
+    "generatedAt": "2026-08-09T16:22:13.002Z"
   }
 }

--- a/docs/reference/audit-enforcement.md
+++ b/docs/reference/audit-enforcement.md
@@ -14,6 +14,8 @@ Diagnostic tools that are user-invoked for inspection (`inspect:queue`, `inspect
 
 `memory:analyze` is a borderline case: it has a measurement (duplicate memories) but is one-shot remediation, not a periodic audit. It's intentionally **not** registered in `AUDIT_TOOL_REGISTRY` even though it has a `WHY.md`.
 
+Likewise `guard:duplicate-exports`, `guard:dockerfile-dist`, `guard:hook-probes`, and `guard:gate-parity`: all four are CI gates but deliberately unregistered (no WHY.md, no canary, no `--summary`) because they are binary "is this in sync?" checks, not measurements with thresholds — the answer to "why doesn't `guard:gate-parity` have a WHY.md like the others."
+
 ## The registered audit tools (16)
 
 Single source of truth: [`packages/tooling/src/audits/audit-tool-registry.ts`](../../packages/tooling/src/audits/audit-tool-registry.ts).

--- a/packages/tooling/src/test/mutation-check.WHY.md
+++ b/packages/tooling/src/test/mutation-check.WHY.md
@@ -47,3 +47,18 @@ packages) — changing what the score measures without refreshing the baseline
 hard-fails. Bump `MUTATION_IMPL_VERSION` when the arithmetic or bucketing
 changes. (3) **Silent skips**: a tracked package with no report is a
 failure, never a pass — the gate cannot be discharged by not running Stryker.
+
+## Onboarding a new package into the ratchet
+
+Four steps, all in one PR (relocated here from `05-tooling.md` — this is the
+only written copy):
+
+1. Copy config-resolver's `stryker.config.mjs` + its `logger-calls` ignorer —
+   NOT cache-invalidation's copy, whose `observability-options` rule is
+   package-specific.
+2. Add a `test:mutation` script and the `@stryker-mutator/*` devDeps to the
+   package.
+3. Add the package to `MUTATED_PACKAGES` (`mutation-check.ts`) — the
+   fingerprint drift this causes forces the explicit baseline refresh.
+4. Add the package's CI step before `mutation:check`; the gate's
+   tracked-set intersection picks the new package up automatically.


### PR DESCRIPTION
## What

First execution of the `/tzurot-doc-audit` § 3b economy pass (doc-61), over the top-3 always-loaded rules files, plus three announced riders on the orchestration skill.

**The trim** (every cut passed the four-question test — constraint-vs-narrative / behavior-changing / single-layer / gate-superseded):

| File | Before | After | Δ |
| --- | --- | --- | --- |
| `05-tooling.md` | 30,540 B | 19,526 B | −11,014 |
| `00-critical.md` | 30,276 B | 24,501 B | −5,775 |
| `02-code-standards.md` | 23,405 B | 15,872 B | −7,533 |
| **rules corpus total** | **166,827 B (≈42k tok)** | **142,502 B (≈36k tok)** | **−24,325 B (≈6k tok/session)** |

What was cut: incident narratives and adoption archaeology, restated whys (some stated 3×), full re-enumerations of content owned by another always-loaded layer (backlog-lint axes → `06-backlog.md`, migration timing → `03-database.md`, CPD commands → `05-tooling.md`), and prose superseded by gates (temporal-marker table → `.husky/pre-commit` scan; drift-detection mechanics → the gates' own error messages). Constraints, command invocations, decision-point triggers, and reference-implementation pointers all stay.

**Correctness fix folded in**: `02-code-standards.md` § Module Organization recommended `import ... from '@tzurot/common-types'` as the GOOD form — that root barrel was removed and the bare specifier is now an ESLint error (`eslint.config.js` "Barrel-kill regression guard"). The section now states the ban.

**Riders (announced, from PR #2027's final review + today's live incident):**
- Orchestration skill: **file-mutating workers REQUIRE `isolation: "worktree"`** — a same-tree worker had its branch yanked by an orchestrator checkout mid-edit today; this is the structural fix.
- The Explore model-inheritance claim now cites its source (Agent tool schema) and is labeled inference-not-probe.
- The Sonnet-pilot recording flow names the append mechanism (edit the task file's notes section; CLI `--notes` REPLACES and has destroyed notes before).

**First-ever scoped baseline DOWN-write**: `lines:update-baseline --surface rules` — baseline 162,450 → 142,502 B, limit 174,450 → 154,502 B, so the trim is locked in as the new ceiling, not headroom to be re-spent.

## Verified, and how

- Applied by a Sonnet-tier worker from a fully-enumerated approved cut list; the orchestrator read the complete diff against the list before commit (zero deviations; the worker's one content flag — the barrel-removal claim — was re-verified against `eslint.config.js:722-744` and stands).
- `pnpm ops lines:check --breakdown` before/after above; `pnpm ops backlog` green; `pnpm ops guard:test-taxonomy` green (the `TESTING.md#test-tier-taxonomy` pointer token survives); the protected `gh:ci-gate` triplication block confirmed intact by grep.

## Review note

Per the economy pass's own conflict-of-interest rule, the owner sees this diff and holds restore authority — flag any cut passage and it comes back in a one-line fixup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Byte accounting note** (review round 2): the table's "before" (166,827 B) is the live measurement at trim time; the baseline's prior stored value (162,450 B) is the last checkpoint — the ~4.4 kB gap is post-checkpoint growth that rode within the 12,000-byte grace margin. The down-write resets both to the measured 142,502 B.