### PR TITLE
feat(tooling): gate that a task is not both live and archived

### DIFF
--- a/packages/tooling/src/dev/backlogLint.test.ts
+++ b/packages/tooling/src/dev/backlogLint.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import {
   ALLOW_ORIGIN_ID_COLLISION_ENV,
+  checkArchiveIdConflicts,
   checkDuplicateTaskIds,
   checkOriginIdCollisions,
   checkTaskTriage,
@@ -402,6 +403,71 @@ describe('checkTaskTriage', () => {
   });
 });
 
+describe('checkArchiveIdConflicts', () => {
+  it('passes when the two directories are disjoint', () => {
+    expect(checkArchiveIdConflicts(['task-10 - live.md'], ['task-9 - archived.md'])).toEqual([]);
+  });
+
+  it('flags a task present in both directories, naming the id and both paths', () => {
+    const [problem] = checkArchiveIdConflicts(
+      ['task-544 - Some-task.md'],
+      ['task-544 - Some-task.md']
+    );
+    expect(problem).toContain('task-544 is BOTH live and archived');
+    expect(problem).toContain('tracker/tasks/task-544 - Some-task.md');
+    expect(problem).toContain('tracker/archive/tasks/task-544 - Some-task.md');
+  });
+
+  it('catches the overlap when the two copies were renamed apart', () => {
+    // Comparing full filenames would miss this: the archive move and a later
+    // title edit leave the same id under two different names, and the live copy
+    // still answers every open-pool query.
+    const [problem] = checkArchiveIdConflicts(
+      ['task-544 - Renamed-after-the-move.md'],
+      ['task-544 - Original-title.md']
+    );
+    expect(problem).toContain('task-544 is BOTH live and archived');
+  });
+
+  it('reports every overlapping id, not just the first', () => {
+    const problems = checkArchiveIdConflicts(
+      ['task-1 - a.md', 'task-2 - b.md', 'task-3 - c.md'],
+      ['task-1 - a.md', 'task-3 - c.md']
+    );
+    expect(problems).toHaveLength(2);
+    expect(problems.join('\n')).toContain('task-1 is BOTH');
+    expect(problems.join('\n')).toContain('task-3 is BOTH');
+    expect(problems.join('\n')).not.toContain('task-2');
+  });
+
+  it('is empty when the archive is empty — the ordinary state', () => {
+    expect(checkArchiveIdConflicts(['task-1 - a.md'], [])).toEqual([]);
+  });
+
+  it('flags two files sharing an id INSIDE the archive, naming every copy', () => {
+    // Same failure shape one directory over: each file looks correct alone, and
+    // a last-writer-wins map would compare one and report neither.
+    const problems = checkArchiveIdConflicts([], ['task-7 - original.md', 'task-7 - a-copy.md']);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('task-7 appears 2 times');
+    expect(problems[0]).toContain('task-7 - original.md');
+    expect(problems[0]).toContain('task-7 - a-copy.md');
+  });
+
+  it('names every archived copy when a live file collides with duplicated ones', () => {
+    const [, liveProblem] = checkArchiveIdConflicts(
+      ['task-7 - live.md'],
+      ['task-7 - one.md', 'task-7 - two.md']
+    );
+    // FULL paths, asserted with their directory prefix — a bare-filename
+    // assertion passes whether or not the second copy is prefixed, which is
+    // exactly how the missing prefix survived into review.
+    expect(liveProblem).toContain('tracker/archive/tasks/task-7 - one.md');
+    expect(liveProblem).toContain('tracker/archive/tasks/task-7 - two.md');
+    expect(liveProblem).toContain('tracker/tasks/task-7 - live.md');
+  });
+});
+
 describe('runBacklogLint', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
 
@@ -654,6 +720,41 @@ describe('runBacklogLint', () => {
     const out = logSpy.mock.calls.flat().join('\n');
     expect(out).toContain('id TASK-1 is already used on origin/develop');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('gates when a task is live and archived at once', async () => {
+    // Wiring, not logic: the pure check has its own suite. What this pins is
+    // that the archive directory is actually read and its findings reach the
+    // exit code — the whole failure was a state nothing looked at.
+    // The backlogTree entry alone makes the archive directory exist AND supplies
+    // its listing — a `files` entry for the same path would be dead weight.
+    mockFs(
+      { 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' },
+      [],
+      { 'task-1 - valid.md': VALID_TASK },
+      {},
+      { 'tracker/archive/tasks': [{ name: 'task-1 - valid.md' }] }
+    );
+
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('task-1 is BOTH live and archived');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('stays clean when the archive directory does not exist at all', async () => {
+    // The ordinary shape for any checkout without an archive: absent must read
+    // as "nothing archived", never as a crash or a finding.
+    mockFs({ 'backlog/now.md': '### 🎯 Current Focus (max 3)\n1. a\n' }, [], {
+      'task-1 - valid.md': VALID_TASK,
+    });
+
+    await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
+
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('Backlog layout in sync');
+    expect(process.exitCode).not.toBe(1);
   });
 
   it('notes the skip and stays clean when origin/develop is unresolvable', async () => {

--- a/packages/tooling/src/dev/backlogLint.ts
+++ b/packages/tooling/src/dev/backlogLint.ts
@@ -26,6 +26,10 @@
  *    task is filed into a blind spot: a filter that returns nothing reads as
  *    "no such work", never as "the label is missing". Done tasks are exempt:
  *    they're finished work awaiting archive.
+ *  - `tracker/tasks/` and `tracker/archive/tasks/` are disjoint by id, and the
+ *    archive itself holds one file per id. An archived task whose live copy
+ *    survived still answers every open-pool query while the operator believes
+ *    it superseded, and both halves parse cleanly, so nothing else surfaces it.
  *
  * Separately, and NOT gating: a warning naming any uncommitted file under
  * `tracker/`. Everything above parses the tracker tree off disk, so a task git
@@ -48,7 +52,12 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import chalk from 'chalk';
 import { checkUncommittedTrackerFiles, readTrackerGitStatus } from './trackerGitStatus.js';
-import { loadTrackerTasks, openTasks, type TrackerTask } from './trackerTasks.js';
+import {
+  loadTrackerTasks,
+  openTasks,
+  TRACKER_TASKS_DIR,
+  type TrackerTask,
+} from './trackerTasks.js';
 
 /** @internal Exported for testing */
 export interface SectionCap {
@@ -276,7 +285,7 @@ function checkDocIdRefs(rootDir: string): string[] {
  * `backlog` is scanned recursively (`backlog/cold/` holds the queue and epic
  * log); the tracker directories are flat but go through the same walk.
  */
-const RELATIVE_LINK_SCAN_DIRS = ['tracker/docs', 'tracker/tasks', 'backlog'];
+const RELATIVE_LINK_SCAN_DIRS = ['tracker/docs', TRACKER_TASKS_DIR, 'backlog'];
 
 /** Every `.md` file under `dir`, recursively, paired with its repo-relative path. */
 function collectMarkdownFiles(dir: string, relDir: string): { abs: string; rel: string }[] {
@@ -521,6 +530,101 @@ export function checkDuplicateTaskIds(tasks: TrackerTask[]): string[] {
     );
 }
 
+const ARCHIVE_TASKS_DIR = 'tracker/archive/tasks';
+
+/**
+ * Markdown filenames in one task directory, or `[]` when it does not exist.
+ *
+ * Deliberately a directory listing rather than a projection of the parsed
+ * `tasks`: a file that fails to parse is absent from that list, and an
+ * unparseable live copy of an archived task is exactly as invisible as a
+ * parseable one — more so, since the parse failure gives no hint that a
+ * second copy exists.
+ */
+function readTaskFileNames(rootDir: string, dir: string): string[] {
+  const abs = join(rootDir, dir);
+  if (!existsSync(abs)) {
+    return [];
+  }
+  // Sorted to match `loadTrackerTasks`, so findings come out in the same order
+  // run to run — `readdirSync` makes no ordering guarantee on a real filesystem.
+  return readdirSync(abs)
+    .filter(name => name.endsWith('.md'))
+    .sort();
+}
+
+/** @internal Exported for testing */
+export function readArchivedTaskFiles(rootDir: string): string[] {
+  return readTaskFileNames(rootDir, ARCHIVE_TASKS_DIR);
+}
+
+/** @internal Exported for testing */
+export function readLiveTaskFiles(rootDir: string): string[] {
+  return readTaskFileNames(rootDir, TRACKER_TASKS_DIR);
+}
+
+/**
+ * Any task id answered by more than one file: across `tracker/tasks/` and
+ * `tracker/archive/tasks/`, or twice within the archive itself.
+ *
+ * The archive is how an item exits the pool, so the two directories must be
+ * disjoint and the archive must hold one file per id — and each copy parses
+ * fine on its own, so nothing else surfaces the overlap. This is
+ * `06-backlog.md`'s "a missing label is indistinguishable from absent work"
+ * read in reverse.
+ *
+ * Compared by id token rather than by full filename, so a rename on either
+ * side cannot hide it — and because the id, not the title, is what every CLI
+ * lookup resolves.
+ *
+ * Two causes, both real, hence a message naming both remedies. A live copy can
+ * SURVIVE an archive move (delete it), or a genuinely new task can be handed a
+ * RECYCLED id (renumber it): the allocator numbers from the live directory
+ * only — probed, `task-9001` in the archive still yielded `TASK-552` — so
+ * archiving the highest-numbered task frees its id for the next create.
+ *
+ * No bypass env var, unlike `checkOriginIdCollisions`: a rename can make that
+ * check spurious, while nothing makes two files answering one id harmless.
+ * @internal Exported for testing
+ */
+export function checkArchiveIdConflicts(liveFiles: string[], archivedFiles: string[]): string[] {
+  const archivedById = new Map<string, string[]>();
+  for (const name of archivedFiles) {
+    const id = fileIdToken(name);
+    archivedById.set(id, [...(archivedById.get(id) ?? []), name]);
+  }
+  // Two files under one id INSIDE the archive is the same failure shape one
+  // directory over: each looks correct alone, and a last-writer-wins map would
+  // compare only one of them and report neither. Accumulating the list closes
+  // that cell as a side effect of not overwriting.
+  const archiveInternal = [...archivedById.entries()]
+    .filter(([, names]) => names.length > 1)
+    .map(
+      ([id, names]) =>
+        `${id} appears ${names.length} times inside ${ARCHIVE_TASKS_DIR}/: ${names.join(', ')} — ` +
+        'the archive is meant to hold one file per id. Delete or renumber the duplicates.'
+    );
+
+  return archiveInternal.concat(
+    liveFiles
+      .map(name => ({ name, archived: archivedById.get(fileIdToken(name)) }))
+      .filter((hit): hit is { name: string; archived: string[] } => hit.archived !== undefined)
+      .map(
+        hit =>
+          `${fileIdToken(hit.name)} is BOTH live and archived: ${TRACKER_TASKS_DIR}/${hit.name} ` +
+          // Prefixed PER FILE, not once before the join: every path in this
+          // message has to be copy-pasteable, and an id with two archived
+          // copies would otherwise print the second as a bare filename.
+          `and ${hit.archived.map(name => `${ARCHIVE_TASKS_DIR}/${name}`).join(', ')} — ` +
+          'the live copy answers every ' +
+          'open-pool query, and every id lookup is ambiguous. If the live copy is a leftover ' +
+          'from an archive move, delete it; if it is genuinely new work that was handed a ' +
+          'recycled id (the allocator numbers from the live directory only), renumber it ' +
+          '(file, `id:`, and `ordinal:`).'
+      )
+  );
+}
+
 /** Escape hatch for the legitimate-rename false positive; mirrors `--allow-stale-current`. */
 export const ALLOW_ORIGIN_ID_COLLISION_ENV = 'TZUROT_ALLOW_ORIGIN_ID_COLLISION';
 
@@ -590,7 +694,8 @@ function reportProblems(problems: string[]): void {
   if (problems.length === 0) {
     console.log(
       chalk.green(
-        '✓ Backlog layout in sync (caps respected, links resolve, tracker store parses, open tasks triaged)'
+        '✓ Backlog layout in sync (caps respected, links resolve, tracker store parses, ' +
+          'open tasks triaged, archive disjoint from the live pool)'
       )
     );
     return;
@@ -604,7 +709,8 @@ function reportProblems(problems: string[]): void {
 /**
  * CLI entry point. Sets a non-zero exit code on any structural problem (cap
  * exceeded, dangling doc reference, unreadable tracker task, untriaged open
- * task, duplicated or origin-colliding task id).
+ * task, duplicated or origin-colliding task id, a task that is both live and
+ * archived).
  */
 export async function runBacklogLint(options: LintOptions = {}): Promise<void> {
   const rootDir = options.rootDir ?? process.cwd();
@@ -625,6 +731,7 @@ export async function runBacklogLint(options: LintOptions = {}): Promise<void> {
     ...trackerProblems,
     ...checkTaskTriage(tasks),
     ...checkDuplicateTaskIds(tasks),
+    ...checkArchiveIdConflicts(readLiveTaskFiles(rootDir), readArchivedTaskFiles(rootDir)),
     ...(bypassOriginCollision ? [] : checkOriginIdCollisions(tasks, origin)),
   ];
   if (bypassOriginCollision) {

--- a/packages/tooling/src/dev/trackerTasks.ts
+++ b/packages/tooling/src/dev/trackerTasks.ts
@@ -20,8 +20,14 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 
-/** Store location relative to the repo root. Matches `backlog.config.yml`. */
-const TRACKER_TASKS_DIR = 'tracker/tasks';
+/**
+ * Store location relative to the repo root. Matches `backlog.config.yml`.
+ *
+ * Exported because `backlogLint` also addresses this directory (to compare it
+ * against the archive); a second local copy of the literal would be a second
+ * source of truth kept in step by hand.
+ */
+export const TRACKER_TASKS_DIR = 'tracker/tasks';
 
 /** @internal Exported for testing */
 export interface TrackerTask {


### PR DESCRIPTION
Found by hand during #2072, not by the gate.

## What went wrong

TASK-544 was archived. A later `git reset` plus a branch checkout during a commit-guard recovery restored the live copy from HEAD — and the archived half was already committed. The same task then lived in `tracker/tasks/` **and** `tracker/archive/tasks/` at once: still MEDIUM priority in every open-pool query, while the operator believed it superseded.

`pnpm ops backlog` was green the whole time. Both copies parse fine, and each directory looks correct on its own — nothing spans the two.

This is `06-backlog.md`'s *"a missing label is indistinguishable from absent work"* read in reverse: **an archived task that is still live is indistinguishable from one that was never archived.**

The trigger isn't exotic. Any sequence that unstages a move and then changes branches restores the deleted half. The CLI is not at fault, which is exactly why a structural check is the right home rather than a note telling people to be careful.

## The check

`checkArchiveIdConflicts` — one directory listing each, one set intersection, hard-fail naming the id and both paths, consistent with every other finding the gate reports.

Two deliberate choices:

- **Compared by id token, not filename.** A rename on either side would otherwise hide the overlap — and a live task reusing an *archived* id is ambiguous for every id-based CLI lookup (`task edit`, `task view`, cross-references) regardless of its title. Strictly stronger than the basename comparison, catching the same case.
- **A directory listing, not a projection of the parsed `tasks`.** A file that fails to parse is absent from that list, and an unparseable live copy of an archived task is *more* invisible than a parseable one — the parse failure gives no hint a second copy exists.

## Verification

Seven unit cases on the pure check plus two through `runBacklogLint` (the gate fires and sets the exit code; an absent archive directory stays clean and silent).

**Four load-bearing tests were canaried** — each mutation reddens its own test and nothing else:

| Mutation | Test that goes red |
| --- | --- |
| remove the check from the `problems` array | gate fires on a live+archived task |
| compare by full filename instead of id token | overlap survives a rename on either side |
| last-writer-wins in the archive id map | two files sharing an id *inside* the archive |
| prefix the archive directory once instead of per file | every archived copy prints a full path |

`pnpm ops backlog` is green against the real tree, and a sweep of the current archive (16 files) found no live duplicates, so this lands green rather than immediately red.

## Scope note

The check reports **archive-internal** duplicates too, not only live↔archive. That was added in review: it is the same failure shape one directory over, it was five lines given the id map already being built, and filing a task for it from inside the file it lives in is what `06-backlog.md`'s admission bar exists to prevent.

**Correction — an earlier version of this section claimed the matrix was "now closed." It isn't.** Locally it is (`checkDuplicateTaskIds` covers live↔live, this check covers live↔archive and archive↔archive), but **origin-live↔local-archive is uncovered**: a branch cut before an archive-move on develop can be handed a recycled id, and nothing fires until merge — where this check does catch it, making it a *delayed* catch rather than a silent miss.

Filed as **TASK-552** rather than fixed here, because the obvious fix is wrong: adding the archive to the origin `ls-tree` pathspec makes every un-rebased branch fail, since a branch predating the archive-move legitimately still has the task live and presents the exact shape of a real collision. Telling those two states apart needs a merge-base or content comparison — a design step, not a one-liner.


## Closing reference

Closes TASK-550.

> Acceptance, verbatim: *"a task file present in both directories fails `pnpm ops backlog`, naming the id."*

Both clauses met — the gating test asserts the non-zero exit, and the message leads with the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
