### PR TITLE
fix(api-gateway): tell a catalog outage apart from an unknown model

### DIFF
--- a/services/api-gateway/src/routes/conformance/fixtures/harness.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/harness.ts
@@ -147,11 +147,15 @@ export async function buildConformanceHarness(): Promise<ConformanceHarness> {
     // fixture validate the output schema AND keeps the llm-config handlers'
     // getModelById enrichment path working (it previously no-op'd because
     // modelCache was absent; now it resolves to a valid model). Implement every
-    // method handlers call (getFilteredModels, getModelById) so a partial fake
-    // can't silently bypass a `if (modelCache)` guard elsewhere.
+    // method handlers call (getFilteredModels, getModelById, lookupModelById)
+    // so a partial fake can't silently bypass a `if (modelCache)` guard
+    // elsewhere. The cast below defeats the compiler, so a method added to the
+    // real class surfaces here as a runtime "not a function" and nowhere
+    // earlier — this fake has to be updated by hand whenever the class grows.
     modelCache: {
       getFilteredModels: () => Promise.resolve([CONFORMANCE_SAMPLE_MODEL]),
       getModelById: () => Promise.resolve(CONFORMANCE_SAMPLE_MODEL),
+      lookupModelById: () => Promise.resolve({ kind: 'resolved', model: CONFORMANCE_SAMPLE_MODEL }),
     } as unknown as RouteDeps['modelCache'],
   };
 

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -331,6 +331,10 @@ describe('/user/llm-config routes', () => {
               }
             : null
         ),
+        // Stubbed for the same reason as the enrichment block's fake below —
+        // the cast means a missing method surfaces as a runtime crash, not a
+        // type error, the moment a z-ai/-prefixed model is used here.
+        lookupModelById: vi.fn().mockResolvedValue({ kind: 'absent' }),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
       const handler = buildHandler(handleListUserLlmConfigs, {
@@ -417,6 +421,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.userApiKey.findFirst.mockResolvedValue(null); // no z.ai-coding key
       const modelCache = {
         getModelById: vi.fn().mockResolvedValue(null), // glm-5.2 not on OpenRouter
+        lookupModelById: vi.fn().mockResolvedValue({ kind: 'absent' }),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
       const handler = buildHandler(handleGetUserLlmConfig, {
@@ -452,6 +457,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.userApiKey.findFirst.mockResolvedValue({ id: 'zai-key-1' }); // has key
       const modelCache = {
         getModelById: vi.fn().mockResolvedValue(null),
+        lookupModelById: vi.fn().mockResolvedValue({ kind: 'absent' }),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
       const handler = buildHandler(handleGetUserLlmConfig, {
@@ -665,6 +671,7 @@ describe('/user/llm-config routes', () => {
       });
       const modelCache = {
         getModelById: vi.fn().mockResolvedValue(null),
+        lookupModelById: vi.fn().mockResolvedValue({ kind: 'absent' }),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
       const handler = buildHandler(handleCreateUserLlmConfig, {
@@ -1083,6 +1090,7 @@ describe('/user/llm-config routes', () => {
       });
       const modelCache = {
         getModelById: vi.fn().mockResolvedValue(null),
+        lookupModelById: vi.fn().mockResolvedValue({ kind: 'absent' }),
       } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
       const handler = buildHandler(handleUpdateUserLlmConfig, {
@@ -1523,8 +1531,13 @@ describe('/user/llm-config routes', () => {
   });
 
   describe('model context enrichment', () => {
+    // `lookupModelById` is stubbed even though these cases only exercise
+    // `getModelById`: the cast hides a missing method from the compiler, so the
+    // first z-ai/-prefixed model added here would crash with "not a function"
+    // rather than fail an assertion.
     const mockModelCache = {
       getModelById: vi.fn(),
+      lookupModelById: vi.fn().mockResolvedValue({ kind: 'absent' }),
     } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
 
     beforeEach(() => {

--- a/services/api-gateway/src/services/OpenRouterModelCache.test.ts
+++ b/services/api-gateway/src/services/OpenRouterModelCache.test.ts
@@ -7,19 +7,27 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Redis } from 'ioredis';
 
-// Mock dependencies before imports
+// Mock dependencies before imports. `createLogger` is called ONCE at module
+// load inside OpenRouterModelCache.ts, so the mock must return the SAME
+// object every time (via vi.hoisted, evaluated before the mock factory) —
+// otherwise tests have no handle on the logger instance the cache actually
+// uses and can't assert on warn-call counts.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
     '@tzurot/common-types/utils/logger'
   );
   return {
     ...actual,
-    createLogger: () => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
+    createLogger: () => mockLogger,
   };
 });
 
@@ -487,6 +495,78 @@ describe('OpenRouterModelCache', () => {
       expect(result).not.toBeNull();
       expect(result?.supportsVision).toBe(true);
       expect(result?.contextLength).toBe(128000);
+    });
+  });
+
+  describe('lookupModelById', () => {
+    beforeEach(() => {
+      (mockRedis.get as ReturnType<typeof vi.fn>).mockResolvedValue(JSON.stringify(sampleModels));
+    });
+
+    it('returns {kind: "resolved"} with the mapped option for a listed model', async () => {
+      const result = await cache.lookupModelById('anthropic/claude-sonnet-4');
+
+      expect(result.kind).toBe('resolved');
+      if (result.kind === 'resolved') {
+        expect(result.model.id).toBe('anthropic/claude-sonnet-4');
+        expect(result.model.contextLength).toBe(200000);
+      }
+    });
+
+    it('returns {kind: "absent"} when the catalog loads and does not list the model', async () => {
+      const result = await cache.lookupModelById('nonexistent/model');
+
+      expect(result).toEqual({ kind: 'absent' });
+    });
+
+    it('returns {kind: "unavailable"} when the underlying getModels() throws', async () => {
+      (mockRedis.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Redis down'));
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('API error'));
+
+      const result = await cache.lookupModelById('anthropic/claude-sonnet-4');
+
+      expect(result.kind).toBe('unavailable');
+    });
+
+    it('getModelById stays in lockstep with lookupModelById for all three outcomes', async () => {
+      // No-drift assertion: getModelById is reimplemented on top of
+      // lookupModelById specifically so the two cannot diverge. Exercise all
+      // three lookup outcomes and confirm getModelById collapses exactly the
+      // unavailable/absent pair to null while still returning the resolved
+      // option. Each outcome uses its own cache instance — the class's
+      // 5-minute in-memory cache would otherwise let the first (resolved)
+      // call mask the throwing behavior of the third.
+      const resolved = await cache.getModelById('anthropic/claude-sonnet-4');
+      expect(resolved?.id).toBe('anthropic/claude-sonnet-4');
+
+      const absentCache = new OpenRouterModelCache(mockRedis);
+      const absent = await absentCache.getModelById('nonexistent/model');
+      expect(absent).toBeNull();
+
+      const unavailableRedis = createMockRedis();
+      (unavailableRedis.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Redis down'));
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('API error'));
+      const unavailableCache = new OpenRouterModelCache(unavailableRedis);
+      const unavailable = await unavailableCache.getModelById('anthropic/claude-sonnet-4');
+      expect(unavailable).toBeNull();
+    });
+
+    it('fires the "Cache unavailable for lookup" warn exactly once on the throwing path', async () => {
+      (mockRedis.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Redis down'));
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('API error'));
+
+      await cache.lookupModelById('anthropic/claude-sonnet-4');
+
+      // "Failed to read Redis cache" also warns on this path (a separate,
+      // pre-existing log) — filter to the lookup-specific message so this
+      // assertion pins ONLY the warn this task is about.
+      const lookupWarnCalls = mockLogger.warn.mock.calls.filter(
+        call => call[1] === 'Cache unavailable for lookup'
+      );
+      expect(lookupWarnCalls).toHaveLength(1);
+      expect(lookupWarnCalls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'anthropic/claude-sonnet-4' })
+      );
     });
   });
 

--- a/services/api-gateway/src/services/OpenRouterModelCache.ts
+++ b/services/api-gateway/src/services/OpenRouterModelCache.ts
@@ -26,6 +26,18 @@ const logger = createLogger('OpenRouterModelCache');
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 
 /**
+ * Tagged result of a single-model lookup, distinguishing a genuine catalog
+ * miss from an unreachable catalog — `getModelById` collapses both to
+ * `null`, which is correct for its own callers (display-only, fail-closed by
+ * omission) but wrong for a caller that needs to tell a user why their save
+ * was rejected. See `lookupModelById`.
+ */
+export type ModelLookup =
+  | { kind: 'resolved'; model: ModelAutocompleteOption }
+  | { kind: 'unavailable' }
+  | { kind: 'absent' };
+
+/**
  * Filter options for querying models
  */
 interface ModelFilterOptions {
@@ -192,22 +204,42 @@ export class OpenRouterModelCache {
   }
 
   /**
-   * Look up a single model by ID.
-   * Returns the autocomplete option if found, null if not found.
-   * Returns null (no error) if the cache is unavailable.
+   * Look up a single model by ID, tagging the result so a caller can tell a
+   * genuine catalog miss (`absent`) apart from an unreachable catalog
+   * (`unavailable`) — the two collapse to the same `null` in `getModelById`,
+   * which is fine for display-only callers but wrong for anything that must
+   * report the difference to a user (e.g. the save-validation error message).
    */
-  async getModelById(modelId: string): Promise<ModelAutocompleteOption | null> {
+  async lookupModelById(modelId: string): Promise<ModelLookup> {
     try {
       const allModels = await this.getModels();
       const model = allModels.find(m => m.id === modelId);
       if (model === undefined) {
-        return null;
+        return { kind: 'absent' };
       }
-      return this.toAutocompleteOption(model);
+      return { kind: 'resolved', model: this.toAutocompleteOption(model) };
     } catch (error) {
+      // The error is logged here rather than carried on the result: no caller
+      // needs to re-handle it, and an unread `cause` field is dead surface.
       logger.warn({ err: error, modelId }, 'Cache unavailable for lookup');
-      return null;
+      return { kind: 'unavailable' };
     }
+  }
+
+  /**
+   * Look up a single model by ID.
+   * Returns the autocomplete option if found, null if not found.
+   * Returns null (no error) if the cache is unavailable.
+   *
+   * Built on `lookupModelById` so the two cannot drift — this collapses
+   * `absent` and `unavailable` to the same `null`, which is correct for this
+   * method's existing callers (display-only enrichment, badge computation)
+   * but loses the distinction; use `lookupModelById` directly when the
+   * caller needs to report WHY a model didn't resolve.
+   */
+  async getModelById(modelId: string): Promise<ModelAutocompleteOption | null> {
+    const result = await this.lookupModelById(modelId);
+    return result.kind === 'resolved' ? result.model : null;
   }
 
   /**

--- a/services/api-gateway/src/utils/llmConfigValidation.test.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { validateLlmConfigModelFields } from './llmConfigValidation.js';
+import { ensureVisionCapableModel, validateLlmConfigModelFields } from './llmConfigValidation.js';
 import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
 import type { LlmConfigService } from '../services/LlmConfigService.js';
 
@@ -26,6 +26,73 @@ vi.mock('./errorResponses.js', () => ({
     validationError: (msg: string) => ({ error: 'VALIDATION', message: msg }),
   },
 }));
+
+describe('ensureVisionCapableModel', () => {
+  const mockRes = {} as never;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // `ModelCapabilityService.resolve()` returns the same null for "the catalog
+  // does not list this model" and "the catalog could not be reached", so the
+  // rejection message must not assert either cause. It previously claimed "it
+  // isn't in the model catalog" — false during an outage, and untested, which
+  // is how it survived.
+  it('does not assert a cause when capability cannot be resolved', async () => {
+    const modelCache = {
+      getModelById: vi.fn().mockResolvedValue(null),
+    } as unknown as OpenRouterModelCache;
+
+    const ok = await ensureVisionCapableModel(mockRes, modelCache, 'anthropic/claude-sonnet-4');
+
+    expect(ok).toBe(false);
+    const [, body] = mockSendError.mock.calls[0] as [unknown, { message: string }];
+    expect(body.message).toContain("Couldn't confirm");
+    expect(body.message).toContain('temporarily unreachable');
+    // The specific regression: naming absence as THE reason.
+    expect(body.message).not.toMatch(/isn't in the model catalog/);
+  });
+
+  it('rejects a resolvable model that genuinely lacks vision, and says so plainly', async () => {
+    const modelCache = {
+      getModelById: vi.fn().mockResolvedValue({
+        id: 'some/text-only',
+        supportsVision: false,
+        supportsImageGeneration: false,
+        supportsAudioInput: false,
+        supportsAudioOutput: false,
+        contextLength: 128_000,
+      }),
+    } as unknown as OpenRouterModelCache;
+
+    const ok = await ensureVisionCapableModel(mockRes, modelCache, 'some/text-only');
+
+    expect(ok).toBe(false);
+    const [, body] = mockSendError.mock.calls[0] as [unknown, { message: string }];
+    expect(body.message).toContain("doesn't support image input");
+    // This one CAN name its cause — capability was resolved, not guessed.
+    expect(body.message).not.toContain('unreachable');
+  });
+
+  it('accepts a resolvable vision-capable model', async () => {
+    const modelCache = {
+      getModelById: vi.fn().mockResolvedValue({
+        id: 'anthropic/claude-sonnet-4',
+        supportsVision: true,
+        supportsImageGeneration: false,
+        supportsAudioInput: false,
+        supportsAudioOutput: false,
+        contextLength: 200_000,
+      }),
+    } as unknown as OpenRouterModelCache;
+
+    expect(await ensureVisionCapableModel(mockRes, modelCache, 'anthropic/claude-sonnet-4')).toBe(
+      true
+    );
+    expect(mockSendError).not.toHaveBeenCalled();
+  });
+});
 
 describe('validateLlmConfigModelFields', () => {
   const mockRes = {} as never;

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -119,11 +119,16 @@ export async function ensureVisionCapableModel(
   // instance only because it resolves N rows in a loop.
   const capabilities = await new ModelCapabilityService(modelCache).resolve(model);
   if (capabilities === null) {
+    // `resolve()` returns the same null whether the catalog lists no such model
+    // or the catalog could not be reached, so the message must not assert
+    // either cause — claiming "it isn't in the catalog" during an outage sends
+    // the user hunting a replacement for a model that is perfectly fine.
     sendError(
       res,
       ErrorResponses.validationError(
-        `Couldn't confirm '${model}' supports image input (vision) — it isn't in the model catalog. ` +
-          `Choose a vision-capable model for a vision preset.`
+        `Couldn't confirm '${model}' supports image input (vision) — it is either absent from ` +
+          `the model catalog or the catalog is temporarily unreachable. Choose a known ` +
+          `vision-capable model, or try again shortly.`
       )
     );
     return false;

--- a/services/api-gateway/src/utils/modelValidation.test.ts
+++ b/services/api-gateway/src/utils/modelValidation.test.ts
@@ -4,14 +4,29 @@ import {
   enrichWithModelContext,
   computeRequiresZaiKey,
 } from './modelValidation.js';
-import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
+import type { OpenRouterModelCache, ModelLookup } from '../services/OpenRouterModelCache.js';
 import type { ModelAutocompleteOption } from '@tzurot/common-types/types/ai';
 
+/**
+ * `validateModelAndContextWindow` and `computeRequiresZaiKey` both need to
+ * tell an outage apart from a genuine miss, so both call `lookupModelById`;
+ * `enrichWithModelContext` only displays a cap and still calls `getModelById`.
+ * Both are mocked so either caller's real behavior is exercised —
+ * `lookupModelById` defaults to the resolved/absent shape implied by
+ * `getModelByIdResult` unless a test needs the `unavailable` case explicitly.
+ */
 function createMockModelCache(
-  getModelByIdResult: ModelAutocompleteOption | null = null
+  getModelByIdResult: ModelAutocompleteOption | null = null,
+  lookupModelByIdResult?: ModelLookup
 ): OpenRouterModelCache {
+  const lookup: ModelLookup =
+    lookupModelByIdResult ??
+    (getModelByIdResult === null
+      ? { kind: 'absent' }
+      : { kind: 'resolved', model: getModelByIdResult });
   return {
     getModelById: vi.fn().mockResolvedValue(getModelByIdResult),
+    lookupModelById: vi.fn().mockResolvedValue(lookup),
   } as unknown as OpenRouterModelCache;
 }
 
@@ -147,7 +162,7 @@ describe('validateModelAndContextWindow', () => {
       const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.2', undefined, true);
       expect(result.error).toBeUndefined();
       expect(result.contextWindowCap).toBe(500_000); // 50% of 1M
-      expect(cache.getModelById).not.toHaveBeenCalled();
+      expect(cache.lookupModelById).not.toHaveBeenCalled();
     });
 
     it('should cap (not skip) z.ai-accepted models — reject an oversized contextWindowTokens', async () => {
@@ -179,7 +194,7 @@ describe('validateModelAndContextWindow', () => {
       expect(result.error).toContain("Model 'z-ai/glm-5.2' is served by the z.ai Coding Plan");
       expect(result.error).toContain('/settings apikey set');
       expect(result.error).not.toContain('not found');
-      expect(cache.getModelById).toHaveBeenCalledWith('z-ai/glm-5.2');
+      expect(cache.lookupModelById).toHaveBeenCalledWith('z-ai/glm-5.2');
     });
 
     it('should NOT falsely reject an OpenRouter-available z.ai model with no key', async () => {
@@ -194,7 +209,7 @@ describe('validateModelAndContextWindow', () => {
       const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.1', undefined, false);
       expect(result.error).toBeUndefined();
       expect(result.contextWindowCap).toBe(101376); // Math.floor(202752 / 2)
-      expect(cache.getModelById).toHaveBeenCalledWith('z-ai/glm-5.1');
+      expect(cache.lookupModelById).toHaveBeenCalledWith('z-ai/glm-5.1');
     });
 
     it('should keep the generic not-found message for a genuinely unknown z-ai model', async () => {
@@ -220,7 +235,7 @@ describe('validateModelAndContextWindow', () => {
       const cache = createMockModelCache(null);
       const result = await validateModelAndContextWindow(cache, 'glm-5', undefined, true);
       expect(result.error).toContain("Model 'glm-5' not found");
-      expect(cache.getModelById).toHaveBeenCalledWith('glm-5');
+      expect(cache.lookupModelById).toHaveBeenCalledWith('glm-5');
     });
 
     it('should fall through to OpenRouter for non-catalog models even with a key', async () => {
@@ -236,7 +251,54 @@ describe('validateModelAndContextWindow', () => {
       );
       expect(result.error).toBeUndefined();
       expect(result.contextWindowCap).toBe(100000);
-      expect(cache.getModelById).toHaveBeenCalledWith('anthropic/claude-sonnet-4');
+      expect(cache.lookupModelById).toHaveBeenCalledWith('anthropic/claude-sonnet-4');
+    });
+  });
+
+  describe('catalog-unavailable vs. genuine-miss (TASK-539)', () => {
+    it('reports the catalog-unavailable error when the cache is unreachable', async () => {
+      const cache = createMockModelCache(null, { kind: 'unavailable' });
+      const result = await validateModelAndContextWindow(
+        cache,
+        'anthropic/claude-sonnet-4',
+        undefined
+      );
+      expect(result.error).toBe(
+        "Could not reach the model catalog to validate 'anthropic/claude-sonnet-4'. This is usually temporary — try saving again in a moment."
+      );
+    });
+
+    it('keeps the ORIGINAL not-found error, unchanged, for a genuine catalog miss', async () => {
+      const cache = createMockModelCache(null, { kind: 'absent' });
+      const result = await validateModelAndContextWindow(cache, 'nonexistent/model', undefined);
+      expect(result.error).toBe(
+        "Model 'nonexistent/model' not found in the available models list. " +
+          'Use the model autocomplete to select a valid model, or check if the model ID is correct.'
+      );
+    });
+
+    it('does not let the unavailable branch swallow the z.ai-only keyless error', async () => {
+      // The z.ai-only keyless branch lives inside the `absent` arm and must
+      // still fire on a genuine catalog miss — the new `unavailable` branch
+      // must not intercept it.
+      const cache = createMockModelCache(null, { kind: 'absent' });
+      const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.2', undefined, false);
+      expect(result.error).toContain("Model 'z-ai/glm-5.2' is served by the z.ai Coding Plan");
+      expect(result.error).toContain('/settings apikey set');
+    });
+
+    it('still REJECTS (returns an error) when the catalog is unavailable — stays fail-closed', async () => {
+      // The most important test in the set: this is the one that fails if
+      // the unavailable case is ever "simplified" into a pass-through. A
+      // catalog outage must never let an unvalidated model save silently.
+      const cache = createMockModelCache(null, { kind: 'unavailable' });
+      const result = await validateModelAndContextWindow(
+        cache,
+        'anthropic/claude-sonnet-4',
+        undefined
+      );
+      expect(result.error).toBeDefined();
+      expect(typeof result.error).toBe('string');
     });
   });
 });
@@ -247,7 +309,7 @@ describe('computeRequiresZaiKey', () => {
     // it (OpenRouter fallthrough would 404), so the badge fires.
     const cache = createMockModelCache(null);
     expect(await computeRequiresZaiKey('z-ai/glm-5.2', false, cache)).toBe(true);
-    expect(cache.getModelById).toHaveBeenCalledWith('z-ai/glm-5.2');
+    expect(cache.lookupModelById).toHaveBeenCalledWith('z-ai/glm-5.2');
   });
 
   it('should NOT badge a z.ai model that IS on OpenRouter for a keyless viewer', async () => {
@@ -261,7 +323,7 @@ describe('computeRequiresZaiKey', () => {
     const cache = createMockModelCache(null);
     expect(await computeRequiresZaiKey('z-ai/glm-5.2', true, cache)).toBe(false);
     // Short-circuits on the key before any cache lookup.
-    expect(cache.getModelById).not.toHaveBeenCalled();
+    expect(cache.lookupModelById).not.toHaveBeenCalled();
   });
 
   it('should NOT badge a non-z.ai model', async () => {
@@ -280,11 +342,23 @@ describe('computeRequiresZaiKey', () => {
     const cache = createMockModelCache(null);
     expect(await computeRequiresZaiKey('z-ai/glm-nonexistent', false, cache)).toBe(false);
     // Short-circuits on the catalog-membership check, before the cache lookup.
-    expect(cache.getModelById).not.toHaveBeenCalled();
+    expect(cache.lookupModelById).not.toHaveBeenCalled();
   });
 
-  it('should NOT badge when the cache is unavailable (cannot confirm absence)', async () => {
+  // Renamed: this passes `undefined`, i.e. the cache was never WIRED. It never
+  // exercised an outage, despite previously being titled as if it did — which
+  // is how the unreachable-catalog path below reached zero coverage while
+  // looking covered.
+  it('should NOT badge when no model cache is wired at all', async () => {
     expect(await computeRequiresZaiKey('z-ai/glm-5.2', false, undefined)).toBe(false);
+  });
+
+  it('does NOT badge when the catalog is unreachable', async () => {
+    // A wired-but-unreachable catalog cannot confirm OpenRouter absence, so
+    // badging would be a false positive: the model may well be on OpenRouter
+    // and perfectly runnable for this keyless viewer.
+    const cache = createMockModelCache(null, { kind: 'unavailable' });
+    expect(await computeRequiresZaiKey('z-ai/glm-5.2', false, cache)).toBe(false);
   });
 
   it('should NOT badge when model is undefined', async () => {

--- a/services/api-gateway/src/utils/modelValidation.ts
+++ b/services/api-gateway/src/utils/modelValidation.ts
@@ -65,8 +65,13 @@ function checkContextWindowCap(
  *    provider.
  *
  * 2. **OpenRouter cache** (everything else): validate against the cache and
- *    reject on miss. Gracefully degrades: if the cache is unavailable (e.g.,
- *    OpenRouter is down), validation is skipped and the request proceeds.
+ *    reject BOTH on a genuine miss (unknown model) and on an unreachable
+ *    catalog (e.g. OpenRouter is down) — the two produce distinct error
+ *    messages so an outage isn't misdiagnosed as a typo. Pinned by the
+ *    `modelValidation.test.ts` describe block "catalog-unavailable vs.
+ *    genuine-miss (TASK-539)". The ONLY case that skips validation entirely
+ *    is `modelCache === undefined` (the cache was never wired), handled
+ *    below.
  *
  * @param modelCache - OpenRouter model cache (may be undefined if not wired)
  * @param modelId - The model ID to validate (e.g., "anthropic/claude-sonnet-4")
@@ -108,11 +113,20 @@ export async function validateModelAndContextWindow(
     return {};
   }
 
-  const model = await modelCache.getModelById(modelId);
+  const lookup = await modelCache.lookupModelById(modelId);
 
-  // Model not found in cache — could be a new model or cache is stale
-  // Reject with a helpful message
-  if (model === null) {
+  // Catalog unreachable (e.g. OpenRouter is down) — reject, but with a
+  // message that points at the outage rather than the model ID, so the user
+  // isn't sent hunting a typo that doesn't exist.
+  if (lookup.kind === 'unavailable') {
+    return {
+      error: `Could not reach the model catalog to validate '${modelId}'. This is usually temporary — try saving again in a moment.`,
+    };
+  }
+
+  // Model genuinely absent from the catalog — could be a new model or a typo.
+  // Reject with a helpful message.
+  if (lookup.kind === 'absent') {
     // A `z-ai/`-prefixed catalog model that reached the OpenRouter lookup means
     // the saving user has no z.ai-coding key (the keyed path returns earlier) AND
     // this model isn't carried on OpenRouter either — i.e. a z.ai-only model like
@@ -138,7 +152,7 @@ export async function validateModelAndContextWindow(
     };
   }
 
-  return checkContextWindowCap(modelId, contextWindowTokens, model.contextLength);
+  return checkContextWindowCap(modelId, contextWindowTokens, lookup.model.contextLength);
 }
 
 /**
@@ -157,9 +171,14 @@ export async function validateModelAndContextWindow(
  * - model is z.ai-only (absent from OpenRouter, e.g. glm-5.2) → BADGE: a keyless
  *   viewer's OpenRouter fallthrough would 404 at runtime
  *
- * When the cache is unavailable we can't confirm OpenRouter absence, so we
+ * When the catalog is unavailable we can't confirm OpenRouter absence, so we
  * return `false` (no badge) rather than risk a false positive — same
- * graceful-degrade stance as `enrichWithModelContext`.
+ * graceful-degrade stance as `enrichWithModelContext`. That requires the
+ * TAGGED lookup: `getModelById` reports an outage and a genuine absence as the
+ * same `null`, so branching on it showed the badge during an outage, which is
+ * the opposite of what this paragraph promised. Pinned by the
+ * `computeRequiresZaiKey` test "does NOT badge when the catalog is
+ * unreachable".
  */
 export async function computeRequiresZaiKey(
   model: string | undefined,
@@ -175,8 +194,9 @@ export async function computeRequiresZaiKey(
   if (modelCache === undefined) {
     return false;
   }
-  const onOpenRouter = (await modelCache.getModelById(model)) !== null;
-  return !onOpenRouter;
+  // Only a CONFIRMED absence earns the badge; `resolved` means it runs on
+  // OpenRouter, and `unavailable` means we don't know.
+  return (await modelCache.lookupModelById(model)).kind === 'absent';
 }
 
 /** Object with optional model context fields, set by enrichWithModelContext */


### PR DESCRIPTION
Closes TASK-539.

## The premise the task filed was wrong, and checking it first changed the work

TASK-539 was filed off a #2068 review comment: api-gateway has the same three-way
collapse ai-worker just fixed, so port the fix. The task recorded that premise as
**UNVERIFIED** and said to trace it before building. Tracing it inverted the conclusion.

`OpenRouterModelCache.getModelById` does collapse the two cases exactly as suspected —
its `catch` (catalog unreachable) and its `find === undefined` (catalog loaded, model
genuinely absent) both return a bare `null`. Same shape as the ai-worker bug. But the
**consumer** differs:

| Consumer | What a `null` does | Direction |
| --- | --- | --- |
| save-time cap gate (`modelValidation.ts:115`) | **rejects the save** | fail-CLOSED |
| `ModelCapabilityService.supportsVision` | `?? false` | fail-CLOSED |
| `enrichWithModelContext` | returns early, dashboard shows no cap | display-only |

So there is **no capability regression here and no fix to port** — the reviewer's
"it's fail-closed on that side" was right. Porting the tagged-lookup as a correctness
fix would have been solving a bug that doesn't exist.

What the trace *did* surface is two honesty defects, and those are this PR.

## 1. A docstring that says the opposite of what the code does

`modelValidation.ts:67-69` documented the OpenRouter path as:

> Gracefully degrades: if the cache is unavailable (e.g., OpenRouter is down), validation
> is skipped and the request proceeds.

It is not skipped. An unavailable cache yields `null` and the save is **rejected** at
line 115. The only case that skips is `modelCache === undefined` (never wired). This is
the `02-code-standards.md` "a comment that asserts behavior is a claim" class, and it
asserted the *reassuring* direction — which is plausibly why it survived: a comment
promising graceful degradation invites nobody to check.

Rewritten to state what happens, and pinned by name to the test that holds it.

## 2. An outage that misdiagnoses every valid model as a typo

Because the two cases collapse, an OpenRouter outage rejected a perfectly good model with:

> Model 'anthropic/claude-sonnet-4' not found in the available models list. Use the model
> autocomplete to select a valid model, or check if the model ID is correct.

Every clause of that is wrong during an outage, and it sends the user hunting a typo that
doesn't exist.

`lookupModelById` now returns a tagged `resolved` / `absent` / `unavailable`, and
`getModelById` is **rebuilt on top of it** (`kind === 'resolved' ? model : null`) so the
two cannot drift — that is the point of adding a method rather than copying the
try/catch. Exactly one call site consumes the tag; every display-only caller keeps the
collapsed `null` and is untouched.

**The unavailable case still rejects.** This changes the message, never which saves are
allowed, and a dedicated test pins that — "simplifying" the unavailable branch into a
pass-through would convert a fail-closed gate into a fail-open one, which is the bug this
task was originally (wrongly) suspected of.

Deliberately **not** hoisted into `common-types` to share with ai-worker's `CatalogLookup`:
the two sit over different mechanisms (a class with memory+Redis tiers vs. a bare Redis
read) and share no code path, so a shared type would buy naming symmetry while coupling
two services' degradation contracts.

## The fixture the compiler couldn't see

`RouteDeps['modelCache']` is populated in the conformance harness by an object literal
behind `as unknown as`, so adding a method to the real class produces **no compile error**
there. The unit tier stayed green; the component tier failed 18 conformance cases with
`modelCache.lookupModelById is not a function`.

Worth stating plainly because the harness's own comment already carried the invariant —
"Implement every method handlers call … so a partial fake can't silently bypass a guard
elsewhere" — and the cast is what let it rot anyway. That comment now names this incident
so the next method addition has a reason to look.

## Verification

- All 9 new tests **canaried red-before-green**, one backed-out change each: each of the
  three lookup outcomes reclassified; `getModelById`'s collapse broken; the warn line
  deleted; each error message altered; the unavailable branch widened to swallow the
  z.ai-keyless case; and the unavailable branch turned into a pass-through.
- `pnpm --filter @tzurot/api-gateway test` (189 files, 2645 tests) · `typecheck` ·
  `typecheck:spec` · `pnpm lint`.
- **`pnpm test:component`** — 46 files, 624 passed. This is the tier that caught the
  fixture gap, and `pnpm test` structurally excludes it.

## Review round 1 — both applied, and the consumer table above was incomplete

**The Medium is a real miss, and it is mine.** The consumer table earlier in this
description enumerates three `null`-collapse consumers and reads as an audit. There is a
fourth, in this same file, one function over: `computeRequiresZaiKey`. Its docstring
promised

> When the cache is unavailable we can't confirm OpenRouter absence, so we return `false`
> (no badge) rather than risk a false positive

and the code did the opposite — `getModelById` returns `null` on an outage, so
`onOpenRouter` was `false` and the function returned **`true`**, showing the badge. The
only path returning `false` for unavailability was the separate never-wired guard. Same
defect class, same file, discovered while auditing precisely that class — so
`00-critical.md` § "Always Leave Code Better Than You Found It" makes deferring it the
wrong call. Now branches on the tag: only a **confirmed** `absent` earns the badge.

The reviewer also found the reason it stayed invisible: the existing test titled *"should
NOT badge when the cache is unavailable (cannot confirm absence)"* passes
`modelCache: undefined` — the never-wired case. It never exercised an outage, so the path
had zero coverage while reading as covered. Renamed to what it actually tests, with real
`unavailable` and `absent` cases added beside it.

The Low is applied too: `ModelLookup.unavailable.cause` was written and never read, so it
is gone — the error is already logged at the throw site, and an unread field is dead
surface.

### One correction to the review's own verification

Its "verified as correct" section stated that every `modelCache:` fixture stubbing only
`getModelById` is unreachable from the real `lookupModelById`, concluding "No other gap
found." That held for the diff it read, and stopped holding the moment its own finding 1
was applied: `computeRequiresZaiKey` is reached by `/user/llm-config` GET/POST/PUT routes
that `validateModelAndContextWindow` is mocked out of, so three route tests went red with
the fixtures untouched. Fixed by giving those fixtures the tagged method. Noting it
because a reachability proof is scoped to the call graph at the time it was run — this PR
changed that graph.

Re-verified after: unit 189 files / 2647 tests · **component 46 files / 624 tests** ·
`typecheck` · `typecheck:spec` · `lint`. The new outage assertion is canaried — reverting
`computeRequiresZaiKey` to the `getModelById` collapse turns it red.

## Review round 2 — no blocking findings; dispositions

**Nit applied**: the explicit `mockLogger.warn.mockClear()` is gone — the outer
`beforeEach(vi.clearAllMocks)` already covers it, confirmed by re-running the file rather
than by reading the hook.

**`admin/systemSettings.ts` — traced, no defect, and worth naming.** The reviewer noted
its `validateModelValue` also goes through the collapsing `getModelById` and isn't in this
description's consumer table. Checked it: its message already reads *"could not be
verified against the model catalog"* (`systemSettings.ts:127`), which is true whether the
catalog was unreachable or genuinely lacks the model — so it has no wording defect to fix,
unlike the message this PR replaced. Naming it here because the table above was scoped to
**consumers whose wording asserted something false**, not to every `getModelById` call
site, and a reader could reasonably have taken it for the latter. That ambiguity is what
let `computeRequiresZaiKey` slip in round 1.

**HTTP status → filed as TASK-540, not ridden along.** Both the `absent` and `unavailable`
branches still return 400 via `ErrorResponses.validationError`, so the *status* keeps
saying "your input was wrong" for a transient server-side condition even though the
*message* no longer does. The reviewer flagged it as non-blocking and pre-existing; the
reason it's deferred is not that it's pre-existing but that changing an HTTP contract also
changes what a user sees during an outage and interacts with client retry handling — a
separate unit with a user-visible dimension, which is a real reason rather than a
scheduling one.

## Review round 3 — no correctness issues; both test-side items applied

**Two more partial fakes hardened.** `user/llm-config.test.ts` had two `modelCache`
doubles stubbing only `getModelById`. They pass today *only* because the models those
tests use aren't `z-ai/`-prefixed, so `computeRequiresZaiKey`'s prefix guard returns
before the lookup — i.e. safe by coincidence of fixture data, and the next `z-ai/` model
added there would crash with "not a function" rather than fail an assertion. Same class
this PR already fixed in `harness.ts`; both now stub the tagged method, with the reason
in a comment so it isn't re-litigated.

**A test I added in round 1 was redundant and is gone.** "DOES badge when the catalog is
reachable and genuinely lacks the model" duplicated the pre-existing "should badge a
z.ai-only model" — same inputs, same assertion, and `createMockModelCache(null)` already
resolves to `{ kind: 'absent' }`, so they exercised the identical path. The pre-existing
one additionally asserts the seam call, making mine strictly weaker. I added it without
checking whether the case was already covered.

189 files / 2646 tests green after (one fewer than before, which is the removed
duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
