### PR TITLE
feat(tooling): discover audit scan dirs instead of listing them

### DIFF
--- a/.github/baselines/test-coverage-baseline.json
+++ b/.github/baselines/test-coverage-baseline.json
@@ -1,6 +1,6 @@
 {
-  "version": 12,
-  "lastUpdated": "2026-07-29T10:42:51.225Z",
+  "version": 14,
+  "lastUpdated": "2026-08-11T12:32:25.536Z",
   "services": {
     "detectedPrismaServices": [
       "packages/common-types/src/services/SystemSettingsService.ts",
@@ -9,6 +9,7 @@
       "packages/conversation-history/src/ConversationSyncService.ts",
       "packages/identity/src/UserService.ts",
       "packages/identity/src/personality/PersonalityLoader.ts",
+      "services/ai-worker/src/services/DescriptionPromptService.ts",
       "services/ai-worker/src/services/LongTermMemoryService.ts",
       "services/ai-worker/src/services/extraction/FactExtractionService.ts",
       "services/api-gateway/src/services/AccountDeletionService.ts",
@@ -28,9 +29,9 @@
   },
   "meta": {
     "toolVersion": "test-audit/1.0",
-    "configHash": "b97e8ab63c1f",
+    "configHash": "70640f4cfd05",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "e7b21540382657c75cbe6662788d47906a238daf",
-    "generatedAt": "2026-07-29T10:42:51.225Z"
+    "generatedFromSha": "63ee212b5b8ec66dc2096bfd554c46db16355986",
+    "generatedAt": "2026-08-11T12:32:25.536Z"
   }
 }

--- a/packages/tooling/src/test/audit-unified.test.ts
+++ b/packages/tooling/src/test/audit-unified.test.ts
@@ -244,10 +244,12 @@ export class SimpleService {
         if (path.includes('bot-client/src')) return true;
         if (path.includes('common-types/src')) return true;
         if (path.includes('tests/e2e')) return false;
+        if (path.endsWith('/services')) return true;
         return false;
       });
 
       mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir.endsWith('/services')) return ['ai-worker'];
         if (dir.includes('ai-worker/src')) return ['KnownService.ts'];
         if (dir.includes('common-types/src/schemas/api')) return ['test-schema.ts'];
         if (dir.includes('common-types/src/types')) return [];
@@ -304,10 +306,12 @@ export class SimpleService {
         if (path.includes('bot-client/src')) return true;
         if (path.includes('common-types/src')) return true;
         if (path.includes('tests/e2e')) return false;
+        if (path.endsWith('/services')) return true;
         return false;
       });
 
       mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir.endsWith('/services')) return ['ai-worker'];
         if (dir.includes('ai-worker/src')) return ['NewService.ts'];
         if (dir.includes('common-types/src/schemas/api')) return [];
         if (dir.includes('common-types/src/types')) return [];
@@ -346,25 +350,41 @@ export class SimpleService {
       expect(result).toBe(false);
     });
 
-    // Parameterized over EACH new serviceDirs entry independently: a Prisma
-    // service under the extracted package, with no component test and not in the
-    // baseline, must be flagged. If the dir weren't scanned (a path typo in
-    // serviceDirs), findServiceFiles would miss it and the audit would wrongly
-    // pass — so a `false` result proves THAT package is in scope. One case per
-    // dir so a typo in either entry fails its own case.
-    it.each(['packages/identity/src', 'packages/conversation-history/src'])(
-      'scans extracted package %s so its Prisma services are ratcheted',
+    // Parameterized over packages discovered under `packages/*\/src` — including
+    // one, `newly-extracted-package`, that was NEVER in the old hardcoded
+    // serviceDirs list. A Prisma service under each, with no component test and
+    // not in the baseline, must be flagged. Before this change, only a
+    // hand-maintained list decided which packages were scanned at all — a
+    // Prisma service under any OTHER package (like `newly-extracted-package`)
+    // would silently escape the ratchet. Discovery closes that: every
+    // `packages/*\/src` directory is scanned, so a `false` result here proves
+    // scanning isn't limited to a remembered list.
+    it.each([
+      'packages/identity/src',
+      'packages/conversation-history/src',
+      'packages/newly-extracted-package/src',
+      // Both roots get a never-in-the-old-list case: the loop body is shared,
+      // but "provably symmetric by inspection" is exactly the claim a test is
+      // supposed to replace.
+      'services/newly-extracted-service/src',
+    ])(
+      'scans package %s via directory discovery so its Prisma services are ratcheted',
       async (pkgDir: string) => {
+        const [root, pkgName] = pkgDir.split('/');
+
         mockExistsSync.mockImplementation((path: string) => {
           if (path.includes('.component.test.ts')) return false;
           if (path.includes('test-coverage-baseline')) return true;
+          if (path.endsWith(`/${root}`)) return true;
           if (path.includes(pkgDir)) return true;
           return false;
         });
 
-        mockReaddirSync.mockImplementation((dir: string) =>
-          dir.includes(pkgDir) ? ['ExtractedService.ts'] : []
-        );
+        mockReaddirSync.mockImplementation((dir: string) => {
+          if (dir.endsWith(`/${root}`)) return [pkgName];
+          if (dir.includes(pkgDir)) return ['ExtractedService.ts'];
+          return [];
+        });
 
         mockStatSync.mockImplementation((path: string) => ({
           isDirectory: () => !path.includes('.ts'),
@@ -409,10 +429,12 @@ export class SimpleService {
         if (path.includes('bot-client/src')) return true;
         if (path.includes('common-types/src')) return true;
         if (path.includes('tests/e2e')) return false;
+        if (path.endsWith('/services')) return true;
         return false;
       });
 
       mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir.endsWith('/services')) return ['ai-worker'];
         if (dir.includes('ai-worker/src')) return ['SimpleService.ts'];
         if (dir.includes('common-types/src/schemas/api')) return [];
         if (dir.includes('common-types/src/types')) return [];
@@ -463,10 +485,12 @@ export class SimpleService {
         if (path.includes('bot-client/src')) return true;
         if (path.includes('common-types/src')) return true;
         if (path.includes('tests/e2e')) return false;
+        if (path.endsWith('/services')) return true;
         return false;
       });
 
       mockReaddirSync.mockImplementation((dir: string) => {
+        if (dir.endsWith('/services')) return ['ai-worker'];
         if (dir.includes('ai-worker/src')) return ['NewService.ts'];
         if (dir.includes('common-types/src/schemas/api')) return [];
         if (dir.includes('common-types/src/types')) return [];

--- a/packages/tooling/src/test/audit-unified.ts
+++ b/packages/tooling/src/test/audit-unified.ts
@@ -54,23 +54,39 @@ const UNIFIED_BASELINE_PATH = '.github/baselines/test-coverage-baseline.json';
 // ============================================================================
 
 /**
+ * Discover scan directories via `packages/*\/src` and `services/*\/src`,
+ * rather than a hand-maintained list. Every package or service that has a
+ * `src/` directory is scanned automatically — so a newly-extracted package
+ * (a Prisma-backed service split out of an existing one, the way
+ * `packages/identity` and `packages/conversation-history` were) enters the
+ * component-test coverage ratchet the moment its `src/` exists, instead of
+ * silently escaping it until someone remembers to add it to a list.
+ */
+function discoverServiceDirs(projectRoot: string): string[] {
+  const dirs: string[] = [];
+
+  for (const root of ['packages', 'services']) {
+    const rootDir = join(projectRoot, root);
+    if (!existsSync(rootDir)) continue;
+
+    for (const entry of readdirSync(rootDir)) {
+      const srcDir = join(rootDir, entry, 'src');
+      if (existsSync(srcDir)) {
+        dirs.push(srcDir);
+      }
+    }
+  }
+
+  return dirs.sort();
+}
+
+/**
  * Find all service files in the project
  */
 function findServiceFiles(projectRoot: string): string[] {
   const services: string[] = [];
 
-  const serviceDirs = [
-    join(projectRoot, 'services/ai-worker/src'),
-    join(projectRoot, 'services/api-gateway/src'),
-    join(projectRoot, 'services/bot-client/src'),
-    join(projectRoot, 'packages/common-types/src'),
-    // Packages outside `services/` that hold Prisma-backed services. Scanned so
-    // their component-test coverage is ratcheted too — otherwise deleting one of
-    // their component tests would silently drop the gate. Add a package here when
-    // it gains a Prisma-using `*Service.ts`.
-    join(projectRoot, 'packages/identity/src'),
-    join(projectRoot, 'packages/conversation-history/src'),
-  ];
+  const serviceDirs = discoverServiceDirs(projectRoot);
 
   for (const dir of serviceDirs) {
     // Loader.ts included: delegation splits (Service orchestrates, Loader holds

--- a/packages/tooling/src/test/audit-version.ts
+++ b/packages/tooling/src/test/audit-version.ts
@@ -22,5 +22,10 @@
  *   v4 — file glob widened to `*(Service|Loader).ts`: delegation splits put the
  *        actual Prisma calls in a Loader (identity's PersonalityLoader) that the
  *        Service-only glob never scanned.
+ *   v5 — serviceDirs replaced by discovery over `packages/*\/src` +
+ *        `services/*\/src`: a hand-maintained list requires remembering to add
+ *        every newly-extracted package (already missed once, for
+ *        packages/identity + packages/conversation-history); discovery closes
+ *        that class of omission structurally.
  */
-export const TEST_AUDIT_IMPL_VERSION = 4;
+export const TEST_AUDIT_IMPL_VERSION = 5;


### PR DESCRIPTION
Closes TASK-178.

## Why

`findServiceFiles` enumerated six scan directories by hand, so every newly-extracted package escaped the component-test coverage ratchet until someone remembered to add it. That already happened once — `packages/identity` and `packages/conversation-history` were added retroactively in #1344. A ratchet whose scope depends on memory is precisely the thing a ratchet exists to replace.

## What

Scan directories are now discovered as `packages/*/src` + `services/*/src`. Everything downstream is unchanged: the `(?:Service|Loader)\.ts$` glob, the `.test.ts` skip, the re-export skip, and the `hasPrismaUsage` filter that decides which files actually gate.

`TEST_AUDIT_IMPL_VERSION` bumped 4 → 5 (measurement-affecting), and the baseline refreshed via `pnpm ops test:audit --update` — the only sanctioned path.

## Verified, not just written

- **Measured no-op on the gate before writing the change.** Discovery newly collects 13 files (12 in `packages/cache-invalidation/src`, 1 `LocalEmbeddingService.ts`). I applied the audit's own `PRISMA_PATTERNS` to each: **all 13 are Prisma-clean**, so they land in `servicesWithoutPrisma`, which does not gate. Confirmed after: `With Prisma: 14`, `Gaps: 0`, `knownGaps` still `[]`.
- **Newly-scanned DIRECTORIES, stated separately from newly-collected files** — I originally enumerated only the latter, which understated the scope change. Eight directories enter scan scope: `packages/{cache-invalidation,clients,config-resolver,embeddings,test-factories,test-utils,tooling}/src` and **`services/website/src`**. Six of those contribute zero matching files; `website` (the Astro site) is among them, so it changes nothing today, but it *is* now in scope and belongs in the enumeration.
- **No exclusion list, because measurement said one would guard nothing.** TASK-178 speculated about excluding `tooling`/`test-utils`/`test-factories` "if they produce noise" — those, plus `clients` and `config-resolver`, contain **zero** `*Service.ts`/`*Loader.ts` files. Dead code avoided.
- **The new test is the deliverable, and it is load-bearing.** The parameterized case gained `packages/newly-extracted-package/src` — a package that was never in the old list. Canary: restoring the hardcoded array turns exactly that case red while the `identity`/`conversation-history` cases stay green, since those *were* in the old list. That asymmetry is the proof discovery is doing the work.
- **One baseline entry moved, and it is not from this change.** `detectedPrismaServices` gained `services/ai-worker/src/services/DescriptionPromptService.ts`. Verified independently: that file sits under `services/ai-worker/src` — already in the *old* list — was added 2026-07-30, after the baseline's 2026-07-29 capture, and has a `.component.test.ts`. The baseline was simply one entry stale; the audit gate compares gaps rather than this list, which is why nothing caught it. No `cache-invalidation`/`embeddings` file entered the list.
- **`knownGaps` was never at risk** — it is empty before and after, so `00-critical`'s "never add new code to knownGaps" had nothing to trip on.

## Gates

`pnpm ops test:audit` (before, after, and post-`--update`), `pnpm --filter @tzurot/tooling test` (2383), `lint`, `tsc --noEmit` — all green. The baseline was regenerated *after* rebasing onto current develop so `generatedFromSha` records a commit in this branch's history.

## Related

`doc-74` lists this as member 4 of the workspace-root sweep: three `guard:*` checks hardcode `packages/*` + `services/*` at the package-root level, and this was the same rot one layer down at `<pkg>/src`. Fixed here independently; the shared helper can absorb it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
