### PR TITLE
docs(skills): order the merge so --delete-branch can work, and verify it

### DIFF
--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-08-09'
+lastUpdated: '2026-08-11'
 ---
 
 # Git Workflow Procedures
@@ -127,6 +127,52 @@ The gate prints exactly one sentinel, and **only `CI_COMPLETE` means CI actually
 
 **Merge gate is green-only.** Per `.claude/rules/00-critical.md` "Never Merge PRs Without Completed CI": every check must be green before `gh pr merge` runs, including release PRs. If a check fails for what looks like infrastructure reasons (binary not found, missing secret, action-setup error), `gh run rerun <run-id> --failed` and re-arm the Monitor — don't merge through the red. The release procedure below assumes a green pipeline.
 
+### Before merging: the head branch must be checked out NOWHERE
+
+**`--delete-branch` fails silently when the head branch is checked out anywhere** — git refuses to delete a checked-out branch, `gh` reports the LOCAL failure, and the merge itself still succeeds. The PR closes as merged and nothing says a branch is still there; it surfaces later as a repo-state-sweep finding, or when someone notices the pile.
+
+**Observed, with the mechanism left open:** on the merges that hit this, the **remote** branch survived as well as the local one (PR #2064's live error text; PR #2061 found later in a sweep; PR #2063 clean once the worktree was removed first). Whether `gh` skips the remote delete _because_ the local one failed, or the two just fail together for a shared reason, is not established — the observation is that both survive, and `gh`'s internal ordering is not the kind of thing that stays fixed across versions. That is why the verification step below exists rather than a rule about what `gh` does: verify the ref, don't reason about the tool.
+
+"Anywhere" is the whole rule, and the easy-to-forget instance is the checkout you are not looking at: a **worktree** (the orchestration skill mandates one for every file-mutating worker, so every delegated unit lands in this state) or the **main checkout** still sitting on the branch after a local review.
+
+The worktree case is the confirmed, load-bearing one — `gh` cannot know about a checkout in another directory. For the main checkout, `gh` may well switch you away itself (the hotfix section below records it doing exactly that), so treat that half as defensive rather than load-bearing; it is unverified for the ordinary feature-PR path and costs nothing either way. Before the merge:
+
+```bash
+git status --short                        # check the main tree BEFORE moving off the branch
+git worktree list                         # find any worktree holding the branch
+git checkout develop                      # get the main checkout off it
+```
+
+`git checkout` refuses rather than discards, so the leading `status` is not protecting against loss — it is there because uncommitted work in the main tree at merge time means something is unfinished, and finding that out _before_ the merge is cheaper than after.
+
+**Check every worktree before removing it — `--force` or not.** Run this against each worktree the previous step listed, and do not skip it because you are using plain `remove`:
+
+```bash
+git fetch -p                                      # --remotes reads LOCAL tracking refs; refresh them first
+git -C <path> status --short                      # empty = no modified or untracked files
+git -C <path> log --oneline --not --remotes       # empty = every commit is on a remote
+git worktree remove <path>                        # only once BOTH are empty
+```
+
+**Plain `git worktree remove` does not protect you here.** It refuses only on a DIRTY worktree — modified or untracked files. A worktree whose work is **committed but never pushed** is clean by that definition, so plain removal takes it with exit 0, and `--delete-branch` at the merge step below then deletes the only ref holding those commits, leaving them reachable solely through a local reflog. Measured end to end in a scratch repo: commit-without-push → `git worktree remove` exit 0 → `git branch -D` → the commit is absent from `git log --all`. That is precisely the resumed-worker scenario in § Resuming a worktree-isolated worker in `/tzurot-orchestration`, which is why the check is unconditional rather than a `--force` caveat.
+
+**`--not --remotes`, not `@{u}..`** — measured: `@{u}` dies with `fatal: no upstream configured` (exit 128) on a branch that was created but never pushed, which is precisely the state you are checking for, so the check would abort exactly when it matters.
+
+**If either is non-empty, do NOT remove the worktree yet — get the work to safety first**, then re-run the check and remove:
+
+```bash
+git -C <path> add -A && git -C <path> commit -m "chore: snapshot before worktree cleanup"
+git -C <path> push -u origin HEAD                                       # if commits were unpushed
+```
+
+Uncommitted work in a worktree is the same hours-of-work class as anywhere else (`00-critical.md` § Destructive Commands): commit and push it, then decide what it was. A merge is never urgent enough to skip that. (`chore:`, not `wip:` — `wip` is not in commitlint's `type-enum`, so the hook rejects it at exactly the moment you need the commit to land.)
+
+**If that push happened, you are no longer ready to merge.** It put a commit on the PR's head branch that CI has never seen, so re-arm the Monitor and wait for a fresh green run before the merge below — `00-critical.md` § Never Merge PRs Without Completed CI requires green on the LATEST commit, and the green-only gate a few sections above applies here with no exception for a recovery commit. Then merge — this is the feature-PR invocation the sections above build up to, and `--delete-branch` is correct here precisely because the branch is disposable:
+
+```bash
+gh pr merge <N> --rebase --delete-branch
+```
+
 ### After PR Merged
 
 ```bash
@@ -134,6 +180,22 @@ git checkout develop
 git pull origin develop
 git branch -d feat/your-feature
 ```
+
+**Then verify the remote branch is actually gone** — the ordering step above makes the delete possible, not certain, and this is what turns any other silent-delete failure into a report instead of a discovery:
+
+```bash
+git ls-remote --exit-code --heads origin "<branch>"; case $? in
+  0) echo "SURVIVED — re-delete" ;;
+  2) echo "deleted ✓" ;;
+  *) echo "UNKNOWN — ls-remote itself failed; the branch's state was NOT checked" ;;
+esac
+```
+
+**This is not the push-verify `ls-remote` from the Commit Procedure above.** That one reads the ref's SHA out of stdout to prove a push landed _at a specific commit_; this one asks only whether the ref exists at all, which is why it wants `--exit-code` and ignores stdout. Same command, opposite questions — don't swap one form for the other.
+
+**Use the `case`, not `&& … || …`.** Measured: the `||` form prints `deleted ✓` immediately after a fatal `Could not read from remote repository`, because `||` catches every nonzero — a network blip, an auth failure or a wrong remote all report the branch gone. A verification step that reports success when it could not run is the failure it exists to catch. `--exit-code` distinguishes the cases (`0` found, `2` no match, anything else an error), so read the status rather than its truthiness.
+
+`git push origin --delete <branch>` re-deletes a survivor. **Never for `develop` or `main`** (`00-critical.md` § Long-Lived Branch Protection) — the `develop`→`main` release PR merges without `--delete-branch`, so nothing here applies to it. That carve-out is about the long-lived BRANCH, not about the word "release": the hotfix flow below cuts a disposable `chore/release-vX.Y.Z-beta.N` branch and does pass `--delete-branch`, so it can survive its merge like any other feature branch — verify it the same way.
 
 ## Dependabot PR Recovery
 

--- a/.claude/skills/tzurot-orchestration/SKILL.md
+++ b/.claude/skills/tzurot-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-orchestration
 description: 'Orchestrator mode: when to delegate implementation to a worker agent, the spec template every worker gets, and the full-diff review gate before any commit. Invoke with /tzurot-orchestration at the start of any implementation unit run in orchestrator mode — the moment a task fix shape is known, before the first src Edit/Write.'
-lastUpdated: '2026-08-10'
+lastUpdated: '2026-08-11'
 ---
 
 # Orchestrator Mode
@@ -106,6 +106,27 @@ A stale base is the failure mode that reads as competence: the worker behaves
 correctly against the code it can see, and confidently "corrects" a spec that
 was right about the code it cannot.
 
+### Resuming a worktree-isolated worker
+
+**A `SendMessage` resume can silently drop the isolation.** Observed: a worker
+spawned with `isolation: "worktree"` (worktree confirmed — it reported a base
+SHA 26 commits stale and stopped on it) was resumed via `SendMessage`; the
+resumed run created its branch and made every edit in the ORCHESTRATOR's tree,
+and `.claude/worktrees/` was empty at completion. The tool result says
+"resumed from transcript" and nothing about isolation, so this fails silently
+in the direction the worktree mandate exists to prevent. A resume runs in the
+BACKGROUND — `SendMessage` returns while the worker's turn is still executing —
+so there is no checkpoint to gate on: the check below races the worker rather
+than preceding it. Run it as soon as the resume returns, and until it comes
+back clean, treat the resumed worker as same-tree and its diff as suspect,
+which means the freeze posture above applies to the orchestrator's own git
+operations:
+
+```bash
+git worktree list                 # the worker's worktree should still be listed
+git branch --show-current         # the orchestrator tree must NOT be on the worker's branch
+```
+
 ## While the worker runs
 
 Pre-stage the next unit's grounding — read the files, profile the data, draft
@@ -130,7 +151,9 @@ use subagents to verify or double-check your own work. Then:
   grounding is suspect (stale worktree base, confused state) — or when the
   worker's agent id did not survive a compaction boundary: ids cannot be
   enumerated afterward (same gap as Monitor ids, `CLAUDE.md` § Compaction
-  Instructions), so a lost id means fresh-spawn is the only path.
+  Instructions), so a lost id means fresh-spawn is the only path. **A resume is
+  not isolation-preserving** — re-verify per § Resuming a worktree-isolated
+  worker before the resumed worker edits anything.
 - Check every reported deviation against the spec's intent, not just its
   letter.
 - Re-run the gates yourself when the worker's verification tails are absent or


### PR DESCRIPTION
Closes TASK-521 and TASK-524. Two procedure gaps in the same seam — a worker's branch outliving its merge — so they ship together.

## Why

The owner noticed feature branches surviving their merges. The cause is not a settings drift: **git refuses to delete a branch that is checked out anywhere**, so `gh pr merge --delete-branch` fails the local delete, leaves the **remote** branch behind as well, and the merge itself still succeeds. Nothing in the output says a branch survived, so it surfaces later as a repo-state-sweep finding.

The orchestration skill mandates `isolation: "worktree"` for every file-mutating worker, which means **every delegated unit ends with its branch checked out in a worktree at merge time**. That is why the survivors correlated with "lately" — the mandate and the merge step compose badly, and neither document mentioned the other.

TASK-524 is the second door into the same state, observed during PR #2065: resuming a worktree-isolated worker via `SendMessage` silently dropped the isolation, and the resumed worker created its branch and made every edit in the **orchestrator's** tree. No damage that time — the tree happened to be clean — but the skill's resume-rather-than-respawn guidance read as unconditionally safe, and it is what puts the orchestrator's own checkout on the worker's branch.

## What

**`/tzurot-git-workflow`** gains a pre-merge ordering step (get the branch checked out nowhere: remove the worktree, move the main checkout off it) and a post-merge verification (`git ls-remote --exit-code --heads`), with the re-delete command and an explicit carve-out that none of it applies to release PRs, where `develop` correctly survives.

**`/tzurot-orchestration`** gains the resume caveat next to the worktree mandate, with the two-command check, plus a pointer at the resume bullet itself so the guidance is not read in isolation.

The ordering half is the fix; the verification half is what turns any *other* silent-delete failure into a report instead of a discovery, which is why both ship rather than just the first.

## Verified, not just written

- **The verification command was probed in both directions** before being documented, not reasoned about: `git ls-remote --exit-code --heads origin <missing>` → `deleted ✓`, and the same against `develop` → prints the ref and reports `SURVIVED`. Two comments I wrote earlier this session asserted external-tool behaviour from memory and were wrong both times, so a documented command shape now gets a probe.
- **The root cause is an observed failure, not a code-read.** The error text (`cannot delete branch ... used by worktree at ...`) was captured live on the PR #2064 merge, and TASK-521's first use on #2063 confirmed the fix end to end: remove worktree → merge → `ls-remote` reports gone.
- **The isolation drop is observed too** — worktree confirmed present (the worker reported a base SHA 26 commits stale and stopped on it), `git worktree list` showing only the main checkout at completion, and the main checkout sitting on the worker's branch.
- Docs-only change: `lines:check`, `backlog:lint` and `guard:workflow-sync` all green on the pre-push gate.

## Scope note

This does not touch `delete_branch_on_merge`, which must stay `false` — it is the flag that deleted `develop` on 2026-08-07, it runs admin-privileged, and it passes straight through `develop`'s deliberately-bypassable ruleset. `guard:repo-settings` continues to assert the `false` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
