### PR TITLE
fix(bot-client): arm nag cooldowns only on confirmed embed delivery

### DIFF
--- a/services/bot-client/src/services/RetentionNagScheduler.test.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.test.ts
@@ -69,7 +69,7 @@ const client = {} as Client;
 describe('RetentionNagScheduler runRetentionNagCheck', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPostOwnerChannelEmbed.mockResolvedValue(undefined);
+    mockPostOwnerChannelEmbed.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -90,6 +90,17 @@ describe('RetentionNagScheduler runRetentionNagCheck', () => {
       7 * 24 * 60 * 60,
       expect.any(String)
     );
+  });
+
+  it('does NOT arm the cooldown when the embed post reports non-delivery — the next tick retries', async () => {
+    mockRetentionPreview.mockResolvedValue({ ok: true, data: makePreview({ eligibleCount: 2 }) });
+    mockPostOwnerChannelEmbed.mockResolvedValue(false);
+    const redis = makeRedis(null);
+
+    await runRetentionNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(redis.setex).not.toHaveBeenCalled();
   });
 
   it('does NOT post while the cooldown key exists (at most one nag per week)', async () => {

--- a/services/bot-client/src/services/RetentionNagScheduler.ts
+++ b/services/bot-client/src/services/RetentionNagScheduler.ts
@@ -151,9 +151,18 @@ export async function runRetentionNagCheck(client: Client, redis: Redis): Promis
       return;
     }
 
-    await postOwnerChannelEmbed(client, buildRetentionNagEmbed(preview));
-    await redis.setex(COOLDOWN_KEY, NAG_COOLDOWN_SECONDS, new Date().toISOString());
-    logger.info({ eligibleCount: preview.totals.eligibleCount }, 'Posted retention nag');
+    // Arm the cooldown only on confirmed delivery: a swallowed post failure
+    // must not buy a week of silence — the next daily tick retries instead.
+    const delivered = await postOwnerChannelEmbed(client, buildRetentionNagEmbed(preview));
+    if (delivered) {
+      await redis.setex(COOLDOWN_KEY, NAG_COOLDOWN_SECONDS, new Date().toISOString());
+      logger.info({ eligibleCount: preview.totals.eligibleCount }, 'Posted retention nag');
+    } else {
+      logger.warn(
+        { eligibleCount: preview.totals.eligibleCount },
+        'Retention nag embed was not delivered; will retry next tick'
+      );
+    }
   } catch (error) {
     // Nag failure must never affect anything else; next daily tick retries.
     logger.warn({ err: error }, 'Retention nag check failed');

--- a/services/bot-client/src/services/SecretRotationNagScheduler.test.ts
+++ b/services/bot-client/src/services/SecretRotationNagScheduler.test.ts
@@ -37,7 +37,7 @@ const client = {} as Client;
 describe('SecretRotationNagScheduler runSecretRotationNagCheck', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPostOwnerChannelEmbed.mockResolvedValue(undefined);
+    mockPostOwnerChannelEmbed.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -61,6 +61,20 @@ describe('SecretRotationNagScheduler runSecretRotationNagCheck', () => {
       7 * 24 * 60 * 60,
       expect.any(String)
     );
+  });
+
+  it('does NOT arm the cooldown when the embed post reports non-delivery — the next tick retries', async () => {
+    mockSecretRotationStatus.mockResolvedValue({
+      ok: true,
+      data: { entries: [OVERDUE_ENTRY], overdueCount: 1 },
+    });
+    mockPostOwnerChannelEmbed.mockResolvedValue(false);
+    const redis = makeRedis(null);
+
+    await runSecretRotationNagCheck(client, redis);
+
+    expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
+    expect(redis.setex).not.toHaveBeenCalled();
   });
 
   it('does NOT post while the cooldown key exists (at most one nag per week)', async () => {

--- a/services/bot-client/src/services/SecretRotationNagScheduler.ts
+++ b/services/bot-client/src/services/SecretRotationNagScheduler.ts
@@ -82,9 +82,15 @@ export async function runSecretRotationNagCheck(client: Client, redis: Redis): P
       })
       .setTimestamp();
 
-    await postOwnerChannelEmbed(client, embed);
-    await redis.setex(COOLDOWN_KEY, NAG_COOLDOWN_SECONDS, new Date().toISOString());
-    logger.info({ overdueCount }, 'Posted rotation nag');
+    // Arm the cooldown only on confirmed delivery: a swallowed post failure
+    // must not buy a week of silence — the next daily tick retries instead.
+    const delivered = await postOwnerChannelEmbed(client, embed);
+    if (delivered) {
+      await redis.setex(COOLDOWN_KEY, NAG_COOLDOWN_SECONDS, new Date().toISOString());
+      logger.info({ overdueCount }, 'Posted rotation nag');
+    } else {
+      logger.warn({ overdueCount }, 'Rotation nag embed was not delivered; will retry next tick');
+    }
   } catch (error) {
     // Nag failure must never affect anything else; next daily tick retries.
     logger.warn({ err: error }, 'Rotation nag check failed');


### PR DESCRIPTION
## Summary

`SecretRotationNagScheduler` and `RetentionNagScheduler` armed their weekly Redis cooldown unconditionally after `postOwnerChannelEmbed(...)` — a silently failed post (unset channel id, non-sendable channel, Discord API error) bought a week of silence on an overdue-rotation or retention warning. Both now gate the `setex` + info-log on the `delivered` boolean the helper already returns (added in #2038), mirroring `ReleaseFlagNagScheduler`: a failed post warn-logs and the next daily tick retries.

Closes TASK-503 (filed from the #2038 review's sibling sweep, scope widened by its round 2 to cover both schedulers).

## Changes

- `SecretRotationNagScheduler.ts` / `RetentionNagScheduler.ts`: `const delivered = await postOwnerChannelEmbed(...)`; cooldown arms only when `delivered`, else `logger.warn(...'was not delivered; will retry next tick')`. Existing setex values and info-log lines unchanged, just moved inside the gate.
- Both test files: default `postOwnerChannelEmbed` mock flipped `undefined` → `true` (`undefined` is falsy — the happy-path tests would have silently depended on the old ungated behavior), plus one new non-delivery test per scheduler asserting `redis.setex` is never called.

## Verified

- Survivor grep: only the three nag schedulers bind `delivered`; the fire-and-forget callers (NightlyDbSyncScheduler, release-DM/retention-notify workers, feedback command) are untouched.
- Both new assertions proven able to fail: gate mutated → test red → gate restored (per-scheduler).
- `pnpm test` (399 files / 6239 bot-client tests green) and `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)