### PR TITLE
fix(tooling): anchor the dockerfile-dist guard on the named runner stage

### DIFF
--- a/packages/tooling/src/dev/check-dockerfile-dist.test.ts
+++ b/packages/tooling/src/dev/check-dockerfile-dist.test.ts
@@ -11,6 +11,7 @@ import {
   loadWorkspacePackages,
   collectTransitiveDeps,
   extractRunnerDistCopies,
+  classifyRunnerStage,
   checkService,
   type WorkspacePackage,
 } from './check-dockerfile-dist.js';
@@ -78,6 +79,90 @@ describe('extractRunnerDistCopies', () => {
     const dockerfile = [
       'FROM node:25-slim AS runner',
       'COPY --from=builder /app/packages/common-types/dist/index.js ./packages/common-types/dist/index.js',
+    ].join('\n');
+
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/common-types']);
+  });
+
+  it('anchors on the stage explicitly named `runner`, ignoring a later stage', () => {
+    const dockerfile = [
+      'FROM node:25-slim AS builder',
+      'COPY --from=pruner /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM scratch AS export',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+    ].join('\n');
+
+    // Only the runner stage's copy is returned — the trailing `export` stage
+    // (added after runner) must not contribute copies.
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/common-types']);
+  });
+
+  it('falls back to the last FROM stage, scanning to end of file, when no stage is named runner', () => {
+    const dockerfile = [
+      'FROM node:25-slim AS builder',
+      'COPY --from=pruner /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM node:25-slim AS final',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+      'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+    ].join('\n');
+
+    expect(extractRunnerDistCopies(dockerfile)).toEqual([
+      'packages/clients',
+      'services/bot-client',
+    ]);
+  });
+
+  it('does not re-anchor onto a stage whose name merely begins with `runner`', () => {
+    const dockerfile = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM node:25-slim AS runner-debug',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+    ].join('\n');
+
+    // `runner-debug` sits AFTER the real runner and would win the last-match
+    // anchor if the pattern terminated on \b instead of end-of-line.
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/common-types']);
+  });
+
+  it('still matches a runner stage with trailing whitespace or a lowercase `as`', () => {
+    const trailingSpace = [
+      'FROM node:25-slim AS runner   ',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM scratch AS export',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+    ].join('\n');
+    const lowercaseAs = trailingSpace.replace('AS runner   ', 'as runner');
+
+    // End-of-line anchoring must not have narrowed these two accepted forms.
+    expect(extractRunnerDistCopies(trailingSpace)).toEqual(['packages/common-types']);
+    expect(extractRunnerDistCopies(lowercaseAs)).toEqual(['packages/common-types']);
+  });
+
+  it('does not match a flag-bearing FROM, degrading to last-stage anchoring', () => {
+    // Characterization of the disclosed RUNNER_STAGE_PATTERN limitation: the
+    // named-runner anchor needs a single-token image reference, so this
+    // Dockerfile takes the last-`FROM` fallback — which here scans the
+    // trailing export stage rather than the runner. Documented, not desired;
+    // no service Dockerfile uses the flag form.
+    const dockerfile = [
+      'FROM --platform=$BUILDPLATFORM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM scratch AS export',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+    ].join('\n');
+
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/clients']);
+  });
+
+  it('uses the LAST stage when multiple stages are named runner', () => {
+    const dockerfile = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
     ].join('\n');
 
     expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/common-types']);
@@ -287,40 +372,63 @@ describe('loadWorkspacePackages', () => {
 });
 
 describe('checkDockerfileDist (orchestration)', () => {
+  // Two services sharing packages/common-types — needed to exercise
+  // aggregation across services (TASK-139), not just single-service checks.
   const PKG_JSON: Record<string, object> = {
     'packages/common-types/package.json': { name: '@tzurot/common-types', dependencies: {} },
     'services/bot-client/package.json': {
       name: '@tzurot/bot-client',
       dependencies: { '@tzurot/common-types': 'workspace:*' },
     },
+    'services/api-gateway/package.json': {
+      name: '@tzurot/api-gateway',
+      dependencies: { '@tzurot/common-types': 'workspace:*' },
+    },
   };
 
-  const IN_SYNC_DOCKERFILE = [
-    'FROM node:25-slim AS runner',
-    'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
-    'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
-  ].join('\n');
+  const SERVICE_DIRS = ['services/bot-client', 'services/api-gateway'];
+
+  const IN_SYNC_DOCKERFILES: Record<string, string> = {
+    'services/bot-client': [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+    ].join('\n'),
+    'services/api-gateway': [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'COPY --from=builder /app/services/api-gateway/dist ./services/api-gateway/dist',
+    ].join('\n'),
+  };
 
   let logSpy: ReturnType<typeof vi.spyOn>;
   let savedExitCode: typeof process.exitCode;
 
-  /** Wire the fs mocks to present the fake workspace above */
-  function mockWorkspace(options: { dockerfile?: string | null } = {}) {
-    const dockerfile = options.dockerfile === undefined ? IN_SYNC_DOCKERFILE : options.dockerfile;
+  /**
+   * Wire the fs mocks to present a fake two-service workspace
+   * (bot-client + api-gateway, both depending on common-types).
+   *
+   * `overrides` replaces one or both services' Dockerfile content by dir
+   * (`services/bot-client` / `services/api-gateway`); `null` means "no
+   * Dockerfile for this service". Omitted services stay in sync.
+   */
+  function mockWorkspace(overrides: Record<string, string | null> = {}) {
+    const dockerfiles: Record<string, string | null> = { ...IN_SYNC_DOCKERFILES, ...overrides };
 
     vi.mocked(readdirSync).mockImplementation(dir => {
       if (String(dir).endsWith('packages')) {
         return ['common-types'] as never;
       }
-      return ['bot-client'] as never;
+      return ['bot-client', 'api-gateway'] as never;
     });
     vi.mocked(existsSync).mockImplementation(path => {
       const p = String(path);
       if (p.endsWith('package.json')) {
         return Object.keys(PKG_JSON).some(key => p.endsWith(key));
       }
-      // Dockerfile existence
-      return dockerfile !== null;
+      // Dockerfile existence, keyed by which service dir the path belongs to
+      const serviceDir = SERVICE_DIRS.find(dir => p.endsWith(`${dir}/Dockerfile`));
+      return serviceDir !== undefined && dockerfiles[serviceDir] !== null;
     });
     vi.mocked(readFileSync).mockImplementation(path => {
       const p = String(path);
@@ -328,7 +436,8 @@ describe('checkDockerfileDist (orchestration)', () => {
       if (pkgKey !== undefined) {
         return JSON.stringify(PKG_JSON[pkgKey]);
       }
-      return dockerfile ?? '';
+      const serviceDir = SERVICE_DIRS.find(dir => p.endsWith(`${dir}/Dockerfile`));
+      return (serviceDir !== undefined ? dockerfiles[serviceDir] : undefined) ?? '';
     });
   }
 
@@ -343,7 +452,7 @@ describe('checkDockerfileDist (orchestration)', () => {
     process.exitCode = savedExitCode;
   });
 
-  it('passes (no exit code) when runner copies match the dependency closure', async () => {
+  it('passes (no exit code) when both services are in sync', async () => {
     mockWorkspace();
 
     const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
@@ -351,13 +460,13 @@ describe('checkDockerfileDist (orchestration)', () => {
 
     expect(process.exitCode).toBeUndefined();
     const output = logSpy.mock.calls.flat().join('\n');
-    expect(output).toContain('Checked 1 service Dockerfile(s)');
+    expect(output).toContain('Checked 2 service Dockerfile(s)');
     expect(output).toContain('All runner-stage dist copies match');
   });
 
   it('sets exit code 1 and reports MISSING when a dep COPY is absent', async () => {
     mockWorkspace({
-      dockerfile: [
+      'services/bot-client': [
         'FROM node:25-slim AS runner',
         'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
       ].join('\n'),
@@ -369,11 +478,49 @@ describe('checkDockerfileDist (orchestration)', () => {
     expect(process.exitCode).toBe(1);
     const output = logSpy.mock.calls.flat().join('\n');
     expect(output).toContain('packages/common-types/dist');
-    expect(output).toContain('1 dist-copy issue');
+    expect(output).toContain('1 issue');
+  });
+
+  it('reports only the broken service and excludes the passing one when one of two is broken', async () => {
+    mockWorkspace({
+      'services/bot-client': [
+        'FROM node:25-slim AS runner',
+        'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+      ].join('\n'), // missing the common-types COPY
+    });
+
+    const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
+    await checkDockerfileDist();
+
+    expect(process.exitCode).toBe(1);
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('@tzurot/bot-client');
+    expect(output).toContain('1 issue');
+    // api-gateway is in sync — it must not surface as a finding
+    expect(output).not.toContain('@tzurot/api-gateway');
+  });
+
+  it('sums findings across both services when both are broken', async () => {
+    mockWorkspace({
+      'services/bot-client': [
+        'FROM node:25-slim AS runner',
+        'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+      ].join('\n'), // missing common-types (1 finding)
+      'services/api-gateway': 'FROM node:25-slim AS runner', // missing common-types AND own dist (2 findings)
+    });
+
+    const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
+    await checkDockerfileDist();
+
+    expect(process.exitCode).toBe(1);
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('@tzurot/bot-client');
+    expect(output).toContain('@tzurot/api-gateway');
+    expect(output).toContain('3 issue');
   });
 
   it('skips services without a Dockerfile and logs the skip in verbose mode', async () => {
-    mockWorkspace({ dockerfile: null });
+    mockWorkspace({ 'services/bot-client': null, 'services/api-gateway': null });
 
     const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
     await checkDockerfileDist({ verbose: true });
@@ -382,5 +529,136 @@ describe('checkDockerfileDist (orchestration)', () => {
     const output = logSpy.mock.calls.flat().join('\n');
     expect(output).toContain('Checked 0 service Dockerfile(s)');
     expect(output).toContain('no Dockerfile, skipped');
+  });
+
+  it('fails, not merely warns, when a Dockerfile has no stage named runner', async () => {
+    mockWorkspace({
+      'services/bot-client': [
+        'FROM node:25-slim AS final',
+        'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+        'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+      ].join('\n'),
+    });
+
+    const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
+    // Deliberately NOT verbose: CI and `pnpm quality` both invoke the guard
+    // without --verbose, so a signal that only appears there is invisible where
+    // it matters. Every dist COPY here is correct — the finding is purely that
+    // the guard cannot prove which stage it checked.
+    await checkDockerfileDist();
+
+    expect(process.exitCode).toBe(1);
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('ANCHOR');
+    expect(output).toContain('@tzurot/bot-client');
+    expect(output).toContain('no stage recognized as');
+    expect(output).toContain('1 issue');
+  });
+
+  it('fails when a stage follows AS runner, since that later stage is what ships', async () => {
+    mockWorkspace({
+      'services/bot-client': [
+        'FROM node:25-slim AS runner',
+        'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+        'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+        'FROM scratch AS export',
+      ].join('\n'),
+    });
+
+    const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
+    await checkDockerfileDist();
+
+    expect(process.exitCode).toBe(1);
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('@tzurot/bot-client');
+    expect(output).toContain('a stage follows `AS runner`');
+    // The runner stage's own copies are complete, so this is the anchoring
+    // finding alone — not a copy finding riding along.
+    expect(output).toContain('1 issue');
+  });
+});
+
+describe('classifyRunnerStage', () => {
+  it('reports named-last only when a stage is named runner AND nothing follows it', () => {
+    expect(classifyRunnerStage('FROM node:25-slim AS runner')).toBe('named-last');
+    expect(classifyRunnerStage('FROM node AS builder\nFROM node AS runner')).toBe('named-last');
+    expect(classifyRunnerStage('FROM node AS runner\nFROM scratch AS export')).toBe(
+      'named-not-last'
+    );
+    expect(classifyRunnerStage('FROM node:25-slim AS runner-debug')).toBe('unnamed');
+    expect(classifyRunnerStage('FROM node:25-slim AS final')).toBe('unnamed');
+    expect(classifyRunnerStage('FROM node:25-slim')).toBe('unnamed');
+  });
+
+  it('classifies a mixed-case stage NAME, not just a mixed-case `as` keyword', () => {
+    // Pins the JSDoc's claim that the `i` flag — required for as/AS keyword
+    // variance — necessarily extends to the stage name too. Also guards a
+    // future accidental tightening to case-sensitive name matching.
+    expect(classifyRunnerStage('FROM node:25-slim AS Runner')).toBe('named-last');
+    expect(classifyRunnerStage('FROM node:25-slim AS RUNNER')).toBe('named-last');
+  });
+
+  it('agrees with the anchoring it reports on', () => {
+    // The classifier describes which path findRunnerStageWindow takes, so the
+    // two must not drift: under `unnamed` a stage appended after the runtime
+    // stage IS scanned (the fallback's exposure); under a named runner it is not.
+    const unnamed = ['FROM node AS final', 'FROM scratch AS export'].join('\n');
+    const named = ['FROM node AS runner', 'FROM scratch AS export'].join('\n');
+    const trailingCopy = '\nCOPY --from=builder /app/packages/clients/dist ./packages/clients/dist';
+
+    expect(classifyRunnerStage(unnamed)).toBe('unnamed');
+    expect(extractRunnerDistCopies(unnamed + trailingCopy)).toEqual(['packages/clients']);
+
+    expect(classifyRunnerStage(named)).toBe('named-not-last');
+    expect(extractRunnerDistCopies(named + trailingCopy)).toEqual([]);
+  });
+
+  it('anchors on the same line the classifier keyed on, across all three outcomes', () => {
+    // classifyRunnerStage and findRunnerStageWindow each run their OWN
+    // last-match scan over RUNNER_STAGE_PATTERN. That duplication is
+    // deliberate (they are cheap and independent), but it is exactly the
+    // drift shape this PR exists to remove — so pin the equivalence across
+    // every outcome rather than the two shapes the test above happens to use.
+    const copy = (pkg: string) => `COPY --from=builder /app/${pkg}/dist ./${pkg}/dist`;
+
+    // named-last: the window is the runner stage, to end of file.
+    const namedLast = [
+      'FROM node AS builder',
+      copy('packages/clients'),
+      'FROM node AS runner',
+      copy('packages/common-types'),
+    ].join('\n');
+    expect(classifyRunnerStage(namedLast)).toBe('named-last');
+    expect(extractRunnerDistCopies(namedLast)).toEqual(['packages/common-types']);
+
+    // named-not-last: the window STOPS at the following stage.
+    const namedNotLast = [namedLast, 'FROM scratch AS export', copy('packages/embeddings')].join(
+      '\n'
+    );
+    expect(classifyRunnerStage(namedNotLast)).toBe('named-not-last');
+    expect(extractRunnerDistCopies(namedNotLast)).toEqual(['packages/common-types']);
+
+    // unnamed: the window is the LAST stage, whatever it is called.
+    const unnamed = namedNotLast.replace('AS runner', 'AS serve');
+    expect(classifyRunnerStage(unnamed)).toBe('unnamed');
+    expect(extractRunnerDistCopies(unnamed)).toEqual(['packages/embeddings']);
+  });
+
+  it('handles multiple runner stages WITH a further stage after the last one', () => {
+    // The two directions are tested separately (last-runner-wins; window stops
+    // at the next stage) but never together, and their interaction is where a
+    // reduce-based last-match scan is easiest to get wrong.
+    const dockerfile = [
+      'FROM node AS runner',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+      'FROM node AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM scratch AS export',
+      'COPY --from=builder /app/packages/embeddings/dist ./packages/embeddings/dist',
+    ].join('\n');
+
+    expect(classifyRunnerStage(dockerfile)).toBe('named-not-last');
+    // The SECOND runner wins the anchor, and the export stage is excluded.
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/common-types']);
   });
 });

--- a/packages/tooling/src/dev/check-dockerfile-dist.ts
+++ b/packages/tooling/src/dev/check-dockerfile-dist.ts
@@ -35,9 +35,14 @@ export interface WorkspacePackage {
 /** @internal Exported for testing */
 export interface DistCopyFinding {
   service: string;
-  kind: 'missing-copy' | 'stale-copy';
-  /** Repo-relative package dir the finding is about */
-  packageDir: string;
+  kind: 'missing-copy' | 'stale-copy' | 'runner-anchor';
+  /**
+   * Repo-relative package dir the finding is about — the dependency whose
+   * `dist` is missing or stale. Absent on `runner-anchor` findings, which are
+   * about the Dockerfile's stage STRUCTURE and identify no package; carrying
+   * the service's own dir there would just restate `service` in path form.
+   */
+  packageDir?: string;
   detail: string;
 }
 
@@ -60,6 +65,31 @@ const DIST_COPY_PATTERN =
 
 /** Matches any Dockerfile stage start, e.g. `FROM node:25-slim AS runner` */
 const STAGE_START_PATTERN = /^\s*FROM\s/i;
+
+/**
+ * Matches a stage named exactly `runner` — case-insensitively, e.g.
+ * `FROM node:25-slim AS runner`. The `i` flag is needed for the legitimate
+ * `as`/`AS` keyword variance and necessarily extends to the stage name too,
+ * so `AS Runner` also anchors here even though Docker's own `--from=` stage
+ * references are case-sensitive. Harmless: no Dockerfile here mixes case.
+ *
+ * The trailing `\s*$` is load-bearing, not tidiness. A `\b` terminator would
+ * also match names that merely BEGIN with `runner` (`AS runner-debug`,
+ * `AS runner.arm64`), since the word/non-word transition is itself a
+ * boundary — and because findRunnerStageWindow anchors on the LAST match, a
+ * `runner-debug` stage placed after the real runner would silently become
+ * the scan window. That is precisely the false negative this anchoring
+ * exists to prevent. Dockerfiles have no inline-comment syntax, so anchoring
+ * at end-of-line is safe; trailing whitespace and a lowercase `as` still match.
+ *
+ * Assumes the image reference is a single token — a flag-bearing form
+ * (`FROM --platform=$BUILDPLATFORM node AS runner`) does NOT match, and the
+ * caller then falls back to last-`FROM` anchoring. That fallback is the
+ * pre-existing behaviour, so the miss degrades rather than breaks; the flag
+ * form is not used by any service Dockerfile here. Same disclosure style as
+ * DIST_COPY_PATTERN above.
+ */
+const RUNNER_STAGE_PATTERN = /^\s*FROM\s+\S+\s+AS\s+runner\s*$/i;
 
 /**
  * Parse a package.json, failing loudly WITH path context — a bare
@@ -158,21 +188,103 @@ export function collectTransitiveDeps(
 }
 
 /**
+ * How confidently this guard can identify the Dockerfile's runtime stage:
+ *
+ * - `named-last` — a stage is named `runner` AND no stage follows it. The only
+ *   state where the stage this guard checks is provably the stage that ships.
+ * - `named-not-last` — a stage is named `runner` but another stage follows it.
+ * - `unnamed` — no stage is recognized as `runner`; {@link findRunnerStageWindow}
+ *   takes the weaker last-`FROM` fallback.
+ *
+ * The two non-`named-last` states are reported as findings rather than logged,
+ * because each breaks a premise the guard's result rests on — and a guard
+ * against silent false negatives must not have a silent failure mode of its
+ * own. `named-not-last` is the sharper of the two: `docker build` with no
+ * `--target` builds the LAST stage, so a stage appended after `runner` is what
+ * actually ships while this guard would go on validating `runner`'s copies.
+ *
+ * No IN-REPO artifact passes `--target` (searched: workflows, package.json,
+ * every service Dockerfile; no railway.json/toml exists). That search
+ * cannot see Railway's per-service dashboard build settings, which leave no
+ * trace here — so this states "no in-repo target", not "no target anywhere".
+ * If this check ever fires on a Dockerfile that deliberately keeps a stage
+ * after `runner`, check Railway's dashboard for an out-of-band `--target`
+ * before assuming the Dockerfile is wrong. The failure is loud and actionable
+ * either way, which is why the guard errs toward reporting the ambiguity.
+ *
+ * @internal Exported for testing
+ */
+export function classifyRunnerStage(
+  dockerfileContent: string
+): 'named-last' | 'named-not-last' | 'unnamed' {
+  const lines = dockerfileContent.split('\n');
+  const runnerIndex = lines.reduce(
+    (last, line, i) => (RUNNER_STAGE_PATTERN.test(line) ? i : last),
+    -1
+  );
+
+  if (runnerIndex === -1) {
+    return 'unnamed';
+  }
+  return lines.slice(runnerIndex + 1).some(line => STAGE_START_PATTERN.test(line))
+    ? 'named-not-last'
+    : 'named-last';
+}
+
+/**
+ * Locate the runner stage's line window: `[start, end)` bounding the lines
+ * that belong to it.
+ *
+ * Anchors on a stage explicitly named `runner` (`FROM ... AS runner`) when
+ * one exists — the window then runs from just after that `FROM` line up to
+ * (but not including) the NEXT stage-start line, so a stage added AFTER
+ * runner (a debug stage, `FROM scratch AS export`) never contributes copies.
+ * If MULTIPLE stages are named `runner` (pathological but possible), the
+ * LAST one wins.
+ *
+ * Falls back to the last `FROM` line in the file, scanning to end-of-file,
+ * when no stage is named `runner` — this keeps single-stage Dockerfiles
+ * (and any legacy Dockerfile that never adopted the `runner` name) working.
+ */
+function findRunnerStageWindow(lines: string[]): { start: number; end: number } {
+  const runnerStageStart = lines.reduce(
+    (last, line, i) => (RUNNER_STAGE_PATTERN.test(line) ? i : last),
+    -1
+  );
+
+  if (runnerStageStart !== -1) {
+    let end = lines.length;
+    for (let i = runnerStageStart + 1; i < lines.length; i++) {
+      if (STAGE_START_PATTERN.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    return { start: runnerStageStart + 1, end };
+  }
+
+  const lastStageStart = lines.reduce(
+    (last, line, i) => (STAGE_START_PATTERN.test(line) ? i : last),
+    -1
+  );
+  return { start: lastStageStart + 1, end: lines.length };
+}
+
+/**
  * Extract the repo-relative package dirs whose `dist` is copied in the
- * Dockerfile's FINAL stage (the runner). Earlier stages (pruner, installer,
- * builder) are ignored — only the runner's copies reach the runtime image.
+ * Dockerfile's runner stage. Earlier stages (pruner, installer, builder) are
+ * ignored — only the runner's copies reach the runtime image. See
+ * {@link findRunnerStageWindow} for how the runner stage's line window is
+ * anchored, including the no-named-`runner`-stage fallback.
  *
  * @internal Exported for testing
  */
 export function extractRunnerDistCopies(dockerfileContent: string): string[] {
   const lines = dockerfileContent.split('\n');
-  const lastStageStart = lines.reduce(
-    (last, line, i) => (STAGE_START_PATTERN.test(line) ? i : last),
-    -1
-  );
+  const { start, end } = findRunnerStageWindow(lines);
 
   const copies: string[] = [];
-  for (const line of lines.slice(lastStageStart + 1)) {
+  for (const line of lines.slice(start, end)) {
     const match = DIST_COPY_PATTERN.exec(line);
     if (match !== null) {
       copies.push(match[1]);
@@ -235,6 +347,28 @@ export function checkService(
 }
 
 /**
+ * A finding for any state where the guard cannot prove it checked the stage
+ * that actually ships, or `null` when it can. See {@link classifyRunnerStage}
+ * for why each state matters.
+ */
+function runnerAnchorFinding(
+  serviceName: string,
+  dockerfileContent: string
+): DistCopyFinding | null {
+  const anchoring = classifyRunnerStage(dockerfileContent);
+  if (anchoring === 'named-last') {
+    return null;
+  }
+
+  const detail =
+    anchoring === 'named-not-last'
+      ? 'a stage follows `AS runner`, so `docker build` without `--target` ships THAT stage while this guard checks `runner` — make `runner` the final stage, or pass `--target runner` and teach this guard about it'
+      : 'no stage recognized as `runner` (the pattern needs `FROM <image> AS runner`), so the weaker last-FROM anchoring is in use and a stage added after the runtime stage would be checked instead of it';
+
+  return { service: serviceName, kind: 'runner-anchor', detail };
+}
+
+/**
  * Scan every service that has a Dockerfile and collect findings.
  */
 function scanServices(
@@ -259,7 +393,14 @@ function scanServices(
     }
 
     servicesChecked++;
-    const serviceFindings = checkService(name, readFileSync(dockerfilePath, 'utf-8'), packages);
+    const dockerfileContent = readFileSync(dockerfilePath, 'utf-8');
+
+    const serviceFindings = checkService(name, dockerfileContent, packages);
+    const anchorFinding = runnerAnchorFinding(name, dockerfileContent);
+    if (anchorFinding !== null) {
+      serviceFindings.push(anchorFinding);
+    }
+
     findings.push(...serviceFindings);
 
     if (verbose && serviceFindings.length === 0) {
@@ -270,10 +411,19 @@ function scanServices(
   return { findings, servicesChecked };
 }
 
+/**
+ * Keyed by kind so a new finding kind cannot silently inherit another's badge.
+ * Labels are padded to a common width so the console output stays columnar.
+ */
+const FINDING_BADGES: Record<DistCopyFinding['kind'], () => string> = {
+  'missing-copy': () => chalk.red.bold('MISSING'),
+  'stale-copy': () => chalk.yellow.bold('STALE  '),
+  'runner-anchor': () => chalk.red.bold('ANCHOR '),
+};
+
 function displayFindings(findings: DistCopyFinding[]): void {
   for (const finding of findings) {
-    const badge =
-      finding.kind === 'missing-copy' ? chalk.red.bold('MISSING') : chalk.yellow.bold('STALE');
+    const badge = FINDING_BADGES[finding.kind]();
     console.log(`  ${badge} ${chalk.white(finding.service)}: ${finding.detail}`);
   }
   console.log('');
@@ -303,7 +453,9 @@ export async function checkDockerfileDist(options: CheckOptions = {}): Promise<v
   if (findings.length === 0) {
     console.log(chalk.green.bold('✅ All runner-stage dist copies match workspace dependencies!'));
   } else {
-    console.log(chalk.red.bold(`Found ${findings.length} dist-copy issue(s).`));
+    // "issue(s)", not "dist-copy issue(s)" — runner-anchor findings are about
+    // WHICH stage got checked, not about a copy being wrong.
+    console.log(chalk.red.bold(`Found ${findings.length} issue(s).`));
     process.exitCode = 1;
   }
 


### PR DESCRIPTION
Closes TASK-139 and TASK-140. Both live in one guard module, so they ship together.

## Why

`guard:dockerfile-dist` exists because runner-stage `dist` COPY lines are hand-maintained and CI never builds the Docker image — a missing one ships an image that crashes at startup with `ERR_MODULE_NOT_FOUND`. A false negative in this guard is therefore the expensive direction, and it had one latent.

**TASK-140**: `extractRunnerDistCopies` anchored on the LAST `FROM` line. That is correct for every Dockerfile in the repo today, but the moment a stage is added *after* runner — a debug stage, `FROM scratch AS export` — the scan window silently moves off the runtime image and the guard reports clean on a broken Dockerfile.

**TASK-139**: the orchestration tests mocked a single-service workspace, so the property they were nominally covering — aggregation across services — was untested. A guard that only ever aggregated one thing could not have been shown to aggregate.

## What

Anchoring is now by name: `FROM ... AS runner`, with the window bounded at the *next* stage start so a later stage contributes nothing. Multiple `runner` stages (pathological but expressible) resolve to the last. When no stage carries the name, it falls back to the previous last-`FROM`-to-EOF behaviour, which is what keeps single-stage Dockerfiles working.

The orchestration fixture is now two services (`bot-client` + `api-gateway`) sharing `packages/common-types`, with per-service Dockerfile overrides.

## Verified, not just written

- **Every real Dockerfile takes the named path.** Grepped `services/*/Dockerfile` for `^FROM`: all four multi-stage builds name their final stage `AS runner` (voice-engine is single-stage Python, no dist copies). So this is not a change that only works on fixtures.
- **Both behaviours canaried red.** Reverting the anchoring to last-`FROM` turns the after-runner-stage test red; making `scanServices` return findings for only the first service turns the summed-count test red. Both restored via file copy, and the full suite is green after.
- **The aggregation test distinguishes the bug it names.** The two broken services contribute an *asymmetric* 1 and 2 findings, so a "count only the first service" regression fails on the total rather than coincidentally matching it.
- **One disclosed limitation, pinned.** `RUNNER_STAGE_PATTERN` needs a single-token image reference, so `FROM --platform=$BUILDPLATFORM node AS runner` does not match and the file degrades to last-`FROM` anchoring. That is a behavioural claim, so it carries a characterization test rather than only a comment — and the degradation direction is the pre-existing behaviour, not a new failure. No service Dockerfile uses the flag form.

## Review round 1

Reviewer caught a Medium that my own verification missed, and it deserves to be recorded rather than quietly folded in: the first version of `RUNNER_STAGE_PATTERN` terminated on `\b`, which also matches names that merely *begin* with `runner` — `AS runner-debug`, `AS runner.arm64`. Because the anchor takes the **last** match, a `runner-debug` stage placed after the real runner would have silently become the scan window. That is the same false negative this PR exists to close, reached through a naming collision instead of an unnamed trailing stage, and none of my tests exercised a `runner`-prefixed name.

The reviewer flagged its own analysis as a regex trace rather than a runtime result, so it was re-checked by executing both patterns against six stage-name forms before applying anything. It held exactly as described. The pattern now anchors at end-of-line, with two tests added: a `runner-debug` stage positioned after the real runner (red under the old `\b` form), and a guard that end-of-line anchoring did not narrow the accepted forms — trailing whitespace and a lowercase `as` still match (red under an over-tightened `runner$`). Both canaried in both directions.

The `\s*$` is now load-bearing rather than cosmetic, so the JSDoc says why, and the "one disclosed limitation" framing above is superseded: the prefix gap was fixed, not disclosed.

## Review round 2

No blocking findings. Three optional items, all taken:

- **The fallback no longer degrades silently.** Round 2's Low observed that when no stage is named `runner`, the guard reverts to last-`FROM` anchoring — carrying the exact exposure this PR removes — with nothing to say so. A new `hasNamedRunnerStage()` predicate now drives a verbose-mode warning naming the service and what the weaker anchoring means. It reports per-service, so a mixed repo would flag only the file that took that path. A guard against silent false negatives should not itself fail silently, which is why this was worth a round rather than a follow-up row.
- **Case-insensitivity documented.** The `i` flag is required for `as`/`AS` variance and unavoidably extends to the stage name, so `AS Runner` anchors too while Docker's own `--from=` references are case-sensitive. The JSDoc now says "exactly `runner` — case-insensitively" rather than implying exact-case.
- **Cosmetic**: a single-element array `.join('\n')` in the test fixture is now a plain string.

The three new tests were canaried together by pointing the predicate at the wrong pattern; all three went red, including the one asserting the predicate and the anchoring cannot drift apart.

Run verbosely against the real repo, all four services report in-sync with no fallback warning — the named path is live everywhere, which is the condition the warning exists to notice the loss of.

## Review round 4 — the premise correction

Round 4 found that the round-2 warning was **unreachable where it mattered** and, more importantly, that TASK-140's premise rested on an unverified fact. Both verified before acting:

- Neither `.github/workflows/ci.yml:153` nor the `quality` script passes `--verbose`, so the "no longer degrades silently" claim in the section above was **false as wired** — the warning only ever appeared for a developer who opted in.
- **No `--target` exists anywhere in the repo** (searched workflows, `package.json`, every `services/*/Dockerfile`; no `railway.json`/`railway.toml` exists). `docker build` without `--target` builds the **last** stage. So a stage appended after `runner` would be the stage that actually *ships*, while named anchoring would go on validating `runner` — the guard would be confidently checking a stage that isn't deployed. Named anchoring is right about *intent*; file position is what decides the *artifact*.

That inverts part of this PR's original motivation, so the guard no longer picks a side. It now treats **both** ambiguous states as hard findings, unconditionally:

| State | Verdict |
|---|---|
| a stage is named `runner` and nothing follows it | pass — the checked stage is provably the shipped one |
| a stage is named `runner` but another follows it | **finding** — the later stage is what ships |
| no stage recognized as `runner` | **finding** — weaker last-`FROM` anchoring is in play |

`classifyRunnerStage` replaces round 2's `hasNamedRunnerStage`, and the reporting moved from a verbose log to a `runner-anchor` finding that sets exit 1. Badges are now a per-kind record rather than a two-way ternary, so a future finding kind can't silently inherit another's badge. The summary line reads "issue(s)" rather than "dist-copy issue(s)", since an anchoring finding is about *which stage got checked*, not about a copy.

All four guarded Dockerfiles end with `AS runner`, so the real repo passes unchanged (verified by running the guard). Both new findings canaried red by suppressing the anchor check. Round 4's remaining Low (the "no stage named" wording being inaccurate for the flag-bearing case) is fixed in passing — the message now reads "no stage recognized as `runner`". The round-3/round-4 duplicate-scan nit is declined: sharing the scan would couple the anchoring check to the window search for no measurable gain at Dockerfile sizes.

Extracting `runnerAnchorFinding` was required, not stylistic — inlining it pushed `scanServices` to cognitive complexity 16 against a limit of 15.

## Gates

`pnpm --filter @tzurot/tooling test` (2416 tests, 159 files), `pnpm --filter @tzurot/tooling lint`, `tsc --noEmit -p packages/tooling/tsconfig.json`, and `pnpm ops guard:dockerfile-dist` against the real repo (4 services, clean) — all green. `@tzurot/tooling` defines no `typecheck` script; the bare `tsc --noEmit` is the equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
