### PR TITLE
feat: blocking questions must surface via a formal channel

### DIFF
--- a/.claude/hooks/blocking-question-channel-check.probe.sh
+++ b/.claude/hooks/blocking-question-channel-check.probe.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Fixture check for blocking-question-channel-check.sh — run after ANY edit to
+# the hook. Asserts the exit-code table over synthetic transcripts: a turn that
+# ends on a question fires unless AskUserQuestion or PushNotification was used
+# in the same turn. Statements, the stop_hook_active re-stop, and a missing
+# transcript all stay silent.
+#
+# Colocated with the hook — the transcript-parsing python is the fragile part;
+# this harness pins its behavior on hook edits.
+#
+# Usage: .claude/hooks/blocking-question-channel-check.probe.sh   (from repo root)
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/blocking-question-channel-check.sh"
+export CLAUDE_PROJECT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+jsonstr() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'; }
+
+# Build a transcript: one user turn + an optional tool_use + a final text block.
+mktx() { # $1=out $2=text $3=tool_name(optional)
+  : > "$1"
+  echo '{"type":"user","isMeta":null,"message":{"content":"go"}}' >> "$1"
+  [ -n "${3:-}" ] && printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"%s","input":{}}]}}\n' "$3" >> "$1"
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":%s}]}}\n' "$(jsonstr "$2")" >> "$1"
+}
+
+fail=0
+check() { # $1=expected_exit $2=label $3=transcript $4=stop_active
+  echo "{\"stop_hook_active\":${4:-false},\"transcript_path\":\"$3\"}" | "$HOOK" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" != "$1" ]; then echo "FAIL [$got≠$1]: $2"; fail=1; else echo "ok   [$got]: $2"; fi
+}
+
+# --- 1. the core fire case ---------------------------------------------------
+mktx "$TMP/a.jsonl" "Both approaches work here. Should I use X or Y?"
+check 2 "closing question, no formal channel this turn" "$TMP/a.jsonl"
+
+# --- 2/3. the formal channels clear it ---------------------------------------
+mktx "$TMP/b.jsonl" "Both approaches work here. Should I use X or Y?" "AskUserQuestion"
+check 0 "same question + AskUserQuestion in the turn" "$TMP/b.jsonl"
+
+mktx "$TMP/c.jsonl" "Both approaches work here. Should I use X or Y?" "PushNotification"
+check 0 "same question + PushNotification in the turn" "$TMP/c.jsonl"
+
+# An unrelated tool does NOT clear it — only the two formal channels do.
+mktx "$TMP/c2.jsonl" "Both approaches work here. Should I use X or Y?" "Bash"
+check 2 "an ordinary tool_use is not a formal channel" "$TMP/c2.jsonl"
+
+# --- 4. a statement close ----------------------------------------------------
+mktx "$TMP/d.jsonl" "Done — the fix is in and every gate is green."
+check 0 "closing statement, no question" "$TMP/d.jsonl"
+
+# --- 5. block-once ------------------------------------------------------------
+check 0 "stop_hook_active re-stop always allows" "$TMP/a.jsonl" true
+
+# --- 6. fail-open on a missing/empty transcript ------------------------------
+check 0 "missing transcript path (fail-open)" "$TMP/does-not-exist.jsonl"
+check 0 "empty transcript path (fail-open)" ""
+
+: > "$TMP/empty.jsonl"
+check 0 "empty transcript file (no text block)" "$TMP/empty.jsonl"
+
+# --- 7. trailing markdown must not hide the mark -----------------------------
+mktx "$TMP/e.jsonl" "That leaves one call to make. **Ship it as-is, right?**"
+check 2 "trailing bold after the question mark still fires" "$TMP/e.jsonl"
+
+TICK=$(printf '\140')
+mktx "$TMP/e2.jsonl" "One thing left: do we keep ${TICK}--strict${TICK}?${TICK}"
+check 2 "trailing backtick after the question mark still fires" "$TMP/e2.jsonl"
+
+mktx "$TMP/e3.jsonl" "So: which one, A or B?   "
+check 2 "trailing whitespace after the question mark still fires" "$TMP/e3.jsonl"
+
+# --- 8. a mid-text question mark is not a closing ask ------------------------
+mktx "$TMP/f.jsonl" "The obvious question is: why did it retry?
+
+Because the busy path throws before the usage row is written. Fixed and green."
+check 0 "question mid-message, statement close — does not fire" "$TMP/f.jsonl"
+
+mktx "$TMP/f2.jsonl" "Should we cache this? I checked, and the answer is no.
+Landed the direct read instead."
+check 0 "question in an earlier line, statement close — does not fire" "$TMP/f2.jsonl"
+
+# Trailing blank lines must not mask the question — the LAST NON-EMPTY line decides.
+mktx "$TMP/f3.jsonl" "Ready to push. Want me to open the PR?
+
+"
+check 2 "trailing blank lines do not mask the closing question" "$TMP/f3.jsonl"
+
+# The final TEXT block is what counts, even when a tool_use follows earlier text.
+mktx "$TMP/g.jsonl" "Gates are green. Merge now or wait for the release cut?" "Read"
+check 2 "question after an unrelated tool_use in the same turn" "$TMP/g.jsonl"
+
+# A formal channel from a PREVIOUS turn does not clear the current one.
+{
+  echo '{"type":"user","isMeta":null,"message":{"content":"go"}}'
+  echo '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"AskUserQuestion","input":{}}]}}'
+  echo '{"type":"user","isMeta":null,"message":{"content":"option 1"}}'
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":%s}]}}\n' \
+    "$(jsonstr "Applied option 1. Should I also bump the baseline?")"
+} > "$TMP/h.jsonl"
+check 2 "formal channel in an EARLIER turn does not clear this one" "$TMP/h.jsonl"
+
+# --- 9. the lenient no-boundary fallback (the one deliberate deviation from ---
+# --- promise-ledger-check: turn_start is None => scan the WHOLE transcript ---
+# A boundary-less transcript (no genuine user message) WITH a formal channel:
+# the lenient scan credits it — silent. Strict-fail would fire here.
+{
+  echo '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"AskUserQuestion","input":{}}]}}'
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":%s}]}}\n' \
+    "$(jsonstr "Truncated transcript. Which option did you want?")"
+} > "$TMP/i.jsonl"
+check 0 "no turn boundary + formal channel anywhere — lenient scan credits it" "$TMP/i.jsonl"
+
+# Same boundary-less shape WITHOUT a formal channel: the fallback still fires.
+{
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":%s}]}}\n' \
+    "$(jsonstr "Truncated transcript. Which option did you want?")"
+} > "$TMP/i2.jsonl"
+check 2 "no turn boundary + no formal channel — still fires" "$TMP/i2.jsonl"
+
+[ "$fail" = 0 ] && echo "ALL PASS" || { echo "FAILURES"; exit 1; }

--- a/.claude/hooks/blocking-question-channel-check.sh
+++ b/.claude/hooks/blocking-question-channel-check.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Stop hook: when the agent ends a turn on a question addressed to the user but
+# never routed that ask through a formal decision surface (AskUserQuestion or
+# PushNotification), block the stop once and remind.
+#
+# Why it matters: remote control surfaces only formal tool decision points. A
+# prose-only question is invisible on the phone, so the session silently stalls
+# until the owner happens to open the terminal.
+#
+# Enforcement geometry mirrors promise-ledger-check.sh: a deterministic scan of
+# the ASSISTANT'S OWN output in the current turn, blocking at most once via the
+# native `stop_hook_active` flag (deliberately NOT an ack file — the retry
+# mechanism is built into the Stop-hook contract). Every external failure — no
+# jq, no python3, unreadable or unparseable transcript — exits 0: a missed
+# reminder is cheaper than blocking every turn end.
+#
+# Block-once and the fire/silent table are pinned by
+# blocking-question-channel-check.probe.sh.
+#
+# Known false-negative shapes, accepted under the fail-open cost model (the
+# rule in 09-interaction-style.md is the primary mechanism; this is a
+# backstop): a question followed by a trailing fenced code block, a closing
+# "?" wrapped in quotes/parentheses, and a "?"-less option list ("Pick one:").
+# Known false-positive shape, accepted the same way (costs one acknowledged
+# turn): a closing inline code span whose content ends in "?" ("Run `foo?`").
+#
+# 09-interaction-style.md § "A Blocking Question Goes Through a Formal Channel".
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Already blocked once this turn-end → allow the stop (no infinite loop).
+ACTIVE=$(jq -r '.stop_hook_active // false' <<<"$INPUT" 2>/dev/null || echo "false")
+[ "$ACTIVE" = "true" ] && exit 0
+
+TRANSCRIPT=$(jq -r '.transcript_path // empty' <<<"$INPUT" 2>/dev/null || echo "")
+[ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ] && exit 0
+
+VERDICT=$(TRANSCRIPT="$TRANSCRIPT" python3 << 'PYEOF'
+import json, os, re, sys
+
+path = os.environ["TRANSCRIPT"]
+try:
+    lines = open(path, encoding="utf-8").read().splitlines()
+except OSError:
+    print("ok"); sys.exit()
+
+
+# A user turn carrying real text, not a tool_result envelope — that bounds the
+# current turn (same delimiter promise-ledger-check.sh uses).
+def is_genuine_user(entry):
+    if entry.get("type") != "user" or entry.get("isMeta"):
+        return False
+    content = entry.get("message", {}).get("content")
+    if isinstance(content, str):
+        return len(content.strip()) > 0
+    if isinstance(content, list):
+        return any(b.get("type") == "text" for b in content)
+    return False
+
+
+records = []
+for ln in lines:
+    ln = ln.strip()
+    if not ln:
+        continue
+    try:
+        records.append(json.loads(ln))
+    except json.JSONDecodeError:
+        continue
+
+turn_start = None
+for i in range(len(records) - 1, -1, -1):
+    if is_genuine_user(records[i]):
+        turn_start = i
+        break
+
+# Boundary not found → scan the WHOLE transcript for the formal channel. That is
+# the lenient direction (an older AskUserQuestion can clear the turn), chosen
+# deliberately: this hook's cost model is the inverse of the promise ledger's —
+# a stale credit costs one missed reminder, while firing on every malformed
+# transcript trains reflexive acknowledgement.
+turn = records[turn_start:] if turn_start is not None else records
+
+FORMAL_TOOLS = {"AskUserQuestion", "PushNotification"}
+
+used_formal_channel = any(
+    block.get("type") == "tool_use" and block.get("name") in FORMAL_TOOLS
+    for entry in turn
+    if entry.get("type") == "assistant"
+    for block in (entry.get("message", {}).get("content", []) or [])
+)
+
+if used_formal_channel:
+    print("ok"); sys.exit()
+
+# The final assistant text = last text block anywhere (robust to the
+# boundary-not-found case; it is always the closing message we read to end).
+final_text = ""
+for entry in records:
+    if entry.get("type") != "assistant":
+        continue
+    for block in entry.get("message", {}).get("content", []) or []:
+        if block.get("type") == "text":
+            final_text = block.get("text", "")
+
+# Question shape: the LAST non-empty line ends with a question mark. Position is
+# the discriminator — a `?` mid-message is ordinary prose (a rhetorical aside, a
+# quoted error, a heading), while a closing line that ends in one is the shape
+# that hands the turn back to the user.
+lines_out = [ln for ln in final_text.splitlines() if ln.strip()]
+if not lines_out:
+    print("ok"); sys.exit()
+
+# Trailing markdown emphasis must not hide the mark: "…right?**" and "…right?`"
+# are the same ask as "…right?".
+last_line = re.sub(r"[*_`\s]+$", "", lines_out[-1])
+
+print("ask" if last_line.endswith("?") else "ok")
+PYEOF
+) || exit 0
+
+[ "$VERDICT" != "ask" ] && exit 0
+
+cat >&2 << 'MSG'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+BLOCKING QUESTION — asked in prose, never through a formal channel
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Your closing message ends on a question, but this turn used neither
+AskUserQuestion nor PushNotification. Remote control surfaces only
+formal tool decision points, so a prose-only ask is invisible on the
+phone and the session stalls until the owner opens the terminal.
+
+Re-surface the pending ask now, then end the turn normally:
+  - AskUserQuestion  — the ask fits structured options (pick one of N)
+  - PushNotification — open-ended asks that no option list captures
+
+If the question was rhetorical, already answered, or not actually
+blocking, say so in one line and stop again (this gate fires only
+once per turn — the next stop proceeds).
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MSG
+exit 2

--- a/.claude/rules/09-interaction-style.md
+++ b/.claude/rules/09-interaction-style.md
@@ -41,6 +41,10 @@ When checking in with the user, name the ONE decision being asked and include a 
 
 Corollary — **bare-token answers get their binding restated**: when the user answers a menu with "1" / "the second one" / "sure", the next reply restates what was chosen ("1 = fix the spend gate in this PR"), and the decision lands in a durable surface if it outlives the session. A bare token with no recorded menu is an unreadable decision later.
 
+## A Blocking Question Goes Through a Formal Channel
+
+A turn that ends blocked on user input MUST surface the ask through `AskUserQuestion` (structured choices) or `PushNotification` (open-ended asks that don't fit the option format). Remote control surfaces only formal tool decision points, so a prose-only question is invisible to the phone and silently stalls the session until the user happens to look. Backstopped by `.claude/hooks/blocking-question-channel-check.sh`.
+
 ## Read Dictated Messages Charitably
 
 The user often dictates by voice, and the transcriber garbles words ("dock sweep" = doc sweep, "striker" = Stryker). Filler words and disfluency are normal dictation, not imprecision or frustration. Resolve odd phrases from context before asking. Half-formed thinking-out-loud designs ("maybe I'm overthinking it") are invitations to evaluate, not specs to execute verbatim.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,10 @@
           {
             "type": "command",
             "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/promise-ledger-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && .claude/hooks/blocking-question-channel-check.sh"
           }
         ]
       }

--- a/packages/tooling/src/dev/check-hook-probes-registry.ts
+++ b/packages/tooling/src/dev/check-hook-probes-registry.ts
@@ -49,6 +49,10 @@ export const HOOK_PROBES: HookProbeEntry[] = [
     probe: '.claude/hooks/bare-token-binding-reminder.probe.sh',
   },
   {
+    hook: '.claude/hooks/blocking-question-channel-check.sh',
+    probe: '.claude/hooks/blocking-question-channel-check.probe.sh',
+  },
+  {
     hook: '.claude/hooks/claim-shape-guard.sh',
     probe: '.claude/hooks/claim-shape-guard.probe.sh',
   },


### PR DESCRIPTION
## Summary

TASK-488 (owner-priority): sometimes a turn ends blocked on user input as a prose-only question — invisible to remote control, which surfaces only formal tool decision points. The session then silently stalls with no phone notification.

Two layers:

- **Rule** (`09-interaction-style.md` § A Blocking Question Goes Through a Formal Channel): a turn that ends blocked on user input must route the ask through `AskUserQuestion` (structured choices) or `PushNotification` (open-ended asks).
- **Stop-hook backstop** (`blocking-question-channel-check.sh`): on turn end, if the closing message's last non-empty line ends with `?` (modulo trailing markdown) and neither formal tool was used **this turn**, block once with re-routing instructions. Modeled on `promise-ledger-check.sh` — same stdin envelope, transcript scan, fail-open posture, and native `stop_hook_active` block-once (deliberately not the pr-merge ack-file: the retry mechanism is built into the Stop-hook contract).

Wiring: registered in the `Stop` hooks array after promise-ledger-check; registry row in `check-hook-probes-registry.ts`.

**One deliberate deviation from promise-ledger's approach, documented at the site**: when no genuine-user-message turn boundary is found, this hook scans the whole transcript for the formal channel (lenient) where promise-ledger fails strict. The cost model is inverted — a stale formal-channel credit costs one missed reminder, while strict-fail would fire on every malformed transcript and train reflexive acknowledgement.

## Verification

- Probe: 17/17 cases green, including the turn-scoping case (an `AskUserQuestion` in an EARLIER turn does not clear the current one) and fail-open cases (missing/empty transcript, `stop_hook_active`).
- `pnpm ops guard:hook-probes`: 11 probes green.
- `pnpm quality` green (rules surface 2003/2147 lines after rebase onto #2030 — no baseline bump).
- `pnpm focus:test`: tooling 2329/2329 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)