### PR TITLE
docs(rules): correct four staleness gaps in always-loaded surfaces

### DIFF
--- a/.claude/rules/02-code-standards.md
+++ b/.claude/rules/02-code-standards.md
@@ -4,13 +4,21 @@
 
 | Rule                     | Limit | Level | Fix Strategy           |
 | ------------------------ | ----- | ----- | ---------------------- |
-| `max-lines`              | 400   | Error | Split + move tests     |
-| `max-lines-per-function` | 100   | Warn  | Extract helpers        |
+| `max-lines`              | 400\* | Error | Split + move tests     |
+| `max-lines-per-function` | 100\* | Warn  | Extract helpers        |
 | `complexity`             | 20    | Warn  | Data-driven approach   |
 | `max-depth`              | 4     | Warn  | Early returns, extract |
 | `max-params`             | 5     | Warn  | Options object pattern |
 | `max-nested-callbacks`   | 3     | Warn  | Extract/flatten        |
 | `max-statements`         | 50    | Warn  | Extract helpers        |
+
+**\* Both line rules run with `skipBlankLines` + `skipComments`**
+(separate `max-lines` and `max-lines-per-function` blocks in `eslint.config.js`,
+carrying the same options), so `wc -l` is NOT the metric — a comment-heavy
+395-raw-line file counted 196, and an unnecessary extraction was justified on
+that false premise. `pnpm lint` is the only arbiter; to see the counted size,
+force it out with
+`npx eslint <file> --rule '{"max-lines":["error",{"max":1,"skipBlankLines":true,"skipComments":true}]}'`.
 
 **Note**: Test files (`*.test.ts`, `*.spec.ts`) are excluded from the
 size/complexity limits above but are still linted (vitest correctness + style
@@ -66,6 +74,14 @@ lookahead prevents backtracking") claim just as much. Naming a mechanism alone
 does not ("uses a lookahead to skip whitespace"), and neither does
 design-structure prose ("cannot be extracted"). Name the test, or hedge in the
 comment itself (`// not verified: assumes the caller already acked`).
+
+**A comment explaining code by what a DEPENDENCY does is an external-system
+claim** — `00-critical.md`'s probe-first rule applies at the moment you write
+the comment, not only when you state the claim in prose. "cac returns the last
+value for a repeated flag", "the timeout means it was delivered": probe (a
+`--help`, a one-line call) or hedge in the comment. Explaining a shape feels
+like documentation rather than assertion, which is exactly why this shape got
+past the rule twice in one session.
 
 In CODE files the VALUE half (`never null`, `always populated`, `cannot be
 <value>`) is caught mechanically by `claim-shape-guard.sh`, which skips `*.md`

--- a/.claude/rules/03-database.md
+++ b/.claude/rules/03-database.md
@@ -166,19 +166,21 @@ const cache = new TTLCache<ValueType>({
 
 `Tier` is the durability tier — see [durability-tiers.md](../../docs/reference/architecture/durability-tiers.md) for what each means and how to sort a new cache into one. **1** = recomputable for free, loss is correctness-neutral. **2** = costs money to regenerate and is conversation-scoped (the history row is the system of record; Redis is L1 only). **3** = costs money and the asset outlives the conversation (needs a home that is not a TTL).
 
-| Cache              | Location                     | TTL           | Tier | Type                                 |
-| ------------------ | ---------------------------- | ------------- | ---- | ------------------------------------ |
-| Channel Activation | `gatewayServiceCalls.ts`     | 30s           | 1    | TTLCache + pub/sub                   |
-| Admin Settings     | `gatewayServiceCalls.ts`     | 60s           | 1    | TTLCache (in-memory)                 |
-| Personality        | `PersonalityService.ts`      | 5 min         | 1    | TTLCache + pub/sub                   |
-| Personality (bot)  | `HttpPersonalityLoader.ts`   | 5 min         | 1    | TTLCache (+ 60s negative)            |
-| Denylist           | `DenylistCache.ts`           | -             | 1    | In-memory + pub/sub                  |
-| User               | `UserService.ts`             | **1h**        | 1    | TTLCache (in-memory)                 |
-| Autocomplete       | `autocompleteCache.ts`       | 60s           | 1    | TTLCache (+ LRU-bounded stale, 500)  |
-| OpenRouter Models  | `OpenRouterModelCache.ts`    | **5 min/24h** | 1    | **Two-tier**: memory L1 → Redis      |
-| Vision Description | `VisionDescriptionCache.ts`  | 1h            | 2    | Redis L1 over `attachmentEnrichment` |
-| Voice Transcript   | `VoiceTranscriptCache.ts`    | **1h**        | 2    | **Redis-backed**, L1 over the row    |
-| Redis Dedup        | `RedisDeduplicationCache.ts` | configurable  | 1    | Redis-backed                         |
+| Cache               | Location                     | TTL           | Tier | Type                                 |
+| ------------------- | ---------------------------- | ------------- | ---- | ------------------------------------ |
+| Channel Activation  | `gatewayServiceCalls.ts`     | 30s           | 1    | TTLCache + pub/sub                   |
+| Admin Settings      | `gatewayServiceCalls.ts`     | 60s           | 1    | TTLCache (in-memory)                 |
+| Personality         | `PersonalityService.ts`      | 5 min         | 1    | TTLCache + pub/sub                   |
+| Personality (bot)   | `HttpPersonalityLoader.ts`   | 5 min         | 1    | TTLCache (+ 60s negative)            |
+| Denylist            | `DenylistCache.ts`           | -             | 1    | In-memory + pub/sub                  |
+| User                | `UserService.ts`             | **1h**        | 1    | TTLCache (in-memory)                 |
+| Autocomplete        | `autocompleteCache.ts`       | 60s           | 1    | TTLCache (+ LRU-bounded stale, 500)  |
+| OpenRouter Models   | `OpenRouterModelCache.ts`    | **5 min/24h** | 1    | **Two-tier**: memory L1 → Redis      |
+| Vision Description  | `VisionDescriptionCache.ts`  | 1h            | 2    | Redis L1 over `attachmentEnrichment` |
+| Voice Transcript    | `VoiceTranscriptCache.ts`    | **1h**        | 2    | **Redis-backed**, L1 over the row    |
+| Redis Dedup         | `RedisDeduplicationCache.ts` | configurable  | 1    | Redis-backed                         |
+| Model Capability    | `ModelCapabilityChecker.ts`  | 5 min         | 1    | TTLCache (maxSize 500)               |
+| Context-Length Memo | `ModelCapabilityChecker.ts`  | 24h           | 1    | TTLCache (maxSize 500)               |
 
 Three rows were wrong before the durability audit and are corrected in bold: `User` said 5 min (it is 1h — `USER_CACHE_TTL_MS`), `OpenRouter Models` hid its 5-minute in-memory L1 in front of the 24h Redis entry, and `Voice Transcript` said "Custom (in-memory)" with no TTL when it is Redis `setex` at `INTERVALS.VOICE_TRANSCRIPT_TTL`. **Verify a row against the constant before relying on it** — every value here was re-read from source, and a stale TTL in an always-loaded table is a wrong premise in every session that reads it.
 

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -154,13 +154,20 @@ All guards hard-fail on findings. `guard:workflow-sync` covers ONLY `claude-code
 ### Backlog lint + digest
 
 ```bash
-pnpm ops backlog                     # Gate: now.md caps + queue.md doc references + task-file integrity + open-task triage labels
+pnpm ops backlog                     # Gate: structural checks over now.md, cross-references, and tracker task files
 pnpm backlog:lint                    # Same check (root-level shortcut)
 pnpm ops backlog:digest              # Session-start briefing from tracker/: per-area counts, oldest 20, newest 10
 pnpm tracker task list --search <t> --plain   # Query the small-item pool (Backlog.md CLI)
 ```
 
 Gate details and the triage axes live in `06-backlog.md`. The digest never gates — it's the session-start aging surface.
+
+**The check list is `backlogLint.ts`'s `problems` array, not this line** — three
+additions landed without this description moving, so read the array rather than
+trusting an enumeration here. `pnpm ops backlog` ALSO prints a **non-gating**
+warning naming any uncommitted file under `tracker/` (invisible to every query
+until committed); it never sets the exit code, so an uncommitted task file does
+not fail CI.
 
 ### Audit-tool infrastructure (Layers 1-3)
 
@@ -186,7 +193,7 @@ EOF
 ```
 
 **Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `debug` (+ standard `build`, `ci`, `revert`, `style`; every valid type is also a valid branch prefix)
-**Scopes:** `ai-worker`, `api-gateway`, `bot-client`, `common-types`, `ci`, `deps`
+**Scopes:** every `packages/` + `services/` directory name (generated), plus `tests` and the static root set — `backlog`, `ci`, `deps`, `docs`, `hooks`, `husky`, `legal`, `prisma`, `repo`, `rules`, `skills`. Source of truth is `allScopes` in `commitlint.config.cjs`; read it rather than trusting a list here.
 
 **Commitlint gotchas** (the hook catches these, but every trip costs a retry): the **full header must be ≤100 chars** (`header-max-length` — the most-tripped rule in practice; count before writing a long subject), the subject must start **lowercase** (`subject-case`), and the scope must be in the configured enum **or omitted entirely** — an unknown scope is rejected, no scope is fine.
 

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-08-11'
+lastUpdated: '2026-08-12'
 ---
 
 # Git Workflow Procedures
@@ -37,7 +37,7 @@ EOF
 
 **Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `debug`
 (`debug` = temporary diagnostic instrumentation, added then removed; see `.claude/rules/05-tooling.md` § "The `debug` type" for when to use it vs. `chore`/`feat`.)
-**Scopes:** `ai-worker`, `api-gateway`, `bot-client`, `common-types`, `ci`, `deps`
+**Scopes:** generated from every `packages/`+`services/` directory, plus `tests` and a static root set (`backlog`, `ci`, `deps`, `docs`, `hooks`, `husky`, `legal`, `prisma`, `repo`, `rules`, `skills`) — source of truth is `allScopes` in `commitlint.config.cjs`.
 
 **Command-shape rules for commit/push** (each class cost multiple cycles in practice):
 


### PR DESCRIPTION
Four review-surfaced corrections to `.claude/rules`, batched into one review-gated PR rather than fragmenting across four. Each was parked because `.claude/rules` is review-gated and the current Opus-5 orchestrator trial (TASK-513) excludes rules edits; the owner widened that boundary for this PR specifically.

Every fact below was re-verified against source in this session, not carried from the task descriptions.

### TASK-538 — `max-lines` is not `wc -l` (`02-code-standards.md`)

The ESLint Limits table listed `400 / Error` with no note that the rule runs `skipBlankLines: true, skipComments: true` (`eslint.config.js:382` — read, confirmed). A reader measuring with `wc -l` concludes a comment-heavy file is over the limit when its counted size is under half that. This happened on #2068: a 395-raw-line file counted 196, and an unnecessary module extraction was performed and justified in the PR body on the false premise — which two review rounds then accepted as accurate.

Both line rules now carry a `*` pointing at a note that names the skip options, says `pnpm lint` is the only arbiter, and gives the one-liner that forces ESLint's own count out.

### TASK-520 — a comment explaining code by what a *dependency* does is an external-system claim (`02-code-standards.md`)

`00-critical.md` already carries the probe-first constraint AND a decision-point trigger, and it was violated twice in one session anyway (#2060: a `cac` repeated-flag claim a probe refuted; #2061: a claim that a timeout implies delivery, when `AbortSignal.timeout` is created at the fetch call and so covers DNS and connect). Both were reviewer catches.

The gap was the trigger's framing, not the constraint: it targets *stating* a claim, which reads as prose or a PR body, so writing a JSDoc that explains why code is shaped a certain way never registered as the moment. Added as one paragraph to the sibling clause in § "A Comment That Asserts Behavior Is a Claim".

I did **not** extend `claim-shape-guard.sh` to catch this (the task raised it as an open question). The shape is "a dependency name followed by a behavioral verb" — the guard has no way to distinguish a dependency name from any other identifier, so it would fire on ordinary prose. Judgment, not a hook.

### TASK-523 — `pnpm ops backlog` description + commit scopes (`05-tooling.md`)

Two separate staleness items in one file, both fixed by naming the source of truth instead of re-listing:

- **The gate description** had drifted past three additions (relative-link resolution and `doc-N` cross-refs from #2063, the uncommitted-tracker warning from #2069). I read `backlogLint.ts`'s `problems` array directly: it runs `checkNowCaps`, `checkQueueDocRefs`, `checkDocIdRefs`, `checkRelativeLinks`, tracker-parse problems, `checkTaskTriage`, `checkDuplicateTaskIds`, `checkOriginIdCollisions`. Rather than re-enumerate a list that has now drifted three times, the line points at the array. The **uncommitted-tracker warning is explicitly marked non-gating** — it prints after `reportProblems` and never touches the exit code (verified at `backlogLint.ts:635-647`), so a reader taking it for a gate would have it exactly backwards.
- **The scope list** (`ai-worker, api-gateway, bot-client, common-types, ci, deps`) was a strict subset of commitlint's `allScopes`, which is generated from every `packages/`+`services/` directory plus a static root set the doc never mentioned: `backlog, ci, deps, docs, hooks, husky, legal, prisma, repo, rules, skills`. The failure direction is the expensive one — an agent trusting the doc believes a valid scope is invalid, omits it, and passes anyway, so it never learns otherwise. (This very PR commits as `docs(rules)`, a scope the old list said did not exist.)

### TASK-537 — two missing cache rows (`03-database.md`)

Both `ModelCapabilityChecker.ts` caches were absent from an inventory whose own text says a wrong row is "a wrong premise in every session that reads it". TTLs re-read from source per that section's instruction:

- `capabilityCache` — `AI_DEFAULTS.MODEL_CAPABILITY_CACHE_TTL_MS` = `5 * 60 * 1000` ✓ 5 min, `maxSize: 500`, Tier 1
- `lastKnownContextLength` — `AI_DEFAULTS.MODEL_CONTEXT_LENGTH_MEMO_TTL_MS` = `INTERVALS.OPENROUTER_MODELS_TTL * 1000`, and `OPENROUTER_MODELS_TTL = 24 * 60 * 60` ✓ 24h, `maxSize: 500`, Tier 1

Both are Tier 1 — recomputable from the OpenRouter catalog, loss is correctness-neutral.

## Verification

- `pnpm quality` — green (full static gate, including `lines:check` and `guard:gate-parity`).
- `pnpm ops lines:check` — rules at **147436/154502 bytes** and **2049/2147 lines**, both within budget.
- `pnpm test` **not run, deliberately**: the diff is markdown-only under `.claude/rules/`, so no TypeScript changed and the unit suite has nothing to exercise. The pre-push hook reached the same classification independently and skipped build+tests.

## Backlog

TASK-520, TASK-523, TASK-537, TASK-538 all close with this PR. TASK-531 (run every command a skill documents) was listed as a co-rider in some task blockers but is a **skills** change, not a rules change — it stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)