### PR TITLE
fix(ai-worker): stop STT and transcript render for own-persona voice references

### DIFF
--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -15,6 +15,7 @@ import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
 import { enrichmentKey } from '../../services/prompt/QuoteFormatter.js';
 import { dedupeReference, renderReference } from '../../services/prompt/RenderableReference.js';
 import { fromStoredReference } from '../../services/prompt/storedReference.js';
+import { isOwnPersonaVoice } from '../../services/voice/ownVoiceGuard.js';
 import type { InlineImageDescription, RawHistoryEntry } from './conversationTypes.js';
 import { resolveSpeakerInfo } from './participantUtils.js';
 
@@ -166,7 +167,7 @@ function renderedImageDescriptions(msg: RawHistoryEntry): InlineImageDescription
  * only its unreachability needs stating.
  */
 function renderedVoiceTranscripts(msg: RawHistoryEntry, normalizedRole: string): string[] {
-  if (normalizedRole === 'assistant') {
+  if (isOwnPersonaVoice(normalizedRole)) {
     return [];
   }
   return msg.messageMetadata?.voiceTranscripts ?? [];

--- a/services/ai-worker/src/services/AttachmentProcessor.test.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.test.ts
@@ -10,6 +10,7 @@ import { AIProvider } from '@tzurot/common-types/constants/ai';
 import { AttachmentType } from '@tzurot/common-types/constants/media';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
+import { OWN_VOICE_DESCRIPTION } from './voice/ownVoiceGuard.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
 const {
@@ -260,6 +261,93 @@ describe('AttachmentProcessor', () => {
         description: 'Hello world',
       });
       expect(mockTranscribeAudio).toHaveBeenCalledTimes(1);
+    });
+
+    describe("the persona's own voice reference (authorRole)", () => {
+      const ownVoiceAttachment = {
+        url: 'https://example.com/own-voice.ogg',
+        contentType: 'audio/ogg',
+        name: 'own-voice.ogg',
+        size: 5000,
+        isVoiceMessage: true,
+        duration: 8,
+      };
+
+      it('never calls transcribeAudio for authorRole="assistant" and renders the static description', async () => {
+        const result = await processAttachmentsParallel({
+          attachments: [ownVoiceAttachment],
+          referenceNumber: 1,
+          personality: mockPersonality,
+          isGuestMode: false,
+          authorRole: 'assistant',
+        });
+
+        expect(mockTranscribeAudio).not.toHaveBeenCalled();
+        expect(result).toHaveLength(1);
+        expect(result[0].attachment).toEqual({
+          kind: 'voice',
+          filename: 'own-voice.ogg',
+          contentType: 'audio/ogg',
+          durationSeconds: 8,
+          description: OWN_VOICE_DESCRIPTION,
+        });
+      });
+
+      it('ignores a preprocessed transcript too — a cache hit predating this guard is still our own TTS', async () => {
+        const result = await processAttachmentsParallel({
+          attachments: [ownVoiceAttachment],
+          referenceNumber: 1,
+          personality: mockPersonality,
+          isGuestMode: false,
+          authorRole: 'assistant',
+          preprocessedAttachments: [
+            {
+              type: AttachmentType.Audio,
+              description: 'a stale cached transcript of our own TTS',
+              originalUrl: ownVoiceAttachment.url,
+              metadata: ownVoiceAttachment,
+            },
+          ],
+        });
+
+        expect(mockTranscribeAudio).not.toHaveBeenCalled();
+        expect(result[0].attachment).toMatchObject({ description: OWN_VOICE_DESCRIPTION });
+      });
+
+      it('still transcribes normally for authorRole="user" (unchanged)', async () => {
+        mockTranscribeAudio.mockResolvedValue({
+          text: 'a human said this',
+          actualProvider: 'voice-engine',
+        });
+
+        const result = await processAttachmentsParallel({
+          attachments: [ownVoiceAttachment],
+          referenceNumber: 1,
+          personality: mockPersonality,
+          isGuestMode: false,
+          authorRole: 'user',
+        });
+
+        expect(mockTranscribeAudio).toHaveBeenCalledTimes(1);
+        expect(result[0].attachment).toMatchObject({ description: 'a human said this' });
+      });
+
+      it('still transcribes normally when authorRole is absent (legacy references, unchanged)', async () => {
+        mockTranscribeAudio.mockResolvedValue({
+          text: 'legacy reference audio',
+          actualProvider: 'voice-engine',
+        });
+
+        const result = await processAttachmentsParallel({
+          attachments: [ownVoiceAttachment],
+          referenceNumber: 1,
+          personality: mockPersonality,
+          isGuestMode: false,
+        });
+
+        expect(mockTranscribeAudio).toHaveBeenCalledTimes(1);
+        expect(result[0].attachment).toMatchObject({ description: 'legacy reference audio' });
+      });
     });
 
     it('should handle regular file attachments', async () => {

--- a/services/ai-worker/src/services/AttachmentProcessor.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.ts
@@ -9,7 +9,10 @@
 import type { Logger } from 'pino';
 import { type AIProvider } from '@tzurot/common-types/constants/ai';
 import { RETRY_CONFIG } from '@tzurot/common-types/constants/timing';
-import { type ReferencedMessage } from '@tzurot/common-types/types/schemas/message';
+import {
+  type ReferencedMessage,
+  type ReferenceAuthorRole,
+} from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { type SttDispatch } from '@tzurot/common-types/types/sttProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -20,6 +23,7 @@ import {
   type BuiltAttachment,
   type RenderableAttachment,
 } from './prompt/QuoteFormatter.js';
+import { isOwnPersonaVoice, OWN_VOICE_DESCRIPTION } from './voice/ownVoiceGuard.js';
 import { withRetry } from '../utils/retry.js';
 import { filterStickersBySetting } from '@tzurot/common-types/services/stickerVisionGate';
 
@@ -43,6 +47,13 @@ interface ProcessSingleAttachmentOptions {
   userApiKey?: string;
   /** Resolved STT dispatch (provider + matching BYOK key when applicable). */
   sttDispatch?: SttDispatch;
+  /**
+   * The REFERENCE's raw authorship stamp (not the derived render role) — used
+   * only to gate voice STT. `'assistant'` means one of our own personas (self
+   * or sibling); absent/`'user'`/`'bot'` leave today's behavior untouched. See
+   * `ownVoiceGuard.ts`.
+   */
+  authorRole?: ReferenceAuthorRole;
   /** Diagnostic context for vision-failure logging (see VisionLoggingContext in VisionProcessor.ts) */
   loggingContext?: VisionLoggingContext;
   /** Explicit provider for vision calls (from `detectVisionProvider` on the personality's vision model) */
@@ -87,6 +98,13 @@ export interface ProcessAttachmentsOptions {
   userApiKey?: string;
   /** Resolved STT dispatch (provider + matching BYOK key when applicable). */
   sttDispatch?: SttDispatch;
+  /**
+   * The REFERENCE's raw authorship stamp (not the derived render role) — used
+   * only to gate voice STT. `'assistant'` means one of our own personas (self
+   * or sibling); absent/`'user'`/`'bot'` leave today's behavior untouched. See
+   * `ownVoiceGuard.ts`.
+   */
+  authorRole?: ReferenceAuthorRole;
   /** Diagnostic context for vision-failure logging */
   loggingContext?: VisionLoggingContext;
   /** Explicit provider for vision calls (from `detectVisionProvider` on the personality's vision model) */
@@ -124,6 +142,7 @@ export async function processAttachmentsParallel(
     preprocessedAttachments,
     userApiKey,
     sttDispatch,
+    authorRole,
     loggingContext,
     visionProvider,
     model,
@@ -174,6 +193,7 @@ export async function processAttachmentsParallel(
             preprocessedAttachments,
             userApiKey,
             sttDispatch,
+            authorRole,
             loggingContext,
             visionProvider,
             model,
@@ -245,14 +265,19 @@ function findPreprocessedByUrl(
   return preprocessedAttachments.find(p => p.originalUrl === url);
 }
 
+/** Options for processing a voice attachment (internal) */
+interface ProcessVoiceOptions {
+  attachment: ProcessSingleAttachmentOptions['attachment'];
+  referenceNumber: number;
+  log: Logger;
+  preprocessed?: ProcessedAttachment;
+  sttDispatch?: SttDispatch;
+  authorRole?: ReferenceAuthorRole;
+}
+
 /** Process voice message attachment */
-async function processVoiceAttachment(
-  attachment: ProcessSingleAttachmentOptions['attachment'],
-  referenceNumber: number,
-  log: Logger,
-  preprocessed?: ProcessedAttachment,
-  sttDispatch?: SttDispatch
-): Promise<BuiltAttachment> {
+async function processVoiceAttachment(options: ProcessVoiceOptions): Promise<BuiltAttachment> {
+  const { attachment, referenceNumber, log, preprocessed, sttDispatch, authorRole } = options;
   // Identity only — NOT a whole RenderableVoice. `kind` and the enrichment are
   // supplied per return site, because the type makes description and status
   // mutually exclusive and a pre-built object cannot commit to either arm.
@@ -262,6 +287,17 @@ async function processVoiceAttachment(
     contentType: attachment.contentType,
     durationSeconds: attachment.duration,
   } as const;
+
+  // Own-persona voice: skip BOTH the preprocessed short-circuit below AND the
+  // STT call — a preprocessed transcript here could be a cache hit computed
+  // before this guard existed, which is still our own TTS transcript.
+  if (isOwnPersonaVoice(authorRole)) {
+    log.debug(
+      { referenceNumber, url: attachment.url },
+      "Skipping STT for the persona's own voice reference"
+    );
+    return { url: attachment.url, attachment: { ...identity, description: OWN_VOICE_DESCRIPTION } };
+  }
 
   if (preprocessed?.description !== undefined && preprocessed.description !== '') {
     log.debug({ referenceNumber, url: attachment.url }, 'Using preprocessed voice transcription');
@@ -371,6 +407,7 @@ async function processSingleAttachment(
     preprocessedAttachments,
     userApiKey,
     sttDispatch,
+    authorRole,
     loggingContext,
     visionProvider,
     model,
@@ -380,7 +417,14 @@ async function processSingleAttachment(
 
   switch (classifyAttachment(attachment)) {
     case 'voice':
-      return processVoiceAttachment(attachment, referenceNumber, log, preprocessed, sttDispatch);
+      return processVoiceAttachment({
+        attachment,
+        referenceNumber,
+        log,
+        preprocessed,
+        sttDispatch,
+        authorRole,
+      });
     case 'image':
       return processImageAttachment({
         attachment,

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -11,6 +11,7 @@ import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/perso
 import { type ProcessedAttachment } from './MultimodalProcessor.js';
 import { enrichmentKey } from './prompt/QuoteFormatter.js';
 import { type ResolvedPersona } from './reference/UserReferencePatterns.js';
+import { OWN_VOICE_DESCRIPTION } from './voice/ownVoiceGuard.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
 const {
@@ -1976,6 +1977,83 @@ describe('ReferencedMessageFormatter', () => {
       // preprocessed metadata — a placeholder must not render as fact.
       expect(formatted).not.toContain('type="audio/unknown"');
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    });
+
+    it('renders the static own-voice description for a deduped assistant reference, even with a real transcript in the preprocessed batch', async () => {
+      // The render-side belt-and-suspenders (design decision #4): the
+      // dependency stage's audio-transcription job can run and produce a real
+      // transcript before this turn's render decides the reference is our own
+      // persona's audio, so the preprocessed transcript existing at all must
+      // not be enough to reach the prompt.
+      const { formatted } = await formatter.formatReferencedMessages(
+        [
+          refWithImage({
+            isDeduplicated: true,
+            attachments: undefined,
+            content: '',
+            authorRole: 'assistant',
+          }),
+        ],
+        mockPersonality,
+        false,
+        {
+          1: [
+            {
+              type: AttachmentType.Audio,
+              description: TRANSCRIPT_SENTINEL,
+              originalUrl: 'https://cdn.example.com/voice.ogg',
+              metadata: {
+                url: 'https://cdn.example.com/voice.ogg',
+                name: 'voice.ogg',
+                contentType: 'audio/ogg',
+                size: 2000,
+                duration: 6,
+              },
+            },
+          ],
+        }
+      );
+
+      expect(formatted).not.toContain(TRANSCRIPT_SENTINEL);
+      expect(formatted).toContain(OWN_VOICE_DESCRIPTION);
+      expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    });
+
+    it('does not fire the drop tripwire on the deliberate own-voice skip', async () => {
+      // The redaction still leaves `description` populated (with the static
+      // text), so `countRenderedEnrichment` counts it the same as a real
+      // transcript — the deliberate skip must not read as a dropped
+      // enrichment.
+      await formatter.formatReferencedMessages(
+        [
+          refWithImage({
+            isDeduplicated: true,
+            attachments: undefined,
+            content: '',
+            authorRole: 'assistant',
+          }),
+        ],
+        mockPersonality,
+        false,
+        {
+          1: [
+            {
+              type: AttachmentType.Audio,
+              description: TRANSCRIPT_SENTINEL,
+              originalUrl: 'https://cdn.example.com/voice.ogg',
+              metadata: {
+                url: 'https://cdn.example.com/voice.ogg',
+                name: 'voice.ogg',
+                contentType: 'audio/ogg',
+                size: 2000,
+                duration: 6,
+              },
+            },
+          ],
+        }
+      );
+
+      expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
     it('pairs the count: every description handed in comes back out', async () => {

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -35,6 +35,7 @@ import {
 import { deriveRefRole } from './prompt/referenceRole.js';
 import { toStoredReference } from './prompt/storedReference.js';
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
+import { isOwnPersonaVoice, redactOwnVoiceTranscript } from './voice/ownVoiceGuard.js';
 import { extractXmlTextContent } from '../utils/xmlTextExtractor.js';
 
 const logger = createLogger('ReferencedMessageFormatter');
@@ -202,6 +203,20 @@ function buildDedupedAttachments(
         },
       });
     }
+  }
+
+  // Render-side belt-and-suspenders: a preprocessed voice description here was
+  // computed by the dependency stage's job, which can run before this turn's
+  // render decides the reference is our own persona's audio — so even a
+  // freshly-produced transcript must not survive into the prompt for an
+  // assistant-authored reference. Applied last, after both loops, so it covers
+  // every voice entry regardless of which loop produced it.
+  if (isOwnPersonaVoice(ref.authorRole)) {
+    return attachments.map(entry =>
+      entry.attachment.kind === 'voice'
+        ? { url: entry.url, attachment: redactOwnVoiceTranscript(entry.attachment) }
+        : entry
+    );
   }
 
   return attachments;
@@ -452,6 +467,7 @@ export class ReferencedMessageFormatter {
       preprocessedAttachments: preprocessedForRef,
       userApiKey,
       sttDispatch,
+      authorRole: ref.authorRole,
       visionProvider,
       model: visionModel,
       requestId: apiKeys?.requestId,

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -51,6 +51,7 @@ import { rewriteRawContent, type RewrittenContent } from './contentRewriter.js';
 import { enrichRawReferences } from './referenceEnricher.js';
 import { recoverRelayEchoIdentities } from './relayEchoRecovery.js';
 import type { ContextDataSource } from './types.js';
+import { isOwnPersonaVoice } from '../voice/ownVoiceGuard.js';
 
 const logger = createLogger('ContextAssembler');
 
@@ -608,7 +609,7 @@ export class ContextAssembler {
         // Skip the bot's own (assistant) voice output: its transcript would just
         // duplicate the message text, and the chat-log renderer drops assistant
         // transcripts anyway — so re-resolving one is a wasted STT call.
-        if (target?.role === MessageRole.Assistant) {
+        if (isOwnPersonaVoice(target?.role)) {
           return;
         }
         // Only re-resolve when the message lacks a transcript — a cache HIT

--- a/services/ai-worker/src/services/prompt/storedReference.test.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.test.ts
@@ -19,6 +19,7 @@ import {
   fromStoredReference,
   toStoredReference,
 } from './storedReference.js';
+import { OWN_VOICE_DESCRIPTION } from '../voice/ownVoiceGuard.js';
 
 const liveRef = (overrides: Partial<ReferencedMessage> = {}): ReferencedMessage => ({
   referenceNumber: 2,
@@ -181,6 +182,78 @@ describe('buildStoredAttachments', () => {
 
     expect(rendered).toEqual([
       { kind: 'voice', filename: undefined, contentType: 'audio/ogg', status: 'untranscribed' },
+    ]);
+  });
+
+  it('renders the static own-voice description on replay, even when a real transcript survived in storage', () => {
+    // Design decision #4 (the render-side belt-and-suspenders): a row
+    // persisted BEFORE this guard existed can still carry a real STT
+    // transcript in attachmentEnrichment. Replay must not let it back into
+    // the prompt just because it survived storage.
+    const rendered = buildStoredAttachments({
+      ...base,
+      authorRole: 'assistant',
+      attachments: [
+        {
+          url: 'https://cdn/own-voice.ogg',
+          contentType: 'audio/ogg',
+          isVoiceMessage: true,
+          duration: 4,
+        },
+      ],
+      attachmentEnrichment: [
+        { url: 'https://cdn/own-voice.ogg', kind: 'voice', description: 'a stale real transcript' },
+      ],
+    });
+
+    expect(rendered).toEqual([
+      {
+        kind: 'voice',
+        filename: undefined,
+        contentType: 'audio/ogg',
+        durationSeconds: 4,
+        description: OWN_VOICE_DESCRIPTION,
+      },
+    ]);
+  });
+
+  it('renders the static own-voice description even with no enrichment at all — never "untranscribed"', () => {
+    const rendered = buildStoredAttachments({
+      ...base,
+      authorRole: 'assistant',
+      attachments: [
+        { url: 'https://cdn/own-voice.ogg', contentType: 'audio/ogg', isVoiceMessage: true },
+      ],
+    });
+
+    expect(rendered).toEqual([
+      {
+        kind: 'voice',
+        filename: undefined,
+        contentType: 'audio/ogg',
+        description: OWN_VOICE_DESCRIPTION,
+      },
+    ]);
+  });
+
+  it('leaves a non-assistant reference unchanged (authorRole absent, N/A case)', () => {
+    const rendered = buildStoredAttachments({
+      ...base,
+      attachments: [
+        { url: 'https://cdn/user-voice.ogg', contentType: 'audio/ogg', isVoiceMessage: true },
+      ],
+      attachmentEnrichment: [
+        { url: 'https://cdn/user-voice.ogg', kind: 'voice', description: 'a real user transcript' },
+      ],
+    });
+
+    expect(rendered).toEqual([
+      {
+        kind: 'voice',
+        filename: undefined,
+        contentType: 'audio/ogg',
+        description: 'a real user transcript',
+      },
     ]);
   });
 });

--- a/services/ai-worker/src/services/prompt/storedReference.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.ts
@@ -30,6 +30,7 @@ import {
 } from './QuoteFormatter.js';
 import { promptTime, type RenderableReference } from './RenderableReference.js';
 import { deriveRefRole } from './referenceRole.js';
+import { isOwnPersonaVoice, redactOwnVoiceTranscript } from '../voice/ownVoiceGuard.js';
 
 const logger = createLogger('StoredReference');
 
@@ -152,6 +153,13 @@ export function buildStoredAttachments(ref: StoredReferencedMessage): Renderable
         ? { kind: 'image', description: entry.description }
         : { kind: 'voice', description: entry.description }
     );
+  }
+
+  // Render-side belt-and-suspenders: a row persisted BEFORE this guard existed
+  // can still carry a real STT transcript in `attachmentEnrichment` — replay
+  // must not let it back into the prompt just because it survived in storage.
+  if (isOwnPersonaVoice(ref.authorRole)) {
+    return attachments.map(att => (att.kind === 'voice' ? redactOwnVoiceTranscript(att) : att));
   }
 
   return attachments;

--- a/services/ai-worker/src/services/voice/ownVoiceGuard.test.ts
+++ b/services/ai-worker/src/services/voice/ownVoiceGuard.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isOwnPersonaVoice,
+  OWN_VOICE_DESCRIPTION,
+  redactOwnVoiceTranscript,
+} from './ownVoiceGuard.js';
+
+describe('isOwnPersonaVoice', () => {
+  it('is true for the literal "assistant" role', () => {
+    expect(isOwnPersonaVoice('assistant')).toBe(true);
+  });
+
+  it.each([
+    ['user' as const, 'a human author'],
+    ['bot' as const, 'a non-persona bot/webhook'],
+    ['system' as const, 'a role from a different vocabulary'],
+    [undefined, 'no stamp at all (legacy rows)'],
+  ])('is false for %s (%s)', (role, _reason) => {
+    expect(isOwnPersonaVoice(role)).toBe(false);
+  });
+});
+
+describe('OWN_VOICE_DESCRIPTION', () => {
+  it('does not reuse the untranscribed-failure vocabulary', () => {
+    // 'untranscribed' is reserved for a genuine STT failure; this text names
+    // a deliberate skip, so it must read differently from a failure.
+    expect(OWN_VOICE_DESCRIPTION.toLowerCase()).not.toContain('untranscribed');
+    expect(OWN_VOICE_DESCRIPTION.toLowerCase()).not.toContain('fail');
+  });
+});
+
+describe('redactOwnVoiceTranscript', () => {
+  it('replaces a real transcript with the static description, keeping identity', () => {
+    const result = redactOwnVoiceTranscript({
+      kind: 'voice',
+      filename: 'voice.ogg',
+      contentType: 'audio/ogg',
+      durationSeconds: 7,
+      description: 'a stale transcript that must not survive',
+    });
+
+    expect(result).toEqual({
+      kind: 'voice',
+      filename: 'voice.ogg',
+      contentType: 'audio/ogg',
+      durationSeconds: 7,
+      description: OWN_VOICE_DESCRIPTION,
+    });
+  });
+
+  it('replaces an untranscribed-failure status with the static description', () => {
+    const result = redactOwnVoiceTranscript({
+      kind: 'voice',
+      filename: 'voice.ogg',
+      durationSeconds: 3,
+      status: 'untranscribed',
+    });
+
+    expect(result).toEqual({
+      kind: 'voice',
+      filename: 'voice.ogg',
+      contentType: undefined,
+      durationSeconds: 3,
+      description: OWN_VOICE_DESCRIPTION,
+    });
+  });
+});

--- a/services/ai-worker/src/services/voice/ownVoiceGuard.ts
+++ b/services/ai-worker/src/services/voice/ownVoiceGuard.ts
@@ -1,0 +1,65 @@
+/**
+ * Own-Persona-Voice Guard
+ *
+ * The single decision point for "is this voice attachment our own persona's
+ * TTS output, and if so what should render in its place." Three sites used to
+ * make this call independently (the reference-attachment pipeline, extended-
+ * context re-resolution, and the chat_log renderer) — this module exists so
+ * they consult ONE predicate instead of three copies of `=== 'assistant'`
+ * drifting apart.
+ *
+ * The reasoning is the same everywhere it applies: a persona's own spoken
+ * delivery of its own message carries no information beyond that message's
+ * text. Re-transcribing it via STT is a wasted (and, for the self-hosted
+ * voice-engine, non-free) call, and rendering the transcript merely duplicates
+ * content the model already has as `content`.
+ */
+
+import { type RenderableVoice } from '../prompt/QuoteFormatter.js';
+
+/**
+ * True when `role` names the responding persona's own turn.
+ *
+ * Accepts both role vocabularies that use the literal string `'assistant'`:
+ * `MessageRole` (conversation-history entries, e.g. extended-context targets)
+ * and `ReferenceAuthorRole` (referenced-message authorship — schema-optional,
+ * classified once in bot-client via applicationId). Typed as `string |
+ * undefined` rather than importing either enum so this predicate has no
+ * dependency on which vocabulary a caller happens to hold.
+ *
+ * Undefined/absent — legacy rows with no stamp, or a role this vocabulary
+ * doesn't recognize (`'user'`, `'bot'`, `'system'`) — is NOT our own voice:
+ * it fails open to whatever the caller does for ordinary audio.
+ */
+export function isOwnPersonaVoice(role: string | undefined): boolean {
+  return role === 'assistant';
+}
+
+/**
+ * Rendered in place of a transcript for the persona's own voice message.
+ * Deliberately NOT the `'untranscribed'` status: that vocabulary is reserved
+ * for a genuine STT failure, and reusing it here would tell the model
+ * transcription broke when nothing was ever attempted.
+ */
+export const OWN_VOICE_DESCRIPTION =
+  "The character's own voice message — its spoken text is the message content.";
+
+/**
+ * Render-side belt-and-suspenders: replace a voice attachment's transcript
+ * (or failure status) with the static own-voice description, regardless of
+ * what it currently carries. Used wherever a reference's voice block is
+ * rendered from something that could have been computed or persisted BEFORE
+ * this guard existed — a stale Redis cache entry, a stored
+ * `attachmentEnrichment` row — so an old transcript cannot leak back in.
+ * Identity fields (filename, contentType, durationSeconds) survive; only the
+ * enrichment changes.
+ */
+export function redactOwnVoiceTranscript(attachment: RenderableVoice): RenderableVoice {
+  return {
+    kind: 'voice',
+    filename: attachment.filename,
+    contentType: attachment.contentType,
+    durationSeconds: attachment.durationSeconds,
+    description: OWN_VOICE_DESCRIPTION,
+  };
+}

--- a/services/ai-worker/src/services/voice/sttDispatchGuardCoverage.test.ts
+++ b/services/ai-worker/src/services/voice/sttDispatchGuardCoverage.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Structural guard against a fifth ad-hoc STT dispatch site.
+ *
+ * TASK-511 found three independent copies of "skip STT/rendering for the
+ * persona's own voice" (the reference pipeline, extended-context
+ * re-resolution, the chat_log renderer) plus one live gap (the reference
+ * pipeline had none at all) — four sites that each had to be found by
+ * reading code, not by a check that would fail on a missing one. This test
+ * is that check: it scans ai-worker's source tree for every
+ * `transcribeAudio(` call site and asserts each one either references the
+ * shared `ownVoiceGuard` module or is named in the ALLOWLIST below with a
+ * reason. A new call site added without consulting the guard fails here
+ * until it does one or the other — exemption becomes a reviewed decision
+ * instead of a silent gap.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * Repo-relative (to `services/ai-worker/src`) paths of files that call
+ * `transcribeAudio(` but are legitimately exempt from consulting
+ * `ownVoiceGuard` directly. Each reason is the actual mechanism, not "it's
+ * fine" — a reviewer re-checking this file should be able to verify the
+ * claim without re-deriving it.
+ */
+const ALLOWLIST: Record<string, string> = {
+  'services/multimodal/AudioProcessor.ts':
+    'The transcribeAudio DEFINITION, not a caller — nothing to guard against itself.',
+  'services/MultimodalProcessor.ts':
+    "processAttachment (via the exported processAttachments) handles the CURRENT message's own " +
+    'attachments only — ConversationInputProcessor.processInputs calls it for context.attachments, ' +
+    'which is always the human user in-band upload, never a reference. authorRole cannot apply here ' +
+    'because there is no reference to carry it.',
+  'jobs/AudioTranscriptionJob.ts':
+    "The BullMQ preprocessing-job handler api-gateway's jobChainOrchestrator dispatches per reference " +
+    'voice attachment, unconditionally (api-gateway threads no authorRole and is out of this scan and ' +
+    "this fix's scope). The render-side guard in ReferencedMessageFormatter/storedReference still " +
+    'keeps the resulting transcript out of the prompt for an assistant-authored reference — this is a ' +
+    'known cost gap (STT still runs and is billed; tracked as TASK-512), not a render-correctness gap.',
+  'jobs/handlers/pipeline/steps/ContextStep.ts':
+    'reTranscribeExtendedContextVoice is a plain STT callback with no role of its own; the guard runs ' +
+    'one call frame up, in ContextAssembler.injectExtendedContextVoiceTranscripts, which returns before ' +
+    'ever invoking this callback for the assistant-role case.',
+};
+
+/** Recursively collect non-test `.ts` source files under `dir`. */
+function walk(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') {
+        continue;
+      }
+      walk(full, files);
+      continue;
+    }
+    if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const callers = walk(SRC_ROOT).filter(f => /\btranscribeAudio\(/.test(readFileSync(f, 'utf-8')));
+
+describe('transcribeAudio dispatch sites consult the shared own-voice guard', () => {
+  // A loose floor, not an exact count: the point is proving the scan itself
+  // works (a path bug that scans an empty tree would otherwise pass
+  // vacuously), not pinning the exact number of call sites.
+  it('the scan finds real call sites', () => {
+    expect(callers.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(callers.map(f => [path.relative(SRC_ROOT, f), f] as const))(
+    '%s references ownVoiceGuard, or is allowlisted with a reason',
+    (relPath, fullPath) => {
+      const content = readFileSync(fullPath, 'utf-8');
+      const referencesGuard = content.includes('ownVoiceGuard');
+      const allowlistReason = ALLOWLIST[relPath];
+      expect(
+        referencesGuard || allowlistReason !== undefined,
+        `${relPath} calls transcribeAudio( but neither imports ownVoiceGuard nor is allowlisted above. ` +
+          "Either gate the call with isOwnPersonaVoice from './voice/ownVoiceGuard.js' (path relative to " +
+          'the caller), or add an ALLOWLIST entry here naming why the guard does not apply.'
+      ).toBe(true);
+    }
+  );
+
+  it('every allowlist entry still names a real caller — a stale entry hides a fixed gap', () => {
+    const callerRelPaths = new Set(callers.map(f => path.relative(SRC_ROOT, f)));
+    const stale = Object.keys(ALLOWLIST).filter(entry => !callerRelPaths.has(entry));
+    expect(
+      stale,
+      `Allowlist entries no longer calling transcribeAudio(: ${stale.join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/tracker/tasks/task-512 - Skip-audio-transcription-job-creation-for-own-persona-voice-references.md
+++ b/tracker/tasks/task-512 - Skip-audio-transcription-job-creation-for-own-persona-voice-references.md
@@ -1,0 +1,22 @@
+---
+id: TASK-512
+title: Skip audio-transcription job creation for own-persona voice references
+status: To Do
+assignee: []
+created_date: '2026-08-10 21:44'
+labels:
+  - 'area:api-gateway'
+  - 'size:S'
+  - 'state:ready'
+dependencies: []
+priority: medium
+ordinal: 512000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Why: jobChainOrchestrator.createAudioTranscriptionJobs (services/api-gateway/src/utils/jobChainOrchestrator.ts, per-refMsg loop ~line 349) dispatches one BullMQ STT job per reference voice attachment regardless of authorRole. TASK-511 (fix branch) guards the RENDER side, so an own-persona transcript never reaches the prompt - but the STT call itself still runs and is billed (or loads the self-hosted voice-engine) for references to our own personas. Found by the TASK-511 class sweep; recorded in the sttDispatchGuardCoverage allowlist entry for jobs/AudioTranscriptionJob.ts.
+Fix shape: thread the reference authorRole into the audio-job params (AudioJobParams / AudioTranscriptionJobData) and skip job creation when authorRole is assistant. Fixture-sweep rule (02-code-standards s8) applies if the wire shape changes.
+Acceptance: no audio-transcription job is enqueued for an assistant-authored reference; user/bot/absent behavior unchanged; the TASK-511 allowlist reason updated to cite the shipped fix.
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## Problem

Prod evidence (debug capture 37ceb5d2, 2026-08-10): a user replied to a persona's voice message, and ai-worker's reference pipeline ran real STT over our own TTS audio, rendering the lossy transcript in the quote's `<voice>` block (transcription errors prove real STT ran: "Ring settles" for "wing settles", "Kush O2" for "Cush O2"). Not a regression — a pickaxe dig over `AttachmentProcessor.ts` found no removed guard: the reply-reference path is the fourth member of the class fixed in June 2026 (fc5faf995 guarded chat_log render + extended-context re-resolution; 0d38a1e24 guarded bot-client forwarded own-bot audio) and never had a guard of its own.

## Fix — consolidation, not a fourth parallel guard

- **`services/voice/ownVoiceGuard.ts`** is the single choke point: `isOwnPersonaVoice(role)`, `OWN_VOICE_DESCRIPTION`, `redactOwnVoiceTranscript(attachment)`. Both June ai-worker guards (`ContextAssembler.injectExtendedContextVoiceTranscripts`, `xmlMetadataFormatters.renderedVoiceTranscripts`) are converted to consult it — no ad-hoc `=== 'assistant'` copies remain (survivor grep: exactly 5 non-test importers).
- **Dispatch guard**: `AttachmentProcessor.processVoiceAttachment` skips BOTH the preprocessed-transcript short-circuit and the STT call when the reference's `authorRole === 'assistant'` (a cache hit predating this fix is still our own TTS transcript). `authorRole` threaded from `ReferencedMessageFormatter` via `ProcessAttachmentsOptions`. Absent/`'user'`/`'bot'` keep today's behavior exactly (pinned by tests).
- **Render-side belt-and-suspenders**: the deduped render path (`buildDedupedAttachments`) and the stored-replay path (`buildStoredAttachments`) redact any voice transcript on an assistant-authored reference to the static own-voice description — covering transcripts computed by the dependency-stage job or persisted in `attachmentEnrichment` before this fix. Identity fields survive; the copy deliberately does NOT reuse the `'untranscribed'` failure status.
- **Structural guard**: `sttDispatchGuardCoverage.test.ts` scans ai-worker source for `transcribeAudio(` call sites and fails on any that neither reference `ownVoiceGuard` nor carry a reasoned ALLOWLIST entry, with a staleness check on the allowlist itself. A fifth ad-hoc site cannot land silently.
- **Drop-tripwire interplay**: the redaction leaves `description` populated, so `countRenderedEnrichment` counts it like a real transcript — the deliberate skip neither fires the dropped-enrichment tripwire nor widens it (pinned by test, mutation-proven both directions).

## Class sweep (every `transcribeAudio`/STT dispatch site)

| Site | Guard | Status |
|---|---|---|
| `AttachmentProcessor.processVoiceAttachment` (reference path) | dispatch guard on `authorRole` | **this fix** |
| `MultimodalProcessor.processAttachmentAsync` | N/A — current message's own in-band attachments, never a reference | allowlisted with reason |
| `multimodal/AudioProcessor.transcribeAudio` | the definition itself | allowlisted |
| `jobs/AudioTranscriptionJob` (BullMQ handler) | render-side guard suppresses the output; the dispatch itself (api-gateway `jobChainOrchestrator`) still enqueues per own-voice reference — **cost gap, tracked as TASK-512** | allowlisted with reason |
| `pipeline/steps/ContextStep.reTranscribeExtendedContextVoice` | guarded one frame up in `ContextAssembler` (June guard, now via the shared predicate) | allowlisted with reason |
| bot-client `VoiceTranscriptionService` (0d38a1e24) | separate mechanism (applicationId), intact, no `transcribeAudio` call | untouched |

## Verified

- `pnpm test` (full, in worktree): 26/26 tasks green; ai-worker 210 files / 4557 tests. `pnpm quality`: green. `typecheck` + `typecheck:spec` + build: clean.
- **Mutation-proof ledger** (Core Principle 9): every new assertion AND both converted June guards proven to fail — each guard disabled → its tests red (including the two pre-existing June tests, canarying that existing coverage is real); `redactOwnVoiceTranscript` broken → the tripwire test red; a temp unguarded `transcribeAudio(` file → structural test red naming the file. All reverted and re-verified green.
- No schema/wire change: `authorRole` already crosses the bot-client→ai-worker seam (`referencedMessageSchema`, classified via applicationId in bot-client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)