### PR TITLE
fix(tooling): say "unknown" when migration status can't be determined

### DIFF
--- a/packages/tooling/src/context/session-context.test.ts
+++ b/packages/tooling/src/context/session-context.test.ts
@@ -102,19 +102,247 @@ describe('getSessionContext', () => {
       const { getSessionContext } = await import('./session-context.js');
       await getSessionContext({});
 
-      // `null` skips the section entirely. Without the guard the empty stdout
-      // parses as an empty pending list, which prints the all-clear — the
-      // exact wrong answer, so that string is what this asserts against.
+      // Without the guard the empty stdout parses as an empty pending list,
+      // which prints the all-clear — the exact wrong answer.
       const output = consoleLogSpy.mock.calls.flat().join(' ');
       expect(output).not.toContain('All migrations applied');
-      // Pin the null path specifically, not merely the absence of one string:
-      // the whole section is skipped. Without this, a regression that dropped
-      // the migration block entirely would still satisfy the assertion above.
+      // ...and silence is the other wrong answer: an unknown must be VISIBLE,
+      // otherwise a DB hang renders identically to a repo with no migrations.
+      expect(output).toContain('Migrations');
+      expect(output).toContain('Status unknown');
+      expect(output).toContain('timed out');
+    });
+
+    it('reports UNKNOWN when the failure carries no readable output at all', async () => {
+      // The third `null` path pre-fix: a thrown value with neither stdout nor
+      // message. Same epistemic state as the timeout — nothing was learned —
+      // so it must degrade the same way rather than to silence.
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') throw 'not an Error object';
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('Status unknown');
+      expect(output).not.toContain('All migrations applied');
+    });
+
+    it('renders the pending list parsed out of a non-zero prisma exit', async () => {
+      // The KNOWN path, which had no test before this change touched its
+      // return shape: prisma exits non-zero precisely when migrations are
+      // pending, so the names arrive on the error's stdout.
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') {
+          const error = new Error('exit 1') as Error & { stdout: string };
+          error.stdout = [
+            'Following migration(s) have not yet been applied:',
+            '- 20260101000000_add_widgets',
+            '- 20260102000000_add_gadgets',
+            '',
+          ].join('\n');
+          throw error;
+        }
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('2 pending migration(s)');
+      expect(output).toContain('20260101000000_add_widgets');
+      expect(output).toContain('20260102000000_add_gadgets');
+      expect(output).not.toContain('Status unknown');
+    });
+
+    it('reports UNKNOWN for a non-zero exit that is not the pending-migrations one', async () => {
+      // The likelier failure of the two this function guards: a refused DB
+      // connection fails FAST rather than hanging, so it never reaches the
+      // timeout branch. Its output carries no pending marker, and reading
+      // "no marker" as "nothing pending" is the same all-clear the timeout
+      // branch exists to prevent.
+      // Fixture copied from a REAL probe against an unreachable database, not
+      // invented: prisma splits the two halves across streams, putting a benign
+      // datasource echo on stdout and the identifying error on stderr. A
+      // synthetic fixture that puts P1001 on stdout passes while the code reads
+      // only stdout — green, and blind to the actual shape.
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') {
+          const error = new Error('command failed') as Error & {
+            stdout: string;
+            stderr: string;
+          };
+          error.stdout = 'Datasource "db": PostgreSQL database "nope" at "127.0.0.1:59999"\n';
+          error.stderr = [
+            'Prisma schema loaded from prisma/schema.prisma.',
+            "Error: P1001: Can't reach database server at `127.0.0.1:59999`",
+            '',
+            'Please make sure your database server is running.',
+          ].join('\n');
+          throw error;
+        }
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).not.toContain('All migrations applied');
+      expect(output).toContain('Status unknown');
+      // The identifying line, from STDERR — not the datasource echo that a
+      // stdout-only read would surface as a plausible-looking wrong reason.
+      expect(output).toContain('P1001');
+      expect(output).not.toContain('Datasource');
+      // ...and only that line, not prisma's whole essay.
+      expect(output).not.toContain('Please make sure your database server');
+    });
+
+    it('surfaces the spawn-failure message instead of the string "undefined"', async () => {
+      // Probed shape for a missing binary: both stream KEYS are present with
+      // the value `undefined`, and the identifying text lives only on
+      // `message`. A presence check on the key plus `String()` yields the
+      // literal "undefined" — non-empty, so it wins over the message fallback
+      // and renders as `failed: undefined`.
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') {
+          const error = new Error('spawnSync npx ENOENT') as Error & {
+            code: string;
+            stdout: undefined;
+            stderr: undefined;
+          };
+          error.code = 'ENOENT';
+          error.stdout = undefined;
+          error.stderr = undefined;
+          throw error;
+        }
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('Status unknown');
+      expect(output).toContain('ENOENT');
+      expect(output).not.toContain('undefined');
+    });
+
+    it('does not absorb stderr noise into the pending-migration list', async () => {
+      // The pending LIST is read from stdout alone. Merging the streams for the
+      // list would let a stderr warning sitting next to the marker be parsed as
+      // a migration name; the merge exists only for the failure REASON.
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') {
+          const error = new Error('exit 1') as Error & { stdout: string; stderr: string };
+          // NO trailing blank line on stdout: the parser stops at the first
+          // blank after the marker, so a fixture that ends with one can never
+          // reach stderr and passes whether the streams are merged or not.
+          // (Written that way first; the canary caught it staying green.)
+          error.stdout = [
+            'Following migration(s) have not yet been applied:',
+            '- 20260101000000_add_widgets',
+          ].join('\n');
+          error.stderr = '- warning: a deprecation notice shaped like a list item';
+          throw error;
+        }
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('1 pending migration(s)');
+      expect(output).toContain('20260101000000_add_widgets');
+      expect(output).not.toContain('deprecation notice');
+    });
+
+    it('says so plainly when both streams are empty, rather than trailing a colon', async () => {
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') {
+          const error = new Error('') as Error & { stdout: string; stderr: string };
+          error.stdout = '';
+          error.stderr = '   \n';
+          throw error;
+        }
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('failed with no readable output');
+      expect(output).not.toContain('failed: ');
+    });
+
+    it('truncates a very long failure line instead of flooding the banner', async () => {
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) => {
+        if (cmd === 'npx') {
+          const error = new Error('boom') as Error & { stdout: string; stderr: string };
+          error.stdout = '';
+          error.stderr = `Error: ${'x'.repeat(400)}`;
+          throw error;
+        }
+        return '';
+      });
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('…');
+      expect(output).not.toContain('x'.repeat(200));
+    });
+
+    it('renders the all-clear when prisma reports the schema up to date', async () => {
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue('');
+      execFileSyncMock.mockImplementation((cmd: string) =>
+        cmd === 'npx' ? 'Database schema is up to date!' : ''
+      );
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('All migrations applied');
+      expect(output).not.toContain('Status unknown');
+    });
+
+    it('prints NO migrations section when the repo has no migrations directory', async () => {
+      // The distinction the unknown line exists to preserve: absent stays
+      // silent. If this went to the unknown branch, every non-Prisma repo
+      // would get a spurious warning at session start.
+      fsMock.existsSync.mockReturnValue(false);
+      execFileSyncMock.mockReturnValue('');
+
+      const { getSessionContext } = await import('./session-context.js');
+      await getSessionContext({});
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
       expect(output).not.toContain('Migrations');
-      // ...and prove the run still completed, so "section skipped" is
-      // distinguishable from "died before printing anything". (Git state is
-      // also absent here — this fixture returns '' for git, so that section
-      // legitimately skips too; the banner is what proves the run finished.)
+      expect(output).not.toContain('Status unknown');
+      // Prove the run completed, so "section skipped" is distinguishable from
+      // "died before printing anything".
       expect(output).toContain('SESSION CONTEXT');
     });
 

--- a/packages/tooling/src/context/session-context.ts
+++ b/packages/tooling/src/context/session-context.ts
@@ -120,23 +120,115 @@ function getCurrentWorkSummary(cwd: string): string | null {
 }
 
 /**
+ * Migration status, with "could not determine" kept distinct from "this repo
+ * has no migrations". Collapsing them into one `null` made a DB hang render
+ * identically to a repo with no `prisma/` directory — total silence — which is
+ * the one degradation a session-startup warning must not choose.
+ */
+type MigrationStatus =
+  { kind: 'absent' } | { kind: 'unknown'; reason: string } | { kind: 'known'; pending: string[] };
+
+/** A status the display function can actually render — everything but `absent`. */
+type ResolvedMigrationStatus = Exclude<MigrationStatus, { kind: 'absent' }>;
+
+const PENDING_MARKER = 'have not yet been applied';
+
+/** Migration names listed under prisma's pending-migrations marker. */
+function parsePendingNames(output: string): string[] {
+  const pending: string[] = [];
+  let inPendingSection = false;
+
+  for (const line of output.split('\n')) {
+    if (line.includes(PENDING_MARKER)) {
+      inPendingSection = true;
+      continue;
+    }
+    if (inPendingSection && line.trim().startsWith('-')) {
+      pending.push(line.trim().substring(1).trim());
+    }
+    if (inPendingSection && line.trim() === '') {
+      break;
+    }
+  }
+
+  return pending;
+}
+
+/**
+ * Everything a failed run wrote, both streams, or `null` when neither is
+ * readable.
+ *
+ * BOTH streams, because prisma splits them and the half that matters is the
+ * one a stdout-only read misses. Probed against a real unreachable database:
+ * stdout carries `Datasource "db": PostgreSQL database …` while stderr carries
+ * `Error: P1001: Can't reach database server at …`. Reading stdout alone
+ * therefore does not fail loudly — it produces a plausible-looking reason
+ * naming the datasource while the actual error goes unread.
+ *
+ * `'stdout' in error` is also true when stdout is the EMPTY STRING (probed),
+ * so a presence check on it cannot be used to fall through to another source.
+ *
+ * And on a SPAWN failure the keys are present with the value `undefined`
+ * (probed against a missing binary: `code` is `ENOENT`, both streams are
+ * `undefined`, and the identifying text lives only on `message`). `String()`
+ * over that yields the literal `"undefined"` — a non-empty string that would
+ * pass a length check and render as `failed: undefined` while suppressing the
+ * `message` fallback that carries the real answer. Hence a nullish check on
+ * the VALUE, not a presence check on the key.
+ */
+function streamText(error: unknown, key: 'stdout' | 'stderr'): string {
+  if (error === null || typeof error !== 'object') return '';
+  const value = (error as Record<string, unknown>)[key];
+  // `encoding: 'utf-8'` on the call makes both streams strings when they hold
+  // anything at all; every other shape (undefined on a spawn failure, a Buffer
+  // if the encoding is ever dropped) is treated as absent so the caller falls
+  // through to `message` — the direction that yields a real answer rather than
+  // a stringified placeholder.
+  return typeof value === 'string' ? value : '';
+}
+
+function capturedOutput(error: unknown): string | null {
+  const streams = [streamText(error, 'stdout'), streamText(error, 'stderr')].filter(
+    text => text.trim().length > 0
+  );
+  if (streams.length > 0) return streams.join('\n');
+  if (error !== null && typeof error === 'object' && 'message' in error) {
+    return String(error.message);
+  }
+  return null;
+}
+
+const REASON_MAX_LENGTH = 160;
+
+/**
+ * The line of a failure's output most likely to identify it, bounded.
+ *
+ * One line because this is rendered into the session banner and prisma's
+ * failures run to many lines of hints and connection detail. The
+ * error-looking line is preferred over the first non-empty one for the same
+ * reason both streams are read: the first line of a prisma failure is
+ * routinely a benign datasource echo, and the identifying `Error: P1001…` sits
+ * several lines below it.
+ */
+function failureLine(output: string): string {
+  const lines = output.split('\n').filter(candidate => candidate.trim().length > 0);
+  const line = (lines.find(candidate => /error/i.test(candidate)) ?? lines[0] ?? '').trim();
+  return line.length > REASON_MAX_LENGTH ? `${line.slice(0, REASON_MAX_LENGTH)}…` : line;
+}
+
+/**
  * Check for pending migrations
  */
-function getPendingMigrations(cwd: string): string[] | null {
+function getPendingMigrations(cwd: string): MigrationStatus {
   // Check if prisma migrations directory exists
   const migrationsDir = join(cwd, 'prisma', 'migrations');
-  if (!existsSync(migrationsDir)) return null;
+  if (!existsSync(migrationsDir)) return { kind: 'absent' };
 
   // Try to get migration status via prisma CLI
   // Using execFileSync with npx to avoid shell injection
-  let result: string;
   try {
-    result = execFileSync('npx', ['prisma', 'migrate', 'status'], {
-      encoding: 'utf-8',
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: MIGRATION_STATUS_TIMEOUT_MS,
-    });
+    // Exit 0 is the only output this function trusts as a complete answer.
+    return { kind: 'known', pending: parsePendingNames(execSuccessOutput(cwd)) };
   } catch (error) {
     // A timeout kill must NOT fall through to the stdout branch below. Node
     // still attaches whatever stdout was captured before the SIGTERM, and
@@ -144,41 +236,60 @@ function getPendingMigrations(cwd: string): string[] | null {
     // so the partial (usually empty) output would fail the content match and
     // return [], reporting "no migrations pending" when the truth is unknown.
     // `code` is the discriminator: `killed` is undefined on this path.
-    if (isTimeoutKill(error)) return null;
-    // Prisma migrate status exits with non-zero when migrations are pending
-    // We need to capture the output from stderr/stdout
-    if (error && typeof error === 'object' && 'stdout' in error) {
-      result = String(error.stdout);
-    } else if (error && typeof error === 'object' && 'message' in error) {
-      result = String(error.message);
-    } else {
-      return null;
+    if (isTimeoutKill(error)) {
+      return {
+        kind: 'unknown',
+        reason: `prisma migrate status timed out after ${MIGRATION_STATUS_TIMEOUT_MS / 1000}s`,
+      };
     }
-  }
-
-  // Look for "Following migration(s) have not yet been applied"
-  if (result.includes('have not yet been applied')) {
-    const lines = result.split('\n');
-    const pending: string[] = [];
-    let inPendingSection = false;
-
-    for (const line of lines) {
-      if (line.includes('have not yet been applied')) {
-        inPendingSection = true;
-        continue;
-      }
-      if (inPendingSection && line.trim().startsWith('-')) {
-        pending.push(line.trim().substring(1).trim());
-      }
-      if (inPendingSection && line.trim() === '') {
-        break;
-      }
+    // Prisma migrate status exits with non-zero when migrations are pending,
+    // so a non-zero exit's output is the answer — when it is the pending shape.
+    //
+    // Two different reads of the same failure, deliberately: the pending LIST
+    // is structured data and comes from stdout alone, while the failure REASON
+    // is diagnostic prose and may come from either stream. Parsing the list out
+    // of the merged blob would let a stderr warning that lands next to the
+    // marker be absorbed as a migration name — and the merge exists only for
+    // the reason, which is the half that was demonstrably on the wrong stream.
+    // If prisma ever moved the list to stderr, the marker check below fails and
+    // the answer degrades to `unknown`, never to a false all-clear.
+    const stdout = streamText(error, 'stdout');
+    const output = capturedOutput(error);
+    if (output === null) {
+      return { kind: 'unknown', reason: 'prisma migrate status failed with no readable output' };
     }
 
-    return pending;
+    // A non-zero exit is only a COMPLETE answer when it is the pending-migrations
+    // exit. Every other non-zero shape — an unreachable database (P1001), schema
+    // drift, a permission error, a spawn failure — carries output that simply
+    // does not contain the marker, and reading that as "no marker, therefore
+    // nothing pending" is the same confident-wrong all-clear this function's
+    // timeout branch exists to prevent. A refused connection fails FAST, so it
+    // is the likelier trigger of the two.
+    if (!stdout.includes(PENDING_MARKER)) {
+      // The fallback keeps the reason a complete sentence when both streams are
+      // whitespace-only — otherwise it renders as a dangling colon.
+      const detail = failureLine(output);
+      return {
+        kind: 'unknown',
+        reason:
+          detail === ''
+            ? 'prisma migrate status failed with no readable output'
+            : `prisma migrate status failed: ${detail}`,
+      };
+    }
+    return { kind: 'known', pending: parsePendingNames(stdout) };
   }
+}
 
-  return [];
+/** The success-path invocation, split out so the `try` above wraps one call. */
+function execSuccessOutput(cwd: string): string {
+  return execFileSync('npx', ['prisma', 'migrate', 'status'], {
+    encoding: 'utf-8',
+    cwd,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: MIGRATION_STATUS_TIMEOUT_MS,
+  });
 }
 
 interface CIStatus {
@@ -316,9 +427,19 @@ function displayRoadmapItems(items: string[]): void {
 /**
  * Display migrations section
  */
-function displayMigrations(pending: string[]): void {
+function displayMigrations(status: ResolvedMigrationStatus): void {
   console.log(chalk.yellow('🗄️  Migrations'));
   console.log(chalk.dim('─'.repeat(50)));
+  if (status.kind === 'unknown') {
+    console.log(`   ${chalk.yellow(`Status unknown — ${status.reason}`)}`);
+    // Deliberately cause-agnostic: an unknown can be a timeout, an unreachable
+    // database, schema drift, or a permission error, and naming reachability
+    // for all of them points a reader at the wrong thing three times out of four.
+    console.log(chalk.dim('     Re-run `pnpm ops context` once the cause is cleared'));
+    console.log('');
+    return;
+  }
+  const { pending } = status;
   if (pending.length > 0) {
     console.log(`   ${chalk.yellow(`${pending.length} pending migration(s)`)}`);
     for (const migration of pending) {
@@ -424,9 +545,9 @@ export async function getSessionContext(options: ContextOptions = {}): Promise<v
   }
 
   if (!skipMigrations) {
-    const pending = getPendingMigrations(cwd);
-    if (pending !== null) {
-      displayMigrations(pending);
+    const migrations = getPendingMigrations(cwd);
+    if (migrations.kind !== 'absent') {
+      displayMigrations(migrations);
     }
   }
 

--- a/packages/tooling/src/utils/timeoutKill.ts
+++ b/packages/tooling/src/utils/timeoutKill.ts
@@ -33,8 +33,9 @@
  * Whether a thrown `execFileSync`/`spawnSync` error is a timeout kill.
  *
  * Call this FIRST in any catch that inspects `stdout`/`stderr` content, and
- * answer "unknown" on true. `getPendingMigrations` (returns `null`) and
- * `fetchRegisteredCommands` (rethrows) are the two shapes that answer takes.
+ * answer "unknown" on true. `getPendingMigrations` (returns a tagged
+ * `{ kind: 'unknown', reason }` status) and `fetchRegisteredCommands`
+ * (rethrows) are the two shapes that answer takes.
  *
  * Not every site needs this helper: where a catch already discriminates on
  * the exit code, a timeout falls out for free — `hasNonTestImporters` treats


### PR DESCRIPTION
Follow-up to #2072's round-12 review finding.

## The gap

#2072 fixed `getPendingMigrations` so a timeout stops claiming **"All migrations applied"** during a DB hang — a confident wrong answer. It returned `null` to do that. But the caller reads `null` as *"this repo has no `prisma/migrations`"*, so after the fix a DB hang rendered as **total silence**.

For a tool whose entire job is warning a developer about exactly this state at session start, silence is the one degradation it must not choose. Never claiming "none pending" when unsure was half the fix; the other half is saying so.

## The change

`getPendingMigrations` returns a tagged `MigrationStatus` instead of collapsing several outcomes into one `null`:

| Outcome | Before | After |
| --- | --- | --- |
| No `prisma/migrations` directory | `null` → no section | `absent` → no section (unchanged) |
| Timeout kill | `null` → no section | `unknown` → visible line naming the timeout |
| Thrown value with nothing readable | `null` → no section | `unknown` → visible line |
| **Non-zero exit without the pending marker** | **`known, []` → "All migrations applied"** | **`unknown` → visible line naming the error** |
| Non-zero exit WITH the pending marker | parsed list | `known` (unchanged) |
| Exit 0 | parsed list | `known` (unchanged) |

**The bolded row is the one that matters most, and it was found in review rather than by me.** It covers a refused connection (P1001), schema drift, a permission error, and a spawn failure — all of which fail *fast* rather than hanging, making them likelier in practice than the 60-second timeout this PR was originally written for. Every one of them used to print the all-clear.

Only exit 0 is trusted as a complete answer; the pending-marker exit is the single non-zero shape that is also complete. `absent` still prints nothing, which is the distinction the whole change exists to preserve — a non-Prisma repo must not get a spurious warning.

## Two probes, both of which changed the code

Neither of these was reasoned to; both were measured, and both had already produced a wrong implementation before the probe ran.

1. **Prisma splits a failure across streams.** Against a real unreachable database, stdout carries `Datasource "db": PostgreSQL database …` while stderr carries `Error: P1001: Can't reach database server at …`. A stdout-only read therefore fails *quietly* — it renders a plausible reason naming the datasource while the actual error goes unread. My original test fixture put P1001 on stdout and passed against the broken read.
2. **On a spawn failure both stream keys exist with the value `undefined`** (`code: 'ENOENT'`, text only on `message`). `'stdout' in error` is also true when stdout is `''`. So a presence check plus `String()` yields the literal `"undefined"` — non-empty, so it wins over the `message` fallback and renders as `failed: undefined`.

Consequently: the reason text reads **both** streams and prefers the error-looking line; the pending **list** is parsed from stdout alone (a merged blob would let a stderr line be absorbed as a migration name); stream values are checked for nullish rather than key presence.

## Verification

Ten migration-status cases. **Six canaried** — each of these mutations reddens its own test and nothing else:

| Mutation | Test that goes red |
| --- | --- |
| timeout branch → `absent` | timeout reports unknown |
| `absent` → `unknown` | non-Prisma repo stays silent |
| drop the marker guard | non-marker exit reports unknown |
| read stdout only | P1001 surfaces from stderr |
| take the first line, not the error line | P1001 surfaces from stderr |
| key-presence instead of nullish check | spawn failure surfaces `ENOENT` |
| parse the list from the merged blob | stderr noise stays out of the list |

One of those tests was wrong on the first attempt in a way worth naming: the stderr-noise fixture ended with a blank line, and the parser stops at the first blank after the marker — so it never reached stderr and passed whether the streams were merged or not. The canary caught it; the fixture now omits the trailing blank.

**Confirmed end to end, not just in unit tests:** `pnpm ops context` against an unreachable database prints `Status unknown — prisma migrate status failed: Error: P1001: Can't reach database server at \`127.0.0.1:59999\``, and against a healthy one still prints `All migrations applied`.

The banner's second line is now cause-agnostic ("Re-run once the cause is cleared") — naming reachability was wrong for three of the four unknown causes.

## Closing reference

Closes TASK-548.

> Acceptance, verbatim: *"a migration-status timeout produces a visible 'unknown' line, and a repo with no migrations directory still produces no section at all."*

Both clauses met, each with its own canaried test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
