### PR TITLE
ci: add workflow_dispatch trigger as webhook-outage escape hatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     # Run on all branches - simplest approach for one-person project
     # No pull_request trigger = no duplicate runs
     branches: ['**']
+  # Manual escape hatch: when GitHub webhook delivery degrades, pushes stop
+  # triggering runs and nothing can start CI by hand. Adds no automatic runs.
+  workflow_dispatch:
 
 # Cancel in-progress runs when new commits are pushed to same branch
 concurrency:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch:` to ci.yml's `on:` block. Closes TASK-446.

During the 2026-08-06 GitHub Actions outage, webhook delivery was throttled to ~15% and pushes stopped triggering CI — two open PRs sat unmergeable for hours with no manual recovery path (`gh workflow run CI` returned HTTP 422: "Workflow does not have workflow_dispatch trigger", probed live during the incident).

The dispatch trigger adds **no automatic runs** — push-only behavior is unchanged in normal operation. It turns a degraded-webhook incident into a one-command recovery: `gh workflow run CI --ref <branch>`.

## Verification

- yml-only change; pre-push gate ran lines/backlog/workflow-sync checks (green).
- `guard:workflow-sync` scope confirmed: it covers only `claude-code-review.yml`/`claude.yml`, so this is a normal develop-targeting PR, not a main-cut.
- Acceptance (`gh workflow run CI --ref <branch>` dispatches successfully) is verifiable only after merge, since GitHub reads triggers from the branch's own workflow file but the workflow must exist on the default-branch registry to be dispatchable by name — will verify post-merge and note here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)