### PR TITLE
feat(tooling): gate that tracker relative links resolve

### DIFF
--- a/backlog/cold/epic-log.md
+++ b/backlog/cold/epic-log.md
@@ -1,6 +1,6 @@
 # Active Epic — Detailed Log
 
-_Per-PR slice detail for the current Active Focus (see [`../active-epic.md`](../active-epic.md)). Reset when the active epic/sweep changes — completed epics' logs live in git history (Memory System Overhaul's log: git history at the 2026-07-17 park; its state summary is in [`themes/memory-system-overhaul.md`](themes/memory-system-overhaul.md))._
+_Per-PR slice detail for the current Active Focus (see [`../active-epic.md`](../active-epic.md)). Reset when the active epic/sweep changes — completed epics' logs live in git history (Memory System Overhaul's log: git history at the 2026-07-17 park; its state summary is in `doc-8`)._
 
 ## Platform-Portable UX Layer (Active Epic)
 

--- a/packages/tooling/src/dev/backlogLint.test.ts
+++ b/packages/tooling/src/dev/backlogLint.test.ts
@@ -6,6 +6,7 @@ import {
   checkOriginIdCollisions,
   checkTaskTriage,
   extractQueueDocRefs,
+  extractRelativeLinks,
   parseSectionCaps,
   runBacklogLint,
   type OriginTaskListing,
@@ -60,6 +61,100 @@ describe('extractQueueDocRefs', () => {
       'prose mentioning doc-99 without backticks is not a reference',
     ].join('\n');
     expect(extractQueueDocRefs(md)).toEqual(['doc-1', 'doc-27']);
+  });
+});
+
+describe('extractRelativeLinks', () => {
+  it('extracts ../ and ./ targets, stripping a trailing fragment', () => {
+    const md = ['[a](../foo.md)', '[b](./bar.md#section)', '[c](../../baz.md)'].join('\n');
+    expect(extractRelativeLinks(md)).toEqual(['../foo.md', './bar.md', '../../baz.md']);
+  });
+
+  it('skips absolute URLs, mailto, and bare anchors', () => {
+    const md = [
+      '[a](https://example.com/foo.md)',
+      '[b](http://example.com/foo.md)',
+      '[c](mailto:someone@example.com)',
+      '[d](#section)',
+    ].join('\n');
+    expect(extractRelativeLinks(md)).toEqual([]);
+  });
+
+  it('skips root-relative paths', () => {
+    expect(extractRelativeLinks('[a](/absolute/path.md)')).toEqual([]);
+  });
+
+  // CommonMark treats a bare target as relative exactly like a dotted one, and
+  // this is the dominant cross-reference style in tracker/docs/. Scoping to the
+  // dotted forms made the gate blind to it — and to 14 dead links written that
+  // way.
+  it('extracts a BARE relative target that looks like a file', () => {
+    expect(extractRelativeLinks('[a](bare-path.md)')).toEqual(['bare-path.md']);
+    expect(extractRelativeLinks('[a](themes/sub.md)')).toEqual(['themes/sub.md']);
+    expect(extractRelativeLinks('[a](img/diagram.png)')).toEqual(['img/diagram.png']);
+    expect(extractRelativeLinks('[a](bare.md#frag)')).toEqual(['bare.md']);
+  });
+
+  it('skips a bare target with no file extension, so prose in brackets is not a path', () => {
+    expect(extractRelativeLinks('[a](some-page)')).toEqual([]);
+    expect(extractRelativeLinks('[see the epic](whatever we call it)')).toEqual([]);
+  });
+
+  it('skips a version string, which is extension-shaped but not a file', () => {
+    // The corpus is release-note-heavy, so `[v3](v3.0.0-beta.199)` is a
+    // plausible future link; `.199` must not read as a file extension.
+    expect(extractRelativeLinks('[v3](v3.0.0-beta.199)')).toEqual([]);
+    expect(extractRelativeLinks('[a](thing.2026)')).toEqual([]);
+    // …while a real extension containing digits still counts.
+    expect(extractRelativeLinks('[a](archive.7z)')).toEqual(['archive.7z']);
+  });
+
+  it('includes image link targets — same rot class as a regular link', () => {
+    expect(extractRelativeLinks('![alt text](../images/diagram.png)')).toEqual([
+      '../images/diagram.png',
+    ]);
+  });
+
+  it('ignores link syntax inside a fenced code block', () => {
+    const md = ['Write links like this:', '', '```markdown', '[t](../made-up.md)', '```'].join(
+      '\n'
+    );
+    expect(extractRelativeLinks(md)).toEqual([]);
+  });
+
+  it('ignores link syntax inside an inline code span', () => {
+    expect(extractRelativeLinks('Use `[t](../made-up.md)` for a relative link.')).toEqual([]);
+  });
+
+  it('still extracts a real link that sits next to a code sample', () => {
+    const md = ['```', '[t](../not-real.md)', '```', '', 'See [the epic](../active-epic.md).'].join(
+      '\n'
+    );
+    expect(extractRelativeLinks(md)).toEqual(['../active-epic.md']);
+  });
+
+  // The four shapes the extractor's docstring says it does not parse. Each of
+  // those sentences is a claim about runtime behavior, so it is pinned here
+  // rather than left as prose (02-code-standards § "A Comment That Asserts
+  // Behavior Is a Claim"). These characterize the CURRENT behavior — if a real
+  // markdown-link parser ever replaces the regex, these are the cases to
+  // revisit, and they will fail loudly rather than drift silently.
+  describe('documented parse limitations', () => {
+    it('a titled link captures the title as part of the target (fails loud)', () => {
+      expect(extractRelativeLinks('[t](../foo.md "Title")')).toEqual(['../foo.md "Title"']);
+    });
+
+    it('a target containing a literal ) truncates at that paren (fails loud)', () => {
+      expect(extractRelativeLinks('[t](../notes (draft).md)')).toEqual(['../notes (draft']);
+    });
+
+    it('link text with nested brackets matches nothing (fails silent)', () => {
+      expect(extractRelativeLinks('[a [b]](../x.md)')).toEqual([]);
+    });
+
+    it('reference-style links match nothing (fails silent)', () => {
+      expect(extractRelativeLinks('[t][ref]\n\n[ref]: ../foo.md')).toEqual([]);
+    });
   });
 });
 
@@ -322,14 +417,27 @@ describe('runBacklogLint', () => {
     process.exitCode = undefined;
   });
 
+  /**
+   * Directory listings for the recursive `backlog/` walk, keyed by
+   * repo-relative directory. Empty by default, which makes `existsSync` report
+   * `backlog/` as absent so the walk skips it — that is what keeps every test
+   * predating the backlog scan unaffected.
+   */
+  type DirTree = Record<string, Array<{ name: string; dir?: boolean }>>;
+
   function mockFs(
     files: Record<string, string>,
     docFiles: string[],
-    trackerFiles: Record<string, string> = { 'task-1 - valid.md': VALID_TASK }
+    trackerFiles: Record<string, string> = { 'task-1 - valid.md': VALID_TASK },
+    docContents: Record<string, string> = {},
+    backlogTree: DirTree = {}
   ): void {
     vi.mocked(existsSync).mockImplementation(p => {
       const path = String(p);
       if (path.endsWith('tracker/docs') || path.endsWith('tracker/tasks')) {
+        return true;
+      }
+      if (Object.keys(backlogTree).some(d => path.endsWith(d))) {
         return true;
       }
       return Object.keys(files).some(suffix => path.endsWith(suffix));
@@ -340,14 +448,34 @@ describe('runBacklogLint', () => {
       if (tracker) {
         return tracker[1];
       }
+      const doc = Object.entries(docContents).find(([name]) => path.endsWith(name));
+      if (doc) {
+        return doc[1];
+      }
       const hit = Object.entries(files).find(([suffix]) => path.endsWith(suffix));
       return hit ? hit[1] : '';
     });
-    vi.mocked(readdirSync).mockImplementation(p => {
+    vi.mocked(readdirSync).mockImplementation(((p: unknown, options?: unknown) => {
       const path = String(p);
-      const listing = path.endsWith('tracker/tasks') ? Object.keys(trackerFiles) : docFiles;
-      return listing as unknown as ReturnType<typeof readdirSync>;
-    });
+      const treeKey = Object.keys(backlogTree).find(d => path.endsWith(d));
+      const entries: Array<{ name: string; dir?: boolean }> =
+        treeKey !== undefined
+          ? backlogTree[treeKey]
+          : (path.endsWith('tracker/tasks') ? Object.keys(trackerFiles) : docFiles).map(name => ({
+              name,
+            }));
+      const wantsFileTypes =
+        typeof options === 'object' &&
+        options !== null &&
+        (options as { withFileTypes?: boolean }).withFileTypes === true;
+      if (wantsFileTypes) {
+        return entries.map(e => ({
+          name: e.name,
+          isDirectory: () => e.dir === true,
+        })) as unknown as ReturnType<typeof readdirSync>;
+      }
+      return entries.map(e => e.name) as unknown as ReturnType<typeof readdirSync>;
+    }) as unknown as typeof readdirSync);
   }
 
   it('passes clean when caps respected, doc refs resolve, and tasks parse', async () => {
@@ -492,6 +620,228 @@ describe('runBacklogLint', () => {
     expect(out).toContain(`${ALLOW_ORIGIN_ID_COLLISION_ENV}=1`);
     expect(out).not.toContain('already used on origin/develop');
     expect(process.exitCode).not.toBe(1);
+  });
+
+  describe('relative link checking', () => {
+    it('passes when a tracker/docs relative link resolves on disk', async () => {
+      mockFs(
+        {
+          'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n',
+          'docs/existing.md': '',
+        },
+        ['doc-1 - Foo.md'],
+        undefined,
+        { 'doc-1 - Foo.md': '[text](../../docs/existing.md)' }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      expect(logSpy.mock.calls.flat().join('\n')).toContain('Backlog layout in sync');
+      expect(process.exitCode).not.toBe(1);
+    });
+
+    it('flags a tracker/docs relative link that does not resolve, naming file and target', async () => {
+      mockFs(
+        { 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' },
+        ['doc-1 - Foo.md'],
+        undefined,
+        { 'doc-1 - Foo.md': '[text](../../docs/missing.md)' }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain(
+        'tracker/docs/doc-1 - Foo.md: dangling relative link → ../../docs/missing.md'
+      );
+      expect(out).toContain('resolved: docs/missing.md');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('strips a trailing #fragment before resolving — passes when the file exists', async () => {
+      mockFs(
+        {
+          'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n',
+          'docs/existing.md': '',
+        },
+        ['doc-1 - Foo.md'],
+        undefined,
+        { 'doc-1 - Foo.md': '[text](../../docs/existing.md#section)' }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      expect(logSpy.mock.calls.flat().join('\n')).toContain('Backlog layout in sync');
+      expect(process.exitCode).not.toBe(1);
+    });
+
+    it('flags a #fragment link whose underlying file is missing', async () => {
+      mockFs(
+        { 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' },
+        ['doc-1 - Foo.md'],
+        undefined,
+        { 'doc-1 - Foo.md': '[text](../../docs/missing.md#section)' }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('dangling relative link → ../../docs/missing.md');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('never reports absolute URLs, mailto, or bare anchors', async () => {
+      mockFs(
+        { 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' },
+        ['doc-1 - Foo.md'],
+        undefined,
+        {
+          'doc-1 - Foo.md': [
+            '[a](https://example.com/foo.md)',
+            '[b](mailto:someone@example.com)',
+            '[c](#section)',
+          ].join('\n'),
+        }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).not.toContain('dangling relative link');
+      expect(process.exitCode).not.toBe(1);
+    });
+
+    it('checks a ../ link inside tracker/tasks/ too — both directories are scanned', async () => {
+      const taskWithLink = VALID_TASK.replace(
+        'Body.',
+        'See [x](../../docs/missing-from-task.md) for detail.'
+      );
+      mockFs({ 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' }, [], {
+        'task-1 - valid.md': taskWithLink,
+      });
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain(
+        'tracker/tasks/task-1 - valid.md: dangling relative link → ../../docs/missing-from-task.md'
+      );
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('resolves a sibling ./foo.md form against the same directory', async () => {
+      mockFs(
+        {
+          'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n',
+          'tracker/docs/sibling.md': '',
+        },
+        ['doc-1 - Foo.md'],
+        undefined,
+        { 'doc-1 - Foo.md': '[text](./sibling.md)' }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      expect(logSpy.mock.calls.flat().join('\n')).toContain('Backlog layout in sync');
+      expect(process.exitCode).not.toBe(1);
+    });
+
+    it('scans backlog/ too, recursing into backlog/cold/', async () => {
+      mockFs(
+        {
+          'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n',
+          'backlog/cold/epic-log.md': '[gone](../missing-target.md)',
+        },
+        ['doc-1 - Foo.md'],
+        undefined,
+        {},
+        { backlog: [{ name: 'cold', dir: true }], 'backlog/cold': [{ name: 'epic-log.md' }] }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      // Resolved against the FILE's directory (backlog/cold/../) rather than
+      // the scan root — the depth distinction the recursion introduces.
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain(
+        'backlog/cold/epic-log.md: dangling relative link → ../missing-target.md'
+      );
+      expect(out).toContain('resolved: backlog/missing-target.md');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('flags a dangling `doc-N` reference in a scanned body, not just in queue.md', async () => {
+      // The cross-reference convention that replaces fragile file links: a
+      // renumber or delete used to leave these dangling everywhere except
+      // queue.md, which is the same rot the relative-link check exists to close.
+      mockFs(
+        { 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' },
+        ['doc-1 - Foo.md'],
+        undefined,
+        { 'doc-1 - Foo.md': 'Parked behind `doc-99`.' }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      const out = logSpy.mock.calls.flat().join('\n');
+      expect(out).toContain('dangling doc reference → doc-99');
+      expect(out).toContain('tracker/docs/doc-1 - Foo.md');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('accepts a `doc-N` reference that resolves', async () => {
+      mockFs(
+        { 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' },
+        ['doc-1 - Foo.md'],
+        undefined,
+        { 'doc-1 - Foo.md': 'See `doc-1` for the theme.' }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      expect(logSpy.mock.calls.flat().join('\n')).toContain('Backlog layout in sync');
+      expect(process.exitCode).not.toBe(1);
+    });
+
+    it('does NOT scan tracker/archive/ — frozen content must not gate a PR', async () => {
+      // The exclusion is a stated design decision in the module docstring, so
+      // it gets pinned: this fixture is fully servable (the dir lists, the file
+      // reads, the link is dead), and stays unreported only because
+      // tracker/archive is absent from RELATIVE_LINK_SCAN_DIRS.
+      mockFs(
+        {
+          'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n',
+          'tracker/archive/old.md': '[gone](../nowhere.md)',
+        },
+        ['doc-1 - Foo.md'],
+        undefined,
+        {},
+        { 'tracker/archive': [{ name: 'old.md' }] }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      expect(logSpy.mock.calls.flat().join('\n')).not.toContain('tracker/archive');
+      expect(process.exitCode).not.toBe(1);
+    });
+
+    it('passes when a backlog/ relative link resolves', async () => {
+      mockFs(
+        {
+          'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n[ref](../docs/real.md)\n',
+          'docs/real.md': '',
+        },
+        ['doc-1 - Foo.md'],
+        undefined,
+        {},
+        { backlog: [{ name: 'now.md' }] }
+      );
+
+      await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+      expect(logSpy.mock.calls.flat().join('\n')).toContain('Backlog layout in sync');
+      expect(process.exitCode).not.toBe(1);
+    });
   });
 });
 

--- a/packages/tooling/src/dev/backlogLint.ts
+++ b/packages/tooling/src/dev/backlogLint.ts
@@ -7,6 +7,13 @@
  *  - `cold/queue.md` doc references (`doc-N`) all resolve to a real file in
  *    `tracker/docs/` (theme content lives there since the themes/ideas→docs
  *    migration; queue.md carries only the ordering).
+ *  - Relative markdown links (`[text](../foo.md)`) inside `tracker/docs/`,
+ *    `tracker/tasks/`, and `backlog/` (recursively) resolve on disk. The
+ *    migration that moved theme content into `tracker/docs/` depth-rewrote
+ *    every outbound relative link once; nothing gated future rot until this
+ *    check. `tracker/archive/` is deliberately NOT scanned — archived content
+ *    is frozen, so gating on it would block a PR over a document nobody is
+ *    going to fix.
  *  - `tracker/tasks/` integrity: every task file parses with an id, title, and
  *    created_date. A task that fails these silently vanishes from the digest,
  *    search, and the aging surface — the same content-destroying failure the
@@ -32,7 +39,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import chalk from 'chalk';
 import { loadTrackerTasks, openTasks, type TrackerTask } from './trackerTasks.js';
 
@@ -95,6 +102,87 @@ export function extractQueueDocRefs(queueMd: string): string[] {
   return refs;
 }
 
+/**
+ * Blank out fenced code blocks and inline code spans before link extraction.
+ *
+ * These files are documentation ABOUT documentation, so a doc explaining link
+ * conventions writes markdown-link syntax as an EXAMPLE. Extracting from those
+ * would report a dangling link against text that was never a link — a failure
+ * that looks like real rot and blocks everyone's `pnpm quality`, which is worse
+ * than any of the shapes this extractor merely fails to see.
+ */
+function stripCode(markdown: string): string {
+  return markdown.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '');
+}
+
+/**
+ * True when `target` addresses a file relative to the document containing it.
+ *
+ * A dot prefix is NOT required — CommonMark treats `[t](foo.md)` as relative
+ * exactly like `[t](./foo.md)`, and the bare form is the dominant style for
+ * sibling cross-references in `tracker/docs/`. Scoping to the dotted forms
+ * alone made this check blind to that whole class.
+ *
+ * A bare target additionally has to look like a FILE — a `.ext` suffix
+ * carrying at least one LETTER. That is what keeps ordinary bracketed prose
+ * from being resolved as a path, and the letter requirement specifically keeps
+ * a version string out: `[v3](v3.0.0-beta.199)` ends in `.199`, which is
+ * extension-SHAPED but is not a file, and this corpus is release-note-heavy
+ * enough for that to be a plausible link. Ruled out entirely: bare fragments,
+ * root-relative paths, and anything carrying a URI scheme (`https:`, `mailto:`).
+ */
+function isRelativeFileTarget(target: string): boolean {
+  if (target === '' || target.startsWith('/')) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return false;
+  if (target.startsWith('./') || target.startsWith('../')) return true;
+  const extension = /\.([a-z0-9]+)$/i.exec(target)?.[1];
+  return extension !== undefined && /[a-z]/i.test(extension);
+}
+
+/**
+ * Extract every markdown link target (`[text](target)`) that resolves relative
+ * to the containing document — dot-prefixed or bare — with any
+ * trailing `#fragment` stripped — the caller resolves the file, not the
+ * anchor. Absolute URLs, `mailto:`, and bare `#anchor` targets are skipped.
+ *
+ * Image links (`![alt](target)`) match the same `[…](…)` shape and are
+ * intentionally included — a dead image path rots the same way a dead doc
+ * link does, and tracker markdown carries no images today to special-case.
+ *
+ * Four known shapes this deliberately does not parse, none of which occurs in
+ * the scanned content today. Two fail LOUD, which is the tolerable direction —
+ * whoever writes one sees a confusing-but-visible report and can look here:
+ *
+ * - a TITLED link (`[t](../foo.md "Title")`) captures `../foo.md "Title"`;
+ * - a target containing a literal `)` (`[t](../notes (draft).md)`) truncates at
+ *   that paren, so it is reported dangling against a mangled path.
+ *
+ * The other two fail SILENT, which is worse, because a genuinely dead link in
+ * one of these shapes is simply never seen:
+ *
+ * - link text containing nested brackets (`[a [b]](../x.md)`) matches nothing;
+ * - reference-style links (`[t][ref]` with `[ref]: ../foo.md` elsewhere) are
+ *   not the inline shape this regex looks for at all.
+ *
+ * Closing the silent pair needs a real markdown-link parser rather than a
+ * wider regex, which is why the disclosure is here instead.
+ * @internal Exported for testing
+ */
+export function extractRelativeLinks(markdown: string): string[] {
+  const targets: string[] = [];
+  const prose = stripCode(markdown);
+  const pattern = /\[[^[\]]*\]\(([^)]+)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(prose)) !== null) {
+    // Strip the fragment first: `foo.md#section` has to be judged on `foo.md`.
+    const target = match[1].trim().split('#')[0];
+    if (isRelativeFileTarget(target)) {
+      targets.push(target);
+    }
+  }
+  return targets;
+}
+
 interface LintOptions {
   /** Repo root (defaults to cwd) */
   rootDir?: string;
@@ -116,20 +204,115 @@ function checkNowCaps(rootDir: string): string[] {
     .map(cap => `now.md: "${cap.section}" has ${cap.count} items (cap ${cap.cap})`);
 }
 
+/**
+ * The `doc-N` ids that currently exist as files in `tracker/docs/`.
+ *
+ * Filenames are `doc-N - Title.md`; matching on the space-delimited id prefix
+ * is what stops `doc-1` from matching `doc-14 - …`.
+ */
+function existingDocIds(rootDir: string): Set<string> {
+  const docsDir = join(rootDir, 'tracker/docs');
+  const files = existsSync(docsDir) ? readdirSync(docsDir) : [];
+  return new Set(files.map(f => String(f).split(' ')[0]));
+}
+
 /** queue.md doc references that don't resolve to a file in tracker/docs/. */
 function checkQueueDocRefs(rootDir: string): string[] {
   const queuePath = join(rootDir, 'backlog/cold/queue.md');
   if (!existsSync(queuePath)) {
     return [];
   }
-  const docsDir = join(rootDir, 'tracker/docs');
-  const files = existsSync(docsDir) ? readdirSync(docsDir) : [];
-  // Filenames are `doc-N - Title.md`; match on the space-delimited id prefix
-  // so `doc-1` never matches `doc-14 - ...`.
-  const existingIds = new Set(files.map(f => f.split(' ')[0]));
+  const existingIds = existingDocIds(rootDir);
   return extractQueueDocRefs(readFileSync(queuePath, 'utf-8'))
     .filter(ref => !existingIds.has(ref))
     .map(ref => `queue.md: dangling doc reference → ${ref} (no tracker/docs/ file)`);
+}
+
+/**
+ * `doc-N` references in the scanned bodies that no longer resolve.
+ *
+ * Cross-references between docs are written as a backticked `doc-N` token
+ * rather than a path — the filenames carry spaces and em-dashes, which make
+ * fragile link targets. That convention was previously validated ONLY inside
+ * `queue.md`, so every other `doc-N` mention could dangle silently through a
+ * renumber or a delete: the same rot class the relative-link check above
+ * closes, in the form the fix for it produces.
+ *
+ * Read from RAW markdown, not the code-stripped text the link extractor uses —
+ * backticks ARE the convention here, so stripping code spans would erase every
+ * reference this is meant to check.
+ */
+function checkDocIdRefs(rootDir: string): string[] {
+  const existingIds = existingDocIds(rootDir);
+  const problems: string[] = [];
+  for (const scanDir of RELATIVE_LINK_SCAN_DIRS) {
+    const dir = join(rootDir, scanDir);
+    if (!existsSync(dir)) {
+      continue;
+    }
+    for (const { abs, rel } of collectMarkdownFiles(dir, scanDir)) {
+      // queue.md has its own check above, with a message specific to the
+      // theme-ordering index; skip it rather than report it twice.
+      if (rel.endsWith('cold/queue.md')) continue;
+      for (const ref of extractQueueDocRefs(readFileSync(abs, 'utf-8'))) {
+        if (!existingIds.has(ref)) {
+          problems.push(`${rel}: dangling doc reference → ${ref} (no tracker/docs/ file)`);
+        }
+      }
+    }
+  }
+  return problems;
+}
+
+/**
+ * The directories whose markdown bodies carry outbound relative links.
+ * `backlog` is scanned recursively (`backlog/cold/` holds the queue and epic
+ * log); the tracker directories are flat but go through the same walk.
+ */
+const RELATIVE_LINK_SCAN_DIRS = ['tracker/docs', 'tracker/tasks', 'backlog'];
+
+/** Every `.md` file under `dir`, recursively, paired with its repo-relative path. */
+function collectMarkdownFiles(dir: string, relDir: string): { abs: string; rel: string }[] {
+  const found: { abs: string; rel: string }[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    const rel = join(relDir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...collectMarkdownFiles(abs, rel));
+    } else if (entry.name.endsWith('.md')) {
+      found.push({ abs, rel });
+    }
+  }
+  return found;
+}
+
+/**
+ * Relative markdown links in the scanned directories that don't resolve to a
+ * file on disk. Each target resolves against the directory of the file that
+ * contains it, not the scan root — `backlog/cold/epic-log.md` and
+ * `backlog/now.md` sit at different depths and their `../` means different
+ * things.
+ */
+function checkRelativeLinks(rootDir: string): string[] {
+  const problems: string[] = [];
+  for (const scanDir of RELATIVE_LINK_SCAN_DIRS) {
+    const dir = join(rootDir, scanDir);
+    if (!existsSync(dir)) {
+      continue;
+    }
+    for (const { abs, rel } of collectMarkdownFiles(dir, scanDir)) {
+      const content = readFileSync(abs, 'utf-8');
+      for (const target of extractRelativeLinks(content)) {
+        const resolved = join(dirname(abs), target);
+        if (!existsSync(resolved)) {
+          problems.push(
+            `${rel}: dangling relative link → ${target} (resolved: ${relative(rootDir, resolved)})`
+          );
+        }
+      }
+    }
+  }
+  return problems;
 }
 
 const AREA_LABEL_PREFIX = 'area:';
@@ -417,6 +600,8 @@ export async function runBacklogLint(options: LintOptions = {}): Promise<void> {
   const problems = [
     ...checkNowCaps(rootDir),
     ...checkQueueDocRefs(rootDir),
+    ...checkDocIdRefs(rootDir),
+    ...checkRelativeLinks(rootDir),
     ...trackerProblems,
     ...checkTaskTriage(tasks),
     ...checkDuplicateTaskIds(tasks),

--- a/tracker/docs/doc-12 - Theme-Observability-Telemetry.md
+++ b/tracker/docs/doc-12 - Theme-Observability-Telemetry.md
@@ -7,7 +7,7 @@ created_date: '2026-07-28 11:11'
 
 ### Theme: Observability & Telemetry
 
-_Focus: structured-log quality, log-query improvements, and analytics — explicitly NOT metrics infrastructure. Codebase-wide decisions on retry counts, timeouts, cache TTLs, and feature adoption currently rely on guesswork. Vision-pipeline telemetry (2026-04-14) was the prototype; the rest extends that pattern. **Approach: this theme stays on Pino + structured logs + Railway query DSL. Time-series metrics + distributed tracing (which may stand up OTel) are the complementary [`production-observability-perf-metrics-tracing.md`](production-observability-perf-metrics-tracing.md) theme — load-correlated perf questions go there, log-shape questions come here.**_
+_Focus: structured-log quality, log-query improvements, and analytics — explicitly NOT metrics infrastructure. Codebase-wide decisions on retry counts, timeouts, cache TTLs, and feature adoption currently rely on guesswork. Vision-pipeline telemetry (2026-04-14) was the prototype; the rest extends that pattern. **Approach: this theme stays on Pino + structured logs + Railway query DSL. Time-series metrics + distributed tracing (which may stand up OTel) are the complementary `doc-16` theme — load-correlated perf questions go there, log-shape questions come here.**_
 
 #### ✨ Telemetry Strategy — Decision-Triggering Metrics
 

--- a/tracker/docs/doc-14 - Theme-Platform-Portable-UX-Layer-Discord-Design-System-—-⏸-PARKED-resumes-as-the-immediate-next-epic.md
+++ b/tracker/docs/doc-14 - Theme-Platform-Portable-UX-Layer-Discord-Design-System-—-⏸-PARKED-resumes-as-the-immediate-next-epic.md
@@ -9,7 +9,7 @@ created_date: '2026-07-28 11:11'
 
 ### Theme: Platform-Portable UX Layer (Discord Design System) — ⏸ PARKED (resumes as the immediate next epic)
 
-**⏸ PARKED 2026-07-23** mid-Phase-3, to let the Automated Inactivity Retention epic ([`../../active-epic.md`](../active-epic.md)) through. **This is the beta-exit gate and resumes the moment retention ships** — it is next-up, not shelved. State below is current as of parking: Phase 3 Waves 0–3 shipped (beta.173/174), **Waves 4–6 remain** (see the Phase 3 row).
+**⏸ PARKED 2026-07-23** mid-Phase-3, to let the Automated Inactivity Retention epic ([`backlog/active-epic.md`](../../backlog/active-epic.md)) through. **This is the beta-exit gate and resumes the moment retention ships** — it is next-up, not shelved. State below is current as of parking: Phase 3 Waves 0–3 shipped (beta.173/174), **Waves 4–6 remain** (see the Phase 3 row).
 
 _Focus: lift the bot's UI + messaging vocabulary to the routing layer's standardization level — encode UX **intent** separately from its Discord expression, so the experience is consistent **by construction** (not reconciled by periodic audits) and portable via adapters. Promoted 2026-07-17 (owner re-sequence: the `/character alias` build deviated from the 04-discord subcommand standards despite the rules table being clear — "no more UX surface until consistency is by construction"; v2-parity PAUSED behind this). Memory System Overhaul parked mid-epic at a natural pause → `doc-8`._
 
@@ -52,7 +52,7 @@ The alias command (#1695) works but shipped action-multiplexed (`action: list|ad
 - **User-scoped aliases**: new tier — a user's personal `@mommy` → character mapping affecting only their own resolution. Schema: `userId` on the alias row (null = global) with per-user uniqueness; resolver step 2 checks the mentioning user's aliases before global ones. The bot-client resolution cache is already keyed `(userId, nameOrId)` — per-user resolution is the cache's natural grain.
 - **User-scoped, NOT persona-scoped** (owner-decided): persona-scoping gets messy AND makes aliases unstable across persona switches.
 - Verified 2026-07-17: **v2 had no scoping at all** — the tiers are new design, not parity.
-- Open product call for the design pass: #1695 lets any character owner add global-effect aliases to their own character; under the tiered model this likely goes away (owners get user-scoped like everyone else; global blessing is the bot owner's). Cross-check the reverse-shadow question in [v2-parity](v2-parity-legacy-retirement.md) Phase 1 — shadowing semantics change per-tier.
+- Open product call for the design pass: #1695 lets any character owner add global-effect aliases to their own character; under the tiered model this likely goes away (owners get user-scoped like everyone else; global blessing is the bot owner's). Cross-check the reverse-shadow question in v2-parity (`doc-27`) Phase 1 — shadowing semantics change per-tier.
 
 ### Owner design inputs (2026-07-18) — ALL RESOLVED at Phase 3 planning (2026-07-20)
 

--- a/tracker/docs/doc-16 - Theme-Production-Observability-—-perf-metrics-distributed-tracing.md
+++ b/tracker/docs/doc-16 - Theme-Production-Observability-—-perf-metrics-distributed-tracing.md
@@ -7,7 +7,7 @@ created_date: '2026-07-28 11:11'
 
 ### Theme: Production Observability — perf metrics + distributed tracing
 
-_Focus: time-series metrics + distributed tracing for load-correlated production issues ONLY — continuous, deterministic performance insight + a foundation for scaling (the perf analog of `deterministic-test-quality-tooling.md`). Logs stay pino + Railway: structured-log/query improvements belong to the complementary [`observability-and-telemetry.md`](observability-and-telemetry.md) theme; this theme owns the metrics/tracing infrastructure (it may stand up OTel) that logs structurally can't provide._
+_Focus: time-series metrics + distributed tracing for load-correlated production issues ONLY — continuous, deterministic performance insight + a foundation for scaling (the perf analog of `deterministic-test-quality-tooling.md`). Logs stay pino + Railway: structured-log/query improvements belong to the complementary `doc-12` theme; this theme owns the metrics/tracing infrastructure (it may stand up OTel) that logs structurally can't provide._
 
 **Surfaced 2026-06-11 (user)** from the preset-PUT-timeout prod bug (tracked at the time in `now.md` § Production Issues; since resolved): intermittent, **load-correlated** issues can't be reproduced in dev and aren't visible in event logs — we log _what happened_ but have ~no aggregated _performance_ signal.
 

--- a/tracker/docs/doc-21 - Theme-Synchronous-Work-Timeout-Budgets.md
+++ b/tracker/docs/doc-21 - Theme-Synchronous-Work-Timeout-Budgets.md
@@ -67,7 +67,7 @@ three separate deferrals, each filed as its own row. There is no fourth raise.
 ### Phase 4 — Fast-pool residue
 
 Coherent sub-cluster from the fast-pool timeout work; overlaps
-[Database Performance Audit](database-performance-audit.md) — fold there if that
+Database Performance Audit (`doc-3`) — fold there if that
 theme is picked up first.
 
 - [ ] Type the `applyFastPoolDeadConnRetry` `$extends` result (2026-07-01)

--- a/tracker/docs/doc-22 - Theme-System-model-intent-linkage-internal.md
+++ b/tracker/docs/doc-22 - Theme-System-model-intent-linkage-internal.md
@@ -7,7 +7,7 @@ created_date: '2026-07-28 11:11'
 
 ### Theme: System model + intent linkage (internal)
 
-_Focus: restore and then MAINTAIN an accurate model of what the system is and why it's shaped that way — the internal counterpart to the user-facing surface owned by [`user-docs-and-discoverability.md`](user-docs-and-discoverability.md)._
+_Focus: restore and then MAINTAIN an accurate model of what the system is and why it's shaped that way — the internal counterpart to the user-facing surface owned by `doc-25`._
 
 #### Why (owner, 2026-07-25)
 
@@ -73,4 +73,4 @@ Researched 2026-07-20 (findings summarised here rather than linked — the full 
 
 - [ ] Only if the map is used and starts drifting: evaluate LID's spec-ID binding to tie intent to code. Re-check its maturity at that point — the numbers above are 2026-07 and it is young enough that a year changes the assessment materially.
 
-**Promote when**: the owner raised it unprompted while scoping the backlog-substrate boulder, so it competes for the next epic slot; Phase 0 alone is small enough to ride as a standalone slice. Related: [`user-docs-and-discoverability.md`](user-docs-and-discoverability.md) owns the user-facing half (its Phase 0 feature inventory is the external counterpart to this theme's Phase 0 map) and [`observability-and-telemetry.md`](observability-and-telemetry.md) addresses the runtime-blindness sibling of this design-time blindness. Surfaced 2026-07-25 (owner).
+**Promote when**: the owner raised it unprompted while scoping the backlog-substrate boulder, so it competes for the next epic slot; Phase 0 alone is small enough to ride as a standalone slice. Related: `doc-25` owns the user-facing half (its Phase 0 feature inventory is the external counterpart to this theme's Phase 0 map) and `doc-12` addresses the runtime-blindness sibling of this design-time blindness. Surfaced 2026-07-25 (owner).

--- a/tracker/docs/doc-25 - Theme-User-facing-docs-discoverability.md
+++ b/tracker/docs/doc-25 - Theme-User-facing-docs-discoverability.md
@@ -20,8 +20,8 @@ The owner's stated staleness fear — "I've been avoiding it because it's gonna 
 - `docs/commands.md` EXISTS and is actively maintained (updated same-week with `/memory facts`) — the reference-layer problem is partly *reachability from Discord*, not absence.
 - `docs/reference/features/` is the designated home for user-facing feature docs (07-documentation); coverage unaudited.
 - The UX design-system spec (`docs/proposals/backlog/ux-design-system-spec.md`) has a discoverability section — check what it already decides before designing anew.
-- Sibling themes: `first-use-onboarding-dm.md` (`doc-6`) (the first-touch slice; keep its DM short, pointing into this theme's surfaces) and [`user-feedback-solicitation-revive-v2-release-notes-delivery.md`](user-feedback-solicitation-revive-v2-release-notes-delivery.md) (comms outbound; shares the system-DM primitive).
-- **Scope boundary** (owner raised the internal half 2026-07-25): this theme owns the **user-facing** surface — what the platform can do, and how a user finds it. The **internal** model (how 1,260 prod files relate, why the architecture is shaped as it is, intent↔code binding) is [`system-model-and-intent-linkage.md`](system-model-and-intent-linkage.md). Shared root cause, different audience and artifact; Phase 0 of each is the external vs. internal inventory and they should be sequenced together if both land.
+- Sibling themes: `first-use-onboarding-dm.md` (`doc-6`) (the first-touch slice; keep its DM short, pointing into this theme's surfaces) and the shipped user-feedback / release-notes-delivery theme (comms outbound; shares the system-DM primitive).
+- **Scope boundary** (owner raised the internal half 2026-07-25): this theme owns the **user-facing** surface — what the platform can do, and how a user finds it. The **internal** model (how 1,260 prod files relate, why the architecture is shaped as it is, intent↔code binding) is `doc-22`. Shared root cause, different audience and artifact; Phase 0 of each is the external vs. internal inventory and they should be sequenced together if both land.
 
 ### Phase 0 — Investigation (cheap, do first)
 

--- a/tracker/docs/doc-4 - Theme-Deterministic-Test-Quality-Tooling-mutation-testing-job-payload-contract.md
+++ b/tracker/docs/doc-4 - Theme-Deterministic-Test-Quality-Tooling-mutation-testing-job-payload-contract.md
@@ -9,7 +9,7 @@ created_date: '2026-07-28 11:11'
 
 ### Theme: Deterministic Test-Quality Tooling (mutation testing + job-payload contract)
 
-_Focus: fill the remaining deterministic-gate rungs so seam/wiring bugs fail the build, not slip through green line-coverage. Sibling to [`production-observability-perf-metrics-tracing.md`](production-observability-perf-metrics-tracing.md) — both make the unsafe/invisible thing deterministic._
+_Focus: fill the remaining deterministic-gate rungs so seam/wiring bugs fail the build, not slip through green line-coverage. Sibling to `doc-16` — both make the unsafe/invisible thing deterministic._
 
 **Surfaced 2026-06-11 (user)** after the iii-b-2 thin-payload referenced-attachment regression (#1184): `jobChainOrchestrator` **had** a referenced-attachment test, and line coverage was green — but it covered only the _fat_ payload shape, so a new wire-shape shipped broken. Three green units, one broken cross-service seam. User's framing: unit tests are repeatedly insufficient for seam/wiring bugs; we want **deterministic checks that fail the build**. We already have strong gates (cpd ratchet, test-audit, depcruise, conformance harness, codecov) — this fills the remaining rungs.
 

--- a/tracker/docs/doc-52 - Idea-Time-range-filtering-on-the-purge-delete-commands-—-`before`-`after`-and-autocomplete-instead-of-fixed-choices-owner-request-2026-07-26.md
+++ b/tracker/docs/doc-52 - Idea-Time-range-filtering-on-the-purge-delete-commands-—-`before`-`after`-and-autocomplete-instead-of-fixed-choices-owner-request-2026-07-26.md
@@ -28,5 +28,5 @@ created_date: '2026-07-28 11:11'
 
 **Rider defect found while grounding**: `/memory delete`'s option description reads `'Only delete memories from this time period (e.g., 7d, 30d, 1y)'`, which promises free-form input — but the option is `addChoices`, a locked dropdown. The description was written for a free-form field that never shipped. Fixed for free if this lands; worth fixing regardless.
 
-**Also worth surfacing to users**: `/memory delete` (batch, filtered, skips locked, preview-then-confirm) already exists and the owner did not know it did. Whatever ships here should consider whether that command is discoverable enough — see [`user-docs-and-discoverability.md`](themes/user-docs-and-discoverability.md).
+**Also worth surfacing to users**: `/memory delete` (batch, filtered, skips locked, preview-then-confirm) already exists and the owner did not know it did. Whatever ships here should consider whether that command is discoverable enough — see `doc-25`.
 

--- a/tracker/docs/doc-6 - Theme-First-Use-Onboarding-DM-data-training-disclosure.md
+++ b/tracker/docs/doc-6 - Theme-First-Use-Onboarding-DM-data-training-disclosure.md
@@ -28,7 +28,7 @@ _Focus: send every user a one-time onboarding DM on first bot use — orienting 
 
 #### Relationship to other themes
 
-- [`user-feedback-solicitation-revive-v2-release-notes-delivery.md`](user-feedback-solicitation-revive-v2-release-notes-delivery.md) — release-notes DMs are the SAME system-DM class (characters-ignore + clearable). Whichever theme goes first should build the shared system-DM primitive; the other consumes it.
+- the shipped user-feedback / release-notes-delivery theme — release-notes DMs are the SAME system-DM class (characters-ignore + clearable). Whichever theme goes first should build the shared system-DM primitive; the other consumes it.
 - The broader "port the remaining v2 features, then get rid of v2 for good" umbrella the user has mentioned — this + release notifications are both members. If more v2-port members accumulate, consider a dedicated umbrella theme.
 
 #### Phases (rough)
@@ -48,4 +48,4 @@ _Focus: send every user a one-time onboarding DM on first bot use — orienting 
 
 - [ ] Orientation copy + the data-training/BYOK disclosure
 - [ ] **BYOK-extraction-billing consent disclosure (owner 2026-07-10)**: when the BYOK-first extraction billing ships (`doc-43` — Idea: BYOK-first extraction billing), users whose own keys will be billed for background memory extraction learn it HERE — owner picked onboarding as the consent surface over a per-user toggle-only approach.
-- [ ] Quick-start slant: owner flags the command surface as overwhelming for new users ("a fuck ton of slash commands") — the onboarding DM is the first-touch slice of the broader discoverability theme ([`user-docs-and-discoverability.md`](user-docs-and-discoverability.md)); keep the DM short and point INTO whatever quick-start surface that theme builds.
+- [ ] Quick-start slant: owner flags the command surface as overwhelming for new users ("a fuck ton of slash commands") — the onboarding DM is the first-touch slice of the broader discoverability theme (`doc-25`); keep the DM short and point INTO whatever quick-start surface that theme builds.


### PR DESCRIPTION
Closes TASK-24.

## Why

The themes/ideas → `tracker/docs/` migration depth-rewrote every outbound relative link once. Nothing gated future rot: `pnpm ops backlog` only checked that `` `doc-N` `` references in `queue.md` resolve to a file in `tracker/docs/`. A dead link in a theme doc silently rots navigation, which is how the five wrong-depth links found in the original sweep got there.

## What

`backlog:lint` gains a check: every relative markdown link in `tracker/docs/`, `tracker/tasks/`, and `backlog/` (recursively — `backlog/cold/` sits a level deeper) is resolved against its **containing file's** directory and must exist.

**Relative means what CommonMark means by it** — `[t](foo.md)` counts exactly like `[t](./foo.md)`. A bare target additionally has to look like a file (a `.ext` suffix), which is what keeps ordinary bracketed prose from being resolved as a path. A trailing `#fragment` is stripped before resolving (the file is checked, not the anchor). Absolute URLs, `mailto:`, and bare `#anchor` targets are skipped — the check is deliberately only about relative links.

`tracker/archive/` is deliberately excluded: archived content is frozen, so gating on it would block a PR over a document nobody is going to fix. That exclusion is now pinned by a test rather than only asserted in a comment.

**`doc-N` cross-references are validated too, across the same scan set.** The fix for the dead links below converts them to the tracker's backticked `doc-N` convention — but that convention was previously checked *only* inside `queue.md`, so every other `doc-N` mention could dangle silently through a renumber or delete. Converting to an unvalidated form would have traded one rot class for another; this closes it. Measured before adding: **64 `doc-N` references across the scan set, all 64 resolve**, so it lands as a no-op on the gate.

## Verified, not just written

- **15 links were already dead**, and this PR fixes all of them. One dot-prefixed (`doc-14` → `../active-epic.md`, also rendering the wrong path as its display text) and **14 bare-relative**, nearly all pointing at pre-migration theme filenames that the `doc-N` rename left behind. They are re-pointed at the tracker's own backticked `doc-N` convention rather than at paths, because the `doc-N` filenames contain spaces and em-dashes and would make fragile link targets; two referenced a theme that was legitimately deleted when it shipped (`1305532d5`), so those lost the link and kept the prose.

- **A correction to an earlier version of this PR body, recorded rather than quietly edited.** It claimed the full relative-link surface had been hand-resolved with "one dead and the rest resolving." That was false. The grep behind it was derived from the implementation's own `./`/`../` assumption, so it was structurally incapable of seeing the bare-relative form — the verification inherited the exact blind spot it was supposed to check, and reviewer round 4 caught it. The authoritative list now comes from running the widened gate itself, which reported all 14 and matched an independent shell sweep.
- **The `backlog/` widening was canaried against the real tree**, not just fixtures: a throwaway `backlog/cold/__canary.md` carrying a dead link made the gate fail and report `resolved: backlog/missing-target.md`. That single run proves both properties at once — `backlog/cold/` is reached recursively, and `../` resolved against the *file's* directory rather than the scan root.
- **Scope is measured, not assumed.** `tracker/` has five other subdirectories; only `archive/` holds markdown (14 files) and it carries zero relative links. `milestones/`, `decisions/`, `drafts/`, `completed/` hold no `.md` at all.
- **Every assertion canaried** (seven mutations): disabling fragment-stripping turns both fragment cases red; disabling the existence check turns 3 red; dropping `tracker/tasks` from the scan list turns the tasks case red; dropping `backlog` turns the recursion case red; *adding* `tracker/archive` turns the exclusion case red; removing the code-strip turns the 3 code-sample cases red; excluding `"` from the target class turns the titled-link case red. All restored green.

**Code samples are excluded.** Fenced blocks and inline code spans are blanked before extraction. These files are documentation *about* documentation, so a doc explaining link conventions writes link syntax as an example — extracting from that would report a dangling link against text that was never a link, failing everyone's `pnpm quality` on valid content. That false-positive direction is worse than any of the shapes below, which is why it's fixed rather than disclosed.

## Known parse limitations

The extractor is a regex over inline `[text](target)` links, and the module docstring now enumerates all four shapes it does not handle, split by failure direction — because that distinction is what matters when one appears:

- **Fails loud** (visible, confusing report): a titled link `[t](../foo.md "Title")`, and a target containing a literal `)`.
- **Fails silent** (a dead link simply never seen): link text with nested brackets `[a [b]](../x.md)`, and reference-style `[t][ref]` links.

None occurs in the scanned content today (each grepped for). Closing the silent pair needs a real markdown-link parser rather than a wider regex, which is why it's disclosed rather than half-fixed.

Each of those four sentences is a claim about runtime behavior, so each is **pinned by a characterization test** rather than left as prose — per `02-code-standards` § "A Comment That Asserts Behavior Is a Claim". They are non-vacuous: excluding `"` from the target character class turns the titled-link case red. If the regex is ever replaced by a real parser, these are the cases that will fail loudly instead of drifting.

A target that resolves to a *directory* passes, since `existsSync` doesn't discriminate — consistent with the existing `checkQueueDocRefs` behaviour rather than new permissiveness.

## Gates

`pnpm --filter @tzurot/tooling test` (2387 tests; `backlogLint.test.ts` alone at 63), `pnpm ops backlog`, `pnpm --filter @tzurot/tooling lint`, `tsc --noEmit` — all green, and the gate was re-run after each rebase onto current develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
