### PR TITLE
fix(api-gateway): skip STT job creation for own-persona voice references

### DIFF
--- a/packages/common-types/src/utils/ownVoice.test.ts
+++ b/packages/common-types/src/utils/ownVoice.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isOwnPersonaVoice } from './ownVoice.js';
+
+describe('isOwnPersonaVoice', () => {
+  it('is true for the literal "assistant" role', () => {
+    expect(isOwnPersonaVoice('assistant')).toBe(true);
+  });
+
+  it.each([
+    ['user' as const, 'a human author'],
+    ['bot' as const, 'a non-persona bot/webhook'],
+    ['system' as const, 'a role from a different vocabulary'],
+    [undefined, 'no stamp at all (legacy rows)'],
+  ])('is false for %s (%s)', (role, _reason) => {
+    expect(isOwnPersonaVoice(role)).toBe(false);
+  });
+});

--- a/packages/common-types/src/utils/ownVoice.ts
+++ b/packages/common-types/src/utils/ownVoice.ts
@@ -1,0 +1,30 @@
+/**
+ * The single decision point for "is this a persona's own spoken turn."
+ * Both api-gateway (job creation) and ai-worker (transcript rendering) must
+ * consult this ONE predicate instead of independently reimplementing
+ * `=== 'assistant'` and drifting apart.
+ *
+ * The reasoning is the same everywhere it applies: a persona's own spoken
+ * delivery of its own message carries no information beyond that message's
+ * text. Re-transcribing it via STT is a wasted (and, for the self-hosted
+ * voice-engine, non-free) call, and rendering the transcript merely
+ * duplicates content the model already has as `content`.
+ */
+
+/**
+ * True when `role` names the responding persona's own turn.
+ *
+ * Accepts both role vocabularies that use the literal string `'assistant'`:
+ * `MessageRole` (conversation-history entries, e.g. extended-context targets)
+ * and `ReferenceAuthorRole` (referenced-message authorship — schema-optional,
+ * classified once in bot-client via applicationId). Typed as `string |
+ * undefined` rather than importing either enum so this predicate has no
+ * dependency on which vocabulary a caller happens to hold.
+ *
+ * Undefined/absent — legacy rows with no stamp, or a role this vocabulary
+ * doesn't recognize (`'user'`, `'bot'`, `'system'`) — is NOT our own voice:
+ * it fails open to whatever the caller does for ordinary audio.
+ */
+export function isOwnPersonaVoice(role: string | undefined): boolean {
+  return role === 'assistant';
+}

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -12,10 +12,10 @@ import {
   neutralizeWrapperClosingTags,
 } from '@tzurot/common-types/utils/promptSanitizer';
 import { escapeXml } from '@tzurot/common-types/utils/xmlBuilder';
+import { isOwnPersonaVoice } from '@tzurot/common-types/utils/ownVoice';
 import { enrichmentKey } from '../../services/prompt/QuoteFormatter.js';
 import { dedupeReference, renderReference } from '../../services/prompt/RenderableReference.js';
 import { fromStoredReference } from '../../services/prompt/storedReference.js';
-import { isOwnPersonaVoice } from '../../services/voice/ownVoiceGuard.js';
 import type { InlineImageDescription, RawHistoryEntry } from './conversationTypes.js';
 import { resolveSpeakerInfo } from './participantUtils.js';
 

--- a/services/ai-worker/src/services/AttachmentProcessor.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.ts
@@ -23,9 +23,10 @@ import {
   type BuiltAttachment,
   type RenderableAttachment,
 } from './prompt/QuoteFormatter.js';
-import { isOwnPersonaVoice, OWN_VOICE_DESCRIPTION } from './voice/ownVoiceGuard.js';
+import { OWN_VOICE_DESCRIPTION } from './voice/ownVoiceGuard.js';
 import { withRetry } from '../utils/retry.js';
 import { filterStickersBySetting } from '@tzurot/common-types/services/stickerVisionGate';
+import { isOwnPersonaVoice } from '@tzurot/common-types/utils/ownVoice';
 
 const logger = createLogger('AttachmentProcessor');
 
@@ -51,7 +52,7 @@ interface ProcessSingleAttachmentOptions {
    * The REFERENCE's raw authorship stamp (not the derived render role) — used
    * only to gate voice STT. `'assistant'` means one of our own personas (self
    * or sibling); absent/`'user'`/`'bot'` leave today's behavior untouched. See
-   * `ownVoiceGuard.ts`.
+   * `@tzurot/common-types/utils/ownVoice` (`isOwnPersonaVoice`).
    */
   authorRole?: ReferenceAuthorRole;
   /** Diagnostic context for vision-failure logging (see VisionLoggingContext in VisionProcessor.ts) */
@@ -102,7 +103,7 @@ export interface ProcessAttachmentsOptions {
    * The REFERENCE's raw authorship stamp (not the derived render role) — used
    * only to gate voice STT. `'assistant'` means one of our own personas (self
    * or sibling); absent/`'user'`/`'bot'` leave today's behavior untouched. See
-   * `ownVoiceGuard.ts`.
+   * `@tzurot/common-types/utils/ownVoice` (`isOwnPersonaVoice`).
    */
   authorRole?: ReferenceAuthorRole;
   /** Diagnostic context for vision-failure logging */

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -35,8 +35,9 @@ import {
 import { deriveRefRole } from './prompt/referenceRole.js';
 import { toStoredReference } from './prompt/storedReference.js';
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
-import { isOwnPersonaVoice, redactOwnVoiceTranscript } from './voice/ownVoiceGuard.js';
+import { redactOwnVoiceTranscript } from './voice/ownVoiceGuard.js';
 import { extractXmlTextContent } from '../utils/xmlTextExtractor.js';
+import { isOwnPersonaVoice } from '@tzurot/common-types/utils/ownVoice';
 
 const logger = createLogger('ReferencedMessageFormatter');
 

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -51,7 +51,7 @@ import { rewriteRawContent, type RewrittenContent } from './contentRewriter.js';
 import { enrichRawReferences } from './referenceEnricher.js';
 import { recoverRelayEchoIdentities } from './relayEchoRecovery.js';
 import type { ContextDataSource } from './types.js';
-import { isOwnPersonaVoice } from '../voice/ownVoiceGuard.js';
+import { isOwnPersonaVoice } from '@tzurot/common-types/utils/ownVoice';
 
 const logger = createLogger('ContextAssembler');
 

--- a/services/ai-worker/src/services/prompt/storedReference.ts
+++ b/services/ai-worker/src/services/prompt/storedReference.ts
@@ -30,7 +30,8 @@ import {
 } from './QuoteFormatter.js';
 import { promptTime, type RenderableReference } from './RenderableReference.js';
 import { deriveRefRole } from './referenceRole.js';
-import { isOwnPersonaVoice, redactOwnVoiceTranscript } from '../voice/ownVoiceGuard.js';
+import { redactOwnVoiceTranscript } from '../voice/ownVoiceGuard.js';
+import { isOwnPersonaVoice } from '@tzurot/common-types/utils/ownVoice';
 
 const logger = createLogger('StoredReference');
 

--- a/services/ai-worker/src/services/voice/ownVoiceGuard.test.ts
+++ b/services/ai-worker/src/services/voice/ownVoiceGuard.test.ts
@@ -1,24 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  isOwnPersonaVoice,
-  OWN_VOICE_DESCRIPTION,
-  redactOwnVoiceTranscript,
-} from './ownVoiceGuard.js';
-
-describe('isOwnPersonaVoice', () => {
-  it('is true for the literal "assistant" role', () => {
-    expect(isOwnPersonaVoice('assistant')).toBe(true);
-  });
-
-  it.each([
-    ['user' as const, 'a human author'],
-    ['bot' as const, 'a non-persona bot/webhook'],
-    ['system' as const, 'a role from a different vocabulary'],
-    [undefined, 'no stamp at all (legacy rows)'],
-  ])('is false for %s (%s)', (role, _reason) => {
-    expect(isOwnPersonaVoice(role)).toBe(false);
-  });
-});
+import { OWN_VOICE_DESCRIPTION, redactOwnVoiceTranscript } from './ownVoiceGuard.js';
 
 describe('OWN_VOICE_DESCRIPTION', () => {
   it('does not reuse the untranscribed-failure vocabulary', () => {

--- a/services/ai-worker/src/services/voice/ownVoiceGuard.ts
+++ b/services/ai-worker/src/services/voice/ownVoiceGuard.ts
@@ -1,39 +1,14 @@
 /**
- * Own-Persona-Voice Guard
+ * Own-Persona-Voice Guard — render side
  *
- * The single decision point for "is this voice attachment our own persona's
- * TTS output, and if so what should render in its place." Three sites used to
- * make this call independently (the reference-attachment pipeline, extended-
- * context re-resolution, and the chat_log renderer) — this module exists so
- * they consult ONE predicate instead of three copies of `=== 'assistant'`
- * drifting apart.
- *
- * The reasoning is the same everywhere it applies: a persona's own spoken
- * delivery of its own message carries no information beyond that message's
- * text. Re-transcribing it via STT is a wasted (and, for the self-hosted
- * voice-engine, non-free) call, and rendering the transcript merely duplicates
- * content the model already has as `content`.
+ * What renders in place of a persona's own voice attachment's transcript.
+ * The "is this our own voice" predicate itself lives in
+ * `@tzurot/common-types/utils/ownVoice` (`isOwnPersonaVoice`) so api-gateway
+ * (job creation) and ai-worker (transcript rendering) consult ONE decision
+ * point instead of independently reimplementing `=== 'assistant'`.
  */
 
 import { type RenderableVoice } from '../prompt/QuoteFormatter.js';
-
-/**
- * True when `role` names the responding persona's own turn.
- *
- * Accepts both role vocabularies that use the literal string `'assistant'`:
- * `MessageRole` (conversation-history entries, e.g. extended-context targets)
- * and `ReferenceAuthorRole` (referenced-message authorship — schema-optional,
- * classified once in bot-client via applicationId). Typed as `string |
- * undefined` rather than importing either enum so this predicate has no
- * dependency on which vocabulary a caller happens to hold.
- *
- * Undefined/absent — legacy rows with no stamp, or a role this vocabulary
- * doesn't recognize (`'user'`, `'bot'`, `'system'`) — is NOT our own voice:
- * it fails open to whatever the caller does for ordinary audio.
- */
-export function isOwnPersonaVoice(role: string | undefined): boolean {
-  return role === 'assistant';
-}
 
 /**
  * Rendered in place of a transcript for the persona's own voice message.

--- a/services/ai-worker/src/services/voice/sttDispatchGuardCoverage.test.ts
+++ b/services/ai-worker/src/services/voice/sttDispatchGuardCoverage.test.ts
@@ -8,10 +8,11 @@
  * reading code, not by a check that would fail on a missing one. This test
  * is that check: it scans ai-worker's source tree for every
  * `transcribeAudio(` call site and asserts each one either references the
- * shared `ownVoiceGuard` module or is named in the ALLOWLIST below with a
- * reason. A new call site added without consulting the guard fails here
- * until it does one or the other — exemption becomes a reviewed decision
- * instead of a silent gap.
+ * shared `isOwnPersonaVoice` predicate (`@tzurot/common-types/utils/ownVoice`)
+ * — directly, or via the render-side `ownVoiceGuard` redact — or is named in
+ * the ALLOWLIST below with a reason. A new call site added without
+ * consulting the guard fails here until it does one or the other —
+ * exemption becomes a reviewed decision instead of a silent gap.
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
@@ -36,11 +37,15 @@ const ALLOWLIST: Record<string, string> = {
     'which is always the human user in-band upload, never a reference. authorRole cannot apply here ' +
     'because there is no reference to carry it.',
   'jobs/AudioTranscriptionJob.ts':
-    "The BullMQ preprocessing-job handler api-gateway's jobChainOrchestrator dispatches per reference " +
-    'voice attachment, unconditionally (api-gateway threads no authorRole and is out of this scan and ' +
-    "this fix's scope). The render-side guard in ReferencedMessageFormatter/storedReference still " +
-    'keeps the resulting transcript out of the prompt for an assistant-authored reference — this is a ' +
-    'known cost gap (STT still runs and is billed; tracked as TASK-512), not a render-correctness gap.',
+    "The BullMQ handler's reference-pipeline producer (api-gateway's jobChainOrchestrator) gates " +
+    'before dispatch: processAttachmentsForJobs consults isOwnPersonaVoice (from ' +
+    '@tzurot/common-types/utils/ownVoice) against the reference authorship and skips ' +
+    'createAudioTranscriptionJobs entirely for an assistant-authored reference (api-gateway is out ' +
+    "of this ai-worker-scoped scan). The second producer, api-gateway's routes/ai/transcribe.ts, is " +
+    'an explicit user-triggered transcription request with no reference authorship to gate on — ' +
+    'deliberately ungated. The render-side guard in ReferencedMessageFormatter/storedReference ' +
+    'remains as belt-and-suspenders for any transcript computed or persisted before this gate ' +
+    'existed.',
   'jobs/handlers/pipeline/steps/ContextStep.ts':
     'reTranscribeExtendedContextVoice is a plain STT callback with no role of its own; the guard runs ' +
     'one call frame up, in ContextAssembler.injectExtendedContextVoiceTranscripts, which returns before ' +
@@ -76,16 +81,18 @@ describe('transcribeAudio dispatch sites consult the shared own-voice guard', ()
   });
 
   it.each(callers.map(f => [path.relative(SRC_ROOT, f), f] as const))(
-    '%s references ownVoiceGuard, or is allowlisted with a reason',
+    '%s references isOwnPersonaVoice/ownVoiceGuard, or is allowlisted with a reason',
     (relPath, fullPath) => {
       const content = readFileSync(fullPath, 'utf-8');
-      const referencesGuard = content.includes('ownVoiceGuard');
+      const referencesGuard =
+        content.includes('isOwnPersonaVoice') || content.includes('ownVoiceGuard');
       const allowlistReason = ALLOWLIST[relPath];
       expect(
         referencesGuard || allowlistReason !== undefined,
-        `${relPath} calls transcribeAudio( but neither imports ownVoiceGuard nor is allowlisted above. ` +
-          "Either gate the call with isOwnPersonaVoice from './voice/ownVoiceGuard.js' (path relative to " +
-          'the caller), or add an ALLOWLIST entry here naming why the guard does not apply.'
+        `${relPath} calls transcribeAudio( but neither imports isOwnPersonaVoice/ownVoiceGuard nor is ` +
+          'allowlisted above. Either gate the call with isOwnPersonaVoice from ' +
+          "'@tzurot/common-types/utils/ownVoice', or add an ALLOWLIST entry here naming why the guard " +
+          'does not apply.'
       ).toBe(true);
     }
   );

--- a/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
@@ -625,6 +625,7 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
       overrides: Partial<{
         content: string;
         attachments: any[];
+        authorRole: 'user' | 'assistant' | 'bot';
       }> = {}
     ) => ({
       referenceNumber,
@@ -637,6 +638,7 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
       content: overrides.content ?? 'Test content',
       embeds: '', // Required field
       attachments: overrides.attachments,
+      authorRole: overrides.authorRole,
     });
 
     it('should create image preprocessing job for referenced message images', async () => {
@@ -1011,6 +1013,147 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
 
       // LLM parent should have 2 dependencies
       expect(flowCall.data.dependencies).toHaveLength(2);
+    });
+
+    describe('own-persona-voice reference skips audio dispatch', () => {
+      // A persona's own spoken delivery of its own message carries no
+      // information beyond that message's text — ai-worker's render side
+      // already discards the transcript for an assistant-authored reference,
+      // so dispatching STT here would run and bill (or load the self-hosted
+      // voice-engine) for output that's thrown away downstream.
+
+      it('does not create an audio job for an assistant-authored voice reference, but its image sibling still dispatches', async () => {
+        const context: JobContext = {
+          kind: 'envelope',
+          rawAssemblyInputs: { rawMessageContent: 'hello' },
+          userId: 'user-123',
+          channelId: 'channel-123',
+          referencedMessages: [
+            createReferencedMessage(1, {
+              content: 'Own voice reply',
+              authorRole: 'assistant',
+              attachments: [
+                {
+                  url: 'https://example.com/own-voice.ogg',
+                  name: 'own-voice.ogg',
+                  contentType: CONTENT_TYPES.AUDIO_OGG,
+                  size: 1024,
+                  isVoiceMessage: true,
+                  duration: 5,
+                },
+                {
+                  url: 'https://example.com/own-image.png',
+                  name: 'own-image.png',
+                  contentType: CONTENT_TYPES.IMAGE_PNG,
+                  size: 2048,
+                },
+              ],
+            }),
+          ],
+        };
+
+        await createJobChain({
+          requestId: 'req-own-voice-skip',
+          personality: mockPersonality,
+          message: 'What did the persona say?',
+          context,
+          responseDestination: mockResponseDestination,
+        });
+
+        expect(flowProducer.add).toHaveBeenCalledTimes(1);
+        const flowCall = (flowProducer.add as any).mock.calls[0][0];
+
+        // Only the image job survives — no AudioTranscription child.
+        expect(flowCall.children).toHaveLength(1);
+        expect(flowCall.children[0].name).toBe(JobType.ImageDescription);
+        expect(flowCall.children.some((c: any) => c.name === JobType.AudioTranscription)).toBe(
+          false
+        );
+      });
+
+      it.each([
+        ['user' as const, 'a human-authored reference'],
+        [undefined, 'a reference with no authorRole stamp at all'],
+      ])('still creates the audio job for %s (%s)', async (authorRole, _reason) => {
+        const context: JobContext = {
+          kind: 'envelope',
+          rawAssemblyInputs: { rawMessageContent: 'hello' },
+          userId: 'user-123',
+          channelId: 'channel-123',
+          referencedMessages: [
+            createReferencedMessage(1, {
+              content: 'Not own voice',
+              authorRole,
+              attachments: [
+                {
+                  url: 'https://example.com/other-voice.ogg',
+                  name: 'other-voice.ogg',
+                  contentType: CONTENT_TYPES.AUDIO_OGG,
+                  size: 1024,
+                  isVoiceMessage: true,
+                  duration: 5,
+                },
+              ],
+            }),
+          ],
+        };
+
+        await createJobChain({
+          requestId: `req-non-own-voice-${String(authorRole)}`,
+          personality: mockPersonality,
+          message: 'What did they say?',
+          context,
+          responseDestination: mockResponseDestination,
+        });
+
+        expect(flowProducer.add).toHaveBeenCalledTimes(1);
+        const flowCall = (flowProducer.add as any).mock.calls[0][0];
+        expect(flowCall.children).toHaveLength(1);
+        expect(flowCall.children[0].name).toBe(JobType.AudioTranscription);
+      });
+
+      it('also skips under the thin-envelope rawReferencedMessages fallback', async () => {
+        // Same fallback the image case exercises above — the ?? in
+        // collectPreprocessingJobs is attachment-type-agnostic, so the skip
+        // must apply on the raw-envelope arm too, not just the assembled one.
+        const context: JobContext = {
+          kind: 'envelope',
+          userId: 'user-123',
+          channelId: 'channel-123',
+          rawAssemblyInputs: {
+            rawMessageContent: 'What did the persona say?',
+            rawReferencedMessages: [
+              createReferencedMessage(1, {
+                content: 'Own voice reply',
+                authorRole: 'assistant',
+                attachments: [
+                  {
+                    url: 'https://example.com/own-voice-thin.ogg',
+                    name: 'own-voice-thin.ogg',
+                    contentType: CONTENT_TYPES.AUDIO_OGG,
+                    size: 1024,
+                    isVoiceMessage: true,
+                    duration: 5,
+                  },
+                ],
+              }),
+            ],
+          },
+        } as JobContext;
+
+        await createJobChain({
+          requestId: 'req-own-voice-skip-thin',
+          personality: mockPersonality,
+          message: 'What did the persona say?',
+          context,
+          responseDestination: mockResponseDestination,
+        });
+
+        expect(flowProducer.add).toHaveBeenCalledTimes(1);
+        const flowCall = (flowProducer.add as any).mock.calls[0][0];
+        expect(flowCall.children).toBeUndefined();
+        expect(flowCall.data.dependencies).toBeUndefined();
+      });
     });
   });
 

--- a/services/api-gateway/src/utils/jobChainOrchestrator.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.ts
@@ -26,8 +26,10 @@ import {
   llmGenerationJobDataSchema,
 } from '@tzurot/common-types/types/jobs';
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
+import { type ReferenceAuthorRole } from '@tzurot/common-types/types/schemas/message';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { isOwnPersonaVoice } from '@tzurot/common-types/utils/ownVoice';
 import type { LlmConfigResolver, VisionConfigResolver } from '@tzurot/config-resolver';
 import { flowProducer } from '../queue.js';
 import { assertJobIdShape } from './validatedQueue.js';
@@ -243,6 +245,7 @@ function processAttachmentsForJobs(
     personality: LoadedPersonality;
     queueName: string;
     referenceNumber?: number;
+    referenceAuthorRole?: ReferenceAuthorRole;
   }
 ): PreprocessingJobsResult {
   // THE sticker kill switch. This is where the spend is committed: every
@@ -262,8 +265,22 @@ function processAttachmentsForJobs(
   const children: FlowJob[] = [];
   const dependencies: JobDependency[] = [];
 
-  // Create audio transcription jobs
-  if (audio.length > 0) {
+  // Create audio transcription jobs — but not for a persona's own voice
+  // reference: ai-worker's render side already discards the transcript for
+  // an assistant-authored reference (isOwnPersonaVoice), so dispatching STT
+  // here would run and bill (or load the self-hosted voice-engine) for
+  // output that's thrown away downstream. Image-description jobs are
+  // unaffected — an assistant reference's images still need describing.
+  if (audio.length > 0 && isOwnPersonaVoice(params.referenceAuthorRole)) {
+    logger.info(
+      {
+        requestId: params.requestId,
+        referenceNumber: params.referenceNumber,
+        skippedCount: audio.length,
+      },
+      'Skipped audio transcription jobs for own-persona-voice reference'
+    );
+  } else if (audio.length > 0) {
     const audioResult = createAudioTranscriptionJobs({
       audioAttachments: audio,
       requestId: params.requestId,
@@ -354,6 +371,7 @@ function collectPreprocessingJobs(
         ...baseJobParams,
         requestIdSuffix: `-ref${refMsg.referenceNumber}`,
         referenceNumber: refMsg.referenceNumber,
+        referenceAuthorRole: refMsg.authorRole,
       });
       children.push(...result.children);
       dependencies.push(...result.dependencies);


### PR DESCRIPTION
## Problem

PR #2055 stopped ai-worker from *rendering* transcripts of our own personas' voice messages, but api-gateway's `jobChainOrchestrator` still enqueued one BullMQ audio-transcription job per reference voice attachment regardless of authorship — real STT ran and was billed (or loaded the self-hosted voice-engine) for output the render side discards. Filed as TASK-512 by the #2055 class sweep; this closes it.

## Fix

- **`isOwnPersonaVoice` moves up to `@tzurot/common-types/utils/ownVoice`** — api-gateway cannot import from ai-worker, and an inline `=== 'assistant'` copy would recreate exactly the drift the #2055 consolidation killed. One implementation (survivor grep: exactly one `export function isOwnPersonaVoice`, in common-types); ai-worker's `ownVoiceGuard` keeps the render-side pieces (`OWN_VOICE_DESCRIPTION`, `redactOwnVoiceTranscript`) and all five ai-worker importer sites swap to the common-types deep subpath (no behavior change — enumeration in the commit).
- **The skip**: `collectPreprocessingJobs`'s referenced-message loop threads `refMsg.authorRole` into `processAttachmentsForJobs` (new optional `referenceAuthorRole`), which skips `createAudioTranscriptionJobs` for an assistant-authored reference and logs the skip (requestId, referenceNumber, skippedCount). **Audio-only**: image-description jobs on the same reference proceed unchanged — an assistant reference's images still need describing. Direct attachments pass no role, unchanged by construction. Both reference arms are covered — `context.referencedMessages` and the thin-envelope `rawAssemblyInputs.rawReferencedMessages` fallback are both `referencedMessageSchema` rows carrying `authorRole` (verified at `rawEnvelope.ts:108` / `message.ts:68`).
- **Structural test updated**: `sttDispatchGuardCoverage` now detects `isOwnPersonaVoice` OR `ownVoiceGuard`, and its `AudioTranscriptionJob.ts` allowlist reason describes the live gate instead of an open cost gap.

## Verified

- Worker gates (in worktree): common-types 2751/2751, ai-worker 4552/4552, api-gateway 2636/2636, build clean, `lint:errors` clean. Pre-push re-ran build/lint/test across all 14 affected packages + `typecheck:spec` green.
- One pre-push catch, fixed and amended before the remote ever saw it: the test helper's `authorRole` override was typed bare `string` where the fixture needs the `'user' | 'assistant' | 'bot'` literal union (`typecheck:spec` — a gate my worker spec omitted; the hook backstopped it).
- **Mutation-proof ledger**: skip disabled → 2 tests red (assistant + thin-envelope cases); predicate broken → its unit case red; temp unguarded `transcribeAudio(` file → structural test red naming the file. All restored and re-verified green.
- **No wire/schema change**: `authorRole` already crosses the seam on `referencedMessageSchema` (optional); `AudioTranscriptionJobData` and all zod queue schemas untouched; the new param is module-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)