### PR TITLE
chore(ci): bump anthropics/claude-code-action to 1.0.187 (main-cut)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run Claude Code Review
         if: github.event.pull_request.base.ref != 'main'
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.183
+        uses: anthropics/claude-code-action@v1.0.187
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -77,7 +77,7 @@ jobs:
       - name: Run Claude Code Review (release)
         if: github.event.pull_request.base.ref == 'main'
         id: claude-review-release
-        uses: anthropics/claude-code-action@v1.0.183
+        uses: anthropics/claude-code-action@v1.0.187
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.183
+        uses: anthropics/claude-code-action@v1.0.187
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

Main-cut carrier for dependabot's #2041. The bump touches only `claude-code-review.yml` and `claude.yml` — the self-validating workflow files that must be byte-identical to `main` for claude-review to run at all. Merging the bump via develop (as #2041 would) silently disables claude-review on every PR until the next release, so per the documented procedure the hunks are cherry-picked from dependabot's branch (`4e96f9bc8`, authorship preserved) onto a branch cut from `main`.

Diff is exactly the three `uses:` pins, `v1.0.183` → `v1.0.187`; nothing else.

## After merge

1. `pnpm ops release:finalize` immediately, to resync `develop` onto `main` before other work piles on.
2. #2041 closes (dependabot detects the dep satisfied once develop resyncs; closed manually otherwise).
3. The remaining dependabot PRs (#2042–#2044) then rebase and ride develop normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)