### PR TITLE
feat: detect and surface a prerelease-flagged newest release

### DIFF
--- a/packages/common-types/src/schemas/api/broadcast.test.ts
+++ b/packages/common-types/src/schemas/api/broadcast.test.ts
@@ -252,6 +252,7 @@ describe('internal route inputs', () => {
       alreadyAnnounced: 1,
       skipped: 0,
       capped: false,
+      newestPrerelease: null,
     });
     expect(result.success).toBe(true);
     expect(ReleaseReconcileResponseSchema.safeParse({ checked: -1 }).success).toBe(false);

--- a/packages/common-types/src/schemas/api/broadcast.ts
+++ b/packages/common-types/src/schemas/api/broadcast.ts
@@ -190,6 +190,11 @@ export const ReleaseReconcileResponseSchema = z.object({
   skipped: z.number().int().min(0),
   /** True when the per-run announcement cap stopped the sweep early. */
   capped: z.boolean(),
+  /**
+   * Tag name of the newest published release when it is prerelease-flagged
+   * (the invariant break that silently kills every release DM), else null.
+   */
+  newestPrerelease: z.string().nullable(),
   /** Announced-but-incomplete sweep outcome (the second sweep of the run). */
   resweep: z
     .object({

--- a/packages/common-types/src/schemas/github/release.test.ts
+++ b/packages/common-types/src/schemas/github/release.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { GitHubReleaseSchema, newestPublishedRelease, type GitHubRelease } from './release.js';
+
+function makeRelease(overrides: Partial<GitHubRelease> = {}): GitHubRelease {
+  return {
+    id: 1,
+    tag_name: 'v3.0.0-beta.166',
+    name: null,
+    body: null,
+    draft: false,
+    prerelease: false,
+    html_url: 'https://github.com/lbds137/tzurot/releases/tag/v3.0.0-beta.166',
+    published_at: '2026-07-15T04:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('GitHubReleaseSchema', () => {
+  it('accepts a real-shaped release payload and strips extras', () => {
+    const parsed = GitHubReleaseSchema.parse({ ...makeRelease(), assets: [], author: {} });
+    expect(parsed).not.toHaveProperty('assets');
+    expect(parsed.tag_name).toBe('v3.0.0-beta.166');
+  });
+
+  it('accepts a draft with null published_at', () => {
+    const parsed = GitHubReleaseSchema.parse(makeRelease({ published_at: null }));
+    expect(parsed.published_at).toBeNull();
+  });
+
+  it('rejects a missing required field', () => {
+    const { tag_name: _tagName, ...withoutTagName } = makeRelease();
+    expect(() => GitHubReleaseSchema.parse(withoutTagName)).toThrow();
+  });
+
+  it('rejects a non-boolean prerelease flag', () => {
+    expect(() => GitHubReleaseSchema.parse({ ...makeRelease(), prerelease: 'true' })).toThrow();
+  });
+});
+
+describe('newestPublishedRelease', () => {
+  it('picks by published_at, not array order', () => {
+    const older = makeRelease({ id: 1, tag_name: 'v-older', published_at: '2026-07-01T00:00:00Z' });
+    const newer = makeRelease({ id: 2, tag_name: 'v-newer', published_at: '2026-07-15T00:00:00Z' });
+    // Oldest listed first — an array-order-picking implementation would
+    // return `older` here, which this assertion catches.
+    expect(newestPublishedRelease([older, newer])).toEqual(newer);
+  });
+
+  it('excludes drafts (null published_at) even when otherwise newest', () => {
+    const draft = makeRelease({ id: 1, tag_name: 'v-draft', published_at: null });
+    const published = makeRelease({
+      id: 2,
+      tag_name: 'v-published',
+      published_at: '2026-07-01T00:00:00Z',
+    });
+    expect(newestPublishedRelease([draft, published])).toEqual(published);
+  });
+
+  it('returns null for an empty list', () => {
+    expect(newestPublishedRelease([])).toBeNull();
+  });
+
+  it('returns null when every release is a draft', () => {
+    const draft = makeRelease({ published_at: null });
+    expect(newestPublishedRelease([draft])).toBeNull();
+  });
+});

--- a/packages/common-types/src/schemas/github/release.ts
+++ b/packages/common-types/src/schemas/github/release.ts
@@ -1,0 +1,40 @@
+/**
+ * GitHub release shape shared by every consumer that reads the releases API
+ * (api-gateway's announce/reconcile pipeline, bot-client's release-flag nag).
+ * Passthrough fields are stripped; `id` is GitHub's numeric release id.
+ */
+
+import { z } from 'zod';
+
+export const GitHubReleaseSchema = z.object({
+  id: z.number().int(),
+  tag_name: z.string().min(1),
+  name: z.string().nullable().optional(),
+  body: z.string().nullable().optional(),
+  draft: z.boolean(),
+  prerelease: z.boolean(),
+  html_url: z.string().min(1),
+  published_at: z.string().nullable().optional(),
+});
+
+export type GitHubRelease = z.infer<typeof GitHubReleaseSchema>;
+
+/**
+ * Newest non-draft release by published_at, or null if none. Drafts carry a
+ * null published_at and are excluded rather than sorted last.
+ */
+export function newestPublishedRelease(releases: GitHubRelease[]): GitHubRelease | null {
+  let newest: GitHubRelease | null = null;
+  let newestTime = -Infinity;
+  for (const release of releases) {
+    if (release.published_at === null || release.published_at === undefined) {
+      continue;
+    }
+    const time = new Date(release.published_at).getTime();
+    if (time > newestTime) {
+      newest = release;
+      newestTime = time;
+    }
+  }
+  return newest;
+}

--- a/packages/tooling/src/deployment/setup-railway-variables.test.ts
+++ b/packages/tooling/src/deployment/setup-railway-variables.test.ts
@@ -130,6 +130,27 @@ ZAI_CODING_API_KEY=test-zai-key
       expect(output).toContain('Would set api-gateway variable: ZAI_CODING_API_KEY');
       expect(output).toContain('Would set ai-worker variable: ZAI_CODING_API_KEY');
     });
+
+    it('sets GITHUB_API_TOKEN on BOTH api-gateway and bot-client', async () => {
+      // The both-services invariant: the gateway's hourly reconcile sweep and
+      // bot-client's daily release-flag nag each read the GitHub releases API,
+      // and both degrade to the unreliable unauthenticated path when the token
+      // is missing — this test pins the manifest pairing so the key can't
+      // quietly drop from either list.
+      mockReadFileSync.mockReturnValue(`
+AI_PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-test-key
+DISCORD_TOKEN=test-discord-token
+DISCORD_CLIENT_ID=123456789
+GITHUB_API_TOKEN=ghp-test-token
+`);
+
+      await setupRailwayVariables({ env: 'dev', dryRun: true, yes: true });
+
+      const output = consoleLogs.join('\n');
+      expect(output).toContain('Would set api-gateway variable: GITHUB_API_TOKEN');
+      expect(output).toContain('Would set bot-client variable: GITHUB_API_TOKEN');
+    });
   });
 
   describe('environment validation', () => {

--- a/packages/tooling/src/deployment/setup-railway-variables.ts
+++ b/packages/tooling/src/deployment/setup-railway-variables.ts
@@ -68,6 +68,22 @@ const SHARED_VARIABLES: VariableConfig[] = [
   },
 ];
 
+/**
+ * GITHUB_API_TOKEN belongs on BOTH api-gateway and bot-client — the gateway's
+ * hourly release-reconcile sweep and bot-client's daily release-flag nag each
+ * read the GitHub releases API. Optional (both fetchers degrade to
+ * unauthenticated), but Railway's shared egress IPs make the per-IP anonymous
+ * rate limit unreliable, so an env that sets it on only one service leaves the
+ * other on the unreliable path. Declared once, listed in both service configs;
+ * a manifest test pins the pairing.
+ */
+const GITHUB_API_TOKEN_VARIABLE: VariableConfig = {
+  key: 'GITHUB_API_TOKEN',
+  description: 'Fine-grained PAT (Contents: Read-only) for GitHub releases API reads',
+  isSecret: true,
+  required: false,
+};
+
 // Service-specific variables
 const BOT_CLIENT_VARIABLES: VariableConfig[] = [
   { key: 'DISCORD_TOKEN', description: 'Discord bot token', isSecret: true, required: true },
@@ -86,6 +102,7 @@ const BOT_CLIENT_VARIABLES: VariableConfig[] = [
     required: false,
     defaultValue: 'false',
   },
+  GITHUB_API_TOKEN_VARIABLE,
 ];
 
 /**
@@ -113,6 +130,7 @@ const API_GATEWAY_VARIABLES: VariableConfig[] = [
     defaultValue: '3000',
   },
   ZAI_CODING_KEY_VARIABLE,
+  GITHUB_API_TOKEN_VARIABLE,
 ];
 
 const AI_WORKER_VARIABLES: VariableConfig[] = [

--- a/services/api-gateway/src/routes/internal/releaseReconcile.test.ts
+++ b/services/api-gateway/src/routes/internal/releaseReconcile.test.ts
@@ -55,6 +55,7 @@ const SUMMARY = {
   alreadyAnnounced: 0,
   skipped: 0,
   capped: false,
+  newestPrerelease: null,
 };
 
 const RESWEEP = {

--- a/services/api-gateway/src/routes/public/githubWebhook.ts
+++ b/services/api-gateway/src/routes/public/githubWebhook.ts
@@ -17,9 +17,10 @@ import type { Queue } from 'bullmq';
 import { z } from 'zod';
 import { getConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { GitHubReleaseSchema } from '@tzurot/common-types/schemas/github/release';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { verifyGitHubSignature } from '../../utils/githubSignature.js';
-import { announceGitHubRelease, GitHubReleaseSchema } from '../../services/releaseAnnounce.js';
+import { announceGitHubRelease } from '../../services/releaseAnnounce.js';
 
 const logger = createLogger('github-webhook');
 

--- a/services/api-gateway/src/services/releaseAnnounce.test.ts
+++ b/services/api-gateway/src/services/releaseAnnounce.test.ts
@@ -7,11 +7,8 @@ vi.mock('./releaseBroadcast.js', () => ({
   enqueueBroadcast: enqueueBroadcastMock,
 }));
 
-import {
-  announceGitHubRelease,
-  GitHubReleaseSchema,
-  type GitHubRelease,
-} from './releaseAnnounce.js';
+import { announceGitHubRelease } from './releaseAnnounce.js';
+import type { GitHubRelease } from '@tzurot/common-types/schemas/github/release';
 
 const deps = {
   prisma: {} as PrismaClient,
@@ -31,25 +28,6 @@ function makeRelease(overrides: Partial<GitHubRelease> = {}): GitHubRelease {
     ...overrides,
   };
 }
-
-describe('GitHubReleaseSchema', () => {
-  it('accepts a real-shaped release payload and strips extras', () => {
-    const parsed = GitHubReleaseSchema.parse({ ...makeRelease(), assets: [], author: {} });
-    expect(parsed).not.toHaveProperty('assets');
-    expect(parsed.tag_name).toBe('v3.0.0-beta.166');
-  });
-
-  it('tolerates null body and name (GitHub sends null, not absent)', () => {
-    expect(GitHubReleaseSchema.safeParse(makeRelease({ body: null, name: null })).success).toBe(
-      true
-    );
-  });
-
-  it('rejects a payload missing the gate fields', () => {
-    const { draft: _draft, ...withoutDraft } = makeRelease();
-    expect(GitHubReleaseSchema.safeParse(withoutDraft).success).toBe(false);
-  });
-});
 
 describe('announceGitHubRelease', () => {
   beforeEach(() => {

--- a/services/api-gateway/src/services/releaseAnnounce.ts
+++ b/services/api-gateway/src/services/releaseAnnounce.ts
@@ -8,11 +8,11 @@
  * the prerelease gate doubles as a "current release only" filter.
  */
 
-import { z } from 'zod';
 import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { Queue } from 'bullmq';
 import type { NotifyLevelValue } from '@tzurot/common-types/schemas/api/notifications';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import type { GitHubRelease } from '@tzurot/common-types/schemas/github/release';
 import { enqueueBroadcast } from './releaseBroadcast.js';
 import {
   parseReleaseSections,
@@ -21,24 +21,6 @@ import {
 } from './releaseNotes.js';
 
 const logger = createLogger('ReleaseAnnounce');
-
-/**
- * The subset of GitHub's release object both triggers consume. Passthrough
- * fields are stripped; `id` is GitHub's numeric release id (stored stringly
- * as the announcement's githubReleaseId).
- */
-export const GitHubReleaseSchema = z.object({
-  id: z.number().int(),
-  tag_name: z.string().min(1),
-  name: z.string().nullable().optional(),
-  body: z.string().nullable().optional(),
-  draft: z.boolean(),
-  prerelease: z.boolean(),
-  html_url: z.string().min(1),
-  published_at: z.string().nullable().optional(),
-});
-
-export type GitHubRelease = z.infer<typeof GitHubReleaseSchema>;
 
 export type AnnounceOutcome =
   | {

--- a/services/api-gateway/src/services/releaseReconcile.test.ts
+++ b/services/api-gateway/src/services/releaseReconcile.test.ts
@@ -27,6 +27,19 @@ vi.mock('./releaseBroadcast.js', async () => {
   };
 });
 
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return { ...actual, createLogger: () => mockLogger };
+});
+
 import {
   createGitHubReleasesFetcher,
   reconcileReleaseAnnouncements,
@@ -36,7 +49,7 @@ import {
   INCOMPLETE_WEDGE_THRESHOLD_MS,
   type FetchGitHubReleases,
 } from './releaseReconcile.js';
-import type { GitHubRelease } from './releaseAnnounce.js';
+import type { GitHubRelease } from '@tzurot/common-types/schemas/github/release';
 
 const NOW = new Date('2026-07-15T12:00:00Z');
 
@@ -72,6 +85,7 @@ describe('reconcileReleaseAnnouncements', () => {
       recipients: 1,
       batches: 1,
     });
+    mockLogger.warn.mockClear();
   });
 
   afterEach(() => {
@@ -131,6 +145,9 @@ describe('reconcileReleaseAnnouncements', () => {
       alreadyAnnounced: 1,
       skipped: 1,
       capped: false,
+      // v-2 is the newest by published_at (hoursAgo(1) < hoursAgo(2)) AND
+      // prerelease-flagged.
+      newestPrerelease: 'v-2',
     });
   });
 
@@ -154,6 +171,46 @@ describe('reconcileReleaseAnnouncements', () => {
     expect(summary.announced).toHaveLength(MAX_ANNOUNCEMENTS_PER_RUN);
     expect(summary.capped).toBe(true);
     expect(announceMock).toHaveBeenCalledTimes(MAX_ANNOUNCEMENTS_PER_RUN);
+  });
+
+  it('warns and surfaces newestPrerelease when the newest release by published_at is prerelease-flagged', async () => {
+    // The prerelease release is NOT the array's first element — an
+    // array-order-picking implementation (instead of published_at) would
+    // pick v-older and fail this assertion.
+    const older = makeRelease({ id: 1, tag_name: 'v-older', published_at: hoursAgo(10) });
+    const newerPrerelease = makeRelease({
+      id: 2,
+      tag_name: 'v-newer',
+      published_at: hoursAgo(1),
+      prerelease: true,
+    });
+    const summary = await reconcileReleaseAnnouncements({
+      ...deps,
+      fetchReleases: withReleases([older, newerPrerelease]),
+    });
+
+    expect(summary.newestPrerelease).toBe('v-newer');
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ version: 'v-newer' }),
+      expect.any(String)
+    );
+  });
+
+  it('does not warn and reports newestPrerelease: null when the newest release is non-prerelease', async () => {
+    const older = makeRelease({
+      id: 1,
+      tag_name: 'v-older-pre',
+      published_at: hoursAgo(10),
+      prerelease: true,
+    });
+    const newerHealthy = makeRelease({ id: 2, tag_name: 'v-newer', published_at: hoursAgo(1) });
+    const summary = await reconcileReleaseAnnouncements({
+      ...deps,
+      fetchReleases: withReleases([older, newerHealthy]),
+    });
+
+    expect(summary.newestPrerelease).toBeNull();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/services/api-gateway/src/services/releaseReconcile.ts
+++ b/services/api-gateway/src/services/releaseReconcile.ts
@@ -32,12 +32,13 @@ import type { Queue } from 'bullmq';
 import { JobType } from '@tzurot/common-types/constants/queue';
 import { VALIDATION_TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { addValidatedJob } from '../utils/validatedQueue.js';
 import {
-  announceGitHubRelease,
   GitHubReleaseSchema,
+  newestPublishedRelease,
   type GitHubRelease,
-} from './releaseAnnounce.js';
+} from '@tzurot/common-types/schemas/github/release';
+import { addValidatedJob } from '../utils/validatedQueue.js';
+import { announceGitHubRelease } from './releaseAnnounce.js';
 import {
   BROADCAST_BATCH_SIZE,
   computeCompletionSummary,
@@ -107,6 +108,11 @@ export interface ReconcileSummary {
   alreadyAnnounced: number;
   skipped: number;
   capped: boolean;
+  /**
+   * Tag name of the newest published release when it is prerelease-flagged
+   * (the invariant break that silently kills every release DM), else null.
+   */
+  newestPrerelease: string | null;
 }
 
 export interface ReconcileDeps {
@@ -123,6 +129,20 @@ export async function reconcileReleaseAnnouncements(
   const cutoff = Date.now() - lookbackHours * 60 * 60 * 1000;
 
   const releases = await deps.fetchReleases();
+
+  // Checked over the FULL fetched list, not the lookback window — the
+  // "newest release is non-prerelease" invariant holds at all times, and
+  // window-scoping this would go silent again 24h after the mis-flag.
+  const newest = newestPublishedRelease(releases);
+  let newestPrerelease: string | null = null;
+  if (newest?.prerelease === true) {
+    newestPrerelease = newest.tag_name;
+    logger.warn(
+      { version: newest.tag_name, publishedAt: newest.published_at },
+      'Newest GitHub release is prerelease-flagged — release DMs are suppressed until it is demoted (release:publish flag choreography, or `gh release edit --prerelease=false`)'
+    );
+  }
+
   const inWindow = releases
     // Drafts carry a null published_at; everything else timestamps.
     .filter(release => {
@@ -142,6 +162,7 @@ export async function reconcileReleaseAnnouncements(
     alreadyAnnounced: 0,
     skipped: 0,
     capped: false,
+    newestPrerelease,
   };
 
   for (const release of inWindow) {

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -69,6 +69,10 @@ import {
   stopSecretRotationNagScheduler,
 } from './services/SecretRotationNagScheduler.js';
 import {
+  startReleaseFlagNagScheduler,
+  stopReleaseFlagNagScheduler,
+} from './services/ReleaseFlagNagScheduler.js';
+import {
   startRetentionNagScheduler,
   stopRetentionNagScheduler,
 } from './services/RetentionNagScheduler.js';
@@ -466,6 +470,12 @@ client.once(Events.ClientReady, () => {
   // cooldown; see SecretRotationNagScheduler for the restart-cadence design).
   startSecretRotationNagScheduler(client, services.cacheRedis);
 
+  // Daily check that the newest GitHub release isn't still prerelease-
+  // flagged → owner-channel nag (same restart-friendly cadence). That flag
+  // doubles as the release-DM announce gate, so a stuck flag silently kills
+  // every DM until this catches it.
+  startReleaseFlagNagScheduler(client, services.cacheRedis);
+
   // Daily retention purge-eligibility check → owner-channel nag (same
   // restart-friendly cadence; nothing purges automatically in Phase 2).
   startRetentionNagScheduler(client, services.cacheRedis);
@@ -551,6 +561,7 @@ async function disposeBotClient(): Promise<void> {
     stopNotificationCacheCleanup();
     stopVerificationCleanupScheduler();
     stopSecretRotationNagScheduler();
+    stopReleaseFlagNagScheduler();
     stopRetentionNagScheduler();
     stopNightlyDbSyncScheduler();
     // ioredis Redis#disconnect is synchronous (returns void) — kept outside

--- a/services/bot-client/src/services/ReleaseFlagNagScheduler.test.ts
+++ b/services/bot-client/src/services/ReleaseFlagNagScheduler.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the release-flag nag scheduler's check cycle.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Client } from 'discord.js';
+import type { Redis } from 'ioredis';
+
+const configMock = vi.hoisted(() => ({
+  value: { GITHUB_API_TOKEN: undefined as string | undefined },
+}));
+vi.mock('@tzurot/common-types/config/config', () => ({
+  getConfig: () => configMock.value,
+}));
+
+const mockPostOwnerChannelEmbed = vi.fn();
+vi.mock('../utils/ownerChannel.js', () => ({
+  postOwnerChannelEmbed: (...args: unknown[]) => mockPostOwnerChannelEmbed(...args),
+}));
+
+import { runReleaseFlagNagCheck } from './ReleaseFlagNagScheduler.js';
+
+function makeRelease(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    tag_name: 'v3.0.0-beta.197',
+    name: null,
+    body: null,
+    draft: false,
+    prerelease: false,
+    html_url: 'https://github.com/lbds137/tzurot/releases/tag/v3.0.0-beta.197',
+    published_at: '2026-08-08T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeFetchImpl(response: { ok: boolean; status?: number; json?: unknown }) {
+  return vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status ?? 200,
+    json: () => Promise.resolve(response.json),
+  }) as unknown as typeof fetch;
+}
+
+function makeRedis(cooldownValue: string | null): Redis {
+  return {
+    get: vi.fn().mockResolvedValue(cooldownValue),
+    setex: vi.fn().mockResolvedValue('OK'),
+  } as unknown as Redis;
+}
+
+const client = {} as Client;
+
+describe('ReleaseFlagNagScheduler runReleaseFlagNagCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configMock.value = { GITHUB_API_TOKEN: undefined };
+    mockPostOwnerChannelEmbed.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('posts the owner embed and arms the weekly cooldown when the newest release is prerelease-flagged', async () => {
+    // The prerelease release is NOT the array's first element — an
+    // array-order-picking implementation would miss it.
+    const older = makeRelease({
+      id: 1,
+      tag_name: 'v-older',
+      published_at: '2026-08-01T00:00:00Z',
+    });
+    const newerPrerelease = makeRelease({
+      id: 2,
+      tag_name: 'v-newer',
+      published_at: '2026-08-08T00:00:00Z',
+      prerelease: true,
+    });
+    vi.stubGlobal('fetch', makeFetchImpl({ ok: true, json: [older, newerPrerelease] }));
+    const redis = makeRedis(null);
+
+    await runReleaseFlagNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    // Seam assertion: the embed content names the flagged tag.
+    const embed = mockPostOwnerChannelEmbed.mock.calls[0][1] as {
+      data: { description?: string };
+    };
+    expect(embed.data.description).toContain('v-newer');
+    // The cooldown value is the nagged TAG (not a timestamp) — that is what
+    // scopes the suppression to this release.
+    expect(redis.setex).toHaveBeenCalledWith(
+      'release-flag-nag:cooldown',
+      7 * 24 * 60 * 60,
+      'v-newer'
+    );
+  });
+
+  it('does NOT post when the newest release is healthy (non-prerelease)', async () => {
+    const healthy = makeRelease({ tag_name: 'v-healthy', prerelease: false });
+    vi.stubGlobal('fetch', makeFetchImpl({ ok: true, json: [healthy] }));
+    const redis = makeRedis(null);
+
+    await runReleaseFlagNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+    expect(redis.setex).not.toHaveBeenCalled();
+  });
+
+  it('does NOT post while the cooldown holds the SAME tag (at most one nag per week per release)', async () => {
+    const prerelease = makeRelease({ tag_name: 'v-flagged', prerelease: true });
+    vi.stubGlobal('fetch', makeFetchImpl({ ok: true, json: [prerelease] }));
+    const redis = makeRedis('v-flagged');
+
+    await runReleaseFlagNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+    expect(redis.setex).not.toHaveBeenCalled();
+  });
+
+  it('DOES post when the cooldown holds a DIFFERENT tag — a new flagged release is a new incident', async () => {
+    const prerelease = makeRelease({ tag_name: 'v-second-incident', prerelease: true });
+    vi.stubGlobal('fetch', makeFetchImpl({ ok: true, json: [prerelease] }));
+    const redis = makeRedis('v-first-incident');
+
+    await runReleaseFlagNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(redis.setex).toHaveBeenCalledWith(
+      'release-flag-nag:cooldown',
+      7 * 24 * 60 * 60,
+      'v-second-incident'
+    );
+  });
+
+  it('does NOT arm the cooldown when the embed post reports non-delivery — the next tick retries', async () => {
+    const prerelease = makeRelease({ prerelease: true });
+    vi.stubGlobal('fetch', makeFetchImpl({ ok: true, json: [prerelease] }));
+    mockPostOwnerChannelEmbed.mockResolvedValue(false);
+    const redis = makeRedis(null);
+
+    await runReleaseFlagNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(redis.setex).not.toHaveBeenCalled();
+  });
+
+  it('swallows a fetch rejection entirely (no throw, no embed)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('network')) as unknown as typeof fetch
+    );
+    const redis = makeRedis(null);
+
+    await expect(runReleaseFlagNagCheck(client, redis)).resolves.toBeUndefined();
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+  });
+
+  it('swallows a non-2xx response (no throw, no embed)', async () => {
+    vi.stubGlobal('fetch', makeFetchImpl({ ok: false, status: 500 }));
+    const redis = makeRedis(null);
+
+    await expect(runReleaseFlagNagCheck(client, redis)).resolves.toBeUndefined();
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+  });
+
+  it('swallows a schema-invalid payload (no throw, no embed)', async () => {
+    vi.stubGlobal('fetch', makeFetchImpl({ ok: true, json: [{ nope: true }] }));
+    const redis = makeRedis(null);
+
+    await expect(runReleaseFlagNagCheck(client, redis)).resolves.toBeUndefined();
+    expect(mockPostOwnerChannelEmbed).not.toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/services/ReleaseFlagNagScheduler.ts
+++ b/services/bot-client/src/services/ReleaseFlagNagScheduler.ts
@@ -1,0 +1,147 @@
+/**
+ * Release Flag Nag Scheduler
+ *
+ * Daily check (plus one shortly after startup) of the GitHub releases API;
+ * posts an owner-channel embed when the newest published release is still
+ * flagged prerelease. That flag doubles as api-gateway's "current release
+ * only" announce gate — if it's stuck on, every release DM silently stops
+ * going out, and nothing else in the stack surfaces the mis-state on its
+ * own (the gateway sweep's WARN log is the other half of this detection;
+ * this is the owner-facing half).
+ *
+ * Cadence design mirrors SecretRotationNagScheduler: bot-client restarts on
+ * every deploy, so a weekly setInterval would effectively never fire. The
+ * CHECK runs daily/on-startup (restart-friendly — restarts make it fire
+ * more often, never less) and a Redis cooldown key caps the NAG at one post
+ * per week PER RELEASE (the key stores the nagged tag, so a different
+ * release becoming flagged is a new incident), surviving deploys precisely
+ * because in-process state does not.
+ *
+ * Deliberately independent of api-gateway: cross-service imports are an
+ * architecture violation (depcruise-enforced), so this fetches the GitHub
+ * releases API directly rather than reusing the gateway's reconcile sweep.
+ */
+
+import { EmbedBuilder, type Client } from 'discord.js';
+import type { Redis } from 'ioredis';
+import { z } from 'zod';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { VALIDATION_TIMEOUTS } from '@tzurot/common-types/constants/timing';
+import {
+  GitHubReleaseSchema,
+  newestPublishedRelease,
+  type GitHubRelease,
+} from '@tzurot/common-types/schemas/github/release';
+import { createIntervalScheduler } from '../utils/intervalScheduler.js';
+import { postOwnerChannelEmbed } from '../utils/ownerChannel.js';
+
+const logger = createLogger('release-flag-nag');
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const STARTUP_DELAY_MS = 60_000;
+/** At most one nag per week PER RELEASE, across restarts. */
+const NAG_COOLDOWN_SECONDS = 7 * 24 * 60 * 60;
+const COOLDOWN_KEY = 'release-flag-nag:cooldown';
+
+// per_page=5 (vs the gateway reconcile's 30): this check needs only the newest
+// published release, and 5 absorbs GitHub's creation-order-vs-published_at
+// skew plus a draft-heavy top of the list. The reconcile fetches 30 because it
+// must cover a whole lookback window, not just the newest.
+const GITHUB_RELEASES_URL = 'https://api.github.com/repos/lbds137/tzurot/releases?per_page=5';
+
+const scheduler = createIntervalScheduler<[Client, Redis]>({
+  intervalMs: CHECK_INTERVAL_MS,
+  startupDelayMs: STARTUP_DELAY_MS,
+  logger,
+  run: (client, redis) => runReleaseFlagNagCheck(client, redis),
+});
+
+/** Start the daily prerelease-flag check (call once from the composition root). */
+export function startReleaseFlagNagScheduler(client: Client, redis: Redis): void {
+  scheduler.start(client, redis);
+}
+
+/** Stop the scheduler (graceful shutdown). */
+export function stopReleaseFlagNagScheduler(): void {
+  scheduler.stop();
+}
+
+/** undefined = fetch/parse failure (best-effort, retried next tick). */
+async function fetchNewestRelease(): Promise<GitHubRelease | null | undefined> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VALIDATION_TIMEOUTS.EXTERNAL_GITHUB_API_CALL);
+  try {
+    const token = getConfig().GITHUB_API_TOKEN;
+    const response = await fetch(GITHUB_RELEASES_URL, {
+      headers: {
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+        'user-agent': 'tzurot-bot-client',
+        ...(token !== undefined ? { authorization: `Bearer ${token}` } : {}),
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      logger.warn({ status: response.status }, 'GitHub releases fetch failed; skipping check');
+      return undefined;
+    }
+    const payload: unknown = await response.json();
+    const parsed = z.array(GitHubReleaseSchema).safeParse(payload);
+    if (!parsed.success) {
+      logger.warn('GitHub releases payload failed schema validation; skipping check');
+      return undefined;
+    }
+    return newestPublishedRelease(parsed.data);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Exported for tests — one full check cycle. */
+export async function runReleaseFlagNagCheck(client: Client, redis: Redis): Promise<void> {
+  try {
+    const newest = await fetchNewestRelease();
+    if (newest?.prerelease !== true) {
+      return;
+    }
+
+    // Cooldown AFTER the mis-state determination: a healthy week costs no
+    // Redis read, and the key only exists while a nag is being suppressed.
+    // The key's VALUE is the nagged tag: a cooldown only silences the SAME
+    // release — a different release becoming newest-and-flagged during the
+    // window is a new incident and nags immediately.
+    const cooling = await redis.get(COOLDOWN_KEY);
+    if (cooling === newest.tag_name) {
+      logger.info(
+        { version: newest.tag_name },
+        'Newest release is prerelease but nag is in cooldown'
+      );
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle('🚩 Newest GitHub release is still prerelease-flagged')
+      .setDescription(
+        `**${newest.tag_name}** is the newest published release but is flagged \`prerelease\` — release DMs are silently suppressed until it is demoted.\n\n` +
+          `Fix: re-run \`pnpm ops release:publish\`, or \`gh release edit ${newest.tag_name} --prerelease=false --latest\`.`
+      )
+      .setTimestamp();
+
+    // Arm the cooldown only on confirmed delivery: a swallowed post failure
+    // must not buy a week of silence — the next daily tick retries instead.
+    const delivered = await postOwnerChannelEmbed(client, embed);
+    if (delivered) {
+      await redis.setex(COOLDOWN_KEY, NAG_COOLDOWN_SECONDS, newest.tag_name);
+      logger.info({ version: newest.tag_name }, 'Posted release-flag nag');
+    } else {
+      logger.warn(
+        { version: newest.tag_name },
+        'Release-flag nag embed was not delivered; will retry next tick'
+      );
+    }
+  } catch (error) {
+    // Nag failure must never affect anything else; next daily tick retries.
+    logger.warn({ err: error }, 'Release-flag nag check failed');
+  }
+}

--- a/services/bot-client/src/utils/ownerChannel.test.ts
+++ b/services/bot-client/src/utils/ownerChannel.test.ts
@@ -38,34 +38,34 @@ describe('postOwnerChannelEmbed', () => {
     configMock.value = { FEEDBACK_CHANNEL_ID: '123456789012345678' };
   });
 
-  it('sends the embed with pings suppressed', async () => {
+  it('sends the embed with pings suppressed and reports delivery', async () => {
     const send = vi.fn().mockResolvedValue({});
     const client = makeClient({ isTextBased: () => true, send });
 
-    await postOwnerChannelEmbed(client, embed);
+    await expect(postOwnerChannelEmbed(client, embed)).resolves.toBe(true);
 
     expect(send).toHaveBeenCalledWith({ embeds: [embed], allowedMentions: { parse: [] } });
   });
 
-  it('is a silent no-op when the channel id is unset', async () => {
+  it('is a silent no-op (not delivered) when the channel id is unset', async () => {
     configMock.value = { FEEDBACK_CHANNEL_ID: undefined };
     const client = makeClient(null);
 
-    await postOwnerChannelEmbed(client, embed);
+    await expect(postOwnerChannelEmbed(client, embed)).resolves.toBe(false);
 
     expect(client.channels.fetch).not.toHaveBeenCalled();
   });
 
-  it('warns-and-returns on a non-sendable channel (no throw)', async () => {
+  it('warns and reports non-delivery on a non-sendable channel (no throw)', async () => {
     const client = makeClient({ isTextBased: () => false });
 
-    await expect(postOwnerChannelEmbed(client, embed)).resolves.toBeUndefined();
+    await expect(postOwnerChannelEmbed(client, embed)).resolves.toBe(false);
   });
 
-  it('swallows a send failure — the caller primary action already succeeded', async () => {
+  it('swallows a send failure and reports non-delivery — the caller primary action already succeeded', async () => {
     const send = vi.fn().mockRejectedValue(new Error('missing access'));
     const client = makeClient({ isTextBased: () => true, send });
 
-    await expect(postOwnerChannelEmbed(client, embed)).resolves.toBeUndefined();
+    await expect(postOwnerChannelEmbed(client, embed)).resolves.toBe(false);
   });
 });

--- a/services/bot-client/src/utils/ownerChannel.ts
+++ b/services/bot-client/src/utils/ownerChannel.ts
@@ -7,6 +7,10 @@
  * so a failed post loses only the notification. Unset channel id → silent
  * no-op (the documented degrade for single-owner deployments without the
  * channel configured).
+ *
+ * Returns whether the embed was actually delivered, so callers that arm a
+ * suppression window (nag cooldowns) can skip arming it on a failed post —
+ * fire-and-forget callers may ignore the return value.
  */
 
 import { type Client, type EmbedBuilder } from 'discord.js';
@@ -15,19 +19,21 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('owner-channel');
 
-export async function postOwnerChannelEmbed(client: Client, embed: EmbedBuilder): Promise<void> {
+export async function postOwnerChannelEmbed(client: Client, embed: EmbedBuilder): Promise<boolean> {
   const channelId = getConfig().FEEDBACK_CHANNEL_ID;
   if (channelId === undefined) {
-    return;
+    return false;
   }
   try {
     const channel = await client.channels.fetch(channelId);
     if (channel === null || !channel.isTextBased() || !('send' in channel)) {
       logger.warn({ channelId }, 'FEEDBACK_CHANNEL_ID is not a sendable text channel');
-      return;
+      return false;
     }
     await channel.send({ embeds: [embed], allowedMentions: { parse: [] } });
+    return true;
   } catch (error) {
     logger.warn({ err: error, channelId }, 'Failed to post embed to owner channel');
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

Closes TASK-500. beta.197 sat on GitHub with `prerelease: true` (and beta.196 undemoted), so the announce pipeline skipped every release DM with `reason=prerelease` — that gate is BY DESIGN the current-release-only filter — and nothing surfaced the mis-state; the owner noticed the silence hours later. This adds detection on both sides of the seam:

- **api-gateway** — the hourly reconcile sweep computes `newestPublishedRelease()` over the FULL fetched list (not the lookback window: the invariant holds at all times, and window-scoping would go silent again 24h after the mis-flag). Prerelease-flagged newest → `logger.warn` + `newestPrerelease` on `ReconcileSummary` and the wire schema.
- **bot-client** — new `ReleaseFlagNagScheduler`: daily + startup check of the releases API, owner-channel embed naming the flagged tag and the fix commands, Redis weekly nag cooldown. Structure/cadence copied from `SecretRotationNagScheduler` (`createIntervalScheduler`, restart-friendly daily check, cooldown key surviving deploys).
- **common-types** — `GitHubReleaseSchema` moves from `releaseAnnounce.ts` to `schemas/github/release` with the `newestPublishedRelease()` helper, so both services share one definition (bot-client can't import from api-gateway; the fetch loop is duplicated deliberately, the schema is not).

## Design notes

- The task sketched "reconcile sweep posts an owner-channel ops embed" — reading the code moved the target: api-gateway has no Discord client and no generic ops-alert job type, so the owner-visible half lives in bot-client where every owner-channel nag already lives. Gateway keeps the hourly WARN + summary field as the log-side record.
- `newestPrerelease` is REQUIRED (not optional) on `ReleaseReconcileResponseSchema`, matching the summary which always sets it. Rolling-deploy skew (new caller validating an old gateway's response) can fail at most one hourly sweep call during the deploy window — the next sweep retries; strictness wins over a permanent optional.

## Verification

- Full `pnpm test` (26/26 tasks) and `pnpm quality` green locally; pre-push pipeline (build+lint+test across 15 packages, typecheck:spec, depcruise, knip:dead, guards) green.
- New assertions proven non-vacuous: prerelease fixtures deliberately NOT first in the array, so an array-order-picking implementation fails them; scheduler test asserts the embed description names the flagged tag (seam assertion), cooldown suppression, and all three failure paths swallow without posting.
- Orchestrated: Sonnet worker implementation, full-diff orchestrator review before commit (one comment fix applied in review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)