### PR TITLE
fix(api-gateway): warn when the releases page may not cover the lookback window

### DIFF
--- a/services/api-gateway/src/services/releaseReconcile.test.ts
+++ b/services/api-gateway/src/services/releaseReconcile.test.ts
@@ -212,6 +212,80 @@ describe('reconcileReleaseAnnouncements', () => {
     expect(summary.newestPrerelease).toBeNull();
     expect(mockLogger.warn).not.toHaveBeenCalled();
   });
+
+  describe('single-page coverage tripwire', () => {
+    it('warns when the page is full and its oldest item is still inside the lookback window', async () => {
+      const releases = Array.from({ length: 30 }, (_unused, i) =>
+        makeRelease({ id: i, tag_name: `v-${i}`, published_at: hoursAgo(i + 1) })
+      );
+      await reconcileReleaseAnnouncements(
+        { ...deps, fetchReleases: withReleases(releases) },
+        { lookbackHours: 168 }
+      );
+
+      // The oldest item (id 29) sits at hoursAgo(30) — still inside a 168h window.
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageSize: 30,
+          oldestPublishedAt: hoursAgo(30),
+          lookbackHours: 168,
+        }),
+        expect.stringContaining('older in-window releases may be missing')
+      );
+    });
+
+    it('finds the oldest item regardless of API return order (order-independent min)', async () => {
+      // Oldest item deliberately NOT at the tail: GitHub return order is not
+      // trusted elsewhere in this module (inWindow re-sorts), so the tripwire
+      // must not assume it either. A tail-element shortcut would fail here.
+      const releases = Array.from({ length: 30 }, (_unused, i) =>
+        makeRelease({ id: i, tag_name: `v-${i}`, published_at: hoursAgo(i + 1) })
+      );
+      const oldest = releases.splice(29, 1)[0]; // published_at = hoursAgo(30)
+      releases.splice(10, 0, oldest); // bury it mid-array
+      await reconcileReleaseAnnouncements(
+        { ...deps, fetchReleases: withReleases(releases) },
+        { lookbackHours: 168 }
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ oldestPublishedAt: hoursAgo(30) }),
+        expect.stringContaining('older in-window releases may be missing')
+      );
+    });
+
+    it('does not warn when the page is full but the oldest item is outside the lookback window', async () => {
+      const releases = Array.from({ length: 30 }, (_unused, i) =>
+        makeRelease({ id: i, tag_name: `v-${i}`, published_at: hoursAgo(i + 1) })
+      );
+      await reconcileReleaseAnnouncements(
+        { ...deps, fetchReleases: withReleases(releases) },
+        { lookbackHours: 24 }
+      );
+
+      // The oldest item (id 29) sits at hoursAgo(30) — outside a 24h window,
+      // so the page's tail is proven to already be out of range.
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('older in-window releases may be missing')
+      );
+    });
+
+    it('does not warn on a short page even when every item is inside the window', async () => {
+      const releases = Array.from({ length: 5 }, (_unused, i) =>
+        makeRelease({ id: i, tag_name: `v-${i}`, published_at: hoursAgo(i + 1) })
+      );
+      await reconcileReleaseAnnouncements(
+        { ...deps, fetchReleases: withReleases(releases) },
+        { lookbackHours: 168 }
+      );
+
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('older in-window releases may be missing')
+      );
+    });
+  });
 });
 
 describe('sweepIncompleteBroadcasts', () => {

--- a/services/api-gateway/src/services/releaseReconcile.ts
+++ b/services/api-gateway/src/services/releaseReconcile.ts
@@ -48,7 +48,9 @@ import {
 
 const logger = createLogger('ReleaseReconcile');
 
-const GITHUB_RELEASES_URL = 'https://api.github.com/repos/lbds137/tzurot/releases?per_page=30';
+/** Single-page fetch size; the sweep's coverage tripwire keys off this. */
+const RELEASES_PAGE_SIZE = 30;
+const GITHUB_RELEASES_URL = `https://api.github.com/repos/lbds137/tzurot/releases?per_page=${RELEASES_PAGE_SIZE}`;
 
 export const DEFAULT_LOOKBACK_HOURS = 24;
 
@@ -62,8 +64,10 @@ export const MAX_ANNOUNCEMENTS_PER_RUN = 3;
 export type FetchGitHubReleases = () => Promise<GitHubRelease[]>;
 
 /**
- * One-page newest-first fetch: 30 releases always covers any allowed
- * lookback window at this repo's release cadence. Token optional —
+ * One-page newest-first fetch: a page of RELEASES_PAGE_SIZE is expected to
+ * cover any allowed lookback window at this repo's release cadence — the
+ * sweep warns when a full page's oldest item is still inside the window
+ * (older in-window releases could exist past the page). Token optional —
  * unauthenticated works, but Railway's shared egress IPs make the
  * per-IP anonymous rate limit unreliable.
  */
@@ -141,6 +145,29 @@ export async function reconcileReleaseAnnouncements(
       { version: newest.tag_name, publishedAt: newest.published_at },
       'Newest GitHub release is prerelease-flagged — release DMs are suppressed until it is demoted (release:publish flag choreography, or `gh release edit --prerelease=false`)'
     );
+  }
+
+  // Coverage tripwire: a full page whose OLDEST non-draft item is still
+  // inside the lookback window means older in-window releases could exist
+  // past this single page (see createGitHubReleasesFetcher's doc comment).
+  if (releases.length >= RELEASES_PAGE_SIZE) {
+    const oldestPublishedAt = releases
+      .map(release => release.published_at)
+      .filter(
+        (publishedAt): publishedAt is string => publishedAt !== null && publishedAt !== undefined
+      )
+      .reduce<string | null>((oldest, current) => {
+        if (oldest === null) {
+          return current;
+        }
+        return new Date(current).getTime() < new Date(oldest).getTime() ? current : oldest;
+      }, null);
+    if (oldestPublishedAt !== null && new Date(oldestPublishedAt).getTime() >= cutoff) {
+      logger.warn(
+        { pageSize: RELEASES_PAGE_SIZE, oldestPublishedAt, lookbackHours },
+        'Releases page is full and its oldest item is still inside the lookback window — older in-window releases may be missing from this single-page sweep'
+      );
+    }
   }
 
   const inWindow = releases


### PR DESCRIPTION
## Summary

`createGitHubReleasesFetcher` pulls one newest-first page of GitHub releases (`?per_page=30`) and assumed that covers any allowed lookback window (≤168h). True at current cadence (~3 releases/week), but a burst pushing an unannounced release past position 30 would silently drop it from the reconcile sweep — a quiet failure mode flagged by the #1651 review. Per TASK-277's recorded decision, this ships the cheap tripwire rather than speculative pagination.

## Changes

- `RELEASES_PAGE_SIZE = 30` extracted and interpolated into the fetch URL, so the tripwire and the fetch can't drift.
- In `reconcileReleaseAnnouncements`: when the page comes back **full** AND its **oldest published item is still inside the lookback window**, `logger.warn` that older in-window releases may be missing (fields: `pageSize`, `oldestPublishedAt`, `lookbackHours`). Log-only by design — no `ReconcileSummary` or wire-schema change.
- The fetcher's doc comment no longer asserts unverified coverage ("always covers" → "expected to cover … the sweep warns when …").
- Three tests using the file's existing fixtures and logger mock: full page + oldest-in-window trips; full page + old tail doesn't; short page doesn't. The negative tests pin absence by the tripwire's own message so the sibling prerelease warn can't mask them.

## Verified

- Trip assertion proven able to fail (condition mutated → red → restored).
- Existing prerelease-warn block and its tests untouched and green.
- `pnpm test` and `pnpm quality` green locally (api-gateway: 189 files / 2631 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)