### PR TITLE
fix(bot-client): outcome-honest fallback when a destructive success render throws

### DIFF
--- a/services/bot-client/src/commands/history/index.test.ts
+++ b/services/bot-client/src/commands/history/index.test.ts
@@ -228,7 +228,19 @@ describe('handleModal', () => {
 
     // The slug is read from the parent message's footer, not the customId.
     expect(mockParsePurgeSlugFromFooter).toHaveBeenCalledWith('slug:lilith');
-    expect(mockHandleDestructiveModalSubmit).toHaveBeenCalled();
+    // Seam assertion: the appliedNotice copy must actually cross the mocked
+    // boundary — the mock cannot distinguish dropped or wrong copy otherwise.
+    expect(mockHandleDestructiveModalSubmit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.any(Function),
+      expect.objectContaining({
+        appliedNotice: {
+          whatApplied: 'The history was deleted',
+          verifySteer: 'Use /history stats to verify.',
+        },
+      })
+    );
   });
 
   it('should reply with error when the slug footer is missing in modal', async () => {

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -153,6 +153,10 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
       const { confirmationPhrase } = hardDeleteModalDisplay(personalitySlug);
       await handleDestructiveModalSubmit(interaction, confirmationPhrase, executeOperation, {
         progressContent: 'Deleting history…',
+        appliedNotice: {
+          whatApplied: 'The history was deleted',
+          verifySteer: 'Use /history stats to verify.',
+        },
       });
       return;
     }

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -480,6 +480,41 @@ describe('handlePurgeModal (modal submission)', () => {
     );
   });
 
+  it('renders the applied-outcome copy when the success render throws after the purge applied', async () => {
+    stub.issuePurgeToken.mockResolvedValueOnce(
+      makeOk({
+        purgeToken: 'purge_test0000test0001',
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
+      })
+    );
+    stub.purge.mockResolvedValueOnce(
+      makeOk({
+        deletedCount: 8,
+        lockedPreserved: 2,
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
+        message: 'ok',
+      })
+    );
+    const interaction = createMockModalInteraction(EXPECTED_PHRASE);
+    interaction.editReply.mockRejectedValueOnce(new Error('Discord API blip'));
+
+    await handlePurgeModal(interaction);
+
+    // The purge already applied — the fallback must confirm it with this
+    // caller's copy, never a failure/retry framing over the applied write.
+    expect(stub.purge).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledTimes(2);
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content: expect.stringContaining(
+        'The memories were purged, but showing the result failed. Use /memory browse to verify.'
+      ),
+      embeds: [],
+      components: [],
+    });
+  });
+
   it('reports failure when token issuance fails (confirmation rejected server-side)', async () => {
     stub.issuePurgeToken.mockResolvedValueOnce(makeErr(400, 'Confirmation required'));
     const interaction = createMockModalInteraction(EXPECTED_PHRASE);

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -279,6 +279,12 @@ export async function handlePurgeModal(interaction: ModalSubmitInteraction): Pro
     expectedPhrase,
     enteredPhrase =>
       executePurgeHandshake(userClient, interaction.user.id, personalityId, enteredPhrase),
-    { progressContent: 'Purging memories…' }
+    {
+      progressContent: 'Purging memories…',
+      appliedNotice: {
+        whatApplied: 'The memories were purged',
+        verifySteer: 'Use /memory browse to verify.',
+      },
+    }
   );
 }

--- a/services/bot-client/src/commands/settings/data/delete.test.ts
+++ b/services/bot-client/src/commands/settings/data/delete.test.ts
@@ -223,6 +223,42 @@ describe('handleDataDeleteModal', () => {
     expect(embed.data.description).toContain('fresh empty account');
   });
 
+  it('renders the applied-outcome copy when the success render throws after the deletion applied', async () => {
+    stub.issueAccountDeleteToken.mockResolvedValue(makeOk({ deleteToken: 'acctdel_tok' }));
+    stub.deleteAccount.mockResolvedValue(
+      makeOk({
+        success: true,
+        summary: {
+          personas: 2,
+          characters: 1,
+          conversationMessages: 10,
+          memories: 5,
+          facts: 3,
+          factsSweptByTag: 4,
+          pendingMemories: 1,
+          diagnosticLogs: 1,
+          characterNames: ['XBot'],
+        },
+      })
+    );
+    const interaction = makeModal('DELETE MY ACCOUNT');
+    mockEditReply.mockRejectedValueOnce(new Error('Discord API blip'));
+
+    await handleDataDeleteModal(interaction as unknown as ModalSubmitInteraction);
+
+    // The deletion already applied — the fallback must confirm it with this
+    // caller's copy, never a failure/retry framing over the applied write.
+    expect(stub.deleteAccount).toHaveBeenCalledTimes(1);
+    expect(mockEditReply).toHaveBeenCalledTimes(2);
+    expect(mockEditReply).toHaveBeenLastCalledWith({
+      content: expect.stringContaining(
+        'Your data was deleted, but showing the result failed. Message the bot again — a fresh account is created automatically.'
+      ),
+      embeds: [],
+      components: [],
+    });
+  });
+
   it('surfaces a failed deletion without a success embed', async () => {
     stub.issueAccountDeleteToken.mockResolvedValue(makeOk({ deleteToken: 'acctdel_tok' }));
     stub.deleteAccount.mockResolvedValue(makeErr(500, 'boom'));

--- a/services/bot-client/src/commands/settings/data/delete.ts
+++ b/services/bot-client/src/commands/settings/data/delete.ts
@@ -258,6 +258,12 @@ export async function handleDataDeleteModal(interaction: ModalSubmitInteraction)
     interaction,
     ACCOUNT_DELETE_CONFIRMATION_PHRASE,
     enteredPhrase => executeDeleteHandshake(userClient, interaction.user.id, enteredPhrase),
-    { progressContent: 'Deleting your account…' }
+    {
+      progressContent: 'Deleting your account…',
+      appliedNotice: {
+        whatApplied: 'Your data was deleted',
+        verifySteer: 'Message the bot again — a fresh account is created automatically.',
+      },
+    }
   );
 }

--- a/services/bot-client/src/commands/voice/voices/purge.test.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.test.ts
@@ -227,7 +227,19 @@ describe('handleVoicePurgeModal', () => {
 
     await handleVoicePurgeModal(interaction);
 
-    expect(mockHandleDestructiveModalSubmit).toHaveBeenCalled();
+    // Seam assertion: the appliedNotice copy must actually cross the mocked
+    // boundary — the mock cannot distinguish dropped or wrong copy otherwise.
+    expect(mockHandleDestructiveModalSubmit).toHaveBeenCalledWith(
+      interaction,
+      expect.anything(),
+      expect.any(Function),
+      expect.objectContaining({
+        appliedNotice: {
+          whatApplied: 'The voices were purged',
+          verifySteer: 'Use /voice voices browse to verify.',
+        },
+      })
+    );
   });
 
   it('invokes clearVoices via the typed client when the destructive callback runs', async () => {

--- a/services/bot-client/src/commands/voice/voices/purge.ts
+++ b/services/bot-client/src/commands/voice/voices/purge.ts
@@ -184,6 +184,10 @@ export async function handleVoicePurgeModalSubmit(
 
   await handleDestructiveModalSubmit(interaction, confirmationPhrase, executeOperation, {
     progressContent: 'Purging voices…',
+    appliedNotice: {
+      whatApplied: 'The voices were purged',
+      verifySteer: 'Use /voice voices browse to verify.',
+    },
   });
 }
 

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.test.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.test.ts
@@ -2,7 +2,7 @@
  * Tests for Tier-B destructive confirmation (typed-phrase flow).
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { ButtonStyle, EmbedBuilder, MessageFlags } from 'discord.js';
 import type {
   APIButtonComponentWithCustomId,
@@ -23,6 +23,23 @@ import {
   FIXED_DELETE_PHRASE,
   type DestructiveConfirmationConfig,
 } from './confirmDestructive.js';
+
+const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }));
+
+vi.mock('@tzurot/common-types/utils/logger', async () => {
+  const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
+    '@tzurot/common-types/utils/logger'
+  );
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: mockLoggerError,
+    }),
+  };
+});
 
 const INVOKER = '123456789012345678';
 const OTHER_USER = '999999999999999999';
@@ -439,6 +456,79 @@ describe('handleDestructiveModalSubmit', () => {
 
     const call = interaction.editReply.mock.calls[0][0] as { content: string };
     expect(call.content.length).toBeGreaterThan(0);
+  });
+
+  describe('outcome-honest applied-fallback when the success render throws', () => {
+    beforeEach(() => {
+      mockLoggerError.mockClear();
+    });
+
+    it('renders the caller-supplied appliedNotice and logs once, without crashing', async () => {
+      const interaction = modalInteraction(modalId, 'DELETE');
+      interaction.editReply.mockRejectedValueOnce(new Error('Discord API blip'));
+      const executeOperation = vi.fn().mockResolvedValue({ success: true, successMessage: 'ok' });
+
+      await handleDestructiveModalSubmit(interaction, 'DELETE', executeOperation, {
+        appliedNotice: {
+          whatApplied: 'The memories were purged',
+          verifySteer: 'Use /memory browse to verify.',
+        },
+      });
+
+      expect(interaction.editReply).toHaveBeenCalledTimes(2);
+      expect(interaction.editReply).toHaveBeenLastCalledWith({
+        content: expect.stringContaining(
+          'The memories were purged, but showing the result failed. Use /memory browse to verify.'
+        ),
+        embeds: [],
+        components: [],
+      });
+      expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to generic copy when appliedNotice is omitted', async () => {
+      const interaction = modalInteraction(modalId, 'DELETE');
+      interaction.editReply.mockRejectedValueOnce(new Error('Discord API blip'));
+      const executeOperation = vi.fn().mockResolvedValue({ success: true, successMessage: 'ok' });
+
+      await handleDestructiveModalSubmit(interaction, 'DELETE', executeOperation);
+
+      expect(interaction.editReply).toHaveBeenLastCalledWith({
+        content: expect.stringContaining(
+          'The operation was applied, but showing the result failed. Re-run the command to verify.'
+        ),
+        embeds: [],
+        components: [],
+      });
+      expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates the failure-arm rejection untouched — no destructiveApplied render', async () => {
+      const interaction = modalInteraction(modalId, 'DELETE');
+      interaction.editReply.mockRejectedValue(new Error('Discord API blip'));
+      const executeOperation = vi.fn().mockResolvedValue({ success: false });
+
+      await expect(
+        handleDestructiveModalSubmit(interaction, 'DELETE', executeOperation)
+      ).rejects.toThrow('Discord API blip');
+
+      expect(interaction.editReply).toHaveBeenCalledTimes(1);
+      // The failure arm has no try/catch, so it never runs the applied-fallback
+      // logger.error path — only the SUCCESS branch's catch is instrumented.
+      expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+
+    it('lets a double-failure (fallback editReply also throws) propagate', async () => {
+      const interaction = modalInteraction(modalId, 'DELETE');
+      interaction.editReply.mockRejectedValue(new Error('still broken'));
+      const executeOperation = vi.fn().mockResolvedValue({ success: true, successMessage: 'ok' });
+
+      await expect(
+        handleDestructiveModalSubmit(interaction, 'DELETE', executeOperation)
+      ).rejects.toThrow('still broken');
+
+      expect(interaction.editReply).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('rejects a malformed modal customId before any work', async () => {

--- a/services/bot-client/src/utils/confirmation/confirmDestructive.ts
+++ b/services/bot-client/src/utils/confirmation/confirmDestructive.ts
@@ -318,7 +318,16 @@ export interface DestructiveOperationResult {
 export interface DestructiveSubmitOptions {
   /** Progress text shown while executeOperation runs (pending-states rule). */
   progressContent?: string;
+  /**
+   * Copy for the outcome-honest fallback when the SUCCESS render throws
+   * after the write applied. When omitted, generic copy is used.
+   */
+  appliedNotice?: { whatApplied: string; verifySteer: string };
 }
+
+/** Default copy for the applied-fallback when the caller supplies none. */
+const DEFAULT_APPLIED_WHAT = 'The operation was applied';
+const DEFAULT_APPLIED_VERIFY_STEER = 'Re-run the command to verify.';
 
 /**
  * Baked phrase-mismatch handling: ephemeral reply showing entered vs expected,
@@ -411,7 +420,26 @@ export async function handleDestructiveModalSubmit(
       reply.content = result.successMessage ?? 'Operation completed successfully.';
     }
 
-    await interaction.editReply(reply);
+    try {
+      await interaction.editReply(reply);
+    } catch (err) {
+      // The write already applied — a throw here is a render/delivery
+      // failure, not an operation failure. Must not read as failed or
+      // retriable, or the user re-runs a destructive op that already ran.
+      logger.error(
+        { err, customId: interaction.customId },
+        'Destructive operation applied but result render failed'
+      );
+      const { whatApplied, verifySteer } = options.appliedNotice ?? {
+        whatApplied: DEFAULT_APPLIED_WHAT,
+        verifySteer: DEFAULT_APPLIED_VERIFY_STEER,
+      };
+      await interaction.editReply({
+        content: renderSpec(CATALOG.error.destructiveApplied(whatApplied, verifySteer)),
+        embeds: [],
+        components: [],
+      });
+    }
   } else {
     await interaction.editReply({
       content: result.errorMessage ?? renderSpec(CATALOG.error.operationFailed('operation')),


### PR DESCRIPTION
## Summary

`handleDestructiveModalSubmit` (the shared Tier-B destructive-confirmation helper) awaited its success render with no catch after `executeOperation` had already applied the write. A Discord API throw at that point propagated to CommandHandler's generic modal catch, which renders a definitive-failure/retry framing over an **already-applied** memory purge, account deletion, history delete, or voice purge — inviting the user to redo a destructive operation that already ran. Same outcome-honesty class as #2050's batchDelete fix; this is the shared-helper half (TASK-508), with the bigger blast radius (account-data deletion is a caller).

## Changes

- Wrap **only** the success-branch `editReply`: on throw, `logger.error` + fall back to `CATALOG.error.destructiveApplied(whatApplied, verifySteer)` (outcome `committed-unconfirmed`, no retry invitation), clearing stale embeds/components. A double-failure (fallback render also throws) still propagates — CommandHandler's catch is the honest last resort.
- The failure arm is untouched: the write did not apply there, so failure framing stays honest.
- New optional `appliedNotice` on `DestructiveSubmitOptions`; all four callers pass tailored copy.

## Verified

- Steer copy checked against real subcommands: `/memory browse`, `/history stats`, `/voice voices browse` all exist (the spec's first-draft `/settings data view`, bare `/history`, and `/voice voices list` do NOT — corrected before commit). Account deletion steers to the auto-recreate prose since no post-delete verify command exists.
- Four new tests, one per arm (caller copy, default copy, failure-arm passthrough, double-failure propagation), each mutation-proven red: removing the try/catch broke 3 tests; swapping the default copy broke the default-copy test; wrapping the failure arm too broke the passthrough test.
- `pnpm --filter @tzurot/bot-client test` (6247 passed), `pnpm --filter @tzurot/tooling test` (2342 passed — raw-content-allowlist unaffected: the helper lives outside the rule's `commands/` scope and caller strings are options-object args), `pnpm lint:errors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)