### PR TITLE
fix: settings dashboard character terminology + cross-channel privacy note

### DIFF
--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.test.ts
@@ -208,7 +208,7 @@ describe('SettingsDashboardBuilder', () => {
       expect(maxMessagesField?.value).toContain('Auto (from admin)');
     });
 
-    it('should show "Auto (from personality)" for personality-sourced values', () => {
+    it('should show "Auto (from character)" for personality-sourced values', () => {
       const config = createTestConfig();
       const session = createTestSession({
         maxMessages: {
@@ -223,7 +223,9 @@ describe('SettingsDashboardBuilder', () => {
       const fields = getEmbedFields(embed);
       const maxMessagesField = fields.find(f => f.name?.includes('Max Messages'));
 
-      expect(maxMessagesField?.value).toContain('Auto (from personality)');
+      // The SOURCE enum stays 'personality' internally; the friendly label is
+      // the user-facing terminology, which standardized on 'character'.
+      expect(maxMessagesField?.value).toContain('Auto (from character)');
     });
 
     it('should show "Auto (from channel)" for channel-sourced values', () => {
@@ -838,6 +840,17 @@ describe('SettingsDashboardBuilder', () => {
       const embed = buildSettingEmbed(config(), staleSession, plainSetting).toJSON();
       const current = (embed.fields ?? []).find(f => f.name === 'Current Value');
       expect(current?.value).toContain('—');
+    });
+  });
+
+  describe('settings copy invariants', () => {
+    it('keeps the privacy note on cross-channel history — informed-consent copy a sweep must not drop', () => {
+      const setting = ALL_SETTINGS.find(s => s.id === 'crossChannelHistoryEnabled');
+      // Owner-mandated informed consent: the setting's risk (venue leakage —
+      // a character referencing private-channel talk somewhere more public)
+      // must stay named at the decision point.
+      expect(setting?.helpText).toContain('Privacy note');
+      expect(setting?.helpText).toContain('more public');
     });
   });
 });

--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardBuilder.ts
@@ -44,7 +44,7 @@ function friendlySourceName(source: SettingSource): string {
     case 'admin':
       return 'admin';
     case 'personality':
-      return 'personality';
+      return 'character';
     case 'channel':
       return 'channel';
     case 'user-default':

--- a/services/bot-client/src/utils/dashboard/settings/settingsConfig.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsConfig.ts
@@ -64,23 +64,25 @@ export const MEMORY_SETTINGS: SettingDefinition[] = [
     emoji: '🔀',
     description:
       'Fill unused context budget with conversation history from other channels. ' +
-      'When enabled, personalities remember conversations from other channels with you.',
+      'When enabled, characters remember conversations from other channels with you.',
     type: SettingType.TRI_STATE,
     helpText:
       'When enabled, fills unused context with conversation history from other channels ' +
-      "where you've talked to this personality",
+      "where you've talked to this character. Privacy note: the character may reference " +
+      'those conversations anywhere it talks to you — including channels more public than ' +
+      'the one they happened in — so leave this disabled if you keep some conversations separate.',
   },
   {
     id: 'shareLtmAcrossPersonalities',
     label: 'Share Memories',
     emoji: '🧠',
     description:
-      'Share long-term memories across all personalities. ' +
-      'When enabled, what you tell one personality is remembered by all others.',
+      'Share long-term memories across all characters. ' +
+      'When enabled, what you tell one character is remembered by all others.',
     type: SettingType.TRI_STATE,
     helpText:
-      'When enabled, long-term memories are shared across all personalities ' +
-      'instead of being per-personality',
+      'When enabled, long-term memories are shared across all characters ' +
+      'instead of being per-character',
   },
   {
     id: 'memoryScoreThreshold',


### PR DESCRIPTION
## Summary

Two owner-spotted items from tonight's prod session, riding ahead of the beta.198 release PR:

- **Terminology leftovers**: the memory settings' description/help text and the cascade-source friendly label still said "personality/personalities" — Wave-3 sweep misses. Now "character(s)". Internal identifiers and enum values deliberately unchanged; one test pin updated to the new label (the red run against the old pin is the can-fail proof).
- **Informed-consent note on Cross-Channel History**: the help text now names the privacy tradeoff the owner originally disabled it by default for — the character may reference cross-channel conversations somewhere more public than where they happened.

## Verification

Settings-dir suite 287/287 green; targeted lint clean; full pre-push pipeline green. No component snapshots involved (embed prose, not command structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)