### PR TITLE
fix(bot-client): only a real timeout renders batch-delete "timed out"

### DIFF
--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -454,5 +454,155 @@ describe('handleBatchDelete', () => {
         content: expect.stringContaining('Autocomplete was unavailable'),
       });
     });
+
+    it('an APPLIED-phase render throw never renders the timed-out/cancelled copy — the delete already committed', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 5,
+          lockedWouldSkip: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: 'all',
+          previewToken: 'preview_test0000test0001',
+        })
+      );
+      stub.batchDelete.mockResolvedValue(
+        makeOk({
+          deletedCount: 5,
+          skippedLocked: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          message: 'Deleted 5 memories.',
+        })
+      );
+
+      const buttonInteraction = createMockButtonInteraction('memory-batch-delete::confirm');
+      // The success-path editReply on the button interaction rejects AFTER
+      // the delete already applied.
+      buttonInteraction.editReply.mockRejectedValue(new Error('Discord API blip'));
+      mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
+
+      const context = createMockContext();
+      await handleBatchDelete(context);
+
+      expect(stub.batchDelete).toHaveBeenCalledTimes(1);
+      // renderSpec prefixes the severity emoji; pin the catalog copy itself.
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining(
+          'The memories were deleted, but showing the result failed. Use /memory browse to verify.'
+        ),
+        embeds: [],
+        components: [],
+      });
+      const allEditReplyContents = (mockEditReply as ReturnType<typeof vi.fn>).mock.calls.map(
+        call => (call[0] as { content?: string }).content
+      );
+      expect(allEditReplyContents).not.toContain('Deletion cancelled - confirmation timed out.');
+    });
+
+    it('a CANCELLED-phase ack throw confirms the cancellation — never a delete-failure or timed-out copy', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 5,
+          lockedWouldSkip: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: 'all',
+          previewToken: 'preview_test0000test0001',
+        })
+      );
+
+      const buttonInteraction = createMockButtonInteraction('memory-batch-delete::cancel');
+      // The cancel ack itself fails — the cancellation is still effective
+      // (no write will run), so the fallback must confirm it.
+      buttonInteraction.update.mockRejectedValue(new Error('Discord API blip'));
+      mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
+
+      const context = createMockContext();
+      await handleBatchDelete(context);
+
+      expect(stub.batchDelete).not.toHaveBeenCalled();
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: 'Deletion cancelled.',
+        embeds: [],
+        components: [],
+      });
+      const cancelPathContents = (mockEditReply as ReturnType<typeof vi.fn>).mock.calls.map(
+        call => (call[0] as { content?: string }).content ?? ''
+      );
+      expect(cancelPathContents.some(c => c.includes('complete the deletion'))).toBe(false);
+      expect(cancelPathContents).not.toContain('Deletion cancelled - confirmation timed out.');
+    });
+
+    it('a CONFIRM-phase throw before the write renders a classified failure, never the timed-out copy, and never calls batchDelete', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 5,
+          lockedWouldSkip: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: 'all',
+          previewToken: 'preview_test0000test0001',
+        })
+      );
+
+      const buttonInteraction = createMockButtonInteraction('memory-batch-delete::confirm');
+      // ackUpdate() awaits interaction.deferUpdate() first — throw there so
+      // the failure happens before userClient.batchDelete is ever called.
+      buttonInteraction.deferUpdate.mockRejectedValue(new Error('Discord API blip'));
+      mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
+
+      const context = createMockContext();
+      await handleBatchDelete(context);
+
+      expect(stub.batchDelete).not.toHaveBeenCalled();
+      const reply = (mockEditReply as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as {
+        content: string;
+        embeds?: unknown[];
+        components?: unknown[];
+      };
+      expect(reply.content).not.toBe('Deletion cancelled - confirmation timed out.');
+      expect(reply.content).toContain('complete the deletion');
+      // The stale confirm embed/buttons must be cleared, like every other arm.
+      expect(reply.embeds).toEqual([]);
+      expect(reply.components).toEqual([]);
+    });
+
+    it('a CONFIRM-phase throw from the !ok failure render also clears the stale confirm UI', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 5,
+          lockedWouldSkip: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: 'all',
+          previewToken: 'preview_test0000test0001',
+        })
+      );
+      stub.batchDelete.mockResolvedValue(makeErr(500, 'internal error'));
+
+      const buttonInteraction = createMockButtonInteraction('memory-batch-delete::confirm');
+      // The !ok classified-failure render itself throws — the second trigger
+      // site that lands in the confirm-phase catch.
+      buttonInteraction.editReply.mockRejectedValue(new Error('Discord API blip'));
+      mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
+
+      const context = createMockContext();
+      await handleBatchDelete(context);
+
+      const reply = (mockEditReply as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as {
+        content: string;
+        embeds?: unknown[];
+        components?: unknown[];
+      };
+      expect(reply.content).not.toBe('Deletion cancelled - confirmation timed out.');
+      expect(reply.content).toContain('complete the deletion');
+      expect(reply.embeds).toEqual([]);
+      expect(reply.components).toEqual([]);
+    });
   });
 });

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -41,6 +41,75 @@ function formatTimeframe(timeframe: string | null): string {
   }
 }
 
+const CANCELLED_MESSAGE = 'Deletion cancelled.';
+
+/**
+ * Render the outer-catch outcome for `handleBatchDelete`, phase-aware so the
+ * message always matches what actually happened to the write. Extracted to
+ * keep the handler's own cognitive complexity within the lint budget —
+ * the branching lives here instead of inline in the catch block.
+ */
+async function renderBatchDeleteCatchOutcome(
+  phase: 'read' | 'cancelled' | 'confirm' | 'applied',
+  error: unknown,
+  userId: string,
+  context: DeferredCommandContext
+): Promise<void> {
+  if (phase === 'applied') {
+    // The delete already committed before this throw — the render/delivery
+    // step is what failed. Must NOT read as cancelled or failed, or the
+    // user retries a deletion that already happened.
+    logger.error({ err: error, userId, phase }, 'Batch delete applied but result render failed');
+    await context.editReply({
+      content: renderSpec(
+        CATALOG.error.destructiveApplied(
+          'The memories were deleted',
+          'Use /memory browse to verify.'
+        )
+      ),
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  if (phase === 'cancelled') {
+    // The user cancelled and no write will happen — only the cancel ack
+    // failed to render. Confirm the cancellation on the fallback surface
+    // (which also clears the stale confirm buttons); a failure message here
+    // would invite retrying a deletion the user just declined.
+    logger.error({ err: error, userId, phase }, 'Batch delete cancel ack render failed');
+    await context.editReply({
+      content: CANCELLED_MESSAGE,
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  if (phase === 'confirm') {
+    // Confirmed but the flow around the write (ack, result render) threw
+    // before completing — nothing was written (the client itself never
+    // throws), so classify as a failure rather than a timeout/cancellation.
+    // Clear the stale confirm embed/buttons like the sibling branches.
+    logger.error({ err: error, userId, phase }, 'Unexpected error');
+    await context.editReply({
+      content: renderSpec(
+        classifyGatewayFailure(error, 'memories', { failedAction: 'complete the deletion' })
+      ),
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+
+  // Still in the resolve/preview READ phase — nothing was written.
+  logger.error({ err: error, userId, phase }, 'Unexpected error');
+  await context.editReply({
+    content: renderSpec(classifyGatewayFailure(error, 'memories', { operation: 'read' })),
+  });
+}
+
 /**
  * Handle /memory delete
  * Shows preview and confirmation before batch deleting
@@ -52,6 +121,11 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
   const options = memoryDeleteOptions(context.interaction);
   const personalityInput = options.character();
   const timeframe = options.timeframe();
+
+  // Tracks how far the flow got before an outer-catch throw, so the catch
+  // can render an outcome-honest message: 'applied' means the delete already
+  // happened, so the catch must never claim it was cancelled or failed.
+  let phase: 'read' | 'cancelled' | 'confirm' | 'applied' = 'read';
 
   try {
     // resolveRequiredPersonality handles the sentinel, genuine-miss ("not found"),
@@ -129,95 +203,100 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
       components,
     });
 
-    // Wait for button interaction
+    // Wait for button interaction. Narrowly scoped: only a collector-wait
+    // failure (an actual timeout) may render the "confirmation timed out"
+    // message — everything past this point has its own phase-aware handling.
+    let buttonInteraction: ButtonInteraction;
     try {
       // eslint-disable-next-line no-restricted-syntax -- Secondary collector inside an exported handler — documented exception in `.claude/rules/04-discord.md`. The customIds use the `command::action::id` format and the parent flow IS routed through CommandHandler; this collector is just the timeout-bounded confirmation wait.
-      const buttonInteraction = await response.awaitMessageComponent({
+      buttonInteraction = await response.awaitMessageComponent({
         componentType: ComponentType.Button,
         filter: (i: ButtonInteraction) => i.user.id === userId,
         time: CONFIRMATION_TIMEOUT,
       });
-
-      if (buttonInteraction.customId === 'memory-batch-delete::cancel') {
-        await buttonInteraction.update({
-          content: 'Deletion cancelled.',
-          embeds: [],
-          components: [],
-        });
-        return;
-      }
-
-      // User confirmed - perform deletion
-      await ackUpdate(buttonInteraction);
-
-      const deleteResult = await userClient.batchDelete({ previewToken: preview.previewToken });
-
-      if (!deleteResult.ok) {
-        await buttonInteraction.editReply({
-          content: renderSpec(
-            classifyGatewayFailure(deleteResult, 'memories', {
-              failedAction: 'delete the memories',
-            })
-          ),
-          embeds: [],
-          components: [],
-        });
-        return;
-      }
-
-      const result = deleteResult.data;
-
-      // Show success. `personalityName` is schema-optional because the gateway
-      // returns the 0-result shape without it when nothing matched; in this
-      // branch the preview already confirmed >0 deletions, so the fallback is
-      // a defense-in-depth guard against the rare preview-to-execute race
-      // (memories deleted by another session between preview and execute).
-      const displayName = result.personalityName ?? preview.personalityName;
-      let successDescription = `Deleted **${result.deletedCount}** memories for **${escapeMarkdown(displayName)}**`;
-
-      if (timeframe !== null) {
-        successDescription += ` from the last **${timeframeDisplay}**`;
-      }
-
-      successDescription += '.';
-
-      if (result.skippedLocked > 0) {
-        successDescription += `\n\n**${result.skippedLocked}** locked memories were preserved.`;
-      }
-
-      const successEmbed = createSuccessEmbed('Memories Deleted', successDescription);
-
-      await buttonInteraction.editReply({
-        embeds: [successEmbed],
-        components: [],
-      });
-
-      logger.info(
-        {
-          userId,
-          personalityId,
-          timeframe,
-          deletedCount: result.deletedCount,
-          skippedLocked: result.skippedLocked,
-        },
-        'Batch delete completed'
-      );
     } catch {
-      // Timeout or error - clear components
+      // Timeout - clear components
       await context.editReply({
         content: 'Deletion cancelled - confirmation timed out.',
         embeds: [],
         components: [],
       });
+      return;
     }
-  } catch (error) {
-    logger.error({ err: error, userId }, 'Unexpected error');
-    await context.editReply({
-      content: renderSpec(
-        // The OUTER catch only fires for the resolve/preview READ phase — the
-        // delete write's failures are caught by the inner try above.
-        classifyGatewayFailure(error, 'memories', { operation: 'read' })
-      ),
+
+    if (buttonInteraction.customId === 'memory-batch-delete::cancel') {
+      // 'cancelled' before the ack: a throw during the ack must confirm the
+      // cancellation, never render a delete-failure (nothing will be written).
+      phase = 'cancelled';
+      await buttonInteraction.update({
+        content: CANCELLED_MESSAGE,
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    // User confirmed - perform deletion
+    phase = 'confirm';
+    await ackUpdate(buttonInteraction);
+
+    const deleteResult = await userClient.batchDelete({ previewToken: preview.previewToken });
+
+    if (!deleteResult.ok) {
+      await buttonInteraction.editReply({
+        content: renderSpec(
+          classifyGatewayFailure(deleteResult, 'memories', {
+            failedAction: 'delete the memories',
+          })
+        ),
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    // The write has applied — from here on, a throw must never render as
+    // cancelled or failed; only the render/delivery step can still fail.
+    phase = 'applied';
+
+    const result = deleteResult.data;
+
+    // Show success. `personalityName` is schema-optional because the gateway
+    // returns the 0-result shape without it when nothing matched; in this
+    // branch the preview already confirmed >0 deletions, so the fallback is
+    // a defense-in-depth guard against the rare preview-to-execute race
+    // (memories deleted by another session between preview and execute).
+    const displayName = result.personalityName ?? preview.personalityName;
+    let successDescription = `Deleted **${result.deletedCount}** memories for **${escapeMarkdown(displayName)}**`;
+
+    if (timeframe !== null) {
+      successDescription += ` from the last **${timeframeDisplay}**`;
+    }
+
+    successDescription += '.';
+
+    if (result.skippedLocked > 0) {
+      successDescription += `\n\n**${result.skippedLocked}** locked memories were preserved.`;
+    }
+
+    const successEmbed = createSuccessEmbed('Memories Deleted', successDescription);
+
+    logger.info(
+      {
+        userId,
+        personalityId,
+        timeframe,
+        deletedCount: result.deletedCount,
+        skippedLocked: result.skippedLocked,
+      },
+      'Batch delete completed'
+    );
+
+    await buttonInteraction.editReply({
+      embeds: [successEmbed],
+      components: [],
     });
+  } catch (error) {
+    await renderBatchDeleteCatchOutcome(phase, error, userId, context);
   }
 }

--- a/services/bot-client/src/ux/catalog/catalog.test.ts
+++ b/services/bot-client/src/ux/catalog/catalog.test.ts
@@ -22,6 +22,13 @@ function allSpecs(): { path: string; spec: MessageSpec }[] {
       path: 'error.committedUnconfirmed+refresh',
       spec: CATALOG.error.committedUnconfirmed('preset', { refreshAffordance: true }),
     },
+    {
+      path: 'error.destructiveApplied',
+      spec: CATALOG.error.destructiveApplied(
+        'The memories were deleted',
+        'Use /memory browse to verify.'
+      ),
+    },
     { path: 'error.gatewayRejection', spec: CATALOG.error.gatewayRejection('Slug already taken') },
     { path: 'error.operationFailed', spec: CATALOG.error.operationFailed('create the character') },
     { path: 'error.permissionDenied', spec: CATALOG.error.permissionDenied('edit this') },

--- a/services/bot-client/src/ux/catalog/catalog.ts
+++ b/services/bot-client/src/ux/catalog/catalog.ts
@@ -85,6 +85,17 @@ export const CATALOG = {
     }),
 
     /**
+     * A destructive write APPLIED with its result already in hand; only
+     * rendering the result failed. Must never read as cancelled or failed —
+     * either invites redoing a destructive operation that already happened.
+     */
+    destructiveApplied: (whatApplied: string, verifySteer: string): MessageSpec => ({
+      severity: 'success',
+      outcome: 'committed-unconfirmed',
+      text: `${whatApplied}, but showing the result failed. ${verifySteer}`,
+    }),
+
+    /**
      * A definitive gateway rejection whose own message is worth surfacing
      * (validation detail, conflict explanation). The gateway emits clean
      * user-appropriate JSON messages (arch rule); bot-client adds the emoji.


### PR DESCRIPTION
## Summary

TASK-234: `handleBatchDelete`'s inner `try` wrapped the entire confirmation flow — the collector wait, the ack, the delete call, and the success rendering — with a bare catch that rendered `'Deletion cancelled - confirmation timed out.'` for ANY throw. A Discord API failure during the success render, i.e. **after the delete had already applied**, told the user the deletion was cancelled — inviting a retry of a deletion that already happened.

## Changes

- The `try` now covers only `awaitMessageComponent`; only a real collector-wait failure renders the timed-out copy.
- A `phase` tracker (`read` → `cancelled` | `confirm` → `applied`) makes the outer catch outcome-honest: an applied-phase throw renders the catalog's new `destructiveApplied` shape ("The memories were deleted, but showing the result failed. Use /memory browse to verify."); a **cancelled**-phase throw (the cancel ack itself failing) confirms the cancellation on the fallback surface — the cancel is effective, so it must never read as a delete failure; a confirm-phase throw classifies via `classifyGatewayFailure` and clears the stale confirm UI like the other arms; read-phase behavior is unchanged.
- The success `logger.info` moved before the final `editReply`, so the applied outcome is on record even when the render throws; all catch logs carry a `phase` field.
- The applied-phase copy lives in `CATALOG.error.destructiveApplied` (the raw-content allowlist is shrink-only — new user-facing copy belongs in the catalog, which is also what keeps the file's raw-literal budget at 5).
- The catch branching lives in a small `renderBatchDeleteCatchOutcome` helper — extraction forced by the `sonarjs/cognitive-complexity` gate, pure mechanical move.

Unchanged: the timeout, cancel, `!ok`-classified, and success paths.

**Scope note:** TASK-234 also proposed wrapping purge.ts's client calls in try/catch. Verified obsolete against the code — the generated user-client returns `GatewayResult` unions and never throws, and purge's `!ok` paths already classify; purge.ts is untouched.

## Verification

- Four new tests, each mutation-proven red against the defective shape it guards: applied-phase render-throw (honest message, no timed-out copy, `batchDelete` called once); cancelled-phase ack-throw (cancellation confirmed, no delete-failure copy, no write); confirm-phase pre-write throw via `deferUpdate` (classified failure, `batchDelete` never called, stale UI cleared); confirm-phase throw from the `!ok` failure render (same branch's second trigger site, stale UI cleared).
- bot-client typecheck + typecheck:spec + full unit suite + lint green; full `pnpm test` and `pnpm quality` green; the tooling raw-content-allowlist sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)