### PR TITLE
fix(common-types): strip trailing slash from gateway base URLs at env parse

### DIFF
--- a/packages/clients/src/clients/transport.test.ts
+++ b/packages/clients/src/clients/transport.test.ts
@@ -132,7 +132,7 @@ describe('callGateway', () => {
     expect(url).toBe('https://example.test/api/user/timezone');
   });
 
-  it('strips a single trailing slash from baseUrl (defensive against misconfig)', async () => {
+  it('strips trailing slashes from baseUrl (defensive against misconfig)', async () => {
     // A misconfigured `GATEWAY_URL=https://example.test/` previously
     // produced `https://example.test//api/...`, which nginx and many CDN
     // configs reject. Normalizing here makes the transport robust against
@@ -141,6 +141,13 @@ describe('callGateway', () => {
     await callGateway({ ...baseOpts, baseUrl: 'https://example.test/' });
     const [url] = fetchSpy.mock.calls[0] as [string];
     expect(url).toBe('https://example.test/api/user/timezone');
+
+    // Doubled-slash misconfig: ops-CLI baseUrls bypass the env schema's strip,
+    // so this layer must handle the case a single-slash strip would miss.
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await callGateway({ ...baseOpts, baseUrl: 'https://example.test//' });
+    const [doubledUrl] = fetchSpy.mock.calls[1] as [string];
+    expect(doubledUrl).toBe('https://example.test/api/user/timezone');
   });
 
   it('defaults write methods (POST/PUT/PATCH/DELETE) to the WRITE timeout', async () => {

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -302,11 +302,14 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
     return { ok: false, kind: 'config', error: 'baseUrl is empty', status: 0 };
   }
 
-  // Strip a single trailing slash so a misconfigured `GATEWAY_URL=...example.test/`
+  // Strip trailing slashes so a misconfigured `GATEWAY_URL=...example.test/`
   // doesn't produce `example.test//api/...` (nginx and many CDN configs reject
   // double-slash paths). All `path` values from generated clients start with
-  // `/`, so this concatenation is well-formed in either case.
-  const normalizedBase = baseUrl.replace(/\/$/, '');
+  // `/`, so this concatenation is well-formed in either case. This is the
+  // defense-in-depth layer for callers that construct a baseUrl OUTSIDE the
+  // env schema's strip (ops CLI Railway-vars reads, raw-env local paths).
+  // ReDoS: {1,64} ceiling; real config values have 0-1 trailing slashes.
+  const normalizedBase = baseUrl.replace(/\/{1,64}$/, '');
 
   try {
     const headers: Record<string, string> = {

--- a/packages/common-types/src/config/config.test.ts
+++ b/packages/common-types/src/config/config.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getConfig, resetConfig, createTestConfig, validateEnv, envSchema } from './config.js';
-import { AIProvider } from '../constants/index.js';
+import { AIProvider, SERVICE_DEFAULTS } from '../constants/index.js';
 
 describe('config', () => {
   // Store original process.env
@@ -244,8 +244,12 @@ describe('config', () => {
       expect(envSchema.parse({ PUBLIC_SITE_URL: 'https://rotzot.example' }).PUBLIC_SITE_URL).toBe(
         'https://rotzot.example'
       );
-      // Trailing slash stripped so `${SITE}/docs/...` never double-slashes.
+      // Trailing slashes stripped so `${SITE}/docs/...` never double-slashes —
+      // including the doubled-slash misconfig, which a single-slash strip would miss.
       expect(envSchema.parse({ PUBLIC_SITE_URL: 'https://rotzot.example/' }).PUBLIC_SITE_URL).toBe(
+        'https://rotzot.example'
+      );
+      expect(envSchema.parse({ PUBLIC_SITE_URL: 'https://rotzot.example//' }).PUBLIC_SITE_URL).toBe(
         'https://rotzot.example'
       );
     });
@@ -253,6 +257,37 @@ describe('config', () => {
     it('rejects a PUBLIC_SITE_URL without a scheme', () => {
       // A bare domain fails `.url()` — fail-fast at startup beats a broken link.
       expect(() => envSchema.parse({ PUBLIC_SITE_URL: 'rotzot.example' })).toThrow();
+    });
+
+    it('defaults GATEWAY_URL to localhost when unset and strips a trailing slash from an explicit value', () => {
+      expect(envSchema.parse({}).GATEWAY_URL).toBe(
+        `http://localhost:${SERVICE_DEFAULTS.API_GATEWAY_PORT}`
+      );
+      expect(envSchema.parse({ GATEWAY_URL: 'https://gateway.example' }).GATEWAY_URL).toBe(
+        'https://gateway.example'
+      );
+      // Trailing slashes stripped so `${GATEWAY_URL}/api/...` never double-slashes —
+      // including the doubled-slash misconfig, which a single-slash strip would miss.
+      expect(envSchema.parse({ GATEWAY_URL: 'https://gateway.example/' }).GATEWAY_URL).toBe(
+        'https://gateway.example'
+      );
+      expect(envSchema.parse({ GATEWAY_URL: 'https://gateway.example//' }).GATEWAY_URL).toBe(
+        'https://gateway.example'
+      );
+    });
+
+    it('honors an explicit PUBLIC_GATEWAY_URL, strips a trailing slash, and stays undefined when unset', () => {
+      expect(envSchema.parse({}).PUBLIC_GATEWAY_URL).toBeUndefined();
+      expect(
+        envSchema.parse({ PUBLIC_GATEWAY_URL: 'https://gateway.example' }).PUBLIC_GATEWAY_URL
+      ).toBe('https://gateway.example');
+      // Trailing slashes stripped so `${PUBLIC_GATEWAY_URL}/...` never double-slashes.
+      expect(
+        envSchema.parse({ PUBLIC_GATEWAY_URL: 'https://gateway.example/' }).PUBLIC_GATEWAY_URL
+      ).toBe('https://gateway.example');
+      expect(
+        envSchema.parse({ PUBLIC_GATEWAY_URL: 'https://gateway.example//' }).PUBLIC_GATEWAY_URL
+      ).toBe('https://gateway.example');
     });
 
     it('should transform ENABLE_HEALTH_SERVER correctly', () => {

--- a/packages/common-types/src/config/config.ts
+++ b/packages/common-types/src/config/config.ts
@@ -117,20 +117,30 @@ export const envSchema = z.object({
     .url()
     .optional()
     .or(z.literal('').transform(() => undefined))
-    .transform(val => val ?? `http://localhost:${SERVICE_DEFAULTS.API_GATEWAY_PORT}`), // Internal URL for API calls (bot-client -> api-gateway)
+    // Strip trailing slashes so callers can concatenate `${GATEWAY_URL}/api/...`
+    // without risking a double slash regardless of how the value is set.
+    // ReDoS: {1,64} ceiling; real config values have 0-1 trailing slashes.
+    .transform(val =>
+      (val ?? `http://localhost:${SERVICE_DEFAULTS.API_GATEWAY_PORT}`).replace(/\/{1,64}$/, '')
+    ), // Internal URL for API calls (bot-client -> api-gateway)
   PUBLIC_GATEWAY_URL: z
     .string()
     .url()
     .optional()
-    .or(z.literal('').transform(() => undefined)), // Public HTTPS URL for external resources (Discord avatar fetching)
+    .or(z.literal('').transform(() => undefined))
+    // Strip trailing slashes so callers can concatenate `${PUBLIC_GATEWAY_URL}/...`
+    // without risking a double slash regardless of how the value is set.
+    // ReDoS: {1,64} ceiling; real config values have 0-1 trailing slashes.
+    .transform(val => val?.replace(/\/{1,64}$/, '')), // Public HTTPS URL for external resources (Discord avatar fetching)
   PUBLIC_SITE_URL: z
     .string()
     .url()
     .optional()
     .or(z.literal('').transform(() => undefined))
-    // Strip a trailing slash so callers can concatenate `${SITE}/docs/...`
+    // Strip trailing slashes so callers can concatenate `${SITE}/docs/...`
     // without risking a double slash regardless of how the value is set.
-    .transform(val => (val ?? 'https://tzurot.org').replace(/\/$/, '')), // Public website base URL; dev sets its own domain so user-facing links stay in-environment
+    // ReDoS: {1,64} ceiling; real config values have 0-1 trailing slashes.
+    .transform(val => (val ?? 'https://tzurot.org').replace(/\/{1,64}$/, '')), // Public website base URL; dev sets its own domain so user-facing links stay in-environment
   CORS_ORIGINS: z
     .string()
     .optional()

--- a/packages/identity/src/personality/PersonalityDefaults.test.ts
+++ b/packages/identity/src/personality/PersonalityDefaults.test.ts
@@ -134,6 +134,25 @@ describe('PersonalityDefaults', () => {
       expect(result).toBe(`http://localhost:3000/avatars/test-bot-${expectedTimestamp}.png`);
     });
 
+    it('strips trailing slashes so the derived path never doubles the separator', () => {
+      process.env.PUBLIC_GATEWAY_URL = 'https://public.example.com/';
+      const result = deriveAvatarUrl('test-bot', testDate, mockLogger);
+      expect(result).toBe(`https://public.example.com/avatars/test-bot-${expectedTimestamp}.png`);
+
+      // Doubled-slash misconfig: the bounded multi-slash strip's reason to exist.
+      process.env.PUBLIC_GATEWAY_URL = 'https://public.example.com//';
+      const doubled = deriveAvatarUrl('test-bot', testDate, mockLogger);
+      expect(doubled).toBe(`https://public.example.com/avatars/test-bot-${expectedTimestamp}.png`);
+    });
+
+    it('treats a slash-only URL as unconfigured (strips to empty, warns)', () => {
+      delete process.env.PUBLIC_GATEWAY_URL;
+      process.env.GATEWAY_URL = '/';
+      const result = deriveAvatarUrl('test-bot', testDate, mockLogger);
+      expect(result).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+
     it('should return undefined and log warning if no URL configured', () => {
       delete process.env.PUBLIC_GATEWAY_URL;
       delete process.env.GATEWAY_URL;

--- a/packages/identity/src/personality/PersonalityDefaults.ts
+++ b/packages/identity/src/personality/PersonalityDefaults.ts
@@ -179,7 +179,13 @@ export function deriveAvatarUrl(
   updatedAt: Date,
   logger: { warn: (obj: object, msg: string) => void }
 ): string | undefined {
-  const publicUrl = process.env.PUBLIC_GATEWAY_URL ?? process.env.GATEWAY_URL;
+  // Reads raw process.env rather than getConfig(): the schema's localhost
+  // default would turn "no gateway configured" into an avatar URL Discord
+  // cannot fetch, where undefined correctly means "no avatar". That bypasses
+  // the env schema's trailing-slash strip, so mirror it here.
+  const rawUrl = process.env.PUBLIC_GATEWAY_URL ?? process.env.GATEWAY_URL;
+  // ReDoS: {1,64} ceiling; real config values have 0-1 trailing slashes.
+  const publicUrl = rawUrl?.replace(/\/{1,64}$/, '');
   if (publicUrl === undefined || publicUrl.length === 0) {
     logger.warn(
       {},


### PR DESCRIPTION
## Summary

Every `${GATEWAY_URL}/...` and `${PUBLIC_GATEWAY_URL}/...` composition site (avatar derivation, typed-client transport, voice-reference fetches, export download URLs, ops-CLI gateway clients) assumes the base carries no trailing slash — a trailing-slash config value would mint `//`-doubled paths at all of them. This tightens the contract at the source and hardens both non-schema layers (TASK-347 from the #1843 review, plus the round-1/round-3 review findings, owner-approved).

## Changes

- `packages/common-types/src/config/config.ts`: `GATEWAY_URL`, `PUBLIC_GATEWAY_URL`, and the pre-existing `PUBLIC_SITE_URL` all strip **all** trailing slashes at parse time (`/\/{1,64}$/` — bounded quantifier per the house ceiling convention). `GATEWAY_URL` folds the strip into its default-applying transform; `PUBLIC_GATEWAY_URL` strips while preserving `undefined` (inferred type stays `string | undefined`, pinned by the unset → `undefined` test).
- `packages/identity/src/personality/PersonalityDefaults.ts`: `deriveAvatarUrl` reads raw `process.env` (deliberately — the schema's localhost default would turn "no gateway configured" into an avatar URL Discord can't fetch, where `undefined` correctly means "no avatar"), so it mirrors the strip locally. A slash-only URL strips to empty and takes the existing "unconfigured" warn path.
- `packages/clients/src/clients/transport.ts`: the defensive strip widens from single-slash to the same bounded multi-slash regex, so every `ServiceClient` caller that constructs a baseUrl outside the schema — both `gateway-client.ts` raw reads (local env and Railway-vars) — is covered by the same normalization. This closes the round-3 review's remaining sweep gap at the shared seam rather than per call site.
- Tests: schema default/explicit/single-slash/double-slash for all three vars + unset → `undefined`; `deriveAvatarUrl` single/double-slash strip + slash-only degrade; transport single/double-slash strip.

Normalization only, no rejection (matches house precedent).

## Verified

- Every new strip assertion proven able to fail: schema transform, `deriveAvatarUrl` strip, and transport strip each mutated → red → restored (the transport double-slash test goes red under the old single-slash regex specifically).
- `pnpm test` and `pnpm quality` green locally (common-types 2746 / identity 180 / clients 199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)