### PR TITLE
fix(bot-client): make the db-sync report promise true on every path

### DIFF
--- a/services/bot-client/src/commands/admin/db-sync.test.ts
+++ b/services/bot-client/src/commands/admin/db-sync.test.ts
@@ -8,12 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { makeErr } from '../../test/gatewayClientStubs.js';
 import type { GatewayResult, OwnerClient } from '@tzurot/clients';
-import {
-  handleDbSync,
-  handleDbSyncDetailsButton,
-  isDbSyncDetailsButton,
-  buildSyncReportText,
-} from './db-sync.js';
+import { handleDbSync, handleDbSyncDetailsButton, isDbSyncDetailsButton } from './db-sync.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
@@ -255,6 +250,26 @@ describe('handleDbSync', () => {
     expect(description).not.toContain('Table mismatch detected');
   });
 
+  it('promises the BUTTON when the stash succeeded (the report is not below)', async () => {
+    mockStoreReport.mockResolvedValue('key-123');
+    stub.dbSync.mockResolvedValue(
+      ok({
+        success: true,
+        timestamp: 'now',
+        schemaVersion: '1.0.0',
+        stats: {},
+        warnings: ['Table mismatch detected'],
+      })
+    );
+
+    const context = createMockContext(false);
+    await handleDbSync(context);
+
+    const description = replyPayload(context).embeds?.[0].data.description ?? '';
+    expect(description).toContain('⚠️ 1 warning(s) — tap **Show details** for the full list');
+    expect(description).not.toContain('report below');
+  });
+
   it('should handle HTTP errors', async () => {
     stub.dbSync.mockResolvedValue(makeErr(500, 'Database not configured'));
 
@@ -351,86 +366,6 @@ describe('handleDbSync', () => {
     expect(context.editReply).toHaveBeenCalledWith({
       content: expect.stringContaining('❌ Database sync failed'),
     });
-  });
-});
-
-describe('buildSyncReportText', () => {
-  const baseResult = {
-    timestamp: '2026-07-11T00:00:00.000Z',
-    schemaVersion: '20260710230428_add_sync_tombstones',
-    stats: {
-      users: { devToProd: 3, prodToDev: 1, conflicts: 0, deleted: 0 },
-      personas: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 2 },
-    },
-    warnings: ['personas: 2 conflicts resolved using last-write-wins'],
-    info: ["Table 'audit_log' excluded: local-only audit trail"],
-    deletions: [
-      { table: 'personas', rowKey: 'aaaa-1111', target: 'prod' as const },
-      { table: 'personas', rowKey: 'bbbb-2222', target: 'dev' as const },
-    ],
-    deletionsTruncated: false,
-  };
-
-  it('includes EVERY table in the stats table, active or not', () => {
-    const report = buildSyncReportText(baseResult, false);
-
-    // Fixed-width rows in a code fence (Discord renders no pipe-tables)
-    expect(report).toContain('```');
-    expect(report).toMatch(/^users\s+3\s+1\s+0\s+0$/m);
-    expect(report).toMatch(/^personas\s+0\s+0\s+0\s+2$/m);
-  });
-
-  it('lists each deletion row with its losing side', () => {
-    const report = buildSyncReportText(baseResult, false);
-
-    expect(report).toContain('## Deletions queued for propagation (2)');
-    expect(report).toContain('- `personas` · `aaaa-1111` → prod');
-    expect(report).toContain('- `personas` · `bbbb-2222` → dev');
-  });
-
-  it('uses would-propagate framing under dry run', () => {
-    const report = buildSyncReportText(baseResult, true);
-
-    expect(report).toContain('# Database Sync Report (dry run)');
-    expect(report).toContain('- Mode: DRY RUN — no changes applied');
-    expect(report).toContain('## Deletions that would propagate (2)');
-  });
-
-  it('marks a gateway-capped deletion list loudly', () => {
-    const report = buildSyncReportText({ ...baseResult, deletionsTruncated: true }, false);
-
-    expect(report).toContain('## Deletions queued for propagation (2+)');
-    expect(report).toContain('Row detail capped by the gateway');
-  });
-
-  it('carries full warnings and info without truncation', () => {
-    const manyWarnings = Array.from({ length: 60 }, (_, i) => `warning line ${i}`);
-    const report = buildSyncReportText({ ...baseResult, warnings: manyWarnings }, false);
-
-    expect(report).toContain('## Warnings (60)');
-    expect(report).toContain('- warning line 0');
-    expect(report).toContain('- warning line 59');
-    expect(report).toContain("- Table 'audit_log' excluded: local-only audit trail");
-  });
-
-  it('neutralizes triple-backticks in warnings (content-derived text)', () => {
-    const report = buildSyncReportText(
-      { ...baseResult, warnings: ['table dump contained ```sql DROP``` fragment'] },
-      false
-    );
-
-    // Raw fences: exactly the stats table's own pair — the warning's run is neutralized
-    expect(report.match(/```/g)).toHaveLength(2);
-    expect(report.replace(/\u200b/g, '')).toContain('```sql DROP```');
-  });
-
-  it('renders explicit None sections for an empty result', () => {
-    const report = buildSyncReportText({}, false);
-
-    expect(report).toContain('_No table stats returned._');
-    expect(report).toContain('## Deletions queued for propagation (0)');
-    expect(report).toContain('## Warnings (0)');
-    expect(report).toContain('None.');
   });
 });
 

--- a/services/bot-client/src/commands/admin/db-sync.ts
+++ b/services/bot-client/src/commands/admin/db-sync.ts
@@ -13,6 +13,11 @@
  * follow-ups (readable text never ships as a file download; house pattern:
  * /inspect's chunked views). When the stash is unavailable the report falls
  * back to the pre-button inline delivery, so details are never silently lost.
+ *
+ * The report RENDERER itself lives in `utils/dbSyncSummary.ts` — the nightly
+ * scheduler attaches the same report to its owner-channel post, and a
+ * `services/` module must not import from `commands/`. Which of the two
+ * deliveries the summary embed promises is passed in as `ReportDelivery`.
  */
 
 import {
@@ -30,106 +35,18 @@ import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { adminDbSyncOptions } from '@tzurot/common-types/generated/commandOptions';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { clientsFor } from '../../utils/gatewayClients.js';
-import { escapeFenceBreaks } from '../../utils/fenceEscape.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
-import { buildSyncSummary, type SyncResult, type TableStats } from '../../utils/dbSyncSummary.js';
+import {
+  buildSyncReportText,
+  buildSyncSummary,
+  type ReportDelivery,
+  type SyncResult,
+} from '../../utils/dbSyncSummary.js';
 import { storeDbSyncReport, fetchDbSyncReport } from './dbSyncReportStore.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { ackUpdate } from '../../ux/render/reply.js';
 
 const logger = createLogger('admin-db-sync');
-
-/** The `## Per-table stats` section — every table, active or not. Fixed-width
- * rows in a code fence: Discord doesn't render markdown pipe-tables, and the
- * fence keeps columns aligned on mobile (same solve as /inspect's memory
- * inspector). */
-function buildStatsSection(stats: Record<string, TableStats>): string[] {
-  const entries = Object.entries(stats);
-  const lines = ['', '## Per-table stats', ''];
-  if (entries.length === 0) {
-    lines.push('_No table stats returned._');
-    return lines;
-  }
-  const tableWidth = Math.max(5, ...entries.map(([table]) => table.length));
-  lines.push('```');
-  lines.push(`${'Table'.padEnd(tableWidth)} dev→prod prod→dev conflicts deleted`);
-  for (const [table, s] of entries) {
-    lines.push(
-      `${table.padEnd(tableWidth)} ${String(s.devToProd ?? 0).padStart(8)} ${String(s.prodToDev ?? 0).padStart(8)} ${String(s.conflicts ?? 0).padStart(9)} ${String(s.deleted ?? 0).padStart(7)}`
-    );
-  }
-  lines.push('```');
-  return lines;
-}
-
-/** The row-level deletions section, with dry-run framing and cap notes. */
-function buildDeletionsSection(result: SyncResult, dryRun: boolean): string[] {
-  const deletions = result.deletions ?? [];
-  const heading = dryRun ? 'Deletions that would propagate' : 'Deletions queued for propagation';
-  const capped = result.deletionsTruncated === true;
-  const lines = ['', `## ${heading} (${deletions.length}${capped ? '+' : ''})`, ''];
-  if (deletions.length === 0) {
-    lines.push('None.');
-    return lines;
-  }
-  for (const d of deletions) {
-    // rowKeys are UUID surrogates today; the escape neutralizes 3+ backtick
-    // runs (fence opens / splitMessage mis-pairing). A future free-text pk
-    // with SINGLE backticks could still end the inline-code span early —
-    // cosmetic only, revisit if a non-UUID pk ever joins SYNC_CONFIG.
-    lines.push(`- \`${d.table}\` · \`${escapeFenceBreaks(d.rowKey)}\` → ${d.target}`);
-  }
-  if (capped) {
-    lines.push(
-      '',
-      '_Row detail capped by the gateway; the per-table Deleted counts above are complete._'
-    );
-  }
-  if (!dryRun) {
-    lines.push(
-      '',
-      '_Rows listed were queued; the per-table Deleted counts reflect what actually executed (a propagation warning explains any gap)._'
-    );
-  }
-  return lines;
-}
-
-/** A counted `## <title> (N)` bullet-list section; explicit `None.` when empty. */
-function buildListSection(title: string, items: string[]): string[] {
-  const lines = ['', `## ${title} (${items.length})`, ''];
-  if (items.length === 0) {
-    lines.push('None.');
-    return lines;
-  }
-  for (const item of items) {
-    // Warnings/info carry table names and row detail — content-derived text
-    lines.push(`- ${escapeFenceBreaks(item)}`);
-  }
-  return lines;
-}
-
-/**
- * The full untruncated report sent inline below the summary embed: every
- * table's stats row, row-level deletion detail, and the complete
- * warnings/info lists. Exported for unit tests.
- */
-export function buildSyncReportText(result: SyncResult, dryRun: boolean): string {
-  const lines: string[] = [`# Database Sync Report${dryRun ? ' (dry run)' : ''}`, ''];
-
-  lines.push(`- Run: ${result.timestamp ?? new Date().toISOString()}`);
-  lines.push(`- Mode: ${dryRun ? 'DRY RUN — no changes applied' : 'LIVE'}`);
-  if (result.schemaVersion !== undefined && result.schemaVersion.length > 0) {
-    lines.push(`- Schema version: ${result.schemaVersion}`);
-  }
-
-  lines.push(...buildStatsSection(result.stats ?? {}));
-  lines.push(...buildDeletionsSection(result, dryRun));
-  lines.push(...buildListSection('Warnings', result.warnings ?? []));
-  lines.push(...buildListSection('Info', result.info ?? []));
-
-  lines.push('');
-  return lines.join('\n');
-}
 
 /** Custom-id prefix for the details reveal (command::action::id per 04-discord). */
 const DB_SYNC_DETAILS_PREFIX = 'admin-dbsync::details::';
@@ -211,19 +128,23 @@ export async function handleDbSync(context: DeferredCommandContext): Promise<voi
     // so the render guards read naturally.
     const result: SyncResult = apiResult.data;
 
-    const embed = new EmbedBuilder()
-      .setColor(dryRun ? DISCORD_COLORS.WARNING : DISCORD_COLORS.SUCCESS)
-      .setTitle(dryRun ? '🔍 Database Sync Preview (Dry Run)' : '✅ Database Sync Complete')
-      .setTimestamp()
-      .setDescription(buildSyncSummary(result, dryRun));
-
     // Default view is the embed alone; the full report hides behind a
     // "Show details" button (owner call: it should stay out of the way unless
     // wanted). The report text is stashed in Redis and the button carries the
     // key — a failed stash falls back to the pre-button inline delivery so
     // the details are never silently lost.
+    //
+    // The stash attempt comes BEFORE the embed because it decides which
+    // delivery the summary's "see the report …" sentences may promise.
     const reportText = buildSyncReportText(result, dryRun);
     const reportKey = await storeDbSyncReport(reportText);
+    const delivery: ReportDelivery = reportKey !== null ? 'button' : 'below';
+
+    const embed = new EmbedBuilder()
+      .setColor(dryRun ? DISCORD_COLORS.WARNING : DISCORD_COLORS.SUCCESS)
+      .setTitle(dryRun ? '🔍 Database Sync Preview (Dry Run)' : '✅ Database Sync Complete')
+      .setTimestamp()
+      .setDescription(buildSyncSummary(result, dryRun, delivery));
 
     if (reportKey !== null) {
       const detailsRow = new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/services/bot-client/src/services/NightlyDbSyncScheduler.test.ts
+++ b/services/bot-client/src/services/NightlyDbSyncScheduler.test.ts
@@ -98,6 +98,12 @@ function postedTitle(): string {
   return title ?? '';
 }
 
+/** The attachments third argument of the Nth postOwnerChannelEmbed call. */
+function postedFiles(index = 0): { attachment: Buffer; name?: string }[] | undefined {
+  const call = mockPostOwnerChannelEmbed.mock.calls[index] as unknown[];
+  return call[2] as { attachment: Buffer; name?: string }[] | undefined;
+}
+
 const client = {} as Client;
 
 describe('startNightlyDbSyncScheduler boot guard', () => {
@@ -300,6 +306,44 @@ describe('NightlyDbSyncScheduler runNightlyDbSync', () => {
     expect(mockPostOwnerChannelEmbed).toHaveBeenCalledTimes(1);
     expect(postedTitle()).toContain('completed with warnings');
     expect(postedDescription()).toContain('1 warning(s)');
+  });
+
+  it('attaches the full report, carrying the warning TEXT the embed only counts', async () => {
+    mockDbSync.mockResolvedValue(okResult(QUIET_STATS, ['deletion propagation skipped: users']));
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    // The embed promises an attached report — the promise is only true if the
+    // warning body actually reaches the file.
+    expect(postedDescription()).toContain('full list in the attached report');
+    const files = postedFiles();
+    expect(files).toHaveLength(1);
+    const body = files?.[0].attachment.toString('utf-8') ?? '';
+    expect(body).toContain('# Database Sync Report');
+    expect(body).toContain('- deletion propagation skipped: users');
+    expect(files?.[0].name).toBe('nightly-db-sync-report.md');
+  });
+
+  it('sends the failure posts without an attachment (no report exists)', async () => {
+    mockDbSync.mockResolvedValue({
+      ok: false,
+      kind: 'http',
+      status: 503,
+      error: 'schema version mismatch',
+    });
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    expect(postedFiles()).toBeUndefined();
+
+    // The throw path is the second failure post shape.
+    vi.clearAllMocks();
+    mockGetSystemSettings.mockResolvedValue(okSettings());
+    mockDbSync.mockRejectedValue(new Error('gateway unreachable'));
+
+    await runNightlyDbSync(client, makeRedis(null));
+
+    expect(postedFiles()).toBeUndefined();
   });
 
   it('posts an owner-channel summary carrying the per-table counts when rows moved', async () => {

--- a/services/bot-client/src/services/NightlyDbSyncScheduler.ts
+++ b/services/bot-client/src/services/NightlyDbSyncScheduler.ts
@@ -30,7 +30,7 @@
  * fires a sync at noon.
  */
 
-import { EmbedBuilder, type Client } from 'discord.js';
+import { AttachmentBuilder, EmbedBuilder, type Client } from 'discord.js';
 import type { Redis } from 'ioredis';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { getConfig } from '@tzurot/common-types/config/config';
@@ -41,6 +41,7 @@ import { getOwnerClient } from '../utils/gatewayClients.js';
 import { createIntervalScheduler } from '../utils/intervalScheduler.js';
 import { postOwnerChannelEmbed } from '../utils/ownerChannel.js';
 import {
+  buildSyncReportText,
   buildSyncSummary,
   hasSyncChanges,
   sumSyncCounters,
@@ -124,8 +125,8 @@ function buildNightlySyncEmbed(result: SyncResult, rowsMoved: boolean): EmbedBui
         ? '🌙 Nightly database sync applied changes'
         : '⚠️ Nightly database sync completed with warnings'
     )
-    .setDescription(buildSyncSummary(result, false))
-    .setFooter({ text: 'Full per-table report: /admin db-sync' })
+    .setDescription(buildSyncSummary(result, false, 'attachment'))
+    .setFooter({ text: 'Full per-table report attached' })
     .setTimestamp();
 }
 
@@ -218,7 +219,16 @@ export async function runNightlyDbSync(client: Client, redis: Redis): Promise<vo
       return;
     }
 
-    await postOwnerChannelEmbed(client, buildNightlySyncEmbed(result.data, rowsMoved));
+    // The embed carries only totals and active tables; the unattended run has
+    // no "Show details" button to fall back on, so the full report ships as a
+    // file alongside it.
+    const reportText = buildSyncReportText(result.data, false);
+    await postOwnerChannelEmbed(client, buildNightlySyncEmbed(result.data, rowsMoved), [
+      new AttachmentBuilder(Buffer.from(reportText, 'utf-8'), {
+        name: 'nightly-db-sync-report.md',
+        description: 'Full nightly db-sync report',
+      }),
+    ]);
     logger.info({ ...totals, warningCount }, 'Nightly sync reportable — posted owner summary');
   } catch (error) {
     logger.error({ err: error }, 'Nightly db sync threw');

--- a/services/bot-client/src/utils/dbSyncSummary.test.ts
+++ b/services/bot-client/src/utils/dbSyncSummary.test.ts
@@ -1,14 +1,20 @@
 /**
  * Tests for the shared db-sync response interpretation + summary rendering.
  *
- * The `buildSyncSummary` cases moved here verbatim when the renderer was
- * extracted from the `/admin db-sync` handler so the nightly scheduler could
- * share it; `hasSyncChanges` / `sumSyncCounters` are the scheduler-facing
- * additions.
+ * The `buildSyncSummary` and `buildSyncReportText` cases moved here verbatim
+ * when those renderers were extracted from the `/admin db-sync` handler so the
+ * nightly scheduler could share them; `hasSyncChanges` / `sumSyncCounters` are
+ * the scheduler-facing additions.
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildSyncSummary, hasSyncChanges, sumSyncCounters } from './dbSyncSummary.js';
+import {
+  buildSyncReportText,
+  buildSyncSummary,
+  hasSyncChanges,
+  sumSyncCounters,
+  type ReportDelivery,
+} from './dbSyncSummary.js';
 
 describe('buildSyncSummary — embed backstop', () => {
   it('caps the active-table list at 30 lines with a see-report tail', () => {
@@ -18,7 +24,7 @@ describe('buildSyncSummary — embed backstop', () => {
         { devToProd: 1, prodToDev: 0, conflicts: 0, deleted: 0 },
       ])
     );
-    const summary = buildSyncSummary({ stats }, false);
+    const summary = buildSyncSummary({ stats }, false, 'below');
 
     expect(summary).toContain('`table_0`:');
     expect(summary).toContain('`table_29`:');
@@ -34,7 +40,8 @@ describe('buildSyncSummary', () => {
         schemaVersion: 'v1',
         stats: { users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 0 } },
       },
-      false
+      false,
+      'below'
     );
 
     expect(summary).toContain('No changes — databases already in sync.');
@@ -48,12 +55,47 @@ describe('buildSyncSummary', () => {
           personas: { devToProd: 4, prodToDev: 0, conflicts: 0, deleted: 0 },
         },
       },
-      false
+      false,
+      'below'
     );
 
     expect(summary).toContain('`users`: 1 dev→prod, 0 prod→dev, 2 conflicts, 3 deleted');
     expect(summary).toContain('`personas`: 4 dev→prod, 0 prod→dev');
     expect(summary).not.toContain('`personas`: 4 dev→prod, 0 prod→dev,');
+  });
+});
+
+describe('buildSyncSummary — report-delivery promise', () => {
+  /** 35 active tables: past the 30-line cap, so the overflow tail renders. */
+  const overflowStats = Object.fromEntries(
+    Array.from({ length: 35 }, (_, i) => [
+      `table_${i}`,
+      { devToProd: 1, prodToDev: 0, conflicts: 0, deleted: 0 },
+    ])
+  );
+
+  it.each([
+    ['below', '⚠️ 2 warning(s) — full list in the report below'],
+    ['button', '⚠️ 2 warning(s) — tap **Show details** for the full list'],
+    ['attachment', '⚠️ 2 warning(s) — full list in the attached report'],
+  ])('points the warning line at the %s delivery', (delivery, expected) => {
+    const summary = buildSyncSummary(
+      { warnings: ['first', 'second'] },
+      false,
+      delivery as ReportDelivery
+    );
+
+    expect(summary).toContain(expected);
+  });
+
+  it.each([
+    ['below', '_…and 5 more — see the report below._'],
+    ['button', '_…and 5 more — tap **Show details** for the full report._'],
+    ['attachment', '_…and 5 more — see the attached report._'],
+  ])('points the overflow line at the %s delivery', (delivery, expected) => {
+    const summary = buildSyncSummary({ stats: overflowStats }, false, delivery as ReportDelivery);
+
+    expect(summary).toContain(expected);
   });
 });
 
@@ -105,8 +147,88 @@ describe('hasSyncChanges', () => {
     const busy = { users: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 2 } };
 
     expect(hasSyncChanges(quiet)).toBe(false);
-    expect(buildSyncSummary({ stats: quiet }, false)).toContain('No changes');
+    expect(buildSyncSummary({ stats: quiet }, false, 'below')).toContain('No changes');
     expect(hasSyncChanges(busy)).toBe(true);
-    expect(buildSyncSummary({ stats: busy }, false)).not.toContain('No changes');
+    expect(buildSyncSummary({ stats: busy }, false, 'below')).not.toContain('No changes');
+  });
+});
+
+describe('buildSyncReportText', () => {
+  const baseResult = {
+    timestamp: '2026-07-11T00:00:00.000Z',
+    schemaVersion: '20260710230428_add_sync_tombstones',
+    stats: {
+      users: { devToProd: 3, prodToDev: 1, conflicts: 0, deleted: 0 },
+      personas: { devToProd: 0, prodToDev: 0, conflicts: 0, deleted: 2 },
+    },
+    warnings: ['personas: 2 conflicts resolved using last-write-wins'],
+    info: ["Table 'audit_log' excluded: local-only audit trail"],
+    deletions: [
+      { table: 'personas', rowKey: 'aaaa-1111', target: 'prod' as const },
+      { table: 'personas', rowKey: 'bbbb-2222', target: 'dev' as const },
+    ],
+    deletionsTruncated: false,
+  };
+
+  it('includes EVERY table in the stats table, active or not', () => {
+    const report = buildSyncReportText(baseResult, false);
+
+    // Fixed-width rows in a code fence (Discord renders no pipe-tables)
+    expect(report).toContain('```');
+    expect(report).toMatch(/^users\s+3\s+1\s+0\s+0$/m);
+    expect(report).toMatch(/^personas\s+0\s+0\s+0\s+2$/m);
+  });
+
+  it('lists each deletion row with its losing side', () => {
+    const report = buildSyncReportText(baseResult, false);
+
+    expect(report).toContain('## Deletions queued for propagation (2)');
+    expect(report).toContain('- `personas` · `aaaa-1111` → prod');
+    expect(report).toContain('- `personas` · `bbbb-2222` → dev');
+  });
+
+  it('uses would-propagate framing under dry run', () => {
+    const report = buildSyncReportText(baseResult, true);
+
+    expect(report).toContain('# Database Sync Report (dry run)');
+    expect(report).toContain('- Mode: DRY RUN — no changes applied');
+    expect(report).toContain('## Deletions that would propagate (2)');
+  });
+
+  it('marks a gateway-capped deletion list loudly', () => {
+    const report = buildSyncReportText({ ...baseResult, deletionsTruncated: true }, false);
+
+    expect(report).toContain('## Deletions queued for propagation (2+)');
+    expect(report).toContain('Row detail capped by the gateway');
+  });
+
+  it('carries full warnings and info without truncation', () => {
+    const manyWarnings = Array.from({ length: 60 }, (_, i) => `warning line ${i}`);
+    const report = buildSyncReportText({ ...baseResult, warnings: manyWarnings }, false);
+
+    expect(report).toContain('## Warnings (60)');
+    expect(report).toContain('- warning line 0');
+    expect(report).toContain('- warning line 59');
+    expect(report).toContain("- Table 'audit_log' excluded: local-only audit trail");
+  });
+
+  it('neutralizes triple-backticks in warnings (content-derived text)', () => {
+    const report = buildSyncReportText(
+      { ...baseResult, warnings: ['table dump contained ```sql DROP``` fragment'] },
+      false
+    );
+
+    // Raw fences: exactly the stats table's own pair — the warning's run is neutralized
+    expect(report.match(/```/g)).toHaveLength(2);
+    expect(report.replace(/\u200b/g, '')).toContain('```sql DROP```');
+  });
+
+  it('renders explicit None sections for an empty result', () => {
+    const report = buildSyncReportText({}, false);
+
+    expect(report).toContain('_No table stats returned._');
+    expect(report).toContain('## Deletions queued for propagation (0)');
+    expect(report).toContain('## Warnings (0)');
+    expect(report).toContain('None.');
   });
 });

--- a/services/bot-client/src/utils/dbSyncSummary.ts
+++ b/services/bot-client/src/utils/dbSyncSummary.ts
@@ -4,13 +4,43 @@
  * Two surfaces consume a sync response — the `/admin db-sync` slash command
  * (interactive, either mode) and the nightly scheduler (real sync, unattended)
  * — so the "did anything move?" predicate and the summary text live here
- * rather than in either consumer. The full report renderer stays with the
- * command: it exists to back the command's own "Show details" button.
+ * rather than in either consumer. The full report renderer is shared for the
+ * same reason: the command stashes it behind its "Show details" button, and
+ * the nightly scheduler attaches it to the owner-channel post.
+ *
+ * The summary's pointer at that report is a parameter, not a constant: each
+ * caller states HOW it delivers the report (`ReportDelivery`) so the embed
+ * never promises a surface that caller does not produce.
  *
  * The `SyncResult` view is deliberately lenient (every field optional) so the
  * render guards read naturally; the tightened `DbSyncResponse` is structurally
  * assignable to it, so consumers annotate rather than assert.
  */
+
+import { escapeFenceBreaks } from './fenceEscape.js';
+
+/** How the caller delivers the full report alongside the summary embed. */
+export type ReportDelivery = 'below' | 'button' | 'attachment';
+
+/**
+ * The sentence tails that point at the report, per delivery. Deliberately a
+ * lookup rather than a branch chain: adding a delivery mode is one row, and
+ * the two pointers for a mode sit next to each other where they can't drift.
+ */
+const REPORT_POINTERS: Record<ReportDelivery, { warning: string; overflow: string }> = {
+  below: {
+    warning: 'full list in the report below',
+    overflow: 'see the report below',
+  },
+  button: {
+    warning: 'tap **Show details** for the full list',
+    overflow: 'tap **Show details** for the full report',
+  },
+  attachment: {
+    warning: 'full list in the attached report',
+    overflow: 'see the attached report',
+  },
+};
 
 export interface TableStats {
   devToProd?: number;
@@ -70,7 +100,10 @@ export function hasSyncChanges(stats: Record<string, TableStats>): boolean {
 const ACTIVE_TABLE_LINES_MAX = 30;
 
 /** One `table: N dev→prod, M prod→dev[, ...]` line per table with activity. */
-function buildActiveTableLines(stats: Record<string, TableStats>): string[] {
+function buildActiveTableLines(
+  stats: Record<string, TableStats>,
+  delivery: ReportDelivery
+): string[] {
   const active = Object.entries(stats).filter(([, s]) => hasActivity(s));
   if (active.length === 0) {
     return ['', 'No changes — databases already in sync.'];
@@ -84,17 +117,24 @@ function buildActiveTableLines(stats: Record<string, TableStats>): string[] {
     );
   }
   if (active.length > ACTIVE_TABLE_LINES_MAX) {
-    lines.push(`_…and ${active.length - ACTIVE_TABLE_LINES_MAX} more — see the report below._`);
+    lines.push(
+      `_…and ${active.length - ACTIVE_TABLE_LINES_MAX} more — ${REPORT_POINTERS[delivery].overflow}._`
+    );
   }
   return lines;
 }
 
 /**
  * The tight embed description: totals line + tables with activity only.
- * Full per-table detail (including quiet tables) lives in the chunked
- * follow-up report, so the embed can never outgrow Discord's description cap.
+ * Full per-table detail (including quiet tables) lives in the report the
+ * caller delivers separately, so the embed can never outgrow Discord's
+ * description cap — `delivery` is how the embed names that surface.
  */
-export function buildSyncSummary(result: SyncResult, dryRun: boolean): string {
+export function buildSyncSummary(
+  result: SyncResult,
+  dryRun: boolean,
+  delivery: ReportDelivery
+): string {
   const lines: string[] = [];
 
   if (result.schemaVersion !== undefined && result.schemaVersion.length > 0) {
@@ -109,16 +149,109 @@ export function buildSyncSummary(result: SyncResult, dryRun: boolean): string {
       '',
       `**${tableCount} tables** · ${totals.devToProd} dev→prod · ${totals.prodToDev} prod→dev · ${totals.conflicts} conflicts · ${totals.deleted} deleted`
     );
-    lines.push(...buildActiveTableLines(stats));
+    lines.push(...buildActiveTableLines(stats, delivery));
   }
 
   const warningCount = result.warnings?.length ?? 0;
   if (warningCount > 0) {
-    lines.push('', `⚠️ ${warningCount} warning(s) — full list in the report below`);
+    lines.push('', `⚠️ ${warningCount} warning(s) — ${REPORT_POINTERS[delivery].warning}`);
   }
   if (dryRun) {
     lines.push('', '*Dry run — no changes were applied.*');
   }
 
+  return lines.join('\n');
+}
+
+/** The `## Per-table stats` section — every table, active or not. Fixed-width
+ * rows in a code fence: Discord doesn't render markdown pipe-tables, and the
+ * fence keeps columns aligned on mobile (same solve as /inspect's memory
+ * inspector). */
+function buildStatsSection(stats: Record<string, TableStats>): string[] {
+  const entries = Object.entries(stats);
+  const lines = ['', '## Per-table stats', ''];
+  if (entries.length === 0) {
+    lines.push('_No table stats returned._');
+    return lines;
+  }
+  const tableWidth = Math.max(5, ...entries.map(([table]) => table.length));
+  lines.push('```');
+  lines.push(`${'Table'.padEnd(tableWidth)} dev→prod prod→dev conflicts deleted`);
+  for (const [table, s] of entries) {
+    lines.push(
+      `${table.padEnd(tableWidth)} ${String(s.devToProd ?? 0).padStart(8)} ${String(s.prodToDev ?? 0).padStart(8)} ${String(s.conflicts ?? 0).padStart(9)} ${String(s.deleted ?? 0).padStart(7)}`
+    );
+  }
+  lines.push('```');
+  return lines;
+}
+
+/** The row-level deletions section, with dry-run framing and cap notes. */
+function buildDeletionsSection(result: SyncResult, dryRun: boolean): string[] {
+  const deletions = result.deletions ?? [];
+  const heading = dryRun ? 'Deletions that would propagate' : 'Deletions queued for propagation';
+  const capped = result.deletionsTruncated === true;
+  const lines = ['', `## ${heading} (${deletions.length}${capped ? '+' : ''})`, ''];
+  if (deletions.length === 0) {
+    lines.push('None.');
+    return lines;
+  }
+  for (const d of deletions) {
+    // rowKeys are UUID surrogates today; the escape neutralizes 3+ backtick
+    // runs (fence opens / splitMessage mis-pairing). A future free-text pk
+    // with SINGLE backticks could still end the inline-code span early —
+    // cosmetic only, revisit if a non-UUID pk ever joins SYNC_CONFIG.
+    lines.push(`- \`${d.table}\` · \`${escapeFenceBreaks(d.rowKey)}\` → ${d.target}`);
+  }
+  if (capped) {
+    lines.push(
+      '',
+      '_Row detail capped by the gateway; the per-table Deleted counts above are complete._'
+    );
+  }
+  if (!dryRun) {
+    lines.push(
+      '',
+      '_Rows listed were queued; the per-table Deleted counts reflect what actually executed (a propagation warning explains any gap)._'
+    );
+  }
+  return lines;
+}
+
+/** A counted `## <title> (N)` bullet-list section; explicit `None.` when empty. */
+function buildListSection(title: string, items: string[]): string[] {
+  const lines = ['', `## ${title} (${items.length})`, ''];
+  if (items.length === 0) {
+    lines.push('None.');
+    return lines;
+  }
+  for (const item of items) {
+    // Warnings/info carry table names and row detail — content-derived text
+    lines.push(`- ${escapeFenceBreaks(item)}`);
+  }
+  return lines;
+}
+
+/**
+ * The full untruncated report: every table's stats row, row-level deletion
+ * detail, and the complete warnings/info lists. The slash command delivers it
+ * behind its "Show details" button (or inline when the stash is unavailable);
+ * the nightly scheduler attaches it as a file.
+ */
+export function buildSyncReportText(result: SyncResult, dryRun: boolean): string {
+  const lines: string[] = [`# Database Sync Report${dryRun ? ' (dry run)' : ''}`, ''];
+
+  lines.push(`- Run: ${result.timestamp ?? new Date().toISOString()}`);
+  lines.push(`- Mode: ${dryRun ? 'DRY RUN — no changes applied' : 'LIVE'}`);
+  if (result.schemaVersion !== undefined && result.schemaVersion.length > 0) {
+    lines.push(`- Schema version: ${result.schemaVersion}`);
+  }
+
+  lines.push(...buildStatsSection(result.stats ?? {}));
+  lines.push(...buildDeletionsSection(result, dryRun));
+  lines.push(...buildListSection('Warnings', result.warnings ?? []));
+  lines.push(...buildListSection('Info', result.info ?? []));
+
+  lines.push('');
   return lines.join('\n');
 }

--- a/services/bot-client/src/utils/ownerChannel.test.ts
+++ b/services/bot-client/src/utils/ownerChannel.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { EmbedBuilder, type Client } from 'discord.js';
+import { AttachmentBuilder, EmbedBuilder, type Client } from 'discord.js';
 
 vi.mock('@tzurot/common-types/utils/logger', async () => {
   const actual = await vi.importActual<typeof import('@tzurot/common-types/utils/logger')>(
@@ -45,6 +45,34 @@ describe('postOwnerChannelEmbed', () => {
     await expect(postOwnerChannelEmbed(client, embed)).resolves.toBe(true);
 
     expect(send).toHaveBeenCalledWith({ embeds: [embed], allowedMentions: { parse: [] } });
+  });
+
+  it('forwards attachments to channel.send when files are passed', async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const client = makeClient({ isTextBased: () => true, send });
+    const file = new AttachmentBuilder(Buffer.from('report body', 'utf-8'), {
+      name: 'report.md',
+    });
+
+    await expect(postOwnerChannelEmbed(client, embed, [file])).resolves.toBe(true);
+
+    expect(send).toHaveBeenCalledWith({
+      embeds: [embed],
+      allowedMentions: { parse: [] },
+      files: [file],
+    });
+  });
+
+  it('omits the files key entirely when no attachments are passed', async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const client = makeClient({ isTextBased: () => true, send });
+
+    await postOwnerChannelEmbed(client, embed);
+
+    // Not just `files: undefined` — the key must be absent, so the six
+    // embed-only call sites keep sending a byte-identical payload.
+    const payload = send.mock.calls[0][0] as Record<string, unknown>;
+    expect('files' in payload).toBe(false);
   });
 
   it('is a silent no-op (not delivered) when the channel id is unset', async () => {

--- a/services/bot-client/src/utils/ownerChannel.ts
+++ b/services/bot-client/src/utils/ownerChannel.ts
@@ -11,15 +11,23 @@
  * Returns whether the embed was actually delivered, so callers that arm a
  * suppression window (nag cooldowns) can skip arming it on a failed post —
  * fire-and-forget callers may ignore the return value.
+ *
+ * Optional `files` ride along for callers whose detail does not fit an embed
+ * (the nightly db-sync attaches its full per-table report). Omitting them
+ * sends the same embed-only payload as before — the key is not added at all.
  */
 
-import { type Client, type EmbedBuilder } from 'discord.js';
+import { type AttachmentBuilder, type Client, type EmbedBuilder } from 'discord.js';
 import { getConfig } from '@tzurot/common-types/config/config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('owner-channel');
 
-export async function postOwnerChannelEmbed(client: Client, embed: EmbedBuilder): Promise<boolean> {
+export async function postOwnerChannelEmbed(
+  client: Client,
+  embed: EmbedBuilder,
+  files?: AttachmentBuilder[]
+): Promise<boolean> {
   const channelId = getConfig().FEEDBACK_CHANNEL_ID;
   if (channelId === undefined) {
     return false;
@@ -30,7 +38,11 @@ export async function postOwnerChannelEmbed(client: Client, embed: EmbedBuilder)
       logger.warn({ channelId }, 'FEEDBACK_CHANNEL_ID is not a sendable text channel');
       return false;
     }
-    await channel.send({ embeds: [embed], allowedMentions: { parse: [] } });
+    await channel.send({
+      embeds: [embed],
+      allowedMentions: { parse: [] },
+      ...(files !== undefined && { files }),
+    });
     return true;
   } catch (error) {
     logger.warn({ err: error, channelId }, 'Failed to post embed to owner channel');


### PR DESCRIPTION
Closes TASK-543 (owner-reported).

## The bug

The db-sync summary embed announces `⚠️ N warning(s) — full list in the report below`. Both surfaces that render it fail to deliver one:

- **Nightly scheduler** posts the embed alone. Warnings were counted and then never shown anywhere — owner-observed with 6 warnings and no report. The warning text is the only place the actual problem is described, so a failed deletion propagation surfaced as a bare number.
- **`/admin db-sync`** moved its full report behind a "Show details" button after that sentence was written, so "below" is true only in the stash-failure fallback path. This second instance was not in the task — it surfaced while grounding, and it's the same class.

The active-table overflow line (`…and N more — see the report below`) carries the same promise and was wrong in the same two places.

## The fix

**Both sentences now take a `ReportDelivery`** — `'below' | 'button' | 'attachment'` — resolved through one lookup table where a mode's two pointers sit adjacent and can't drift. **No default value**: a future caller has to state how it delivers the report rather than silently inheriting a wrong promise.

- Slash path computes the Redis stash first and passes `'button'` or `'below'` accordingly, so the sentence tracks the branch actually taken.
- Nightly path passes `'attachment'` and ships the report as `nightly-db-sync-report.md`, via a new optional `files` argument on `postOwnerChannelEmbed`. Its footer no longer points at `/admin db-sync` for detail that is now attached.

`buildSyncReportText` (plus its three private section builders) moves from `commands/admin/db-sync.ts` to `utils/dbSyncSummary.ts` verbatim — a `services/` module must not import from `commands/`. Both module docstrings claimed the renderer "stays with the command"; corrected.

## Verification

- `pnpm --filter @tzurot/bot-client test` — 400 files / 6281 tests green. `pnpm quality` green.
- **Seams pinned on both shared helpers**, since each has multiple callers: all three delivery modes × both sentences (6 cases); `files` forwarded to `channel.send` when passed, and the key **absent** (not `undefined`) when omitted, so the six embed-only call sites send a byte-identical payload; the nightly attachment asserted to carry the warning **string** — not just to exist — because the promise is only true if the body reaches the file; both nightly failure posts asserted to send no attachment.
- Canaried two assertions rather than trusting green: stripping warnings from the nightly report reddens the attachment-content test; flipping the `attachment` tail to the old text reddens the delivery test. Both restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)