### PR TITLE
feat: warn when tracker files are uncommitted

### DIFF
--- a/packages/tooling/src/dev/backlogLint.test.ts
+++ b/packages/tooling/src/dev/backlogLint.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import {
   ALLOW_ORIGIN_ID_COLLISION_ENV,
   checkDuplicateTaskIds,
@@ -17,6 +18,12 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
   readFileSync: vi.fn(),
   readdirSync: vi.fn(),
+}));
+
+// The runBacklogLint suite's beforeEach sets a clean-tree default (''); tests
+// that exercise the warning path override it with their own porcelain output.
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
 }));
 
 describe('parseSectionCaps', () => {
@@ -408,6 +415,9 @@ describe('runBacklogLint', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    // Clean tracker tree unless a test says otherwise — `resetAllMocks` drops
+    // the implementation, so this has to be re-set every time.
+    vi.mocked(execFileSync).mockReturnValue('');
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     process.exitCode = undefined;
   });
@@ -494,12 +504,71 @@ describe('runBacklogLint', () => {
     expect(process.exitCode).not.toBe(1);
   });
 
+  it('warns on an uncommitted tracker file but does not set a non-zero exit code', async () => {
+    mockFs(
+      {
+        'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n2. b\n',
+        'backlog/cold/queue.md': '- **Foo** (`doc-1`)\n',
+      },
+      ['doc-1 - Foo.md']
+    );
+    // NUL-terminated: readTrackerGitStatus passes `-z` (see trackerGitStatus.ts).
+    vi.mocked(execFileSync).mockReturnValue('?? tracker/tasks/task-537 - new.md\0');
+
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('Backlog layout in sync');
+    expect(out).toContain('Uncommitted tracker files');
+    expect(out).toContain('tracker/tasks/task-537 - new.md (untracked)');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('prints nothing extra and stays exit-neutral when the git read fails', async () => {
+    // The documented contract at the seam that matters — the CLI's own output,
+    // not readTrackerGitStatus in isolation. In CI the tracker tree is clean
+    // and an unresolvable git call is uninteresting, so silence is correct.
+    mockFs(
+      {
+        'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n2. b\n',
+        'backlog/cold/queue.md': '- **Foo** (`doc-1`)\n',
+      },
+      ['doc-1 - Foo.md']
+    );
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('not a git repository');
+    });
+
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('Backlog layout in sync');
+    expect(out).not.toContain('Uncommitted tracker files');
+    expect(process.exitCode).not.toBe(1);
+  });
+
   it('flags a cap violation and sets a non-zero exit code', async () => {
     mockFs({ 'backlog/now.md': '### ⚡ Quick Wins (max 2)\n- a\n- b\n- c\n' }, []);
 
     await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
     expect(logSpy.mock.calls.flat().join('\n')).toContain('has 3 items (cap 2)');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('prints the advisory warning alongside a real structural problem', async () => {
+    // The two blocks are independent — gating problems set the exit code, the
+    // warning never does — but every other test exercises one branch with the
+    // other quiet. This pins that a failing run still names the uncommitted
+    // file rather than the warning being swallowed by the problem report.
+    mockFs({ 'backlog/now.md': '### ⚡ Quick Wins (max 2)\n- a\n- b\n- c\n' }, []);
+    vi.mocked(execFileSync).mockReturnValue('?? tracker/tasks/task-537 - new.md\0');
+
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('has 3 items (cap 2)');
+    expect(out).toContain('tracker/tasks/task-537 - new.md (untracked)');
     expect(process.exitCode).toBe(1);
   });
 
@@ -845,14 +914,18 @@ describe('runBacklogLint', () => {
   });
 });
 
-// The one real git/OS seam this module introduces. A parse bug here fails
-// toward a false positive that sets process.exitCode = 1, tripping everyone's
-// quality gate — so the shell-out is mocked and its parse/trim/filter exercised
-// directly, the way ci-gate.test.ts covers fetchRuns' execFileSync.
+// The only git/OS seam left in this module — the other one moved to
+// trackerGitStatus.ts with its own colocated tests. It is also the
+// higher-stakes of the two: a parse bug here fails toward a false positive that
+// sets process.exitCode = 1, tripping everyone's quality gate — so the
+// shell-out is mocked and its parse/trim/filter exercised directly, the way
+// ci-gate.test.ts covers fetchRuns' execFileSync.
 describe('readOriginTaskFiles', () => {
-  // Reset BEFORE each test, not only after: the top-level static import already
-  // cached this module with the real child_process, so without a reset the
-  // FIRST test's doMock would not apply and it would shell out to real git.
+  // Reset BEFORE each test, not only after: this file's hoisted
+  // `vi.mock('node:child_process')` already bound the static import to a shared
+  // `vi.fn()`, so without a reset the FIRST test's doMock would not apply and
+  // the call would hit that stub (returning undefined) instead of the per-test
+  // ls-tree fixture.
   beforeEach(() => {
     vi.resetModules();
   });

--- a/packages/tooling/src/dev/backlogLint.ts
+++ b/packages/tooling/src/dev/backlogLint.ts
@@ -27,6 +27,12 @@
  *    "no such work", never as "the label is missing". Done tasks are exempt:
  *    they're finished work awaiting archive.
  *
+ * Separately, and NOT gating: a warning naming any uncommitted file under
+ * `tracker/`. Everything above parses the tracker tree off disk, so a task git
+ * has never seen passes every check — green while invisible to the digest and
+ * to every query. That one is advisory because a half-written task file is a
+ * legitimate working state.
+ *
  * Run via `pnpm ops backlog`. Exits non-zero on a structural problem so it can
  * gate in `pnpm quality` and CI. This is a binary "is the layout in sync?"
  * check, NOT an audit-class tool — no baseline / WHY.md / canary
@@ -41,6 +47,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import chalk from 'chalk';
+import { checkUncommittedTrackerFiles, readTrackerGitStatus } from './trackerGitStatus.js';
 import { loadTrackerTasks, openTasks, type TrackerTask } from './trackerTasks.js';
 
 /** @internal Exported for testing */
@@ -624,6 +631,21 @@ export async function runBacklogLint(options: LintOptions = {}): Promise<void> {
     );
   }
   reportProblems(problems);
+
+  const trackerGitStatus = readTrackerGitStatus(rootDir);
+  if (trackerGitStatus !== null) {
+    const uncommitted = checkUncommittedTrackerFiles(trackerGitStatus);
+    if (uncommitted.length > 0) {
+      console.log(
+        chalk.yellow(
+          '⚠ Uncommitted tracker files — these are invisible to every query until committed:'
+        )
+      );
+      for (const warning of uncommitted) {
+        console.log(chalk.yellow(`   - ${warning}`));
+      }
+    }
+  }
 
   if (problems.length > 0) {
     process.exitCode = 1;

--- a/packages/tooling/src/dev/trackerGitStatus.test.ts
+++ b/packages/tooling/src/dev/trackerGitStatus.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import {
+  checkUncommittedTrackerFiles,
+  PORCELAIN_ENTRY_SEPARATOR,
+  readTrackerGitStatus,
+  TRACKER_STATUS_TIMEOUT_MS,
+} from './trackerGitStatus.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+/**
+ * Entries are NUL-TERMINATED in `-z` output, so each fixture ends with one.
+ * Built from the exported constant rather than a literal: hardcoding `\0` here
+ * would let a separator change leave every fixture on the old delimiter, and
+ * this file would stop being the thing that catches the drift.
+ */
+function entries(...lines: string[]): string {
+  return lines.map(l => `${l}${PORCELAIN_ENTRY_SEPARATOR}`).join('');
+}
+
+describe('checkUncommittedTrackerFiles', () => {
+  it('reports an untracked (??) entry', () => {
+    expect(checkUncommittedTrackerFiles(entries('?? tracker/tasks/task-537 - new.md'))).toEqual([
+      'tracker/tasks/task-537 - new.md (untracked)',
+    ]);
+  });
+
+  it('reports a worktree-modified entry ( M)', () => {
+    expect(checkUncommittedTrackerFiles(entries(' M tracker/tasks/task-1 - edited.md'))).toEqual([
+      'tracker/tasks/task-1 - edited.md (modified, not staged)',
+    ]);
+  });
+
+  it('does NOT report a staged-only entry (second column is a space)', () => {
+    // A  path and M  path are both about to be committed — not a warning.
+    expect(
+      checkUncommittedTrackerFiles(
+        entries('A  tracker/tasks/task-2 - staged-new.md', 'M  tracker/tasks/task-3 - staged.md')
+      )
+    ).toEqual([]);
+  });
+
+  it('produces no warnings for empty porcelain output', () => {
+    expect(checkUncommittedTrackerFiles('')).toEqual([]);
+  });
+
+  it('labels a worktree-deleted entry as deleted, not modified', () => {
+    expect(checkUncommittedTrackerFiles(entries(' D tracker/tasks/task-4 - gone.md'))).toEqual([
+      'tracker/tasks/task-4 - gone.md (deleted, not staged)',
+    ]);
+  });
+
+  // All seven of git's unmerged pairs, not just the UU everyone thinks of.
+  // Four (DD, UD, UA, AA) carry a worktree byte that means something else on
+  // its own, so a second-column-only lookup calls them plain deletes/adds —
+  // which is what this table exists to prevent regressing to.
+  it.each(['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU'])(
+    'labels the %s unmerged pair as a merge conflict',
+    pair => {
+      expect(
+        checkUncommittedTrackerFiles(entries(`${pair} tracker/tasks/task-5 - clash.md`))
+      ).toEqual(['tracker/tasks/task-5 - clash.md (merge conflict)']);
+    }
+  );
+
+  it('reports a spaced path verbatim — which every real tracker filename is', () => {
+    // Under `-z` git applies no quoting at all, so the path needs no unwrapping.
+    // Without it, this arrives as `"tracker/tasks/task-9 - a real name.md"` and
+    // every warning this tool prints would carry quotes.
+    expect(
+      checkUncommittedTrackerFiles(entries('?? tracker/tasks/task-9 - a real name.md'))
+    ).toEqual(['tracker/tasks/task-9 - a real name.md (untracked)']);
+  });
+
+  it('passes through non-ASCII and raw control bytes untouched', () => {
+    // The em dash is the common case in tracker/; the control byte is what the
+    // old hand-rolled unquoter could only render as its octal digits.
+    expect(checkUncommittedTrackerFiles(entries('?? tracker/tasks/task-7 - em — dash.md'))).toEqual(
+      ['tracker/tasks/task-7 - em — dash.md (untracked)']
+    );
+  });
+
+  it('keeps a filename that itself contains " -> " intact', () => {
+    // Rename detection is off (see readTrackerGitStatus), so an arrow in an
+    // entry is part of the name, never git's separator. Splitting on it would
+    // silently report `execute.md` for this file.
+    expect(
+      checkUncommittedTrackerFiles(entries('?? tracker/tasks/task-1 - plan -> execute.md'))
+    ).toEqual(['tracker/tasks/task-1 - plan -> execute.md (untracked)']);
+  });
+
+  it('labels a worktree type change', () => {
+    expect(checkUncommittedTrackerFiles(entries(' T tracker/tasks/task-8 - swapped.md'))).toEqual([
+      'tracker/tasks/task-8 - swapped.md (type changed, not staged)',
+    ]);
+  });
+
+  it('falls back to a generic label for an unrecognized worktree status byte', () => {
+    expect(checkUncommittedTrackerFiles(entries(' X tracker/tasks/task-6 - odd.md'))).toEqual([
+      'tracker/tasks/task-6 - odd.md (uncommitted change)',
+    ]);
+  });
+
+  it('reports every warning-worthy entry, not just the first', () => {
+    // The N-entry half of the contract: per-status behavior is covered above,
+    // but nothing else pins that the loop accumulates rather than returning
+    // early — while still skipping the staged-only entry between them.
+    expect(
+      checkUncommittedTrackerFiles(
+        entries('?? tracker/tasks/a.md', 'A  tracker/tasks/staged.md', ' M tracker/tasks/b.md')
+      )
+    ).toEqual(['tracker/tasks/a.md (untracked)', 'tracker/tasks/b.md (modified, not staged)']);
+  });
+
+  it('does not split on a newline, which is a legal filename byte under -z', () => {
+    // The reason the separator had to move off '\n': a name containing one
+    // would otherwise be torn into two bogus entries.
+    expect(checkUncommittedTrackerFiles(entries('?? tracker/tasks/two\nline.md'))).toEqual([
+      'tracker/tasks/two\nline.md (untracked)',
+    ]);
+  });
+});
+
+describe('readTrackerGitStatus', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns git output verbatim on success', () => {
+    vi.mocked(execFileSync).mockReturnValue('?? tracker/tasks/task-7 - new.md\0');
+    expect(readTrackerGitStatus('/repo')).toBe('?? tracker/tasks/task-7 - new.md\0');
+  });
+
+  it('returns null when the git call fails', () => {
+    // The whole point of the seam: a repo-less or broken git must degrade to
+    // "no answer", never throw out of `pnpm ops backlog`.
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('not a git repository');
+    });
+    expect(readTrackerGitStatus('/repo')).toBeNull();
+  });
+
+  it('passes every flag the parser and the contract depend on', () => {
+    // -z: otherwise git quotes and escapes any path with a space (every tracker
+    // filename) or a non-ASCII byte, and the parser would have to undo it.
+    // renames=false: otherwise a staged-rename-then-edited file arrives as one
+    // entry holding two paths.
+    // untracked-files=all: otherwise a wholly-untracked directory collapses to
+    // one `?? dir/` entry instead of naming the files inside it.
+    vi.mocked(execFileSync).mockReturnValue('');
+    readTrackerGitStatus('/repo');
+
+    const [, args, options] = vi.mocked(execFileSync).mock.calls[0];
+    expect(args).toEqual([
+      '--no-optional-locks',
+      '-c',
+      'status.renames=false',
+      'status',
+      '--porcelain',
+      '-z',
+      '--untracked-files=all',
+      '--',
+      'tracker/',
+    ]);
+    // `cwd` has no type-level enforcement — drop it and git silently reports on
+    // whatever directory the process happens to be in, which for a tool that
+    // runs from hooks is not necessarily this repo. `timeout` likewise: without
+    // it a stalled git blocks `pnpm quality` and the pre-push hook outright
+    // instead of degrading to the documented silent skip.
+    expect(options).toMatchObject({ cwd: '/repo', timeout: TRACKER_STATUS_TIMEOUT_MS });
+  });
+});

--- a/packages/tooling/src/dev/trackerGitStatus.ts
+++ b/packages/tooling/src/dev/trackerGitStatus.ts
@@ -1,0 +1,158 @@
+/**
+ * Uncommitted-tracker-file detection for `pnpm ops backlog`.
+ *
+ * `backlogLint.ts` parses the tracker store off disk, so a task file that has
+ * never been committed passes every structural check — green while invisible
+ * to the digest and to every query. This module supplies the advisory warning
+ * that closes that gap. It is deliberately NOT a gate: a half-written task
+ * file is a legitimate working state.
+ *
+ * Split out of `backlogLint.ts` on a measurement rather than a hunch — that
+ * file had reached exactly 400 counted lines against the 400-line `max-lines`
+ * error, so the next edit to it would have failed CI for whoever made it.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** Entries in `-z` output are NUL-TERMINATED, so the split yields a trailing ''. */
+export const PORCELAIN_ENTRY_SEPARATOR = '\0';
+
+/**
+ * Bound on the status read, matching `ci-gate.ts`'s shell-out timeouts.
+ *
+ * `--no-optional-locks` below avoids losing the index-lock race, but that only
+ * covers the contended case — a corrupted index, a network-mounted `.git`, or a
+ * pathological untracked tree can still stall. This call is synchronous inside
+ * `pnpm quality` and the pre-push hook, so an unbounded hang blocks the gate
+ * rather than degrading. Bounded, a stall throws and lands in the same `catch`
+ * as any other failure: the warning is skipped and nothing else is affected.
+ */
+export const TRACKER_STATUS_TIMEOUT_MS = 15_000;
+
+/**
+ * Read `git status --porcelain -z` for the tracker tree; failure is a normal answer.
+ *
+ * Every flag here was settled by running the command, not by reading docs:
+ *
+ * - `-z` is the load-bearing one. Without it git C-quotes and backslash-escapes
+ *   any path containing a space — which EVERY `tracker/` filename has, being
+ *   `task-N - title.md` — plus non-ASCII bytes under the default `quotePath`,
+ *   and the em dash / `→` / `↔` are common in this corpus. With `-z`, entries
+ *   are NUL-terminated and git applies no quoting, so nothing downstream has to
+ *   unquote or un-escape anything and a raw control byte in a name survives
+ *   instead of arriving as `\001`. This replaced a hand-rolled unquoter that
+ *   had cost three review rounds and still carried a documented octal-decoding
+ *   gap; `-z` removes the gap by removing the encoding.
+ *
+ * ACCEPTED LIMITATION, at the Node boundary rather than git's: a POSIX filename
+ * is a byte string, not necessarily valid UTF-8, and `encoding: 'utf-8'` below
+ * makes Node substitute U+FFFD for any invalid sequence. Measured — a file
+ * named with a raw `0xFF` byte is emitted by git verbatim and read back as
+ * `tracker/bad�name.md`. So "git applies no encoding" is true of git and
+ * NOT true end to end. Left as-is deliberately: reading a Buffer would make the
+ * round-trip lossless but every consumer (chalk, `console.log`) would then need
+ * byte-wise output to print it, and the degradation here is one replacement
+ * character in an otherwise-correct path rather than the whole-path mangling
+ * the octal case produced. Every file the tracker CLI creates is UTF-8.
+ * - `status.renames=false`: with detection on, a staged-rename-then-edited file
+ *   is reported as one entry whose "path" is two paths (`old -> new` without
+ *   `-z`, two NUL-separated fields with it). Off, the same change is reported
+ *   as the `D  old` / `AM new` pair git would otherwise have collapsed —
+ *   measured, and the one-path-per-entry consequence is pinned by the
+ *   "keeps a filename that itself contains ` -> ` intact" test.
+ * - `--no-optional-locks` because plain `status` opportunistically refreshes
+ *   the index stat cache and takes `.git/index.lock` to write it back. This
+ *   runs inside `pnpm quality` and the pre-push hook alongside husky, and
+ *   losing that race would degrade to a silent skip of the warning.
+ * - `--untracked-files=all` because the default collapses a wholly-untracked
+ *   DIRECTORY into one `?? tracker/newdir/` entry (measured) instead of listing
+ *   what is inside it, and this warning's contract is to name the uncommitted
+ *   *files*.
+ */
+export function readTrackerGitStatus(rootDir: string): string | null {
+  try {
+    return execFileSync(
+      'git',
+      [
+        '--no-optional-locks',
+        '-c',
+        'status.renames=false',
+        'status',
+        '--porcelain',
+        '-z',
+        '--untracked-files=all',
+        '--',
+        'tracker/',
+      ],
+      {
+        cwd: rootDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: TRACKER_STATUS_TIMEOUT_MS,
+      }
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Git's seven unmerged (conflict) status pairs. These are matched on BOTH
+ * columns, because four of them carry a worktree byte that means something
+ * else on its own: `DD`/`UD` look like a plain delete and `AA`/`UA` like a
+ * plain add, so a second-column-only lookup mislabels them.
+ *
+ * `AA` is the one to care about here rather than a curiosity: two branches
+ * independently filing a tracker task at the same path produce exactly it,
+ * which is the collision TASK-453 is about.
+ */
+const UNMERGED_STATUS_PAIRS = new Set(['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']);
+
+/**
+ * Worktree-column status byte → what actually happened to the file, for the
+ * non-conflict cases. Only bytes git can actually put in that column are
+ * listed — no rename/copy entry belongs here (rename detection is off, see
+ * `readTrackerGitStatus`), and `A` reaches this column only inside the
+ * unmerged pairs above, which are matched before this table is consulted.
+ */
+const WORKTREE_STATUS_LABELS: Record<string, string> = {
+  M: 'modified, not staged',
+  D: 'deleted, not staged',
+  T: 'type changed, not staged',
+};
+
+/**
+ * Uncommitted tracker entries, as human-readable warning lines.
+ *
+ * Each `-z` entry is `XY path`, NUL-terminated. An untracked file (`??`) or a
+ * worktree-modified file (`Y` is not a space, e.g. ` M`, ` D`) is invisible to
+ * every query until committed — that is what this warns about. A staged-only
+ * entry (`Y` is a space, e.g. `A  path`, `M  path`) is about to be committed
+ * and is not a warning.
+ *
+ * The path is taken as-is: `readTrackerGitStatus` passes `-z`, so git
+ * applies no quoting or escaping, and it disables rename detection, so an
+ * entry is one path and a `" -> "` inside it belongs to somebody's filename.
+ * Both rationales live at that function; this one just relies on them.
+ * @internal Exported for testing
+ */
+export function checkUncommittedTrackerFiles(porcelain: string): string[] {
+  const warnings: string[] = [];
+  for (const line of porcelain.split(PORCELAIN_ENTRY_SEPARATOR)) {
+    // Entries are NUL-TERMINATED, so the final split always yields one empty
+    // string. That is the only empty an entry can be — git's format is
+    // `XY path` — so match it exactly rather than trimming, which would also
+    // swallow a malformed whitespace-only entry worth noticing.
+    if (line === '') continue;
+    const status = line.slice(0, 2);
+    const path = line.slice(3);
+    if (status === '??') {
+      warnings.push(`${path} (untracked)`);
+    } else if (UNMERGED_STATUS_PAIRS.has(status)) {
+      warnings.push(`${path} (merge conflict)`);
+    } else if (status[1] !== ' ') {
+      warnings.push(`${path} (${WORKTREE_STATUS_LABELS[status[1]] ?? 'uncommitted change'})`);
+    }
+  }
+  return warnings;
+}


### PR DESCRIPTION
Closes TASK-534.

## The problem

`pnpm ops backlog` parses tracker task files **off disk**. Git never enters the
picture, so a task file that has never been committed parses fine, triages fine, and
the gate prints:

```
✓ Backlog layout in sync (caps respected, links resolve, tracker store parses, open tasks triaged)
```

Green-plus-invisible is the worst combination available: the author gets positive
confirmation the task is well-formed at the exact moment it is failing to persist. An
uncommitted task is invisible to the digest, to every `tracker task list` query, and to
every future session — the same content-destroying failure mode the old markdown
follow-ups table had.

This happened **three times in one session**. TASK-530 rode three autosquash rebases as
an untracked file. TASK-533 was left behind when attention moved to code. TASK-537 was
filed, verified, and **cited in a PR body as tracked** while sitting untracked — caught
only because a reviewer went looking for the file and couldn't find it. The first two
were caught by a manual `git status`, which is exactly the kind of check that works
until it doesn't.

## The change

A warning — never a failure — naming any uncommitted file under `tracker/`.

- `readTrackerGitStatus(rootDir)` — `execFileSync('git', ['status', '--porcelain', '--',
  'tracker/'], …)` (array args per `00-critical` § Shell Command Safety), returning
  `null` on any failure. Mirrors the `readOriginTaskFiles` split already in this file.
- `checkUncommittedTrackerFiles(porcelain)` — pure, takes the git output as a string so
  it tests without a repo.

**Untracked (`??`) and worktree-modified (`Y` not a space) warn; staged-only does not** —
`A  path` / `M  path` are about to be committed, and warning about them would train
people to ignore the warning.

Two deliberate non-behaviors:

- **`process.exitCode` is never set by this check.** A half-written task file is a
  legitimate working state, and `pnpm ops backlog` runs in both `pnpm quality` and the
  pre-push hook — a hard failure there would block pushes repo-wide and teach people to
  bypass the gate.
- **A failed git read prints nothing at all** — no warning, no dim note. In CI the
  tracker tree is always clean, so silence is the correct output, and an unresolvable
  git call isn't interesting.

## Verification

- **Every new assertion canaried red-before-green**, one mutation at a time: `??`
  detection flipped to a non-matching status; the worktree-column condition forced to
  `false` and then to `true` (this is the staged-vs-unstaged canary — a test that passes
  under both is measuring nothing); the empty-line guard removed; a `process.exitCode = 1`
  temporarily added inside the warning block. Source restored and confirmed identical
  after each.
- **End-to-end probe against a real repo**, since a real-repo signal is the whole point.
  With a throwaway `tracker/tasks/zz-orch-probe.md` present:

  ```
  ✓ Backlog layout in sync (caps respected, links resolve, tracker store parses, open tasks triaged)
  ⚠ Uncommitted tracker files — these are invisible to every query until committed:
     - tracker/tasks/zz-orch-probe.md (untracked)
  EXIT(untracked): 0
  ```

  and with a clean tree, the green line alone at `EXIT(clean): 0`.

- `pnpm test` (26 packages) · `pnpm quality` (full chain through `guard:gate-parity`) ·
  `@tzurot/tooling` build (`tsc`) and lint. The tooling package defines no `typecheck` /
  `typecheck:spec` script — `build` runs `tsc` and is the type gate here.

## Review round 1 — all five findings applied

No blocking findings. One of them was **under-rated by the reviewer, and only a probe
against real data showed it**:

**Non-ASCII paths (reviewer: "Low … worth a mental note").** The reviewer reasoned
"typical task filenames are plain ASCII." That is false for this repo — a survey of
`tracker/` found dozens of filenames carrying `—`, `→`, `↔`, `≥`, `⏸`, or `…`, and
`core.quotePath` is unset (git's default `true`). A live `git status --porcelain` run
confirms the consequence:

```
?? "tracker/tasks/zz-probe-\342\200\224-em-dash.md"
```

So the warning would have named the file with an unreadable, un-copy-pasteable octal
string — for precisely the files it exists to name, and for the `doc-*` set in
particular. Fixed by passing `-c core.quotePath=false`, pinned by a test asserting the
exact argv, and re-probed end to end (the em dash now renders literally). The reviewer's
*principle* was right and its *severity* was wrong; recording that rather than quietly
taking the fix.

The other four: a test for `readTrackerGitStatus`'s `catch` branch, which no test
reached (Medium — correct, and the gap is real: the branch was untested); a per-status
label map so a worktree-**deleted** or merge-**conflicted** entry is no longer mislabeled
"modified"; the now-stale "the one real git/OS seam" comment; and the module header,
which enumerated every check but not this one.

Three new assertions canaried red-before-green (catch → rethrow; argv → quotePath flag
removed; label map → old hardcoded string), source restored byte-identical after each.

## Review round 2 — all three applied, and round 1's label claim was an overclaim

**Correcting the round-1 note above rather than editing it away.** It said the per-status
map stopped a merge-conflicted entry being mislabeled. It only partly did, and the
reviewer was right to call it: git has **seven** unmerged pairs — `DD AU UD UA DU AA UU` —
and the map read only the second byte, so `DD`/`UD` still read as plain deletes and
`AA`/`UA` as plain adds. Four of seven wrong. The doc comment asserting the warning
"does catch" both cases was the same overclaim in code, which is exactly what
`02-code-standards.md` § "a comment that asserts behavior is a claim" is for.

Verified by probe rather than from the reviewer's table — a real add/add merge in a
throwaway repo gives `AA both-added.txt`. Now matched on **both** columns, with all seven
pairs pinned by `it.each`. Backing the branch out turns all seven red.

`AA` is worth more than the completeness argument: two branches independently filing a
tracker task at the same path produce exactly it, which is the collision **TASK-453**
already describes. This warning's own directory is where that lands.

**The rename finding was real but not for the stated reason**, which matters because
applying it as diagnosed would have fixed nothing. The review attributed the `old -> new`
path to a worktree-column `R`/`C`. Probing says otherwise: an unstaged rename is reported
as ` D` of the old path plus `??` of the new one, and a staged rename is `R ` — worktree
column a space, already skipped as staged-only. The arrow actually arrives via **`RM`** (a
staged rename whose new file was then edited), confirmed as
`RM tracker/orig.md -> tracker/renamed.md`. Only the new name exists on disk, so that is
what the warning now reports. The same probes retired the speculative `R`/`A` label
entries (unreachable in that column) and added the real `T` (typechange).

Third finding — no integration-level test for the git-read-fails path — was correct and is
now pinned at the seam that matters, the CLI's own output: green line, no warning block,
exit code untouched.

## Review round 3 — both findings were bugs I added in round 2, plus a bigger one I found chasing them

Round 2's path-accuracy fix introduced a path-accuracy bug: the `" -> "` split ran on
**every** line regardless of status, so an untracked file whose own name contains that
substring would be reported as just the fragment after it. Classic rider — a follow-up
addition dodging the scrutiny the primary change got.

Rather than gate the split on `R`/`C` as suggested, I took the review's *other* option,
which dissolves both findings at once: `readTrackerGitStatus` now also passes
**`-c status.renames=false`**. Probed — `RM old -> new` becomes the `D  old` / `AM new`
pair, so **no arrow notation is ever emitted**. The split is deleted rather than
conditioned (finding 1 gone by construction), and round 2's "never a worktree-column `R`"
comment stops being incidentally-true-under-default-config and becomes true because we
set the config (finding 2 gone by construction). Less code, not more.

### The one the review didn't find, and neither did my earlier probes

Chasing finding 1, a probe turned up something worse: **git C-quotes any path containing
a space**, independently of `core.quotePath`, on git 2.50.1 — verified in this repo:

```
?? "tracker/tasks/task-996 - realistic filename with spaces.md"
```

Every file under `tracker/` is named `task-N - title.md`. So the shipped warning would
have wrapped **essentially every path it ever printed** in quotes — not copy-pasteable,
which is the one job it has.

Round 1's end-to-end probe missed it because both probe files I used (`zz-orch-probe.md`,
`zz-probe-—-em-dash.md`) were space-free: I verified the em-dash mechanism with a filename
that lacked the other property, which is "verifying the mechanism is not verifying the
scenario" almost verbatim. Fixed with `unquotePorcelainPath` (strip quotes, unescape
`\"`/`\\`/`\n`/`\t`), and re-probed with a name carrying **both** properties at once:

```
⚠ Uncommitted tracker files — these are invisible to every query until committed:
   - tracker/tasks/task-995 - a realistic name with — an em dash.md (untracked)
```

Canaries: dropping the unquote reddens two tests; **re-introducing round 2's arrow split
reddens the arrow-in-filename test** (so it pins the exact regression); dropping
`status.renames=false` reddens the argv test. Source restored byte-identical after each.

## Review round 4 — no correctness bugs; two applied, one already tracked

**Named C escapes beyond `\n`/`\t`.** The fallback returned the escape *letter*, so a CR
in a filename came back as `hasrcarriage.md`. Git does emit these — probed:
`?? "has\rcarriage.md"`. Full table now (`\a \b \f \n \r \t \v`), with `\\`/`\"` still
falling through correctly.

Git's **octal** form (`\001`) is deliberately left undecoded and pinned as a documented
limitation, following the `extractRelativeLinks` precedent already in this file:
`core.quotePath=false` removes the only common source of octal (non-ASCII), so what
remains is a filename holding a raw control byte, and carrying an octal decoder nothing
exercises is worse than a loud, tested gap.

**`--no-optional-locks`.** Plain `status` opportunistically refreshes the index stat cache
and takes `.git/index.lock` to write it back; this runs inside `pnpm quality` and the
pre-push hook alongside husky, and losing that race degrades to a silent skip of the
warning. Confirmed the flag works in this exact invocation before adding it.

**`05-tooling.md`'s one-liner** — correct, and already **TASK-523**, which I appended to
earlier today recording this as its third accumulated omission (the link-resolution gate,
the commitlint scope list, and now this advisory warning). It needs a `.claude/rules` PR,
which this branch can't carry.

### A correction on my own test

The documented-limitation assertion I first wrote expected `ctl01byte.md`; the code
produces `ctl001byte.md`. The implementation was right and my expectation was a bad guess
about my own regex — `\001` matches as `\0`, the fallback yields `"0"`, and the literal
`01` survives, so only the backslash is lost. Fixed the assertion, not the behavior.

Canaries: dropping the escape table reddens the named-escape test; dropping
`--no-optional-locks` reddens the argv test. Final end-to-end probe with a corpus-shaped
name (spaces *and* an em dash) prints the path clean at exit 0.

## Review round 5 — one finding measured and acted on, one refuted by probe

### The `max-lines` finding was right, and the measurement is worse than the guess

The reviewer flagged 816 raw lines and correctly noted they couldn't run lint to get the
counted total. Measured it by forcing the rule to report:

| | counted lines |
| --- | --- |
| `backlogLint.ts` on `origin/develop` | **323** |
| `backlogLint.ts` with this PR | **400** |
| the `max-lines` error threshold | **400** |

It passed only because the rule errors on `> max`. **Zero headroom** — and this PR's 77
counted lines are what consumed it, so the next person to touch that file would have hit
a CI failure caused by work I did.

Extracted the feature into `trackerGitStatus.ts` + colocated test (`backlogLint.ts` 400 →
338, new module 64). Test parity is exact: 90 before, 65 + 25 after, none lost.

Worth being precise about why this extraction is legitimate where an earlier one in
**#2068 was not**: there I claimed `max-lines` *forced* a split having measured with
`wc -l`, and the counted total was 196 — under half. Here the counted total is the metric,
it says 400/400, and the split follows from that. Same rule, opposite conclusion, because
this time the number is the one the rule actually uses.

### The space-quoting claim: reviewer's reading refuted, probe stands

The review challenged round 3's "git C-quotes any path containing a space, independent of
`core.quotePath`", citing `quote.c`'s documented trigger set (control chars, `"`, `\`,
DEL, and ≥0x80 under the default) — noting a plain space is not among them, and that they
could not run a probe to check.

Re-probed in isolation, one variable at a time, git 2.50.1:

```
?? "has\ttab.md"
?? "has one space.md"      ← only special character is a space → QUOTED
?? has-dash.md             ← unquoted
?? plainname.md            ← unquoted
```

Identical under the default config and under `core.quotePath=false`. The claim holds for
porcelain v1 output as shipped; the documented trigger set does not describe what this git
actually emits. The comment now says so with the isolation spelled out, so the next reader
doesn't have to re-derive it from `quote.c` and reach the wrong answer.

The reviewer was right that it deserved an isolated check — the original probe conflated a
space with an em dash, which is the same one-variable-at-a-time gap that let the defect in
originally.

## Review round 6 — `-z` dissolves the quoting subsystem entirely

The reviewer suggested `git status --porcelain -z` would remove the escaping machinery
the last three rounds were spent getting right, and was explicit that they couldn't probe
it and were reasoning from documented behavior. Given that the previous round's
docs-based claim turned out not to match this git, probing first:

| filename property | without `-z` | with `-z` |
| --- | --- | --- |
| space / em dash | `?? "tracker/em — dash.md"` | `?? tracker/em — dash.md` |
| raw control byte | `?? "tracker/ctl\001byte.md"` | the `001` byte, verbatim |

`-z` does not make the quoting easier to undo — git does not apply it at all, and paths
come through byte-for-byte. So it does not patch the problem, it deletes the problem.

Removed: `unquotePorcelainPath`, the `C_ESCAPES` table, and the `core.quotePath=false`
override (**156 lines out, 89 in**; module 64 → 49 counted lines). Entries now split on
NUL. **The documented octal-decoding limitation stops existing** rather than staying a
tolerated gap with a "fails loud" test guarding it.

This is the third time in this PR the right move was to dissolve a class rather than
handle it — round 3's `status.renames=false` deleted the arrow-splitting logic,
round 5's `--untracked-files=all` made "names files" true by construction, and now this.
Each traded an intricate-but-correct parser for a flag, and each came from probing what
git emits rather than reasoning about what it should.

The delimiter change immediately caught a stale newline-terminated fixture in
`backlogLint.test.ts`'s integration test — the tests doing exactly their job. A new case
pins the reason the separator had to move: a filename containing a newline is legal and
would otherwise be torn into two bogus entries.

Canaries: dropping `-z` reddens the argv test; switching the separator back to `\n`
reddens 16 tests. Re-probed end to end with all four properties at once — a directory
containing a space, an em dash, and a literal `" -> "` in a filename:

```
⚠ Uncommitted tracker files — these are invisible to every query until committed:
   - tracker/new dir/task-991 - spaces and — an em dash.md (untracked)
   - tracker/tasks/task-990 - plain -> arrow.md (untracked)
```

The second finding (a third private `execFileSync`-try/catch-null helper, now 3-for-3
across `packages/tooling`) is left alone deliberately: this call needs `encoding`,
`stdio`, and two extra flags the existing two-arg `execFileSafe` signature does not take,
and per `02-code-standards.md`'s duplication-vs-wrong-abstraction guidance a shared
wrapper isn't worth it yet. Recorded here rather than filed, since the reviewer framed it
as a note for a hypothetical fourth occurrence rather than work.

## Review round 7 — three nits, all applied

- **The loop's N-entry contract wasn't pinned.** Per-status behavior was covered
  exhaustively and one test proved two staged-only entries produce zero warnings, but
  nothing asserted that two warning-worthy entries both come back. Now tested with
  untracked + staged + modified in one blob, so it also pins that the staged entry is
  skipped *between* the two warnings. Canary: an early return reddens six tests.
- **The test helper hardcoded `\0`** instead of importing `PORCELAIN_ENTRY_SEPARATOR`.
  That is a real drift trap, not style: change the separator and every fixture keeps
  building on the old delimiter, so this file stops being what catches it. The constant
  now does the job it was exported for.
- **`line.trim() === ''` was broader than its stated intent.** Under `-z` the only
  genuinely empty entry is the trailing split artifact, so `line === ''` says exactly
  that; trimming additionally swallowed a hypothetical whitespace-only entry that would
  be worth noticing.

The reviewer also independently re-verified two claims from this description rather than
trusting them (the global-flag ordering before the `status` subcommand, and the seven
unmerged pairs against the `it.each` table) — both held.

### On the round count

Eight rounds on ~90 lines is a lot, and the severity trend is why it wasn't waste:
round 3 caught a correctness bug this PR itself introduced; round 5 caught a measurement
error plus a zero-headroom lint trap; round 6 replaced the quoting subsystem with a flag;
round 7 is nits. Descending, and the expensive findings were all in the first half.

## Review round 8 — two applied; the comment rot was self-inflicted, twice

**A comment this PR falsified.** `backlogLint.test.ts`'s `readOriginTaskFiles` block
explained its `resetModules` by saying the static import had "cached this module with the
real child_process." True before this PR; false after round 1 added a hoisted
`vi.mock('node:child_process')`, which binds that same static import to a shared
`vi.fn()`. Behavior was unaffected — `doMock` + `resetModules` still override correctly —
but the stated mechanism was wrong, which `02-code-standards.md` treats as a claim.

Checking it surfaced a **second** staleness the review did not flag, from the same PR:
the comment above it read "one of two git/OS seams **in this module** … covered above,"
and round 6's extraction moved `readTrackerGitStatus` out to `trackerGitStatus.ts`
entirely. Both rewritten.

The pattern worth naming: every structural change in this PR silently invalidated a
comment somewhere else — the hoisted mock broke a mocking-mechanism comment, the file
split broke a module-inventory comment. Neither is catchable by tests or lint, because a
comment cannot fail.

**The warning-plus-problem interaction was untested.** Every integration test had either a
clean tree with a warning or a structural problem with a quiet warning, never both, so
nothing pinned that a *failing* run still names the uncommitted file. Added, and canaried
by making the warning skip whenever problems exist.

Also worth noting the reviewer's own care here: it measured `backlogLint.ts` at 653 raw
lines, saw that this description cites 400/338, and explicitly declined to treat that as a
contradiction — correctly identifying the figures as ESLint's counted lines
(`skipBlankLines`/`skipComments`) which it had no way to re-derive. That distinction is
the exact one this PR got wrong in an earlier round, and the review did not repeat it.

## Review round 9 — one real limitation documented, one correction to the record

**The UTF-8 boundary finding is right, and it falsified a claim of mine.** A POSIX
filename is a byte string, not necessarily valid UTF-8, and `encoding: 'utf-8'` makes
Node substitute U+FFFD for any invalid sequence. Probed:

```
git -z emits:  ?? tracker/bad 377 name.md      (raw 0xFF byte, verbatim)
Node returns:  "?? tracker/bad�name.md"   (replacement char)
```

So my comment's "paths come through byte-for-byte verbatim" was true of **git** and false
**end to end** — the same overclaim shape this PR has hit repeatedly. Reworded to say
where the boundary actually is, and the limitation is now documented explicitly, the way
the octal gap was before `-z` removed it.

Left as an accepted limitation rather than fixed: a lossless round-trip means reading a
Buffer, which pushes byte-wise output onto every consumer (chalk, `console.log`) to print
it. The degradation is one replacement character inside an otherwise-correct path — not
the whole-path mangling the octal case produced — and every file the tracker CLI creates
is UTF-8.

**Correction on the `max-lines` note.** The review reads this description as saying
`backlogLint.ts` currently sits at 400/400 with zero headroom. That was the
**pre-extraction** state, and it is what motivated the split; the file has been at **338**
counted since, re-measured just now. My round-5 write-up put the before and after in a
table but referred to "zero headroom" in prose afterward without re-stating that the split
resolved it, which is a fair way to be misread — so: current counted lines are
`backlogLint.ts` **338** and `trackerGitStatus.ts` **49**, against the 400 threshold. No
trimming needed and no landmine for the next contributor.

## Review round 10 — a timeout, an import move, and a filed follow-up

**The timeout finding caught an inconsistency in this PR's own reasoning.** The docstring
argues at length for `--no-optional-locks` because a stall in the pre-push path is
unacceptable — and then left the call unbounded, so a corrupted index or a
network-mounted `.git` would block `pnpm quality` outright instead of degrading. Bounded
at 15s via an exported constant, matching `ci-gate.ts`'s pattern and its stated
"degrade, don't hang" rationale. A timeout throw lands in the existing `catch`, producing
exactly the documented silent skip with no new branch. Canaried by removing the option.

The import-grouping nit is applied (node builtins → external → relative).

**Filed TASK-541** for the reviewer's suggested follow-up rather than leaving it in prose:
`readOriginTaskFiles` and the two private `execFileSafe` helpers in `context/` are still
unbounded and run in the same hook paths. The task also records *why* a shared wrapper was
declined here (differing options per call site; `02-code-standards.md` prefers duplication
to the wrong abstraction) so it isn't re-litigated from scratch.

### Stopping condition

This is the eleventh push on ~90 lines. Every round found something real, but the last
four produced a documented limitation, a comment fix, a test, and a one-line timeout —
none changed happy-path behavior. Recording the judgment explicitly: from here, anything
short of a correctness finding gets filed and fixed forward rather than iterated in this
PR, because the marginal value per CI cycle has gone negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
