### PR TITLE
fix(ai-worker): guard computeWindowCap against inverted window bounds

### DIFF
--- a/services/ai-worker/src/services/FreeTierRequestQuota.test.ts
+++ b/services/ai-worker/src/services/FreeTierRequestQuota.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Redis } from 'ioredis';
 import { CACHE_KEY_PREFIXES } from '@tzurot/common-types/constants/redis-keys';
+
+// Module-scope logger (not injectable), so asserting the once-per-instance
+// inverted-bounds warn requires mocking the logger module per package convention.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return { ...actual, createLogger: () => mockLogger };
+});
+
 import {
   FreeTierRequestQuota,
   FREE_TIER_ACTIVE_KEY,
@@ -67,6 +81,28 @@ describe('computeWindowCap', () => {
     [50, 5], // heavy contention → floor
   ])('N=%i → cap %i', (n, expected) => {
     expect(quota.computeWindowCap(n)).toBe(expected);
+  });
+});
+
+describe('computeWindowCap — inverted min/max guard (defense-in-depth)', () => {
+  it('clamps with the swapped pair when minPerWindow > maxPerWindow, and warns once', () => {
+    const invertedConfig: FreeTierQuotaConfig = { ...CONFIG, minPerWindow: 30, maxPerWindow: 5 };
+    const { quota } = build(undefined, invertedConfig);
+
+    // N=3 → raw 13, strictly between the swapped-pair bounds (floor 5, ceiling
+    // 30) — the old buggy `Math.max(min, Math.min(max, raw))` form would
+    // collapse this to the constant minPerWindow (30), losing the dynamic
+    // scaling; the corrected clamp lets 13 through.
+    expect(quota.computeWindowCap(3)).toBe(13);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      { minPerWindow: 30, maxPerWindow: 5 },
+      expect.stringContaining('inverted')
+    );
+
+    // A second call on the SAME instance must not warn again.
+    quota.computeWindowCap(1);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/ai-worker/src/services/FreeTierRequestQuota.ts
+++ b/services/ai-worker/src/services/FreeTierRequestQuota.ts
@@ -128,6 +128,8 @@ export class FreeTierRequestQuota {
   private readonly redis: Redis;
   /** Normalized per-call config provider (see constructor doc). */
   private readonly configProvider: () => FreeTierQuotaConfig;
+  /** Set on the first inverted-bounds warn so the log fires once per instance, not per call. */
+  private warnedInvertedWindowBounds = false;
 
   constructor(
     redis: Redis,
@@ -222,12 +224,26 @@ export class FreeTierRequestQuota {
     }
   }
 
-  /** The dynamic per-user cap for a given concurrent-user count. */
+  /**
+   * The dynamic per-user cap for a given concurrent-user count. The admin
+   * write surface enforces `minPerWindow <= maxPerWindow`; this guard is
+   * defense-in-depth for direct/legacy config paths and is behavior-preserving
+   * for valid configs.
+   */
   computeWindowCap(activeUsers: number): number {
     const config = this.configProvider();
     const windowFraction = config.windowMinutes / MINUTES_PER_DAY;
     const raw = Math.floor((config.globalDailyBudget * windowFraction) / Math.max(activeUsers, 1));
-    return Math.max(config.minPerWindow, Math.min(config.maxPerWindow, raw));
+    if (config.minPerWindow > config.maxPerWindow && !this.warnedInvertedWindowBounds) {
+      this.warnedInvertedWindowBounds = true;
+      logger.warn(
+        { minPerWindow: config.minPerWindow, maxPerWindow: config.maxPerWindow },
+        'Free-tier window bounds are inverted (min > max) — clamping with the swapped pair'
+      );
+    }
+    const floor = Math.min(config.minPerWindow, config.maxPerWindow);
+    const ceiling = Math.max(config.minPerWindow, config.maxPerWindow);
+    return Math.max(floor, Math.min(ceiling, raw));
   }
 
   private logDeny(


### PR DESCRIPTION
## Summary

Defense-in-depth for TASK-243: `computeWindowCap` clamped with `Math.max(min, Math.min(max, raw))`, so an inverted `minPerWindow > maxPerWindow` pair silently collapsed the dynamic per-user cap to a constant `minPerWindow` — the contention scaling disappeared with no signal. The admin write surface already validates the pair (`validateWindowPair`, #1605), but the read site had no guard.

## Changes

- `computeWindowCap` now derives `floor`/`ceiling` via `Math.min`/`Math.max` over the configured pair and clamps with those — byte-identical results for every valid config, dynamic behavior preserved under an inverted one.
- Logs a structured `warn` **once per instance** (not per call — config resolves per decision, so an unthrottled warn would fire on every request under a standing misconfiguration).
- JSDoc states the invariant split: write surface enforces `min <= max`; this guard covers direct/legacy config paths.

## Verification

- New test injects an inverted config through the existing `build()` config param and asserts the swapped-pair clamp (`N=3 → 13`) plus warn-once across two calls. Mutation-proven: reverting the clamp to the old form turns the test red (`expected 30 to be 13`). Notably the first draft's test value (N=0) did NOT go red under mutation — both formulas coincide there — and was corrected because of the mutation check.
- `pnpm test` (full unit suite) and `pnpm quality` green locally; ai-worker `typecheck`, `typecheck:spec`, `lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)