### PR TITLE
fix(tooling): disclose two more link-gate parse limitations, unify the doc-N prefix

### DIFF
--- a/packages/tooling/src/dev/backlogLint.test.ts
+++ b/packages/tooling/src/dev/backlogLint.test.ts
@@ -141,12 +141,19 @@ describe('extractRelativeLinks', () => {
     expect(extractRelativeLinks(md)).toEqual(['../active-epic.md']);
   });
 
-  // The four shapes the extractor's docstring says it does not parse. Each of
-  // those sentences is a claim about runtime behavior, so it is pinned here
-  // rather than left as prose (02-code-standards § "A Comment That Asserts
-  // Behavior Is a Claim"). These characterize the CURRENT behavior — if a real
-  // markdown-link parser ever replaces the regex, these are the cases to
-  // revisit, and they will fail loudly rather than drift silently.
+  // The shapes the extractor's docstring says it mishandles. Each of those
+  // sentences is a claim about runtime behavior, so it is pinned here rather
+  // than left as prose (02-code-standards § "A Comment That Asserts Behavior Is
+  // a Claim"). These characterize the CURRENT behavior — if a real markdown-link
+  // parser ever replaces the regex, these are the cases to revisit, and they
+  // will fail loudly rather than drift silently.
+  //
+  // The first four are misses. The last two run the other way: an OVER-match
+  // that reports non-paths as dangling, and a stripCode assumption that
+  // swallows real links. Both directions belong here — a limitation that
+  // produces a spurious CI failure is as much a documented behavior as one that
+  // produces a blind spot, and it is the direction that actually costs someone
+  // a red `pnpm quality` on text that was never a path.
   describe('documented parse limitations', () => {
     it('a titled link captures the title as part of the target (fails loud)', () => {
       expect(extractRelativeLinks('[t](../foo.md "Title")')).toEqual(['../foo.md "Title"']);
@@ -162,6 +169,31 @@ describe('extractRelativeLinks', () => {
 
     it('reference-style links match nothing (fails silent)', () => {
       expect(extractRelativeLinks('[t][ref]\n\n[ref]: ../foo.md')).toEqual([]);
+    });
+
+    // Not hypothetical: the first draft of the task that filed this limitation
+    // wrote these two examples in link form, and the gate reported both as
+    // dangling within minutes of them being written down.
+    it('over-matches a bare domain-like target (fails loud, wrong direction)', () => {
+      expect(extractRelativeLinks('see [docs](example.com) here')).toEqual(['example.com']);
+      expect(extractRelativeLinks('the [runtime](Node.js) version')).toEqual(['Node.js']);
+    });
+
+    // The workaround the docstring offers, in both spellings a writer would
+    // reach for. Documenting an escape hatch that does not work would be worse
+    // than documenting none.
+    it('backticking suppresses the over-match, around the link or the target', () => {
+      expect(extractRelativeLinks('see `[docs](example.com)` here')).toEqual([]);
+      expect(extractRelativeLinks('see [docs](`example.com`) here')).toEqual([]);
+    });
+
+    it('stripCode drops a real link when inline backticks are unbalanced', () => {
+      expect(extractRelativeLinks('a `span here and [t](../real.md) then `another` tail')).toEqual(
+        []
+      );
+      // Balanced, same link: it survives. Without this half the assertion above
+      // would pass for any reason at all — including the link never being seen.
+      expect(extractRelativeLinks('a `span` and [t](../real.md) tail')).toEqual(['../real.md']);
     });
   });
 });
@@ -651,7 +683,12 @@ describe('runBacklogLint', () => {
 
     await runBacklogLint({ rootDir: '/repo', origin: NO_ORIGIN_FILES });
 
-    expect(logSpy.mock.calls.flat().join('\n')).toContain('dangling doc reference → doc-1');
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('dangling doc reference → doc-1');
+    // Repo-relative, the same convention checkDocIdRefs uses. A bare `queue.md:`
+    // prefix reads as a different kind of location than its sibling's full path,
+    // for a finding about the same convention.
+    expect(out).toContain('backlog/cold/queue.md: dangling doc reference → doc-1');
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/tooling/src/dev/backlogLint.ts
+++ b/packages/tooling/src/dev/backlogLint.ts
@@ -126,6 +126,12 @@ export function extractQueueDocRefs(queueMd: string): string[] {
  * would report a dangling link against text that was never a link — a failure
  * that looks like real rot and blocks everyone's `pnpm quality`, which is worse
  * than any of the shapes this extractor merely fails to see.
+ *
+ * Assumes BALANCED delimiters, and fails SILENTLY when they are not. An odd
+ * number of inline backticks makes the span regex pair the wrong two, so a run
+ * of real prose is blanked along with any links inside it — measured: in
+ * ``a `span here and [t](../real.md) then `another` tail``, the real
+ * `../real.md` link is swallowed and never checked. Pinned in backlogLint.test.ts § `documented parse limitations`.
  */
 function stripCode(markdown: string): string {
   return markdown.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '');
@@ -182,6 +188,20 @@ function isRelativeFileTarget(target: string): boolean {
  *
  * Closing the silent pair needs a real markdown-link parser rather than a
  * wider regex, which is why the disclosure is here instead.
+ *
+ * A fifth shape fails loud in the OTHER direction — an over-match, not a miss.
+ * `isRelativeFileTarget` accepts any bare target ending in `.letters`, so a
+ * bracket-paren pair wrapped around a bare domain or a dotted product name is
+ * resolved as a sibling path and reported dangling: measured, `[docs](example.com)`
+ * yields `example.com` and `[runtime](Node.js)` yields `Node.js`. Narrowing is
+ * not available, because the accepting rule is the same one that admits
+ * `[t](foo.md)` — the dominant sibling-link style in this corpus — and `js`,
+ * `io`, and `sh` are real file extensions as much as they are real TLDs.
+ * Backticking the text is the workaround (`stripCode` blanks it), and it works
+ * whether the backticks wrap the whole link or just the target; both measured.
+ * Demonstrated rather than hypothetical: the first draft of the task that filed
+ * this limitation wrote those two examples in link form, and the gate reported
+ * both as dangling within minutes. Pinned in backlogLint.test.ts § `documented parse limitations`.
  * @internal Exported for testing
  */
 export function extractRelativeLinks(markdown: string): string[] {
@@ -239,9 +259,18 @@ function checkQueueDocRefs(rootDir: string): string[] {
     return [];
   }
   const existingIds = existingDocIds(rootDir);
+  // Repo-relative, matching checkDocIdRefs below — the two checks report the
+  // same finding about the same convention, and a bare `queue.md` prefix reads
+  // as a different kind of location than its sibling's full path. Derived from
+  // queuePath rather than written out again, so the message cannot drift away
+  // from the file actually read. (checkRelativeLinks reaches the same repo-
+  // relative form by a different route — its `rel` accumulates down the
+  // directory walk — so the shared property is "derived from the real path",
+  // not a shared mechanism.)
+  const queueRel = relative(rootDir, queuePath);
   return extractQueueDocRefs(readFileSync(queuePath, 'utf-8'))
     .filter(ref => !existingIds.has(ref))
-    .map(ref => `queue.md: dangling doc reference → ${ref} (no tracker/docs/ file)`);
+    .map(ref => `${queueRel}: dangling doc reference → ${ref} (no tracker/docs/ file)`);
 }
 
 /**


### PR DESCRIPTION
Three residues from the relative-link gate, batched because they are one file.

## 1. The over-match that already bit

`isRelativeFileTarget` accepts any bare target ending in `.letters`, so a bracket-paren pair wrapped around a bare domain or a dotted product name resolves as a sibling path and is reported dangling. Measured, not reasoned:

| Input | Extracted |
| --- | --- |
| `[docs](example.com)` | `example.com` |
| `[runtime](Node.js)` | `Node.js` |

This is the wrong direction of failure — a confusing red `pnpm quality` over text that was never a path.

**Narrowing is not available.** The accepting rule is the same one that admits `[t](foo.md)`, the dominant sibling-link style in this corpus, and `js` / `io` / `sh` are real file extensions as much as they are real TLDs. Any rule that rejects the first pair rejects the second. So it is disclosed and pinned instead, with the backtick workaround verified in **both** spellings a writer would actually reach for (around the whole link, and around the target alone) — documenting an escape hatch that does not work would be worse than documenting none.

Not hypothetical: the first draft of TASK-522 itself wrote those two examples in link form, and the gate reported both within minutes.

## 2. The silent one

`stripCode` assumes balanced backticks. An odd count pairs the wrong two and blanks a run of real prose along with any links inside it:

```
a `span here and [t](../real.md) then `another` tail   →   []
```

The real `../real.md` is swallowed and never checked, so the gate reports clean. That is the worse direction — a genuinely dead link in a file with an odd backtick simply isn't seen.

The pin asserts **both halves**: the link is lost when unbalanced, and survives when balanced. Without the second half the first would pass for any reason at all, including the link never being extracted in the first place.

## 3. The cosmetic one

`checkQueueDocRefs` prefixed its finding with a bare `queue.md` while its sibling `checkDocIdRefs` uses the full repo-relative path — for a finding about the same convention, in the same gate output. Unified on the full path.

Deferred in the filing round because it costs a CI round for zero behavioural change; it rides here with the docstring work in the same file, which is what it was waiting for. Not deferred on origin.

## Where the pins live

The four previously-disclosed shapes were already pinned in a `documented parse limitations` block. These two join them there rather than sitting among the behaviour tests, and the block's header now says it covers **both directions** — the four misses, plus an over-match and a swallow. A limitation that produces a spurious CI failure is as much a documented behaviour as one that produces a blind spot, and it is the one that actually costs someone a red gate.

The docstrings point at that describe block by name rather than at individual test titles, which drift.

## Not done, and not a defect

`checkDocIdRefs` and `checkRelativeLinks` each walk the scan dirs separately, and `existingDocIds` is computed twice. Harmless at this corpus size, and TASK-522 itself scopes folding them into one pass to "if the tree grows" — so this is a design decision, not a tracked follow-up.

## Verification

79 tests green in the file; `pnpm test` and `pnpm quality` green; `pnpm ops backlog` green against the real tree.

Only one of the three items changes behaviour, and it is canaried: reverting the message prefix to `queue.md:` reddens exactly one test (`1 failed | 78 passed`). The other two are characterization pins of behaviour this PR deliberately does **not** change — they exist so a future narrowing has to update them on purpose rather than drift past them silently.

The behaviours themselves were established by running `extractRelativeLinks` against each shape before any prose was written, rather than by reading the regex.

## Closing reference

Closes TASK-522.

> Acceptance, verbatim: *"the docstring enumerates every shape the extractor mishandles, each pinned or explicitly hedged per 02-code-standards; both doc-N checks use the same prefix convention."*

- *enumerates every shape* — met: four pre-existing misses, plus the over-match and the `stripCode` imbalance added here.
- *each pinned or explicitly hedged* — met, and stronger than the bar: all six are **pinned**, not hedged. The four pre-existing ones already were.
- *both doc-N checks use the same prefix convention* — met; `checkQueueDocRefs` now emits the repo-relative path, asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
