### PR TITLE
feat(ai-worker): warn on suspect reasoning mis-channel shape

### DIFF
--- a/services/ai-worker/src/services/ResponsePostProcessor.test.ts
+++ b/services/ai-worker/src/services/ResponsePostProcessor.test.ts
@@ -670,4 +670,81 @@ Key elements: stay in persona.`;
       );
     });
   });
+
+  // Predicate unit tests live with the predicate: src/utils/reasoningMischannel.test.ts
+  describe('suspect mis-channel telemetry (step 9)', () => {
+    const shortReply = 'I would honestly die without our little talks.';
+
+    beforeEach(() => {
+      mockExtractThinkingBlocks.mockReturnValue({
+        thinkingContent: null,
+        visibleContent: shortReply,
+      });
+    });
+
+    it('emits warn when structured reasoning dwarfs a short visible reply', () => {
+      processor.processResponse(shortReply, { reasoning_content: 'x'.repeat(2263) }, undefined, {
+        personalityName: 'TestBot',
+        userName: 'TestUser',
+        modelName: 'glm-4.5-air',
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelName: 'glm-4.5-air',
+          personalityName: 'TestBot',
+          apiReasoningLength: 2263,
+          cleanedContentLength: shortReply.length,
+        }),
+        expect.stringContaining('Suspect reasoning mis-channel')
+      );
+    });
+
+    it('does not emit the mis-channel warn for a normal-length reply', () => {
+      const normalReply = 'y'.repeat(900);
+      mockExtractThinkingBlocks.mockReturnValue({
+        thinkingContent: null,
+        visibleContent: normalReply,
+      });
+
+      processor.processResponse(normalReply, { reasoning_content: 'x'.repeat(2263) }, undefined, {
+        personalityName: 'TestBot',
+        userName: 'TestUser',
+        modelName: 'glm-4.5-air',
+      });
+
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('Suspect reasoning mis-channel')
+      );
+    });
+
+    it('does not emit the mis-channel warn when no structured reasoning exists', () => {
+      processor.processResponse(shortReply, undefined, undefined, {
+        personalityName: 'TestBot',
+        userName: 'TestUser',
+        modelName: 'glm-4.5-air',
+      });
+
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('Suspect reasoning mis-channel')
+      );
+    });
+
+    it('does not emit the mis-channel warn for models outside the observed family', () => {
+      // A mandatory-reasoning model on the incident's exact length shape:
+      // this is its normal operating mode, not a suspect signature.
+      processor.processResponse(shortReply, { reasoning_content: 'x'.repeat(2263) }, undefined, {
+        personalityName: 'TestBot',
+        userName: 'TestUser',
+        modelName: 'openai/gpt-oss-120b',
+      });
+
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('Suspect reasoning mis-channel')
+      );
+    });
+  });
 });

--- a/services/ai-worker/src/services/ResponsePostProcessor.ts
+++ b/services/ai-worker/src/services/ResponsePostProcessor.ts
@@ -20,6 +20,7 @@ import {
 } from '../utils/thinkingExtraction.js';
 import { replacePromptPlaceholders } from '../utils/promptPlaceholders.js';
 import { unwrapUnknownWrapperTags } from '../utils/wrapperTagUnwrap.js';
+import { isSuspectReasoningMischannel } from '../utils/reasoningMischannel.js';
 
 const logger = createLogger('ResponsePostProcessor');
 
@@ -275,16 +276,41 @@ export class ResponsePostProcessor {
       );
     }
 
-    // Step 8: Reasoning-mode actual-vs-requested telemetry. Some models
-    // (notably `z-ai/glm-4.5-air:free`) accept a reasoning flag but don't
-    // always actually emit reasoning — the response comes back as if
-    // reasoning was disabled. When we're investigating model-inference
-    // stickiness that produces duplicate responses, knowing whether
-    // reasoning actually engaged for each turn is a load-bearing signal.
-    //
-    // Level split: engaged-as-expected is `info` (routine); ignored-flag
-    // is `warn` so incident correlation (`@level:warn` grep) surfaces it
-    // quickly without paging through every successful response.
+    // Steps 8-9: reasoning telemetry (log-only; never alters the result)
+    this.logReasoningTelemetry(cleanedContent, thinkingContent, apiReasoning, context);
+
+    return {
+      cleanedContent,
+      thinkingContent,
+      wasDeduplicated,
+      onlyThinkingProduced,
+    };
+  }
+
+  /**
+   * Emit reasoning telemetry for a processed response. Log-only — never
+   * alters the processed result.
+   *
+   * Step 8: actual-vs-requested engagement. Some models (notably
+   * `z-ai/glm-4.5-air:free`) accept a reasoning flag but don't always
+   * actually emit reasoning — the response comes back as if reasoning was
+   * disabled. When investigating model-inference stickiness that produces
+   * duplicate responses, knowing whether reasoning actually engaged for each
+   * turn is a load-bearing signal. Level split: engaged-as-expected is `info`
+   * (routine); ignored-flag is `warn` so incident correlation
+   * (`@level:warn` grep) surfaces it quickly.
+   *
+   * Step 9: suspect mis-channel watch (family scoping and never-gate
+   * rationale in `../utils/reasoningMischannel.ts`). Independent of
+   * `reasoningEnabled`: the signature is about what the model actually
+   * returned, not what was requested.
+   */
+  private logReasoningTelemetry(
+    cleanedContent: string,
+    thinkingContent: string | null,
+    apiReasoning: string | null,
+    context: ResponseProcessingContext
+  ): void {
     if (context.reasoningEnabled === true) {
       const reasoningActuallyEngaged = thinkingContent !== null && thinkingContent.length > 0;
       const apiReasoningLength = apiReasoning !== null ? apiReasoning.length : 0;
@@ -318,11 +344,23 @@ export class ResponsePostProcessor {
       }
     }
 
-    return {
-      cleanedContent,
-      thinkingContent,
-      wasDeduplicated,
-      onlyThinkingProduced,
-    };
+    if (
+      apiReasoning !== null &&
+      isSuspectReasoningMischannel({
+        modelName: context.modelName,
+        contentLength: cleanedContent.length,
+        reasoningLength: apiReasoning.length,
+      })
+    ) {
+      logger.warn(
+        {
+          modelName: context.modelName,
+          personalityName: context.personalityName,
+          apiReasoningLength: apiReasoning.length,
+          cleanedContentLength: cleanedContent.length,
+        },
+        'Suspect reasoning mis-channel: visible content is a small fraction of structured reasoning — confirm via the diagnostic row'
+      );
+    }
   }
 }

--- a/services/ai-worker/src/utils/reasoningMischannel.test.ts
+++ b/services/ai-worker/src/utils/reasoningMischannel.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the suspect reasoning mis-channel predicate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isSuspectReasoningMischannel } from './reasoningMischannel.js';
+
+const glm = (contentLength: number, reasoningLength: number): boolean =>
+  isSuspectReasoningMischannel({ modelName: 'glm-4.5-air', contentLength, reasoningLength });
+
+describe('isSuspectReasoningMischannel', () => {
+  it('matches the observed mis-channel shape (short content, reasoning dwarfs it)', () => {
+    // The incident row: content 68 chars, reasoning_content 2,263 chars
+    expect(glm(68, 2263)).toBe(true);
+  });
+
+  it('matches empty visible content with substantial reasoning', () => {
+    expect(glm(0, 600)).toBe(true);
+  });
+
+  it('does not match a normal-length reply with long reasoning', () => {
+    expect(glm(900, 2700)).toBe(false);
+  });
+
+  it('does not match short content with short reasoning', () => {
+    expect(glm(68, 400)).toBe(false);
+  });
+
+  it('does not match short content when reasoning is under the ratio floor', () => {
+    expect(glm(250, 600)).toBe(false);
+  });
+
+  it('excludes content at exactly the 300-char boundary (strict <)', () => {
+    expect(glm(300, 2000)).toBe(false);
+    expect(glm(299, 2000)).toBe(true);
+  });
+
+  it('excludes reasoning at exactly the 500-char boundary (strict >)', () => {
+    expect(glm(100, 500)).toBe(false);
+    expect(glm(100, 501)).toBe(true);
+  });
+
+  it('includes the exact 3x ratio boundary (inclusive >=)', () => {
+    expect(glm(200, 600)).toBe(true);
+    expect(glm(200, 599)).toBe(false);
+  });
+
+  it('does not match models outside the observed family, even on the incident shape', () => {
+    // Mandatory-reasoning models emit huge reasoning with short replies as
+    // their normal shape — the signature is only suspect for the GLM family.
+    for (const model of ['deepseek/deepseek-r1', 'openai/gpt-oss-120b', 'stepfun/step-3.5']) {
+      expect(
+        isSuspectReasoningMischannel({ modelName: model, contentLength: 68, reasoningLength: 2263 })
+      ).toBe(false);
+    }
+  });
+
+  it('matches GLM-family model ids regardless of provider prefix or casing', () => {
+    expect(
+      isSuspectReasoningMischannel({
+        modelName: 'z-ai/GLM-5.2',
+        contentLength: 68,
+        reasoningLength: 2263,
+      })
+    ).toBe(true);
+  });
+
+  it('does not match when modelName is absent (unattributable)', () => {
+    expect(
+      isSuspectReasoningMischannel({
+        modelName: undefined,
+        contentLength: 68,
+        reasoningLength: 2263,
+      })
+    ).toBe(false);
+  });
+});

--- a/services/ai-worker/src/utils/reasoningMischannel.ts
+++ b/services/ai-worker/src/utils/reasoningMischannel.ts
@@ -1,0 +1,56 @@
+/**
+ * Suspect reasoning mis-channel detection (watch signal only).
+ *
+ * glm-4.5-air has been observed writing its entire in-character reply into
+ * `reasoning_content` while emitting a throwaway fragment as visible content.
+ * The length signature alone cannot distinguish that mis-channel from a
+ * deliberately brief reply that follows long genuine meta-reasoning, so this
+ * predicate must never drive automatic promotion or retry (a misfire would
+ * leak real meta-reasoning to the user). Warn-level telemetry only; confirm
+ * any hit by reading the request's llm_diagnostic_logs row.
+ *
+ * The check is scoped to the model family where the mis-channel was observed
+ * and its noise rate was measured. Mandatory-reasoning models (GPT-OSS,
+ * StepFun, DeepSeek R1, etc.) produce reasoning many times longer than a
+ * short final reply as their NORMAL operating shape — running this signature
+ * unscoped would flood the warn channel with by-design responses and dilute
+ * the signal. Expanding the family list is a deliberate act that needs its
+ * own noise-rate measurement.
+ */
+
+/** Model-name substrings whose responses are eligible for the mis-channel check */
+const MISCHANNEL_MODEL_FAMILIES = ['glm'] as const;
+
+const MISCHANNEL_MAX_CONTENT_LENGTH = 300;
+const MISCHANNEL_MIN_REASONING_LENGTH = 500;
+const MISCHANNEL_MIN_REASONING_TO_CONTENT_RATIO = 3;
+
+/** Inputs for the mis-channel signature check */
+export interface MischannelCheckInput {
+  /** Model identifier for family scoping; undefined disables the check (unattributable) */
+  modelName: string | undefined;
+  /** Length of the cleaned visible content */
+  contentLength: number;
+  /** Length of the structured API reasoning */
+  reasoningLength: number;
+}
+
+/**
+ * Whether a response matches the suspect reasoning mis-channel signature:
+ * an eligible-family model returned a short visible reply dwarfed by
+ * structured reasoning (see the threshold docs above).
+ */
+export function isSuspectReasoningMischannel(input: MischannelCheckInput): boolean {
+  if (input.modelName === undefined) {
+    return false;
+  }
+  const model = input.modelName.toLowerCase();
+  if (!MISCHANNEL_MODEL_FAMILIES.some(family => model.includes(family))) {
+    return false;
+  }
+  return (
+    input.contentLength < MISCHANNEL_MAX_CONTENT_LENGTH &&
+    input.reasoningLength > MISCHANNEL_MIN_REASONING_LENGTH &&
+    input.reasoningLength >= MISCHANNEL_MIN_REASONING_TO_CONTENT_RATIO * input.contentLength
+  );
+}


### PR DESCRIPTION
## What

Adds warn-level telemetry when a GLM-family response matches the suspect reasoning mis-channel signature: visible content under 300 chars while structured API reasoning exceeds 500 chars and ≥3x the content length. Watch signal only — no behavior change. The predicate lives in `utils/reasoningMischannel.ts` and is **scoped to the GLM model family** — mandatory-reasoning models (GPT-OSS, StepFun, DeepSeek R1, …) produce huge-reasoning/short-reply as their normal shape, so an unscoped check would flood the warn channel with by-design responses (round-2 review finding, applied).

## Why

glm-4.5-air (the free-tier default) was observed in prod writing its entire 2,263-char in-character reply into `reasoning_content` while delivering a 68-char throwaway fragment as the visible message (requestId `479b3251`, 2026-08-10T02:00Z). The extraction pipeline handled the response correctly — the mis-channel is model-side.

**Measurement before design** (prod `llm_diagnostic_logs`, ~22h window = full 24h retention): 132 GLM-family requests; exactly 1 genuine mis-channel (glm-4.5-air, 1/63); glm-5.2 0/64. Critically, one legitimate glm-5.2 row (deliberately brief reply after long genuine meta-reasoning) carried the identical length signature — verified by reading both rows' content. **No automatic guard (promotion or retry) can act on this signature without some rate of leaking real meta-reasoning to users**, which is why this ships as telemetry rather than a behavior fix.

Owner-approved disposition: watch. The warn gives durable frequency data via Railway log queries beyond the diagnostic table's 24h retention. If recurrence shows up, the escalation paths are prod-config-only (reasoning-off for the free default, or free default → glm-5.2) and need no release.

## Verification

- `pnpm test` green (full suite) and `pnpm quality` green; ai-worker 4567 tests / 211 files green after the round-2 changes.
- Predicate unit-tested in its own colocated file (11 cases: incident shape, boundaries at 300/500/3x with correct inequality directions, family scoping incl. absent modelName) + 4 pipeline tests asserting the warn fires/doesn't through `processResponse` (incl. a non-GLM model on the incident's exact shape).
- Mutation-proven twice: disabling the length predicate turns 3 tests red; bypassing the family gate turns 2 tests red (one per file).

Noise expectation is now scope-consistent with the measurement: GLM-family traffic only, measured ~1 false positive per ~132 requests/day. The log message says "suspect" and points at the diagnostic row for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)