### PR TITLE
docs(skills): isolation check, PR closing-claim trigger, Opus-5 default

### DIFF
--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -81,6 +81,22 @@ git push -u origin feat/your-feature
 gh pr create --base develop --title "feat: description" --assignee @me
 ```
 
+### Before writing a closing reference in the PR body
+
+**The moment before typing `Closes TASK-N` (or "completes doc-N", "finishes the
+X sweep") is the trigger — re-open the referenced task file and QUOTE its
+acceptance line verbatim into the PR body, then state per clause whether it is
+met.** Recalling the acceptance from memory is what fails: an overclaim survives
+paraphrase easily and rarely survives being placed next to the words it
+contradicts. If any clause is unmet, the PR says **partial** and names the task
+that carries the remainder — `00-critical.md` § Completion claims required the
+re-read already and was cited back by a reviewer on a PR that skipped it, so
+what this adds is the moment, not the standard.
+
+The same check applies to any exhaustiveness claim in the body ("every call
+site", "all N modules", "the whole module"): name the enumeration command whose
+output backs it, or scope the sentence to what was actually swept.
+
 ### Arm CI monitor (required)
 
 Immediately after `gh pr create` — and after any subsequent `git push` to an open PR — start a `Monitor` that waits for CI to complete and reports new review comments back. **Do not skip this step and do not wait for the user to ask about CI status.**

--- a/.claude/skills/tzurot-orchestration/SKILL.md
+++ b/.claude/skills/tzurot-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-orchestration
 description: 'Orchestrator mode: when to delegate implementation to a worker agent, the spec template every worker gets, and the full-diff review gate before any commit. Invoke with /tzurot-orchestration at the start of any implementation unit run in orchestrator mode — the moment a task fix shape is known, before the first src Edit/Write.'
-lastUpdated: '2026-08-11'
+lastUpdated: '2026-08-12'
 ---
 
 # Orchestrator Mode
@@ -22,11 +22,19 @@ gate that stops worker defects before CI does.
 Who drives the main loop determines the delegation posture. The mechanism is
 quality — fresh context plus an independent diff review — not budget.
 
-| Driver                       | Posture                                                                                                                                                                                                                                                                                   |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Fable main loop**          | Delegate implementation to `opus-implementer` by DEFAULT. "It's small" is not an inline justification. Inline only for: trivial mechanical edits (~a few lines), fixes discovered mid-review of a worker's diff, or work where writing the spec costs more than the edit.                 |
-| **Opus main loop**           | Delegate substantive units — the fresh-context worker plus a separate diff review is the quality mechanism. But do NOT delegate work finishable in a handful of tool calls: Opus 5 over-delegates by documented tendency (prompting guide § controlling subagent spawning).               |
-| **Bulk reading/exploration** | Explore/Plan agents, either driver. Reading fan-out is delegation's cheapest and least risky use. **Any read fan-out of ~4+ files, or any search across unknown locations, goes to `Explore` with `model: "haiku"` passed on the Agent call — never inline** (mechanism below the table). |
+**Opus 5 orchestrating Sonnet workers is the SETTLED DEFAULT for drain
+sessions** (owner verdict, TASK-513) — Fable is reserved for design, semantic,
+and taste-heavy work, not held as the ordinary driver. Release operations are
+**not** model-scoped: release safety rests on the per-release owner-approval
+gate (`00-critical.md` § Merge Approval), which is model-independent. Schema and
+migration work, and any owner-taste call, still escalate to the owner regardless
+of driver.
+
+| Driver                                                 | Posture                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fable main loop** _(design / semantic / taste work)_ | Delegate implementation to `opus-implementer` by DEFAULT. "It's small" is not an inline justification. Inline only for: trivial mechanical edits (~a few lines), fixes discovered mid-review of a worker's diff, or work where writing the spec costs more than the edit.                 |
+| **Opus main loop** _(DEFAULT — drain sessions)_        | Delegate substantive units — the fresh-context worker plus a separate diff review is the quality mechanism. But do NOT delegate work finishable in a handful of tool calls: Opus 5 over-delegates by documented tendency (prompting guide § controlling subagent spawning).               |
+| **Bulk reading/exploration**                           | Explore/Plan agents, either driver. Reading fan-out is delegation's cheapest and least risky use. **Any read fan-out of ~4+ files, or any search across unknown locations, goes to `Explore` with `model: "haiku"` passed on the Agent call — never inline** (mechanism below the table). |
 
 **Why Explore gets `model: "haiku"` per-call**: the built-in Explore inherits
 the main-loop model (per the Agent tool's own schema: an omitted `model` "uses
@@ -94,6 +102,23 @@ yanked mid-edit). Same-tree spawns are for read-only analysis only. Should the
 rule nonetheless be violated and a file-mutating worker found sharing the tree,
 the damage-control posture is: the orchestrator FREEZES its own git operations
 (checkout, pull, rebase, merge) until the worker reports.
+
+**Passing the flag is not proof it took effect — verify the tree immediately
+after dispatch**, before the orchestrator does anything else with git:
+
+```bash
+git worktree list        # a NEW tree must be listed for the worker
+```
+
+Only the main tree listed means the worker is in the SHARED tree despite
+`isolation: "worktree"` (observed: a spawn silently got no worktree, the worker
+ran `git checkout -b` in the shared tree, and the orchestrator's branch moved
+mid-turn — a review fixup landed on the worker's branch and cost a cherry-pick
+to recover). Why the flag can be ignored is **unknown and unprobed** — do not
+record a cause. The response is the damage-control freeze above: no checkout,
+pull, rebase, or merge until the worker reports. The weaker universal guard is
+worth having too — re-read `git branch --show-current` immediately before any
+commit, since a background agent can move it under you.
 
 Before trusting any code-grounded output from a worktree-isolated worker,
 verify the worktree's base against the intended SHA:

--- a/.claude/skills/tzurot-review-response/SKILL.md
+++ b/.claude/skills/tzurot-review-response/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-review-response
 description: 'PR review-response iteration: classify each finding by EDIT SHAPE (trivial → auto-apply as a test-gated fixup commit; semantic → ASK), check reviewer-vs-agent signal conflict, batch-present the four sections, and step back at ~3 automated rounds (a rule of thumb, not a hard stop). Invoke with /tzurot-review-response the moment a claude-review or human reviewer posts findings on a PR — before applying anything.'
-lastUpdated: '2026-08-08'
+lastUpdated: '2026-08-12'
 ---
 
 # Review-Response Iteration
@@ -170,6 +170,14 @@ The four sections (Auto-applied / Asks / Dismissed / Backlog candidates) MUST ap
 - A **file-the-batch** item lands under Backlog candidates tagged `[batch]`, naming which theme-doc phase or idea doc now owns the pass.
 
 Without the tags both dispositions are invisible in the summary: a do-it-now fix reads as an ordinary trivial edit, and a filed batch reads as an ordinary deferral.
+
+**A correction EDITS the original sentence; it does not annotate it.** A round
+that falsifies a claim usually produces two edits — the code fix, reported
+above, and the claim itself, which is easy to leave behind. Appending "update:
+actually…" under a wrong sentence in a PR body, a comment, or a doc leaves that
+sentence leading the document, and the lead is what the next reader takes away.
+Rewrite it. (General to any corrected claim; it sits here because the round
+summary is where the falsification lands.)
 
 **Never present a raw unified diff.** Categorization IS the presentation — it lets the user bulk-confirm the auto-applied group and focus attention on the semantic asks without having to visually separate them.
 


### PR DESCRIPTION
Three review-gated `.claude/skills` edits, batched because they are all skill text and each is a few lines.

## TASK-542 — orchestration: verify isolation actually applied

An `opus-implementer` spawned with `isolation: "worktree"` did **not** get a worktree: `git worktree list` showed only the main tree, the worker ran `git checkout -b` in the shared tree, and the orchestrator's branch moved mid-turn — a review fixup landed on the worker's branch and cost a cherry-pick plus a stray remote-branch deletion to recover. The skill already mandated the flag and described a damage-control freeze for the *violation* case; it had nothing for the case where the flag is passed and silently no-ops, which is worse because the orchestrator has no reason to suspect anything.

Adds a post-dispatch `git worktree list` check at the moment of dispatch, plus the weaker universal guard (re-read `git branch --show-current` before any commit).

**Why the flag was ignored is unknown and was not probed** — the text says so rather than recording a cause.

> Acceptance: *"the orchestration skill names the post-dispatch isolation check at the moment of dispatch, so a silently-ignored isolation flag is caught before the orchestrator trusts the tree."*

Met, both clauses: the check sits inside § Worktree spawns immediately after the dispatch mandate, and it is stated as a precondition on trusting the tree.

## TASK-547 — git-workflow: a moment for the completion-claim rule

`00-critical.md` § "Completion claims require re-reading the scope definition" already existed; #2072 violated it and the reviewer cited that exact rule back. The rule targets a **state** (having a completion claim) rather than a **moment**, so nothing fires.

Adds a decision-point step before `gh pr create`: before writing any closing reference, re-open the task and quote its acceptance line verbatim into the body, disposing of it per clause; unmet clauses make the PR **partial** and name the task carrying the remainder. Quoting is the mechanism — an overclaim survives paraphrase and rarely survives sitting next to the words it contradicts. Extended to exhaustiveness claims ("every call site", "all N modules"), which failed the same way in that PR.

> Acceptance: *"the git-workflow skill names the moment before a closing reference is written, and the check is quoting the acceptance line rather than recalling it."*

Met, both clauses. This PR body is the first application.

Second half of the task landed in review-response: **a correction edits the sentence that was wrong**; appending "actually…" underneath leaves the wrong statement leading the document.

## TASK-551 — orchestration: record the settled default

TASK-513 closed with the owner's verdict that Opus 5 orchestrating Sonnet workers is the **default** drain-session driver, but that lived only in a Done task file and machine-local memory. Records it above the mode table, along with release operations no longer being model-scoped (release safety rests on the per-release owner-approval gate, which is model-independent). Schema/migration and owner-taste calls still escalate.

> Acceptance: *"the skill states the default driver without needing TASK-513 read alongside it."*

Met — the TASK-513 reference is a citation, not a dependency; the paragraph stands alone.

## Verification

Docs-only: pre-push ran `lines:check` (rules 147519/154502 B, CURRENT 29003/39237 B), `backlog:lint`, and `guard:workflow-sync` — all green. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)