### PR TITLE
refactor(bot-client): dedupe the catalogModel test fixture

### DIFF
--- a/services/bot-client/src/commands/models/autocomplete.test.ts
+++ b/services/bot-client/src/commands/models/autocomplete.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AutocompleteInteraction } from 'discord.js';
-import type { CatalogModel } from '../../utils/modelCatalog.js';
+import { catalogModel } from '../../test/catalogModel.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -27,24 +27,6 @@ vi.mock('../../utils/modelCatalog.js', async importOriginal => {
 
 import { handleAutocomplete } from './autocomplete.js';
 
-function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
-  return {
-    name: overrides.id,
-    contextLength: 200_000,
-    supportsVision: false,
-    supportsImageGeneration: false,
-    supportsAudioInput: false,
-    supportsAudioOutput: false,
-    promptPricePerMillion: 3,
-    completionPricePerMillion: 15,
-    isZaiCoding: overrides.id.startsWith('z-ai/'),
-    docsUrl: null,
-    source: 'openrouter',
-    hasPricing: true,
-    ...overrides,
-  };
-}
-
 function interaction(focused: string): AutocompleteInteraction {
   return {
     options: { getFocused: () => focused },
@@ -58,7 +40,14 @@ describe('handleAutocomplete', () => {
   it('returns choices with name+value and a z.ai marker', async () => {
     catalogMock.fetchModelCatalog.mockResolvedValue([
       catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }),
-      catalogModel({ id: 'z-ai/glm-5.2', name: 'GLM-5.2', contextLength: 1_000_000 }),
+      // This suite doesn't exercise the z.ai-merge `source` distinction, so pin
+      // 'openrouter' explicitly rather than relying on the builder's id-prefix default.
+      catalogModel({
+        id: 'z-ai/glm-5.2',
+        name: 'GLM-5.2',
+        contextLength: 1_000_000,
+        source: 'openrouter',
+      }),
     ]);
     const ix = interaction('glm');
     await handleAutocomplete(ix);

--- a/services/bot-client/src/commands/models/browse.test.ts
+++ b/services/bot-client/src/commands/models/browse.test.ts
@@ -10,8 +10,8 @@ import type {
 } from 'discord.js';
 import type { UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import type { CatalogModel } from '../../utils/modelCatalog.js';
 import { makeOk, makeErr } from '../../test/gatewayClientStubs.js';
+import { catalogModel } from '../../test/catalogModel.js';
 import { mockListWalletKeysResponse, mockListLlmConfigsResponse } from '@tzurot/test-factories';
 
 vi.mock('@tzurot/common-types/generated/commandOptions', async () => {
@@ -64,24 +64,6 @@ import {
   isModelsBrowseSelectInteraction,
 } from './browse.js';
 import { __resetBrowseUserCachesForTests } from './browseUserCache.js';
-
-function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
-  return {
-    name: overrides.id,
-    contextLength: 200_000,
-    supportsVision: false,
-    supportsImageGeneration: false,
-    supportsAudioInput: false,
-    supportsAudioOutput: false,
-    promptPricePerMillion: 3,
-    completionPricePerMillion: 15,
-    isZaiCoding: overrides.id.startsWith('z-ai/'),
-    docsUrl: null,
-    source: 'openrouter',
-    hasPricing: true,
-    ...overrides,
-  };
-}
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/services/bot-client/src/commands/models/card.test.ts
+++ b/services/bot-client/src/commands/models/card.test.ts
@@ -5,21 +5,13 @@
 import { describe, it, expect } from 'vitest';
 import { buildModelCard } from './card.js';
 import type { UsableCatalogModel } from '../../utils/modelCatalog.js';
+import { catalogModel } from '../../test/catalogModel.js';
 
+/** Thin local wrapper: the shared builder covers CatalogModel; only the
+ * usability/canUse fields (UsableCatalogModel's own addition) live here. */
 function usable(overrides: Partial<UsableCatalogModel> & { id: string }): UsableCatalogModel {
   return {
-    name: overrides.id,
-    contextLength: 200_000,
-    supportsVision: false,
-    supportsImageGeneration: false,
-    supportsAudioInput: false,
-    supportsAudioOutput: false,
-    promptPricePerMillion: 3,
-    completionPricePerMillion: 15,
-    isZaiCoding: false,
-    docsUrl: null,
-    source: 'openrouter',
-    hasPricing: true,
+    ...catalogModel(overrides),
     usability: 'usable',
     canUse: true,
     ...overrides,

--- a/services/bot-client/src/commands/models/view.test.ts
+++ b/services/bot-client/src/commands/models/view.test.ts
@@ -6,8 +6,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ChatInputCommandInteraction } from 'discord.js';
 import type { UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import type { CatalogModel } from '../../utils/modelCatalog.js';
 import { makeOk, makeErr } from '../../test/gatewayClientStubs.js';
+import { catalogModel } from '../../test/catalogModel.js';
 import { mockListWalletKeysResponse } from '@tzurot/test-factories';
 
 let viewModelId = 'anthropic/claude-sonnet-4';
@@ -47,24 +47,6 @@ vi.mock('../../utils/gatewayClients.js', () => ({
 
 import { handleView } from './view.js';
 
-function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
-  return {
-    name: overrides.id,
-    contextLength: 200_000,
-    supportsVision: false,
-    supportsImageGeneration: false,
-    supportsAudioInput: false,
-    supportsAudioOutput: false,
-    promptPricePerMillion: 3,
-    completionPricePerMillion: 15,
-    isZaiCoding: false,
-    docsUrl: null,
-    source: 'openrouter',
-    hasPricing: true,
-    ...overrides,
-  };
-}
-
 function ctx(): DeferredCommandContext {
   const editReply = vi.fn();
   const interaction = { user: { id: 'u1' }, editReply } as unknown as ChatInputCommandInteraction;
@@ -96,7 +78,15 @@ describe('handleView', () => {
     // billed on their own key). Empty-Set-on-failure regressed exactly this.
     viewModelId = 'z-ai/glm-4.5-air';
     catalogMock.fetchCatalogModelById.mockResolvedValue(
-      catalogModel({ id: 'z-ai/glm-4.5-air', name: 'GLM 4.5 Air', source: 'both' })
+      // glm-4.5-air is a real coding-plan member, so the builder's computed
+      // isZaiCoding default is true; this suite doesn't exercise the ⚡ badge,
+      // so pin the original false rather than let the default drift in.
+      catalogModel({
+        id: 'z-ai/glm-4.5-air',
+        name: 'GLM 4.5 Air',
+        source: 'both',
+        isZaiCoding: false,
+      })
     );
     walletStub.listWalletKeys.mockResolvedValue(makeErr(500, 'wallet down'));
     const context = ctx();
@@ -112,7 +102,15 @@ describe('handleView', () => {
   it('renders the piggyback model as free for a CONFIRMED keyless user', async () => {
     viewModelId = 'z-ai/glm-4.5-air';
     catalogMock.fetchCatalogModelById.mockResolvedValue(
-      catalogModel({ id: 'z-ai/glm-4.5-air', name: 'GLM 4.5 Air', source: 'both' })
+      // glm-4.5-air is a real coding-plan member, so the builder's computed
+      // isZaiCoding default is true; this suite doesn't exercise the ⚡ badge,
+      // so pin the original false rather than let the default drift in.
+      catalogModel({
+        id: 'z-ai/glm-4.5-air',
+        name: 'GLM 4.5 Air',
+        source: 'both',
+        isZaiCoding: false,
+      })
     );
     // beforeEach default: wallet fetch OK with zero keys = confirmed guest
     const context = ctx();

--- a/services/bot-client/src/commands/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AutocompleteInteraction, User } from 'discord.js';
 import { mockListLlmConfigsResponse, mockLlmConfigSummary } from '@tzurot/test-factories';
 import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
-import type { CatalogModel } from '../../utils/modelCatalog.js';
+import { catalogModel } from '../../test/catalogModel.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -41,24 +41,6 @@ vi.mock('../../utils/modelCatalog.js', async importOriginal => {
 });
 
 const { handleAutocomplete, __resetGlobalConfigCacheForTests } = await import('./autocomplete.js');
-
-function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
-  return {
-    name: overrides.id,
-    contextLength: 200_000,
-    supportsVision: false,
-    supportsImageGeneration: false,
-    supportsAudioInput: false,
-    supportsAudioOutput: false,
-    promptPricePerMillion: 3,
-    completionPricePerMillion: 15,
-    isZaiCoding: false,
-    docsUrl: null,
-    source: 'openrouter',
-    hasPricing: true,
-    ...overrides,
-  };
-}
 
 interface UserClientStub {
   listUserLlmConfigs: ReturnType<typeof vi.fn>;

--- a/services/bot-client/src/test/catalogModel.test.ts
+++ b/services/bot-client/src/test/catalogModel.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Pins the shared builder's computed defaults — the drift between hand-rolled
+ * copies of exactly these two fields is what motivated the builder, so the
+ * derivation itself gets a test (same precedent as gatewayClientStubs.test.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import { catalogModel } from './catalogModel.js';
+
+describe('catalogModel builder defaults', () => {
+  it('computes zai-catalog source and isZaiCoding for a real coding-plan model id', () => {
+    const model = catalogModel({ id: 'z-ai/glm-5.2' });
+    expect(model.isZaiCoding).toBe(true);
+    expect(model.source).toBe('zai-catalog');
+  });
+
+  it('treats a z-ai/-prefixed id that is NOT a coding-plan model as openrouter (membership, not prefix)', () => {
+    const model = catalogModel({ id: 'z-ai/not-a-real-model' });
+    expect(model.isZaiCoding).toBe(false);
+    expect(model.source).toBe('openrouter');
+  });
+
+  it('computes openrouter defaults for a non-z-ai id', () => {
+    const model = catalogModel({ id: 'anthropic/claude-sonnet-4' });
+    expect(model.isZaiCoding).toBe(false);
+    expect(model.source).toBe('openrouter');
+  });
+
+  it('lets explicit overrides win over the computed defaults', () => {
+    const model = catalogModel({ id: 'z-ai/glm-5.2', source: 'openrouter', isZaiCoding: false });
+    expect(model.isZaiCoding).toBe(false);
+    expect(model.source).toBe('openrouter');
+  });
+});

--- a/services/bot-client/src/test/catalogModel.ts
+++ b/services/bot-client/src/test/catalogModel.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared `CatalogModel` test fixture builder.
+ *
+ * `CatalogModel` (the merged OpenRouter + z.ai catalog shape consumed by
+ * `/models`, `/preset`, and the shared autocomplete responder) was hand-built
+ * with slightly-diverged defaults in three test files. This builder is the
+ * single source: `isZaiCoding` and `source` default via
+ * `isZaiCodingPlanModel()` — the same GLM-family membership check production's
+ * `fromOpenRouter`/z.ai-merge logic uses (a `z-ai/`-prefixed id that is not a
+ * real coding-plan model computes `false`/`'openrouter'`, matching
+ * production). The computed `source` is only ever `'openrouter'` or
+ * `'zai-catalog'` — never `'both'`, which production's z.ai merge emits when
+ * a coding-plan model is ALSO present in the OpenRouter feed (the common case
+ * for real z.ai models). Callers needing `'both'`, or any other different
+ * value, pass an explicit override.
+ */
+import { isZaiCodingPlanModel } from '@tzurot/common-types/constants/ai';
+import type { CatalogModel } from '../utils/modelCatalog.js';
+
+export function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
+  const isZaiId = isZaiCodingPlanModel(overrides.id);
+  return {
+    name: overrides.id,
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    isZaiCoding: isZaiId,
+    docsUrl: null,
+    source: isZaiId ? 'zai-catalog' : 'openrouter',
+    hasPricing: true,
+    ...overrides,
+  };
+}

--- a/services/bot-client/src/utils/modelCatalog.test.ts
+++ b/services/bot-client/src/utils/modelCatalog.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ModelAutocompleteOption } from '@tzurot/common-types/types/ai';
 import { InfraError } from '@tzurot/clients';
+import { catalogModel } from '../test/catalogModel.js';
 
 // Mock the OpenRouter fetch layer so tests control the OpenRouter side of the
 // merge; the z.ai catalog half comes from the real listZaiCodingPlanModels().
@@ -21,7 +22,6 @@ import {
   formatCapabilities,
   zaiDisplayName,
   zaiReleasedToUnix,
-  type CatalogModel,
 } from './modelCatalog.js';
 
 const fetchModelsMock = vi.mocked(fetchModels);
@@ -172,23 +172,17 @@ describe('fetchCatalogModelById', () => {
 });
 
 describe('annotateUsability', () => {
-  const cat = (overrides: Partial<CatalogModel> & { id: string }): CatalogModel => ({
-    ...model(overrides),
-    isZaiCoding: overrides.id.startsWith('z-ai/'),
-    docsUrl: null,
-    source: 'openrouter',
-    hasPricing: true,
-    ...overrides,
-  });
-
   it('marks free models usable regardless of keys', () => {
-    const [r] = annotateUsability([cat({ id: 'google/gemma:free' })], new Set());
+    const [r] = annotateUsability([catalogModel({ id: 'google/gemma:free' })], new Set());
     expect(r.usability).toBe('free');
     expect(r.canUse).toBe(true);
   });
 
   it('marks the piggyback model free/usable for a KEYLESS (guest) user', () => {
-    const [r] = annotateUsability([cat({ id: 'z-ai/glm-4.5-air', source: 'both' })], new Set());
+    const [r] = annotateUsability(
+      [catalogModel({ id: 'z-ai/glm-4.5-air', source: 'both' })],
+      new Set()
+    );
     expect(r.usability).toBe('free');
     expect(r.canUse).toBe(true);
   });
@@ -197,7 +191,7 @@ describe('annotateUsability', () => {
     // An ElevenLabs key buys voice, not models — the wallet is non-empty but
     // holds no chat-capable key, so the free-tier presentation still applies.
     const [r] = annotateUsability(
-      [cat({ id: 'z-ai/glm-4.5-air', source: 'both' })],
+      [catalogModel({ id: 'z-ai/glm-4.5-air', source: 'both' })],
       new Set(['elevenlabs'])
     );
     expect(r.usability).toBe('free');
@@ -207,7 +201,7 @@ describe('annotateUsability', () => {
   it('keeps key-based verdicts for the piggyback model when the user HAS a key', () => {
     // Key-holders are billed on their own key — normal source-based routing
     const [r] = annotateUsability(
-      [cat({ id: 'z-ai/glm-4.5-air', source: 'both' })],
+      [catalogModel({ id: 'z-ai/glm-4.5-air', source: 'both' })],
       new Set(['openrouter'])
     );
     expect(r.usability).toBe('usable');
@@ -215,13 +209,13 @@ describe('annotateUsability', () => {
   });
 
   it('keeps the unknown verdict for the piggyback model when the wallet fetch failed', () => {
-    const [r] = annotateUsability([cat({ id: 'z-ai/glm-4.5-air', source: 'both' })], null);
+    const [r] = annotateUsability([catalogModel({ id: 'z-ai/glm-4.5-air', source: 'both' })], null);
     expect(r.usability).toBe('unknown');
   });
 
   it('marks an OpenRouter model usable when the user has an openrouter key', () => {
     const [r] = annotateUsability(
-      [cat({ id: 'anthropic/claude-sonnet-4' })],
+      [catalogModel({ id: 'anthropic/claude-sonnet-4' })],
       new Set(['openrouter'])
     );
     expect(r.usability).toBe('usable');
@@ -229,14 +223,21 @@ describe('annotateUsability', () => {
   });
 
   it('flags needs-openrouter-key when the user has no key', () => {
-    const [r] = annotateUsability([cat({ id: 'anthropic/claude-sonnet-4' })], new Set());
+    const [r] = annotateUsability([catalogModel({ id: 'anthropic/claude-sonnet-4' })], new Set());
     expect(r.usability).toBe('needs-openrouter-key');
     expect(r.canUse).toBe(false);
   });
 
   it('flags needs-zai-key for a z.ai-ONLY model (zai-catalog) without a z.ai key', () => {
     const [r] = annotateUsability(
-      [cat({ id: 'z-ai/glm-5.2', isZaiCoding: true, source: 'zai-catalog', hasPricing: false })],
+      [
+        catalogModel({
+          id: 'z-ai/glm-5.2',
+          isZaiCoding: true,
+          source: 'zai-catalog',
+          hasPricing: false,
+        }),
+      ],
       new Set(['openrouter']) // an OpenRouter key does NOT unlock a z.ai-only model
     );
     expect(r.usability).toBe('needs-zai-key');
@@ -245,7 +246,14 @@ describe('annotateUsability', () => {
 
   it('marks a z.ai-only model usable with a zai-coding key', () => {
     const [r] = annotateUsability(
-      [cat({ id: 'z-ai/glm-5.2', isZaiCoding: true, source: 'zai-catalog', hasPricing: false })],
+      [
+        catalogModel({
+          id: 'z-ai/glm-5.2',
+          isZaiCoding: true,
+          source: 'zai-catalog',
+          hasPricing: false,
+        }),
+      ],
       new Set(['zai-coding'])
     );
     expect(r.canUse).toBe(true);
@@ -254,7 +262,7 @@ describe('annotateUsability', () => {
   it('treats a coding-plan model on BOTH sources as usable via EITHER key', () => {
     // z-ai/glm-5 lives on OpenRouter too — an OR key (fallthrough) or a z.ai key
     // (direct) both unlock it.
-    const both = cat({ id: 'z-ai/glm-5', isZaiCoding: true, source: 'both' });
+    const both = catalogModel({ id: 'z-ai/glm-5', isZaiCoding: true, source: 'both' });
     expect(annotateUsability([both], new Set(['openrouter']))[0].canUse).toBe(true);
     expect(annotateUsability([both], new Set(['zai-coding']))[0].canUse).toBe(true);
     // Neither key → name BOTH paths, not just one.
@@ -262,13 +270,13 @@ describe('annotateUsability', () => {
   });
 
   it('marks non-free models unknown when keys could not be fetched (null providers)', () => {
-    const [r] = annotateUsability([cat({ id: 'anthropic/claude-sonnet-4' })], null);
+    const [r] = annotateUsability([catalogModel({ id: 'anthropic/claude-sonnet-4' })], null);
     expect(r.usability).toBe('unknown');
     expect(r.canUse).toBe(false);
   });
 
   it('keeps free models usable even when keys could not be fetched (null providers)', () => {
-    const [r] = annotateUsability([cat({ id: 'google/gemma:free' })], null);
+    const [r] = annotateUsability([catalogModel({ id: 'google/gemma:free' })], null);
     expect(r.usability).toBe('free');
     expect(r.canUse).toBe(true);
   });
@@ -277,7 +285,7 @@ describe('annotateUsability', () => {
     // e.g. z-ai/glm-4.6 — on OpenRouter, not in the coding-plan catalog, so
     // source is plain 'openrouter' and the z-ai/ prefix must NOT imply z.ai.
     const [r] = annotateUsability(
-      [cat({ id: 'z-ai/glm-4.6', isZaiCoding: false, source: 'openrouter' })],
+      [catalogModel({ id: 'z-ai/glm-4.6', isZaiCoding: false, source: 'openrouter' })],
       new Set(['zai-coding']) // a z.ai key does NOT unlock it
     );
     expect(r.usability).toBe('needs-openrouter-key');

--- a/services/bot-client/src/utils/modelCatalogAutocomplete.test.ts
+++ b/services/bot-client/src/utils/modelCatalogAutocomplete.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AutocompleteInteraction } from 'discord.js';
-import type { CatalogModel } from './modelCatalog.js';
+import { catalogModel } from '../test/catalogModel.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -30,22 +30,6 @@ vi.mock('./modelCatalog.js', async importOriginal => {
 });
 
 import { respondWithCatalogAutocomplete } from './modelCatalogAutocomplete.js';
-
-function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
-  return {
-    name: overrides.id,
-    contextLength: 200_000,
-    supportsVision: false,
-    supportsImageGeneration: false,
-    supportsAudioInput: false,
-    supportsAudioOutput: false,
-    promptPricePerMillion: 3,
-    completionPricePerMillion: 15,
-    isZaiCoding: overrides.id.startsWith('z-ai/'),
-    source: overrides.id.startsWith('z-ai/') ? 'zai-catalog' : 'openrouter',
-    ...overrides,
-  } as CatalogModel;
-}
 
 function mockInteraction(): AutocompleteInteraction {
   return { respond: vi.fn() } as unknown as AutocompleteInteraction;


### PR DESCRIPTION
## Summary

Closes TASK-435 — and completes it beyond its original scope: the task (and round 1 of this PR) enumerated **3** hand-rolled `CatalogModel` fixture builders; the round-2 review's value-based grep found **4 more** (`view.test.ts`, `browse.test.ts`, `modelCatalog.test.ts`'s `cat()`, `card.test.ts`'s `usable()`). All seven now route through one shared typed builder.

- **`services/bot-client/src/test/catalogModel.ts`**: `isZaiCoding`/`source` default via `isZaiCodingPlanModel()` — real GLM-family *membership*, the same check production's z.ai-merge uses, not a `z-ai/` prefix approximation. Plain typed return, no `as CatalogModel` cast anywhere. Docstring states the computed `source` is never `'both'` (production's merged case) — callers pass it explicitly.
- **`catalogModel.test.ts`** pins the derivation, including the membership-vs-prefix distinction (`z-ai/not-a-real-model` → `false`/`'openrouter'`) and override precedence.
- `card.test.ts`'s `usable()` stays as a thin local wrapper (spread + usability fields) — `UsableCatalogModel` knowledge has one consumer and stays local. `modelCatalog.test.ts`'s `model()` helper (raw pre-merge rows for the tests of production's OWN computation) is deliberately untouched — converting it would couple those tests to a mirror of the thing they test.

## Divergence reconciliation (pure dedupe — no test's observable fixture values changed)

Every call site in all seven files was enumerated. Where the builder's membership-computed defaults differ from a file's old hardcoded values on a fixture a test observes (`view.test.ts`'s `glm-4.5-air` cases), explicit overrides pin the original values with comments. Everywhere else the defaults agree or explicit overrides already existed.

## Verification

- Full `pnpm test` (26/26 tasks) + `pnpm quality` green locally after each round; the five newly-touched suites re-run in isolation (72/72).
- Repo-wide value-based grep (distinctive default lines, not function names) shows zero remaining hand-rolled `CatalogModel` builders — the only other hits build `ModelAutocompleteOption`, a genuinely different (pre-merge) layer.
- Zero `as CatalogModel` casts repo-wide.
- Orchestrated: Sonnet worker implementation resumed across rounds, full-diff orchestrator review before each commit; round-2 findings (membership swap, builder test, the 4-site sweep, docstring tightening) all applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)