### PR TITLE
fix(tooling): bound the gate-reachable synchronous shell-outs (partial pass)

### DIFF
--- a/packages/tooling/src/audits/baseline-meta.test.ts
+++ b/packages/tooling/src/audits/baseline-meta.test.ts
@@ -2,15 +2,37 @@
  * Tests for the baseline metadata helpers.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// The only shell-out in this module is the SHA read inside buildBaselineMeta.
+// Returns a well-formed 40-hex SHA so the shape assertion below still means
+// what it did when this test read the real repo.
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => `${'a1b2c3d4'.repeat(5)}\n`),
+}));
+
+import { execFileSync } from 'node:child_process';
 import {
   buildBaselineMeta,
   checkMetaDrift,
   hashConfigSlice,
+  BASELINE_SHA_TIMEOUT_MS,
   type BaselineMeta,
 } from './baseline-meta.js';
 
 describe('buildBaselineMeta', () => {
+  it('bounds the git SHA read with BASELINE_SHA_TIMEOUT_MS', () => {
+    vi.mocked(execFileSync).mockClear();
+
+    buildBaselineMeta('1.0.0', 'abc123def456');
+
+    const calls = vi.mocked(execFileSync).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call[2]).toMatchObject({ timeout: BASELINE_SHA_TIMEOUT_MS });
+    }
+  });
+
   it('returns a populated meta block', () => {
     const meta = buildBaselineMeta('1.0.0', 'abc123def456');
     expect(meta.toolVersion).toBe('1.0.0');

--- a/packages/tooling/src/audits/baseline-meta.ts
+++ b/packages/tooling/src/audits/baseline-meta.ts
@@ -123,11 +123,21 @@ export function hashConfigSlice(slice: unknown): string {
   return createHash('sha256').update(serialized).digest('hex').slice(0, 12);
 }
 
+/**
+ * Bound on the SHA read. Only the manual `*:update-baseline` commands reach
+ * this — not the gate — so the stake is a developer watching a stalled
+ * command rather than a blocked pipeline. Bounded anyway: it is the same
+ * catch-and-degrade shape as every other probe, and the catch below already
+ * answers `unknown`.
+ */
+export const BASELINE_SHA_TIMEOUT_MS = 15_000;
+
 function getGitSha(): string {
   try {
     return execFileSync('git', ['rev-parse', 'HEAD'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: BASELINE_SHA_TIMEOUT_MS,
     }).trim();
   } catch {
     return 'unknown';

--- a/packages/tooling/src/audits/check-claude-content-refs.test.ts
+++ b/packages/tooling/src/audits/check-claude-content-refs.test.ts
@@ -3,6 +3,12 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+
+// Every other test here injects `validCommands`, so this mock is reached only
+// by the default-path test below — the one case that spawns `pnpm ops --help`.
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn(() => '') }));
+
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -10,6 +16,7 @@ import {
   findContentRefs,
   parseRegisteredCommands,
   checkClaudeContentRefs,
+  OPS_HELP_TIMEOUT_MS,
 } from './check-claude-content-refs.js';
 import { parseSummary } from './summary.js';
 
@@ -268,6 +275,51 @@ describe('checkClaudeContentRefs (CLI entry point with --summary)', () => {
       expect(summary.findings).toBe(0);
       expect(exitSpy).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('fetchRegisteredCommands (no injected validCommands)', () => {
+  it('bounds the `pnpm ops --help` spawn with OPS_HELP_TIMEOUT_MS', async () => {
+    vi.mocked(execFileSync).mockClear();
+
+    await withTempRepo(async root => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        // No `validCommands`, so the guard falls through to the real spawn.
+        await checkClaudeContentRefs({ repoRoot: root, summary: true });
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+
+    const calls = vi.mocked(execFileSync).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call[2]).toMatchObject({ timeout: OPS_HELP_TIMEOUT_MS });
+    }
+  });
+});
+
+describe('fetchRegisteredCommands timeout handling', () => {
+  it('throws on a timeout kill rather than parsing the partial help text', async () => {
+    // Non-empty partial stdout is the hazard: without the guard it passes the
+    // length check and parses as the COMPLETE command set, so every command
+    // past the truncation point reads as a dangling reference and reddens
+    // `pnpm quality` on a clean commit.
+    vi.mocked(execFileSync).mockImplementation(() => {
+      const error = new Error('timed out') as Error & { code: string; stdout: string };
+      error.code = 'ETIMEDOUT';
+      error.stdout = 'Commands:\n  db:status   Show migration status\n  db:mig';
+      throw error;
+    });
+
+    await withTempRepo(async root => {
+      await expect(checkClaudeContentRefs({ repoRoot: root, summary: true })).rejects.toThrow(
+        /Timed out fetching/
+      );
+    });
+
+    vi.mocked(execFileSync).mockImplementation(() => '');
   });
 });
 

--- a/packages/tooling/src/audits/check-claude-content-refs.ts
+++ b/packages/tooling/src/audits/check-claude-content-refs.ts
@@ -19,6 +19,7 @@ import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { emitSummary } from './summary.js';
+import { isTimeoutKill } from '../utils/timeoutKill.js';
 
 /**
  * Threshold beyond which a file's `lastUpdated` frontmatter triggers a
@@ -225,6 +226,15 @@ export function parseRegisteredCommands(helpOutput: string): Set<string> {
 }
 
 /**
+ * Bound on the help spawn. This guard runs inside `pnpm quality`, so an
+ * unbounded stall blocks the gate outright. Generous because the call boots
+ * pnpm, tsx and the whole CLI — a short bound would redden a working gate,
+ * and a timeout here lands in the existing throw path below rather than
+ * silently yielding an empty command set.
+ */
+export const OPS_HELP_TIMEOUT_MS = 60_000;
+
+/**
  * Fetch the registered command set by invoking `pnpm ops --help` and
  * parsing the output. Spawns the actual CLI so the audit catches the
  * same commands `pnpm ops` would surface in interactive use.
@@ -236,6 +246,7 @@ function fetchRegisteredCommands(repoRoot: string): Set<string> {
       cwd: repoRoot,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: OPS_HELP_TIMEOUT_MS,
     });
   } catch (err) {
     // pnpm ops --help may exit non-zero on the unsupported-engine warning,
@@ -248,6 +259,16 @@ function fetchRegisteredCommands(repoRoot: string): Set<string> {
     // pnpm ops reference looks dangling, masking the real cause behind
     // a confusing avalanche of false-positive findings. Throw with the
     // original error attached so the failure is attributable.
+    // A TIMEOUT kill also carries stdout — partial, whatever the CLI had
+    // written before the SIGTERM — and non-empty partial help text would pass
+    // the length check below and parse as the COMPLETE command set. Every
+    // command past the truncation point would then read as dangling, reddening
+    // `pnpm quality` on a clean commit for no reason a reader could find.
+    // Same guard as `getPendingMigrations` in `session-context.ts`; see
+    // `utils/timeoutKill.ts` for the measurement behind it.
+    if (isTimeoutKill(err)) {
+      throw new Error('Timed out fetching the pnpm ops command list', { cause: err });
+    }
     const rawStdout = (err as { stdout?: unknown }).stdout;
     if (typeof rawStdout === 'string' && rawStdout.length > 0) {
       output = rawStdout;

--- a/packages/tooling/src/context/session-context.test.ts
+++ b/packages/tooling/src/context/session-context.test.ts
@@ -46,6 +46,78 @@ describe('getSessionContext', () => {
   });
 
   describe('git state', () => {
+    it('bounds every execFileSafe shell-out with SESSION_CONTEXT_TIMEOUT_MS', async () => {
+      execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args.includes('rev-parse')) return 'main';
+        if (cmd === 'git' && args.includes('status')) return '';
+        if (cmd === 'git' && args.includes('log')) return '';
+        return '';
+      });
+
+      const { getSessionContext, SESSION_CONTEXT_TIMEOUT_MS } =
+        await import('./session-context.js');
+      await getSessionContext({ skipMigrations: true });
+
+      const gitCalls = execFileSyncMock.mock.calls.filter(call => call[0] === 'git');
+      expect(gitCalls.length).toBeGreaterThan(0);
+      for (const call of gitCalls) {
+        expect(call[2]).toMatchObject({ timeout: SESSION_CONTEXT_TIMEOUT_MS });
+      }
+    });
+
+    it('bounds the prisma migration check with its own larger timeout', async () => {
+      // The migration check only runs when the migrations directory exists and
+      // skipMigrations is not set — the default path for `pnpm ops context`.
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockReturnValue('');
+
+      const { getSessionContext, MIGRATION_STATUS_TIMEOUT_MS } =
+        await import('./session-context.js');
+      await getSessionContext({});
+
+      const npxCalls = execFileSyncMock.mock.calls.filter(call => call[0] === 'npx');
+      expect(npxCalls.length).toBeGreaterThan(0);
+      for (const call of npxCalls) {
+        expect(call[2]).toMatchObject({ timeout: MIGRATION_STATUS_TIMEOUT_MS });
+      }
+    });
+
+    it('reports migrations as UNKNOWN on a timeout kill, not as "none pending"', async () => {
+      // The regression this guards: a killed prisma still carries stdout, and
+      // the content branch below would read the empty/partial text as "no
+      // pending migrations" — a confident wrong answer in session startup.
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') {
+          const error = new Error('timed out') as Error & { code: string; stdout: string };
+          error.code = 'ETIMEDOUT';
+          error.stdout = '';
+          throw error;
+        }
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      // `null` skips the section entirely. Without the guard the empty stdout
+      // parses as an empty pending list, which prints the all-clear — the
+      // exact wrong answer, so that string is what this asserts against.
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).not.toContain('All migrations applied');
+      // Pin the null path specifically, not merely the absence of one string:
+      // the whole section is skipped. Without this, a regression that dropped
+      // the migration block entirely would still satisfy the assertion above.
+      expect(output).not.toContain('Migrations');
+      // ...and prove the run still completed, so "section skipped" is
+      // distinguishable from "died before printing anything". (Git state is
+      // also absent here — this fixture returns '' for git, so that section
+      // legitimately skips too; the banner is what proves the run finished.)
+      expect(output).toContain('SESSION CONTEXT');
+    });
+
     it('should show current branch', async () => {
       execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
         if (cmd === 'git' && args.includes('rev-parse')) return 'feature/test-branch';

--- a/packages/tooling/src/context/session-context.ts
+++ b/packages/tooling/src/context/session-context.ts
@@ -9,6 +9,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import chalk from 'chalk';
+import { isTimeoutKill } from '../utils/timeoutKill.js';
 
 /* eslint-disable sonarjs/cognitive-complexity, sonarjs/no-duplicate-string -- CLI orchestrator: git state collection → migration status → service health with decorative output separators */
 
@@ -25,6 +26,25 @@ interface GitState {
 }
 
 /**
+ * Bound on everything `execFileSafe` runs — the local git probes AND
+ * `getCIStatus`'s `gh` calls, one of which (`gh run list`) is a network round
+ * trip. Deliberately one value despite that split, unlike
+ * `check-workflow-sync.ts`, which gives its network `git fetch` a larger
+ * bound: there, a spurious timeout silently skips a guard whose whole job is
+ * catching drift, so the cost is asymmetric. Here every failure already
+ * degrades to `null` and the caller just omits a display section, and 15s on
+ * a `gh` call matches `ci-gate.ts`'s existing `HEAD_FETCH_TIMEOUT_MS`.
+ */
+export const SESSION_CONTEXT_TIMEOUT_MS = 15_000;
+
+/**
+ * Separate, larger bound for the migration check. That call spawns npx, boots
+ * the Prisma CLI and opens a database connection, so it is legitimately far
+ * slower than a git probe — the git value would make a working check flaky.
+ */
+export const MIGRATION_STATUS_TIMEOUT_MS = 60_000;
+
+/**
  * Execute a command safely with array arguments (no shell injection)
  */
 function execFileSafe(command: string, args: string[], cwd: string): string | null {
@@ -33,6 +53,7 @@ function execFileSafe(command: string, args: string[], cwd: string): string | nu
       encoding: 'utf-8',
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: SESSION_CONTEXT_TIMEOUT_MS,
     }).trim();
   } catch {
     return null;
@@ -114,8 +135,16 @@ function getPendingMigrations(cwd: string): string[] | null {
       encoding: 'utf-8',
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: MIGRATION_STATUS_TIMEOUT_MS,
     });
   } catch (error) {
+    // A timeout kill must NOT fall through to the stdout branch below. Node
+    // still attaches whatever stdout was captured before the SIGTERM, and
+    // prisma typically hangs on the DB connection before printing anything —
+    // so the partial (usually empty) output would fail the content match and
+    // return [], reporting "no migrations pending" when the truth is unknown.
+    // `code` is the discriminator: `killed` is undefined on this path.
+    if (isTimeoutKill(error)) return null;
     // Prisma migrate status exits with non-zero when migrations are pending
     // We need to capture the output from stderr/stdout
     if (error && typeof error === 'object' && 'stdout' in error) {

--- a/packages/tooling/src/context/session-state.test.ts
+++ b/packages/tooling/src/context/session-state.test.ts
@@ -26,7 +26,12 @@ vi.mock('node:fs', () => ({
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
-import { saveSession, loadSession, clearSession } from './session-state.js';
+import {
+  saveSession,
+  loadSession,
+  clearSession,
+  SESSION_STATE_TIMEOUT_MS,
+} from './session-state.js';
 
 describe('session-state', () => {
   let consoleLogSpy: MockInstance;
@@ -59,6 +64,16 @@ describe('session-state', () => {
   });
 
   describe('saveSession', () => {
+    it('bounds every execFileSafe shell-out with SESSION_STATE_TIMEOUT_MS', async () => {
+      await saveSession();
+
+      const gitCalls = vi.mocked(execFileSync).mock.calls.filter(call => call[0] === 'git');
+      expect(gitCalls.length).toBeGreaterThan(0);
+      for (const call of gitCalls) {
+        expect(call[2]).toMatchObject({ timeout: SESSION_STATE_TIMEOUT_MS });
+      }
+    });
+
     it('should save session state to file', async () => {
       await saveSession();
 

--- a/packages/tooling/src/context/session-state.ts
+++ b/packages/tooling/src/context/session-state.ts
@@ -22,6 +22,13 @@ interface SessionState {
 const SESSION_FILE = '.claude-session.json';
 
 /**
+ * Bound on every shell-out this module makes. `execFileSafe` already treats
+ * any failure as `null` — bounded, a stall degrades into that same answer
+ * instead of hanging a session save/load.
+ */
+export const SESSION_STATE_TIMEOUT_MS = 15_000;
+
+/**
  * Execute a command safely with array arguments
  */
 function execFileSafe(command: string, args: string[], cwd: string): string | null {
@@ -30,6 +37,7 @@ function execFileSafe(command: string, args: string[], cwd: string): string | nu
       encoding: 'utf-8',
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: SESSION_STATE_TIMEOUT_MS,
     }).trim();
   } catch {
     return null;

--- a/packages/tooling/src/dev/backlogLint.test.ts
+++ b/packages/tooling/src/dev/backlogLint.test.ts
@@ -972,4 +972,22 @@ describe('readOriginTaskFiles', () => {
 
     expect(readOriginTaskFiles('/repo')).toEqual({ resolvable: false, files: [] });
   });
+
+  it('bounds both git calls with ORIGIN_TASKS_TIMEOUT_MS', async () => {
+    const calls: { args: string[]; options: unknown }[] = [];
+    vi.doMock('node:child_process', () => ({
+      execFileSync: (_cmd: string, args: string[], options: unknown) => {
+        calls.push({ args, options });
+        return '';
+      },
+    }));
+    const { readOriginTaskFiles, ORIGIN_TASKS_TIMEOUT_MS } = await import('./backlogLint.js');
+
+    readOriginTaskFiles('/repo');
+
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.options).toMatchObject({ timeout: ORIGIN_TASKS_TIMEOUT_MS });
+    }
+  });
 });

--- a/packages/tooling/src/dev/backlogLint.ts
+++ b/packages/tooling/src/dev/backlogLint.ts
@@ -458,12 +458,20 @@ function fileIdToken(path: string): string {
   return name.split(' ')[0].replace(/\.md$/i, '').toLowerCase();
 }
 
+/**
+ * Bound on both origin reads below. This runs inside `pnpm quality` and CI;
+ * a stalled git must degrade to the documented `resolvable: false` answer
+ * rather than hang the gate.
+ */
+export const ORIGIN_TASKS_TIMEOUT_MS = 15_000;
+
 /** Read the origin listing via git; unresolvable is a normal, non-fatal answer. */
 export function readOriginTaskFiles(rootDir: string): OriginTaskListing {
   try {
     execFileSync('git', ['rev-parse', '--verify', 'origin/develop'], {
       cwd: rootDir,
       stdio: 'ignore',
+      timeout: ORIGIN_TASKS_TIMEOUT_MS,
     });
   } catch {
     return { resolvable: false, files: [] };
@@ -472,7 +480,12 @@ export function readOriginTaskFiles(rootDir: string): OriginTaskListing {
     const raw = execFileSync(
       'git',
       ['ls-tree', '-r', '--name-only', 'origin/develop', '--', 'tracker/tasks/'],
-      { cwd: rootDir, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }
+      {
+        cwd: rootDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: ORIGIN_TASKS_TIMEOUT_MS,
+      }
     );
     return {
       resolvable: true,

--- a/packages/tooling/src/dev/check-deferred-refs.test.ts
+++ b/packages/tooling/src/dev/check-deferred-refs.test.ts
@@ -16,6 +16,7 @@ import {
   extractDeferredRefs,
   matchFiles,
   checkDeferredRefs,
+  DEFERRED_REFS_TIMEOUT_MS,
 } from './check-deferred-refs.js';
 import type { TrackerTask } from './trackerTasks.js';
 
@@ -331,6 +332,19 @@ describe('checkDeferredRefs (CLI entry)', () => {
 
     expect(readdirSync).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('bounds the staged-file git read with DEFERRED_REFS_TIMEOUT_MS', async () => {
+    mockStore(SAMPLE_TASKS);
+    vi.mocked(execFileSync).mockReturnValue('README.md\n');
+
+    await checkDeferredRefs({ staged: true });
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      ['diff', '--cached', '--name-only'],
+      expect.objectContaining({ timeout: DEFERRED_REFS_TIMEOUT_MS })
+    );
   });
 
   it('accepts an explicit file list without touching git', async () => {

--- a/packages/tooling/src/dev/check-deferred-refs.ts
+++ b/packages/tooling/src/dev/check-deferred-refs.ts
@@ -218,10 +218,19 @@ export function matchFiles(files: string[], refs: DeferredRef[]): DeferredMatch[
   return matches;
 }
 
+/**
+ * Bound on the staged-file read. This tool is wired into pre-commit and
+ * pre-push and is informational-only — the outer `checkDeferredRefs` catch
+ * already treats any failure as "skip the reminder", so a bounded stall
+ * degrades into that same silent skip instead of hanging the hook.
+ */
+export const DEFERRED_REFS_TIMEOUT_MS = 15_000;
+
 /** Resolve the staged file list from git */
 function getStagedFiles(): string[] {
   const output = execFileSync('git', ['diff', '--cached', '--name-only'], {
     encoding: 'utf-8',
+    timeout: DEFERRED_REFS_TIMEOUT_MS,
   });
   return output.split('\n').filter(line => line.length > 0);
 }

--- a/packages/tooling/src/dev/check-workflow-sync.test.ts
+++ b/packages/tooling/src/dev/check-workflow-sync.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Every other test here injects `runGit`, so this mock is reached only by the
+// default-path test below — the one case that exercises the real `execFileSync`.
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn(() => '') }));
+
+import { execFileSync } from 'node:child_process';
 import {
   checkWorkflowSync,
   diffWorkflowsAgainstMain,
   isMainCutBranch,
   resolveExplicitBase,
+  WORKFLOW_SYNC_TIMEOUT_MS,
+  WORKFLOW_FETCH_TIMEOUT_MS,
 } from './check-workflow-sync.js';
 
 /** Build a runGit stub from a handler map keyed on the git subcommand. */
@@ -28,6 +36,46 @@ describe('resolveExplicitBase', () => {
     // Push-only CI never sets GITHUB_BASE_REF, and GITHUB_REF is the branch\'s
     // own name — deliberately NOT used as a target signal.
     expect(resolveExplicitBase({ env: { GITHUB_REF: 'refs/heads/fix/ci-typo' } })).toBeNull();
+  });
+});
+
+describe('defaultRunGit (no injected runGit)', () => {
+  it('bounds the LOCAL git shell-outs with WORKFLOW_SYNC_TIMEOUT_MS', () => {
+    vi.mocked(execFileSync).mockClear();
+    vi.mocked(execFileSync).mockReturnValue('');
+
+    // No `runGit` in the options, so the guard falls through to defaultRunGit.
+    // Every ref resolves here, so no fetch is reached — all calls are local.
+    checkWorkflowSync({ env: {} });
+
+    const calls = vi.mocked(execFileSync).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call[1]).not.toContain('fetch');
+      expect(call[2]).toMatchObject({ timeout: WORKFLOW_SYNC_TIMEOUT_MS });
+    }
+  });
+
+  it('gives the NETWORK fetch its own larger bound', () => {
+    // A local-probe value is the wrong scale for a round trip to GitHub, and
+    // this guard fails open — so a spurious timeout would silently skip the
+    // check that catches workflow drift.
+    vi.mocked(execFileSync).mockClear();
+    vi.mocked(execFileSync).mockImplementation(((_cmd: string, args: string[]) => {
+      // Missing ref (the shallow-checkout case) is what drives ensureRef to fetch.
+      if (args[0] === 'rev-parse') throw new Error('unknown revision');
+      return '';
+    }) as unknown as typeof execFileSync);
+
+    checkWorkflowSync({ env: {} });
+
+    const fetches = vi.mocked(execFileSync).mock.calls.filter(c => c[1]?.[0] === 'fetch');
+    expect(fetches.length).toBeGreaterThan(0);
+    for (const call of fetches) {
+      expect(call[2]).toMatchObject({ timeout: WORKFLOW_FETCH_TIMEOUT_MS });
+    }
+
+    vi.mocked(execFileSync).mockReturnValue('');
   });
 });
 

--- a/packages/tooling/src/dev/check-workflow-sync.ts
+++ b/packages/tooling/src/dev/check-workflow-sync.ts
@@ -50,8 +50,28 @@ export interface WorkflowSyncOptions {
   runGit?: (args: string[]) => string;
 }
 
+/**
+ * Bound on the LOCAL git calls this guard makes (`rev-parse`, `merge-base`,
+ * `diff`). Runs inside `pnpm quality` and CI, and the failure path already
+ * fails open with a warning — bounded, a stall lands in that same path
+ * instead of hanging the gate.
+ */
+export const WORKFLOW_SYNC_TIMEOUT_MS = 15_000;
+
+/**
+ * Separate, larger bound for the one NETWORK call — `ensureRef`'s
+ * `git fetch`. A local-probe value is the wrong scale for a round trip to
+ * GitHub, and the cost of getting it wrong is asymmetric here: this guard
+ * fails OPEN, so a spurious timeout skips the check silently, and the thing
+ * it checks is whether a workflow-file drift has silently disabled
+ * claude-review on every PR. A slow network must not look like "no drift".
+ */
+export const WORKFLOW_FETCH_TIMEOUT_MS = 60_000;
+
 function defaultRunGit(args: string[]): string {
-  return execFileSync('git', args, { encoding: 'utf-8' });
+  // `fetch` is the only network op in this module; everything else is local.
+  const timeout = args[0] === 'fetch' ? WORKFLOW_FETCH_TIMEOUT_MS : WORKFLOW_SYNC_TIMEOUT_MS;
+  return execFileSync('git', args, { encoding: 'utf-8', timeout });
 }
 
 /**

--- a/packages/tooling/src/dev/find-dead-files.test.ts
+++ b/packages/tooling/src/dev/find-dead-files.test.ts
@@ -162,11 +162,47 @@ describe('find-dead-files', () => {
       ]);
 
       expect(result).toBe(true);
+      const { DEAD_FILES_GREP_TIMEOUT_MS } = await import('./find-dead-files.js');
       expect(mockExecFileSync).toHaveBeenCalledWith(
         'grep',
         expect.arrayContaining(['/foo\\.js[\'"]', 'services/', 'packages/']),
-        expect.anything()
+        expect.objectContaining({ timeout: DEAD_FILES_GREP_TIMEOUT_MS })
       );
+    });
+
+    it('answers TRUE on a timeout kill, so an unknown is never called dead', async () => {
+      // The two failures are not symmetric: grep's exit-1 means "no importers"
+      // (below), but a timeout means "we did not find out". Answering false
+      // there would promote a live file onto the deletion-candidate list.
+      const { hasNonTestImporters } = await import('./find-dead-files.js');
+
+      mockExecFileSync.mockImplementation(() => {
+        const error = new Error('timed out') as Error & { code: string; stdout: string };
+        error.code = 'ETIMEDOUT';
+        error.stdout = ''; // partial/empty, exactly as a real kill leaves it
+        throw error;
+      });
+
+      expect(
+        hasNonTestImporters('services/bot-client/src/utils/live.ts', ['services/', 'packages/'])
+      ).toBe(true);
+    });
+
+    it('answers TRUE on a grep ERROR (exit 2), not "no importers"', async () => {
+      // Exit 2 is grep's "I could not do the search" (unreadable dir, bad
+      // pattern) — distinct from exit 1's definite no-match. Only exit 1 may
+      // send a file to the deletion-candidate list.
+      const { hasNonTestImporters } = await import('./find-dead-files.js');
+
+      mockExecFileSync.mockImplementation(() => {
+        const error = new Error('grep error') as Error & { status: number };
+        error.status = 2;
+        throw error;
+      });
+
+      expect(
+        hasNonTestImporters('services/bot-client/src/utils/live.ts', ['services/', 'packages/'])
+      ).toBe(true);
     });
 
     it('should return false when grep finds no matches', async () => {
@@ -260,9 +296,13 @@ describe('find-dead-files', () => {
         throw error;
       });
 
-      // Second call: grep for deadCode importers (no matches = dead)
+      // Second call: grep for deadCode importers (no matches = dead).
+      // `status: 1` is what grep actually sets for no-match; only that exit
+      // code means "definitely no importers".
       mockExecFileSync.mockImplementationOnce(() => {
-        throw new Error('No matches');
+        const error = new Error('No matches') as Error & { status: number };
+        error.status = 1;
+        throw error;
       });
 
       const result = findDeadFiles();
@@ -308,9 +348,11 @@ describe('find-dead-files', () => {
         throw error;
       });
 
-      // grep: no importers
+      // grep: no importers — `status: 1` is grep's real no-match exit code.
       mockExecFileSync.mockImplementationOnce(() => {
-        throw new Error('No matches');
+        const error = new Error('No matches') as Error & { status: number };
+        error.status = 1;
+        throw error;
       });
 
       runFindDeadFiles();

--- a/packages/tooling/src/dev/find-dead-files.ts
+++ b/packages/tooling/src/dev/find-dead-files.ts
@@ -51,6 +51,14 @@ export function filterFalsePositives(files: string[]): string[] {
 }
 
 /**
+ * Bound on the importer-verification grep, so a stall degrades instead of
+ * hanging the caller. The catch below treats ONLY grep's exit-1 as "no
+ * matches": a timeout or any other failure answers "unknown", because "no
+ * importers" is what promotes a file onto the dead list.
+ */
+export const DEAD_FILES_GREP_TIMEOUT_MS = 15_000;
+
+/**
  * Check if a file has any non-test importers using grep.
  * Returns true if the file is imported by at least one non-test file
  * (other than itself).
@@ -74,7 +82,11 @@ export function hasNonTestImporters(filePath: string, searchDirs: string[]): boo
         `/${name}\\.js['"]`,
         ...searchDirs,
       ],
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: DEAD_FILES_GREP_TIMEOUT_MS,
+      }
     );
 
     // Filter out the file itself from results
@@ -84,9 +96,15 @@ export function hasNonTestImporters(filePath: string, searchDirs: string[]): boo
       .filter(line => line.length > 0 && line !== filePath);
 
     return importers.length > 0;
-  } catch {
-    // grep returns exit code 1 when no matches found
-    return false;
+  } catch (error) {
+    // Only grep's exit 1 actually means "no matches". Exit 2 (unreadable dir,
+    // bad pattern), a timeout kill, or a spawn failure all mean "we did not
+    // find out" — and here the two answers are not equally safe, because a
+    // wrong `false` promotes a live file onto the dead-file list. Anything
+    // that is not a definite no-match answers `true`, so an unknown never
+    // becomes a deletion candidate.
+    const status = (error as { status?: unknown }).status;
+    return status !== 1;
   }
 }
 
@@ -106,6 +124,8 @@ export function findDeadFiles(): FindDeadFilesResult {
   // Run knip in production mode
   let knipOutput: string;
   try {
+    // Deliberately unbounded: a full-repo knip pass legitimately runs for
+    // minutes, so a short timeout would turn this working gate flaky.
     knipOutput = execFileSync('pnpm', ['knip', '--production', '--include', 'files'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/tooling/src/dev/focus-runner.test.ts
+++ b/packages/tooling/src/dev/focus-runner.test.ts
@@ -81,6 +81,22 @@ describe('focus-runner', () => {
       );
     });
 
+    it('bounds every git call with FOCUS_RUNNER_TIMEOUT_MS', async () => {
+      mockExecFileSync
+        .mockReturnValueOnce('feature-branch\n') // git branch --show-current
+        .mockReturnValueOnce('abc123\n') // git rev-parse origin/develop
+        .mockReturnValueOnce(''); // git status --porcelain
+
+      const { runFocusedTask, FOCUS_RUNNER_TIMEOUT_MS } = await import('./focus-runner.js');
+
+      runFocusedTask({ task: 'test' });
+
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      for (const call of mockExecFileSync.mock.calls) {
+        expect(call[2]).toMatchObject({ timeout: FOCUS_RUNNER_TIMEOUT_MS });
+      }
+    });
+
     it('should use HEAD^1 when on main branch', async () => {
       // Setup git commands for main branch
       mockExecFileSync

--- a/packages/tooling/src/dev/focus-runner.ts
+++ b/packages/tooling/src/dev/focus-runner.ts
@@ -17,6 +17,13 @@ interface FocusRunnerOptions {
 }
 
 /**
+ * Bound on every git call this runner makes. Each call already degrades to a
+ * fallback or `null`/`false` on failure — bounded, a stall lands in that same
+ * degradation path instead of hanging a local `pnpm focus:*` invocation.
+ */
+export const FOCUS_RUNNER_TIMEOUT_MS = 15_000;
+
+/**
  * Detect the appropriate git base for comparison
  */
 function detectGitBase(): string | null {
@@ -24,6 +31,7 @@ function detectGitBase(): string | null {
     const branch = execFileSync('git', ['branch', '--show-current'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: FOCUS_RUNNER_TIMEOUT_MS,
     }).trim();
 
     if (branch === 'main' || branch === 'master') {
@@ -35,6 +43,7 @@ function detectGitBase(): string | null {
       execFileSync('git', ['rev-parse', '--verify', 'origin/develop'], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: FOCUS_RUNNER_TIMEOUT_MS,
       });
       return 'origin/develop';
     } catch {
@@ -43,6 +52,7 @@ function detectGitBase(): string | null {
         execFileSync('git', ['rev-parse', '--verify', 'origin/main'], {
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: FOCUS_RUNNER_TIMEOUT_MS,
         });
         return 'origin/main';
       } catch {
@@ -62,6 +72,7 @@ function hasUncommittedChanges(): boolean {
     const status = execFileSync('git', ['status', '--porcelain'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: FOCUS_RUNNER_TIMEOUT_MS,
     }).trim();
     return status.length > 0;
   } catch {
@@ -98,6 +109,9 @@ export function runFocusedTask(options: FocusRunnerOptions): void {
   console.log(`\x1b[36m› Running focused ${task}...\x1b[0m`);
   console.log(`\x1b[90m› turbo ${turboArgs.join(' ')}\x1b[0m\n`);
 
+  // Deliberately unbounded: this is the actual lint/test/build run, not a
+  // probe, so it legitimately runs for minutes — a bound would turn a working
+  // command flaky. Same reasoning as the knip spawn in find-dead-files.ts.
   const result = spawnSync('turbo', turboArgs, {
     stdio: 'inherit',
     shell: false,

--- a/packages/tooling/src/gh/ci-gate.test.ts
+++ b/packages/tooling/src/gh/ci-gate.test.ts
@@ -213,6 +213,67 @@ describe('describeHeadMismatch', () => {
   });
 });
 
+describe('gitHasCommit timeout wiring', () => {
+  it('passes COMMIT_CHECK_TIMEOUT_MS to the underlying git call', async () => {
+    // The tests below run real git, so nothing there observes the option.
+    vi.resetModules();
+    const opts: Record<string, unknown>[] = [];
+    vi.doMock('node:child_process', () => ({
+      execFileSync: (_cmd: string, _args: string[], o: Record<string, unknown>) => {
+        opts.push(o);
+        return '';
+      },
+    }));
+    const mod = await import('./ci-gate.js');
+    mod.gitHasCommit('a'.repeat(40));
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+
+    expect(opts).toHaveLength(1);
+    expect(opts[0].timeout).toBe(mod.COMMIT_CHECK_TIMEOUT_MS);
+  });
+
+  it('answers TRUE on a timeout, so a busy git does not read as a bad SHA', async () => {
+    // `false` here hard-aborts gate arming with "does not name a commit",
+    // telling the caller to use `$(git rev-parse HEAD)` — which the mandated
+    // invocation already does. Unknown must not impersonate not-found.
+    vi.resetModules();
+    vi.doMock('node:child_process', () => ({
+      execFileSync: () => {
+        const error = new Error('timed out') as Error & { code: string };
+        error.code = 'ETIMEDOUT';
+        throw error;
+      },
+    }));
+    const mod = await import('./ci-gate.js');
+    const result = mod.gitHasCommit('a'.repeat(40));
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+
+    expect(result).toBe(true);
+  });
+
+  it('still answers FALSE for a genuinely absent commit', async () => {
+    // The check's actual purpose: a hand-completed SHA must still be rejected
+    // before the gate burns its full timeout polling for a commit that isn't
+    // there. The timeout carve-out must not weaken this.
+    vi.resetModules();
+    vi.doMock('node:child_process', () => ({
+      execFileSync: () => {
+        const error = new Error('not found') as Error & { status: number };
+        error.status = 1;
+        throw error;
+      },
+    }));
+    const mod = await import('./ci-gate.js');
+    const result = mod.gitHasCommit('b'.repeat(40));
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+
+    expect(result).toBe(false);
+  });
+});
+
 describe('gitHasCommit', () => {
   it('resolves HEAD of this repo', () => {
     const head = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
@@ -641,6 +702,27 @@ describe('the argv that actually reaches gh', () => {
     const warnings: string[] = [];
     await captureArgv(mod => mod.fetchRuns('a'.repeat(40), m => warnings.push(m)), full);
     expect(warnings[0]).toContain('page ceiling');
+  });
+
+  it('bounds the report pass but leaves the watch pass unbounded', async () => {
+    // The watch pass is deliberately a long wait; a bound there would defeat
+    // it. Only the single report call the agent reads carries a timeout.
+    vi.resetModules();
+    const opts: Record<string, unknown>[] = [];
+    vi.doMock('node:child_process', () => ({
+      execFileSync: (_cmd: string, _args: string[], o: Record<string, unknown>) => {
+        opts.push(o);
+        return '';
+      },
+    }));
+    const mod = await import('./ci-gate.js');
+    mod.runChecks(1992, true);
+    mod.runChecks(1992, false);
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+
+    expect(opts[0].timeout).toBeUndefined();
+    expect(opts[1].timeout).toBe(mod.CHECKS_REPORT_TIMEOUT_MS);
   });
 
   it('watches with an explicit interval, then reports without watching', async () => {

--- a/packages/tooling/src/gh/ci-gate.ts
+++ b/packages/tooling/src/gh/ci-gate.ts
@@ -25,6 +25,7 @@
 import { execFileSync } from 'node:child_process';
 import { UsageError } from '../utils/errors.js';
 import { REPO } from './github-api.js';
+import { isTimeoutKill } from '../utils/timeoutKill.js';
 
 /** Full 40-char hex. The API silently returns nothing for an abbreviated SHA. */
 const FULL_SHA = /^[0-9a-f]{40}$/i;
@@ -113,6 +114,13 @@ export interface GateArgs {
 }
 
 /**
+ * Bound on the local existence check. Unlike the fetches below, a timeout
+ * here is answered as "exists" rather than folded into the not-found path —
+ * see the catch for why the two answers must differ.
+ */
+export const COMMIT_CHECK_TIMEOUT_MS = 15_000;
+
+/**
  * Whether the SHA names a commit in this repo.
  *
  * The format check alone is not enough, and the gap is not hypothetical: a SHA
@@ -124,9 +132,21 @@ export interface GateArgs {
  */
 export function gitHasCommit(sha: string): boolean {
   try {
-    execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], { stdio: 'ignore' });
+    execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], {
+      stdio: 'ignore',
+      timeout: COMMIT_CHECK_TIMEOUT_MS,
+    });
     return true;
-  } catch {
+  } catch (error) {
+    // A TIMEOUT is "could not check", not "does not exist" — and the two must
+    // not share an answer, because `false` here hard-aborts gate arming with a
+    // message telling the caller to use `$(git rev-parse HEAD)`, which is
+    // exactly what they did. Answer true and let the runs-API polling be the
+    // arbiter, matching how `fetchPrHeadSha`/`classifyHeadSha` treat their own
+    // "could not tell" below. A genuinely absent object fails this check fast;
+    // a slow one means git is busy (repack/gc, disk contention), not that the
+    // commit is missing.
+    if (isTimeoutKill(error)) return true;
     return false;
   }
 }
@@ -456,6 +476,18 @@ export async function waitForCi(sha: string, deps: WaitDeps): Promise<WaitOutcom
   }
 }
 
+/**
+ * Bound on the REPORT pass only. The watch pass is deliberately a long wait —
+ * bounding it would defeat its purpose — so it stays unbounded and the bound
+ * applies solely to the single `gh pr checks` call the agent reads.
+ *
+ * Deliberately looser than the 15s `gh api` bounds above: those fetch one JSON
+ * document, while this renders the whole check list, and losing it costs the
+ * agent the report the gate exists to produce. The bound is here to stop a
+ * hang, not to enforce a latency budget.
+ */
+export const CHECKS_REPORT_TIMEOUT_MS = 60_000;
+
 export function runChecks(prNumber: number, watch: boolean, log = console.log): void {
   const args = ['pr', 'checks', String(prNumber)];
   if (watch) args.push('--watch', '--interval=30');
@@ -464,6 +496,7 @@ export function runChecks(prNumber: number, watch: boolean, log = console.log): 
       encoding: 'utf-8',
       // The watch pass is only a wait; the final pass is the report the agent reads.
       stdio: watch ? ['pipe', 'ignore', 'ignore'] : ['pipe', 'inherit', 'inherit'],
+      timeout: watch ? undefined : CHECKS_REPORT_TIMEOUT_MS,
     });
   } catch (error) {
     // A NONZERO EXIT is expected and must be ignored: `gh pr checks` exits

--- a/packages/tooling/src/test/mutation-gate.test.ts
+++ b/packages/tooling/src/test/mutation-gate.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { evaluateMutationGate, runMutationGate } from './mutation-gate.js';
+import {
+  evaluateMutationGate,
+  runMutationGate,
+  MUTATION_GATE_TIMEOUT_MS,
+} from './mutation-gate.js';
 import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
@@ -103,12 +107,12 @@ describe('runMutationGate', () => {
     expect(mockExec).toHaveBeenCalledWith(
       'git',
       ['diff', '--name-only', 'origin/main...HEAD'],
-      expect.anything()
+      expect.objectContaining({ timeout: MUTATION_GATE_TIMEOUT_MS })
     );
     expect(mockExec).toHaveBeenCalledWith(
       'pnpm',
       ['exec', 'turbo', 'ls', '--filter', '...[origin/main]', '--output=json'],
-      expect.anything()
+      expect.objectContaining({ timeout: MUTATION_GATE_TIMEOUT_MS })
     );
   });
 

--- a/packages/tooling/src/test/mutation-gate.ts
+++ b/packages/tooling/src/test/mutation-gate.ts
@@ -78,9 +78,18 @@ export function evaluateMutationGate(
   return { run: reasons.length > 0, reasons };
 }
 
+/**
+ * Bound on both shell-outs below. This gate is FAIL-OPEN (see the module
+ * doc): a bounded stall throws into the existing `catch` in `runMutationGate`
+ * and yields `run: true`, same as any other evaluation error, instead of
+ * hanging the CI step.
+ */
+export const MUTATION_GATE_TIMEOUT_MS = 15_000;
+
 function gitChangedFiles(base: string): string[] {
   const out = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], {
     encoding: 'utf-8',
+    timeout: MUTATION_GATE_TIMEOUT_MS,
   });
   return out
     .split('\n')
@@ -94,6 +103,7 @@ function turboAffectedPackages(base: string): string[] {
     ['exec', 'turbo', 'ls', '--filter', `...[${base}]`, '--output=json'],
     {
       encoding: 'utf-8',
+      timeout: MUTATION_GATE_TIMEOUT_MS,
     }
   );
   // turbo's version banner goes to stderr, but be defensive about any

--- a/packages/tooling/src/utils/timeoutKill.test.ts
+++ b/packages/tooling/src/utils/timeoutKill.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { isTimeoutKill } from './timeoutKill.js';
+
+describe('isTimeoutKill', () => {
+  it('is true for a REAL timeout kill, with the partial-stdout hazard present', () => {
+    // Deliberately not a synthetic `{ code: 'ETIMEDOUT' }` fixture: the whole
+    // point of this helper is what Node actually attaches, so the test drives
+    // a genuine bounded child. The command prints before sleeping, so the
+    // thrown error carries partial stdout — the exact shape that makes a
+    // content-branching catch return a confident wrong answer.
+    let caught: unknown;
+    try {
+      execFileSync('sh', ['-c', 'printf partial; sleep 5'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 300,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(isTimeoutKill(caught)).toBe(true);
+    // Pin the two facts the module's doc comment asserts, so a Node change
+    // that moves them fails here rather than silently disabling the guard.
+    expect((caught as { stdout?: string }).stdout).toBe('partial');
+    expect((caught as { killed?: unknown }).killed).toBeUndefined();
+  });
+
+  it('is false for an ordinary non-zero exit that carries real output', () => {
+    // The case the guard must NOT swallow: `grep`-style exit 1, where the
+    // catch legitimately wants to inspect the output.
+    let caught: unknown;
+    try {
+      execFileSync('sh', ['-c', 'printf real; exit 1'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 30_000,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(isTimeoutKill(caught)).toBe(false);
+    expect((caught as { stdout?: string }).stdout).toBe('real');
+  });
+
+  it('is false for non-error inputs rather than throwing', () => {
+    expect(isTimeoutKill(undefined)).toBe(false);
+    expect(isTimeoutKill(null)).toBe(false);
+    expect(isTimeoutKill('ETIMEDOUT')).toBe(false);
+    expect(isTimeoutKill({})).toBe(false);
+    expect(isTimeoutKill(new Error('plain'))).toBe(false);
+  });
+});

--- a/packages/tooling/src/utils/timeoutKill.ts
+++ b/packages/tooling/src/utils/timeoutKill.ts
@@ -1,0 +1,47 @@
+/**
+ * Distinguishing a bounded shell-out's TIMEOUT from an ordinary non-zero exit.
+ *
+ * Why this exists as its own module: adding a `timeout` to an `execFileSync`
+ * call replaces "hangs forever" with "throws" — which is an improvement only
+ * when the surrounding `catch` treats the throw honestly. Several catches in
+ * this package branch on the error's `stdout` content, because a non-zero exit
+ * legitimately carries the output they want (`prisma migrate status` exits
+ * non-zero precisely when migrations are pending; `grep` exits 1 on no match).
+ * A timeout kill lands in that same catch carrying PARTIAL output, so those
+ * branches would read it as a real, complete answer and return a confident
+ * wrong result instead of an honest "unknown".
+ *
+ * Measured, not assumed — probing `execFileSync` against a command killed by
+ * its own `timeout` option gives:
+ *
+ *   code    = 'ETIMEDOUT'
+ *   signal  = 'SIGTERM'
+ *   killed  = undefined      <-- NOT true; a `killed` check never fires
+ *   stdout  = whatever was written before the kill
+ *
+ * `code` is therefore the discriminator. `killed` is the intuitive guess and
+ * the wrong one: a guard written against it type-checks, reads correctly, and
+ * silently never fires.
+ *
+ * Both facts above — the populated `stdout` and the undefined `killed` — are
+ * pinned by `timeoutKill.test.ts`, which drives a real bounded child rather
+ * than a synthetic error fixture, so a Node change that moves them fails the
+ * suite instead of quietly disabling this guard.
+ */
+
+/**
+ * Whether a thrown `execFileSync`/`spawnSync` error is a timeout kill.
+ *
+ * Call this FIRST in any catch that inspects `stdout`/`stderr` content, and
+ * answer "unknown" on true. `getPendingMigrations` (returns `null`) and
+ * `fetchRegisteredCommands` (rethrows) are the two shapes that answer takes.
+ *
+ * Not every site needs this helper: where a catch already discriminates on
+ * the exit code, a timeout falls out for free — `hasNonTestImporters` treats
+ * only grep's exit 1 as a real no-match, and a timeout carries no `status` at
+ * all, so it lands in the "unknown" arm without naming this function.
+ */
+export function isTimeoutKill(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  return (error as { code?: unknown }).code === 'ETIMEDOUT';
+}


### PR DESCRIPTION
Partial pass on TASK-541 — **does not close it**. See "Scope" below for exactly what is and is not covered.

#2069 bounded `readTrackerGitStatus` after review pointed out that a synchronous git call inside `pnpm quality` and the pre-push hook blocks the gate outright if it stalls, rather than degrading. The same shape survived elsewhere in `packages/tooling`.

## Approach

Most bounded sites already had a `try`/`catch` treating any failure as one normal answer, so a timeout throw lands in the **existing** degradation path unchanged. **Three sites did not** — their catches branch on error CONTENT, and those needed a new guard (see "Timeout misclassification" below). The original framing here said "no new branches, no new error handling" across the board; that was wrong for exactly those three. 15s per site, matching the house value (`TRACKER_STATUS_TIMEOUT_MS`, `ci-gate.ts`).

One exported constant per module. A shared wrapper stays **declined** for the same reason as in #2069: the call sites need different options (encoding, stdio, extra flags), and `02-code-standards.md` prefers duplication over the wrong abstraction. That's now five sites of this shape; if a sixth appears it's worth revisiting.

| Module | Constant | Sites |
|---|---|---|
| `dev/backlogLint.ts` | `ORIGIN_TASKS_TIMEOUT_MS` | both origin reads in `readOriginTaskFiles` |
| `dev/check-workflow-sync.ts` | `WORKFLOW_SYNC_TIMEOUT_MS` | `defaultRunGit` |
| `dev/check-deferred-refs.ts` | `DEFERRED_REFS_TIMEOUT_MS` | `getStagedFiles` |
| `dev/focus-runner.ts` | `FOCUS_RUNNER_TIMEOUT_MS` | 4 git calls |
| `test/mutation-gate.ts` | `MUTATION_GATE_TIMEOUT_MS` | `gitChangedFiles` + `turboAffectedPackages` |
| `dev/find-dead-files.ts` | `DEAD_FILES_GREP_TIMEOUT_MS` | the importer-verification grep |
| `context/session-context.ts` | `SESSION_CONTEXT_TIMEOUT_MS` | `execFileSafe` |
| `context/session-state.ts` | `SESSION_STATE_TIMEOUT_MS` | `execFileSafe` |

## Deliberately left unbounded

The `pnpm knip` spawn in `find-dead-files.ts`. A full-repo knip pass legitimately runs for minutes, so a 15s bound would convert a working gate into a flaky one. Stated in a comment at the call site, per the task's "or the ones left unbounded have a stated reason" clause.

## Scope corrections worth flagging

- **The task named three sites; this PR bounds eleven.** That widening is deliberate and announced. It still does NOT meet the task's unqualified acceptance line — roughly 20 files remain unbounded, tracked in TASK-546.
- **Two of the three named sites don't match the task's rationale.** `session-context.ts` / `session-state.ts` are reachable only via `pnpm ops context:*`, not the hook/quality paths the task assumed ("all three run in the same hook/quality paths"). Bounded anyway — a hang in an interactive command is still a hang — but on the weaker rationale, and the filed premise was wrong.
- Two sites the task called "git calls" are a `grep` (`find-dead-files.ts`) and a `pnpm exec turbo` (`mutation-gate.ts`). Line numbers were unambiguous, so intent was clear; noting the imprecision rather than pretending the spec was exact.

## Testing

Each bound is asserted in its colocated test by inspecting the options object crossing the mocked `execFileSync` seam.

**One gap found and closed during review**: `check-workflow-sync.test.ts` drives every case through an injected `runGit` stub and never mocked `execFileSync`, so `defaultRunGit` — the real wrapper — was untested. Added a default-path test that omits `runGit`, and **canaried it**: removing the timeout turns it red (1 failed / 16 passed), so the assertion measures something rather than passing either way.

The `mutation-gate.ts` comment asserts the bound degrades into the gate's fail-open path; that behavior is pinned by the existing `it('fails OPEN (run=true) when git or turbo throws')`.

## Verification

- `pnpm --filter @tzurot/tooling test` — 160 files, **2456 passed** (2455 before, +1 new).
- `pnpm quality` — green (full static gate).
- `pnpm test` — 26/26 tasks successful across all packages.

## Residual risk

`turboAffectedPackages` now carries a 15s bound. `turbo ls` is a fast graph query, but on a cold CI machine a spurious timeout would throw into the fail-open path and run mutation tests unnecessarily — a cost, not a correctness problem. Flagging it as the one bound whose value is a judgment call rather than obviously ample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Scope correction (round 4)

**This is a PARTIAL pass, and does NOT close TASK-541.** The earlier framing here — "the wider sweep is what the task actually specified" — was an overclaim, correctly caught in review. TASK-541's acceptance line is unqualified ("no unbounded synchronous shell-out remains in `packages/tooling`"), and roughly 20 files still have unbounded calls with no stated reason.

What this PR actually covers, and why that boundary:

- **Gate-reachable sites** (`backlogLint`, `check-workflow-sync`, `check-deferred-refs`, `focus-runner`, `mutation-gate`, `find-dead-files` grep, `check-claude-content-refs`) — a stall blocks `pnpm quality` or a hook outright. Strong rationale.
- **`session-context` / `session-state`** — interactive only; bounded on the weaker "a hang is still a hang" rationale.
- **`baseline-meta`** — update-baseline paths only; same weaker rationale.
- **`ci-gate`'s `gitHasCommit` and `runChecks`** — folded in this round because this file was cited here as the house precedent while two of its four calls didn't follow it, and it backs the PR-monitoring loop. `runChecks` bounds only the REPORT pass; the `--watch` pass is deliberately a long wait and stays unbounded.

**Everything else is tracked in TASK-546**, which supersedes the too-narrow TASK-544 (archived — it scoped only release/deploy, missing `gh/github-api.ts`, the audit helpers, and the inspect/utils commands). TASK-541 stays OPEN until TASK-546 lands, rather than being marked Done against a bar it doesn't meet.

Those remaining sites are not a mechanical follow-on: release scripts have no degrade path and arguably *should* fail loud, and several calls are interactive or legitimately long-running. Each needs a per-site decision, which is why it's its own unit rather than another round here.

### Round-5 dispositions

- **Report-pass bound raised 15s → 60s.** The reviewer was right that `CHECKS_REPORT_TIMEOUT_MS` guards the one call the whole gate flow hinges on, and that a large check list on a slow API day could plausibly exceed 15s. The sibling 15s bounds fetch a single JSON document; this renders the full table. The bound exists to stop a hang, not to enforce a latency budget, so it is now looser than its siblings with that reason stated at the constant.
- **Declined: collapsing the thirteen `15_000` constants into one shared default.** Not on duplication grounds — a shared constant is not the wrong-abstraction trap, and the reviewer is right that it would not disturb the options-object shape. Declined because the sites agree on 15s by coincidence of scale, not by shared meaning: they bound a local git probe, a `grep`, a `gh api` call, and a CLI boot respectively. Two constants in this PR are already 60s for exactly that reason, and a third just moved. A shared default would assert a coupling that the values themselves keep contradicting, and the next divergence would have to un-share it.


## Timeout misclassification (rounds 6-7)

Bounding a call adds a failure mode its `catch` never anticipated. On a timeout kill Node **still attaches whatever `stdout` was captured before the SIGTERM**, so any catch that branches on error *content* reads that partial output as a real, complete answer. Three sites in this PR had that shape, and two of them turned a visible hang into a confident wrong answer:

| Site | Was (unbounded) | Would have become | Now |
|---|---|---|---|
| `getPendingMigrations` | hangs visibly | "no migrations pending" during a DB hang, straight into session startup | `null` = unknown |
| `hasNonTestImporters` | hangs visibly | live file reported as a **deletion** candidate | `true` = assume imported |
| `fetchRegisteredCommands` | hangs visibly | truncated help parsed as the full command set → false dangling-ref findings redden `pnpm quality` | throws |

The unknown-value at each site is picked by **which wrong answer is dangerous**, not which is convenient.

`isTimeoutKill` (`utils/timeoutKill.ts`) is the shared discriminator. Its behavior was **probed, not assumed** — and the probe corrected the suggested fix:

```
code   = 'ETIMEDOUT'   <- the discriminator
signal = 'SIGTERM'
killed = undefined     <- the intuitive guess; a `killed` guard never fires
stdout = 'partial'     <- the hazard
```

Its test drives a real bounded child rather than a synthetic `{code:'ETIMEDOUT'}` fixture, so a Node change that moves those facts fails the suite instead of silently disabling the guard. All four new guards were canaried together — removing them turns exactly four tests red.

### Round-7 dispositions

- **Fixed:** `fetchRegisteredCommands` guard (both reviewers flagged it independently; I had fixed two sites of this class and missed the third I bounded in this same PR).
- **Fixed:** test gaps at all three `isTimeoutKill` call sites plus a seam test for `COMMIT_CHECK_TIMEOUT_MS`. The reviewer was right that deleting any guard would not previously have turned a test red.
- **Declined, with a measurement:** `--exclude-dir=node_modules` on the importer grep. Measured on this repo at **38ms** against a 15s bound — `--include=*.ts` restricts what grep reads, and pnpm's per-package `node_modules` are symlink farms that `grep -r` does not descend into (it follows symlinks only for command-line arguments). ~400x headroom, so the silent-fallback scenario needs a machine three orders of magnitude slower.

### Round-8 dispositions

- **Fixed:** `check-workflow-sync`'s `git fetch` now carries its own `WORKFLOW_FETCH_TIMEOUT_MS = 60_000` instead of inheriting the 15s local-probe bound. Taken rather than merely documented because the asymmetry is real — it is the one network op in that module — and the consequence is worse than elsewhere: this guard fails OPEN, so a spurious timeout skips it silently, and what it guards is whether a workflow-file drift has silently disabled `claude-review` on every PR. A slow network must not look like "no drift". Test covers both branches (local calls keep 15s, the fetch gets 60s) and was canaried.
- **Declined:** rewording `gitHasCommit`'s failure message to allow for "git hung" alongside "bad SHA". The current message is precise about the case that actually occurs — every bad SHA so far came from hand-transcription, and the message names the fix (`$(git rev-parse HEAD)`). Adding a second hypothesis to cover a contended `.git/index.lock` on a call that is normally sub-millisecond would dilute a message that currently tells the reader exactly what to do, in exchange for a scenario neither of us has observed. If it is ever observed, the message is one line to change.

### Round-9 dispositions

- **Fixed:** `gitHasCommit` now answers `true` on a timeout instead of `false`. Round 8 declined a related note, but that decline judged only the *message wording* and never asked the actual question — whether a timeout should hard-fail at all. It should not: `false` means "does not name a commit", which aborts gate arming immediately after a push and tells the caller to use `$(git rev-parse HEAD)`, which the mandated invocation already does. Unknown now defers to the runs-API polling, matching how `fetchPrHeadSha`/`classifyHeadSha` treat their own "could not tell". Two tests: the carve-out, and that a genuinely absent commit still returns `false` — the carve-out must not weaken what the check is for.
- **Accepted correction:** the round-8 rationale blamed `.git/index.lock` contention. `git cat-file -e` is a read-only object lookup and never touches the index, so the cited mechanism was wrong. The concern was still valid via other paths (repack/gc, disk contention); the trigger named was not.
- **Also fixed:** `COMMIT_CHECK_TIMEOUT_MS` had been inserted *between* `gitHasCommit`'s JSDoc and the function, orphaning the docstring. Reordered.

### What this PR turned out to be

Worth stating plainly, because the title undersells it. The timeouts were the easy half. The real content is that **adding a throw to a `catch` written before throws were possible changes what that catch means**, and four sites needed a different answer as a result:

- Three had a content branch that read partial stdout as complete (`getPendingMigrations`, `hasNonTestImporters`, `fetchRegisteredCommands`).
- One had no content branch at all (`gitHasCommit`, `stdio: 'ignore'`) — its single catch-all answer was itself a meaningful negative rather than a neutral degrade.

That last one is the sharper form of the class, and the one easiest to miss: the question is not "does this catch inspect content" but "is this catch's one answer a neutral *unknown*, or a *claim*?" `return null` is neutral. `return false` ("does not exist") and `return []` ("nothing pending") are claims, and a timeout must not be allowed to make them.

### Round-10 disposition

Round 10 was clean on correctness ("no action required before merge") with one non-blocking observation scoped as pre-existing: `hasNonTestImporters` mapped a *genuine* grep failure to `false` = "no importers", same as grep's ordinary no-match. Origin is not a disposition, and there was no technical reason to defer two lines in a file already open — so it is fixed rather than filed.

**Only grep's exit 1 now means "no matches".** Exit 2 (unreadable directory, bad pattern), a timeout kill, and a spawn failure all answer "unknown" → `true`, so nothing that failed to search can send a live file to the deletion-candidate list. This subsumed the `isTimeoutKill` special case here, so the catch got simpler rather than longer.

**Two existing tests broke, and the fixtures were the reason.** Both threw a bare `new Error('No matches')` with no `status`, while grep sets `status: 1` on a real no-match. The old unconditional `catch { return false }` made every error equivalent, so the omission was invisible; giving the exit code meaning exposed it. The fixtures were corrected to model the real producer — assertions and intent unchanged, and this file's own sibling test already set `status = 1` correctly. Worth naming explicitly because it sits next to `00-critical.md`'s "never modify tests to make them pass": the change here makes those two tests start testing something, rather than relaxing them.

That is the same failure this PR keeps finding, one layer up — imprecision in the code licensed imprecision in the fixtures, because when every failure collapses to one answer no fixture can look wrong.
